### PR TITLE
Flatten the pride stockings distribution

### DIFF
--- a/data/json/items/armor/boots.json
+++ b/data/json/items/armor/boots.json
@@ -2959,7 +2959,6 @@
         "id": "stockings_black",
         "name": { "str_sp": "black stockings (pair)" },
         "description": "This one is colored black.",
-        "weight": 140,
         "color": "dark_gray",
         "append": true
       },
@@ -2967,7 +2966,6 @@
         "id": "stockings_white",
         "name": { "str_sp": "white stockings (pair)" },
         "description": "This one is colored white.",
-        "weight": 70,
         "color": "light_gray",
         "append": true
       },
@@ -2975,7 +2973,6 @@
         "id": "stockings_white_striped",
         "name": { "str_sp": "striped stockings (pair)" },
         "description": "This one is black, with white stripes.  Or is it white with black stripes?",
-        "weight": 45,
         "color": "light_gray",
         "append": true
       },
@@ -2983,7 +2980,6 @@
         "id": "stockings_red",
         "name": { "str_sp": "red stockings (pair)" },
         "description": "This one is colored red.",
-        "weight": 30,
         "color": "red",
         "append": true
       },
@@ -2991,7 +2987,6 @@
         "id": "stockings_red_polka_dot",
         "name": { "str_sp": "red polka dot stockings (pair)" },
         "description": "This one is colored red with a polka dot pattern.",
-        "weight": 45,
         "color": "light_red",
         "append": true
       },
@@ -2999,7 +2994,6 @@
         "id": "stockings_red_floral",
         "name": { "str_sp": "red floral stockings (pair)" },
         "description": "This one is colored in various shades of red with a floral pattern.",
-        "weight": 40,
         "color": "red",
         "append": true
       },
@@ -3007,7 +3001,6 @@
         "id": "stockings_yellow",
         "name": { "str_sp": "yellow stockings (pair)" },
         "description": "This one is colored yellow.",
-        "weight": 10,
         "color": "yellow",
         "append": true
       },
@@ -3015,7 +3008,6 @@
         "id": "stockings_green",
         "name": { "str_sp": "green stockings (pair)" },
         "description": "This one is colored green.",
-        "weight": 40,
         "color": "green",
         "append": true
       },
@@ -3023,7 +3015,6 @@
         "id": "stockings_orange_striped",
         "name": { "str_sp": "orange striped stockings (pair)" },
         "description": "This one is colored orange with a striped pattern.",
-        "weight": 45,
         "color": "light_red",
         "append": true
       },
@@ -3031,7 +3022,6 @@
         "id": "stockings_blue",
         "name": { "str_sp": "blue stockings (pair)" },
         "description": "This one is colored blue.",
-        "weight": 60,
         "color": "blue",
         "append": true
       },
@@ -3039,7 +3029,6 @@
         "id": "stockings_blue_striped",
         "name": { "str_sp": "blue striped stockings (pair)" },
         "description": "This one is colored blue and white with a striped pattern.",
-        "weight": 20,
         "color": "blue",
         "append": true
       },
@@ -3047,7 +3036,6 @@
         "id": "stockings_blue_floral",
         "name": { "str_sp": "blue floral stockings (pair)" },
         "description": "This one is colored in various shades of blue with a floral pattern.",
-        "weight": 40,
         "color": "blue",
         "append": true
       },
@@ -3055,7 +3043,6 @@
         "id": "stockings_blue_checkered",
         "name": { "str_sp": "blue checkered stockings (pair)" },
         "description": "This one is colored blue and black with a checkered pattern.",
-        "weight": 20,
         "color": "blue",
         "append": true
       },
@@ -3063,7 +3050,6 @@
         "id": "stockings_purple",
         "name": { "str_sp": "purple stockings (pair)" },
         "description": "This one is colored purple.",
-        "weight": 50,
         "color": "magenta",
         "append": true
       },
@@ -3071,7 +3057,6 @@
         "id": "stockings_purple_striped",
         "name": { "str_sp": "purple striped stockings (pair)" },
         "description": "This one is colored purple and white with a striped pattern.",
-        "weight": 50,
         "color": "light_red",
         "append": true
       },
@@ -3079,7 +3064,6 @@
         "id": "stockings_purple_polka_dot",
         "name": { "str_sp": "purple polka dot stockings (pair)" },
         "description": "This one is colored purple with a polka dot pattern.",
-        "weight": 35,
         "color": "magenta",
         "append": true
       },
@@ -3087,7 +3071,6 @@
         "id": "stockings_purple_floral",
         "name": { "str_sp": "purple floral stockings (pair)" },
         "description": "This one is colored in various shades of purple with a floral pattern.",
-        "weight": 40,
         "color": "magenta",
         "append": true
       },
@@ -3095,7 +3078,6 @@
         "id": "stockings_pink",
         "name": { "str_sp": "pink stockings (pair)" },
         "description": "This one is colored pink.",
-        "weight": 35,
         "color": "magenta",
         "append": true
       },
@@ -3103,7 +3085,6 @@
         "id": "stockings_pink_striped",
         "name": { "str_sp": "pink striped stockings (pair)" },
         "description": "This one is colored pink and white with a striped pattern.",
-        "weight": 45,
         "color": "light_red",
         "append": true
       },
@@ -3111,7 +3092,6 @@
         "id": "stockings_pink_polka_dot",
         "name": { "str_sp": "pink polka dot stockings (pair)" },
         "description": "This one is colored pink with a polka dot pattern.",
-        "weight": 35,
         "color": "light_red",
         "append": true
       },
@@ -3119,7 +3099,6 @@
         "id": "stockings_green_striped",
         "name": { "str_sp": "green striped stockings (pair)" },
         "description": "This one is colored green and white with a striped pattern.",
-        "weight": 40,
         "color": "green",
         "append": true
       },
@@ -3127,7 +3106,6 @@
         "id": "stockings_gray_striped",
         "name": { "str_sp": "gray striped stockings (pair)" },
         "description": "This one is colored gray and white with a striped pattern.",
-        "weight": 55,
         "color": "light_gray",
         "append": true
       },
@@ -3135,7 +3113,6 @@
         "id": "stockings_brown",
         "name": { "str_sp": "brown stockings (pair)" },
         "description": "This one is colored brown.",
-        "weight": 80,
         "color": "brown",
         "append": true
       },
@@ -3143,7 +3120,6 @@
         "id": "stockings_brown_polka_dot",
         "name": { "str_sp": "brown polka dot stockings (pair)" },
         "description": "This one is colored brown with a polka dot pattern.",
-        "weight": 20,
         "color": "brown",
         "append": true
       },
@@ -3151,7 +3127,7 @@
         "id": "stockings_pride_default",
         "name": { "str_sp": "pride flag stockings (pair)" },
         "description": "This one has patterns akin to the pride flag.",
-        "weight": 80,
+        "weight": 2,
         "color": "yellow",
         "append": true
       },
@@ -3159,7 +3135,7 @@
         "id": "stockings_pride_lesbian",
         "name": { "str_sp": "lesbian flag stockings (pair)" },
         "description": "This one has patterns akin to the lesbian flag.",
-        "weight": 75,
+        "weight": 2,
         "color": "red",
         "append": true
       },
@@ -3167,7 +3143,7 @@
         "id": "stockings_pride_bisexual",
         "name": { "str_sp": "bisexual flag stockings (pair)" },
         "description": "This one has patterns akin to the bisexual flag.",
-        "weight": 45,
+        "weight": 2,
         "color": "magenta",
         "append": true
       },
@@ -3175,7 +3151,7 @@
         "id": "stockings_pride_transgender",
         "name": { "str_sp": "transgender flag stockings (pair)" },
         "description": "This one has patterns akin to the transgender flag.",
-        "weight": 90,
+        "weight": 2,
         "color": "blue",
         "append": true
       },
@@ -3183,7 +3159,7 @@
         "id": "stockings_pride_asexual",
         "name": { "str_sp": "asexual flag stockings (pair)" },
         "description": "This one has patterns akin to the asexual flag.",
-        "weight": 75,
+        "weight": 2,
         "color": "magenta",
         "append": true
       },
@@ -3191,7 +3167,7 @@
         "id": "stockings_pride_aromantic",
         "name": { "str_sp": "aromantic flag stockings (pair)" },
         "description": "This one has patterns akin to the aromantic flag.",
-        "weight": 65,
+        "weight": 2,
         "color": "green",
         "append": true
       },
@@ -3199,7 +3175,7 @@
         "id": "stockings_pride_pansexual",
         "name": { "str_sp": "pansexual flag stockings (pair)" },
         "description": "This one has patterns akin to the pansexual flag.",
-        "weight": 75,
+        "weight": 2,
         "color": "blue",
         "append": true
       },
@@ -3207,7 +3183,7 @@
         "id": "stockings_pride_genderqueer",
         "name": { "str_sp": "genderqueer flag stockings (pair)" },
         "description": "This one has patterns akin to the genderqueer flag.",
-        "weight": 55,
+        "weight": 2,
         "color": "magenta",
         "append": true
       },
@@ -3215,7 +3191,7 @@
         "id": "stockings_pride_genderfluid",
         "name": { "str_sp": "genderfluid flag stockings (pair)" },
         "description": "This one has patterns akin to the genderfluid flag.",
-        "weight": 45,
+        "weight": 2,
         "color": "magenta",
         "append": true
       },
@@ -3223,7 +3199,7 @@
         "id": "stockings_pride_agender",
         "name": { "str_sp": "agender flag stockings (pair)" },
         "description": "This one has patterns akin to the agender flag.",
-        "weight": 45,
+        "weight": 2,
         "color": "dark_gray",
         "append": true
       },
@@ -3231,7 +3207,7 @@
         "id": "stockings_pride_nonbinary",
         "name": { "str_sp": "non-binary flag stockings (pair)" },
         "description": "This one has patterns akin to the non-binary flag.",
-        "weight": 75,
+        "weight": 2,
         "color": "yellow",
         "append": true
       },
@@ -3239,7 +3215,7 @@
         "id": "stockings_pride_intersex",
         "name": { "str_sp": "intersex flag stockings (pair)" },
         "description": "This one has patterns akin to the intersex flag.",
-        "weight": 55,
+        "weight": 2,
         "color": "yellow",
         "append": true
       },
@@ -3247,7 +3223,7 @@
         "id": "stockings_pride_polysexual",
         "name": { "str_sp": "polysexual flag stockings (pair)" },
         "description": "This one has patterns akin to the polysexual flag.",
-        "weight": 25,
+        "weight": 2,
         "color": "green",
         "append": true
       }

--- a/data/json/items/armor/boots.json
+++ b/data/json/items/armor/boots.json
@@ -2960,174 +2960,197 @@
         "name": { "str_sp": "black stockings (pair)" },
         "description": "This one is colored black.",
         "color": "dark_gray",
-        "append": true
+        "append": true,
+        "weight": 3
       },
       {
         "id": "stockings_white",
         "name": { "str_sp": "white stockings (pair)" },
         "description": "This one is colored white.",
         "color": "light_gray",
-        "append": true
+        "append": true,
+        "weight": 3
       },
       {
         "id": "stockings_white_striped",
         "name": { "str_sp": "striped stockings (pair)" },
         "description": "This one is black, with white stripes.  Or is it white with black stripes?",
         "color": "light_gray",
-        "append": true
+        "append": true,
+        "weight": 3
       },
       {
         "id": "stockings_red",
         "name": { "str_sp": "red stockings (pair)" },
         "description": "This one is colored red.",
         "color": "red",
-        "append": true
+        "append": true,
+        "weight": 3
       },
       {
         "id": "stockings_red_polka_dot",
         "name": { "str_sp": "red polka dot stockings (pair)" },
         "description": "This one is colored red with a polka dot pattern.",
         "color": "light_red",
-        "append": true
+        "append": true,
+        "weight": 3
       },
       {
         "id": "stockings_red_floral",
         "name": { "str_sp": "red floral stockings (pair)" },
         "description": "This one is colored in various shades of red with a floral pattern.",
         "color": "red",
-        "append": true
+        "append": true,
+        "weight": 3
       },
       {
         "id": "stockings_yellow",
         "name": { "str_sp": "yellow stockings (pair)" },
         "description": "This one is colored yellow.",
         "color": "yellow",
-        "append": true
+        "append": true,
+        "weight": 3
       },
       {
         "id": "stockings_green",
         "name": { "str_sp": "green stockings (pair)" },
         "description": "This one is colored green.",
         "color": "green",
-        "append": true
+        "append": true,
+        "weight": 3
       },
       {
         "id": "stockings_orange_striped",
         "name": { "str_sp": "orange striped stockings (pair)" },
         "description": "This one is colored orange with a striped pattern.",
         "color": "light_red",
-        "append": true
+        "append": true,
+        "weight": 3
       },
       {
         "id": "stockings_blue",
         "name": { "str_sp": "blue stockings (pair)" },
         "description": "This one is colored blue.",
         "color": "blue",
-        "append": true
+        "append": true,
+        "weight": 3
       },
       {
         "id": "stockings_blue_striped",
         "name": { "str_sp": "blue striped stockings (pair)" },
         "description": "This one is colored blue and white with a striped pattern.",
         "color": "blue",
-        "append": true
+        "append": true,
+        "weight": 3
       },
       {
         "id": "stockings_blue_floral",
         "name": { "str_sp": "blue floral stockings (pair)" },
         "description": "This one is colored in various shades of blue with a floral pattern.",
         "color": "blue",
-        "append": true
+        "append": true,
+        "weight": 3
       },
       {
         "id": "stockings_blue_checkered",
         "name": { "str_sp": "blue checkered stockings (pair)" },
         "description": "This one is colored blue and black with a checkered pattern.",
         "color": "blue",
-        "append": true
+        "append": true,
+        "weight": 3
       },
       {
         "id": "stockings_purple",
         "name": { "str_sp": "purple stockings (pair)" },
         "description": "This one is colored purple.",
         "color": "magenta",
-        "append": true
+        "append": true,
+        "weight": 3
       },
       {
         "id": "stockings_purple_striped",
         "name": { "str_sp": "purple striped stockings (pair)" },
         "description": "This one is colored purple and white with a striped pattern.",
         "color": "light_red",
-        "append": true
+        "append": true,
+        "weight": 3
       },
       {
         "id": "stockings_purple_polka_dot",
         "name": { "str_sp": "purple polka dot stockings (pair)" },
         "description": "This one is colored purple with a polka dot pattern.",
         "color": "magenta",
-        "append": true
+        "append": true,
+        "weight": 3
       },
       {
         "id": "stockings_purple_floral",
         "name": { "str_sp": "purple floral stockings (pair)" },
         "description": "This one is colored in various shades of purple with a floral pattern.",
         "color": "magenta",
-        "append": true
+        "append": true,
+        "weight": 3
       },
       {
         "id": "stockings_pink",
         "name": { "str_sp": "pink stockings (pair)" },
         "description": "This one is colored pink.",
         "color": "magenta",
-        "append": true
+        "append": true,
+        "weight": 3
       },
       {
         "id": "stockings_pink_striped",
         "name": { "str_sp": "pink striped stockings (pair)" },
         "description": "This one is colored pink and white with a striped pattern.",
         "color": "light_red",
-        "append": true
+        "append": true,
+        "weight": 3
       },
       {
         "id": "stockings_pink_polka_dot",
         "name": { "str_sp": "pink polka dot stockings (pair)" },
         "description": "This one is colored pink with a polka dot pattern.",
         "color": "light_red",
-        "append": true
+        "append": true,
+        "weight": 3
       },
       {
         "id": "stockings_green_striped",
         "name": { "str_sp": "green striped stockings (pair)" },
         "description": "This one is colored green and white with a striped pattern.",
         "color": "green",
-        "append": true
+        "append": true,
+        "weight": 3
       },
       {
         "id": "stockings_gray_striped",
         "name": { "str_sp": "gray striped stockings (pair)" },
         "description": "This one is colored gray and white with a striped pattern.",
         "color": "light_gray",
-        "append": true
+        "append": true,
+        "weight": 3
       },
       {
         "id": "stockings_brown",
         "name": { "str_sp": "brown stockings (pair)" },
         "description": "This one is colored brown.",
         "color": "brown",
-        "append": true
+        "append": true,
+        "weight": 3
       },
       {
         "id": "stockings_brown_polka_dot",
         "name": { "str_sp": "brown polka dot stockings (pair)" },
         "description": "This one is colored brown with a polka dot pattern.",
         "color": "brown",
-        "append": true
+        "append": true,
+        "weight": 3
       },
       {
         "id": "stockings_pride_default",
         "name": { "str_sp": "pride flag stockings (pair)" },
         "description": "This one has patterns akin to the pride flag.",
-        "weight": 2,
         "color": "yellow",
         "append": true
       },
@@ -3135,7 +3158,6 @@
         "id": "stockings_pride_lesbian",
         "name": { "str_sp": "lesbian flag stockings (pair)" },
         "description": "This one has patterns akin to the lesbian flag.",
-        "weight": 2,
         "color": "red",
         "append": true
       },
@@ -3143,7 +3165,6 @@
         "id": "stockings_pride_bisexual",
         "name": { "str_sp": "bisexual flag stockings (pair)" },
         "description": "This one has patterns akin to the bisexual flag.",
-        "weight": 2,
         "color": "magenta",
         "append": true
       },
@@ -3151,7 +3172,6 @@
         "id": "stockings_pride_transgender",
         "name": { "str_sp": "transgender flag stockings (pair)" },
         "description": "This one has patterns akin to the transgender flag.",
-        "weight": 2,
         "color": "blue",
         "append": true
       },
@@ -3159,7 +3179,6 @@
         "id": "stockings_pride_asexual",
         "name": { "str_sp": "asexual flag stockings (pair)" },
         "description": "This one has patterns akin to the asexual flag.",
-        "weight": 2,
         "color": "magenta",
         "append": true
       },
@@ -3167,7 +3186,6 @@
         "id": "stockings_pride_aromantic",
         "name": { "str_sp": "aromantic flag stockings (pair)" },
         "description": "This one has patterns akin to the aromantic flag.",
-        "weight": 2,
         "color": "green",
         "append": true
       },
@@ -3175,7 +3193,6 @@
         "id": "stockings_pride_pansexual",
         "name": { "str_sp": "pansexual flag stockings (pair)" },
         "description": "This one has patterns akin to the pansexual flag.",
-        "weight": 2,
         "color": "blue",
         "append": true
       },
@@ -3183,7 +3200,6 @@
         "id": "stockings_pride_genderqueer",
         "name": { "str_sp": "genderqueer flag stockings (pair)" },
         "description": "This one has patterns akin to the genderqueer flag.",
-        "weight": 2,
         "color": "magenta",
         "append": true
       },
@@ -3191,7 +3207,6 @@
         "id": "stockings_pride_genderfluid",
         "name": { "str_sp": "genderfluid flag stockings (pair)" },
         "description": "This one has patterns akin to the genderfluid flag.",
-        "weight": 2,
         "color": "magenta",
         "append": true
       },
@@ -3199,7 +3214,6 @@
         "id": "stockings_pride_agender",
         "name": { "str_sp": "agender flag stockings (pair)" },
         "description": "This one has patterns akin to the agender flag.",
-        "weight": 2,
         "color": "dark_gray",
         "append": true
       },
@@ -3207,7 +3221,6 @@
         "id": "stockings_pride_nonbinary",
         "name": { "str_sp": "non-binary flag stockings (pair)" },
         "description": "This one has patterns akin to the non-binary flag.",
-        "weight": 2,
         "color": "yellow",
         "append": true
       },
@@ -3215,7 +3228,6 @@
         "id": "stockings_pride_intersex",
         "name": { "str_sp": "intersex flag stockings (pair)" },
         "description": "This one has patterns akin to the intersex flag.",
-        "weight": 2,
         "color": "yellow",
         "append": true
       },
@@ -3223,7 +3235,6 @@
         "id": "stockings_pride_polysexual",
         "name": { "str_sp": "polysexual flag stockings (pair)" },
         "description": "This one has patterns akin to the polysexual flag.",
-        "weight": 2,
         "color": "green",
         "append": true
       }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Lesbian stockings are less common than transgender stockings for no discernable reason. Also our weights distribution for this item's variants is extremely complex despite those weights not being based on anything.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Flatten the distribution of pride stockings in relation to each other. Remove the weighting from all the variants except pride to stick to the original ratio of pride/non pride stockings somewhat.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Teeeechnically a weight of 3 would have been closer to the original ratio than a weight of 2. Ideally being ~2.8, I rounded down but we can round up, I can also come up with a weight distribution that sticks to the original distribution of 1.35:1 non pride/pride.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
