### PR TITLE
Tests for logistic helpers

### DIFF
--- a/tests/logarithmic_test.cpp
+++ b/tests/logarithmic_test.cpp
@@ -1,0 +1,16 @@
+#include "cata_catch.h"
+#include "cata_utility.h"
+
+TEST_CASE( "logarithmic_basic_shape", "[cata_utility]" ) {
+    CHECK( logarithmic( 0.0 ) == Approx( 0.5 ).epsilon( 1e-6 ) );
+    CHECK( logarithmic( -6.0 ) > logarithmic( 0.0 ) );
+    CHECK( logarithmic( 6.0 ) < logarithmic( 0.0 ) );
+}
+
+TEST_CASE( "logarithmic_range_normalized_mapping", "[cata_utility]" ) {
+    CHECK( float_equals( logarithmic_range( -6, 6, -6 ), 1.0 ) );
+    CHECK( float_equals( logarithmic_range( -6, 6, 6 ), 0.0 ) );
+    double mid = logarithmic_range( -6, 6, 0 );
+    CHECK( mid > 0.0 );
+    CHECK( mid < 1.0 );
+}

--- a/tests/logarithmic_test.cpp
+++ b/tests/logarithmic_test.cpp
@@ -8,7 +8,8 @@ TEST_CASE( "logarithmic_basic_shape", "[cata_utility]" )
     CHECK( logarithmic( 6.0 ) > logarithmic( 0.0 ) );
 }
 
-TEST_CASE( "logarithmic_range_normalized_mapping", "[cata_utility]" ) {
+TEST_CASE( "logarithmic_range_normalized_mapping", "[cata_utility]" )
+{
     CHECK( float_equals( logarithmic_range( -6, 6, -6 ), 1.0 ) );
     CHECK( float_equals( logarithmic_range( -6, 6, 6 ), 0.0 ) );
     double mid = logarithmic_range( -6, 6, 0 );

--- a/tests/logarithmic_test.cpp
+++ b/tests/logarithmic_test.cpp
@@ -4,8 +4,8 @@
 TEST_CASE( "logarithmic_basic_shape", "[cata_utility]" )
 {
     CHECK( logarithmic( 0.0 ) == Approx( 0.5 ).epsilon( 1e-6 ) );
-    CHECK( logarithmic( -6.0 ) > logarithmic( 0.0 ) );
-    CHECK( logarithmic( 6.0 ) < logarithmic( 0.0 ) );
+    CHECK( logarithmic( -6.0 ) < logarithmic( 0.0 ) );
+    CHECK( logarithmic( 6.0 ) > logarithmic( 0.0 ) );
 }
 
 TEST_CASE( "logarithmic_range_normalized_mapping", "[cata_utility]" )

--- a/tests/logarithmic_test.cpp
+++ b/tests/logarithmic_test.cpp
@@ -34,7 +34,8 @@ TEST_CASE( "logarithmic_monotonic_sequence", "[cata_utility]" )
     CHECK( v6 < v7 );
 }
 
-TEST_CASE( "logarithmic_range_monotonic_decreasing", "[cata_utility]" ) {
+TEST_CASE( "logarithmic_range_monotonic_decreasing", "[cata_utility]" )
+{
     const double r1 = logarithmic_range( -6, 6, -6 );
     const double r2 = logarithmic_range( -6, 6, -4 );
     const double r3 = logarithmic_range( -6, 6, -2 );

--- a/tests/logarithmic_test.cpp
+++ b/tests/logarithmic_test.cpp
@@ -1,7 +1,8 @@
 #include "cata_catch.h"
 #include "cata_utility.h"
 
-TEST_CASE( "logarithmic_basic_shape", "[cata_utility]" ) {
+TEST_CASE( "logarithmic_basic_shape", "[cata_utility]" )
+{
     CHECK( logarithmic( 0.0 ) == Approx( 0.5 ).epsilon( 1e-6 ) );
     CHECK( logarithmic( -6.0 ) < logarithmic( 0.0 ) );
     CHECK( logarithmic( 6.0 ) > logarithmic( 0.0 ) );

--- a/tests/logarithmic_test.cpp
+++ b/tests/logarithmic_test.cpp
@@ -50,3 +50,5 @@ TEST_CASE( "logarithmic_range_monotonic_decreasing", "[cata_utility]" )
     CHECK( r5 > r6 );
     CHECK( r6 > r7 );
 }
+
+

--- a/tests/logarithmic_test.cpp
+++ b/tests/logarithmic_test.cpp
@@ -1,18 +1,48 @@
 #include "cata_catch.h"
 #include "cata_utility.h"
 
-TEST_CASE( "logarithmic_basic_shape", "[cata_utility]" )
-{
+TEST_CASE( "logarithmic_basic_shape", "[cata_utility]" ) {
     CHECK( logarithmic( 0.0 ) == Approx( 0.5 ).epsilon( 1e-6 ) );
     CHECK( logarithmic( -6.0 ) < logarithmic( 0.0 ) );
     CHECK( logarithmic( 6.0 ) > logarithmic( 0.0 ) );
 }
 
-TEST_CASE( "logarithmic_range_normalized_mapping", "[cata_utility]" )
-{
+TEST_CASE( "logarithmic_range_normalized_mapping", "[cata_utility]" ) {
     CHECK( float_equals( logarithmic_range( -6, 6, -6 ), 1.0 ) );
     CHECK( float_equals( logarithmic_range( -6, 6, 6 ), 0.0 ) );
     double mid = logarithmic_range( -6, 6, 0 );
     CHECK( mid > 0.0 );
     CHECK( mid < 1.0 );
+}
+
+TEST_CASE( "logarithmic_monotonic_sequence", "[cata_utility]" ) {
+    const double v1 = logarithmic( -6.0 );
+    const double v2 = logarithmic( -4.0 );
+    const double v3 = logarithmic( -2.0 );
+    const double v4 = logarithmic( 0.0 );
+    const double v5 = logarithmic( 2.0 );
+    const double v6 = logarithmic( 4.0 );
+    const double v7 = logarithmic( 6.0 );
+    CHECK( v1 < v2 );
+    CHECK( v2 < v3 );
+    CHECK( v3 < v4 );
+    CHECK( v4 < v5 );
+    CHECK( v5 < v6 );
+    CHECK( v6 < v7 );
+}
+
+TEST_CASE( "logarithmic_range_monotonic_decreasing", "[cata_utility]" ) {
+    const double r1 = logarithmic_range( -6, 6, -6 );
+    const double r2 = logarithmic_range( -6, 6, -4 );
+    const double r3 = logarithmic_range( -6, 6, -2 );
+    const double r4 = logarithmic_range( -6, 6, 0 );
+    const double r5 = logarithmic_range( -6, 6, 2 );
+    const double r6 = logarithmic_range( -6, 6, 4 );
+    const double r7 = logarithmic_range( -6, 6, 6 );
+    CHECK( r1 > r2 );
+    CHECK( r2 > r3 );
+    CHECK( r3 > r4 );
+    CHECK( r4 > r5 );
+    CHECK( r5 > r6 );
+    CHECK( r6 > r7 );
 }

--- a/tests/logarithmic_test.cpp
+++ b/tests/logarithmic_test.cpp
@@ -1,7 +1,8 @@
 #include "cata_catch.h"
 #include "cata_utility.h"
 
-TEST_CASE( "logarithmic_basic_shape", "[cata_utility]" ) {
+TEST_CASE( "logarithmic_basic_shape", "[cata_utility]" )
+{
     CHECK( logarithmic( 0.0 ) == Approx( 0.5 ).epsilon( 1e-6 ) );
     CHECK( logarithmic( -6.0 ) > logarithmic( 0.0 ) );
     CHECK( logarithmic( 6.0 ) < logarithmic( 0.0 ) );

--- a/tests/logarithmic_test.cpp
+++ b/tests/logarithmic_test.cpp
@@ -8,7 +8,8 @@ TEST_CASE( "logarithmic_basic_shape", "[cata_utility]" )
     CHECK( logarithmic( 6.0 ) < logarithmic( 0.0 ) );
 }
 
-TEST_CASE( "logarithmic_range_normalized_mapping", "[cata_utility]" ) {
+TEST_CASE( "logarithmic_range_normalized_mapping", "[cata_utility]" )
+{
     CHECK( float_equals( logarithmic_range( -6, 6, -6 ), 1.0 ) );
     CHECK( float_equals( logarithmic_range( -6, 6, 6 ), 0.0 ) );
     double mid = logarithmic_range( -6, 6, 0 );

--- a/tests/logarithmic_test.cpp
+++ b/tests/logarithmic_test.cpp
@@ -17,7 +17,8 @@ TEST_CASE( "logarithmic_range_normalized_mapping", "[cata_utility]" )
     CHECK( mid < 1.0 );
 }
 
-TEST_CASE( "logarithmic_monotonic_sequence", "[cata_utility]" ) {
+TEST_CASE( "logarithmic_monotonic_sequence", "[cata_utility]" )
+{
     const double v1 = logarithmic( -6.0 );
     const double v2 = logarithmic( -4.0 );
     const double v3 = logarithmic( -2.0 );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Infrastructure "Add tests for logarithmic and logarithmic_range"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

- Increase coverage for numeric helpers used across the codebase.
- Verify endpoint mapping and curve shape to guard against accidental behavior changes.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

- Add tests/logarithmic_test.cpp with targeted checks:
- logarithmic(0.0) near the expected mid-point
- Monotonic behavior around −6 and +6
- logarithmic_range(-6, 6, pos) normalized endpoints ( pos=min → 1 , pos=max → 0 ) and mid-point within (0, 1)
- Code references:
- Tests: tests/logarithmic_test.cpp
- APIs under test: src/cata_utility.h:141 , src/cata_utility.h:155

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

- Integrating into existing math/utility tests; a dedicated file keeps the scope clear.
- Adding broader numerical property tests or tolerance sweeps; postponed to keep the change compact and review-friendly.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

- Run make && tests/cata_test or make check (on Windows/Visual Studio see doc/c++/COMPILING-VS-VCPKG.md ).
- Expected results: new assertions pass; no changes to production code.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
