### PR TITLE
return early if there are no stats

### DIFF
--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -2999,6 +2999,9 @@ std::vector<std::string> inventory_selector::get_stats() const
 {
     header_stats stats = get_raw_stats();
     std::vector<std::string> lines( stats.size() );
+    if( lines.size() == 0 ) {
+        return lines;
+    }
     std::vector<size_t> line_rindex( stats.size() );
     size_t blockEnd = 0;
     for( size_t blockStart = 0; blockStart < stats.size(); blockStart = blockEnd ) {

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -2999,7 +2999,7 @@ std::vector<std::string> inventory_selector::get_stats() const
 {
     header_stats stats = get_raw_stats();
     std::vector<std::string> lines( stats.size() );
-    if( lines.size() == 0 ) {
+    if( lines.empty() ) {
         return lines;
     }
     std::vector<size_t> line_rindex( stats.size() );


### PR DESCRIPTION
#### Summary
Bugfixes "fix a crash when opening the item comparison window"

#### Purpose of change
Fixes #84160

#### Describe the solution
The crash happens when we try to dereference an element of an empty vector. If the vector is empty then there’s nothing at all for the function to do, so it should just return early.

#### Testing
Open the game and press `shift-I` to open the inventory comparison window.

#### Additional context
This crash was introduced by PR #83953