### PR TITLE
Move ACT_BUILD handler to build_construction_activity_actor

### DIFF
--- a/src/activity_actor.h
+++ b/src/activity_actor.h
@@ -81,6 +81,7 @@ class activity_actor
 
         /**
          * Used to generate the progress display at the top of the screen
+         * See player_activity::get_progress_message()
          */
         virtual std::string get_progress_message( const player_activity &act ) const;
 

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -2002,6 +2002,37 @@ class tent_deconstruct_activity_actor : public activity_actor
         static std::unique_ptr<activity_actor> deserialize( JsonValue &jsin );
 };
 
+class build_construction_activity_actor : public activity_actor
+{
+    public:
+        build_construction_activity_actor() = default;
+        explicit build_construction_activity_actor( const tripoint_abs_ms &construction_location ) :
+            construction_location( construction_location ) {};
+
+        const activity_id &get_type() const override {
+            static const activity_id ACT_BUILD( "ACT_BUILD" );
+            return ACT_BUILD;
+        }
+
+        void start( player_activity &, Character & ) override {};
+        void do_turn( player_activity &act, Character &you ) override;
+        void finish( player_activity &, Character & ) override {};
+
+        void complete_construction( player_activity &act, Character &you );
+        std::string get_progress_message( const player_activity & ) const override;
+
+        std::unique_ptr<activity_actor> clone() const override {
+            return std::make_unique<build_construction_activity_actor>( *this );
+        }
+
+        void serialize( JsonOut &jsout ) const override;
+        static std::unique_ptr<activity_actor> deserialize( JsonValue &jsin );
+
+    private:
+        tripoint_abs_ms construction_location;
+
+};
+
 class reel_cable_activity_actor : public activity_actor
 {
     private:

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -81,7 +81,6 @@
 #include "vpart_position.h"
 #include "weather.h"
 
-static const activity_id ACT_BUILD( "ACT_BUILD" );
 static const activity_id ACT_FETCH_REQUIRED( "ACT_FETCH_REQUIRED" );
 static const activity_id ACT_MOVE_LOOT( "ACT_MOVE_LOOT" );
 static const activity_id ACT_MULTIPLE_BUTCHER( "ACT_MULTIPLE_BUTCHER" );
@@ -2842,8 +2841,7 @@ static bool construction_activity( Character &you, const zone_data * /*zone*/,
         you.consume_tools( it );
     }
     you.backlog.emplace_front( activity_to_restore );
-    you.assign_activity( ACT_BUILD );
-    you.activity.placement = here.get_abs( src_loc );
+    you.assign_activity( build_construction_activity_actor( here.get_abs( src_loc ) ) );
     return true;
 }
 
@@ -3594,8 +3592,7 @@ bool construction_do( Character &you, const activity_reason_info &act_info,
     if( reason == do_activity_reason::CAN_DO_CONSTRUCTION ) {
         if( here.partial_con_at( src_loc ) ) {
             you.backlog.emplace_front( ACT_MULTIPLE_CONSTRUCTION );
-            you.assign_activity( ACT_BUILD );
-            you.activity.placement = src;
+            you.assign_activity( build_construction_activity_actor( src ) );
             return false;
         }
         if( construction_activity( you, zone, src_loc, act_info, ACT_MULTIPLE_CONSTRUCTION ) ) {

--- a/src/construction.h
+++ b/src/construction.h
@@ -123,7 +123,6 @@ void place_construction( std::vector<construction_group_str_id> const &groups );
 void load_construction( const JsonObject &jo );
 void reset_constructions();
 construction_id construction_menu( bool blueprint );
-void complete_construction( Character *you );
 bool has_pre_flags( const construction &con, furn_id const &f, ter_id const &t );
 bool can_construct( const construction &con, const tripoint_bub_ms &p );
 bool player_can_build( Character &you, const read_only_visitable &inv, const construction &con,

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -101,7 +101,6 @@
 #include "weather.h"
 
 static const activity_id ACT_ATM( "ACT_ATM" );
-static const activity_id ACT_BUILD( "ACT_BUILD" );
 static const activity_id ACT_HARVEST( "ACT_HARVEST" );
 static const activity_id ACT_OPERATION( "ACT_OPERATION" );
 
@@ -4973,8 +4972,7 @@ void iexamine::part_con( Character &you, tripoint_bub_ms const &examp )
                 here.partial_con_remove( examp );
             }
         } else {
-            you.assign_activity( ACT_BUILD );
-            you.activity.placement = here.get_abs( examp );
+            you.assign_activity( build_construction_activity_actor( here.get_abs( examp ) ) );
         }
         return;
     }

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -10,7 +10,6 @@
 #include "bodypart.h"
 #include "calendar.h"
 #include "character.h"
-#include "construction.h"
 #include "creature.h"
 #include "debug.h"
 #include "dialogue.h"
@@ -22,7 +21,6 @@
 #include "item.h"
 #include "itype.h"
 #include "magic.h"
-#include "map.h"
 #include "messages.h"
 #include "rng.h"
 #include "skill.h"
@@ -41,7 +39,6 @@
 static const activity_id ACT_AIM( "ACT_AIM" );
 static const activity_id ACT_ARMOR_LAYERS( "ACT_ARMOR_LAYERS" );
 static const activity_id ACT_ATM( "ACT_ATM" );
-static const activity_id ACT_BUILD( "ACT_BUILD" );
 static const activity_id ACT_CHOP_LOGS( "ACT_CHOP_LOGS" );
 static const activity_id ACT_CHOP_PLANKS( "ACT_CHOP_PLANKS" );
 static const activity_id ACT_CHOP_TREE( "ACT_CHOP_TREE" );
@@ -190,19 +187,6 @@ std::optional<std::string> player_activity::get_progress_message( const avatar &
             const int percentage = ( ( moves_total - moves_left ) * 100 ) / moves_total;
 
             extra_info = string_format( "%d%%", percentage );
-        }
-
-        if( type == ACT_BUILD ) {
-            map &here = get_map();
-
-            partial_con *pc =
-                here.partial_con_at( here.get_bub( u.activity.placement ) );
-            if( pc ) {
-                int counter = std::min( pc->counter, 10000000 );
-                const int percentage = counter / 100000;
-
-                extra_info = string_format( "%d%%", percentage );
-            }
         }
 
         if( type == ACT_SPELLCASTING ) {

--- a/src/savegame_legacy.cpp
+++ b/src/savegame_legacy.cpp
@@ -12,7 +12,6 @@
 static const activity_id ACT_AIM( "ACT_AIM" );
 static const activity_id ACT_ARMOR_LAYERS( "ACT_ARMOR_LAYERS" );
 static const activity_id ACT_ATM( "ACT_ATM" );
-static const activity_id ACT_BUILD( "ACT_BUILD" );
 static const activity_id ACT_BURROW( "ACT_BURROW" );
 static const activity_id ACT_BUTCHER( "ACT_BUTCHER" );
 static const activity_id ACT_CRACKING( "ACT_CRACKING" );
@@ -213,7 +212,7 @@ void player_activity::deserialize_legacy_type( int legacy_type, activity_id &des
         ACT_BUTCHER,
         activity_id::NULL_ID(), // ACT_LONGSALVAGE is an actor now
         activity_id::NULL_ID(), // ACT_FORAGE is an actor now
-        ACT_BUILD,
+        activity_id::NULL_ID(), // ACT_BUILD is an actor now
         activity_id::NULL_ID(), // ACT_VEHICLE is an actor now
         activity_id::NULL_ID(), // ACT_REFILL_VEHICLE is deprecated
         ACT_TRAIN,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Infrastructure "move ACT_BUILD handler to build_construction_activity_actor"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Update legacy activities.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

See title. Nothing special with this one.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

- Completed a construction (dig shallow pit, then dig pit).
- Ordered an NPC to complete Construction: Blueprint multi-activity successfully.
- Ordered an NPC to complete Construction: Blueprint in a 0.H save, confirmed no errors/crashes and legacy activity cancelled when loaded with these changes.
- Confirmed build construction activity (de)serialized correctly with NPC still building for correct duration after a save/load
- Confirmed build construction progress percentage is correctly displayed.
- Confirmed constructions can be cancelled/resumed for both the player and NPCs.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
