### PR TITLE
default volume_encumber_modifier to 0

### DIFF
--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -175,7 +175,7 @@ void pocket_data::load( const JsonObject &jo )
                   units::default_length_from_volume( raw_volume_capacity ) * M_SQRT2 );
         optional( jo, was_loaded, "min_item_length", min_item_length );
         optional( jo, was_loaded, "extra_encumbrance", extra_encumbrance, 0 );
-        optional( jo, was_loaded, "volume_encumber_modifier", volume_encumber_modifier, 1 );
+        optional( jo, was_loaded, "volume_encumber_modifier", volume_encumber_modifier, 0 );
         optional( jo, was_loaded, "ripoff", ripoff, 0 );
         optional( jo, was_loaded, "activity_noise", activity_noise );
     }

--- a/src/itype.h
+++ b/src/itype.h
@@ -330,7 +330,7 @@ struct armor_portion_data {
     // When storage is full, how much it encumbers the player.
     int max_encumber = -1;
 
-    // how much an item can hold comfortably compared to an average item
+    // how much additional encumbrance caused to the limb(s) associated with this sublimb(s) coverage definition, per 0.25 liters of stored items
     float volume_encumber_modifier = 0;
 
     // Percentage of the body part that this item covers.

--- a/src/itype.h
+++ b/src/itype.h
@@ -331,7 +331,7 @@ struct armor_portion_data {
     int max_encumber = -1;
 
     // how much an item can hold comfortably compared to an average item
-    float volume_encumber_modifier = 1;
+    float volume_encumber_modifier = 0;
 
     // Percentage of the body part that this item covers.
     // This determines how likely it is to hit the item instead of the player.

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -516,11 +516,14 @@ TEST_CASE( "item_rigidity", "[iteminfo][rigidity]" )
         SECTION( "encumbrance when empty and full" ) {
             // test_waterskin does not define "encumbrance" or "max_encumbrance", so base
             // encumbrance is 0, and max_encumbrance is set by the item factory (finalize_post)
-            // based on the pocket "max_contains_volume" (1 encumbrance per 250 ml).
+            // based on the pocket "max_contains_volume"
+            // prior to #84176, items that did not define their encumbrance scaled at a rate of 1 enc per 0.25 liter stored
+            // Now, expected behavior is that it is 0 enc per 0.25 stored; this means the test waterskin stores for "free"
+            // this is an example of undesirable JSON implementation, but it is a more sensible fallback than 1.0 was
             CHECK( item_info_str( waterskin, encumbrance ) ==
                    "--\n"
                    "<color_c_white>Encumbrance</color>"
-                   "  <color_c_yellow>0</color>, When full  <color_c_yellow>6</color>: The <color_c_cyan>legs</color>.\n" );
+                   "  <color_c_yellow>0</color>, When full  <color_c_yellow>0</color>: The <color_c_cyan>legs</color>.\n" );
 
             // test_backpack has an explicit "encumbrance" and "max_encumbrance"
             CHECK( item_info_str( backpack, encumbrance ) ==


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "default undefined encumbrance:liter to none instead of 4:1"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #84133 among many other issues
Currently any time you don't specify this number, it causes an encumbrance of 4 per liter of storage which is essentially, entirely unusable (most things hover around 1 encumbrance per liter). But that's not all, it also doubles up for every sublocation you don't specify, so for example in #84144 the work pants have a second coverage definition for the knees but since this wasn't specified, the knees added an additional 4 encumbrance per liter to the pants on top of their other defined scaling.
This still affects a lot of items in the game and it would be a major headache to track them all down.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Make the number assume that unspecified encumbrance scaling means the intention was no encumbrance (since it was often also defined elsewhere).
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
There are a lot.
The volume_encumber_modifier field is incredibly unintuitive, since it is measured in per 0.25 liter quantities. Making this more clear, would probably be good.
Another alternative would be to add json integrity checks to make sure each sublocation defines an encumbrance since currently sublocation encumbrance is an optional field.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Compiled and checked out a couple items to make sure my changes were functional. Here's a before and after of an example affected item, Denim Overalls. Now they have their creator's intended encumbrance scaling.
<img width="625" height="442" alt="denim overalls before" src="https://github.com/user-attachments/assets/20f8aaec-ea86-4033-be0c-80b00ebdb2d8" />

<img width="628" height="453" alt="denim overalls after" src="https://github.com/user-attachments/assets/bb4e610a-0b13-4836-97e8-8975bdeab714" />


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
If there are any items that for whatever reason were *intended* to have a scaling of 4 encumbrance per liter of storage, then we can fix those manually. To my knowledge, there are none, though.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
