### PR TITLE
Rebalance Aikido to emphasize surviving and escaping opponents

### DIFF
--- a/data/json/martialarts.json
+++ b/data/json/martialarts.json
@@ -28,7 +28,7 @@
     "type": "martial_art",
     "id": "style_aikido",
     "name": { "str": "Aikido" },
-    "description": "Aikido is a Japanese martial art focused on self-defense, while minimizing injury to the attacker.  It uses defensive throws and disarms but its techniques lack offensive power.",
+    "description": "Aikido is a Japanese martial art focused on self-defense, while minimizing injury to the attacker.  It uses defensive throws and disarms but its techniques lack offensive power.  Modern instruction in the United States tends to emphasize escaping assailants, and disengaging at the first opportunity.",
     "initiate": [ "You enter the hanmi stance.", "%s enters a relaxed combat posture." ],
     "priority": 1,
     "learn_difficulty": 5,
@@ -37,32 +37,21 @@
       {
         "id": "buff_aikido_static1",
         "name": "Aikido Stance",
-        "description": "By disregarding offense in favor of defense, you are better at protecting yourself.\n\nBlocked damage reduced by 100% of Dexterity, +2 blocking effectiveness, +1.0 Dodging skill.",
+        "description": "By disregarding offense in favor of defense, you are better at protecting yourself.\n\nYou have +2 blocking effectiveness and +1.0 Dodging skill, but do 20% less damage.",
         "unarmed_allowed": true,
-        "melee_allowed": true,
+        "melee_allowed": false,
         "flat_bonuses": [
-          { "stat": "block", "scaling-stat": "dex", "scale": 1.0 },
           { "stat": "block_effectiveness", "scale": 2.0 },
-          { "stat": "dodge", "scale": 1.0 }
+          { "stat": "dodge", "scale": 1.0 },
+          { "stat": "damage", "scale": -0.2 }
         ]
-      },
-      {
-        "id": "buff_aikido_static2",
-        "name": "Intermediate Aikido",
-        "description": "An intermediate Aikido practitioner can protect themselves against multiple opponents.\n\nBlocked damage reduced by 100% of Dexterity, +1 blocking effectiveness, +1 block attempt, +1 dodge attempt.",
-        "unarmed_allowed": true,
-        "melee_allowed": true,
-        "skill_requirements": [ { "name": "unarmed", "level": 3 } ],
-        "bonus_dodges": 1,
-        "bonus_blocks": 1,
-        "flat_bonuses": [ { "stat": "block", "scaling-stat": "dex", "scale": 1.0 }, { "stat": "block_effectiveness", "scale": 1.0 } ]
       },
       {
         "id": "buff_aikido_static3",
         "name": "Advanced Aikido",
-        "description": "An advanced Aikido practitioner can protect themselves against even more opponents than normal.\n\n+1 blocking effectiveness, +1 block attempt, +1 dodge attempt.",
+        "description": "An advanced Aikido practitioner can protect themselves even against multiple opponents.\n\n+1 blocking effectiveness, +1 block attempt, +1 dodge attempt.",
         "unarmed_allowed": true,
-        "melee_allowed": true,
+        "melee_allowed": false,
         "skill_requirements": [ { "name": "unarmed", "level": 5 } ],
         "bonus_dodges": 1,
         "bonus_blocks": 1,
@@ -73,23 +62,23 @@
       {
         "id": "buff_aikido_onblock",
         "name": "Fluid Blocking",
-        "description": "After a smooth block, you prepare to counter your foe.\n\n-10% move cost.\nLasts 1 turn.",
-        "skill_requirements": [ { "name": "unarmed", "level": 1 } ],
+        "description": "While successfully blocking, you can further reduce damage from all attacks.\n\n+15% effective armor.\nLasts 1 turn.",
+        "skill_requirements": [ { "name": "unarmed", "level": 6 } ],
         "unarmed_allowed": true,
-        "melee_allowed": true,
+        "melee_allowed": false,
         "buff_duration": 1,
-        "mult_bonuses": [ { "stat": "movecost", "scale": 0.9 } ]
+        "mult_bonuses": [ { "stat": "armor", "scale": 1.15 } ]
       }
     ],
     "ondodge_buffs": [
       {
         "id": "buff_aikido_ondodge",
         "name": "Fluid Dodging",
-        "description": "After a smooth dodge, you prepare to counter your foe.\n\n-10% move cost.\nLasts 1 turn.",
+        "description": "After a dodge, you have an opportunity for a clean escape.\n\n-50% move cost.\nLasts 1 turn.",
         "unarmed_allowed": true,
         "melee_allowed": true,
         "buff_duration": 1,
-        "mult_bonuses": [ { "stat": "movecost", "scale": 0.9 } ]
+        "mult_bonuses": [ { "stat": "movecost", "scale": 0.5 } ]
       }
     ],
     "techniques": [

--- a/data/json/martialarts.json
+++ b/data/json/martialarts.json
@@ -37,37 +37,42 @@
       {
         "id": "buff_aikido_static1",
         "name": "Aikido Stance",
-        "description": "By disregarding offense in favor of defense, you are better at protecting yourself.\n\nYou have +2 blocking effectiveness and +1.0 Dodging skill, but do 20% less damage.",
+        "description": "By disregarding offense in favor of defense, you are better at protecting yourself.\n\nYou have +2 blocking effectiveness and +1.0 Dodging skill.",
         "unarmed_allowed": true,
         "melee_allowed": false,
-        "flat_bonuses": [
-          { "stat": "block_effectiveness", "scale": 2.0 },
-          { "stat": "dodge", "scale": 1.0 },
-          { "stat": "damage", "scale": -0.2 }
-        ]
+        "flat_bonuses": [ { "stat": "block_effectiveness", "scale": 2.0 }, { "stat": "dodge", "scale": 1.0 } ]
+      },
+      {
+        "id": "buff_aikido_static2",
+        "name": "Intermediate Aikido",
+        "description": "You've learned the fundamentals of Aikido.  Your movement would be familiar to any practioners in a pre-Cataclysm dojo.\n\nBlocked damage reduced by 25% of Dexterity, +1 blocking effectiveness, +1 dodge attempt.",
+        "unarmed_allowed": true,
+        "melee_allowed": false,
+        "skill_requirements": [ { "name": "unarmed", "level": 3 } ],
+        "bonus_dodges": 1,
+        "flat_bonuses": [ { "stat": "block", "scaling-stat": "dex", "scale": 0.25 }, { "stat": "block_effectiveness", "scale": 1.0 } ]
       },
       {
         "id": "buff_aikido_static3",
         "name": "Advanced Aikido",
-        "description": "An advanced Aikido practitioner can protect themselves even against multiple opponents.\n\n+1 blocking effectiveness, +1 block attempt, +1 dodge attempt.",
+        "description": "An advanced Aikido practitioner can protect themselves even against multiple opponents.\n\n+1 dodge attempt, and one dodge each turn will not consume stamina.",
         "unarmed_allowed": true,
         "melee_allowed": false,
-        "skill_requirements": [ { "name": "unarmed", "level": 5 } ],
+        "skill_requirements": [ { "name": "unarmed", "level": 6 } ],
         "bonus_dodges": 1,
-        "bonus_blocks": 1,
-        "flat_bonuses": [ { "stat": "block_effectiveness", "scale": 1.0 } ]
+        "free_dodges": 1
       }
     ],
     "onblock_buffs": [
       {
         "id": "buff_aikido_onblock",
         "name": "Fluid Blocking",
-        "description": "While successfully blocking, you can further reduce damage from all attacks.\n\n+15% effective armor.\nLasts 1 turn.",
-        "skill_requirements": [ { "name": "unarmed", "level": 6 } ],
+        "description": "After a smooth block, you prepare to counter your foe.\n\n-10% move cost.\nLasts 1 turn.",
+        "skill_requirements": [ { "name": "unarmed", "level": 1 } ],
         "unarmed_allowed": true,
         "melee_allowed": false,
         "buff_duration": 1,
-        "mult_bonuses": [ { "stat": "armor", "scale": 1.15 } ]
+        "mult_bonuses": [ { "stat": "movecost", "scale": 0.9 } ]
       }
     ],
     "ondodge_buffs": [
@@ -76,7 +81,7 @@
         "name": "Fluid Dodging",
         "description": "After a dodge, you have an opportunity for a clean escape.\n\n-50% move cost.\nLasts 1 turn.",
         "unarmed_allowed": true,
-        "melee_allowed": true,
+        "melee_allowed": false,
         "buff_duration": 1,
         "mult_bonuses": [ { "stat": "movecost", "scale": 0.5 } ]
       }

--- a/doc/JSON/MARTIALART_JSON.md
+++ b/doc/JSON/MARTIALART_JSON.md
@@ -97,6 +97,7 @@ These are defined in JSON as `martial_art`, which sets rules for usage and appli
     "max_stacks": 8,                     // Maximum number of stacks on the buff. Buff bonuses are multiplied by current buff intensity
     "bonus_blocks": 1,                   // Extra blocks per turn
     "bonus_dodges": 1,                   // Extra dodges per turn
+    "free_dodges": 1,                    // Dodges per turn that won't consume stamina. Can be higher than actual amount of dodges, but won't add more dodges.
     "flat_bonuses": [  ],                // Flat bonuses, see Bonuses below
     "mult_bonuses": [  ],                // Multiplicative bonuses, see Bonuses below
   }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1065,6 +1065,11 @@ double Character::aim_per_move( const item &gun, double recoil,
     return std::min( aim_speed, recoil - limit );
 }
 
+void Character::mod_free_dodges( int added )
+{
+    num_free_dodges += added;
+}
+
 int Character::get_dodges_left() const
 {
     return dodges_left;
@@ -1078,6 +1083,21 @@ void Character::set_dodges_left( int dodges )
 void Character::mod_dodges_left( int mod )
 {
     dodges_left += mod;
+}
+
+int Character::get_free_dodges_left() const
+{
+    return free_dodges_left;
+}
+
+void Character::set_free_dodges_left( int dodges )
+{
+    free_dodges_left = dodges;
+}
+
+void Character::mod_free_dodges_left( int mod )
+{
+    free_dodges_left += mod;
 }
 
 void Character::consume_dodge_attempts()
@@ -1763,11 +1783,19 @@ void Character::on_try_dodge()
     // Each attempt consumes an available dodge
     consume_dodge_attempts();
 
-    const int base_burn_rate = get_option<int>( player_base_stamina_burn_rate );
-    const float dodge_skill_modifier = ( 20.0f - get_skill_level( skill_dodge ) ) / 20.0f;
-    burn_energy_legs( - std::floor( static_cast<float>( base_burn_rate ) * 6.0f *
-                                    dodge_skill_modifier ) );
-    set_activity_level( EXTRA_EXERCISE );
+    add_msg_debug( debugmode::DF_MELEE,
+                   "Dodging with %d total dodges, %d total free dodges, %d free dodges left",
+                   get_num_dodges(), get_num_free_dodges(), get_free_dodges_left() );
+
+    if( get_free_dodges_left() > 0 ) {
+        mod_free_dodges_left( -1 );
+    } else {
+        const int base_burn_rate = get_option<int>( player_base_stamina_burn_rate );
+        const float dodge_skill_modifier = ( 20.0f - get_skill_level( skill_dodge ) ) / 20.0f;
+        burn_energy_legs( - std::floor( static_cast<float>( base_burn_rate ) * 6.0f *
+                                        dodge_skill_modifier ) );
+        set_activity_level( EXTRA_EXERCISE );
+    }
 }
 
 void Character::on_dodge( Creature *source, float difficulty, float training_level )
@@ -2192,9 +2220,11 @@ void Character::process_turn()
     if( in_sleep_state() ) {
         blocks_left = 0;
         set_dodges_left( 0 );
+        set_free_dodges_left( 0 );
     } else if( moves > 0 ) {
         blocks_left = get_num_blocks();
         set_dodges_left( get_num_dodges() );
+        set_free_dodges_left( get_num_free_dodges() );
     }
 
     // auto-learning. This is here because skill-increases happens all over the place:

--- a/src/character.h
+++ b/src/character.h
@@ -647,7 +647,10 @@ class Character : public Creature, public visitable
         /** Modifiers to character speed, with descriptions */
         std::vector<speed_bonus_effect> speed_bonus_effects;
 
+        // How many chances to dodge(this turn) does the character have left?
         int dodges_left;
+        // How many dodges(this turn) will not consume stamina?
+        int free_dodges_left;
 
     public:
         std::vector<speed_bonus_effect> get_speed_bonus_effects() const;
@@ -837,6 +840,14 @@ class Character : public Creature, public visitable
         int get_dodges_left() const;
         void set_dodges_left( int dodges );
         void mod_dodges_left( int mod );
+
+
+        // Mod the actual base value, *not* the amount left for this turn
+        void mod_free_dodges( int added );
+
+        int get_free_dodges_left() const;
+        void set_free_dodges_left( int dodges );
+        void mod_free_dodges_left( int mod );
         void consume_dodge_attempts();
         ret_val<void> can_try_dodge( bool ignore_dodges_left = false ) const;
 

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -348,6 +348,7 @@ void Creature::reset_bonuses()
 {
     num_blocks = 1;
     num_dodges = 1;
+    num_free_dodges = 0;
     num_blocks_bonus = 0;
     num_dodges_bonus = 0;
 
@@ -2318,6 +2319,11 @@ int Creature::get_num_blocks() const
 int Creature::get_num_dodges() const
 {
     return num_dodges + num_dodges_bonus;
+}
+
+int Creature::get_num_free_dodges() const
+{
+    return num_free_dodges;
 }
 
 int Creature::get_num_blocks_bonus() const

--- a/src/creature.h
+++ b/src/creature.h
@@ -742,6 +742,7 @@ class Creature : public viewer
          */
         virtual int get_num_blocks() const;
         virtual int get_num_dodges() const;
+        virtual int get_num_free_dodges() const;
         virtual int get_num_blocks_bonus() const;
         virtual int get_num_dodges_bonus() const;
         virtual int get_num_dodges_base() const;
@@ -1254,6 +1255,8 @@ class Creature : public viewer
 
         int num_blocks = 0; // base number of blocks/dodges per turn
         int num_dodges = 0;
+        // Total number of free dodges available per turn. Only available as "bonus".
+        int num_free_dodges = 0;
         int num_blocks_bonus = 0; // bonus ""
         int num_dodges_bonus = 0;
 

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -1114,31 +1114,24 @@ std::string ma_buff::get_description( bool passive ) const
     }
 
     if( dodges_bonus > 0 ) {
-        dump += string_format(
-                    n_gettext( "* Will give a <good>+%s</good> bonus to <info>dodge</info> for the stack",
-                               "* Will give a <good>+%s</good> bonus to <info>dodge</info> per stack",
-                               max_stacks ),
-                    dodges_bonus ) + "\n";
+        dump += string_format( _( "* Can dodge <good>+%d</good> extra times per turn" ),
+                               dodges_bonus ) + "\n";
     } else if( dodges_bonus < 0 ) {
-        dump += string_format(
-                    n_gettext( "* Will give a <bad>%s</bad> penalty to <info>dodge</info> for the stack",
-                               "* Will give a <bad>%s</bad> penalty to <info>dodge</info> per stack",
-                               max_stacks ),
-                    dodges_bonus ) + "\n";
+        dump += string_format( _( "* Can dodge <bad>+%d</bad> fewer times per turn" ),
+                               dodges_bonus ) + "\n";
+    }
+
+    if( free_dodges > 0 ) {
+        dump += string_format( _( "* <good>+%d</good> dodges each turn will not consume stamina" ),
+                               free_dodges ) + "\n";
     }
 
     if( blocks_bonus > 0 ) {
-        dump += string_format(
-                    n_gettext( "* Will give a <good>+%s</good> bonus to <info>block</info> for the stack",
-                               "* Will give a <good>+%s</good> bonus to <info>block</info> per stack",
-                               max_stacks ),
-                    blocks_bonus ) + "\n";
+        dump += string_format( _( "* Can block <good>+%d</good> extra times per turn" ),
+                               blocks_bonus ) + "\n";
     } else if( blocks_bonus < 0 ) {
-        dump += string_format(
-                    n_gettext( "* Will give a <bad>%s</bad> penalty to <info>block</info> for the stack",
-                               "* Will give a <bad>%s</bad> penalty to <info>block</info> per stack",
-                               max_stacks ),
-                    blocks_bonus ) + "\n";
+        dump += string_format( _( "* Can block <bad>+%d</bad> fewer times per turn" ),
+                               blocks_bonus ) + "\n";
     }
 
     if( quiet ) {
@@ -2364,7 +2357,8 @@ void ma_details_ui_impl::init_data()
                     buffs_total++;
                     std::vector<std::string> buff_lines =
                         string_split( replace_colors( buff->get_description( passive ) ), '\n' );
-                    buffs_text[title] = buff_lines;
+                    // Merge our accumulated text into the existing one. There might be more than one buff of this type, so we want to display all of them.
+                    buffs_text[title].insert( buffs_text[title].end(), buff_lines.begin(), buff_lines.end() );
                 }
             }
         };

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -380,6 +380,7 @@ void ma_buff::load( const JsonObject &jo, std::string_view src )
     optional( jo, was_loaded, "persists", persists, false );
 
     optional( jo, was_loaded, "bonus_dodges", dodges_bonus, 0 );
+    optional( jo, was_loaded, "free_dodges", free_dodges, 0 );
     optional( jo, was_loaded, "bonus_blocks", blocks_bonus, 0 );
 
     optional( jo, was_loaded, "quiet", quiet, false );
@@ -979,6 +980,7 @@ ma_buff::ma_buff()
     max_stacks = 1; // total number of stacks this buff can have
 
     dodges_bonus = 0; // extra dodges, like karate
+    free_dodges = 0; // number of dodges that won't consume stamina
     blocks_bonus = 0; // extra blocks, like karate
 
 }
@@ -1010,8 +1012,11 @@ bool ma_buff::is_valid_character( const Character &u ) const
 
 void ma_buff::apply_character( Character &u ) const
 {
+    // Note: MAs typically have multiple buffs, using a setter here is probably a mistake!
     u.mod_num_dodges_bonus( dodges_bonus );
+    // This uses a setter, but it's actually just mod() because it unnecessarily gets the existing bonus.
     u.set_num_blocks_bonus( u.get_num_blocks_bonus() + blocks_bonus );
+    u.mod_free_dodges( free_dodges );
 }
 
 int ma_buff::hit_bonus( const Character &u ) const

--- a/src/martialarts.h
+++ b/src/martialarts.h
@@ -310,6 +310,7 @@ class ma_buff
         bool persists = false; // prevent buff removal when switching styles
 
         int dodges_bonus = 0; // extra dodges, like karate
+        int free_dodges = 0; // number of dodges that won't consume stamina
         int blocks_bonus = 0; // extra blocks, like karate
 
         /** All kinds of bonuses by types to damage, hit, armor etc. */

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -3875,6 +3875,7 @@ void Creature::store( JsonOut &jsout ) const
 
     jsout.member( "blocks_left", num_blocks );
     jsout.member( "dodges_left", num_dodges );
+    jsout.member( "num_free_dodges", num_free_dodges );
     jsout.member( "num_blocks_bonus", num_blocks_bonus );
     jsout.member( "num_dodges_bonus", num_dodges_bonus );
 


### PR DESCRIPTION
#### Summary
Balance "Rebalance Aikido to emphasize surviving and escaping opponents"

#### Purpose of change
<img width="1652" height="165" alt="image" src="https://github.com/user-attachments/assets/c2aa9e5a-49c7-4cc8-85c6-cad4d3cd918f" />

(Note: @anoobindisguise  is not 100% correct here, blocking effectiveness does not translate 1:1 to damage blocked, but actually modifies it in difficult to explain mathy ways. The scaling is still extraordinary.)

Aikido is supposed to be a *defensive* martial art. I took a year of it in college (Yeah yeah, I'm not a real martial artist) and my instruction included lots of running away. LOTS. I was also taught to dodge, and deflect (what we could call "blocking" ingame) if needed, but only when cornered. Otherwise the instruction was focused on escaping.

Aikido ingame doesn't really do that. Instead it gives you an *enormous* amount of blocking effectiveness, to the point where you can essentially null out all attacks just by being really good at unarmed.

While the mental image of Anid hurricane-fisting everything to death while no-selling their attacks is very funny, it's also very wrong for what Aikido is supposed to be. In addition, it's *incredibly strong*. So clearly some changes are needed.

#### Describe the solution
Rebalance it. Remove essentially all the dex scaling, leaving the flat buffs alone. (Blocking *is* a kind of defense.)

Also, remove allowing melee weapons. I certainly did not receive any instruction in melee weapons. I was expressly taught to discard anything I might be carrying - things can be replaced, your life cannot. Despite that I did receive instruction on what to do in unexpected situations - where one is caught unaware and might be carrying groceries, or something else innocuous. So the dodging buff still intentionally allows "melee weapons" without any specific weapon category.

Furthermore, apply a damage debuff to the base Aikido stance. You *are* supposed to be protecting yourself, not striking at your opponent(s). You still could, but that's not really Aikido anymore.

Lastly, to really emphasize the running away aspect I changed the -10% move cost buff on dodge to -50%. So you can move fast (away from your attackers), but not attack fast.

#### Describe alternatives you've considered

#### Testing
Documentation suggests that the armor buff on block will not work and I'm not sure on the damage modifier.

Haven't done any general balance testing, yet.

Need to do some testing before I undraft this.

#### Additional context

Need to migrate the `buff_aikido_static2` effect away