### PR TITLE
Make permanent effect always at least 1 second long

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1852,9 +1852,10 @@ void Creature::add_effect( const effect_source &source, const efftype_id &eff_id
 
     if( !found ) {
         // If we don't already have it then add a new one
-
         // Now we can make the new effect for application
-        effect e( effect_source( source ), &type, dur, bp.id(), permanent, intensity, calendar::turn );
+
+        time_duration duration = permanent ? std::max( dur, 1_seconds ) : dur;
+        effect e( effect_source( source ), &type, duration, bp.id(), permanent, intensity, calendar::turn );
 
         ( *effects )[eff_id][bp] = e;
         if( Character *ch = as_character() ) {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1213,6 +1213,17 @@ std::vector<std::string> monster::extended_description() const
         } else {
             tmp.emplace_back( "Lifespan end time: n/a <color_yellow>(indefinite)</color>" );
         }
+
+        const std::vector<std::reference_wrapper<const effect>> all_effects = get_effects();
+        if( !all_effects.empty() ) {
+            tmp.emplace_back( "Applied effects:" );
+            for( const effect &eff : all_effects ) {
+                const std::string is_permanent = eff.is_permanent() ? "(permanent)" : "";
+                tmp.emplace_back( string_format( "%s (%s) %s", eff.get_id().c_str(),
+                                                 to_string_writable( eff.get_duration() ).c_str(),
+                                                 is_permanent.c_str() ) );
+            }
+        }
     }
 
     std::vector<std::string> ret;


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
I received a reports that shattering armor weakpoint effect ends 1 second after applying, despite being permanent
It seems if effect has duration of 0, the game strips it no matter what, even if it is permanent
#### Describe the solution
Before setting an effect, check if it's permanent, and make it's duration at least 1 second
Also debug print the effect info in monster extended description
#### Describe alternatives you've considered
Figure where the game exactly checks for duration, and make it skip it here - it is questionable if such place even exist
Fix it only for weakpoint application
#### Testing
Shoot armored zombies, armor shatters and do not expire anymore