### PR TITLE
Introduction of failure to damaged items to work for some items (6/?)

### DIFF
--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -3745,6 +3745,12 @@ std::optional<int> iuse::tazer( Character *p, item *it, const tripoint_bub_ms &p
         return std::nullopt;
     }
 
+    if( !it->activation_success() ) {
+        p->add_msg_if_player( m_bad, _( "You try to activate your %s, but nothing happens." ),
+                              it->tname() );
+        return std::nullopt;
+    }
+
     npc *foe = dynamic_cast<npc *>( target );
     if( foe != nullptr &&
         !foe->is_enemy() &&
@@ -3995,6 +4001,14 @@ std::optional<int> iuse::solarpack( Character *p, item *it, const tripoint_bub_m
                               it->tname() );
         return std::nullopt;
     }
+
+    if( !it->activation_success() ) {
+        p->add_msg_if_player( m_bad,
+                              _( "You try to unfold your %s, but it keeps falling back to its folded configuration." ),
+                              it->tname() );
+        return std::nullopt;
+    }
+
     p->add_msg_if_player(
         _( "You unfold the solar array from the pack.  You still need to connect it with a cable." ) );
 
@@ -4011,6 +4025,14 @@ std::optional<int> iuse::solarpack_off( Character *p, item *it, const tripoint_b
                   it->typeId().str() );
         return std::nullopt;
     }
+
+    if( !it->activation_success() ) {
+        m_bad,
+        p->add_msg_if_player( _( "You try to fold your %s into the pack, but it keeps falling out." ),
+                              it->tname() );
+        return std::nullopt;
+    }
+
     if( !p->is_worn( *it ) ) {  // folding when not worn
         p->add_msg_if_player( _( "You fold your portable solar array into the pack." ) );
     } else {
@@ -4942,6 +4964,14 @@ std::optional<int> iuse::spray_can( Character *p, item *it, const tripoint_bub_m
     if( !dest_ ) {
         return std::nullopt;
     }
+
+    if( !it->activation_success() ) {
+        p->add_msg_if_player( m_bad,
+                              _( "Your attempt to perform a test spray with your %s is unsuccessful. Nothing happens." ),
+                              it->tname() );
+        return std::nullopt;
+    }
+
     return handle_ground_graffiti( *p, it, _( "Spray what?" ), &here, dest_.value() );
 }
 
@@ -5180,6 +5210,12 @@ std::optional<int> iuse::stimpack( Character *p, item *it, const tripoint_bub_ms
     if( !it->ammo_sufficient( p ) ) {
         p->add_msg_if_player( m_info, _( "The stimulant delivery system is empty." ) );
         return std::nullopt;
+
+    } else if( !it->activation_success() ) {
+        p->add_msg_if_player( m_bad,
+                              _( "nothing happens when you try to inject yourself with your %s. Try again." ), it->tname() );
+        return std::nullopt;
+
     } else {
         p->add_msg_if_player( _( "You inject yourself with the stimulants." ) );
         // Intensity is 2 here because intensity = 1 is the comedown
@@ -5455,6 +5491,12 @@ std::optional<int> iuse::robotcontrol( Character *p, item *it, const tripoint_bu
             !p->has_flag( json_flag_ENHANCED_VISION ) ) {
             p->add_msg_if_player( m_info,
                                   _( "You'll need to put on reading glasses before you can see the screen." ) );
+            return std::nullopt;
+        }
+
+        if( !it->activation_success() ) {
+            p->add_msg_if_player( m_bad,
+                                  _( "The screen of the %s remains blank." ), it->tname() );
             return std::nullopt;
         }
 
@@ -7355,6 +7397,12 @@ std::optional<int> iuse::remoteveh( Character *p, item *it, const tripoint_bub_m
     } );
 
     if( choice < 0 || choice > 1 ) {
+        return std::nullopt;
+    }
+
+    if( !it->activation_success() ) {
+        add_msg( m_bad,
+                 _( "Your %s doesn't seem to respond to your actions." ), it->tname() );
         return std::nullopt;
     }
 

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -4027,8 +4027,8 @@ std::optional<int> iuse::solarpack_off( Character *p, item *it, const tripoint_b
     }
 
     if( !it->activation_success() ) {
-        m_bad,
-        p->add_msg_if_player( _( "You try to fold your %s into the pack, but it keeps falling out." ),
+        p->add_msg_if_player( m_bad,
+                              _( "You try to fold your %s into the pack, but it keeps falling out." ),
                               it->tname() );
         return std::nullopt;
     }

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -4967,7 +4967,7 @@ std::optional<int> iuse::spray_can( Character *p, item *it, const tripoint_bub_m
 
     if( !it->activation_success() ) {
         p->add_msg_if_player( m_bad,
-                              _( "Your attempt to perform a test spray with your %s is unsuccessful. Nothing happens." ),
+                              _( "Your attempt to perform a test spray with your %s is unsuccessful.  Nothing happens." ),
                               it->tname() );
         return std::nullopt;
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Penalize use of damaged items by giving them a risk of failing to work when used.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Check for activation failure on use and produce an error message and no action on failure.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Debug spawned and debug damaged items with the modified effects and verified both the normal and failure paths were available.
However, ROBOTCONTROL. SOLARPACK, and SOLARPACK_OFF are not used by any base game items, and so weren't tested.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
