### PR TITLE
Doctor's Office Tweaks

### DIFF
--- a/data/json/mapgen/office_doctor.json
+++ b/data/json/mapgen/office_doctor.json
@@ -23,9 +23,9 @@
         "   #f.f|IccS|..|HHllO#  ",
         "   #|+|||||||..|H...O#  ",
         "   #o..d.h.y|..|H...O#  ",
-        "   #d.hd.h..+..|H...6#  ",
-        "   #o......y|..|||X||#R ",
-        "   #|+|||||||...y...5#R ",
+        "   #d.hd.h..+..|H....#  ",
+        "   #o......y|..|||=||#R ",
+        "   #|+|||||||...y....#R ",
         "   #C.+..|..+........;~ ",
         "   #C<|s&|&s|y.eccScc#4 ",
         "   ###################  ",
@@ -41,25 +41,14 @@
         "c": { "item": "gear_medical", "chance": 60, "repeat": [ 2, 4 ] },
         "e": { "item": "SUS_fridge_breakroom", "chance": 80 },
         "t": { "item": "gear_medical", "chance": 60, "repeat": [ 2, 4 ] },
-        "f": { "item": "SUS_office_filing_cabinet", "chance": 70, "repeat": [ 1, 3 ] },
+        "f": [
+          { "item": "SUS_office_filing_cabinet", "chance": 70, "repeat": [ 1, 3 ] },
+          { "item": "record_patient", "chance": 80 }
+        ],
         "^": { "item": "gear_medical", "chance": 60, "repeat": [ 1, 2 ] }
       },
-      "place_items": [ { "item": "record_patient", "x": 7, "y": 6, "chance": 50 } ],
-      "place_loot": [ { "item": "anesthetic_kit", "x": 16, "y": [ 14, 17 ], "chance": 75, "ammo": 100 } ],
-      "computers": {
-        "5": {
-          "name": "Medical Supply Access",
-          "security": 2,
-          "options": [ { "name": "Unlock Door", "action": "unlock" } ],
-          "failures": [ { "action": "shutdown" }, { "action": "alarm" } ]
-        },
-        "6": {
-          "name": "Medical Supply Access",
-          "security": 2,
-          "options": [ { "name": "Lock Door", "action": "lock" }, { "name": "Unlock Door", "action": "unlock" } ],
-          "failures": [ { "action": "shutdown" }, { "action": "alarm" } ]
-        }
-      }
+      "place_items": [ { "item": "record_patient", "x": 7, "y": 6, "chance": 100 } ],
+      "place_loot": [ { "item": "anesthetic_kit", "x": 16, "y": [ 14, 17 ], "chance": 75, "ammo": 100 } ]
     }
   },
   {
@@ -201,7 +190,9 @@
         { "group": "gear_medical", "x": [ 4, 5 ], "y": 10, "chance": 60, "repeat": [ 2, 5 ] },
         { "group": "drugs_analgesic", "x": [ 4, 5 ], "y": 12, "chance": 75, "repeat": [ 1, 3 ] },
         { "group": "drugs_rare", "x": [ 4, 5 ], "y": 14, "chance": 75 },
-        { "item": "anesthetic_kit", "x": [ 4, 5 ], "y": 14, "chance": 75, "ammo": 100 }
+        { "item": "anesthetic_kit", "x": [ 4, 5 ], "y": 14, "chance": 75, "ammo": 100 },
+        { "item": "record_patient", "x": 7, "y": 20, "chance": 100 },
+        { "item": "record_patient", "x": 4, "y": 19, "chance": 100 }
       ]
     }
   },
@@ -316,9 +307,9 @@
         " 0...t|...|t...|.ddd..0 ",
         " #.W.B|...|B.W.|yrA..o# ",
         " ##|||||!|||||||||||||# ",
-        "  #u!...........X....H# ",
-        "  ###|+|||+||||5|....H# ",
-        "    #c..|...^c|||OOO.H# ",
+        "  #u!...........=....H# ",
+        "  ###|+|||+||||||....H# ",
+        "    #c..|...^c|||HHH.H# ",
         "    #S..'.?/..c######## ",
         "    #S..|.....c#4       ",
         "    ############        ",
@@ -336,14 +327,6 @@
         "'": "t_door_glass_o"
       },
       "furniture": { "?": "f_bed", "/": "f_bed", "Y": "f_sofa", "T": "f_table", "A": "f_armchair", "R": "f_trashcan" },
-      "computers": {
-        "5": {
-          "name": "Medical Supply Access",
-          "security": 2,
-          "options": [ { "name": "Unlock Door", "action": "unlock" } ],
-          "failures": [ { "action": "shutdown" }, { "action": "alarm" } ]
-        }
-      },
       "items": {
         "B": { "item": "hospital_bed", "chance": 60 },
         "R": { "item": "SUS_trash_trashcan_public", "chance": 50 },
@@ -351,12 +334,12 @@
         "e": { "item": "SUS_fridge_breakroom", "chance": 80 },
         "C": { "item": "dresser", "chance": 75 },
         "T": { "item": "office_breakroom", "chance": 80 },
-        "f": { "item": "SUS_office_filing_cabinet", "chance": 90 },
+        "f": [ { "item": "SUS_office_filing_cabinet", "chance": 90 }, { "item": "record_patient", "chance": 80 } ],
         "H": [
-          { "item": "harddrugs", "chance": 60 },
+          { "item": "harddrugs", "chance": 60, "repeat": [ 1, 3 ] },
           { "item": "gear_medical", "chance": 60, "repeat": [ 1, 3 ] },
           { "item": "drugs_analgesic", "chance": 60, "repeat": [ 1, 3 ] },
-          { "item": "drugs_rare", "chance": 60 },
+          { "item": "drugs_rare", "chance": 60, "repeat": [ 1, 3 ] },
           { "item": "surgery", "chance": 60 }
         ],
         "?": { "item": "autodoc_supplies", "chance": 100 },
@@ -417,7 +400,7 @@
       "furniture": { "b": "f_bed", "c": "f_armchair", "i": "f_filing_cabinet", "?": "f_bed", "/": "f_bed" },
       "items": {
         "b": { "item": "hospital_bed", "chance": 60 },
-        "i": { "item": "SUS_office_filing_cabinet", "chance": 70 },
+        "i": [ { "item": "SUS_office_filing_cabinet", "chance": 70 }, { "item": "record_patient", "chance": 80 } ],
         "L": [
           { "item": "harddrugs", "chance": 60, "repeat": [ 1, 3 ] },
           { "item": "gear_medical", "chance": 60, "repeat": [ 1, 3 ] },


### PR DESCRIPTION

#### Summary
None

#### Purpose of change
Some tweaks to the doctor's office, mainly giving them more place to spawn the patient records in and replace the computer locked metal doors with a locked wooden door.

#### Describe the solution
Gives more places to have the patients records, replace computer locked metal doors with locked wooden doors, tweaked some drug spawn.

#### Describe alternatives you've considered
Make the chance on the records lower?

#### Testing
![Screenshot_20251215_154028](https://github.com/user-attachments/assets/6eb3b7f5-41b4-487e-9597-6b7732364502)
![Screenshot_20251215_153938](https://github.com/user-attachments/assets/7fe705e0-ba0e-4802-b4f1-255cd7f870bc)
![Screenshot_20251215_153852](https://github.com/user-attachments/assets/126dca45-5e1b-4788-b105-3d52f12b1d92)


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
