### PR TITLE
Butchery blocks corpse rising

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -9795,6 +9795,10 @@ void butchery_activity_actor::do_turn( player_activity &act, Character &you )
         // Uses max(1, ..) to prevent it going all the way to zero, which would stop the activity by the general `activity_actor` handling.
         // Instead, the checks for `bd.empty()` will make sure to stop the activity by explicitly setting it to zero.
         act.moves_left = std::max( 1, to_moves<int>( this_bd->time_to_butcher - this_bd->progress ) );
+
+        item &corpse_item = *this_bd->corpse;
+        corpse_item.set_var( butcher_progress_time_var(),
+                             to_turns<double>( calendar::turn - calendar::start_of_cataclysm ) );
     }
 }
 

--- a/src/butchery.cpp
+++ b/src/butchery.cpp
@@ -143,6 +143,11 @@ std::string butcher_progress_var( const butcher_type action )
     return io::enum_to_string( action ) + "_progress";
 }
 
+std::string butcher_progress_time_var()
+{
+    return "butchery_progress_time";
+}
+
 // How much of `butcher_type` has already been completed, in range [0..1], 0=not started yet, 1=completed.
 // used for resuming previously started butchery
 double butcher_get_progress( const item &corpse_item, const butcher_type action )
@@ -1063,6 +1068,7 @@ void destroy_the_carcass( const butchery_data &bd, Character &you )
     const field_type_id type_gib = corpse->gibType();
 
     corpse_item.erase_var( butcher_progress_var( action ) );
+    corpse_item.erase_var( butcher_progress_time_var() );
 
     if( action == butcher_type::QUARTER ) {
         butchery_quarter( &corpse_item, you );

--- a/src/butchery.h
+++ b/src/butchery.h
@@ -43,6 +43,8 @@ int butcher_time_to_cut( Character &you, const item &corpse_item, butcher_type a
 
 std::string butcher_progress_var( butcher_type action );
 
+std::string butcher_progress_time_var();
+
 double butcher_get_progress( const item &corpse_item, butcher_type action );
 
 butcher_type get_butcher_type( player_activity *act );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -15,6 +15,7 @@
 #include "ammo.h"
 #include "avatar.h"
 #include "bionics.h"
+#include "butchery.h"
 #include "calendar.h"
 #include "cata_assert.h"
 #include "cata_utility.h"
@@ -2327,7 +2328,13 @@ bool item::ready_to_revive( map &here, const tripoint_bub_ms &pos ) const
         age_in_hours /= ( damage_level() + 1 );
     }
     int rez_factor = 48 - age_in_hours;
-    if( age_in_hours > 6 && ( rez_factor <= 0 || one_in( rez_factor ) ) ) {
+
+    // Arbitrary limit allowing you to take breaks to eat, instruct companions, etc., but not long enough to
+    // easily be abused to keep corpses from rising as a strategy.
+    bool butchery_block = calendar::turn - ( calendar::start_of_cataclysm +
+                          time_duration::from_turns<double>(
+                              get_var( butcher_progress_time_var(), 0.0 ) ) ) < 30_minutes;
+    if( age_in_hours > 6 && !butchery_block && ( rez_factor <= 0 || one_in( rez_factor ) ) ) {
         // If we're a special revival zombie, wait to get up until the player is nearby.
         const bool isReviveSpecial = has_flag( flag_REVIVE_SPECIAL );
         if( isReviveSpecial ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #84083.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Update an item variable in the corpse each tick to indicate when the last time the corpse was affected by a butchery activity.
When determining whether a corpse can raise, check if the time indicated by the variable is younger than 30 minutes, and block raising if so. Corpses without the variable gets the time of the start of the cataclysm, so things go weird if you change time to earlier than that (but a lot of things probably go haywire if that's done).

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Somehow try to translate butchery into damage to the corpse. That gets messy from the get go, as yield is partially based on the state of the corpse, which is, obviously, only done at the end, where the corpse has been fully butchered. You'd have to determine the butchery products at the outset (store it in the butchery data) for such an approach to work.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
- Prepared a save with a started butchery (of a bulldog), loaded it, complete the butchery with no issues.
- Repeated the above and waited, again with no issues.
- Also use add_msg output to display the timer at every corpse check (every 10 minutes), as well as the butchery block variable, to verify they behaved as expected.
- Debug spawned and killed a cow, debug waited 7 hours, started butchery, stopped after 10%, waited 40 minutes and saw the output correctly allow rising at the next check after 30 minutes, resumed and finished the butchery with no issues.
- 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Since progress is stored in the butchery data only (apart from a variable in the corpse if paused), it's no wonder the extensive abuse involved in butchering the corpse had no effect on whether it rose or not: From the point of the raising logic, the corpse was untouched since death.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
