### PR TITLE
Move Psychic Scream to rebalance category, add a bit of documentation for modmods 

### DIFF
--- a/data/mods/MindOverMatterNoKnacks/eocs/eocs_crystal_awakening.json
+++ b/data/mods/MindOverMatterNoKnacks/eocs/eocs_crystal_awakening.json
@@ -1,17 +1,5 @@
 [
   {
-    "//": "Only necessary until artifactization of crystals is complete",
-    "type": "effect_on_condition",
-    "id": "EOC_PYROKIN_MATRIX_AWAKENING",
-    "effect": [
-      {
-        "u_message": "You gaze into the strange crystal and the light slowly grows brighter.  It starts pulsing, first slowly and more rapidly, and your head starts pounding in time with the light.  You tear your gaze away but the pounding in your head remains."
-      },
-      { "u_add_effect": "psionic_overload", "duration": "1 hours" },
-      { "u_add_effect": "stunned", "duration": 10 }
-    ]
-  },
-  {
     "type": "effect_on_condition",
     "id": "EOC_TELEKIN_MATRIX_AWAKENING",
     "effect": [

--- a/data/mods/MindOverMatterNoKnacks/items/item_blacklist.json
+++ b/data/mods/MindOverMatterNoKnacks/items/item_blacklist.json
@@ -8,6 +8,7 @@
       "matrix_crystal_clairsentience",
       "matrix_crystal_electrokinesis",
       "matrix_crystal_photokinesis",
+      "matrix_crystal_pyrokinesis",
       "matrix_crystal_coruscating"
     ]
   }

--- a/data/mods/MindOverMatterNoKnacks/modinfo.json
+++ b/data/mods/MindOverMatterNoKnacks/modinfo.json
@@ -5,7 +5,7 @@
     "name": "Mind Over Matter: Psychic Scream",
     "authors": [ "Standing-Storm" ],
     "description": "Changes Mind Over Matter so that only psychic knacks exist, meaning only those born with them have psychic powers.  Removes higher-level feral psions and psionic awakenings, leaves crafting and locations.\n\nTriffids and mi-go still get powerful psychics, so watch out.",
-    "category": "misc_additions",
+    "category": "rebalance",
     "dependencies": [ "dda", "mindovermatter" ]
   }
 ]

--- a/doc/IN_REPO_MODS.md
+++ b/doc/IN_REPO_MODS.md
@@ -74,3 +74,9 @@ Furthermore, mods which are shipped with the game but are not working correctly 
 If the mod otherwise meets inclusion criteria but lacks a curator (i.e. has been declared orphaned), it's as simple as having someone else step forward as the new curator.
 
 Otherwise, it needs to either be made to meet the criteria, or it simply isn't going to be staying in the CleverRaven repository.
+
+## Mods that Modify In-Repo Mods
+
+Mods that modify existing in-repo mods can be accepted for inclusion; however they must still meet the general mod criteria. A modmod must change the core mod it's modifying enough to create a new curated experience with a particular goal. Sorcerer, which changes Magiclysm's magic-learning system from finding and reading books to killing monsters and leveling up, with additional bonuses depending on specific bloodlines, is acceptable. A mod that simply removed owlbears and golems from the forests would not be. In addition, modmods must have maintainers or be subject to removal. 
+
+Finally, modmods must be placed in the `rebalance` mod category. 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "Move Psychic Scream to rebalance category, add a bit of documentation for modmods "

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Talked to Maleclypse about this 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Move Psychic Scream to the `rebalance` category, the official place that modmods go. 

Write some documentation about modmods now that we have two. 

Blacklist the awakening pyrokinetic matrix crystal in Psychic Scream now that #84213 is ready to go. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I’m not dead-set on the term modmod
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
