### PR TITLE
Remove anvilmancy (the ability to teleport anvils above zombies)

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -10092,7 +10092,7 @@ bool zone_sort_activity_actor::stage_think( player_activity &act, Character &you
     return true;
 }
 
-void zone_sort_activity_actor::stage_do( player_activity &, Character &you )
+void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
 {
     const map &here = get_map();
     const zone_manager &mgr = zone_manager::get_manager();
@@ -10138,6 +10138,25 @@ void zone_sort_activity_actor::stage_do( player_activity &, Character &you )
         // out of moves, or unloaded item container was destroyed or prompted an activity restart
         if( !move_and_reset ) {
             return;
+        }
+
+        bool can_reach_any_dest = false;
+        for( const tripoint_abs_ms &possible_dest : dest_set ) {
+            const tripoint_bub_ms dest_bub = here.get_bub( possible_dest );
+            if( !zone_sorting::route_to_destination( you, act, dest_bub, stage ) ) {
+                continue; // Not a valid destination
+            }
+            // This is a separate statement so we can have specific messaging if this failure state is reached.
+            if( here.is_open_air( dest_bub ) ) {
+                you.add_msg_if_player( _( "You can't sort things into the air!" ) );
+                continue;
+            }
+            can_reach_any_dest = true;
+            break;
+        }
+
+        if( !can_reach_any_dest ) {
+            continue;
         }
 
         zone_sorting::move_item( you, vp, src_bub, dest_set, thisitem, num_processed );

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -2884,7 +2884,7 @@ class zone_sort_activity_actor : public zone_activity_actor
 
         void stage_init( player_activity &, Character &you ) override;
         bool stage_think( player_activity &act, Character &you ) override;
-        void stage_do( player_activity &, Character &you ) override;
+        void stage_do( player_activity &act, Character &you ) override;
 
         void serialize( JsonOut &jsout ) const override;
         static std::unique_ptr<activity_actor> deserialize( JsonValue &jsin );


### PR DESCRIPTION
#### Summary
Bugfixes "Remove anvilmancy (the ability to teleport anvils above zombies)"

#### Purpose of change
Teleporting anvils into the sky is a silly exploit

#### Describe the solution
Fix it.

Check that we can actually reach the destination before sorting an item there.

#### Describe alternatives you've considered
Fixing the teleport issues in general, requires a major refactor of zone sorting.

#### Testing
Sort some anvils across open ground - works

Try to sort anvil into sky - doesn't work

Try to sort anvil one tile into air - doesn't work

#### Additional context
Minor concerns about the computational cost of pathfinding in this function, but I'll wait to see if it actually is an issue.
