### PR TITLE
Fix the greeter bot shaking down new contributors for every comment

### DIFF
--- a/.github/workflows/greet-first-time-comment.yml
+++ b/.github/workflows/greet-first-time-comment.yml
@@ -22,13 +22,18 @@ jobs:
         run: |
           commenter="${{ github.event.comment.user.login }}"
           echo "Debug: Checking comment counts for... $commenter"
-          comment_count=$(gh search prs --owner=CleverRaven --repo=Cataclysm-DDA --commenter $commenter --json id | jq 'length')
+          comment_count_all_PR=$(gh search prs --repo=CleverRaven/Cataclysm-DDA --commenter $commenter --json id | jq 'length')
+          num_PRs_authored=$(gh search prs --repo=CleverRaven/Cataclysm-DDA --author $commenter --json id | jq 'length')
+          
+          num_times_commented=$(gh pr view $PR_NUMBER --json comments --jq "[.comments.[].author.login | match(\"$commenter\")] | length")
 
-          echo "Debug: $commenter with $comment_count total comments, including checked comment."
-          echo "comment_count=$comment_count" >> $GITHUB_OUTPUT
+          echo "Debug: $commenter with $comment_count_all_PR PRs commented on, including checked comment. PR contains $num_times_commented comments from them. They have authored $num_PRs_authored PRs in CleverRaven."
+          echo "comment_count_all_PR=$comment_count_all_PR" >> $GITHUB_OUTPUT
+          echo "num_times_commented=$num_times_commented" >> $GITHUB_OUTPUT
+          echo "num_PRs_authored=$num_PRs_authored" >> $GITHUB_OUTPUT
 
       - name: Greet commenters with no previous comments
-        if: steps.pr-comment-check.outputs.comment_count == 1
+        if: steps.pr-comment-check.outputs.comment_count_all_PR == 1 && steps.pr-comment-check.outputs.num_times_commented == 1 && steps.pr-comment-check.outputs.num_PRs_authored == 0
         run: |
           # I have no earthly idea how to pass the commenter on from the previous run (I have tried), so let's just re-acquire it.
           commenter_name="${{ github.event.comment.user.login }}"


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
https://github.com/CleverRaven/Cataclysm-DDA/pull/84208#issuecomment-3655932782
https://github.com/CleverRaven/Cataclysm-DDA/pull/84208#issuecomment-3656832362
https://github.com/CleverRaven/Cataclysm-DDA/pull/84208#issuecomment-3657607823

etc

#### Describe the solution
The previous requirement for posting a greeting was: Only one PR could be found with them as a commenter.

Tighten up the conditions. Now a greeting comment will only happen if:
-They have **0** authored PRs here.
-They have only ever commented in one PR.
-They only have one comment in that PR. (So their second comment onwards will not get a new greeting)

#### Describe alternatives you've considered
Outsource making github actions to someone who knows what they're doing. Sadly, nobody took me up on this offer.

#### Testing
Ran a bunch of the github api calls locally in cmd. Got very frustrated with [a fun bug](https://github.com/cli/cli/issues/3425). Switched to using powershell. The dry runs passed.

Was sufficiently disturbed by JQ's devilry that I then went to try it on a fork. Spent the next 2 hours learning the extent of JQ's evil (also github API's! `gh search prs --owner=foo --repo=bar` gets you all repositories that `foo` owns! WHY!!!)

Anyway, @harakka pitched in and it's working now. https://github.com/RenechCDDA/Workflow_TEST/pull/1

#### Additional context

