### PR TITLE
[MoM] `ephemerial riftwalker`s can Oubliette you

### DIFF
--- a/data/mods/MindOverMatter/dimensions/innawood_mom.json
+++ b/data/mods/MindOverMatter/dimensions/innawood_mom.json
@@ -1,8 +1,8 @@
 [
- {
+  {
     "type": "region_settings",
     "id": "mom_innawood",
-    "copy-from": "mom_innawood",
+    "copy-from": "default",
     "cities": null,
     "highways": null,
     "place_roads": false,

--- a/data/mods/MindOverMatter/dimensions/innawood_mom.json
+++ b/data/mods/MindOverMatter/dimensions/innawood_mom.json
@@ -1,0 +1,11 @@
+[
+ {
+    "type": "region_settings",
+    "id": "mom_innawood",
+    "copy-from": "mom_innawood",
+    "cities": null,
+    "highways": null,
+    "place_roads": false,
+    "feature_flag_settings": { "blacklist": [ "LAB", "MAN_MADE", "MILITARY", "URBAN", "FARM", "EXODII", "HIGHLANDS" ], "whitelist": [  ] }
+  }
+]

--- a/data/mods/MindOverMatter/dimensions/mycus_world/comestibles.json
+++ b/data/mods/MindOverMatter/dimensions/mycus_world/comestibles.json
@@ -1,0 +1,13 @@
+[
+  {
+    "id": "water_mycus",
+    "type": "ITEM",
+    "subtypes": [ "COMESTIBLE" ],
+    "copy-from": "water",
+    "name": { "str_sp": "fungal water" },
+    "description": "Water, the stuff of life.  Specifically, fungal life.  This water is cloudy, transformed into a fungal sea.  You probably should not drink this.",
+    "quench": 30,
+    "parasites": 5,
+    "contamination": [ { "disease": "fungal_contamination", "probability": 100 } ]
+  }
+]

--- a/data/mods/MindOverMatter/dimensions/mycus_world/diseases.json
+++ b/data/mods/MindOverMatter/dimensions/mycus_world/diseases.json
@@ -1,0 +1,12 @@
+[
+  {
+    "type": "disease_type",
+    "id": "fungal_contamination",
+    "min_duration": "7 d",
+    "max_duration": "21 d",
+    "min_intensity": 1,
+    "max_intensity": 3,
+    "health_threshold": 210,
+    "symptoms": "fungus"
+  }
+]

--- a/data/mods/MindOverMatter/dimensions/mycus_world/furniture_and_terrain.json
+++ b/data/mods/MindOverMatter/dimensions/mycus_world/furniture_and_terrain.json
@@ -1,22 +1,6 @@
 [
   {
     "type": "terrain",
-    "id": "t_mom_mycus_world_groundcover",
-    "copy-from": "t_region_pseudo",
-    "name": "pseudo terrain",
-    "description": "This should never actually show up, it should have been replaced with regional terrain.",
-    "move_cost": 1
-  },
-  {
-    "type": "terrain",
-    "id": "t_mom_mycus_world_groundcover_forest",
-    "copy-from": "t_region_pseudo",
-    "name": "pseudo terrain",
-    "description": "This should never actually show up, it should have been replaced with regional terrain.",
-    "move_cost": 1
-  },
-  {
-    "type": "terrain",
     "id": "t_trunk_fungal",
     "looks_like": "t_trunk",
     "name": "fungal tree trunk",

--- a/data/mods/MindOverMatter/dimensions/mycus_world/furniture_and_terrain.json
+++ b/data/mods/MindOverMatter/dimensions/mycus_world/furniture_and_terrain.json
@@ -1,0 +1,40 @@
+[
+  {
+    "type": "terrain",
+    "id": "t_mom_mycus_world_groundcover",
+    "copy-from": "t_region_pseudo",
+    "name": "pseudo terrain",
+    "description": "This should never actually show up, it should have been replaced with regional terrain.",
+    "move_cost": 1
+  },
+  {
+    "type": "terrain",
+    "id": "t_mom_mycus_world_groundcover_forest",
+    "copy-from": "t_region_pseudo",
+    "name": "pseudo terrain",
+    "description": "This should never actually show up, it should have been replaced with regional terrain.",
+    "move_cost": 1
+  },
+  {
+    "type": "terrain",
+    "id": "t_trunk_fungal",
+    "looks_like": "t_trunk",
+    "name": "fungal tree trunk",
+    "description": "A section of trunk from a fungal tree that has collapsed or fallen over due to being overcome with rot.  It looks like those pictures of smokers' lungs they showed you back in school.",
+    "symbol": "1",
+    "color": "brown",
+    "move_cost": 4,
+    "coverage": 45,
+    "flags": [ "TRANSPARENT", "FLAMMABLE_ASH", "DIGGABLE", "REDUCE_SCENT", "MOUNTABLE", "SHORT" ],
+    "bash": {
+      "str_min": 80,
+      "str_max": 180,
+      "sound": "crunch!",
+      "sound_fail": "whack!",
+      "ter_set": "t_dirt",
+      "items": [ { "item": "splinter", "count": [ 5, 15 ] } ],
+      "hit_field": [ "fd_dust", 2 ],
+      "destroyed_field": [ "fd_splinters", 1 ]
+    }
+  }
+]

--- a/data/mods/MindOverMatter/dimensions/mycus_world/furniture_and_terrain.json
+++ b/data/mods/MindOverMatter/dimensions/mycus_world/furniture_and_terrain.json
@@ -20,5 +20,18 @@
       "hit_field": [ "fd_dust", 2 ],
       "destroyed_field": [ "fd_splinters", 1 ]
     }
+  },
+  {
+    "type": "terrain",
+    "id": "t_puddle_mycus",
+    "name": "recess",
+    "description": "A shallow pit in the ground.  The surface is covered in a thin coating of mycus spores.",
+    "looks_like": "t_dirt",
+    "symbol": "~",
+    "color": "light_blue",
+    "move_cost": 3,
+    "liquid_source": { "id": "water_mycus", "count": [ 40, 240 ] },
+    "flags": [ "TRANSPARENT", "LIQUIDCONT" ],
+    "examine_action": "finite_water_source"
   }
 ]

--- a/data/mods/MindOverMatter/dimensions/mycus_world/mapgen.json
+++ b/data/mods/MindOverMatter/dimensions/mycus_world/mapgen.json
@@ -1,0 +1,60 @@
+[
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "mom_mycus_world_default",
+    "object": {
+      "mapgensize": [ 24, 24 ],
+      "rows": [
+        "                        ",
+        "           1            ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "   1                    ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        "
+      ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ],
+      "nested": { "1": { "chunks": [ [ "null", 100 ], [ "mom_mycus_world_extra_1", 1 ] ] } }
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "mom_mycus_world_extra_1",
+    "object": {
+      "mapgensize": [ 12, 12 ],
+      "rows": [
+        "            ",
+        "            ",
+        "            ",
+        "   ..  ..   ",
+        "  ..   ...  ",
+        "         .. ",
+        "  ..     .. ",
+        "  ...     . ",
+        "   ..   ... ",
+        "     .  ..  ",
+        "    ..  ..  ",
+        "      ..    "
+      ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "terrain": { ".": "t_fungus_mound" }
+    }
+  }
+]

--- a/data/mods/MindOverMatter/dimensions/mycus_world/overmapgen.json
+++ b/data/mods/MindOverMatter/dimensions/mycus_world/overmapgen.json
@@ -15,12 +15,12 @@
     "type": "mapgen",
     "om_terrain": [ "mom_mycus_world_default" ],
     "weight": 3,
-    "object": { "fill_ter": "t_mom_mycus_world_groundcover" }
+    "object": { "fill_ter": "t_region_groundcover" }
   },
   {
     "type": "mapgen",
     "om_terrain": "mom_mycus_world_default",
     "weight": 1,
-    "object": { "fill_ter": "t_mom_mycus_world_groundcover" }
+    "object": { "fill_ter": "t_region_groundcover" }
   }
 ]

--- a/data/mods/MindOverMatter/dimensions/mycus_world/overmapgen.json
+++ b/data/mods/MindOverMatter/dimensions/mycus_world/overmapgen.json
@@ -1,0 +1,26 @@
+[
+  {
+    "type": "overmap_terrain",
+    "id": "mom_mycus_world_default",
+    "copy-from": "generic_open_land",
+    "name": "fungal field",
+    "sym": ".",
+    "travel_cost_type": "field",
+    "looks_like": "meadow_core",
+    "color": "green",
+    "see_cost": "none",
+    "flags": [ "NO_ROTATE" ]
+  },
+  {
+    "type": "mapgen",
+    "om_terrain": [ "mom_mycus_world_default" ],
+    "weight": 3,
+    "object": { "fill_ter": "t_mom_mycus_world_groundcover" }
+  },
+  {
+    "type": "mapgen",
+    "om_terrain": "mom_mycus_world_default",
+    "weight": 1,
+    "object": { "fill_ter": "t_mom_mycus_world_groundcover" }
+  }
+]

--- a/data/mods/MindOverMatter/dimensions/mycus_world/region_settings.json
+++ b/data/mods/MindOverMatter/dimensions/mycus_world/region_settings.json
@@ -1,0 +1,127 @@
+[
+  {
+    "type": "region_settings",
+    "id": "mom_mycus_world",
+    "copy-from": "default",
+    "cities": null,
+    "highways": null,
+    "place_roads": false,
+    "forest_trails": null,
+    "place_specials": false,
+    "rivers": null,
+    "lakes": null,
+    "ocean": null,
+    "forests": "mom_mycus_world",
+    "terrain_furniture": "mom_mycus_world",
+    "default_oter": [
+      "open_air",
+      "open_air",
+      "open_air",
+      "open_air",
+      "open_air",
+      "open_air",
+      "open_air",
+      "open_air",
+      "open_air",
+      "open_air",
+      "mom_mycus_world_default",
+      "solid_earth",
+      "empty_rock",
+      "empty_rock",
+      "deep_rock",
+      "deep_rock",
+      "deep_rock",
+      "deep_rock",
+      "deep_rock",
+      "deep_rock",
+      "deep_rock"
+    ],
+    "default_groundcover": [ [ "t_mom_mycus_world_groundcover", 1 ] ],
+    "feature_flag_settings": { "blacklist": [ "LAB", "MAN_MADE", "MILITARY", "URBAN", "FARM", "EXODII", "HIGHLANDS" ], "whitelist": [ "FUNGAL" ] }
+  },
+  {
+    "type": "region_settings_terrain_furniture",
+    "id": "mom_mycus_world",
+    "copy-from": "default",
+    "ter_furn": [ "mom_mycus_world_t_region_groundcover", "mom_mycus_world_t_region_groundcover_forest" ]
+  },
+  {
+    "type": "region_terrain_furniture",
+    "id": "mom_mycus_world_t_region_groundcover",
+    "ter_id": "t_mom_mycus_world_groundcover",
+    "replace_with_terrain": [ [ "t_fungus_floor_out", 600 ], [ "t_fungus_mound", 1 ], [ "t_dirt", 20 ] ]
+  },
+  {
+    "type": "region_terrain_furniture",
+    "id": "mom_mycus_world_t_region_groundcover_forest",
+    "ter_id": "t_mom_mycus_world_groundcover_forest",
+    "replace_with_terrain": [ [ "t_fungus_floor_out", 300 ], [ "t_fungus_mound", 4 ], [ "t_shrub_fungal", 10 ], [ "t_dirt", 20 ] ]
+  },
+  {
+    "type": "region_settings_forest_mapgen",
+    "id": "mom_mycus_world",
+    "biomes": [ "biome_forest_mom_mycus_world" ]
+  },
+  {
+    "type": "region_settings_forest",
+    "id": "mom_mycus_world",
+    "copy-from": "default",
+    "noise_threshold_forest": 0.45,
+    "noise_threshold_forest_thick": 1,
+    "noise_threshold_swamp_adjacent_water": 1,
+    "noise_threshold_swamp_isolated": 1
+  },
+  {
+    "type": "forest_biome_mapgen",
+    "id": "biome_forest_mom_mycus_world",
+    "terrains": [ "forest" ],
+    "sparseness_adjacency_factor": 3,
+    "item_group": "forest",
+    "item_group_chance": 0,
+    "item_spawn_iterations": 1,
+    "groundcover": [ [ "t_mom_mycus_world_groundcover_forest", 1 ] ],
+    "components": [
+      "mom_mycus_world_trees_forest",
+      "mom_mycus_world_shrubs_and_flowers_forest",
+      "mom_mycus_world_clutter_forest",
+      "mom_mycus_world_water_forest"
+    ]
+  },
+  {
+    "type": "forest_biome_component",
+    "id": "mom_mycus_world_trees_forest",
+    "sequence": 0,
+    "chance": 12,
+    "types": [ [ "t_tree_fungal", 128 ], [ "t_tree_fungal_young", 32 ] ]
+  },
+  {
+    "type": "forest_biome_component",
+    "id": "mom_mycus_world_shrubs_and_flowers_forest",
+    "sequence": 1,
+    "chance": 10,
+    "types": [ [ "t_shrub_fungal", 120 ], [ "t_tree_fungal_young", 10 ] ]
+  },
+  {
+    "type": "forest_biome_component",
+    "id": "mom_mycus_world_clutter_forest",
+    "sequence": 2,
+    "chance": 80,
+    "types": [
+      [ "t_trunk_fungal", 128 ],
+      [ "t_dirtmound", 128 ],
+      [ "f_boulder_small", 128 ],
+      [ "f_rubble_rock", 32 ],
+      [ "f_boulder_medium", 8 ],
+      [ "f_boulder_large", 1 ],
+      [ "t_pit", 1 ],
+      [ "t_pit_shallow", 1 ]
+    ]
+  },
+  {
+    "type": "forest_biome_component",
+    "id": "mom_mycus_world_water_forest",
+    "sequence": 3,
+    "chance": 512,
+    "types": [ [ "t_puddle", 1 ] ]
+  }
+]

--- a/data/mods/MindOverMatter/dimensions/mycus_world/region_settings.json
+++ b/data/mods/MindOverMatter/dimensions/mycus_world/region_settings.json
@@ -80,30 +80,25 @@
     "item_group_chance": 0,
     "item_spawn_iterations": 1,
     "groundcover": [ [ "t_region_groundcover_forest", 1 ] ],
-    "components": [
-      "mom_mycus_world_trees_forest",
-      "mom_mycus_world_shrubs_and_flowers_forest",
-      "mom_mycus_world_clutter_forest",
-      "mom_mycus_world_water_forest"
-    ]
+    "components": [ "trees_forest", "shrubs_and_flowers_forest", "clutter_forest", "water_forest" ]
   },
   {
     "type": "forest_biome_component",
-    "id": "mom_mycus_world_trees_forest",
+    "id": "trees_forest",
     "sequence": 0,
     "chance": 12,
     "types": [ [ "t_tree_fungal", 128 ], [ "t_tree_fungal_young", 32 ] ]
   },
   {
     "type": "forest_biome_component",
-    "id": "mom_mycus_world_shrubs_and_flowers_forest",
+    "id": "shrubs_and_flowers_forest",
     "sequence": 1,
     "chance": 10,
     "types": [ [ "t_shrub_fungal", 120 ], [ "t_tree_fungal_young", 10 ] ]
   },
   {
     "type": "forest_biome_component",
-    "id": "mom_mycus_world_clutter_forest",
+    "id": "clutter_forest",
     "sequence": 2,
     "chance": 80,
     "types": [
@@ -119,9 +114,9 @@
   },
   {
     "type": "forest_biome_component",
-    "id": "mom_mycus_world_water_forest",
+    "id": "water_forest",
     "sequence": 3,
     "chance": 512,
-    "types": [ [ "t_puddle", 1 ] ]
+    "types": [ [ "t_puddle", 1 ], [ "t_puddle_mycus", 10 ] ]
   }
 ]

--- a/data/mods/MindOverMatter/dimensions/mycus_world/region_settings.json
+++ b/data/mods/MindOverMatter/dimensions/mycus_world/region_settings.json
@@ -49,13 +49,19 @@
     "type": "region_terrain_furniture",
     "id": "mom_mycus_world_t_region_groundcover",
     "ter_id": "t_region_groundcover",
-    "replace_with_terrain": [ [ "t_fungus_floor_out", 600 ], [ "t_fungus_mound", 1 ], [ "t_dirt", 20 ] ]
+    "replace_with_terrain": [ [ "t_fungus_floor_out", 600 ], [ "t_fungus", 150 ], [ "t_fungus_mound", 1 ], [ "t_dirt", 20 ] ]
   },
   {
     "type": "region_terrain_furniture",
     "id": "mom_mycus_world_t_region_groundcover_forest",
     "ter_id": "t_region_groundcover_forest",
-    "replace_with_terrain": [ [ "t_fungus_floor_out", 300 ], [ "t_fungus_mound", 4 ], [ "t_shrub_fungal", 10 ], [ "t_dirt", 20 ] ]
+    "replace_with_terrain": [
+      [ "t_fungus_floor_out", 300 ],
+      [ "t_fungus", 150 ],
+      [ "t_fungus_mound", 4 ],
+      [ "t_shrub_fungal", 10 ],
+      [ "t_dirt", 20 ]
+    ]
   },
   {
     "type": "region_settings_forest_mapgen",
@@ -94,7 +100,7 @@
     "id": "shrubs_and_flowers_forest",
     "sequence": 1,
     "chance": 10,
-    "types": [ [ "t_shrub_fungal", 120 ], [ "t_tree_fungal_young", 10 ] ]
+    "types": [ [ "t_shrub_fungal", 120 ], [ "t_tree_fungal_young", 10 ], [ "t_marloss", 1 ] ]
   },
   {
     "type": "forest_biome_component",

--- a/data/mods/MindOverMatter/dimensions/mycus_world/region_settings.json
+++ b/data/mods/MindOverMatter/dimensions/mycus_world/region_settings.json
@@ -7,7 +7,7 @@
     "highways": null,
     "place_roads": false,
     "forest_trails": null,
-    "place_specials": false,
+    "place_specials": true,
     "rivers": null,
     "lakes": null,
     "ocean": null,

--- a/data/mods/MindOverMatter/dimensions/mycus_world/region_settings.json
+++ b/data/mods/MindOverMatter/dimensions/mycus_world/region_settings.json
@@ -36,7 +36,7 @@
       "deep_rock",
       "deep_rock"
     ],
-    "default_groundcover": [ [ "t_mom_mycus_world_groundcover", 1 ] ],
+    "default_groundcover": [ [ "t_region_groundcover", 1 ] ],
     "feature_flag_settings": { "blacklist": [ "LAB", "MAN_MADE", "MILITARY", "URBAN", "FARM", "EXODII", "HIGHLANDS" ], "whitelist": [ "FUNGAL" ] }
   },
   {
@@ -48,13 +48,13 @@
   {
     "type": "region_terrain_furniture",
     "id": "mom_mycus_world_t_region_groundcover",
-    "ter_id": "t_mom_mycus_world_groundcover",
+    "ter_id": "t_region_groundcover",
     "replace_with_terrain": [ [ "t_fungus_floor_out", 600 ], [ "t_fungus_mound", 1 ], [ "t_dirt", 20 ] ]
   },
   {
     "type": "region_terrain_furniture",
     "id": "mom_mycus_world_t_region_groundcover_forest",
-    "ter_id": "t_mom_mycus_world_groundcover_forest",
+    "ter_id": "t_region_groundcover_forest",
     "replace_with_terrain": [ [ "t_fungus_floor_out", 300 ], [ "t_fungus_mound", 4 ], [ "t_shrub_fungal", 10 ], [ "t_dirt", 20 ] ]
   },
   {
@@ -79,7 +79,7 @@
     "item_group": "forest",
     "item_group_chance": 0,
     "item_spawn_iterations": 1,
-    "groundcover": [ [ "t_mom_mycus_world_groundcover_forest", 1 ] ],
+    "groundcover": [ [ "t_region_groundcover_forest", 1 ] ],
     "components": [
       "mom_mycus_world_trees_forest",
       "mom_mycus_world_shrubs_and_flowers_forest",

--- a/data/mods/MindOverMatter/monsters/feral_psychics.json
+++ b/data/mods/MindOverMatter/monsters/feral_psychics.json
@@ -1520,6 +1520,14 @@
           "cooldown": { "math": [ "17 + rand(32)" ] },
           "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
           "monster_message": "The lights around %1$s waver and shapes appear near %3$s."
+        },
+        {
+          "id": "psi_teleport3_oubliette",
+          "type": "spell",
+          "spell_data": { "id": "teleport_oubliette_monster", "min_level": 6 },
+          "cooldown": { "math": [ "25 + rand(50)" ] },
+          "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+          "monster_message": "%1$s touches %3$s and the air around %3$s warps."
         }
       ],
       "flags": [ "CLIMBS", "HARDTOSHOOT", "TELEPORT_IMMUNE" ]

--- a/data/mods/MindOverMatter/monsters/monster_eoc_spells.json
+++ b/data/mods/MindOverMatter/monsters/monster_eoc_spells.json
@@ -590,7 +590,7 @@
     "effect": [
       { "math": [ "_dimension_time = 3600 + rand(259200)" ] },
       {
-        "switch": { "math": [ "rand(400)" ] },
+        "switch": { "math": [ "rand(4)" ] },
         "cases": [
           {
             "case": 0,

--- a/data/mods/MindOverMatter/monsters/monster_eoc_spells.json
+++ b/data/mods/MindOverMatter/monsters/monster_eoc_spells.json
@@ -544,11 +544,11 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_TELEPORT_OUBLIETTE_MONSTER",
-    "condition": { 
-      "not": { 
-        "or": [ 
+    "condition": {
+      "not": {
+        "or": [
           { "u_has_flag": "TELESTOP" },
-          { "not": { "u_has_flag": "TELEPORT_IMMUNE" } },
+          { "u_has_flag": "TELEPORT_IMMUNE" },
           { "u_has_flag": "TELEPORT_LOCK" },
           { "u_has_worn_with_flag": "DIMENSIONAL_ANCHOR" }
         ]
@@ -556,36 +556,29 @@
     },
     "effect": [
       { "math": [ "_damage_done = 50 + rand(100)" ] },
-      { "if": { 
-        "and": [ 
-          "u_is_character", {
-            "math": [
-              "_damage_done",
-              ">=",
-              "(u_hp('arm_l') + u_hp('arm_r') + u_hp('leg_l') + u_hp('leg_r') + u_hp('torso') + u_hp('head')) / 3"
-            ]
-          }
-        ]
-      },
-        "then": [ 
-          { "if": "u_is_avatar",
+      {
+        "if": {
+          "and": [
+            "u_is_character",
+            {
+              "math": [
+                "_damage_done",
+                ">=",
+                "(u_hp('arm_l') + u_hp('arm_r') + u_hp('leg_l') + u_hp('leg_r') + u_hp('torso') + u_hp('head')) / 3"
+              ]
+            }
+          ]
+        },
+        "then": [
+          {
+            "if": "u_is_avatar",
             "then": [ { "run_eocs": "EOC_MOM_OUBLIETTE_MONSTER_PICK_DIMENSION" } ],
             "else": [ { "u_die": { "remove_corpse": true, "supress_message": true, "remove_from_creature_tracker": false } } ]
-          },
-        ]
-      },
-      { "if": { 
-        "and": [
-          "u_is_monster", 
-          {
-            "math": [
-              "_damage_done",
-              ">=",
-              "u_hp('ALL')"
-            ]
           }
         ]
       },
+      {
+        "if": { "and": [ "u_is_monster", { "math": [ "_damage_done", ">=", "u_hp('ALL')" ] } ] },
         "then": [ { "u_die": { "remove_corpse": true, "supress_message": true, "remove_from_creature_tracker": false } } ]
       }
     ],
@@ -597,24 +590,10 @@
     "effect": [
       { "math": [ "_dimension_time = 3600 + rand(259200)" ] },
       {
-        "switch": { "math": [ "rand(1)" ] },
+        "switch": { "math": [ "rand(400)" ] },
         "cases": [
           {
             "case": 0,
-            "effect": [
-              {
-                "u_travel_to_dimension": "highlands",
-                "npc_travel_radius": 0,
-                "region_type": "highlands",
-                "npc_travel_filter": "none",
-                "fail_message": "You experience brief vertigo, but nothing dangerous seems to happen.",
-                "success_message": "Your surroundings warp and fold before reforming into a strange landscape."
-              },
-              { "run_eocs": "EOC_PORTAL_HIGHLANDS_RETURN", "time_in_future": { "math": [ "_dimension_time" ] } },
-            ]
-          },
-          {
-            "case": 1,
             "effect": [
               {
                 "u_travel_to_dimension": "mom_innawood",
@@ -624,11 +603,39 @@
                 "fail_message": "You experience brief vertigo, but nothing dangerous seems to happen.",
                 "success_message": "Your surroundings warp and fold before reforming into a strange landscape."
               },
-              { "run_eocs": "EOC_PORTAL_OUBLIETTE_RETURN", "time_in_future": { "math": [ "_dimension_time" ] } },
+              { "run_eocs": "EOC_PORTAL_OUBLIETTE_RETURN", "time_in_future": { "math": [ "_dimension_time" ] } }
+            ]
+          },
+          {
+            "case": 3,
+            "effect": [
+              {
+                "u_travel_to_dimension": "highlands",
+                "npc_travel_radius": 0,
+                "region_type": "highlands",
+                "npc_travel_filter": "none",
+                "fail_message": "You experience brief vertigo, but nothing dangerous seems to happen.",
+                "success_message": "Your surroundings warp and fold before reforming into a strange landscape."
+              },
+              { "run_eocs": "EOC_PORTAL_HIGHLANDS_RETURN", "time_in_future": { "math": [ "_dimension_time" ] } }
+            ]
+          },
+          {
+            "case": 4,
+            "effect": [
+              {
+                "u_travel_to_dimension": "mycus_world",
+                "npc_travel_radius": 0,
+                "region_type": "mom_mycus_world",
+                "npc_travel_filter": "none",
+                "fail_message": "You experience brief vertigo, but nothing dangerous seems to happen.",
+                "success_message": "Your surroundings warp and fold before reforming into a strange landscape."
+              },
+              { "run_eocs": "EOC_PORTAL_OUBLIETTE_RETURN", "time_in_future": { "math": [ "_dimension_time" ] } }
             ]
           }
         ]
-      }  
+      }
     ]
   },
   {

--- a/data/mods/MindOverMatter/monsters/monster_eoc_spells.json
+++ b/data/mods/MindOverMatter/monsters/monster_eoc_spells.json
@@ -521,6 +521,130 @@
     ]
   },
   {
+    "id": "teleport_oubliette_monster",
+    "type": "SPELL",
+    "name": { "str": "[Ψ]Oubliette Monster", "//~": "NO_I18N" },
+    "description": {
+      "str": "The monster sends you to another dimension, just like you could have done to it.  Turnabout is fair play.",
+      "//~": "NO_I18N"
+    },
+    "message": "",
+    "teachable": false,
+    "valid_targets": [ "hostile" ],
+    "spell_class": "TELEPORTER",
+    "skill": "metaphysics",
+    "flags": [ "PSIONIC", "CONCENTRATE", "SILENT", "NO_HANDS", "NO_LEGS" ],
+    "max_level": 10,
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_TELEPORT_OUBLIETTE_MONSTER",
+    "shape": "blast",
+    "min_range": 3,
+    "max_range": 3
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_TELEPORT_OUBLIETTE_MONSTER",
+    "condition": { 
+      "not": { 
+        "or": [ 
+          { "u_has_flag": "TELESTOP" },
+          { "not": { "u_has_flag": "TELEPORT_IMMUNE" } },
+          { "u_has_flag": "TELEPORT_LOCK" },
+          { "u_has_worn_with_flag": "DIMENSIONAL_ANCHOR" }
+        ]
+      }
+    },
+    "effect": [
+      { "math": [ "_damage_done = 50 + rand(100)" ] },
+      { "if": { 
+        "and": [ 
+          "u_is_character", {
+            "math": [
+              "_damage_done",
+              ">=",
+              "(u_hp('arm_l') + u_hp('arm_r') + u_hp('leg_l') + u_hp('leg_r') + u_hp('torso') + u_hp('head')) / 3"
+            ]
+          }
+        ]
+      },
+        "then": [ 
+          { "if": "u_is_avatar",
+            "then": [ { "run_eocs": "EOC_MOM_OUBLIETTE_MONSTER_PICK_DIMENSION" } ],
+            "else": [ { "u_die": { "remove_corpse": true, "supress_message": true, "remove_from_creature_tracker": false } } ]
+          },
+        ]
+      },
+      { "if": { 
+        "and": [
+          "u_is_monster", 
+          {
+            "math": [
+              "_damage_done",
+              ">=",
+              "u_hp('ALL')"
+            ]
+          }
+        ]
+      },
+        "then": [ { "u_die": { "remove_corpse": true, "supress_message": true, "remove_from_creature_tracker": false } } ]
+      }
+    ],
+    "false_effect": { "u_message": "You feel a strange, inward force.", "type": "neutral" }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_MOM_OUBLIETTE_MONSTER_PICK_DIMENSION",
+    "effect": [
+      { "math": [ "_dimension_time = 3600 + rand(259200)" ] },
+      {
+        "switch": { "math": [ "rand(1)" ] },
+        "cases": [
+          {
+            "case": 0,
+            "effect": [
+              {
+                "u_travel_to_dimension": "highlands",
+                "npc_travel_radius": 0,
+                "region_type": "highlands",
+                "npc_travel_filter": "none",
+                "fail_message": "You experience brief vertigo, but nothing dangerous seems to happen.",
+                "success_message": "Your surroundings warp and fold before reforming into a strange landscape."
+              },
+              { "run_eocs": "EOC_PORTAL_HIGHLANDS_RETURN", "time_in_future": { "math": [ "_dimension_time" ] } },
+            ]
+          },
+          {
+            "case": 1,
+            "effect": [
+              {
+                "u_travel_to_dimension": "mom_innawood",
+                "npc_travel_radius": 0,
+                "region_type": "mom_innawood",
+                "npc_travel_filter": "none",
+                "fail_message": "You experience brief vertigo, but nothing dangerous seems to happen.",
+                "success_message": "Your surroundings warp and fold before reforming into a strange landscape."
+              },
+              { "run_eocs": "EOC_PORTAL_OUBLIETTE_RETURN", "time_in_future": { "math": [ "_dimension_time" ] } },
+            ]
+          }
+        ]
+      }  
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PORTAL_OUBLIETTE_RETURN",
+    "effect": [
+      {
+        "u_travel_to_dimension": "",
+        "npc_travel_radius": 0,
+        "npc_travel_filter": "none",
+        "fail_message": "Nothing seems to change.",
+        "success_message": "Your surroundings warp and fold into the recesses of the world you know."
+      }
+    ]
+  },
+  {
     "type": "SPELL",
     "id": "whispering_amalgamation_apply_mindsight",
     "name": { "str": "Eater apply mindsight", "//~": "NO_I18N" },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[MoM] `ephemerial riftwalker`s can Oubliette you"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

You know how if you're a powerful teleporter you can banish your enemies to other dimensions?

 `ephemerial riftwalker`s are powerful teleporters.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Give `ephemerial riftwalker`s the Oubliette power, allowing them to banish targets to other dimensions. This works like player banish, in that it checks the target's HP vs the power limit and only works if HP is below the limit. For monsters, the HP limit is just their HP. For characters, it's the sum of your limb HP divided by 3, so it's not possible to be banished if you're at full health. 

(Your HP is also modified by your size, to simulate volume calculations--it's easier for them to Oubliette mouse mutants than bear mutants)

If you do get banished, you're sent to another dimension for a period of time before dimensional instability draws you back to the main world (and so I don't have to either make a way to escape each dimension or just make it an elaborate Game Over screen), where time varies between 1 hour and 3 days. At the moment, you can be sent to:

- The Highlands
- Innawood
- A dimension overgrown by the Mycus

More dimensions as I think of them.

These are not equal odds--you're most likely to be sent to Innawood, as I figure "Earth but humanity never evolved for some reason" has uncountable variations across the multiverse

If you're a teleporter, have the Teleport Lock effect, or are wearing an active 5-point anchor, you are immune to Oubliette.

If monsters or NPCs get banished they just die. This is how the player version of Oubliette already works. Maybe some of them find their way back to Earth but tracking that isn't necessary. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

The Mycus dimension:
<img width="1143" height="848" alt="Untitled" src="https://github.com/user-attachments/assets/f7c466ae-1768-41b1-afd6-c304bb2df510" />

(looks like young fungal trees don't have a sprite)

The attack works and sends you to other dimensions.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Not that this is _not_ the Innawood of the Innawood mod--no specific Innawood items or specials spawn. It's just a standard world with no roads or cities and with most specials blocked from spawn. If we ever get some ability to make dimensions draw on mod content, then I'll be able to make it more Innawood and put megafauna in there. 

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
