### PR TITLE
Don't allow character to sell their arms or legs

### DIFF
--- a/src/trade_ui.cpp
+++ b/src/trade_ui.cpp
@@ -233,6 +233,10 @@ void trade_ui::autobalance()
     int const sign = _cpane == _you ? -1 : 1;
     if( ( sign < 0 && _balance < 0 ) || ( sign > 0 && _balance > 0 ) ) {
         inventory_entry &entry = _panes[_cpane]->get_active_column().get_highlighted();
+        if( !entry.is_selectable() ) {
+            popup( _( "%s cannot be traded." ), entry.any_item()->tname() );
+            return;
+        }
         size_t const avail = entry.get_available_count() - entry.chosen_count;
         double const price = npc_trading::trading_price( *_parties[-_cpane + 1], *_parties[_cpane],
                              entry_t{ entry.any_item(), 1 } ) * sign;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
<img width="1241" height="568" alt="image" src="https://github.com/user-attachments/assets/c0622922-ea88-4b11-a75e-fcbc1d9b9f8d" />


#### Describe the solution
Autobalance actually checks whether the selected item can be traded, and refuses if not.

#### Describe alternatives you've considered


#### Testing
Debugged some fur onto my character, tried to pawn it to Smokes in exchange for bullets. He wouldn't accept it.

#### Additional context
