### PR TITLE
Allow fields to track their sources (i.e. who started a fire)

### DIFF
--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -38,6 +38,7 @@
 #include "dispersion.h"
 #include "effect.h"
 #include "effect_on_condition.h"
+#include "effect_source.h"
 #include "enums.h"
 #include "event.h"
 #include "event_bus.h"
@@ -923,7 +924,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
         const std::optional<tripoint_bub_ms> pnt = choose_adjacent( _( "Start a fire where?" ) );
         if( pnt && here.is_flammable( *pnt ) && !here.get_field( *pnt, fd_fire ) ) {
             add_msg_activate();
-            here.add_field( *pnt, fd_fire, 1 );
+            here.add_field( *pnt, fd_fire, 1, 0_turns, true, effect_source( this ) );
             if( has_unfulfilled_pyromania() ) {
                 fulfill_pyromania_msg( _( "You happily light a fire." ), 5, 10, 3_hours, 2_hours );
             }

--- a/src/character_health.cpp
+++ b/src/character_health.cpp
@@ -61,6 +61,7 @@
 #include "morale.h"
 #include "move_mode.h"
 #include "mutation.h"
+#include "npc.h"
 #include "options.h"
 #include "output.h"
 #include "pimpl.h"
@@ -2800,6 +2801,11 @@ int Character::hitall( int dam, int vary, Creature *source )
 void Character::on_hurt( Creature *source, bool disturb /*= true*/ )
 {
     const map &here = get_map();
+
+    // If we actually know the source, and the source is the player, flag the NPC as being unjustly attacked
+    if( is_npc() && source && source == &get_player_character() && !as_npc()->guaranteed_hostile() ) {
+        as_npc()->hit_by_player = true;
+    }
 
     if( has_trait( trait_ADRENALINE ) && !has_effect( effect_adrenaline ) &&
         ( get_part_hp_cur( body_part_head ) < 25 ||

--- a/src/field.cpp
+++ b/src/field.cpp
@@ -6,7 +6,10 @@
 #include <utility>
 
 #include "calendar.h"
+#include "effect_source.h"
 #include "rng.h"
+
+class Creature;
 
 static const field_type_str_id field_fd_fire( "fd_fire" );
 
@@ -71,6 +74,21 @@ void field_entry::mod_field_intensity( int mod )
 time_duration field_entry::get_field_age() const
 {
     return age;
+}
+
+Creature *field_entry::get_causer() const
+{
+    return causer.resolve_creature();
+}
+
+void field_entry::set_causer( effect_source source )
+{
+    causer = source;
+}
+
+effect_source field_entry::get_effect_source() const
+{
+    return causer;
 }
 
 time_duration field_entry::set_field_age( const time_duration &new_age )
@@ -157,7 +175,7 @@ If you wish to modify an already existing field use find_field and modify the re
 Intensity defaults to 1, and age to 0 (permanent) if not specified.
 */
 bool field::add_field( const field_type_id &field_type_to_add, const int new_intensity,
-                       const time_duration &new_age )
+                       const time_duration &new_age, effect_source source )
 {
     // sanity check, we don't want to store fd_null
     if( !field_type_to_add ) {
@@ -172,13 +190,15 @@ bool field::add_field( const field_type_id &field_type_to_add, const int new_int
             prev_intensity = 0;
         }
         it->second.set_field_intensity( prev_intensity + new_intensity );
+        it->second.set_causer( source );
         return false;
     }
     if( !_displayed_field_type ||
         field_type_to_add.obj().priority >= _displayed_field_type.obj().priority ) {
         _displayed_field_type = field_type_to_add;
     }
-    _field_type_list[field_type_to_add] = field_entry( field_type_to_add, new_intensity, new_age );
+    _field_type_list[field_type_to_add] = field_entry( field_type_to_add, new_intensity, new_age,
+                                          source );
     return true;
 }
 

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -46,6 +46,7 @@
 #include "damage.h"
 #include "debug.h"
 #include "effect.h" // for weed_msg
+#include "effect_source.h"
 #include "enums.h"
 #include "event.h"
 #include "event_bus.h"
@@ -254,6 +255,8 @@ static const efftype_id effect_weak_antibiotic( "weak_antibiotic" );
 static const efftype_id effect_weak_antibiotic_visible( "weak_antibiotic_visible" );
 static const efftype_id effect_webbed( "webbed" );
 static const efftype_id effect_weed_high( "weed_high" );
+
+static const faction_id faction_your_followers( "your_followers" );
 
 static const furn_str_id furn_f_translocator_buoy( "f_translocator_buoy" );
 
@@ -3623,6 +3626,9 @@ std::optional<int> iuse::molotov_lit( Character *p, item *it, const tripoint_bub
 
     if( !p ) {
         // It was thrown or dropped, so burst into flames
+        // This bool is a bit nasty, once it's left the character's inventory we're really not sure who threw or dropped it!
+        // But items assign ownership on pickup by a character, so if the owner is your_followers then it stands to reason it must be the player.
+        const bool thrown_by_player_or_follower = it->get_owner() == faction_your_followers;
         map &here = get_map();
         // Because fields decay with a half-life, we need to know how long it takes for the field to decay and set the age to slightly before that.
         // the duration is also used for the effect's timer. It's hilariously lethal regardless.
@@ -3631,9 +3637,17 @@ std::optional<int> iuse::molotov_lit( Character *p, item *it, const tripoint_bub
         for( const tripoint_bub_ms &pt : here.points_in_radius( pos, 1, 0 ) ) {
             Creature *critter = get_creature_tracker().creature_at( pt, true );
             if( critter && one_in( 2 ) ) {
-                critter->add_effect( effect_onfire, target_duration );
+                if( thrown_by_player_or_follower ) {
+                    critter->add_effect( effect_source( &get_player_character() ), effect_onfire, target_duration );
+                } else {
+                    critter->add_effect( effect_onfire, target_duration );
+                }
             } else if( !here.get_field( pt, fd_fire ) && one_in( 2 ) ) {
-                here.add_field( pt, fd_fire, 1, base_age );
+                if( thrown_by_player_or_follower ) {
+                    here.add_field( pt, fd_fire, 1, base_age, true, effect_source( &get_player_character() ) );
+                } else {
+                    here.add_field( pt, fd_fire, 1, base_age );
+                }
             }
         }
         avatar &player = get_avatar();

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -37,6 +37,7 @@
 #include "dialogue_helpers.h"
 #include "effect.h"
 #include "effect_on_condition.h"
+#include "effect_source.h"
 #include "enum_conversions.h"
 #include "enums.h"
 #include "explosion.h"
@@ -1516,7 +1517,7 @@ bool firestarter_actor::resolve_start( Character *p, map *here,
 {
     switch( type ) {
         case start_type::FIRE:
-            return here->add_field( pos, fd_fire, 1, 10_minutes );
+            return here->add_field( pos, fd_fire, 1, 10_minutes, true, effect_source( p ) );
         case start_type::SMOKER:
             return iexamine::smoker_fire( *p, pos );
         case start_type::KILN:

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -6692,7 +6692,7 @@ bool map::mopsafe_field_at( const tripoint_bub_ms &p )
 }
 
 bool map::add_field( const tripoint_bub_ms &p, const field_type_id &type_id, int intensity,
-                     const time_duration &age, bool hit_player )
+                     const time_duration &age, bool hit_player, effect_source source )
 {
     if( !inbounds( p ) ) {
         return false;
@@ -6731,7 +6731,7 @@ bool map::add_field( const tripoint_bub_ms &p, const field_type_id &type_id, int
     current_submap->ensure_nonuniform();
     invalidate_max_populated_zlev( p.z() );
 
-    if( current_submap->get_field( l ).add_field( converted_type_id, intensity, age ) ) {
+    if( current_submap->get_field( l ).add_field( converted_type_id, intensity, age, source ) ) {
         //Only adding it to the count if it doesn't exist.
         if( !current_submap->field_count++ ) {
             get_cache( p.z() ).field_cache.set(

--- a/src/map.h
+++ b/src/map.h
@@ -1549,7 +1549,8 @@ class map
          */
         bool add_field(
             const tripoint_bub_ms &p, const field_type_id &type_id, int intensity = INT_MAX,
-            const time_duration &age = 0_turns, bool hit_player = true );
+            const time_duration &age = 0_turns, bool hit_player = true,
+            effect_source source = effect_source() );
         /**
          * Remove field entry at xy, ignored if the field entry is not present.
          */

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -1098,7 +1098,7 @@ void field_processor_fd_fire( const tripoint_bub_ms &p, field_entry &cur, field_
                 maptile dst_tile = here.maptile_at_internal( dst );
                 field_entry *fire_there = dst_tile.find_field( fd_fire );
                 if( !fire_there ) {
-                    here.add_field( dst, fd_fire, 1, 0_turns, false );
+                    here.add_field( dst, fd_fire, 1, 0_turns, true, cur.get_effect_source() );
                     cur.mod_field_intensity( -1 );
                 } else {
                     // Don't fuel raging fires or they'll burn forever
@@ -1273,7 +1273,7 @@ void field_processor_fd_fire( const tripoint_bub_ms &p, field_entry &cur, field_
             if( nearfire != nullptr ) {
                 nearfire->mod_field_age( -2_turns );
             } else {
-                here.add_field( dst_p, fd_fire, 1, 0_turns, false );
+                here.add_field( dst_p, fd_fire, 1, 0_turns, true, cur.get_effect_source() );
             }
             // Fueling fires above doesn't cost fuel
         }
@@ -1327,7 +1327,7 @@ void field_processor_fd_fire( const tripoint_bub_ms &p, field_entry &cur, field_
                 ) ) {
                 // Nearby open flammable ground? Set it on fire.
                 // Make the new fire quite weak, so that it doesn't start jumping around instantly
-                if( here.add_field( dst_p, fd_fire, 1, 2_minutes, false ) ) {
+                if( here.add_field( dst_p, fd_fire, 1, 2_minutes, true, cur.get_effect_source() ) ) {
                     // Consume a bit of our fuel
                     cur.set_field_age( cur.get_field_age() + 1_minutes );
                 }
@@ -1387,7 +1387,7 @@ void field_processor_fd_fire( const tripoint_bub_ms &p, field_entry &cur, field_
                 ) ) {
                 // Nearby open flammable ground? Set it on fire.
                 // Make the new fire quite weak, so that it doesn't start jumping around instantly
-                if( here.add_field( dst_p, fd_fire, 1, 2_minutes, false ) ) {
+                if( here.add_field( dst_p, fd_fire, 1, 2_minutes, true, cur.get_effect_source() ) ) {
                     // Consume a bit of our fuel
                     cur.set_field_age( cur.get_field_age() + 1_minutes );
                 }
@@ -1600,7 +1600,7 @@ void map::player_in_field( Character &you )
 
                     int total_damage = 0;
                     for( const bodypart_id &part_burned : parts_burned ) {
-                        const dealt_damage_instance dealt = you.deal_damage( nullptr, part_burned,
+                        const dealt_damage_instance dealt = you.deal_damage( cur.get_causer(), part_burned,
                                                             damage_instance( damage_heat, rng( burn_min, burn_max ) ) );
                         total_damage += dealt.type_damage( damage_heat );
                     }
@@ -2085,7 +2085,7 @@ void map::monster_in_field( monster &z )
 
         // Finally, apply damage
         if( dam > 0 ) {
-            z.apply_damage( nullptr, z.get_random_body_part_of_type( bp_type::torso ), dam, true );
+            z.apply_damage( cur.get_causer(), z.get_random_body_part_of_type( bp_type::torso ), dam, true );
             z.check_dead_state( this );
         }
     }

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1555,14 +1555,14 @@ int monster::calc_movecost( const map &here, const tripoint_bub_ms &from,
     auto get_filtered_fieldcost = [&]( const field & field ) {
         int cost = 0;
         // filter fields whether they are ignored
-        for( const auto [field_id, field_entry] : field ) {
-            if( !is_immune_field( field_id ) ) {
-                const int mc = field_entry.get_intensity_level().move_cost;
+        for( const std::pair<const int_id<field_type>, field_entry> &pair : field ) {
+            if( !is_immune_field( pair.first ) ) {
+                const int mc = pair.second.get_intensity_level().move_cost;
                 if( mc >= 0 ) {
                     cost += mc;
                 } else {
                     debugmsg( "%s cannot pass through field %s. monster::calc_movecost expects to be called with valid destination.",
-                              get_name(), field_id->get_name() );
+                              get_name(), pair.first->get_name() );
                     return -1;
                 }
             }

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -75,7 +75,7 @@ extern std::map<std::string, std::list<input_event>> quick_shortcuts_map;
  * Changes that break backwards compatibility should bump this number, so the game can
  * load a legacy format loader.
  */
-const int savegame_version = 38;
+const int savegame_version = 39;
 
 /*
  * This is a global set by detected version header in .sav, maps.txt, or overmap.

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -4998,6 +4998,7 @@ void submap::store( JsonOut &jsout ) const
                     jsout.write( cur.get_field_type().id() );
                     jsout.write( cur.get_field_intensity() );
                     jsout.write( cur.get_field_age() );
+                    cur.get_effect_source().serialize( jsout );
                 }
                 jsout.end_array();
             }
@@ -5259,18 +5260,20 @@ void submap::load( const JsonValue &jv, const std::string &member_name, int vers
                     field_type_str_id ft = field_type_str_id( type_value.get_string() );
                     const int intensity = field_json.next_int();
                     const int age = field_json.next_int();
+                    effect_source source;
+                    if( version >= 39 ) {
+                        const JsonObject source_obj = field_json.next_object();
+                        source.deserialize( source_obj );
+                    }
                     if( auto it = field_migrations.find( ft ); it != field_migrations.end() ) {
                         ft = it->second;
                     }
                     if( !ft.is_valid() ) {
                         debugmsg( "invalid field_type_str_id '%s'", ft.c_str() );
                     } else if( ft != field_type_str_id::NULL_ID() &&
-                               m->fld[i][j].add_field( ft.id(), intensity, time_duration::from_turns( age ) ) ) {
+                               m->fld[i][j].add_field( ft.id(), intensity, time_duration::from_turns( age ), source ) ) {
                         field_count++;
                     }
-                } else { // Handle removed int enum method
-                    field_json.next_value(); // Skip intensity
-                    field_json.next_value(); // Skip age
                 }
             }
         }

--- a/tests/submap_load_test.cpp
+++ b/tests/submap_load_test.cpp
@@ -872,7 +872,8 @@ static JsonValue submap_fd_pre_migration = json_loader::from_string( submap_fd_p
 static void load_from_jsin( submap &sm, const JsonValue &jsin )
 {
     // Ensure that the JSON is up to date for our savegame version
-    REQUIRE( savegame_version == 38 );
+    REQUIRE( savegame_version == 39 );
+    // Important note for future testmakers: Submaps can have their own version, different from the savegame_version. Good luck with that.
     int version = 0;
     JsonObject sm_json = jsin.get_object();
     if( sm_json.has_member( "version" ) ) {


### PR DESCRIPTION
#### Summary
Features "Allow fields to track their sources (i.e. who started a fire)"

#### Purpose of change
Fires usually have a clear cause and effect. Someone starts them, they then spread and possibly hurt people or monsters.

The problem: Fires don't actually track that. If a player starts a fire which kills a mission monster, the monster dies... to "nothing". The player isn't credited for the kill, any [morale effects for murder](https://github.com/CleverRaven/Cataclysm-DDA/pull/84242) aren't applied, etc. This broke missions *quite often* when molotovs were absurd walls of doom, and it allowed players to get away with murder.

Nobody blames you for locking the door to their friends' apartment and burning the place down.

#### Describe the solution
Well, they should.

I added an optional `effect_source` to fields which is set when constructing the field.

If the source is present, any* damage that field applies will be blamed on the source.

*applies generically to all damaging fields for monsters, but may only apply to fires for characters. Because these are coded in two different places when they don't need to be 🙃

When fire spreads, it copies its effect_source to the newly created fire fields. So lighting a building on fire credits(blames) the player for the entire fire.

A... kind of hacky implementation was added for molotovs as well.

No other field types currently track their source, just fires. Only generic support was added.

#### Describe alternatives you've considered


#### Testing
Burned down the evac shelter with the starting NPC inside.

My character felt bad about murdering them.

#### Additional context

Known issues:
None!
