### PR TITLE
Require metal melting tools for melting metal

### DIFF
--- a/data/json/recipes/recipe_others.json
+++ b/data/json/recipes/recipe_others.json
@@ -3268,7 +3268,11 @@
     "time": "1 h",
     "autolearn": true,
     "qualities": [ { "id": "HAMMER", "level": 3 } ],
-    "tools": [ [ [ "surface_heat", 10, "LIST" ] ] ],
+    "tools": [
+      [ [ "metalworking_tongs_any", 1, "LIST" ] ],
+      [ [ "can_medium", -1 ], [ "crucible", -1 ], [ "crucible_clay", -1 ] ],
+      [ [ "forge", 10 ] ]
+    ],
     "components": [ [ [ "scrap_aluminum", 5 ], [ "material_aluminium_ingot", 1 ] ] ]
   },
   {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
This recipe came to my attention and I saw it needed a tweak.

#### Describe the solution
Require metalworking tools, not just a heat source, and presumably not even a crucible? Though I did add a soup can as moderns ones are almost always steel and that would be fine for aluminum melting.

#### Describe alternatives you've considered
Removing it is valid too, it's pretty sketchy in the first place.
Better tuning for the fuel requirement is possible.
More expansive tong and crucible requirements would be fine, do we have a generic "pick up hot things" requirement?

#### Testing
It loads and stuff.