### PR TITLE
map boards display a map behind glass so just make them readable

### DIFF
--- a/data/json/furniture_and_terrain/furniture-storage.json
+++ b/data/json/furniture_and_terrain/furniture-storage.json
@@ -1119,18 +1119,22 @@
     },
     "examine_action": {
       "type": "effect_on_condition",
-      "effect_on_conditions": [{
-        "id": "eoc_pick_and_read_map",
-        "effect": [{
-          "u_map_run_item_eocs": "all",
-          "loc": { "context_val": "pos" },
-          "accessible": false,
-          "search_data": [ { "category": "maps" } ],
-          "title": "test",
-          "true_eocs": [ { "id": "EOC_ACTIVATE_MAP", "effect": [ { "u_activate": "reveal_map" } ] } ],
-          "false_eocs": [ { "id": "EOC_NO_MAP", "effect": [ { "u_message": "no map found" } ] } ]
-        }]
-      }]
+      "effect_on_conditions": [
+        {
+          "id": "eoc_pick_and_read_map",
+          "effect": [
+            {
+              "u_map_run_item_eocs": "all",
+              "loc": { "context_val": "pos" },
+              "accessible": false,
+              "search_data": [ { "category": "maps" } ],
+              "title": "test",
+              "true_eocs": [ { "id": "EOC_ACTIVATE_MAP", "effect": [ { "u_activate": "reveal_map" } ] } ],
+              "false_eocs": [ { "id": "EOC_NO_MAP", "effect": [ { "u_message": "no map found" } ] } ]
+            }
+          ]
+        }
+      ]
     },
     "bash": {
       "str_min": 6,

--- a/data/json/furniture_and_terrain/furniture-storage.json
+++ b/data/json/furniture_and_terrain/furniture-storage.json
@@ -1128,9 +1128,7 @@
               "loc": { "context_val": "pos" },
               "accessible": false,
               "search_data": [ { "category": "maps" } ],
-              "title": "test",
-              "true_eocs": [ { "id": "EOC_ACTIVATE_MAP", "effect": [ { "u_activate": "reveal_map" } ] } ],
-              "false_eocs": [ { "id": "EOC_NO_MAP", "effect": [ { "u_message": "no map found" } ] } ]
+              "true_eocs": [ { "id": "EOC_ACTIVATE_MAP", "effect": [ { "u_activate": "reveal_map" } ] } ]
             }
           ]
         }

--- a/data/json/furniture_and_terrain/furniture-storage.json
+++ b/data/json/furniture_and_terrain/furniture-storage.json
@@ -1117,41 +1117,21 @@
         { "item": "glass_sheet", "count": 1 }
       ]
     },
-    "lockpick_result": "f_board_map_o",
-    "lockpick_message": "With a satisfying click, the locked glass panel opens.",
-    "examine_action": "locked_object_pickable",
-    "bash": {
-      "str_min": 6,
-      "str_max": 20,
-      "sound": "glass breaking!",
-      "sound_fail": "whack!",
-      "sound_vol": 16,
-      "sound_fail_vol": 12,
-      "furn_set": "f_board_map_b",
-      "items": [ { "item": "glass_shard", "count": [ 25, 50 ] } ]
-    }
-  },
-  {
-    "type": "furniture",
-    "id": "f_board_map_o",
-    "name": "open map board",
-    "looks_like": "f_bulletin",
-    "description": "A successfully picked metal board with an open glass panel used to display a map.",
-    "symbol": "6",
-    "color": "light_gray",
-    "move_cost_mod": -1,
-    "coverage": 75,
-    "required_str": -1,
-    "flags": [ "TRANSPARENT", "PLACE_ITEM" ],
-    "deconstruct": {
-      "items": [
-        { "item": "pipe", "count": 4 },
-        { "item": "sheet_metal", "count": 1 },
-        { "item": "hinge", "count": 2 },
-        { "item": "glass_sheet", "count": 1 }
-      ]
+    "examine_action": {
+      "type": "effect_on_condition",
+      "effect_on_conditions": [{
+        "id": "eoc_pick_and_read_map",
+        "effect": [{
+          "u_map_run_item_eocs": "all",
+          "loc": { "context_val": "pos" },
+          "accessible": false,
+          "search_data": [ { "category": "maps" } ],
+          "title": "test",
+          "true_eocs": [ { "id": "EOC_ACTIVATE_MAP", "effect": [ { "u_activate": "reveal_map" } ] } ],
+          "false_eocs": [ { "id": "EOC_NO_MAP", "effect": [ { "u_message": "no map found" } ] } ]
+        }]
+      }]
     },
-    "rotates_to": "INDOORFLOOR",
     "bash": {
       "str_min": 6,
       "str_max": 20,

--- a/data/json/obsoletion_and_migration_0.J/furniture.json
+++ b/data/json/obsoletion_and_migration_0.J/furniture.json
@@ -3,5 +3,10 @@
     "type": "ter_furn_migration",
     "from_furn": "f_broken_boat",
     "to_furn": "f_beach_log"
+  },
+  {
+    "type": "ter_furn_migration",
+    "from_furn": "f_board_map_o",
+    "to_furn": "f_board_map_b"
   }
 ]

--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -2803,6 +2803,7 @@ Search items around you on the map, and run EoC on them
 | "min_radius", "max_radius" | optional | int or [variable object](#variable-object) | radius around the location/talker that would be searched |
 | "title" | optional | string or [variable object](#variable-object) | name of the menu that would be shown, if `manual` or `manual_mult` values are used |
 | "search_data" | optional | `search_data` | sets the condition(s) for the target item; lack of search_data means any item can be picked; see [search_data](#search_data) for syntax |
+| "accessible" | optional | boolean | if true or unspecified then only accessible items are found |
 | "true_eocs", "false_eocs" | optional | string, [variable object](#variable-object), inline EoC, or range of all of them | if item was picked successfully, all EoCs from `true_eocs` are run, otherwise all EoCs from `false_eocs` are run; picked item is returned as npc |
 
 ##### Valid talkers:

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -2186,6 +2186,20 @@ void inventory_selector::add_map_items( const tripoint_bub_ms &target, bool add_
     }
 }
 
+void inventory_selector::add_inaccessible_map_items( const tripoint_bub_ms &target,
+        bool add_efiles )
+{
+    map &here = get_map();
+    if( !here.accessible_items( target ) ) {
+        map_stack items = here.i_at( target );
+        const std::string name = to_upper_case( here.name( target ) );
+        const item_category map_cat( name, no_translation( name ), translation(), 100 );
+        _add_map_items( target, map_cat, items, [target]( item & it ) {
+            return item_location( map_cursor( tripoint_bub_ms( target ) ), &it );
+        }, add_efiles );
+    }
+}
+
 void inventory_selector::add_vehicle_items( const tripoint_bub_ms &target, bool add_efiles )
 {
     const std::optional<vpart_reference> ovp = get_map().veh_at( target ).cargo();

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -655,6 +655,7 @@ class inventory_selector
         void add_character_items( Character &character, bool add_efiles = false );
         void add_character_ebooks( Character &character );
         void add_map_items( const tripoint_bub_ms &target, bool add_efiles = false );
+        void add_inaccessible_map_items( const tripoint_bub_ms &target, bool add_efiles = false );
         void add_vehicle_items( const tripoint_bub_ms &target, bool add_efiles = false );
         void add_nearby_items( int radius = 1, bool add_efiles = false );
         void add_remote_map_items( tinymap *remote_map, const tripoint_omt_ms &target );


### PR DESCRIPTION
#### Summary
Features "allow the player to simply read map boards without forcing them to smash it"

#### Purpose of change
Fixes #84205

Currently you have to either pick the lock or smash the glass, then pick up the map, then read it. But the whole point of a map board is to display the map readably.

#### Describe the solution
I added an EOC to `f_map_board` that finds the map inside the board and activates it.

There currently can only be one examine action on a piece of furniture so I ditched the lockpicking. Map boards that have previously been picked will be migrated to smashed map boards. If you smash a map board then you must pick the map up out of the wreckage before you can read it.

#### Describe alternatives you've considered
I thought about occasionally making the map board dirty, such as by checking for bloodstains on the map tile, but that can be done later.

#### Testing
Wandered around until I found a trailhead. Read the map board.
