### PR TITLE
[Bugfix]: In EOC u_query_omt, distance_limit are not visualized on overmap UI when using tiles

### DIFF
--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -4655,10 +4655,17 @@ talk_effect_fun_t::func f_query_omt( const JsonObject &jo, std::string_view memb
                 tripoint_abs_ms abs_ms = read_var_value( *target_var, d ).tripoint();
                 target_pos = project_to<coords::omt>( abs_ms );
             }
-
+            int distance = distance_limit.evaluate( d );
+            bool is_distance_set = distance != INT_MAX;
+            if( is_distance_set ) {
+                ui::omap::range_mark( target_pos, distance );
+            }
             tripoint_abs_omt pick =
                 ui::omap::choose_point( message.evaluate( d ).translated(), target_pos, false,
-                                        distance_limit.evaluate( d ) );
+                                        distance );
+            if( is_distance_set ) {
+                ui::omap::range_mark( target_pos, distance, false );
+            }
             if( pick != tripoint_abs_omt::invalid ) {
                 tripoint_abs_ms abs_pos_ms = project_to<coords::ms>( pick );
                 // aim at the center of OMT

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -2796,6 +2796,85 @@ std::optional<city> ui::omap::select_city( uilist &cities_menu,
     return ret_val;
 }
 
+void ui::omap::range_mark( const tripoint_abs_omt &origin, int range, bool add_notes,
+                           const std::string &message )
+{
+    std::vector<tripoint_abs_omt> note_pts;
+
+    if( trigdist ) {
+        note_pts.reserve( range * 7 ); // actual multiplier varies from 5.33 to 8, mostly 6 to 7
+        for( const tripoint_abs_omt &pos : points_on_radius_circ( origin, range ) ) {
+            note_pts.emplace_back( pos );
+        }
+    } else {
+        note_pts.reserve( range * 8 );
+        //North Limit
+        for( int x = origin.x() - range; x < origin.x() + range + 1; x++ ) {
+            note_pts.emplace_back( x, origin.y() - range, origin.z() );
+        }
+        //South
+        for( int x = origin.x() - range; x < origin.x() + range + 1; x++ ) {
+            note_pts.emplace_back( x, origin.y() + range, origin.z() );
+        }
+        //West
+        for( int y = origin.y() - range; y < origin.y() + range + 1; y++ ) {
+            note_pts.emplace_back( origin.x() - range, y, origin.z() );
+        }
+        //East
+        for( int y = origin.y() - range; y < origin.y() + range + 1; y++ ) {
+            note_pts.emplace_back( origin.x() + range, y, origin.z() );
+        }
+    }
+
+    for( tripoint_abs_omt &pt : note_pts ) {
+        if( add_notes ) {
+            if( !overmap_buffer.has_note( pt ) ) {
+                overmap_buffer.add_note( pt, message );
+            }
+        } else {
+            if( overmap_buffer.has_note( pt ) && overmap_buffer.note( pt ) == message ) {
+                overmap_buffer.delete_note( pt );
+            }
+        }
+    }
+}
+
+void ui::omap::line_mark( const tripoint_abs_omt &origin, const tripoint_abs_omt &dest,
+                          bool add_notes,
+                          const std::string &message )
+{
+    std::vector<tripoint_abs_omt> note_pts = line_to( origin, dest );
+
+    for( const tripoint_abs_omt &pt : note_pts ) {
+        if( add_notes ) {
+            if( !overmap_buffer.has_note( pt ) ) {
+                overmap_buffer.add_note( pt, message );
+            }
+        } else {
+            if( overmap_buffer.has_note( pt ) && overmap_buffer.note( pt ) == message ) {
+                overmap_buffer.delete_note( pt );
+            }
+        }
+    }
+}
+
+void ui::omap::path_mark(
+    const std::vector<tripoint_abs_omt> &note_pts, bool add_notes,
+    const std::string &message )
+{
+    for( const tripoint_abs_omt &pt : note_pts ) {
+        if( add_notes ) {
+            if( !overmap_buffer.has_note( pt ) ) {
+                overmap_buffer.add_note( pt, message );
+            }
+        } else {
+            if( overmap_buffer.has_note( pt ) && overmap_buffer.note( pt ) == message ) {
+                overmap_buffer.delete_note( pt );
+            }
+        }
+    }
+}
+
 void ui::omap::force_quit()
 {
     overmap_ui::generated_omts.clear();

--- a/src/overmap_ui.h
+++ b/src/overmap_ui.h
@@ -107,6 +107,17 @@ void setup_cities_menu( uilist &cities_menu, std::vector<city> &cities_container
 std::optional<city> select_city( uilist &cities_menu, std::vector<city> &cities_container,
                                  bool random = false );
 
+void range_mark( const tripoint_abs_omt &origin, int range, bool add_notes = true,
+                 const std::string &message = "Y;X: MAX RANGE" );
+
+void line_mark(
+    const tripoint_abs_omt &origin, const tripoint_abs_omt &dest, bool add_notes = true,
+    const std::string &message = "R;X: PATH" );
+
+void path_mark(
+    const std::vector<tripoint_abs_omt> &note_pts, bool add_notes = true,
+    const std::string &message = "R;X: PATH" );
+
 void force_quit();
 } // namespace omap
 


### PR DESCRIPTION
#### Summary
Bugfixes "distance_limit of EOC 'u_query_omt' not visualized on overmap UI when using tiles"

#### Purpose of change


#### Describe the solution

I noticed that when using the u_query_omt EOC and specifying the distance_limit parameter, the range was not visualized in the overmap UI. I later found out that this EOC currently does not support visualizing the range when using Tiles, so I added this capability.

While fixing the issue, I refactored the code by moving the three functions—om_range_mark, om_line_mark, and om_path_mark—originally in faction_camp to overmap_ui. This makes the responsibility division more logical and allows other modules to use these functions as well.

#### Describe alternatives you've considered

No other alternative solutions have been identified so far.

#### Testing
After adding the visualization code, you can now see the range indicator when using Tiles.

<img width="1165" height="977" alt="image" src="https://github.com/user-attachments/assets/01c9bf58-01ea-435d-bf70-0d0698027d6e" />

#### Additional context

None

