### PR TITLE
If gunmod is a gun itself, do not replace it's barrel length

### DIFF
--- a/src/item_gun_tool_ammo.cpp
+++ b/src/item_gun_tool_ammo.cpp
@@ -606,7 +606,7 @@ units::length item::barrel_length() const
         units::length l = type->gun->barrel_length;
         for( const item *mod : mods() ) {
             // if a gun has a barrel length specifying mod then use that length for sure
-            if( mod->type->gunmod->barrel_length > 0_mm ) {
+            if( !mod->is_gun() && mod->type->gunmod->barrel_length > 0_mm ) {
                 l = mod->type->gunmod->barrel_length;
                 // if we find an explicit barrel mod then use that and quit the loop
                 break;


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fix #82968
#### Describe the solution
Apply snippet
#### Testing

<img width="1333" height="1190" alt="image" src="https://github.com/user-attachments/assets/b0947893-3cfa-4071-a9c0-4aa3c8abe10a" />

#### Additional context
Surprised it works natively and shows stats of gl if gl firing mode is picked 

<img width="2552" height="397" alt="image" src="https://github.com/user-attachments/assets/9f9aa6c0-f4ec-45a6-9d4e-1bbc553918c9" />