### PR TITLE
Move ACT_WAIT handlers to activity_actors

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -105,6 +105,8 @@
 #include "uilist.h"
 #include "uistate.h"
 #include "units.h"
+#include "weather.h"
+#include "weather_type.h"
 #include "value_ptr.h"
 #include "veh_interact.h"
 #include "veh_type.h"
@@ -196,8 +198,11 @@ static const activity_id ACT_UNLOAD_LOOT( "ACT_UNLOAD_LOOT" );
 static const activity_id ACT_VEHICLE( "ACT_VEHICLE" );
 static const activity_id ACT_VEHICLE_FOLD( "ACT_VEHICLE_FOLD" );
 static const activity_id ACT_VEHICLE_UNFOLD( "ACT_VEHICLE_UNFOLD" );
+static const activity_id ACT_WAIT( "ACT_WAIT" );
 static const activity_id ACT_WAIT_FOLLOWERS( "ACT_WAIT_FOLLOWERS" );
+static const activity_id ACT_WAIT_NPC( "ACT_WAIT_NPC" );
 static const activity_id ACT_WAIT_STAMINA( "ACT_WAIT_STAMINA" );
+static const activity_id ACT_WAIT_WEATHER( "ACT_WAIT_WEATHER" );
 static const activity_id ACT_WASH( "ACT_WASH" );
 static const activity_id ACT_WEAR( "ACT_WEAR" );
 static const activity_id ACT_WIELD( "ACT_WIELD" );
@@ -331,7 +336,7 @@ static const std::string gun_mechanical_simple( "gun_mechanical_simple" );
 
 std::string activity_actor::get_progress_message( const player_activity &act ) const
 {
-    if( act.moves_total > 0 ) {
+    if( act.moves_total > 0 && act.moves_total != calendar::INDEFINITELY_LONG * 100 ) {
         const int pct = ( ( act.moves_total - act.moves_left ) * 100 ) / act.moves_total;
         return string_format( "%d%%", pct );
     } else {
@@ -9978,10 +9983,27 @@ std::unique_ptr<activity_actor> butchery_activity_actor::deserialize( JsonValue 
     return actor.clone();
 }
 
-void wait_stamina_activity_actor::start( player_activity &act, Character & )
+void wait_activity_actor::start( player_activity &act, Character & )
 {
-    act.moves_total = calendar::INDEFINITELY_LONG;
-    act.moves_left = calendar::INDEFINITELY_LONG;
+    act.moves_total = to_moves<int>( initial_wait_time );
+    act.moves_left = act.moves_total;
+}
+
+void wait_activity_actor::finish( player_activity &act, Character &who )
+{
+    who.add_msg_if_player( _( "You finish waiting." ) );
+    act.set_to_null();
+}
+
+void wait_activity_actor::serialize( JsonOut &jsout ) const
+{
+    jsout.start_object();
+    jsout.end_object();
+}
+
+std::unique_ptr<activity_actor> wait_activity_actor::deserialize( JsonValue & )
+{
+    return wait_activity_actor().clone();
 }
 
 void wait_stamina_activity_actor::do_turn( player_activity &act, Character &you )
@@ -10013,20 +10035,28 @@ void wait_stamina_activity_actor::finish( player_activity &act, Character &you )
     act.set_to_null();
 }
 
-void wait_stamina_activity_actor::serialize( JsonOut &jsout ) const
-{
-    jsout.write_null();
-}
-
 std::unique_ptr<activity_actor> wait_stamina_activity_actor::deserialize( JsonValue & )
 {
     return wait_stamina_activity_actor().clone();
 }
 
-void wait_followers_activity_actor::start( player_activity &act, Character & )
+void wait_weather_activity_actor::do_turn( player_activity &act, Character &who )
 {
-    act.moves_total = calendar::INDEFINITELY_LONG;
-    act.moves_left = calendar::INDEFINITELY_LONG;
+    if( get_weather().weather_changed ) {
+        finish( act, who );
+    }
+}
+
+void wait_weather_activity_actor::finish( player_activity &act, Character &who )
+{
+    who.add_msg_if_player( string_format( _( "The weather changed to %s!" ),
+                                          get_weather().weather_id->name ) );
+    wait_activity_actor::finish( act, who );
+}
+
+std::unique_ptr<activity_actor> wait_weather_activity_actor::deserialize( JsonValue & )
+{
+    return wait_weather_activity_actor().clone();
 }
 
 std::vector<npc *> wait_followers_activity_actor::get_absent_followers( Character &you )
@@ -10036,7 +10066,6 @@ std::vector<npc *> wait_followers_activity_actor::get_absent_followers( Characte
         return ( att == NPCATT_FOLLOW || att == NPCATT_ACTIVITY ) && rl_dist( n.pos_bub(), you.pos_bub() ) > n.follow_distance();
     } );
 }
-
 
 void wait_followers_activity_actor::do_turn( player_activity &act, Character &you )
 {
@@ -10055,14 +10084,30 @@ void wait_followers_activity_actor::finish( player_activity &act, Character &you
     act.set_to_null();
 }
 
-void wait_followers_activity_actor::serialize( JsonOut &jsout ) const
-{
-    jsout.write_null();
-}
-
 std::unique_ptr<activity_actor> wait_followers_activity_actor::deserialize( JsonValue & )
 {
-    return wait_stamina_activity_actor().clone();
+    return wait_followers_activity_actor().clone();
+}
+
+void wait_npc_activity_actor::finish( player_activity &act, Character &who )
+{
+    who.add_msg_if_player( _( "%s finishes with you…" ), waiting_for_npc_name );
+    act.set_to_null();
+}
+
+void wait_npc_activity_actor::serialize( JsonOut &jsout ) const
+{
+    jsout.start_object();
+    jsout.member( "waiting_for_npc_name", waiting_for_npc_name );
+    jsout.end_object();
+}
+
+std::unique_ptr<activity_actor> wait_npc_activity_actor::deserialize( JsonValue &jsin )
+{
+    wait_npc_activity_actor actor;
+    JsonObject data = jsin.get_object();
+    data.read( "waiting_for_npc_name", actor.waiting_for_npc_name );
+    return actor.clone();
 }
 
 void zone_activity_actor::do_turn( player_activity &act, Character &you )
@@ -10401,8 +10446,11 @@ deserialize_functions = {
     { ACT_VEHICLE, &vehicle_activity_actor::deserialize },
     { ACT_VEHICLE_FOLD, &vehicle_folding_activity_actor::deserialize },
     { ACT_VEHICLE_UNFOLD, &vehicle_unfolding_activity_actor::deserialize },
+    { ACT_WAIT, &wait_activity_actor::deserialize },
     { ACT_WAIT_FOLLOWERS, &wait_followers_activity_actor::deserialize },
+    { ACT_WAIT_NPC, &wait_npc_activity_actor::deserialize },
     { ACT_WAIT_STAMINA, &wait_stamina_activity_actor::deserialize },
+    { ACT_WAIT_WEATHER, &wait_weather_activity_actor::deserialize },
     { ACT_WASH, &wash_activity_actor::deserialize },
     { ACT_WEAR, &wear_activity_actor::deserialize },
     { ACT_WIELD, &wield_activity_actor::deserialize},

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -134,9 +134,6 @@ static const activity_id ACT_TREE_COMMUNION( "ACT_TREE_COMMUNION" );
 static const activity_id ACT_VEHICLE_DECONSTRUCTION( "ACT_VEHICLE_DECONSTRUCTION" );
 static const activity_id ACT_VEHICLE_REPAIR( "ACT_VEHICLE_REPAIR" );
 static const activity_id ACT_VIBE( "ACT_VIBE" );
-static const activity_id ACT_WAIT( "ACT_WAIT" );
-static const activity_id ACT_WAIT_NPC( "ACT_WAIT_NPC" );
-static const activity_id ACT_WAIT_WEATHER( "ACT_WAIT_WEATHER" );
 
 static const ammotype ammo_battery( "battery" );
 
@@ -242,9 +239,6 @@ activity_handlers::finish_functions = {
     { ACT_HEATING, heat_item_finish },
     { ACT_MEND_ITEM, mend_item_finish },
     { ACT_TOOLMOD_ADD, toolmod_add_finish },
-    { ACT_WAIT, wait_finish },
-    { ACT_WAIT_WEATHER, wait_weather_finish },
-    { ACT_WAIT_NPC, wait_npc_finish },
     { ACT_SOCIALIZE, socialize_finish },
     { ACT_OPERATION, operation_finish },
     { ACT_VIBE, vibe_finish },
@@ -1484,18 +1478,6 @@ void activity_handlers::dismember_do_turn( player_activity * /*act*/, Character 
     you->burn_energy_arms( -20 );
 }
 
-void activity_handlers::wait_finish( player_activity *act, Character *you )
-{
-    you->add_msg_if_player( _( "You finish waiting." ) );
-    act->set_to_null();
-}
-
-void activity_handlers::wait_weather_finish( player_activity *act, Character *you )
-{
-    you->add_msg_if_player( _( "You finish waiting." ) );
-    act->set_to_null();
-}
-
 void activity_handlers::find_mount_do_turn( player_activity *act, Character *you )
 {
     //npc only activity
@@ -1539,12 +1521,6 @@ void activity_handlers::find_mount_do_turn( player_activity *act, Character *you
             you->set_destination( route, player_activity( ACT_FIND_MOUNT ) );
         }
     }
-}
-
-void activity_handlers::wait_npc_finish( player_activity *act, Character *you )
-{
-    you->add_msg_if_player( _( "%s finishes with you…" ), act->str_values[0] );
-    act->set_to_null();
 }
 
 void activity_handlers::socialize_finish( player_activity *act, Character *you )

--- a/src/activity_handlers.h
+++ b/src/activity_handlers.h
@@ -258,9 +258,7 @@ void teach_finish( player_activity *act, Character *you );
 void toolmod_add_finish( player_activity *act, Character *you );
 void train_finish( player_activity *act, Character *you );
 void vibe_finish( player_activity *act, Character *you );
-void wait_finish( player_activity *act, Character *you );
 void wait_npc_finish( player_activity *act, Character *you );
-void wait_weather_finish( player_activity *act, Character *you );
 
 int move_cost( const item &it, const tripoint_bub_ms &src, const tripoint_bub_ms &dest );
 int move_cost_cart( const item &it, const tripoint_bub_ms &src, const tripoint_bub_ms &dest,

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -122,10 +122,6 @@ static const activity_id ACT_MULTIPLE_STUDY( "ACT_MULTIPLE_STUDY" );
 static const activity_id ACT_SPELLCASTING( "ACT_SPELLCASTING" );
 static const activity_id ACT_VEHICLE_DECONSTRUCTION( "ACT_VEHICLE_DECONSTRUCTION" );
 static const activity_id ACT_VEHICLE_REPAIR( "ACT_VEHICLE_REPAIR" );
-static const activity_id ACT_WAIT( "ACT_WAIT" );
-static const activity_id ACT_WAIT_FOLLOWERS( "ACT_WAIT_FOLLOWERS" );
-static const activity_id ACT_WAIT_STAMINA( "ACT_WAIT_STAMINA" );
-static const activity_id ACT_WAIT_WEATHER( "ACT_WAIT_WEATHER" );
 
 static const bionic_id bio_remote( "bio_remote" );
 
@@ -1314,22 +1310,13 @@ static void wait()
         // Waiting
         activity_id actType;
         if( as_m.ret == 13 ) {
-            actType = ACT_WAIT_WEATHER;
+            player_character.assign_activity( wait_weather_activity_actor() );
         } else if( as_m.ret == 14 ) {
-            actType = ACT_WAIT_STAMINA;
-        } else if( as_m.ret == 15 ) {
-            actType = ACT_WAIT_FOLLOWERS;
-        } else {
-            actType = ACT_WAIT;
-        }
-
-        if( actType == ACT_WAIT_STAMINA ) {
             player_character.assign_activity( wait_stamina_activity_actor() );
-        } else if( actType == ACT_WAIT_FOLLOWERS ) {
+        } else if( as_m.ret == 15 ) {
             player_character.assign_activity( wait_followers_activity_actor() );
         } else {
-            player_activity new_act( actType, 100 * to_turns<int>( time_to_wait ), 0 );
-            player_character.assign_activity( new_act );
+            player_character.assign_activity( wait_activity_actor( time_to_wait ) );
         }
     }
 }

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -77,7 +77,6 @@ static const activity_id ACT_TRAIN( "ACT_TRAIN" );
 static const activity_id ACT_TRAIN_TEACHER( "ACT_TRAIN_TEACHER" );
 static const activity_id ACT_VEHICLE_DECONSTRUCTION( "ACT_VEHICLE_DECONSTRUCTION" );
 static const activity_id ACT_VEHICLE_REPAIR( "ACT_VEHICLE_REPAIR" );
-static const activity_id ACT_WAIT_NPC( "ACT_WAIT_NPC" );
 
 static const efftype_id effect_allow_sleep( "allow_sleep" );
 static const efftype_id effect_asked_for_item( "asked_for_item" );
@@ -685,9 +684,8 @@ void talk_function::lesser_give_aid( npc &p )
             player_character.remove_effect( effect_bleed, bp );
         }
     }
-    const int moves = to_moves<int>( 15_minutes );
-    player_character.assign_activity( ACT_WAIT_NPC, moves );
-    player_character.activity.str_values.push_back( p.get_name() );
+    player_character.assign_activity( wait_npc_activity_actor( 15_minutes, p.get_name() ) );
+
     p.add_effect( effect_currently_busy, 60_minutes );
 }
 
@@ -707,10 +705,7 @@ void talk_function::lesser_give_all_aid( npc &p )
             }
         }
     }
-
-    const int moves = to_moves<int>( 30_minutes );
-    player_character.assign_activity( ACT_WAIT_NPC, moves );
-    player_character.activity.str_values.push_back( p.get_name() );
+    player_character.assign_activity( wait_npc_activity_actor( 30_minutes, p.get_name() ) );
     p.add_effect( effect_currently_busy, 120_minutes );
 }
 
@@ -730,10 +725,7 @@ void talk_function::give_aid( npc &p )
             player_character.remove_effect( effect_infected, bp );
         }
     }
-
-    const int moves = to_moves<int>( 30_minutes );
-    player_character.assign_activity( ACT_WAIT_NPC, moves );
-    player_character.activity.str_values.push_back( p.get_name() );
+    player_character.assign_activity( wait_npc_activity_actor( 30_minutes, p.get_name() ) );
     p.add_effect( effect_currently_busy, 120_minutes );
 }
 
@@ -759,10 +751,7 @@ void talk_function::give_all_aid( npc &p )
             }
         }
     }
-
-    const int moves = to_moves<int>( 60_minutes );
-    player_character.assign_activity( ACT_WAIT_NPC, moves );
-    player_character.activity.str_values.push_back( p.get_name() );
+    player_character.assign_activity( wait_npc_activity_actor( 60_minutes, p.get_name() ) );
     p.add_effect( effect_currently_busy, 240_minutes );
 }
 
@@ -814,9 +803,7 @@ void talk_function::buy_haircut( npc &p )
 {
     Character &player_character = get_player_character();
     player_character.add_morale( morale_haircut, 5, 5, 720_minutes, 3_minutes );
-    const int moves = to_moves<int>( 20_minutes );
-    player_character.assign_activity( ACT_WAIT_NPC, moves );
-    player_character.activity.str_values.push_back( p.get_name() );
+    player_character.assign_activity( wait_npc_activity_actor( 20_minutes, p.get_name() ) );
     add_msg( m_good, _( "%s gives you a decent haircut…" ), p.get_name() );
 }
 
@@ -824,9 +811,7 @@ void talk_function::buy_shave( npc &p )
 {
     Character &player_character = get_player_character();
     player_character.add_morale( morale_shave, 10, 10, 360_minutes, 3_minutes );
-    const int moves = to_moves<int>( 5_minutes );
-    player_character.assign_activity( ACT_WAIT_NPC, moves );
-    player_character.activity.str_values.push_back( p.get_name() );
+    player_character.assign_activity( wait_npc_activity_actor( 5_minutes, p.get_name() ) );
     add_msg( m_good, _( "%s gives you a decent shave…" ), p.get_name() );
 }
 

--- a/src/savegame_legacy.cpp
+++ b/src/savegame_legacy.cpp
@@ -30,9 +30,6 @@ static const activity_id ACT_START_ENGINES( "ACT_START_ENGINES" );
 static const activity_id ACT_START_FIRE( "ACT_START_FIRE" );
 static const activity_id ACT_TRAIN( "ACT_TRAIN" );
 static const activity_id ACT_VIBE( "ACT_VIBE" );
-static const activity_id ACT_WAIT( "ACT_WAIT" );
-static const activity_id ACT_WAIT_NPC( "ACT_WAIT_NPC" );
-static const activity_id ACT_WAIT_WEATHER( "ACT_WAIT_WEATHER" );
 
 namespace std
 {
@@ -204,7 +201,7 @@ void player_activity::deserialize_legacy_type( int legacy_type, activity_id &des
         ACT_RELOAD,
         activity_id::NULL_ID(), // ACT_READ is an actor now
         activity_id::NULL_ID(), // ACT_GAME is an actor now
-        ACT_WAIT,
+        activity_id::NULL_ID(), // ACT_WAIT is an actor now
         activity_id::NULL_ID(), // ACT_CRAFT is an actor now
         activity_id::NULL_ID(), // ACT_LONGCRAFT is deprecated
         ACT_DISASSEMBLE,
@@ -215,7 +212,7 @@ void player_activity::deserialize_legacy_type( int legacy_type, activity_id &des
         activity_id::NULL_ID(), // ACT_VEHICLE is an actor now
         activity_id::NULL_ID(), // ACT_REFILL_VEHICLE is deprecated
         ACT_TRAIN,
-        ACT_WAIT_WEATHER,
+        activity_id::NULL_ID(), // ACT_WAIT_WEATHER is an actor now
         activity_id::NULL_ID(), // ACT_FIRSTAID is an actor now
         activity_id::NULL_ID(), //ACT_FISH is an actor now
         activity_id::NULL_ID(), //ACT_PICKAXE is an actor now
@@ -241,7 +238,7 @@ void player_activity::deserialize_legacy_type( int legacy_type, activity_id &des
         ACT_REPAIR_ITEM,
         ACT_MEND_ITEM,
         activity_id::NULL_ID(), // ACT_GUNMOD_ADD
-        ACT_WAIT_NPC,
+        activity_id::NULL_ID(), // ACT_WAIT_NPC is an actor now
         activity_id::NULL_ID(), // ACT_CLEAR_RUBBLE
         ACT_MEDITATE,
         activity_id::NULL_ID() // NUM_ACTIVITIES

--- a/src/weather.h
+++ b/src/weather.h
@@ -205,6 +205,8 @@ class weather_manager
         weather_type_id weather_id = WEATHER_NULL;
         int winddirection = 0;
         int windspeed = 0;
+        // whether the last update_weather() resulted in `weather_id` changing
+        bool weather_changed = false;
 
         // For debug menu option "Force temperature"
         std::optional<units::temperature> forced_temperature;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Infrastructure "move ACT_WAIT handlers to activity_actors"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Update legacy activities.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

See title. Notes:
- The updated handlers are: ACT_WAIT, ACT_WAIT_WEATHER, ACT_WAIT_NPC to `wait_activity_actor`, `wait_weather_activity_actor`, and `wait_npc_activity_actor` respectively.
- All wait activity actors inherit from wait_activity_actor and show progress if a wait time is provided.
- `weather_manager` caches weather changes from `update_weather()` so that `wait_weather_activity_actor` reads from the manager instead of the manager cancelling the activity.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

- Waited with various time durations in the '\\' menu successfully.
- Waited for followers to catch up successfully.
- Waited for stamina to recover successfully.
- Assigned talk topic `TALK_RANCH_DOCTOR_AID_DONE` to an NPC, received both `give_aid` effect and the assigned wait.
- Waited for weather to change successfully.
- Waited through an autosave in 0.H, confirmed no errors/crashes and legacy activity cancelled when loaded with these changes.
- Waited through an autosave and reloaded, still waiting as intended on load.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
