### PR TITLE
Improved controller support with an alternate button layout triggered via LT, radial menus and RT to confirm movement

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -18,7 +18,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_R_UP"
+        "key": "RS_UP"
       }
     ]
   },
@@ -41,7 +41,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_R_DOWN"
+        "key": "RS_DOWN"
       }
     ]
   },
@@ -64,7 +64,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_R_LEFT"
+        "key": "RS_LEFT"
       }
     ]
   },
@@ -87,7 +87,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_R_RIGHT"
+        "key": "RS_RIGHT"
       }
     ]
   },
@@ -152,7 +152,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_L_UP"
+        "key": "LS_UP"
       }
     ]
   },
@@ -179,7 +179,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_L_DOWN"
+        "key": "LS_DOWN"
       }
     ]
   },
@@ -206,7 +206,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_L_LEFT"
+        "key": "LS_LEFT"
       }
     ]
   },
@@ -233,7 +233,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_L_RIGHT"
+        "key": "LS_RIGHT"
       }
     ]
   },
@@ -256,7 +256,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_L_LEFTUP"
+        "key": "LS_UP_LEFT"
       }
     ]
   },
@@ -279,7 +279,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_L_RIGHTUP"
+        "key": "LS_UP_RIGHT"
       }
     ]
   },
@@ -302,7 +302,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_L_LEFTDOWN"
+        "key": "LS_DOWN_LEFT"
       }
     ]
   },
@@ -325,7 +325,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_L_RIGHTDOWN"
+        "key": "LS_DOWN_RIGHT"
       }
     ]
   },
@@ -426,7 +426,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_R_UP"
+        "key": "ALT_UP"
       }
     ]
   },
@@ -449,7 +449,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_R_DOWN"
+        "key": "ALT_DOWN"
       }
     ]
   },
@@ -469,7 +469,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_UP"
+        "key": "UP"
       }
     ]
   },
@@ -489,7 +489,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_DOWN"
+        "key": "DOWN"
       }
     ]
   },
@@ -509,7 +509,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_LEFT"
+        "key": "LEFT"
       }
     ]
   },
@@ -660,7 +660,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_R_UP"
+        "key": "ALT_UP"
       }
     ]
   },
@@ -683,7 +683,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_R_DOWN"
+        "key": "ALT_DOWN"
       }
     ]
   },
@@ -984,7 +984,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
+        "key": "L_RADIAL_N"
       }
     ]
   },
@@ -1011,7 +1011,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NE"
+        "key": "L_RADIAL_NE"
       }
     ]
   },
@@ -1038,7 +1038,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_E"
+        "key": "L_RADIAL_E"
       }
     ]
   },
@@ -1065,7 +1065,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SE"
+        "key": "L_RADIAL_SE"
       }
     ]
   },
@@ -1092,7 +1092,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_S"
+        "key": "L_RADIAL_S"
       }
     ]
   },
@@ -1119,7 +1119,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SW"
+        "key": "L_RADIAL_SW"
       }
     ]
   },
@@ -1146,7 +1146,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_W"
+        "key": "L_RADIAL_W"
       }
     ]
   },
@@ -1170,7 +1170,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_ALT_DPAD_UP"
+        "key": "ALT_UP"
       }
     ]
   },
@@ -1190,7 +1190,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_ALT_DPAD_DOWN"
+        "key": "ALT_DOWN"
       }
     ]
   },
@@ -1217,7 +1217,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NW"
+        "key": "L_RADIAL_NW"
       }
     ]
   },
@@ -1244,7 +1244,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_N"
+        "key": "R_RADIAL_N"
       }
     ]
   },
@@ -1359,7 +1359,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
+        "key": "L_RADIAL_N"
       }
     ]
   },
@@ -1382,7 +1382,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NE"
+        "key": "L_RADIAL_NE"
       }
     ]
   },
@@ -1398,7 +1398,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_E"
+        "key": "L_RADIAL_E"
       }
     ]
   },
@@ -1421,7 +1421,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SE"
+        "key": "L_RADIAL_SE"
       }
     ]
   },
@@ -1444,7 +1444,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_R_UP"
+        "key": "ALT_UP"
       }
     ]
   },
@@ -1467,7 +1467,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_R_DOWN"
+        "key": "ALT_DOWN"
       }
     ]
   },
@@ -1483,7 +1483,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_S"
+        "key": "L_RADIAL_S"
       }
     ]
   },
@@ -1506,7 +1506,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SW"
+        "key": "L_RADIAL_SW"
       }
     ]
   },
@@ -1522,7 +1522,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_W"
+        "key": "L_RADIAL_W"
       }
     ]
   },
@@ -1661,7 +1661,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
+        "key": "L_RADIAL_N"
       }
     ]
   },
@@ -1684,7 +1684,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NE"
+        "key": "L_RADIAL_NE"
       }
     ]
   },
@@ -1700,7 +1700,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_E"
+        "key": "L_RADIAL_E"
       }
     ]
   },
@@ -1716,7 +1716,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SE"
+        "key": "L_RADIAL_SE"
       }
     ]
   },
@@ -1734,7 +1734,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_S"
+        "key": "L_RADIAL_S"
       }
     ]
   },
@@ -1757,7 +1757,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_R_UP"
+        "key": "ALT_UP"
       }
     ]
   },
@@ -1780,7 +1780,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_R_DOWN"
+        "key": "ALT_DOWN"
       }
     ]
   },
@@ -1803,7 +1803,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_SW"
+        "key": "R_RADIAL_SW"
       }
     ]
   },
@@ -1830,7 +1830,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_W"
+        "key": "L_RADIAL_SW"
       }
     ]
   },
@@ -1853,7 +1853,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NW"
+        "key": "L_RADIAL_NW"
       }
     ]
   },
@@ -1879,7 +1879,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_ALT_DPAD_UP"
+        "key": "ALT_UP"
       }
     ]
   },
@@ -1905,7 +1905,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_ALT_DPAD_DOWN"
+        "key": "ALT_DOWN"
       }
     ]
   },
@@ -1929,7 +1929,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
+        "key": "L_RADIAL_N"
       }
     ]
   },
@@ -1949,7 +1949,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NE"
+        "key": "L_RADIAL_NE"
       }
     ]
   },
@@ -1965,7 +1965,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_E"
+        "key": "L_RADIAL_E"
       }
     ]
   },
@@ -1981,7 +1981,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SE"
+        "key": "L_RADIAL_SE"
       }
     ]
   },
@@ -1997,7 +1997,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
+        "key": "L_RADIAL_N"
       }
     ]
   },
@@ -2013,7 +2013,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NE"
+        "key": "L_RADIAL_NE"
       }
     ]
   },
@@ -2029,7 +2029,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
+        "key": "L_RADIAL_N"
       }
     ]
   },
@@ -2049,7 +2049,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NE"
+        "key": "L_RADIAL_NE"
       }
     ]
   },
@@ -2065,7 +2065,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_E"
+        "key": "L_RADIAL_E"
       }
     ]
   },
@@ -2107,7 +2107,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
+        "key": "L_RADIAL_N"
       }
     ]
   },
@@ -2123,7 +2123,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NE"
+        "key": "L_RADIAL_NE"
       }
     ]
   },
@@ -2147,7 +2147,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_E"
+        "key": "L_RADIAL_E"
       }
     ]
   },
@@ -2167,7 +2167,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SE"
+        "key": "L_RADIAL_SE"
       }
     ]
   },
@@ -2333,7 +2333,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
+        "key": "L_RADIAL_N"
       }
     ]
   },
@@ -2396,7 +2396,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NE"
+        "key": "L_RADIAL_NE"
       }
     ]
   },
@@ -2423,7 +2423,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_E"
+        "key": "L_RADIAL_E"
       }
     ]
   },
@@ -2450,7 +2450,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SE"
+        "key": "L_RADIAL_SE"
       }
     ]
   },
@@ -2477,7 +2477,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_S"
+        "key": "L_RADIAL_S"
       }
     ]
   },
@@ -2504,7 +2504,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SW"
+        "key": "L_RADIAL_SW"
       }
     ]
   },
@@ -2701,6 +2701,10 @@
         "mod": [
           "shift"
         ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "L_RADIAL_SW"
       }
     ]
   },
@@ -2720,6 +2724,10 @@
         "mod": [
           "shift"
         ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "L_RADIAL_W"
       }
     ]
   },
@@ -2758,6 +2766,10 @@
         "mod": [
           "shift"
         ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "R_RADIAL_N"
       }
     ]
   },
@@ -2777,6 +2789,10 @@
         "mod": [
           "shift"
         ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "R_RADIAL_NE"
       }
     ]
   },
@@ -2796,6 +2812,10 @@
         "mod": [
           "shift"
         ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "R_RADIAL_E"
       }
     ]
   },
@@ -2815,6 +2835,10 @@
         "mod": [
           "shift"
         ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "R_RADIAL_SE"
       }
     ]
   },
@@ -2834,6 +2858,10 @@
         "mod": [
           "shift"
         ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "R_RADIAL_S"
       }
     ]
   },
@@ -2853,6 +2881,10 @@
         "mod": [
           "shift"
         ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "R_RADIAL_SW"
       }
     ]
   },
@@ -2865,6 +2897,10 @@
       {
         "input_method": "keyboard_any",
         "key": "w"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "R_RADIAL_W"
       }
     ]
   },
@@ -2884,6 +2920,10 @@
         "mod": [
           "shift"
         ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "R_RADIAL_NW"
       }
     ]
   },
@@ -2906,7 +2946,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
+        "key": "L_RADIAL_S"
       }
     ]
   },
@@ -2953,7 +2993,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NE"
+        "key": "L_RADIAL_NE"
       }
     ]
   },
@@ -3076,6 +3116,10 @@
         "mod": [
           "shift"
         ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "L_RADIAL_SW"
       }
     ]
   },
@@ -3186,6 +3230,10 @@
         "mod": [
           "shift"
         ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "L_RADIAL_N"
       }
     ]
   },
@@ -3197,6 +3245,10 @@
       {
         "input_method": "keyboard_any",
         "key": "g"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "L_RADIAL_NE"
       }
     ]
   },
@@ -3208,6 +3260,10 @@
       {
         "input_method": "keyboard_any",
         "key": "c"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "L_RADIAL_E"
       }
     ]
   },
@@ -3262,7 +3318,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_LB"
+        "key": "LB"
       }
     ]
   },
@@ -3286,7 +3342,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RB"
+        "key": "RB"
       }
     ]
   },
@@ -3314,7 +3370,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RT"
+        "key": "RT"
       }
     ]
   },
@@ -3342,7 +3398,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
+        "key": "L_RADIAL_N"
       }
     ]
   },
@@ -3358,7 +3414,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NE"
+        "key": "L_RADIAL_NE"
       }
     ]
   },
@@ -3374,7 +3430,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_E"
+        "key": "L_RADIAL_E"
       }
     ]
   },
@@ -3390,7 +3446,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SE"
+        "key": "L_RADIAL_SE"
       }
     ]
   },
@@ -3417,7 +3473,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_S"
+        "key": "L_RADIAL_S"
       }
     ]
   },
@@ -3472,7 +3528,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_S"
+        "key": "L_RADIAL_S"
       }
     ]
   },
@@ -3488,7 +3544,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SW"
+        "key": "L_RADIAL_SW"
       }
     ]
   },
@@ -3582,7 +3638,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RB"
+        "key": "RB"
       }
     ]
   },
@@ -3604,7 +3660,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_LB"
+        "key": "LB"
       }
     ]
   },
@@ -3630,7 +3686,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RS"
+        "key": "RS"
       }
     ]
   },
@@ -3759,7 +3815,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_NE"
+        "key": "R_RADIAL_NE"
       }
     ]
   },
@@ -4198,7 +4254,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_R_DOWN"
+        "key": "RS_DOWN"
       }
     ]
   },
@@ -4220,7 +4276,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_R_UP"
+        "key": "ALT_UP"
       }
     ]
   },
@@ -4242,7 +4298,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_R_DOWN"
+        "key": "ALT_DOWN"
       }
     ]
   },
@@ -4296,7 +4352,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
+        "key": "L_RADIAL_N"
       }
     ]
   },
@@ -4312,7 +4368,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NE"
+        "key": "L_RADIAL_NE"
       }
     ]
   },
@@ -4328,7 +4384,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_E"
+        "key": "L_RADIAL_E"
       }
     ]
   },
@@ -4344,7 +4400,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SE"
+        "key": "L_RADIAL_SE"
       }
     ]
   },
@@ -4360,7 +4416,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_S"
+        "key": "L_RADIAL_S"
       }
     ]
   },
@@ -4376,7 +4432,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SW"
+        "key": "L_RADIAL_SW"
       }
     ]
   },
@@ -4392,7 +4448,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
+        "key": "L_RADIAL_N"
       }
     ]
   },
@@ -4408,7 +4464,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NE"
+        "key": "L_RADIAL_NE"
       }
     ]
   },
@@ -4424,7 +4480,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_E"
+        "key": "L_RADIAL_E"
       }
     ]
   },
@@ -4440,7 +4496,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SE"
+        "key": "L_RADIAL_SE"
       }
     ]
   },
@@ -4456,7 +4512,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_S"
+        "key": "L_RADIAL_S"
       }
     ]
   },
@@ -4472,7 +4528,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SW"
+        "key": "L_RADIAL_SW"
       }
     ]
   },
@@ -4488,7 +4544,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_N"
+        "key": "R_RADIAL_N"
       }
     ]
   },
@@ -4504,7 +4560,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_W"
+        "key": "L_RADIAL_W"
       }
     ]
   },
@@ -4520,7 +4576,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NW"
+        "key": "L_RADIAL_NW"
       }
     ]
   },
@@ -4536,7 +4592,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_NE"
+        "key": "R_RADIAL_NE"
       }
     ]
   },
@@ -4552,7 +4608,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_E"
+        "key": "R_RADIAL_E"
       }
     ]
   },
@@ -4568,7 +4624,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_SE"
+        "key": "R_RADIAL_SE"
       }
     ]
   },
@@ -4615,7 +4671,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_ALT_DPAD_UP"
+        "key": "ALT_UP"
       }
     ]
   },
@@ -4631,7 +4687,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_ALT_DPAD_DOWN"
+        "key": "ALT_DOWN"
       }
     ]
   },
@@ -4654,7 +4710,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_ALT_DPAD_UP"
+        "key": "ALT_UP"
       }
     ]
   },
@@ -4677,7 +4733,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_R_DOWN"
+        "key": "ALT_DOWN"
       }
     ]
   },
@@ -4700,7 +4756,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_R_UP"
+        "key": "ALT_UP"
       }
     ]
   },
@@ -4723,7 +4779,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_ALT_DPAD_DOWN"
+        "key": "ALT_DOWN"
       }
     ]
   },
@@ -4739,7 +4795,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
+        "key": "L_RADIAL_N"
       }
     ]
   },
@@ -4762,7 +4818,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_ALT_DPAD_DOWN"
+        "key": "ALT_DOWN"
       }
     ]
   },
@@ -4785,7 +4841,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_ALT_DPAD_UP"
+        "key": "ALT_UP"
       }
     ]
   },
@@ -5119,7 +5175,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SW"
+        "key": "L_RADIAL_SW"
       }
     ]
   },
@@ -5135,7 +5191,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
+        "key": "L_RADIAL_N"
       }
     ]
   },
@@ -5151,7 +5207,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_E"
+        "key": "L_RADIAL_E"
       }
     ]
   },
@@ -5174,7 +5230,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_W"
+        "key": "L_RADIAL_W"
       }
     ]
   },
@@ -5190,7 +5246,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NE"
+        "key": "L_RADIAL_NE"
       }
     ]
   },
@@ -5206,7 +5262,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SE"
+        "key": "L_RADIAL_SE"
       }
     ]
   },
@@ -5233,7 +5289,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NW"
+        "key": "L_RADIAL_NW"
       }
     ]
   },
@@ -5256,7 +5312,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_S"
+        "key": "L_RADIAL_S"
       }
     ]
   },
@@ -5310,7 +5366,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
+        "key": "L_RADIAL_N"
       }
     ]
   },
@@ -5333,7 +5389,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NE"
+        "key": "L_RADIAL_NE"
       }
     ]
   },
@@ -5356,7 +5412,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_E"
+        "key": "L_RADIAL_E"
       }
     ]
   },
@@ -5379,7 +5435,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SE"
+        "key": "L_RADIAL_SE"
       }
     ]
   },
@@ -5402,7 +5458,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_S"
+        "key": "L_RADIAL_S"
       }
     ]
   },
@@ -5418,7 +5474,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SW"
+        "key": "L_RADIAL_SW"
       }
     ]
   },
@@ -5441,7 +5497,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
+        "key": "L_RADIAL_N"
       }
     ]
   },
@@ -5464,7 +5520,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_R_UP"
+        "key": "ALT_UP"
       }
     ]
   },
@@ -5487,7 +5543,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_R_DOWN"
+        "key": "ALT_DOWN"
       }
     ]
   },
@@ -5510,7 +5566,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
+        "key": "L_RADIAL_N"
       }
     ]
   },
@@ -5538,7 +5594,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RT"
+        "key": "RT"
       }
     ]
   },
@@ -5568,7 +5624,7 @@
     "bindings": [
       {
         "input_method": "gamepad",
-        "key": "JOY_R_UP"
+        "key": "RS_UP"
       }
     ]
   },
@@ -5580,7 +5636,7 @@
     "bindings": [
       {
         "input_method": "gamepad",
-        "key": "JOY_R_RIGHT"
+        "key": "RS_RIGHT"
       }
     ]
   },
@@ -5592,7 +5648,7 @@
     "bindings": [
       {
         "input_method": "gamepad",
-        "key": "JOY_R_DOWN"
+        "key": "RS_DOWN"
       }
     ]
   },
@@ -5604,7 +5660,7 @@
     "bindings": [
       {
         "input_method": "gamepad",
-        "key": "JOY_R_LEFT"
+        "key": "RS_LEFT"
       }
     ]
   },
@@ -5644,7 +5700,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_ALT_X"
+        "key": "ALT_X"
       }
     ]
   },
@@ -5668,7 +5724,7 @@
     "bindings": [
       {
         "input_method": "gamepad",
-        "key": "JOY_X"
+        "key": "X"
       }
     ]
   },
@@ -5688,7 +5744,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_SE"
+        "key": "R_RADIAL_SE"
       }
     ]
   },
@@ -5729,7 +5785,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_B"
+        "key": "B"
       }
     ]
   },
@@ -5745,7 +5801,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_ALT_B"
+        "key": "ALT_B"
       }
     ]
   },
@@ -5790,10 +5846,6 @@
         "mod": [
           "shift"
         ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_E"
       }
     ]
   },
@@ -5813,6 +5865,10 @@
         "mod": [
           "shift"
         ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "L_RADIAL_E"
       }
     ]
   },
@@ -5857,7 +5913,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_ALT_RS"
+        "key": "ALT_RS"
       }
     ]
   },
@@ -5880,7 +5936,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RS"
+        "key": "RS"
       }
     ]
   },
@@ -5915,7 +5971,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_S"
+        "key": "R_RADIAL_S"
       }
     ]
   },
@@ -5981,7 +6037,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_ALT_DPAD_RIGHT"
+        "key": "ALT_RIGHT"
       }
     ]
   },
@@ -6004,7 +6060,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_DPAD_LEFT"
+        "key": "LEFT"
       }
     ]
   },
@@ -6027,7 +6083,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_ALT_DPAD_LEFT"
+        "key": "ALT_LEFT"
       }
     ]
   },
@@ -6050,7 +6106,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_DPAD_UP"
+        "key": "UP"
       }
     ]
   },
@@ -6079,7 +6135,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NE"
+        "key": "L_RADIAL_NE"
       }
     ]
   },
@@ -6095,7 +6151,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_DPAD_RIGHT"
+        "key": "RIGHT"
       }
     ]
   },
@@ -6118,7 +6174,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_ALT_RB"
+        "key": "ALT_RB"
       }
     ]
   },
@@ -6162,6 +6218,10 @@
         "mod": [
           "shift"
         ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "L_RADIAL_NW"
       }
     ]
   },
@@ -6177,7 +6237,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_Y"
+        "key": "Y"
       }
     ]
   },
@@ -6217,7 +6277,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_LB"
+        "key": "LB"
       }
     ]
   },
@@ -6264,7 +6324,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_DPAD_DOWN"
+        "key": "DOWN"
       }
     ]
   },
@@ -6336,7 +6396,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_NE"
+        "key": "R_RADIAL_NE"
       }
     ]
   },
@@ -6359,7 +6419,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_SW"
+        "key": "R_RADIAL_SW"
       }
     ]
   },
@@ -6405,7 +6465,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SE"
+        "key": "L_RADIAL_SE"
       }
     ]
   },
@@ -6428,7 +6488,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
+        "key": "L_RADIAL_N"
       }
     ]
   },
@@ -6445,10 +6505,6 @@
       {
         "input_method": "keyboard_code",
         "key": "KEYPAD_MINUS"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NW"
       }
     ]
   },
@@ -6475,7 +6531,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_S"
+        "key": "L_RADIAL_S"
       }
     ]
   },
@@ -6498,7 +6554,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_W"
+        "key": "L_RADIAL_W"
       }
     ]
   },
@@ -6521,7 +6577,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SW"
+        "key": "L_RADIAL_SW"
       }
     ]
   },
@@ -6575,7 +6631,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_ALT_LS"
+        "key": "ALT_LS"
       }
     ]
   },
@@ -6591,7 +6647,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_LS"
+        "key": "LS"
       }
     ]
   },
@@ -6658,7 +6714,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_N"
+        "key": "R_RADIAL_N"
       }
     ]
   },
@@ -6674,7 +6730,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_BACK"
+        "key": "BACK"
       }
     ]
   },
@@ -6714,7 +6770,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_W"
+        "key": "R_RADIAL_W"
       }
     ]
   },
@@ -6737,7 +6793,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_E"
+        "key": "R_RADIAL_E"
       }
     ]
   },
@@ -6749,7 +6805,7 @@
     "bindings": [
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_NW"
+        "key": "R_RADIAL_NW"
       }
     ]
   },
@@ -6799,7 +6855,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_ALT_START"
+        "key": "ALT_START"
       }
     ]
   },
@@ -6821,7 +6877,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_ALT_BACK"
+        "key": "ALT_BACK"
       }
     ]
   },
@@ -7027,7 +7083,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_ALT_LB"
+        "key": "ALT_LB"
       }
     ]
   },
@@ -7089,7 +7145,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_A"
+        "key": "A"
       }
     ]
   },
@@ -7112,7 +7168,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_ALT_A"
+        "key": "ALT_A"
       }
     ]
   },
@@ -7136,7 +7192,7 @@
     "bindings": [
       {
         "input_method": "gamepad",
-        "key": "JOY_R_RIGHTUP"
+        "key": "RS_UP_RIGHT"
       }
     ]
   },
@@ -7148,7 +7204,7 @@
     "bindings": [
       {
         "input_method": "gamepad",
-        "key": "JOY_R_RIGHTDOWN"
+        "key": "RS_DOWN_RIGHT"
       }
     ]
   },
@@ -7160,7 +7216,7 @@
     "bindings": [
       {
         "input_method": "gamepad",
-        "key": "JOY_R_LEFTDOWN"
+        "key": "RS_DOWN_LEFT"
       }
     ]
   },
@@ -7172,7 +7228,7 @@
     "bindings": [
       {
         "input_method": "gamepad",
-        "key": "JOY_R_LEFTUP"
+        "key": "RS_UP_LEFT"
       }
     ]
   },
@@ -7206,7 +7262,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RB"
+        "key": "RB"
       }
     ]
   },
@@ -7222,7 +7278,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_START"
+        "key": "START"
       }
     ]
   },
@@ -7324,7 +7380,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_ALT_RT"
+        "key": "ALT_RT"
       }
     ]
   },
@@ -7340,7 +7396,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_ALT_Y"
+        "key": "ALT_Y"
       }
     ]
   },
@@ -7388,7 +7444,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_R_UP"
+        "key": "ALT_UP"
       }
     ]
   },
@@ -7411,7 +7467,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_R_DOWN"
+        "key": "ALT_DOWN"
       }
     ]
   },
@@ -7449,7 +7505,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NE"
+        "key": "L_RADIAL_NE"
       }
     ]
   },
@@ -7476,7 +7532,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
+        "key": "L_RADIAL_N"
       }
     ]
   },
@@ -7500,7 +7556,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_E"
+        "key": "L_RADIAL_E"
       }
     ]
   },
@@ -7520,7 +7576,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_W"
+        "key": "L_RADIAL_W"
       }
     ]
   },
@@ -7547,7 +7603,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SE"
+        "key": "L_RADIAL_SE"
       }
     ]
   },
@@ -7563,7 +7619,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
+        "key": "L_RADIAL_N"
       }
     ]
   },
@@ -7579,7 +7635,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_S"
+        "key": "L_RADIAL_S"
       }
     ]
   },
@@ -7595,7 +7651,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_E"
+        "key": "L_RADIAL_E"
       }
     ]
   },
@@ -7614,7 +7670,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_W"
+        "key": "L_RADIAL_W"
       }
     ]
   },
@@ -7637,7 +7693,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RS"
+        "key": "RS"
       }
     ]
   },
@@ -7673,7 +7729,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_UP"
+        "key": "UP"
       }
     ]
   },
@@ -7697,7 +7753,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_DOWN"
+        "key": "DOWN"
       }
     ]
   },
@@ -7745,7 +7801,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_UP"
+        "key": "UP"
       }
     ]
   },
@@ -7769,7 +7825,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_DOWN"
+        "key": "DOWN"
       }
     ]
   },
@@ -7923,7 +7979,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
+        "key": "L_RADIAL_N"
       }
     ]
   },
@@ -7950,7 +8006,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NE"
+        "key": "L_RADIAL_NE"
       }
     ]
   },
@@ -7977,7 +8033,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_E"
+        "key": "L_RADIAL_E"
       }
     ]
   },
@@ -8001,7 +8057,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_ALT_DPAD_UP"
+        "key": "ALT_UP"
       }
     ]
   },
@@ -8021,7 +8077,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_ALT_DPAD_DOWN"
+        "key": "ALT_DOWN"
       }
     ]
   },
@@ -8048,7 +8104,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SE"
+        "key": "L_RADIAL_SE"
       }
     ]
   },
@@ -8075,7 +8131,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_S"
+        "key": "L_RADIAL_S"
       }
     ]
   },
@@ -8102,7 +8158,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SW"
+        "key": "L_RADIAL_SW"
       }
     ]
   },
@@ -8129,7 +8185,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_W"
+        "key": "L_RADIAL_W"
       }
     ]
   },
@@ -8156,7 +8212,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NW"
+        "key": "L_RADIAL_NW"
       }
     ]
   },
@@ -8183,7 +8239,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_N"
+        "key": "R_RADIAL_N"
       }
     ]
   },
@@ -8210,7 +8266,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_NE"
+        "key": "R_RADIAL_NE"
       }
     ]
   },
@@ -8237,7 +8293,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_E"
+        "key": "R_RADIAL_E"
       }
     ]
   },
@@ -8264,7 +8320,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_SE"
+        "key": "R_RADIAL_SE"
       }
     ]
   },
@@ -8287,7 +8343,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_S"
+        "key": "R_RADIAL_S"
       }
     ]
   },
@@ -8314,7 +8370,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_ALT_DPAD_DOWN"
+        "key": "ALT_DOWN"
       }
     ]
   },
@@ -8341,7 +8397,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_ALT_DPAD_UP"
+        "key": "ALT_UP"
       }
     ]
   },
@@ -8361,7 +8417,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_UP"
+        "key": "UP"
       }
     ]
   },
@@ -8381,7 +8437,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_DOWN"
+        "key": "DOWN"
       }
     ]
   },
@@ -8401,7 +8457,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_LEFT"
+        "key": "LEFT"
       }
     ]
   },
@@ -8456,7 +8512,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NW"
+        "key": "L_RADIAL_NW"
       }
     ]
   },
@@ -8472,7 +8528,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_W"
+        "key": "L_RADIAL_W"
       }
     ]
   },
@@ -8499,7 +8555,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RS"
+        "key": "L_RADIAL_N"
       }
     ]
   },
@@ -8526,7 +8582,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
+        "key": "L_RADIAL_N"
       }
     ]
   },
@@ -8558,7 +8614,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NE"
+        "key": "L_RADIAL_NE"
       }
     ]
   },
@@ -8581,7 +8637,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_E"
+        "key": "L_RADIAL_E"
       }
     ]
   },
@@ -8597,7 +8653,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SE"
+        "key": "L_RADIAL_SE"
       }
     ]
   },
@@ -8613,7 +8669,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_S"
+        "key": "L_RADIAL_S"
       }
     ]
   },
@@ -8640,7 +8696,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SW"
+        "key": "L_RADIAL_SW"
       }
     ]
   },
@@ -8688,7 +8744,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
+        "key": "L_RADIAL_N"
       }
     ]
   },
@@ -8704,7 +8760,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NE"
+        "key": "ALT_UP"
       }
     ]
   },
@@ -8720,7 +8776,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_E"
+        "key": "L_RADIAL_E"
       }
     ]
   },
@@ -8740,7 +8796,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_S"
+        "key": "ALT_DOWN"
       }
     ]
   },
@@ -8768,7 +8824,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_LEFT"
+        "key": "LEFT"
       }
     ]
   },
@@ -8994,6 +9050,10 @@
       {
         "input_method": "keyboard_code",
         "key": "KEYPAD_0"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "R_RADIAL_NW"
       }
     ]
   },
@@ -9017,6 +9077,10 @@
         "mod": [
           "shift"
         ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "R_RADIAL_N"
       }
     ]
   },
@@ -9040,6 +9104,10 @@
         "mod": [
           "shift"
         ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "R_RADIAL_NE"
       }
     ]
   },
@@ -9052,6 +9120,10 @@
       {
         "input_method": "keyboard_any",
         "key": "o"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "R_RADIAL_E"
       }
     ]
   },
@@ -9068,6 +9140,10 @@
       {
         "input_method": "keyboard_any",
         "key": "U"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "R_RADIAL_SW"
       }
     ]
   },
@@ -9091,6 +9167,10 @@
         "mod": [
           "shift"
         ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "R_RADIAL_SE"
       }
     ]
   },
@@ -9137,6 +9217,10 @@
         "mod": [
           "shift"
         ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "R_RADIAL_S"
       }
     ]
   },
@@ -9324,7 +9408,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
+        "key": "L_RADIAL_N"
       }
     ]
   },
@@ -9355,7 +9439,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_S"
+        "key": "L_RADIAL_S"
       }
     ]
   },
@@ -9382,7 +9466,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_E"
+        "key": "L_RADIAL_E"
       }
     ]
   },
@@ -9409,7 +9493,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_W"
+        "key": "L_RADIAL_W"
       }
     ]
   },
@@ -9440,7 +9524,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NW"
+        "key": "L_RADIAL_NW"
       }
     ]
   },
@@ -9467,7 +9551,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
+        "key": "L_RADIAL_N"
       }
     ]
   },
@@ -9494,7 +9578,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_E"
+        "key": "L_RADIAL_E"
       }
     ]
   },
@@ -9521,7 +9605,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_W"
+        "key": "L_RADIAL_W"
       }
     ]
   },
@@ -9548,7 +9632,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
+        "key": "L_RADIAL_N"
       }
     ]
   },
@@ -9575,7 +9659,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_S"
+        "key": "L_RADIAL_S"
       }
     ]
   },
@@ -9629,7 +9713,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
+        "key": "L_RADIAL_N"
       }
     ]
   },
@@ -9660,7 +9744,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_S"
+        "key": "L_RADIAL_S"
       }
     ]
   },
@@ -9687,7 +9771,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_E"
+        "key": "L_RADIAL_E"
       }
     ]
   },
@@ -9737,7 +9821,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
+        "key": "L_RADIAL_N"
       }
     ]
   },
@@ -9764,7 +9848,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NE"
+        "key": "L_RADIAL_NE"
       }
     ]
   },
@@ -9791,7 +9875,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_E"
+        "key": "L_RADIAL_E"
       }
     ]
   },
@@ -9824,7 +9908,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
+        "key": "L_RADIAL_N"
       }
     ]
   },
@@ -9863,7 +9947,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_S"
+        "key": "L_RADIAL_S"
       }
     ]
   },
@@ -9896,7 +9980,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_E"
+        "key": "L_RADIAL_E"
       }
     ]
   },
@@ -9929,7 +10013,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_W"
+        "key": "L_RADIAL_W"
       }
     ]
   },
@@ -9973,7 +10057,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
+        "key": "L_RADIAL_N"
       }
     ]
   },
@@ -9989,7 +10073,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NE"
+        "key": "L_RADIAL_NE"
       }
     ]
   },
@@ -10005,7 +10089,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_E"
+        "key": "L_RADIAL_E"
       }
     ]
   },
@@ -10021,7 +10105,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SE"
+        "key": "L_RADIAL_SE"
       }
     ]
   },
@@ -10037,7 +10121,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_N"
+        "key": "R_RADIAL_N"
       }
     ]
   },
@@ -10053,7 +10137,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_NE"
+        "key": "R_RADIAL_NE"
       }
     ]
   },
@@ -10069,7 +10153,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_E"
+        "key": "R_RADIAL_E"
       }
     ]
   },
@@ -10085,7 +10169,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_SE"
+        "key": "R_RADIAL_SE"
       }
     ]
   },
@@ -10101,7 +10185,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_S"
+        "key": "R_RADIAL_S"
       }
     ]
   },
@@ -10117,7 +10201,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_SW"
+        "key": "R_RADIAL_SW"
       }
     ]
   },
@@ -10133,7 +10217,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_W"
+        "key": "R_RADIAL_W"
       }
     ]
   },
@@ -10149,7 +10233,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_NW"
+        "key": "R_RADIAL_NW"
       }
     ]
   },
@@ -10527,7 +10611,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_R_UP"
+        "key": "ALT_UP"
       }
     ]
   },
@@ -10550,7 +10634,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_R_DOWN"
+        "key": "ALT_DOWN"
       }
     ]
   },
@@ -10573,7 +10657,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_R_UP"
+        "key": "ALT_UP"
       }
     ]
   },
@@ -10596,7 +10680,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_R_DOWN"
+        "key": "ALT_DOWN"
       }
     ]
   },
@@ -10619,7 +10703,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
+        "key": "L_RADIAL_N"
       }
     ]
   },
@@ -10642,7 +10726,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NE"
+        "key": "L_RADIAL_NE"
       }
     ]
   },
@@ -10665,7 +10749,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_E"
+        "key": "L_RADIAL_E"
       }
     ]
   },
@@ -10688,7 +10772,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SE"
+        "key": "L_RADIAL_SE"
       }
     ]
   },
@@ -10711,7 +10795,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_S"
+        "key": "L_RADIAL_S"
       }
     ]
   },
@@ -10727,7 +10811,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
+        "key": "L_RADIAL_N"
       }
     ]
   },
@@ -10743,7 +10827,7 @@
       },
       {
         "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
+        "key": "L_RADIAL_N"
       }
     ]
   },

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -4,18 +4,9 @@
     "id": "UILIST.UP",
     "name": "Pan up",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "UP"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "8"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_8"
-      }
+      { "input_method": "keyboard_any", "key": "UP" },
+      { "input_method": "keyboard_any", "key": "8" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_8" }
     ]
   },
   {
@@ -23,18 +14,9 @@
     "id": "UILIST.DOWN",
     "name": "Pan down",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "DOWN"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "2"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_2"
-      }
+      { "input_method": "keyboard_any", "key": "DOWN" },
+      { "input_method": "keyboard_any", "key": "2" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_2" }
     ]
   },
   {
@@ -42,18 +24,9 @@
     "id": "UILIST.LEFT",
     "name": "Pan left",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "LEFT"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "4"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_4"
-      }
+      { "input_method": "keyboard_any", "key": "LEFT" },
+      { "input_method": "keyboard_any", "key": "4" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_4" }
     ]
   },
   {
@@ -61,83 +34,40 @@
     "id": "UILIST.RIGHT",
     "name": "Pan right",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "RIGHT"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "6"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_6"
-      }
+      { "input_method": "keyboard_any", "key": "RIGHT" },
+      { "input_method": "keyboard_any", "key": "6" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_6" }
     ]
   },
   {
     "type": "keybinding",
     "id": "UILIST.FILTER",
     "name": "Filter",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "/"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_DIVIDE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "/" }, { "input_method": "keyboard_code", "key": "KEYPAD_DIVIDE" } ]
   },
   {
     "type": "keybinding",
     "id": "UILIST.QUIT",
     "name": "Cancel menu",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "ESC"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "ESC" } ]
   },
   {
     "type": "keybinding",
     "id": "SHOW_DESCRIPTION",
     "category": "MELEE_STYLE_PICKER",
     "name": "Show description of melee style",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "d"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "d" } ]
   },
   {
     "type": "keybinding",
     "id": "UP",
     "name": "Pan up",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "k"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "UP"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "8"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_8"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_L_UP"
-      }
+      { "input_method": "keyboard_any", "key": "k" },
+      { "input_method": "keyboard_any", "key": "UP" },
+      { "input_method": "keyboard_any", "key": "8" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_8" },
+      { "input_method": "gamepad", "key": "JOY_L_UP" }
     ]
   },
   {
@@ -145,26 +75,11 @@
     "id": "DOWN",
     "name": "Pan down",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "j"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "DOWN"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "2"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_2"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_L_DOWN"
-      }
+      { "input_method": "keyboard_any", "key": "j" },
+      { "input_method": "keyboard_any", "key": "DOWN" },
+      { "input_method": "keyboard_any", "key": "2" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_2" },
+      { "input_method": "gamepad", "key": "JOY_L_DOWN" }
     ]
   },
   {
@@ -172,26 +87,11 @@
     "id": "LEFT",
     "name": "Pan left",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "h"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "LEFT"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "4"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_4"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_L_LEFT"
-      }
+      { "input_method": "keyboard_any", "key": "h" },
+      { "input_method": "keyboard_any", "key": "LEFT" },
+      { "input_method": "keyboard_any", "key": "4" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_4" },
+      { "input_method": "gamepad", "key": "JOY_L_LEFT" }
     ]
   },
   {
@@ -199,26 +99,11 @@
     "id": "RIGHT",
     "name": "Pan right",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "l"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "RIGHT"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "6"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_6"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_L_RIGHT"
-      }
+      { "input_method": "keyboard_any", "key": "l" },
+      { "input_method": "keyboard_any", "key": "RIGHT" },
+      { "input_method": "keyboard_any", "key": "6" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_6" },
+      { "input_method": "gamepad", "key": "JOY_L_RIGHT" }
     ]
   },
   {
@@ -226,22 +111,10 @@
     "id": "LEFTUP",
     "name": "Pan up-left",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "y"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "7"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_7"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_L_LEFTUP"
-      }
+      { "input_method": "keyboard_any", "key": "y" },
+      { "input_method": "keyboard_any", "key": "7" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_7" },
+      { "input_method": "gamepad", "key": "JOY_L_LEFTUP" }
     ]
   },
   {
@@ -249,22 +122,10 @@
     "id": "RIGHTUP",
     "name": "Pan up-right",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "u"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "9"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_9"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_L_RIGHTUP"
-      }
+      { "input_method": "keyboard_any", "key": "u" },
+      { "input_method": "keyboard_any", "key": "9" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_9" },
+      { "input_method": "gamepad", "key": "JOY_L_RIGHTUP" }
     ]
   },
   {
@@ -272,22 +133,10 @@
     "id": "LEFTDOWN",
     "name": "Pan down-left",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "b"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "1"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_1"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_L_LEFTDOWN"
-      }
+      { "input_method": "keyboard_any", "key": "b" },
+      { "input_method": "keyboard_any", "key": "1" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_1" },
+      { "input_method": "gamepad", "key": "JOY_L_LEFTDOWN" }
     ]
   },
   {
@@ -295,139 +144,68 @@
     "id": "RIGHTDOWN",
     "name": "Pan down-right",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "n"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "3"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_3"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_L_RIGHTDOWN"
-      }
+      { "input_method": "keyboard_any", "key": "n" },
+      { "input_method": "keyboard_any", "key": "3" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_3" },
+      { "input_method": "gamepad", "key": "JOY_L_RIGHTDOWN" }
     ]
   },
   {
     "type": "keybinding",
     "id": "HOME",
     "name": "Home",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "HOME"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "HOME" } ]
   },
   {
     "type": "keybinding",
     "id": "END",
     "name": "End",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "END"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "END" } ]
   },
   {
     "type": "keybinding",
     "id": "PAGE_UP",
     "name": "Page up",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "PPAGE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "PPAGE" } ]
   },
   {
     "type": "keybinding",
     "id": "PAGE_DOWN",
     "name": "Page down",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "NPAGE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "NPAGE" } ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_UP",
     "name": "Scroll up",
-    "bindings": [
-      {
-        "input_method": "mouse",
-        "key": "SCROLL_UP"
-      }
-    ]
+    "bindings": [ { "input_method": "mouse", "key": "SCROLL_UP" } ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_DOWN",
     "name": "Scroll down",
-    "bindings": [
-      {
-        "input_method": "mouse",
-        "key": "SCROLL_DOWN"
-      }
-    ]
+    "bindings": [ { "input_method": "mouse", "key": "SCROLL_DOWN" } ]
   },
   {
     "type": "keybinding",
     "id": "SELECT_ALL",
     "category": "PICKUP",
     "name": "Select all",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": ","
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "," } ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_ITEM_INFO_UP",
     "category": "PICKUP",
     "name": "Scroll item info up",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "<"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ",",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "<" }, { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_ITEM_INFO_DOWN",
     "category": "PICKUP",
     "name": "Scroll item info down",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": ">"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ".",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": ">" }, { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
@@ -435,18 +213,9 @@
     "category": "PICKUP",
     "name": "Previous item",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "k"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "UP"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_UP"
-      }
+      { "input_method": "keyboard_any", "key": "k" },
+      { "input_method": "keyboard_any", "key": "UP" },
+      { "input_method": "gamepad", "key": "JOY_UP" }
     ]
   },
   {
@@ -455,18 +224,9 @@
     "category": "PICKUP",
     "name": "Next item",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "j"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "DOWN"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_DOWN"
-      }
+      { "input_method": "keyboard_any", "key": "j" },
+      { "input_method": "keyboard_any", "key": "DOWN" },
+      { "input_method": "gamepad", "key": "JOY_DOWN" }
     ]
   },
   {
@@ -475,18 +235,9 @@
     "category": "PICKUP",
     "name": "Unmark selected item",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "h"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "LEFT"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_LEFT"
-      }
+      { "input_method": "keyboard_any", "key": "h" },
+      { "input_method": "keyboard_any", "key": "LEFT" },
+      { "input_method": "gamepad", "key": "JOY_LEFT" }
     ]
   },
   {
@@ -494,16 +245,7 @@
     "id": "RIGHT",
     "category": "PICKUP",
     "name": "Mark selected item",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "l"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "RIGHT"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "l" }, { "input_method": "keyboard_any", "key": "RIGHT" } ]
   },
   {
     "type": "keybinding",
@@ -511,21 +253,9 @@
     "category": "AUTO_NOTES",
     "name": "Enable auto notes for map extras",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "e"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "E"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "e",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_any", "key": "e" },
+      { "input_method": "keyboard_char", "key": "E" },
+      { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] }
     ]
   },
   {
@@ -534,21 +264,9 @@
     "category": "AUTO_NOTES",
     "name": "Toggle auto notes option",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "s"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "S"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "s",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_any", "key": "s" },
+      { "input_method": "keyboard_char", "key": "S" },
+      { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] }
     ]
   },
   {
@@ -557,21 +275,9 @@
     "category": "AUTO_NOTES",
     "name": "Disable auto notes for map extras",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "d"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "D"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "d",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_any", "key": "d" },
+      { "input_method": "keyboard_char", "key": "D" },
+      { "input_method": "keyboard_code", "key": "d", "mod": [ "shift" ] }
     ]
   },
   {
@@ -579,81 +285,35 @@
     "id": "CHANGE_MAPEXTRA_CHARACTER",
     "category": "AUTO_NOTES",
     "name": "Change a symbol for map extra",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "="
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "=" } ]
   },
   {
     "type": "keybinding",
     "id": "CHOOSE_INVLET",
     "category": "SPELL_MENU",
     "name": "Choose a hotkey for a spell",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "="
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "=" } ]
   },
   {
     "type": "keybinding",
     "id": "CAST_IGNORE",
     "category": "SPELL_MENU",
     "name": "Toggle ignore distractions",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "I"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "i",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "I" }, { "input_method": "keyboard_code", "key": "i", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_UP_SPELL_MENU",
     "category": "SPELL_MENU",
     "name": "Scroll up spell info",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "<"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ",",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "<" }, { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_DOWN_SPELL_MENU",
     "category": "SPELL_MENU",
     "name": "Scroll down spell info",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": ">"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ".",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": ">" }, { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
@@ -661,21 +321,9 @@
     "category": "SPELL_MENU",
     "name": "Toggle spell as favorite",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "*"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MULTIPLY"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "8",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_char", "key": "*" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
+      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] }
     ]
   },
   {
@@ -684,21 +332,9 @@
     "category": "AUTO_PICKUP",
     "name": "Add rule",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "a"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "A"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "a",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_any", "key": "a" },
+      { "input_method": "keyboard_char", "key": "A" },
+      { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] }
     ]
   },
   {
@@ -707,21 +343,9 @@
     "category": "AUTO_PICKUP",
     "name": "Remove rule",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "r"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "R"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "r",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_any", "key": "r" },
+      { "input_method": "keyboard_char", "key": "R" },
+      { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] }
     ]
   },
   {
@@ -730,21 +354,9 @@
     "category": "AUTO_PICKUP",
     "name": "Copy rule",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "c"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "C"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "c",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_any", "key": "c" },
+      { "input_method": "keyboard_char", "key": "C" },
+      { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] }
     ]
   },
   {
@@ -753,21 +365,9 @@
     "category": "AUTO_PICKUP",
     "name": "Move rule global <-> character",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "m"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "M"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "m",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_any", "key": "m" },
+      { "input_method": "keyboard_char", "key": "M" },
+      { "input_method": "keyboard_code", "key": "m", "mod": [ "shift" ] }
     ]
   },
   {
@@ -776,21 +376,9 @@
     "category": "AUTO_PICKUP",
     "name": "Enable rule",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "e"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "E"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "e",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_any", "key": "e" },
+      { "input_method": "keyboard_char", "key": "E" },
+      { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] }
     ]
   },
   {
@@ -799,21 +387,9 @@
     "category": "AUTO_PICKUP",
     "name": "Disable rule",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "d"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "D"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "d",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_any", "key": "d" },
+      { "input_method": "keyboard_char", "key": "D" },
+      { "input_method": "keyboard_code", "key": "d", "mod": [ "shift" ] }
     ]
   },
   {
@@ -822,18 +398,9 @@
     "category": "AUTO_PICKUP",
     "name": "Move rule up",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "="
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "+"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_PLUS"
-      }
+      { "input_method": "keyboard_any", "key": "=" },
+      { "input_method": "keyboard_char", "key": "+" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" }
     ]
   },
   {
@@ -841,16 +408,7 @@
     "id": "MOVE_RULE_DOWN",
     "category": "AUTO_PICKUP",
     "name": "Move rule down",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "-"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MINUS"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "-" }, { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" } ]
   },
   {
     "type": "keybinding",
@@ -858,21 +416,9 @@
     "category": "AUTO_PICKUP",
     "name": "Test rule",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "t"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "T"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "t",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_any", "key": "t" },
+      { "input_method": "keyboard_char", "key": "T" },
+      { "input_method": "keyboard_code", "key": "t", "mod": [ "shift" ] }
     ]
   },
   {
@@ -881,21 +427,9 @@
     "category": "AUTO_PICKUP",
     "name": "Enable auto pickup option",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "s"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "S"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "s",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_any", "key": "s" },
+      { "input_method": "keyboard_char", "key": "S" },
+      { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] }
     ]
   },
   {
@@ -904,33 +438,12 @@
     "category": "AUTO_PICKUP",
     "name": "Quit",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "ESC"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "q"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "Q"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "q",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "SPACE"
-      },
-      {
-        "input_method": "mouse",
-        "key": "MOUSE_RIGHT"
-      }
+      { "input_method": "keyboard_any", "key": "ESC" },
+      { "input_method": "keyboard_any", "key": "q" },
+      { "input_method": "keyboard_char", "key": "Q" },
+      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "SPACE" },
+      { "input_method": "mouse", "key": "MOUSE_RIGHT" }
     ]
   },
   {
@@ -939,21 +452,9 @@
     "category": "SAFEMODE",
     "name": "Add default ruleset",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "~"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "`",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
-      }
+      { "input_method": "keyboard_char", "key": "~" },
+      { "input_method": "keyboard_code", "key": "`", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" }
     ]
   },
   {
@@ -962,25 +463,10 @@
     "category": "SAFEMODE",
     "name": "Add rule",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "a"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "A"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "a",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NE"
-      }
+      { "input_method": "keyboard_any", "key": "a" },
+      { "input_method": "keyboard_char", "key": "A" },
+      { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_NE" }
     ]
   },
   {
@@ -989,25 +475,10 @@
     "category": "SAFEMODE",
     "name": "Remove rule",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "r"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "R"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "r",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_E"
-      }
+      { "input_method": "keyboard_any", "key": "r" },
+      { "input_method": "keyboard_char", "key": "R" },
+      { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_E" }
     ]
   },
   {
@@ -1016,25 +487,10 @@
     "category": "SAFEMODE",
     "name": "Copy rule",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "c"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "C"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "c",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SE"
-      }
+      { "input_method": "keyboard_any", "key": "c" },
+      { "input_method": "keyboard_char", "key": "C" },
+      { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_SE" }
     ]
   },
   {
@@ -1043,25 +499,10 @@
     "category": "SAFEMODE",
     "name": "Move rule global <-> character",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "m"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "M"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "m",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_S"
-      }
+      { "input_method": "keyboard_any", "key": "m" },
+      { "input_method": "keyboard_char", "key": "M" },
+      { "input_method": "keyboard_code", "key": "m", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_S" }
     ]
   },
   {
@@ -1070,25 +511,10 @@
     "category": "SAFEMODE",
     "name": "Enable rule",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "e"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "E"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "e",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SW"
-      }
+      { "input_method": "keyboard_any", "key": "e" },
+      { "input_method": "keyboard_char", "key": "E" },
+      { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_SW" }
     ]
   },
   {
@@ -1097,25 +523,10 @@
     "category": "SAFEMODE",
     "name": "Disable rule",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "d"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "D"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "d",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_W"
-      }
+      { "input_method": "keyboard_any", "key": "d" },
+      { "input_method": "keyboard_char", "key": "D" },
+      { "input_method": "keyboard_code", "key": "d", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_W" }
     ]
   },
   {
@@ -1124,22 +535,10 @@
     "category": "SAFEMODE",
     "name": "Move rule up",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "="
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "+"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_PLUS"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_ALT_DPAD_UP"
-      }
+      { "input_method": "keyboard_any", "key": "=" },
+      { "input_method": "keyboard_char", "key": "+" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" },
+      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_UP" }
     ]
   },
   {
@@ -1148,18 +547,9 @@
     "category": "SAFEMODE",
     "name": "Move rule down",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "-"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MINUS"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_ALT_DPAD_DOWN"
-      }
+      { "input_method": "keyboard_any", "key": "-" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" },
+      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_DOWN" }
     ]
   },
   {
@@ -1168,25 +558,10 @@
     "category": "SAFEMODE",
     "name": "Test rule",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "t"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "T"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "t",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NW"
-      }
+      { "input_method": "keyboard_any", "key": "t" },
+      { "input_method": "keyboard_char", "key": "T" },
+      { "input_method": "keyboard_code", "key": "t", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_NW" }
     ]
   },
   {
@@ -1195,25 +570,10 @@
     "category": "SAFEMODE",
     "name": "Enable safemode option",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "s"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "S"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "s",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_N"
-      }
+      { "input_method": "keyboard_any", "key": "s" },
+      { "input_method": "keyboard_char", "key": "S" },
+      { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_R_N" }
     ]
   },
   {
@@ -1222,33 +582,12 @@
     "category": "SAFEMODE",
     "name": "Quit",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "ESC"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "q"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "Q"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "q",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "SPACE"
-      },
-      {
-        "input_method": "mouse",
-        "key": "MOUSE_RIGHT"
-      }
+      { "input_method": "keyboard_any", "key": "ESC" },
+      { "input_method": "keyboard_any", "key": "q" },
+      { "input_method": "keyboard_char", "key": "Q" },
+      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "SPACE" },
+      { "input_method": "mouse", "key": "MOUSE_RIGHT" }
     ]
   },
   {
@@ -1256,12 +595,7 @@
     "id": "USAGE_HELP",
     "category": "SORT_ARMOR",
     "name": "Display usage help",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "F1"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "F1" } ]
   },
   {
     "type": "keybinding",
@@ -1269,18 +603,9 @@
     "category": "SORT_ARMOR",
     "name": "Select armor for moving",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "s"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "RETURN"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "KEYPAD_ENTER"
-      }
+      { "input_method": "keyboard_any", "key": "s" },
+      { "input_method": "keyboard_any", "key": "RETURN" },
+      { "input_method": "keyboard_any", "key": "KEYPAD_ENTER" }
     ]
   },
   {
@@ -1289,18 +614,9 @@
     "category": "PANEL_MGMT",
     "name": "Select panel for moving",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "s"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "RETURN"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "KEYPAD_ENTER"
-      }
+      { "input_method": "keyboard_any", "key": "s" },
+      { "input_method": "keyboard_any", "key": "RETURN" },
+      { "input_method": "keyboard_any", "key": "KEYPAD_ENTER" }
     ]
   },
   {
@@ -1308,28 +624,14 @@
     "id": "TOGGLE_PANEL",
     "category": "PANEL_MGMT",
     "name": "Toggle panel off",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "TAB"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "TAB" } ]
   },
   {
     "type": "keybinding",
     "id": "CHANGE_SIDE",
     "category": "SORT_ARMOR",
     "name": "Change side armor is worn on",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "c"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "c" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" } ]
   },
   {
     "type": "keybinding",
@@ -1337,21 +639,9 @@
     "category": "SORT_ARMOR",
     "name": "Toggle armor visibility on character sprite",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "H"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "h",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NE"
-      }
+      { "input_method": "keyboard_char", "key": "H" },
+      { "input_method": "keyboard_code", "key": "h", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_NE" }
     ]
   },
   {
@@ -1359,16 +649,7 @@
     "id": "ASSIGN_INVLETS",
     "category": "SORT_ARMOR",
     "name": "Assign invlets to armor",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "r"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_E"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "r" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_E" } ]
   },
   {
     "type": "keybinding",
@@ -1376,21 +657,9 @@
     "category": "SORT_ARMOR",
     "name": "Sort armor into natural layer order",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "S"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "s",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SE"
-      }
+      { "input_method": "keyboard_char", "key": "S" },
+      { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_SE" }
     ]
   },
   {
@@ -1398,54 +667,21 @@
     "id": "SCROLL_ITEM_INFO_UP",
     "category": "SORT_ARMOR",
     "name": "Scroll item info up",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "<"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ",",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "<" }, { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_ITEM_INFO_DOWN",
     "category": "SORT_ARMOR",
     "name": "Scroll item info down",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": ">"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ".",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": ">" }, { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "EQUIP_ARMOR",
     "category": "SORT_ARMOR",
     "name": "Equip armor from inventory",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "e"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_S"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "e" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_S" } ]
   },
   {
     "type": "keybinding",
@@ -1453,21 +689,9 @@
     "category": "SORT_ARMOR",
     "name": "Equip armor from inventory at this position",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "E"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "e",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SW"
-      }
+      { "input_method": "keyboard_char", "key": "E" },
+      { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_SW" }
     ]
   },
   {
@@ -1475,63 +699,24 @@
     "id": "REMOVE_ARMOR",
     "category": "SORT_ARMOR",
     "name": "Unequip selected armor",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "u"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_W"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "u" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_W" } ]
   },
   {
     "type": "keybinding",
     "id": "HELP_KEYBINDINGS",
     "name": "Display keybindings menu",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "?"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "/",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "?" }, { "input_method": "keyboard_code", "key": "/", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "FILTER",
     "name": "Filter",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "f"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "F"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "f",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "/"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_DIVIDE"
-      }
+      { "input_method": "keyboard_any", "key": "f" },
+      { "input_method": "keyboard_char", "key": "F" },
+      { "input_method": "keyboard_code", "key": "f", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "/" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_DIVIDE" }
     ]
   },
   {
@@ -1539,21 +724,9 @@
     "id": "RESET_FILTER",
     "name": "Reset filter",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "r"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "R"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "r",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_any", "key": "r" },
+      { "input_method": "keyboard_char", "key": "R" },
+      { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] }
     ]
   },
   {
@@ -1561,24 +734,14 @@
     "id": "SCROLL_RECIPE_INFO_UP",
     "category": "CRAFTING",
     "name": "Scroll recipe info up",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "["
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "[" } ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_RECIPE_INFO_DOWN",
     "category": "CRAFTING",
     "name": "Scroll recipe info down",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "]"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "]" } ]
   },
   {
     "type": "keybinding",
@@ -1586,21 +749,9 @@
     "category": "CRAFTING",
     "name": "Show recipe result",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "e"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "E"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "e",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_any", "key": "e" },
+      { "input_method": "keyboard_char", "key": "E" },
+      { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] }
     ]
   },
   {
@@ -1614,16 +765,7 @@
     "id": "TOGGLE_RECIPE_UNREAD",
     "category": "CRAFTING",
     "name": "Toggle read/unread",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "v"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "v" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" } ]
   },
   {
     "type": "keybinding",
@@ -1631,21 +773,9 @@
     "category": "CRAFTING",
     "name": "Mark all recipes as read",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "V"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "v",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NE"
-      }
+      { "input_method": "keyboard_char", "key": "V" },
+      { "input_method": "keyboard_code", "key": "v", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_NE" }
     ]
   },
   {
@@ -1653,50 +783,21 @@
     "id": "TOGGLE_UNREAD_RECIPES_FIRST",
     "category": "CRAFTING",
     "name": "Show unread recipes on top",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "u"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_E"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "u" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_E" } ]
   },
   {
     "type": "keybinding",
     "id": "CHOOSE_CRAFTER",
     "category": "CRAFTING",
     "name": "Choose crafter",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "c"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "c" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_SE" } ]
   },
   {
     "type": "keybinding",
     "id": "CYCLE_BATCH",
     "category": "CRAFTING",
     "name": "Batch crafting",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": [
-          "b"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_S"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": [ "b" ] }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_S" } ]
   },
   {
     "type": "keybinding",
@@ -1704,21 +805,9 @@
     "category": "CRAFTING",
     "name": "Scroll item info up",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "<"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ",",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_ALT_DPAD_UP"
-      }
+      { "input_method": "keyboard_char", "key": "<" },
+      { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_UP" }
     ]
   },
   {
@@ -1727,21 +816,9 @@
     "category": "CRAFTING",
     "name": "Scroll item info down",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": ">"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ".",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_ALT_DPAD_DOWN"
-      }
+      { "input_method": "keyboard_char", "key": ">" },
+      { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_DOWN" }
     ]
   },
   {
@@ -1750,21 +827,9 @@
     "category": "CRAFTING",
     "name": "Related recipes",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "L"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "l",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_SW"
-      }
+      { "input_method": "keyboard_char", "key": "L" },
+      { "input_method": "keyboard_code", "key": "l", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_R_SW" }
     ]
   },
   {
@@ -1773,25 +838,10 @@
     "category": "CRAFTING",
     "name": "Toggle recipes to be shown in favorite tab",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "*"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MULTIPLY"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "8",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_W"
-      }
+      { "input_method": "keyboard_char", "key": "*" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
+      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_W" }
     ]
   },
   {
@@ -1800,21 +850,9 @@
     "category": "CRAFTING",
     "name": "Compare recipe to item in inventory",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "I"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "i",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NW"
-      }
+      { "input_method": "keyboard_char", "key": "I" },
+      { "input_method": "keyboard_code", "key": "i", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_NW" }
     ]
   },
   {
@@ -1822,25 +860,10 @@
     "id": "LEVEL_UP",
     "name": "Go up",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "PPAGE"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "<"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ",",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_ALT_DPAD_UP"
-      }
+      { "input_method": "keyboard_any", "key": "PPAGE" },
+      { "input_method": "keyboard_char", "key": "<" },
+      { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_UP" }
     ]
   },
   {
@@ -1848,25 +871,10 @@
     "id": "LEVEL_DOWN",
     "name": "Go down",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "NPAGE"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": ">"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ".",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_ALT_DPAD_DOWN"
-      }
+      { "input_method": "keyboard_any", "key": "NPAGE" },
+      { "input_method": "keyboard_char", "key": ">" },
+      { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_DOWN" }
     ]
   },
   {
@@ -1875,22 +883,10 @@
     "category": "SOKOBAN",
     "name": "Next level",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "="
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "+"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_PLUS"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
-      }
+      { "input_method": "keyboard_any", "key": "=" },
+      { "input_method": "keyboard_char", "key": "+" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" }
     ]
   },
   {
@@ -1899,18 +895,9 @@
     "category": "SOKOBAN",
     "name": "Previous level",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "-"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MINUS"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NE"
-      }
+      { "input_method": "keyboard_any", "key": "-" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_NE" }
     ]
   },
   {
@@ -1918,80 +905,35 @@
     "id": "RESET",
     "category": "SOKOBAN",
     "name": "Reset level",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "r"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_E"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "r" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_E" } ]
   },
   {
     "type": "keybinding",
     "id": "UNDO",
     "category": "SOKOBAN",
     "name": "Undo move",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "u"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "u" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_SE" } ]
   },
   {
     "type": "keybinding",
     "id": "NEW",
     "category": "MINESWEEPER",
     "name": "Create new level",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "n"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "n" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" } ]
   },
   {
     "type": "keybinding",
     "id": "FLAG",
     "category": "MINESWEEPER",
     "name": "Toggle flag",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "f"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "f" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_NE" } ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_SPACE",
     "category": "LIGHTSON",
     "name": "Toggle lights",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": " "
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": " " }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" } ]
   },
   {
     "type": "keybinding",
@@ -1999,18 +941,9 @@
     "category": "LIGHTSON",
     "name": "Toggle lights",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "5"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_5"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NE"
-      }
+      { "input_method": "keyboard_any", "key": "5" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_5" },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_NE" }
     ]
   },
   {
@@ -2018,66 +951,33 @@
     "id": "RESET",
     "category": "LIGHTSON",
     "name": "Reset level",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "r"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_E"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "r" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_E" } ]
   },
   {
     "type": "keybinding",
     "id": "CONFIRM",
     "name": "Confirm choice",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "RETURN"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "KEYPAD_ENTER"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "RETURN" }, { "input_method": "keyboard_any", "key": "KEYPAD_ENTER" } ]
   },
   {
     "type": "keybinding",
     "id": "CONFIRM_MULTIPLE",
     "name": "Confirm and continue",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "SPACE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "SPACE" } ]
   },
   {
     "type": "keybinding",
     "id": "SAVE_DEFAULT_MODS",
     "category": "MODMANAGER_DIALOG",
     "name": "Save mods as default",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "s"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "s" } ]
   },
   {
     "type": "keybinding",
     "id": "VIEW_MOD_DESCRIPTION",
     "category": "MODMANAGER_DIALOG",
     "name": "View full mod description",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "v"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "v" } ]
   },
   {
     "type": "keybinding",
@@ -2085,18 +985,9 @@
     "category": "MODMANAGER_DIALOG",
     "name": "Move selected mod down",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "="
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "+"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_PLUS"
-      }
+      { "input_method": "keyboard_any", "key": "=" },
+      { "input_method": "keyboard_char", "key": "+" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" }
     ]
   },
   {
@@ -2104,54 +995,21 @@
     "id": "MOVE_MOD_UP",
     "category": "MODMANAGER_DIALOG",
     "name": "Move selected mod up",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "-"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MINUS"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "-" }, { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" } ]
   },
   {
     "type": "keybinding",
     "id": "NEXT_CATEGORY_TAB",
     "category": "MODMANAGER_DIALOG",
     "name": "Move to next category tab",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": ">"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ".",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": ">" }, { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "PREV_CATEGORY_TAB",
     "category": "MODMANAGER_DIALOG",
     "name": "Move to previous category tab",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "<"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ",",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "<" }, { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
@@ -2159,33 +1017,12 @@
     "category": "MODMANAGER_DIALOG",
     "name": "Quit",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "ESC"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "q"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "Q"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "q",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "SPACE"
-      },
-      {
-        "input_method": "mouse",
-        "key": "MOUSE_RIGHT"
-      }
+      { "input_method": "keyboard_any", "key": "ESC" },
+      { "input_method": "keyboard_any", "key": "q" },
+      { "input_method": "keyboard_char", "key": "Q" },
+      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "SPACE" },
+      { "input_method": "mouse", "key": "MOUSE_RIGHT" }
     ]
   },
   {
@@ -2194,33 +1031,12 @@
     "category": "OPTIONS",
     "name": "Quit",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "ESC"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "q"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "Q"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "q",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "SPACE"
-      },
-      {
-        "input_method": "mouse",
-        "key": "MOUSE_RIGHT"
-      }
+      { "input_method": "keyboard_any", "key": "ESC" },
+      { "input_method": "keyboard_any", "key": "q" },
+      { "input_method": "keyboard_char", "key": "Q" },
+      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "SPACE" },
+      { "input_method": "mouse", "key": "MOUSE_RIGHT" }
     ]
   },
   {
@@ -2229,21 +1045,9 @@
     "category": "STRING_INPUT",
     "name": "Pick random world name",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "*"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MULTIPLY"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "8",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_char", "key": "*" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
+      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] }
     ]
   },
   {
@@ -2252,21 +1056,9 @@
     "category": "WORLDGEN_CONFIRM_DIALOG",
     "name": "Pick random world name",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "*"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MULTIPLY"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "8",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_char", "key": "*" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
+      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] }
     ]
   },
   {
@@ -2276,33 +1068,12 @@
     "category": "WORLDGEN_CONFIRM_DIALOG",
     "name": "Exit worldgen screen",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "ESC"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "q"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "Q"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "q",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "SPACE"
-      },
-      {
-        "input_method": "mouse",
-        "key": "MOUSE_RIGHT"
-      }
+      { "input_method": "keyboard_any", "key": "ESC" },
+      { "input_method": "keyboard_any", "key": "q" },
+      { "input_method": "keyboard_char", "key": "Q" },
+      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "SPACE" },
+      { "input_method": "mouse", "key": "MOUSE_RIGHT" }
     ]
   },
   {
@@ -2311,21 +1082,9 @@
     "category": "WORLDGEN_CONFIRM_DIALOG",
     "name": "View mod manager",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "m"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "M"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "m",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_any", "key": "m" },
+      { "input_method": "keyboard_char", "key": "M" },
+      { "input_method": "keyboard_code", "key": "m", "mod": [ "shift" ] }
     ]
   },
   {
@@ -2334,21 +1093,9 @@
     "category": "WORLDGEN_CONFIRM_DIALOG",
     "name": "View advanced world settings",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "s"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "S"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "s",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_any", "key": "s" },
+      { "input_method": "keyboard_char", "key": "S" },
+      { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] }
     ]
   },
   {
@@ -2357,21 +1104,9 @@
     "category": "WORLDGEN_CONFIRM_DIALOG",
     "name": "Finalize world creation",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "f"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "F"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "f",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_any", "key": "f" },
+      { "input_method": "keyboard_char", "key": "F" },
+      { "input_method": "keyboard_code", "key": "f", "mod": [ "shift" ] }
     ]
   },
   {
@@ -2380,21 +1115,9 @@
     "category": "WORLDGEN_CONFIRM_DIALOG",
     "name": "Randomize world settings",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "a"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "A"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "a",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_any", "key": "a" },
+      { "input_method": "keyboard_char", "key": "A" },
+      { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] }
     ]
   },
   {
@@ -2403,21 +1126,9 @@
     "category": "WORLDGEN_CONFIRM_DIALOG",
     "name": "Reset world settings and mods",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "r"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "R"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "r",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_any", "key": "r" },
+      { "input_method": "keyboard_char", "key": "R" },
+      { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] }
     ]
   },
   {
@@ -2426,33 +1137,12 @@
     "category": "DISPLAY_HELP",
     "name": "Quit",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "ESC"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "q"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "Q"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "q",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "SPACE"
-      },
-      {
-        "input_method": "mouse",
-        "key": "MOUSE_RIGHT"
-      }
+      { "input_method": "keyboard_any", "key": "ESC" },
+      { "input_method": "keyboard_any", "key": "q" },
+      { "input_method": "keyboard_char", "key": "Q" },
+      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "SPACE" },
+      { "input_method": "mouse", "key": "MOUSE_RIGHT" }
     ]
   },
   {
@@ -2461,33 +1151,12 @@
     "category": "SCROLLABLE_TEXT",
     "name": "Quit",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "ESC"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "q"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "Q"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "q",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "SPACE"
-      },
-      {
-        "input_method": "mouse",
-        "key": "MOUSE_RIGHT"
-      }
+      { "input_method": "keyboard_any", "key": "ESC" },
+      { "input_method": "keyboard_any", "key": "q" },
+      { "input_method": "keyboard_char", "key": "Q" },
+      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "SPACE" },
+      { "input_method": "mouse", "key": "MOUSE_RIGHT" }
     ]
   },
   {
@@ -2495,309 +1164,119 @@
     "id": "DELETE_NOTE",
     "category": "OVERMAP_NOTES",
     "name": "Delete note",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "D"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "d",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "D" }, { "input_method": "keyboard_code", "key": "d", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "EDIT_NOTE",
     "category": "OVERMAP_NOTES",
     "name": "Edit note",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "E"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "e",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "E" }, { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "MARK_DANGER",
     "category": "OVERMAP_NOTES",
     "name": "Mark danger",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "R"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "r",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "R" }, { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "look",
     "category": "OVERMAP",
     "name": "Look around",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": ";"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": ";" } ]
   },
   {
     "type": "keybinding",
     "id": "DELETE_NOTE",
     "category": "OVERMAP",
     "name": "Delete note",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "D"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "d",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "D" }, { "input_method": "keyboard_code", "key": "d", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "CREATE_NOTE",
     "category": "OVERMAP",
     "name": "Create/edit note",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "N"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "n",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "N" }, { "input_method": "keyboard_code", "key": "n", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "MARK_DANGER",
     "category": "OVERMAP",
     "name": "Mark danger",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "R"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "r",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "R" }, { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "LIST_NOTES",
     "category": "OVERMAP",
     "name": "List notes",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "L"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "l",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "L" }, { "input_method": "keyboard_code", "key": "l", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_BLINKING",
     "category": "OVERMAP",
     "name": "Toggle blinking",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "B"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "b",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "B" }, { "input_method": "keyboard_code", "key": "b", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_OVERLAYS",
     "category": "OVERMAP",
     "name": "Toggle overlays",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "O"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "o",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "O" }, { "input_method": "keyboard_code", "key": "o", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_LAND_USE_CODES",
     "category": "OVERMAP",
     "name": "Toggle land use codes",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "A"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "a",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "A" }, { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_MAP_NOTES",
     "category": "OVERMAP",
     "name": "Toggle map notes",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "G"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "g",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "G" }, { "input_method": "keyboard_code", "key": "g", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_CITY_LABELS",
     "category": "OVERMAP",
     "name": "Toggle city labels",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "C"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "c",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "C" }, { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_MAP_REVEALS",
     "category": "OVERMAP",
     "name": "Toggle highlighting map reveals",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "V"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "v",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "V" }, { "input_method": "keyboard_code", "key": "v", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_HORDES",
     "category": "OVERMAP",
     "name": "Toggle hordes",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "H"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "h",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "H" }, { "input_method": "keyboard_code", "key": "h", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_OVERMAP_WEATHER",
     "category": "OVERMAP",
     "name": "Toggle visible weather",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "w"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "w" } ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_FOREST_TRAILS",
     "category": "OVERMAP",
     "name": "Toggle forest trails",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "T"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "t",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "T" }, { "input_method": "keyboard_code", "key": "t", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
@@ -2805,21 +1284,9 @@
     "category": "OVERMAP",
     "name": "Toggle fast travel",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "x"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "x",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
-      }
+      { "input_method": "keyboard_char", "key": "x" },
+      { "input_method": "keyboard_code", "key": "x", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" }
     ]
   },
   {
@@ -2827,24 +1294,14 @@
     "id": "COLLAPSE_OVERMAP_SIDEBAR_HEADERS",
     "category": "OVERMAP",
     "name": "Collapse all overmap sidebar headers",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "{"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "{" } ]
   },
   {
     "type": "keybinding",
     "id": "EXPAND_OVERMAP_SIDEBAR_HEADERS",
     "category": "OVERMAP",
     "name": "Expand all overmap sidebar headers",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "}"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "}" } ]
   },
   {
     "type": "keybinding",
@@ -2852,21 +1309,9 @@
     "category": "OVERMAP",
     "name": "Toggle explored",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "E"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "e",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NE"
-      }
+      { "input_method": "keyboard_char", "key": "E" },
+      { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_NE" }
     ]
   },
   {
@@ -2874,149 +1319,76 @@
     "id": "PLACE_TERRAIN",
     "category": "OVERMAP",
     "name": "Place overmap terrain",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "t"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "t" } ]
   },
   {
     "type": "keybinding",
     "id": "PLACE_SPECIAL",
     "category": "OVERMAP",
     "name": "Place overmap special",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "s"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "s" } ]
   },
   {
     "type": "keybinding",
     "id": "SET_SPECIAL_ARGS",
     "category": "OVERMAP",
     "name": "Set overmap special arguments",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "a"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "a" } ]
   },
   {
     "type": "keybinding",
     "id": "LONG_TELEPORT",
     "category": "OVERMAP",
     "name": "Teleport to cursor",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "d"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "d" } ]
   },
   {
     "type": "keybinding",
     "id": "REVEAL_MAP",
     "category": "OVERMAP",
     "name": "Reveal map",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "r"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "r" } ]
   },
   {
     "type": "keybinding",
     "id": "MODIFY_HORDE",
     "category": "OVERMAP",
     "name": "Modify existing horde or place new one",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "p"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "p" } ]
   },
   {
     "type": "keybinding",
     "id": "PRINT_NOISE_MAPS",
     "category": "OVERMAP",
     "name": "Print noise maps",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": ","
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "," } ]
   },
   {
     "type": "keybinding",
     "name": "View missions",
     "category": "OVERMAP",
     "id": "MISSIONS",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "M"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "m",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "M" }, { "input_method": "keyboard_code", "key": "m", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "name": "Define Point of Interest",
     "category": "OVERMAP",
     "id": "CREATE_POINT_OF_INTEREST",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "P"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "p",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "P" }, { "input_method": "keyboard_code", "key": "p", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "ROTATE",
     "category": "OVERMAP_EDITOR",
     "name": "Rotate",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "r"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "r" } ]
   },
   {
     "type": "keybinding",
     "id": "SEARCH",
     "name": "Search",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "/"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_DIVIDE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "/" }, { "input_method": "keyboard_code", "key": "KEYPAD_DIVIDE" } ]
   },
   {
     "type": "keybinding",
@@ -3024,33 +1396,12 @@
     "name": "Close map",
     "category": "OVERMAP",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "m"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "ESC"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "q"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "Q"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "q",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "SPACE"
-      }
+      { "input_method": "keyboard_any", "key": "m" },
+      { "input_method": "keyboard_any", "key": "ESC" },
+      { "input_method": "keyboard_any", "key": "q" },
+      { "input_method": "keyboard_char", "key": "Q" },
+      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "SPACE" }
     ]
   },
   {
@@ -3058,70 +1409,30 @@
     "id": "QUIT",
     "name": "Exit screen",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "ESC"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "q"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "Q"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "q",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "SPACE"
-      }
+      { "input_method": "keyboard_any", "key": "ESC" },
+      { "input_method": "keyboard_any", "key": "q" },
+      { "input_method": "keyboard_char", "key": "Q" },
+      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "SPACE" }
     ]
   },
   {
     "type": "keybinding",
     "id": "CHOOSE_DESTINATION",
     "name": "Choose destination",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "W"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "w",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "W" }, { "input_method": "keyboard_code", "key": "w", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "GO_TO_DESTINATION",
     "name": "Go to destination",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "g"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "g" } ]
   },
   {
     "type": "keybinding",
     "id": "CENTER_ON_DESTINATION",
     "name": "Center on destination",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "c"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "c" } ]
   },
   {
     "type": "keybinding",
@@ -3129,22 +1440,10 @@
     "category": "TARGET",
     "name": "Fire weapon",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "f"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "RETURN"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "KEYPAD_ENTER"
-      },
-      {
-        "input_method": "mouse",
-        "key": "MOUSE_RIGHT"
-      }
+      { "input_method": "keyboard_any", "key": "f" },
+      { "input_method": "keyboard_any", "key": "RETURN" },
+      { "input_method": "keyboard_any", "key": "KEYPAD_ENTER" },
+      { "input_method": "mouse", "key": "MOUSE_RIGHT" }
     ]
   },
   {
@@ -3153,29 +1452,11 @@
     "category": "TARGET",
     "name": "Previous target",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "BACKTAB"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "TAB",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "mouse",
-        "key": "SCROLL_UP"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "PPAGE"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_LB"
-      }
+      { "input_method": "keyboard_char", "key": "BACKTAB" },
+      { "input_method": "keyboard_code", "key": "TAB", "mod": [ "shift" ] },
+      { "input_method": "mouse", "key": "SCROLL_UP" },
+      { "input_method": "keyboard_any", "key": "PPAGE" },
+      { "input_method": "gamepad", "key": "JOY_LB" }
     ]
   },
   {
@@ -3184,22 +1465,10 @@
     "category": "TARGET",
     "name": "Next target",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "TAB"
-      },
-      {
-        "input_method": "mouse",
-        "key": "SCROLL_DOWN"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "NPAGE"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RB"
-      }
+      { "input_method": "keyboard_any", "key": "TAB" },
+      { "input_method": "mouse", "key": "SCROLL_DOWN" },
+      { "input_method": "keyboard_any", "key": "NPAGE" },
+      { "input_method": "gamepad", "key": "JOY_RB" }
     ]
   },
   {
@@ -3208,26 +1477,11 @@
     "category": "TARGET",
     "name": "Aim",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "."
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_PERIOD"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "5"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_5"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RT"
-      }
+      { "input_method": "keyboard_any", "key": "." },
+      { "input_method": "keyboard_code", "key": "KEYPAD_PERIOD" },
+      { "input_method": "keyboard_any", "key": "5" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_5" },
+      { "input_method": "gamepad", "key": "JOY_RT" }
     ]
   },
   {
@@ -3235,76 +1489,35 @@
     "id": "STOPAIM",
     "category": "TARGET",
     "name": "Stop Aiming",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": ","
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "," } ]
   },
   {
     "type": "keybinding",
     "id": "AIMED_SHOT",
     "category": "TARGET",
     "name": "Aimed shot",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "a"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "a" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" } ]
   },
   {
     "type": "keybinding",
     "id": "CAREFUL_SHOT",
     "category": "TARGET",
     "name": "Careful shot",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "c"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "c" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_NE" } ]
   },
   {
     "type": "keybinding",
     "id": "PRECISE_SHOT",
     "category": "TARGET",
     "name": "Precise shot",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "p"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_E"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "p" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_E" } ]
   },
   {
     "type": "keybinding",
     "id": "SWITCH_AMMO",
     "category": "TARGET",
     "name": "Switch ammo",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "o"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "o" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_SE" } ]
   },
   {
     "type": "keybinding",
@@ -3312,25 +1525,10 @@
     "category": "TARGET",
     "name": "Switch firing modes",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "s"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "F"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "f",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_S"
-      }
+      { "input_method": "keyboard_any", "key": "s" },
+      { "input_method": "keyboard_char", "key": "F" },
+      { "input_method": "keyboard_code", "key": "f", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_S" }
     ]
   },
   {
@@ -3338,28 +1536,14 @@
     "id": "TOGGLE_TURRET_LINES",
     "category": "TARGET",
     "name": "Toggle turret lines",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "t"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "t" } ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_UNLOAD_RAS_WEAPON",
     "category": "TARGET",
     "name": "Whether to unload your bow etc after canceling a shot",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "-"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MINUS"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "-" }, { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" } ]
   },
   {
     "type": "keybinding",
@@ -3367,25 +1551,10 @@
     "category": "TARGET",
     "name": "Toggle snap-to-target",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "*"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MULTIPLY"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "8",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_S"
-      }
+      { "input_method": "keyboard_char", "key": "*" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
+      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_S" }
     ]
   },
   {
@@ -3393,60 +1562,31 @@
     "id": "TOGGLE_MOVE_CURSOR_VIEW",
     "category": "TARGET",
     "name": "Toggle shift view / move cursor",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "v"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SW"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "v" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_SW" } ]
   },
   {
     "type": "keybinding",
     "id": "SELECT",
     "name": "Select with mouse",
-    "bindings": [
-      {
-        "input_method": "mouse",
-        "key": "MOUSE_LEFT"
-      }
-    ]
+    "bindings": [ { "input_method": "mouse", "key": "MOUSE_LEFT" } ]
   },
   {
     "type": "keybinding",
     "id": "CLICK_AND_DRAG",
     "name": "Click and drag with mouse",
-    "bindings": [
-      {
-        "input_method": "mouse",
-        "key": "MOUSE_LEFT_PRESSED"
-      }
-    ]
+    "bindings": [ { "input_method": "mouse", "key": "MOUSE_LEFT_PRESSED" } ]
   },
   {
     "type": "keybinding",
     "id": "SEC_SELECT",
     "name": "Secondary select",
-    "bindings": [
-      {
-        "input_method": "mouse",
-        "key": "MOUSE_RIGHT"
-      }
-    ]
+    "bindings": [ { "input_method": "mouse", "key": "MOUSE_RIGHT" } ]
   },
   {
     "type": "keybinding",
     "id": "MOUSE_MOVE",
     "name": "Mouse move",
-    "bindings": [
-      {
-        "input_method": "mouse",
-        "key": "MOUSE_MOVE"
-      }
-    ]
+    "bindings": [ { "input_method": "mouse", "key": "MOUSE_MOVE" } ]
   },
   {
     "type": "keybinding",
@@ -3454,225 +1594,93 @@
     "category": "PICK_WORLD_DIALOG",
     "name": "Quit",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "ESC"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "q"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "Q"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "q",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "SPACE"
-      },
-      {
-        "input_method": "mouse",
-        "key": "MOUSE_RIGHT"
-      }
+      { "input_method": "keyboard_any", "key": "ESC" },
+      { "input_method": "keyboard_any", "key": "q" },
+      { "input_method": "keyboard_char", "key": "Q" },
+      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "SPACE" },
+      { "input_method": "mouse", "key": "MOUSE_RIGHT" }
     ]
   },
   {
     "type": "keybinding",
     "id": "NEXT_TAB",
     "name": "Go to next tab",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "TAB"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RB"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "TAB" }, { "input_method": "gamepad", "key": "JOY_RB" } ]
   },
   {
     "type": "keybinding",
     "id": "PREV_TAB",
     "name": "Go to previous tab",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "BACKTAB"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "TAB",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_LB"
-      }
+      { "input_method": "keyboard_char", "key": "BACKTAB" },
+      { "input_method": "keyboard_code", "key": "TAB", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_LB" }
     ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_FAST_SCROLL",
     "name": "Toggle fast scroll",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "f"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "f" } ]
   },
   {
     "type": "keybinding",
     "id": "EXTENDED_DESCRIPTION",
     "name": "Show extended description",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "e"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RS"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "e" }, { "input_method": "gamepad", "key": "JOY_RS" } ]
   },
   {
     "type": "keybinding",
     "id": "CHANGE_MONSTER_NAME",
     "name": "Change monster name",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "c"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "c" } ]
   },
   {
     "type": "keybinding",
     "id": "TRAVEL_TO",
     "name": "Travel to destination",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "T"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "t",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "T" }, { "input_method": "keyboard_code", "key": "t", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "CENTER",
     "name": "Center on character",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "0"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_0"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "0" }, { "input_method": "keyboard_code", "key": "KEYPAD_0" } ]
   },
   {
     "type": "keybinding",
     "id": "HELP",
     "category": "CARAVAN",
     "name": "Display help",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "0"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_0"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "0" }, { "input_method": "keyboard_code", "key": "KEYPAD_0" } ]
   },
   {
     "type": "keybinding",
     "id": "CHANGE_GENDER",
     "name": "Change gender",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "@"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "2",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "@" }, { "input_method": "keyboard_code", "key": "2", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "CHANGE_OUTFIT",
     "name": "Change outfit",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "$"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "4",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "$" }, { "input_method": "keyboard_code", "key": "4", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "SWITCH_GENDER",
     "name": "Customize character",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "y"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "y" } ]
   },
   {
     "type": "keybinding",
     "id": "MEDICAL_MENU",
     "name": "Open medical menu",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "@"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "2",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_NE"
-      }
+      { "input_method": "keyboard_char", "key": "@" },
+      { "input_method": "keyboard_code", "key": "2", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_R_NE" }
     ]
   },
   {
@@ -3680,119 +1688,49 @@
     "id": "SAVE_TEMPLATE",
     "category": "DEFENSE_SETUP",
     "name": "Save template",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "!"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "1",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "!" }, { "input_method": "keyboard_code", "key": "1", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "START",
     "category": "DEFENSE_SETUP",
     "name": "Start",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "S"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "s",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "S" }, { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "DELETE_TEMPLATE",
     "category": "MAIN_MENU",
     "name": "Delete template",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "d"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "d" } ]
   },
   {
     "type": "keybinding",
     "id": "SAVE_TEMPLATE",
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Save template",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "!"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "1",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "!" }, { "input_method": "keyboard_code", "key": "1", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "REROLL_CHARACTER",
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Reroll random character",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "%"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "5",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "%" }, { "input_method": "keyboard_code", "key": "5", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "REROLL_CHARACTER_WITH_SCENARIO",
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Reroll random character with scenario",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "^"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "6",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "^" }, { "input_method": "keyboard_code", "key": "6", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "RANDOMIZE_CHAR_NAME",
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Pick random character name",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "n"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "n" } ]
   },
   {
     "type": "keybinding",
@@ -3800,21 +1738,9 @@
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Pick random character description",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "*"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MULTIPLY"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "8",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_char", "key": "*" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
+      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] }
     ]
   },
   {
@@ -3822,92 +1748,35 @@
     "id": "CHANGE_START_OF_CATACLYSM",
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Change Cataclysm start date",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "#"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "3",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "#" }, { "input_method": "keyboard_code", "key": "3", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "CHANGE_START_OF_GAME",
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Change game start date",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "&"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "7",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "&" }, { "input_method": "keyboard_code", "key": "7", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "RESET_CALENDAR",
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Reset scenario calendar",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "~"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "`",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "~" }, { "input_method": "keyboard_code", "key": "`", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "CHOOSE_CITY",
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Choose character starting city",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "C"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "c",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "C" }, { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "CHOOSE_LOCATION",
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Choose character starting location",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "/"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_DIVIDE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "/" }, { "input_method": "keyboard_code", "key": "KEYPAD_DIVIDE" } ]
   },
   {
     "type": "keybinding",
@@ -3915,24 +1784,14 @@
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Exit new character screen",
     "//": "separate entry, because the global entry also has 'q' and 'Q' listed, which conflicts with the character name entry feature of this dialog",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "ESC"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "ESC" } ]
   },
   {
     "type": "keybinding",
     "id": "SORT",
     "category": "NEW_CHAR_PROFESSIONS",
     "name": "Toggle sorting order",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "s"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "s" } ]
   },
   {
     "type": "keybinding",
@@ -3940,21 +1799,9 @@
     "category": "NEW_CHAR_PROFESSIONS",
     "name": "Randomize profession",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "*"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MULTIPLY"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "8",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_char", "key": "*" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
+      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] }
     ]
   },
   {
@@ -3963,21 +1810,9 @@
     "category": "NEW_CHAR_TRAITS",
     "name": "Randomize trait",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "*"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MULTIPLY"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "8",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_char", "key": "*" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
+      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] }
     ]
   },
   {
@@ -3986,21 +1821,9 @@
     "category": "NEW_CHAR_SCENARIOS",
     "name": "Randomize scenario",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "*"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MULTIPLY"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "8",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_char", "key": "*" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
+      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] }
     ]
   },
   {
@@ -4008,481 +1831,201 @@
     "id": "SORT",
     "category": "NEW_CHAR_SCENARIOS",
     "name": "Toggle sorting order",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "s"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "s" } ]
   },
   {
     "type": "keybinding",
     "id": "CHANGE_START_OF_CATACLYSM",
     "category": "NEW_CHAR_SCENARIOS",
     "name": "Change cataclysm start date",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "#"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "3",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "#" }, { "input_method": "keyboard_code", "key": "3", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "CHANGE_START_OF_GAME",
     "category": "NEW_CHAR_SCENARIOS",
     "name": "Change game start date",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "&"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "7",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "&" }, { "input_method": "keyboard_code", "key": "7", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "RESET_CALENDAR",
     "category": "NEW_CHAR_SCENARIOS",
     "name": "Reset scenario calendar",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "~"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "`",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "~" }, { "input_method": "keyboard_code", "key": "`", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_SKILL_INFO_UP",
     "category": "NEW_CHAR_SKILLS",
     "name": "Scroll description up",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "<"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ",",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "<" }, { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_SKILL_INFO_DOWN",
     "category": "NEW_CHAR_SKILLS",
     "name": "Scroll description down",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": ">"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ".",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": ">" }, { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_INFOBOX_UP",
     "name": "Scroll description up",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "<"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ",",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "<" }, { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_INFOBOX_DOWN",
     "name": "Scroll description down",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": ">"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ".",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": ">" }, { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "PREV_CATEGORY",
     "category": "PROFICIENCY_WINDOW",
     "name": "Previous proficiency category",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "<"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ",",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "<" }, { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "NEXT_CATEGORY",
     "category": "PROFICIENCY_WINDOW",
     "name": "Next proficiency category",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": ">"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ".",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": ">" }, { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "REFILL",
     "category": "APP_INTERACT",
     "name": "Refill tank/battery",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "f"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "f" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" } ]
   },
   {
     "type": "keybinding",
     "id": "SIPHON",
     "category": "APP_INTERACT",
     "name": "Siphon from tank",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "s"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "s" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_NE" } ]
   },
   {
     "type": "keybinding",
     "id": "RENAME",
     "category": "APP_INTERACT",
     "name": "Rename appliance",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "e"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_E"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "e" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_E" } ]
   },
   {
     "type": "keybinding",
     "id": "REMOVE",
     "category": "APP_INTERACT",
     "name": "Take down appliance",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "r"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "r" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_SE" } ]
   },
   {
     "type": "keybinding",
     "id": "PLUG",
     "category": "APP_INTERACT",
     "name": "Plug in appliance",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "g"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_S"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "g" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_S" } ]
   },
   {
     "type": "keybinding",
     "id": "DISCONNECT_GRID",
     "category": "APP_INTERACT",
     "name": "Separate from power grid",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "c"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SW"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "c" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_SW" } ]
   },
   {
     "type": "keybinding",
     "id": "INSTALL",
     "category": "VEH_INTERACT",
     "name": "Install part",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "i"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "i" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" } ]
   },
   {
     "type": "keybinding",
     "id": "REPAIR",
     "category": "VEH_INTERACT",
     "name": "Repair part",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "r"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "r" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_NE" } ]
   },
   {
     "type": "keybinding",
     "id": "MEND",
     "category": "VEH_INTERACT",
     "name": "Mend part",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "m"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_E"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "m" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_E" } ]
   },
   {
     "type": "keybinding",
     "id": "REFILL",
     "category": "VEH_INTERACT",
     "name": "Refill tank/battery",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "f"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "f" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_SE" } ]
   },
   {
     "type": "keybinding",
     "id": "UNLOAD",
     "category": "VEH_INTERACT",
     "name": "Unload fuel bunker",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "d"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_S"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "d" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_S" } ]
   },
   {
     "type": "keybinding",
     "id": "REMOVE",
     "category": "VEH_INTERACT",
     "name": "Remove part",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "o"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SW"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "o" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_SW" } ]
   },
   {
     "type": "keybinding",
     "id": "RENAME",
     "category": "VEH_INTERACT",
     "name": "Rename vehicle",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "e"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_N"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "e" }, { "input_method": "gamepad", "key": "JOY_RADIAL_R_N" } ]
   },
   {
     "type": "keybinding",
     "id": "SIPHON",
     "category": "VEH_INTERACT",
     "name": "Siphon from tank",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "s"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_W"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "s" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_W" } ]
   },
   {
     "type": "keybinding",
     "id": "TIRE_CHANGE",
     "category": "VEH_INTERACT",
     "name": "Change tire",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "c"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NW"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "c" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_NW" } ]
   },
   {
     "type": "keybinding",
     "id": "CHANGE_SHAPE",
     "category": "VEH_INTERACT",
     "name": "Change part shape",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "p"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_NE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "p" }, { "input_method": "gamepad", "key": "JOY_RADIAL_R_NE" } ]
   },
   {
     "type": "keybinding",
     "id": "ASSIGN_CREW",
     "category": "VEH_INTERACT",
     "name": "Assign crew",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "w"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_E"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "w" }, { "input_method": "gamepad", "key": "JOY_RADIAL_R_E" } ]
   },
   {
     "type": "keybinding",
     "id": "RELABEL",
     "category": "VEH_INTERACT",
     "name": "Relabel a portion of a vehicle",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "a"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_SE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "a" }, { "input_method": "gamepad", "key": "JOY_RADIAL_R_SE" } ]
   },
   {
     "type": "keybinding",
     "id": "NEXT_TAB",
     "category": "VEH_INTERACT",
     "name": "Go to next tab",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "TAB"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "TAB" } ]
   },
   {
     "type": "keybinding",
@@ -4490,17 +2033,8 @@
     "category": "VEH_INTERACT",
     "name": "Go to previous tab",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "BACKTAB"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "TAB",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_char", "key": "BACKTAB" },
+      { "input_method": "keyboard_code", "key": "TAB", "mod": [ "shift" ] }
     ]
   },
   {
@@ -4508,32 +2042,14 @@
     "id": "FUEL_LIST_UP",
     "category": "VEH_INTERACT",
     "name": "Scroll up through fuel list",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "["
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_ALT_DPAD_UP"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "[" }, { "input_method": "gamepad", "key": "JOY_ALT_DPAD_UP" } ]
   },
   {
     "type": "keybinding",
     "id": "FUEL_LIST_DOWN",
     "category": "VEH_INTERACT",
     "name": "Scroll down through fuel list",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "]"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_ALT_DPAD_DOWN"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "]" }, { "input_method": "gamepad", "key": "JOY_ALT_DPAD_DOWN" } ]
   },
   {
     "type": "keybinding",
@@ -4541,21 +2057,9 @@
     "category": "VEH_INTERACT",
     "name": "Scroll up through vehicle part descriptions",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "<"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ",",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_ALT_DPAD_UP"
-      }
+      { "input_method": "keyboard_char", "key": "<" },
+      { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_UP" }
     ]
   },
   {
@@ -4564,21 +2068,9 @@
     "category": "VEH_INTERACT",
     "name": "Scroll down through vehicle part descriptions",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": ">"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ".",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_ALT_DPAD_DOWN"
-      }
+      { "input_method": "keyboard_char", "key": ">" },
+      { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_DOWN" }
     ]
   },
   {
@@ -4587,21 +2079,9 @@
     "category": "VEH_INTERACT",
     "name": "Scroll up through vehicle overview",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "{"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "[",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_ALT_DPAD_UP"
-      }
+      { "input_method": "keyboard_char", "key": "{" },
+      { "input_method": "keyboard_code", "key": "[", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_UP" }
     ]
   },
   {
@@ -4610,21 +2090,9 @@
     "category": "VEH_INTERACT",
     "name": "Scroll down through vehicle overview",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "}"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "]",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_ALT_DPAD_DOWN"
-      }
+      { "input_method": "keyboard_char", "key": "}" },
+      { "input_method": "keyboard_code", "key": "]", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_DOWN" }
     ]
   },
   {
@@ -4632,16 +2100,7 @@
     "id": "TOGGLE_UNAVAILABLE_CONSTRUCTIONS",
     "category": "CONSTRUCTION",
     "name": "Toggle unavailable constructions",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": ";"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": ";" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" } ]
   },
   {
     "type": "keybinding",
@@ -4649,21 +2108,9 @@
     "category": "CONSTRUCTION",
     "name": "Scroll to previous stage",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "<"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ",",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_ALT_DPAD_DOWN"
-      }
+      { "input_method": "keyboard_char", "key": "<" },
+      { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_DOWN" }
     ]
   },
   {
@@ -4672,33 +2119,16 @@
     "category": "CONSTRUCTION",
     "name": "Scroll to next stage",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": ">"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ".",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_ALT_DPAD_UP"
-      }
+      { "input_method": "keyboard_char", "key": ">" },
+      { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_UP" }
     ]
   },
   {
     "type": "keybinding",
     "id": "EDITMAP_SHOW_ALL",
     "name": "Show all",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "v"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "v" } ]
   },
   {
     "type": "keybinding",
@@ -4706,18 +2136,9 @@
     "category": "EDITMAP_FEATURE",
     "name": "Confirm and quit",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "e"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "r"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "t"
-      }
+      { "input_method": "keyboard_any", "key": "e" },
+      { "input_method": "keyboard_any", "key": "r" },
+      { "input_method": "keyboard_any", "key": "t" }
     ]
   },
   {
@@ -4725,283 +2146,145 @@
     "id": "RESIZE",
     "category": "EDITMAP_SHAPE",
     "name": "Resize",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "s"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "s" } ]
   },
   {
     "type": "keybinding",
     "id": "START",
     "category": "EDITMAP_SHAPE",
     "name": "To start",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "z"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "z" } ]
   },
   {
     "type": "keybinding",
     "id": "SWAP",
     "category": "EDITMAP_SHAPE",
     "name": "Swap origin and target",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "y"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "y" } ]
   },
   {
     "type": "keybinding",
     "id": "EDITMAP_MOVE",
     "name": "Move shape",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "m"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "m" } ]
   },
   {
     "type": "keybinding",
     "id": "EDITMAP_TOGGLE_POST_PROCESS_GENERATORS",
     "name": "Toggle post-process generators",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "p"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "p" } ]
   },
   {
     "type": "keybinding",
     "id": "EDITMAP_TAB",
     "name": "Switch to move point / confirm",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "TAB"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "TAB" } ]
   },
   {
     "type": "keybinding",
     "id": "EDIT_TRAPS",
     "category": "EDITMAP",
     "name": "Edit traps",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "t"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "t" } ]
   },
   {
     "type": "keybinding",
     "id": "EDIT_FIELDS",
     "category": "EDITMAP",
     "name": "Edit fields",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "f"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "f" } ]
   },
   {
     "type": "keybinding",
     "id": "EDIT_RADS",
     "category": "EDITMAP",
     "name": "Edit radiation",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "a"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "a" } ]
   },
   {
     "type": "keybinding",
     "id": "EDIT_TERRAIN",
     "category": "EDITMAP",
     "name": "Edit terrain",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "e"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "e" } ]
   },
   {
     "type": "keybinding",
     "id": "EDIT_FURNITURE",
     "category": "EDITMAP",
     "name": "Edit furniture",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "r"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "r" } ]
   },
   {
     "type": "keybinding",
     "id": "EDIT_OVERMAP",
     "category": "EDITMAP",
     "name": "Edit overmap/mapgen",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "o"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "o" } ]
   },
   {
     "type": "keybinding",
     "id": "EDIT_ITEMS",
     "category": "EDITMAP",
     "name": "Edit items",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "i"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "i" } ]
   },
   {
     "type": "keybinding",
     "id": "EDIT_MONSTER",
     "category": "EDITMAP",
     "name": "Edit creatures",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "m"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "m" } ]
   },
   {
     "type": "keybinding",
     "id": "SHOW_ALL",
     "category": "EDITMAP",
     "name": "Show whole map",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "v"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "v" } ]
   },
   {
     "type": "keybinding",
     "id": "LEFT_WIDE",
     "name": "Wide move left",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "H"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "h",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "H" }, { "input_method": "keyboard_code", "key": "h", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "RIGHT_WIDE",
     "name": "Wide move right",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "L"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "l",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "L" }, { "input_method": "keyboard_code", "key": "l", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "UP_WIDE",
     "name": "Wide move up",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "K"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "k",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "K" }, { "input_method": "keyboard_code", "key": "k", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "DOWN_WIDE",
     "name": "Wide move down",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "J"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "j",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "J" }, { "input_method": "keyboard_code", "key": "j", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "CATEGORY_SELECTION",
     "category": "INVENTORY",
     "name": "Toggle category selection mode",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "t"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "t" } ]
   },
   {
     "type": "keybinding",
     "id": "VIEW_CATEGORY_MODE",
     "name": "Toggle inventory view to show item categories",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": ";"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": ";" } ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_NUMPAD_NAVIGATION",
     "name": "Toggle navigation with numpad numbers",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "F5"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "F5" } ]
   },
   {
     "type": "keybinding",
@@ -5009,18 +2292,9 @@
     "category": "INVENTORY",
     "name": "Set item filter",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "/"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_DIVIDE"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SW"
-      }
+      { "input_method": "keyboard_any", "key": "/" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_DIVIDE" },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_SW" }
     ]
   },
   {
@@ -5028,32 +2302,14 @@
     "id": "EXAMINE",
     "category": "INVENTORY",
     "name": "Examine",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "e"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "e" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" } ]
   },
   {
     "type": "keybinding",
     "id": "WIELD",
     "category": "INVENTORY",
     "name": "Wield",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "w"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_E"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "w" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_E" } ]
   },
   {
     "type": "keybinding",
@@ -5061,21 +2317,9 @@
     "category": "INVENTORY",
     "name": "Wear",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "W"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "w",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_W"
-      }
+      { "input_method": "keyboard_char", "key": "W" },
+      { "input_method": "keyboard_code", "key": "w", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_W" }
     ]
   },
   {
@@ -5083,32 +2327,14 @@
     "id": "EXAMINE_CONTENTS",
     "category": "INVENTORY",
     "name": "Examine contents",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "o"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "o" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_NE" } ]
   },
   {
     "type": "keybinding",
     "id": "ORGANIZE_MENU",
     "category": "INVENTORY",
     "name": "Organize contents",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "i"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "i" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_SE" } ]
   },
   {
     "type": "keybinding",
@@ -5116,25 +2342,10 @@
     "category": "INVENTORY",
     "name": "Toggle item as favorite",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "*"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MULTIPLY"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "8",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NW"
-      }
+      { "input_method": "keyboard_char", "key": "*" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
+      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_NW" }
     ]
   },
   {
@@ -5143,21 +2354,9 @@
     "category": "INVENTORY",
     "name": "Show/hide contents",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": ">"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ".",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_S"
-      }
+      { "input_method": "keyboard_char", "key": ">" },
+      { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_S" }
     ]
   },
   {
@@ -5177,19 +2376,7 @@
     "id": "CONTAIN_MODE",
     "category": "INVENTORY",
     "name": "Toggle contain mode for unloaded items",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "U"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "u",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "U" }, { "input_method": "keyboard_code", "key": "u", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
@@ -5197,21 +2384,9 @@
     "category": "BIONICS",
     "name": "Toggle activate/examine",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "!"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "1",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
-      }
+      { "input_method": "keyboard_char", "key": "!" },
+      { "input_method": "keyboard_code", "key": "1", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" }
     ]
   },
   {
@@ -5220,21 +2395,9 @@
     "category": "BIONICS",
     "name": "Toggle safe fuel mod",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "S"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "s",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NE"
-      }
+      { "input_method": "keyboard_char", "key": "S" },
+      { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_NE" }
     ]
   },
   {
@@ -5243,21 +2406,9 @@
     "category": "BIONICS",
     "name": "Toggle sprite",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "H"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "h",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_E"
-      }
+      { "input_method": "keyboard_char", "key": "H" },
+      { "input_method": "keyboard_code", "key": "h", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_E" }
     ]
   },
   {
@@ -5266,21 +2417,9 @@
     "category": "BIONICS",
     "name": "Open refuel menu",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "R"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "r",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SE"
-      }
+      { "input_method": "keyboard_char", "key": "R" },
+      { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_SE" }
     ]
   },
   {
@@ -5289,21 +2428,9 @@
     "category": "BIONICS",
     "name": "Toggle auto start mod",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "A"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "a",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_S"
-      }
+      { "input_method": "keyboard_char", "key": "A" },
+      { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_S" }
     ]
   },
   {
@@ -5311,16 +2438,7 @@
     "id": "SORT",
     "category": "BIONICS",
     "name": "Sort bionics list",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "s"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SW"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "s" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_SW" } ]
   },
   {
     "type": "keybinding",
@@ -5328,21 +2446,9 @@
     "category": "MUTATIONS",
     "name": "Toggle activate/examine",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "!"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "1",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
-      }
+      { "input_method": "keyboard_char", "key": "!" },
+      { "input_method": "keyboard_code", "key": "1", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" }
     ]
   },
   {
@@ -5350,38 +2456,14 @@
     "id": "SCROLL_TRAIT_INFO_UP",
     "category": "MUTATIONS",
     "name": "Scroll mutation info up",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "<"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ",",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "<" }, { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_TRAIT_INFO_DOWN",
     "category": "MUTATIONS",
     "name": "Scroll mutation info down",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": ">"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ".",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": ">" }, { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
@@ -5389,21 +2471,9 @@
     "category": "MEDICAL",
     "name": "Use item",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "A"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "a",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
-      }
+      { "input_method": "keyboard_char", "key": "A" },
+      { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" }
     ]
   },
   {
@@ -5412,26 +2482,11 @@
     "category": "DEFAULTMODE",
     "id": "pause",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "."
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_PERIOD"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "5"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_5"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RT"
-      }
+      { "input_method": "keyboard_any", "key": "." },
+      { "input_method": "keyboard_code", "key": "KEYPAD_PERIOD" },
+      { "input_method": "keyboard_any", "key": "5" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_5" },
+      { "input_method": "gamepad", "key": "JOY_RT" }
     ]
   },
   {
@@ -5450,119 +2505,70 @@
     "name": "Center view",
     "category": "DEFAULTMODE",
     "id": "center",
-    "bindings": []
+    "bindings": [  ]
   },
   {
     "type": "keybinding",
     "name": "Move view north",
     "category": "DEFAULTMODE",
     "id": "shift_n",
-    "bindings": [
-      {
-        "input_method": "gamepad",
-        "key": "JOY_R_UP"
-      }
-    ]
+    "bindings": [ { "input_method": "gamepad", "key": "JOY_R_UP" } ]
   },
   {
     "type": "keybinding",
     "name": "Move view east",
     "category": "DEFAULTMODE",
     "id": "shift_e",
-    "bindings": [
-      {
-        "input_method": "gamepad",
-        "key": "JOY_R_RIGHT"
-      }
-    ]
+    "bindings": [ { "input_method": "gamepad", "key": "JOY_R_RIGHT" } ]
   },
   {
     "type": "keybinding",
     "name": "Move view south",
     "category": "DEFAULTMODE",
     "id": "shift_s",
-    "bindings": [
-      {
-        "input_method": "gamepad",
-        "key": "JOY_R_DOWN"
-      }
-    ]
+    "bindings": [ { "input_method": "gamepad", "key": "JOY_R_DOWN" } ]
   },
   {
     "type": "keybinding",
     "name": "Move view west",
     "category": "DEFAULTMODE",
     "id": "shift_w",
-    "bindings": [
-      {
-        "input_method": "gamepad",
-        "key": "JOY_R_LEFT"
-      }
-    ]
+    "bindings": [ { "input_method": "gamepad", "key": "JOY_R_LEFT" } ]
   },
   {
     "type": "keybinding",
     "name": "Open door",
     "category": "DEFAULTMODE",
     "id": "open",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "o"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "o" } ]
   },
   {
     "type": "keybinding",
     "name": "Close door",
     "category": "DEFAULTMODE",
     "id": "close",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "c"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "c" } ]
   },
   {
     "type": "keybinding",
     "name": "Smash nearby terrain",
     "category": "DEFAULTMODE",
     "id": "smash",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "s"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_ALT_X"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "s" }, { "input_method": "gamepad", "key": "JOY_ALT_X" } ]
   },
   {
     "type": "keybinding",
     "name": "Examine nearby terrain or furniture",
     "category": "DEFAULTMODE",
     "id": "examine",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "e"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "e" } ]
   },
   {
     "type": "keybinding",
     "name": "Examine nearby terrain, furniture, and items",
     "category": "DEFAULTMODE",
     "id": "examine_and_pickup",
-    "bindings": [
-      {
-        "input_method": "gamepad",
-        "key": "JOY_X"
-      }
-    ]
+    "bindings": [ { "input_method": "gamepad", "key": "JOY_X" } ]
   },
   {
     "type": "keybinding",
@@ -5570,18 +2576,9 @@
     "category": "DEFAULTMODE",
     "id": "advinv",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "/"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_DIVIDE"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_SE"
-      }
+      { "input_method": "keyboard_any", "key": "/" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_DIVIDE" },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_R_SE" }
     ]
   },
   {
@@ -5589,12 +2586,7 @@
     "name": "Pick up items from one nearby tile",
     "category": "DEFAULTMODE",
     "id": "pickup",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "g"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "g" } ]
   },
   {
     "type": "keybinding",
@@ -5608,21 +2600,9 @@
     "category": "DEFAULTMODE",
     "id": "grab",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "G"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "g",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_B"
-      }
+      { "input_method": "keyboard_char", "key": "G" },
+      { "input_method": "keyboard_code", "key": "g", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_B" }
     ]
   },
   {
@@ -5630,16 +2610,7 @@
     "name": "Haul items along the ground",
     "category": "DEFAULTMODE",
     "id": "haul",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "\\"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_ALT_B"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "\\" }, { "input_method": "gamepad", "key": "JOY_ALT_B" } ]
   },
   {
     "type": "keybinding",
@@ -5652,19 +2623,7 @@
     "name": "Zone activities",
     "category": "DEFAULTMODE",
     "id": "loot",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "O"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "o",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "O" }, { "input_method": "keyboard_code", "key": "o", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
@@ -5672,21 +2631,9 @@
     "category": "DEFAULTMODE",
     "id": "butcher",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "B"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "b",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_E"
-      }
+      { "input_method": "keyboard_char", "key": "B" },
+      { "input_method": "keyboard_code", "key": "b", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_E" }
     ]
   },
   {
@@ -5694,35 +2641,14 @@
     "name": "Chat with NPC",
     "category": "DEFAULTMODE",
     "id": "chat",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "C"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "c",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "C" }, { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "name": "Look around",
     "category": "DEFAULTMODE",
     "id": "look",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": ";"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "x"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": ";" }, { "input_method": "keyboard_any", "key": "x" } ]
   },
   {
     "type": "keybinding",
@@ -5736,21 +2662,9 @@
     "category": "DEFAULTMODE",
     "id": "peek",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "X"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "x",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_ALT_RS"
-      }
+      { "input_method": "keyboard_char", "key": "X" },
+      { "input_method": "keyboard_code", "key": "x", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_ALT_RS" }
     ]
   },
   {
@@ -5759,21 +2673,9 @@
     "category": "DEFAULTMODE",
     "id": "listitems",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "V"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "v",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RS"
-      }
+      { "input_method": "keyboard_char", "key": "V" },
+      { "input_method": "keyboard_code", "key": "v", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RS" }
     ]
   },
   {
@@ -5781,78 +2683,35 @@
     "name": "Zones manager",
     "category": "DEFAULTMODE",
     "id": "zones",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "Y"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "y",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "Y" }, { "input_method": "keyboard_code", "key": "y", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "name": "Open inventory",
     "category": "DEFAULTMODE",
     "id": "inventory",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "i"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_S"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "i" }, { "input_method": "gamepad", "key": "JOY_RADIAL_R_S" } ]
   },
   {
     "type": "keybinding",
     "name": "Compare two items",
     "category": "DEFAULTMODE",
     "id": "compare",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "I"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "i",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "I" }, { "input_method": "keyboard_code", "key": "i", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "name": "Swap inventory letters",
     "category": "DEFAULTMODE",
     "id": "organize",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "="
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "=" } ]
   },
   {
     "type": "keybinding",
     "name": "Use item",
     "category": "DEFAULTMODE",
     "id": "apply",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "a"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "a" } ]
   },
   {
     "type": "keybinding",
@@ -5860,21 +2719,9 @@
     "category": "DEFAULTMODE",
     "id": "apply_wielded",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "A"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "a",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_ALT_DPAD_RIGHT"
-      }
+      { "input_method": "keyboard_char", "key": "A" },
+      { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_RIGHT" }
     ]
   },
   {
@@ -5883,21 +2730,9 @@
     "category": "DEFAULTMODE",
     "id": "wear",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "W"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "w",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_DPAD_LEFT"
-      }
+      { "input_method": "keyboard_char", "key": "W" },
+      { "input_method": "keyboard_code", "key": "w", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_DPAD_LEFT" }
     ]
   },
   {
@@ -5906,21 +2741,9 @@
     "category": "DEFAULTMODE",
     "id": "take_off",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "T"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "t",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_ALT_DPAD_LEFT"
-      }
+      { "input_method": "keyboard_char", "key": "T" },
+      { "input_method": "keyboard_code", "key": "t", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_LEFT" }
     ]
   },
   {
@@ -5929,21 +2752,9 @@
     "category": "DEFAULTMODE",
     "id": "eat",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "E"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "e",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_DPAD_UP"
-      }
+      { "input_method": "keyboard_char", "key": "E" },
+      { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_DPAD_UP" }
     ]
   },
   {
@@ -5958,21 +2769,9 @@
     "category": "DEFAULTMODE",
     "id": "read",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "R"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "r",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NE"
-      }
+      { "input_method": "keyboard_char", "key": "R" },
+      { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_NE" }
     ]
   },
   {
@@ -5980,16 +2779,7 @@
     "name": "Wield",
     "category": "DEFAULTMODE",
     "id": "wield",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "w"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_DPAD_RIGHT"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "w" }, { "input_method": "gamepad", "key": "JOY_DPAD_RIGHT" } ]
   },
   {
     "type": "keybinding",
@@ -5997,21 +2787,9 @@
     "category": "DEFAULTMODE",
     "id": "pick_style",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "_"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "-",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_ALT_RB"
-      }
+      { "input_method": "keyboard_char", "key": "_" },
+      { "input_method": "keyboard_code", "key": "-", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_ALT_RB" }
     ]
   },
   {
@@ -6031,47 +2809,21 @@
     "name": "Insert item",
     "category": "DEFAULTMODE",
     "id": "insert",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "v"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "v" } ]
   },
   {
     "type": "keybinding",
     "name": "Unload item",
     "category": "DEFAULTMODE",
     "id": "unload",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "U"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "u",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "U" }, { "input_method": "keyboard_code", "key": "u", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "name": "Throw item",
     "category": "DEFAULTMODE",
     "id": "throw",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "t"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_Y"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "t" }, { "input_method": "gamepad", "key": "JOY_Y" } ]
   },
   {
     "type": "keybinding",
@@ -6084,12 +2836,7 @@
     "name": "Blind throw item",
     "category": "LOOK",
     "id": "throw_blind",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "t"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "t" } ]
   },
   {
     "type": "keybinding",
@@ -6102,63 +2849,28 @@
     "name": "Fire wielded item",
     "category": "DEFAULTMODE",
     "id": "fire",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "f"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_LB"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "f" }, { "input_method": "gamepad", "key": "JOY_LB" } ]
   },
   {
     "type": "keybinding",
     "name": "Toggle attack mode of wielded item",
     "category": "DEFAULTMODE",
     "id": "select_fire_mode",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "F"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "f",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "F" }, { "input_method": "keyboard_code", "key": "f", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "name": "Select default ammo for wielded weapon which do not use a magazine",
     "category": "DEFAULTMODE",
     "id": "select_default_ammo",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "F3"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "F3" } ]
   },
   {
     "type": "keybinding",
     "name": "Drop item",
     "category": "DEFAULTMODE",
     "id": "drop",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "d"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_DPAD_DOWN"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "d" }, { "input_method": "gamepad", "key": "JOY_DPAD_DOWN" } ]
   },
   {
     "type": "keybinding",
@@ -6171,43 +2883,21 @@
     "name": "Drop item to adjacent tile",
     "category": "DEFAULTMODE",
     "id": "drop_adj",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "D"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "d",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "D" }, { "input_method": "keyboard_code", "key": "d", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "name": "View/activate bionics",
     "category": "DEFAULTMODE",
     "id": "bionics",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "p"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "p" } ]
   },
   {
     "type": "keybinding",
     "name": "View/activate mutations",
     "category": "DEFAULTMODE",
     "id": "mutations",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "["
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "[" } ]
   },
   {
     "type": "keybinding",
@@ -6215,21 +2905,9 @@
     "category": "DEFAULTMODE",
     "id": "medical",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "N"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "n",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_NE"
-      }
+      { "input_method": "keyboard_char", "key": "N" },
+      { "input_method": "keyboard_code", "key": "n", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_R_NE" }
     ]
   },
   {
@@ -6238,21 +2916,9 @@
     "category": "DEFAULTMODE",
     "id": "bodystatus",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "{"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "[",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_SW"
-      }
+      { "input_method": "keyboard_char", "key": "{" },
+      { "input_method": "keyboard_code", "key": "[", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_R_SW" }
     ]
   },
   {
@@ -6261,21 +2927,9 @@
     "category": "DEFAULTMODE",
     "id": "sort_armor",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "+"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_PLUS"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "=",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_char", "key": "+" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" },
+      { "input_method": "keyboard_code", "key": "=", "mod": [ "shift" ] }
     ]
   },
   {
@@ -6284,21 +2938,9 @@
     "category": "DEFAULTMODE",
     "id": "wait",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "|"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "\\",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SE"
-      }
+      { "input_method": "keyboard_char", "key": "|" },
+      { "input_method": "keyboard_code", "key": "\\", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_SE" }
     ]
   },
   {
@@ -6307,21 +2949,9 @@
     "category": "DEFAULTMODE",
     "id": "craft",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "&"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "7",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
-      }
+      { "input_method": "keyboard_char", "key": "&" },
+      { "input_method": "keyboard_code", "key": "7", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" }
     ]
   },
   {
@@ -6330,18 +2960,9 @@
     "category": "DEFAULTMODE",
     "id": "recraft",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "-"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MINUS"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NW"
-      }
+      { "input_method": "keyboard_any", "key": "-" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_NW" }
     ]
   },
   {
@@ -6350,25 +2971,10 @@
     "category": "DEFAULTMODE",
     "id": "construct",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "*"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MULTIPLY"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "8",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_S"
-      }
+      { "input_method": "keyboard_char", "key": "*" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
+      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_S" }
     ]
   },
   {
@@ -6377,21 +2983,9 @@
     "category": "DEFAULTMODE",
     "id": "disassemble",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "("
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "9",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_W"
-      }
+      { "input_method": "keyboard_char", "key": "(" },
+      { "input_method": "keyboard_code", "key": "9", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_W" }
     ]
   },
   {
@@ -6400,21 +2994,9 @@
     "category": "DEFAULTMODE",
     "id": "sleep",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "$"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "4",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SW"
-      }
+      { "input_method": "keyboard_char", "key": "$" },
+      { "input_method": "keyboard_code", "key": "4", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_SW" }
     ]
   },
   {
@@ -6428,19 +3010,7 @@
     "name": "Control vehicle",
     "category": "DEFAULTMODE",
     "id": "control_vehicle",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "^"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "6",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "^" }, { "input_method": "keyboard_code", "key": "6", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
@@ -6454,21 +3024,9 @@
     "category": "DEFAULTMODE",
     "id": "safemode",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "!"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "1",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_ALT_LS"
-      }
+      { "input_method": "keyboard_char", "key": "!" },
+      { "input_method": "keyboard_code", "key": "1", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_ALT_LS" }
     ]
   },
   {
@@ -6476,54 +3034,21 @@
     "name": "Ignore nearby enemy",
     "category": "DEFAULTMODE",
     "id": "ignore_enemy",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "'"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_LS"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "'" }, { "input_method": "gamepad", "key": "JOY_LS" } ]
   },
   {
     "type": "keybinding",
     "name": "Whitelist enemy",
     "category": "DEFAULTMODE",
     "id": "whitelist_enemy",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "~"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "`",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "~" }, { "input_method": "keyboard_code", "key": "`", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "name": "Save and quit",
     "category": "DEFAULTMODE",
     "id": "save",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "S"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "s",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "S" }, { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
@@ -6537,21 +3062,9 @@
     "category": "DEFAULTMODE",
     "id": "player_data",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "@"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "2",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_N"
-      }
+      { "input_method": "keyboard_char", "key": "@" },
+      { "input_method": "keyboard_code", "key": "2", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_R_N" }
     ]
   },
   {
@@ -6559,27 +3072,13 @@
     "name": "View map",
     "category": "DEFAULTMODE",
     "id": "map",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "m"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_BACK"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "m" }, { "input_method": "gamepad", "key": "JOY_BACK" } ]
   },
   {
     "type": "keybinding",
     "name": "View map",
     "id": "map",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": ";"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": ";" } ]
   },
   {
     "type": "keybinding",
@@ -6593,21 +3092,9 @@
     "category": "DEFAULTMODE",
     "id": "missions",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "M"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "m",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_W"
-      }
+      { "input_method": "keyboard_char", "key": "M" },
+      { "input_method": "keyboard_code", "key": "m", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_R_W" }
     ]
   },
   {
@@ -6616,21 +3103,9 @@
     "category": "DEFAULTMODE",
     "id": "factions",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "#"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "3",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_E"
-      }
+      { "input_method": "keyboard_char", "key": "#" },
+      { "input_method": "keyboard_code", "key": "3", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_R_E" }
     ]
   },
   {
@@ -6638,83 +3113,36 @@
     "name": "View character's morale",
     "category": "DEFAULTMODE",
     "id": "morale",
-    "bindings": [
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_NW"
-      }
-    ]
+    "bindings": [ { "input_method": "gamepad", "key": "JOY_RADIAL_R_NW" } ]
   },
   {
     "type": "keybinding",
     "name": "View message log",
     "category": "DEFAULTMODE",
     "id": "messages",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "P"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "p",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "P" }, { "input_method": "keyboard_code", "key": "p", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "name": "View help",
     "category": "DEFAULTMODE",
     "id": "help",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "0"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_0"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "0" }, { "input_method": "keyboard_code", "key": "KEYPAD_0" } ]
   },
   {
     "type": "keybinding",
     "name": "Zoom in",
     "id": "zoom_in",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "z"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_ALT_START"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "z" }, { "input_method": "gamepad", "key": "JOY_ALT_START" } ]
   },
   {
     "type": "keybinding",
     "name": "Zoom out",
     "id": "zoom_out",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "Z"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "z",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_ALT_BACK"
-      }
+      { "input_method": "keyboard_char", "key": "Z" },
+      { "input_method": "keyboard_code", "key": "z", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_ALT_BACK" }
     ]
   },
   {
@@ -6734,17 +3162,8 @@
     "id": "DEBUG_DIALOGUE_DL_CONDITIONAL",
     "name": "Toggle debug dialogue dynamic_line conditionals",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "CTRL+C"
-      },
-      {
-        "input_method": "keyboard_code",
-        "mod": [
-          "ctrl"
-        ],
-        "key": "c"
-      }
+      { "input_method": "keyboard_char", "key": "CTRL+C" },
+      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "c" }
     ]
   },
   {
@@ -6752,17 +3171,8 @@
     "id": "DEBUG_DIALOGUE_RESP_CONDITIONAL",
     "name": "Toggle debug dialogue response conditionals",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "CTRL+D"
-      },
-      {
-        "input_method": "keyboard_code",
-        "mod": [
-          "ctrl"
-        ],
-        "key": "d"
-      }
+      { "input_method": "keyboard_char", "key": "CTRL+D" },
+      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "d" }
     ]
   },
   {
@@ -6770,17 +3180,8 @@
     "id": "DEBUG_DIALOGUE_DL_EFFECT",
     "name": "Toggle debug dialogue dynamic_line effects",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "CTRL+T"
-      },
-      {
-        "input_method": "keyboard_code",
-        "mod": [
-          "ctrl"
-        ],
-        "key": "t"
-      }
+      { "input_method": "keyboard_char", "key": "CTRL+T" },
+      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "t" }
     ]
   },
   {
@@ -6788,17 +3189,8 @@
     "id": "DEBUG_DIALOGUE_RESP_EFFECT",
     "name": "Toggle debug dialogue response effects",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "CTRL+Y"
-      },
-      {
-        "input_method": "keyboard_code",
-        "mod": [
-          "ctrl"
-        ],
-        "key": "y"
-      }
+      { "input_method": "keyboard_char", "key": "CTRL+Y" },
+      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "y" }
     ]
   },
   {
@@ -6806,17 +3198,8 @@
     "id": "DEBUG_DIALOGUE_SHOW_ALL_RESPONSE",
     "name": "Toggle debug dialogue show hidden responses",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "CTRL+R"
-      },
-      {
-        "input_method": "keyboard_code",
-        "mod": [
-          "ctrl"
-        ],
-        "key": "r"
-      }
+      { "input_method": "keyboard_char", "key": "CTRL+R" },
+      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "r" }
     ]
   },
   {
@@ -6825,21 +3208,9 @@
     "category": "CALENDAR_UI",
     "name": "Reset time point to initial value",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "r"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "R"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "r",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_any", "key": "r" },
+      { "input_method": "keyboard_char", "key": "R" },
+      { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] }
     ]
   },
   {
@@ -6853,36 +3224,21 @@
     "category": "DEBUG_SPELLS",
     "id": "TOGGLE_ALL_SPELL",
     "name": "Toggle all spells",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "t"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "t" } ]
   },
   {
     "type": "keybinding",
     "category": "DEBUG_SPELLS",
     "id": "UNLEARN_SPELL",
     "name": "Unlearn a spell",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "u"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "u" } ]
   },
   {
     "type": "keybinding",
     "category": "DEBUG_SPELLS",
     "id": "SHOW_ONLY_LEARNED",
     "name": "Show only learned",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "a"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "a" } ]
   },
   {
     "type": "keybinding",
@@ -6912,16 +3268,7 @@
     "name": "Reload item",
     "category": "DEFAULTMODE",
     "id": "reload_item",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "r"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_ALT_LB"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "r" }, { "input_method": "gamepad", "key": "JOY_ALT_LB" } ]
   },
   {
     "type": "keybinding",
@@ -6971,18 +3318,9 @@
     "category": "DEFAULTMODE",
     "id": "action_menu",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "RETURN"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "KEYPAD_ENTER"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_A"
-      }
+      { "input_method": "keyboard_any", "key": "RETURN" },
+      { "input_method": "keyboard_any", "key": "KEYPAD_ENTER" },
+      { "input_method": "gamepad", "key": "JOY_A" }
     ]
   },
   {
@@ -6991,21 +3329,9 @@
     "category": "DEFAULTMODE",
     "id": "item_action_menu",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "%"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "5",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_ALT_A"
-      }
+      { "input_method": "keyboard_char", "key": "%" },
+      { "input_method": "keyboard_code", "key": "5", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_ALT_A" }
     ]
   },
   {
@@ -7025,48 +3351,28 @@
     "name": "Move view northeast",
     "category": "DEFAULTMODE",
     "id": "shift_ne",
-    "bindings": [
-      {
-        "input_method": "gamepad",
-        "key": "JOY_R_RIGHTUP"
-      }
-    ]
+    "bindings": [ { "input_method": "gamepad", "key": "JOY_R_RIGHTUP" } ]
   },
   {
     "type": "keybinding",
     "name": "Move view southeast",
     "category": "DEFAULTMODE",
     "id": "shift_se",
-    "bindings": [
-      {
-        "input_method": "gamepad",
-        "key": "JOY_R_RIGHTDOWN"
-      }
-    ]
+    "bindings": [ { "input_method": "gamepad", "key": "JOY_R_RIGHTDOWN" } ]
   },
   {
     "type": "keybinding",
     "name": "Move view southwest",
     "category": "DEFAULTMODE",
     "id": "shift_sw",
-    "bindings": [
-      {
-        "input_method": "gamepad",
-        "key": "JOY_R_LEFTDOWN"
-      }
-    ]
+    "bindings": [ { "input_method": "gamepad", "key": "JOY_R_LEFTDOWN" } ]
   },
   {
     "type": "keybinding",
     "name": "Move view northwest",
     "category": "DEFAULTMODE",
     "id": "shift_nw",
-    "bindings": [
-      {
-        "input_method": "gamepad",
-        "key": "JOY_R_LEFTUP"
-      }
-    ]
+    "bindings": [ { "input_method": "gamepad", "key": "JOY_R_LEFTUP" } ]
   },
   {
     "type": "keybinding",
@@ -7091,32 +3397,14 @@
     "name": "Autoattack",
     "category": "DEFAULTMODE",
     "id": "autoattack",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "TAB"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RB"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "TAB" }, { "input_method": "gamepad", "key": "JOY_RB" } ]
   },
   {
     "type": "keybinding",
     "name": "Main menu",
     "category": "DEFAULTMODE",
     "id": "main_menu",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "ESC"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_START"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "ESC" }, { "input_method": "gamepad", "key": "JOY_START" } ]
   },
   {
     "type": "keybinding",
@@ -7165,7 +3453,7 @@
     "name": "Cycle movement mode",
     "category": "DEFAULTMODE",
     "id": "cycle_move",
-    "bindings": []
+    "bindings": [  ]
   },
   {
     "type": "keybinding",
@@ -7203,21 +3491,9 @@
     "category": "DEFAULTMODE",
     "id": "open_movement",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "\""
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "'",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_ALT_RT"
-      }
+      { "input_method": "keyboard_char", "key": "\"" },
+      { "input_method": "keyboard_code", "key": "'", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_ALT_RT" }
     ]
   },
   {
@@ -7225,16 +3501,7 @@
     "id": "cast_spell",
     "name": "Supernatural abilities",
     "category": "DEFAULTMODE",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "]"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_ALT_Y"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "]" }, { "input_method": "gamepad", "key": "JOY_ALT_Y" } ]
   },
   {
     "type": "keybinding",
@@ -7247,19 +3514,7 @@
     "id": "diary",
     "name": "Open diary / achievements / scores",
     "category": "DEFAULTMODE",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": ")"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "0",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": ")" }, { "input_method": "keyboard_code", "key": "0", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
@@ -7267,21 +3522,9 @@
     "category": "LIST_ITEMS",
     "name": "Scroll item info up",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "<"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ",",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_ALT_DPAD_UP"
-      }
+      { "input_method": "keyboard_char", "key": "<" },
+      { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_UP" }
     ]
   },
   {
@@ -7290,21 +3533,9 @@
     "category": "LIST_ITEMS",
     "name": "Scroll item info down",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": ">"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ".",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_ALT_DPAD_DOWN"
-      }
+      { "input_method": "keyboard_char", "key": ">" },
+      { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_DOWN" }
     ]
   },
   {
@@ -7313,36 +3544,12 @@
     "category": "LIST_ITEMS",
     "name": "Compare",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "I"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "i",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "c"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "C"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "c",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NE"
-      }
+      { "input_method": "keyboard_char", "key": "I" },
+      { "input_method": "keyboard_code", "key": "i", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "c" },
+      { "input_method": "keyboard_char", "key": "C" },
+      { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_NE" }
     ]
   },
   {
@@ -7351,25 +3558,10 @@
     "category": "LIST_ITEMS",
     "name": "Examine",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "e"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "E"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "e",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
-      }
+      { "input_method": "keyboard_any", "key": "e" },
+      { "input_method": "keyboard_char", "key": "E" },
+      { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" }
     ]
   },
   {
@@ -7378,22 +3570,10 @@
     "category": "LIST_ITEMS",
     "name": "Increase priority",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "="
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "+"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_PLUS"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_E"
-      }
+      { "input_method": "keyboard_any", "key": "=" },
+      { "input_method": "keyboard_char", "key": "+" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_E" }
     ]
   },
   {
@@ -7402,18 +3582,9 @@
     "category": "LIST_ITEMS",
     "name": "Decrease priority",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "-"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MINUS"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_W"
-      }
+      { "input_method": "keyboard_any", "key": "-" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_W" }
     ]
   },
   {
@@ -7422,25 +3593,10 @@
     "category": "LIST_ITEMS",
     "name": "Change sort order",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "s"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "S"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "s",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SE"
-      }
+      { "input_method": "keyboard_any", "key": "s" },
+      { "input_method": "keyboard_char", "key": "S" },
+      { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_SE" }
     ]
   },
   {
@@ -7448,67 +3604,28 @@
     "id": "SAFEMODE_BLACKLIST_ADD",
     "category": "LIST_MONSTERS",
     "name": "Add to safe mode blacklist",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "a"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "a" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" } ]
   },
   {
     "type": "keybinding",
     "id": "SAFEMODE_BLACKLIST_REMOVE",
     "category": "LIST_MONSTERS",
     "name": "Remove from safe mode blacklist",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "r"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_S"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "r" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_S" } ]
   },
   {
     "type": "keybinding",
     "id": "look",
     "category": "LIST_MONSTERS",
     "name": "Look around",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "x"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_E"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "x" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_E" } ]
   },
   {
     "type": "keybinding",
     "id": "fire",
     "category": "LIST_MONSTERS",
-    "name": {
-      "ctxt": "verb",
-      "str": "Fire"
-    },
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "f"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_W"
-      }
-    ]
+    "name": { "ctxt": "verb", "str": "Fire" },
+    "bindings": [ { "input_method": "keyboard_any", "key": "f" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_W" } ]
   },
   {
     "type": "keybinding",
@@ -7516,21 +3633,9 @@
     "category": "LOOK",
     "name": "List items and monsters",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "V"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "v",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RS"
-      }
+      { "input_method": "keyboard_char", "key": "V" },
+      { "input_method": "keyboard_code", "key": "v", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RS" }
     ]
   },
   {
@@ -7538,12 +3643,7 @@
     "id": "REASSIGN",
     "category": "BIONICS",
     "name": "Reassign inventory letter",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "="
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "=" } ]
   },
   {
     "type": "keybinding",
@@ -7551,22 +3651,10 @@
     "category": "BIONICS",
     "name": "Move cursor up",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "8"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_8"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "UP"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_UP"
-      }
+      { "input_method": "keyboard_any", "key": "8" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_8" },
+      { "input_method": "keyboard_any", "key": "UP" },
+      { "input_method": "gamepad", "key": "JOY_UP" }
     ]
   },
   {
@@ -7575,22 +3663,10 @@
     "category": "BIONICS",
     "name": "Move cursor down",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "DOWN"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "2"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_2"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_DOWN"
-      }
+      { "input_method": "keyboard_any", "key": "DOWN" },
+      { "input_method": "keyboard_any", "key": "2" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_2" },
+      { "input_method": "gamepad", "key": "JOY_DOWN" }
     ]
   },
   {
@@ -7598,24 +3674,14 @@
     "id": "REASSIGN",
     "category": "MUTATIONS",
     "name": "Reassign inventory letter",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "="
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "=" } ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_SPRITE",
     "category": "MUTATIONS",
     "name": "Toggle sprite",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": ","
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "," } ]
   },
   {
     "type": "keybinding",
@@ -7623,22 +3689,10 @@
     "category": "MUTATIONS",
     "name": "Pan up",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "8"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_8"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "UP"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_UP"
-      }
+      { "input_method": "keyboard_any", "key": "8" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_8" },
+      { "input_method": "keyboard_any", "key": "UP" },
+      { "input_method": "gamepad", "key": "JOY_UP" }
     ]
   },
   {
@@ -7647,22 +3701,10 @@
     "category": "MUTATIONS",
     "name": "Pan down",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "DOWN"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "2"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_2"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_DOWN"
-      }
+      { "input_method": "keyboard_any", "key": "DOWN" },
+      { "input_method": "keyboard_any", "key": "2" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_2" },
+      { "input_method": "gamepad", "key": "JOY_DOWN" }
     ]
   },
   {
@@ -7671,52 +3713,28 @@
     "category": "HELP_KEYBINDINGS",
     "name": "Exit this keybinding screen",
     "//": "separate entry, because the global entry also has 'q', 'Q' and space listed, which conflicts with the search text input",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "ESC"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "ESC" } ]
   },
   {
     "type": "keybinding",
     "id": "UP",
     "category": "HELP_KEYBINDINGS",
     "name": "Pan up",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "UP"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "UP" } ]
   },
   {
     "type": "keybinding",
     "id": "DOWN",
     "category": "HELP_KEYBINDINGS",
     "name": "Pan down",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "DOWN"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "DOWN" } ]
   },
   {
     "type": "keybinding",
     "id": "REMOVE",
     "category": "HELP_KEYBINDINGS",
     "name": "Remove keybinding",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "-"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MINUS"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "-" }, { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" } ]
   },
   {
     "type": "keybinding",
@@ -7724,21 +3742,9 @@
     "category": "HELP_KEYBINDINGS",
     "name": "Reset keybinding",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "*"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "8",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MULTIPLY"
-      }
+      { "input_method": "keyboard_char", "key": "*" },
+      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] },
+      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" }
     ]
   },
   {
@@ -7747,21 +3753,9 @@
     "category": "HELP_KEYBINDINGS",
     "name": "Add local keybinding",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "+"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_PLUS"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "=",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_char", "key": "+" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" },
+      { "input_method": "keyboard_code", "key": "=", "mod": [ "shift" ] }
     ]
   },
   {
@@ -7769,28 +3763,14 @@
     "id": "ADD_GLOBAL",
     "category": "HELP_KEYBINDINGS",
     "name": "Add global keybinding",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "="
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "=" } ]
   },
   {
     "type": "keybinding",
     "id": "EXECUTE",
     "category": "HELP_KEYBINDINGS",
     "name": "Execute action keybinding",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "."
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_PERIOD"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "." }, { "input_method": "keyboard_code", "key": "KEYPAD_PERIOD" } ]
   },
   {
     "type": "keybinding",
@@ -7798,25 +3778,10 @@
     "category": "ZONES_MANAGER",
     "name": "Add zone",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "a"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "A"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "a",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
-      }
+      { "input_method": "keyboard_any", "key": "a" },
+      { "input_method": "keyboard_char", "key": "A" },
+      { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" }
     ]
   },
   {
@@ -7825,25 +3790,10 @@
     "category": "ZONES_MANAGER",
     "name": "Add personal zone",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "p"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "P"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "p",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NE"
-      }
+      { "input_method": "keyboard_any", "key": "p" },
+      { "input_method": "keyboard_char", "key": "P" },
+      { "input_method": "keyboard_code", "key": "p", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_NE" }
     ]
   },
   {
@@ -7852,25 +3802,10 @@
     "category": "ZONES_MANAGER",
     "name": "Remove zone",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "r"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "R"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "r",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_E"
-      }
+      { "input_method": "keyboard_any", "key": "r" },
+      { "input_method": "keyboard_char", "key": "R" },
+      { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_E" }
     ]
   },
   {
@@ -7879,22 +3814,10 @@
     "category": "ZONES_MANAGER",
     "name": "Move zone up",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "="
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "+"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_PLUS"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_ALT_DPAD_UP"
-      }
+      { "input_method": "keyboard_any", "key": "=" },
+      { "input_method": "keyboard_char", "key": "+" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" },
+      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_UP" }
     ]
   },
   {
@@ -7903,18 +3826,9 @@
     "category": "ZONES_MANAGER",
     "name": "Move zone down",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "-"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MINUS"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_ALT_DPAD_DOWN"
-      }
+      { "input_method": "keyboard_any", "key": "-" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" },
+      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_DOWN" }
     ]
   },
   {
@@ -7923,25 +3837,10 @@
     "category": "ZONES_MANAGER",
     "name": "Show zone on map",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "m"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "M"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "m",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SE"
-      }
+      { "input_method": "keyboard_any", "key": "m" },
+      { "input_method": "keyboard_char", "key": "M" },
+      { "input_method": "keyboard_code", "key": "m", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_SE" }
     ]
   },
   {
@@ -7950,25 +3849,10 @@
     "category": "ZONES_MANAGER",
     "name": "Toggle display of zone markers",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "t"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "T"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "t",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_S"
-      }
+      { "input_method": "keyboard_any", "key": "t" },
+      { "input_method": "keyboard_char", "key": "T" },
+      { "input_method": "keyboard_code", "key": "t", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_S" }
     ]
   },
   {
@@ -7977,25 +3861,10 @@
     "category": "ZONES_MANAGER",
     "name": "Enable zone",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "e"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "E"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "e",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SW"
-      }
+      { "input_method": "keyboard_any", "key": "e" },
+      { "input_method": "keyboard_char", "key": "E" },
+      { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_SW" }
     ]
   },
   {
@@ -8004,25 +3873,10 @@
     "category": "ZONES_MANAGER",
     "name": "Disable zone",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "d"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "D"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "d",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_W"
-      }
+      { "input_method": "keyboard_any", "key": "d" },
+      { "input_method": "keyboard_char", "key": "D" },
+      { "input_method": "keyboard_code", "key": "d", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_W" }
     ]
   },
   {
@@ -8031,25 +3885,10 @@
     "category": "ZONES_MANAGER",
     "name": "Enable personal zones",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "z"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "Z"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "z",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NW"
-      }
+      { "input_method": "keyboard_any", "key": "z" },
+      { "input_method": "keyboard_char", "key": "Z" },
+      { "input_method": "keyboard_code", "key": "z", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_NW" }
     ]
   },
   {
@@ -8058,25 +3897,10 @@
     "category": "ZONES_MANAGER",
     "name": "Disable personal zones",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "x"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "X"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "x",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_N"
-      }
+      { "input_method": "keyboard_any", "key": "x" },
+      { "input_method": "keyboard_char", "key": "X" },
+      { "input_method": "keyboard_code", "key": "x", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_R_N" }
     ]
   },
   {
@@ -8085,25 +3909,10 @@
     "category": "ZONES_MANAGER",
     "name": "Enable vehicle zones",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "c"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "C"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "c",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_NE"
-      }
+      { "input_method": "keyboard_any", "key": "c" },
+      { "input_method": "keyboard_char", "key": "C" },
+      { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_R_NE" }
     ]
   },
   {
@@ -8112,25 +3921,10 @@
     "category": "ZONES_MANAGER",
     "name": "Disable vehicle zones",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "v"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "V"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "v",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_E"
-      }
+      { "input_method": "keyboard_any", "key": "v" },
+      { "input_method": "keyboard_char", "key": "V" },
+      { "input_method": "keyboard_code", "key": "v", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_R_E" }
     ]
   },
   {
@@ -8139,25 +3933,10 @@
     "category": "ZONES_MANAGER",
     "name": "Show all zones / hide distant zones",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "s"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "S"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "s",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_SE"
-      }
+      { "input_method": "keyboard_any", "key": "s" },
+      { "input_method": "keyboard_char", "key": "S" },
+      { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_R_SE" }
     ]
   },
   {
@@ -8166,21 +3945,9 @@
     "category": "ZONES_MANAGER",
     "name": "Change shown faction",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "F"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "f",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_S"
-      }
+      { "input_method": "keyboard_char", "key": "F" },
+      { "input_method": "keyboard_code", "key": "f", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_R_S" }
     ]
   },
   {
@@ -8189,25 +3956,10 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Page down",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "NPAGE"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": ">"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ".",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_ALT_DPAD_DOWN"
-      }
+      { "input_method": "keyboard_any", "key": "NPAGE" },
+      { "input_method": "keyboard_char", "key": ">" },
+      { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_DOWN" }
     ]
   },
   {
@@ -8216,25 +3968,10 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Page up",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "PPAGE"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "<"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ",",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_ALT_DPAD_UP"
-      }
+      { "input_method": "keyboard_any", "key": "PPAGE" },
+      { "input_method": "keyboard_char", "key": "<" },
+      { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_UP" }
     ]
   },
   {
@@ -8243,18 +3980,9 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Pan up",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "k"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "UP"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_UP"
-      }
+      { "input_method": "keyboard_any", "key": "k" },
+      { "input_method": "keyboard_any", "key": "UP" },
+      { "input_method": "gamepad", "key": "JOY_UP" }
     ]
   },
   {
@@ -8263,18 +3991,9 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Pan down",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "j"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "DOWN"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_DOWN"
-      }
+      { "input_method": "keyboard_any", "key": "j" },
+      { "input_method": "keyboard_any", "key": "DOWN" },
+      { "input_method": "gamepad", "key": "JOY_DOWN" }
     ]
   },
   {
@@ -8283,18 +4002,9 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Select left inventory",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "h"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "LEFT"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_LEFT"
-      }
+      { "input_method": "keyboard_any", "key": "h" },
+      { "input_method": "keyboard_any", "key": "LEFT" },
+      { "input_method": "gamepad", "key": "JOY_LEFT" }
     ]
   },
   {
@@ -8302,28 +4012,14 @@
     "id": "RIGHT",
     "category": "ADVANCED_INVENTORY",
     "name": "Select right inventory",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "l"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "RIGHT"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "l" }, { "input_method": "keyboard_any", "key": "RIGHT" } ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_TAB",
     "category": "ADVANCED_INVENTORY",
     "name": "Toggle tab",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "TAB"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "TAB" } ]
   },
   {
     "type": "keybinding",
@@ -8331,25 +4027,10 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Toggle vehicle",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "v"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "V"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "v",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NW"
-      }
+      { "input_method": "keyboard_any", "key": "v" },
+      { "input_method": "keyboard_char", "key": "V" },
+      { "input_method": "keyboard_code", "key": "v", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_NW" }
     ]
   },
   {
@@ -8357,16 +4038,7 @@
     "id": "TOGGLE_AUTO_PICKUP",
     "category": "ADVANCED_INVENTORY",
     "name": "Toggle auto pickup for item",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "p"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_W"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "p" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_W" } ]
   },
   {
     "type": "keybinding",
@@ -8374,25 +4046,10 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Examine",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "e"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "E"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "e",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RS"
-      }
+      { "input_method": "keyboard_any", "key": "e" },
+      { "input_method": "keyboard_char", "key": "E" },
+      { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RS" }
     ]
   },
   {
@@ -8401,25 +4058,10 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Change sorting mode",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "s"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "S"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "s",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
-      }
+      { "input_method": "keyboard_any", "key": "s" },
+      { "input_method": "keyboard_char", "key": "S" },
+      { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" }
     ]
   },
   {
@@ -8427,32 +4069,14 @@
     "id": "MOVE_SINGLE_ITEM",
     "category": "ADVANCED_INVENTORY",
     "name": "Move a single item",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "RETURN"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "KEYPAD_ENTER"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "RETURN" }, { "input_method": "keyboard_any", "key": "KEYPAD_ENTER" } ]
   },
   {
     "type": "keybinding",
     "id": "MOVE_VARIABLE_ITEM",
     "category": "ADVANCED_INVENTORY",
     "name": "Move some items",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "m"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "m" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_NE" } ]
   },
   {
     "type": "keybinding",
@@ -8460,21 +4084,9 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Move item stack",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "M"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "m",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_E"
-      }
+      { "input_method": "keyboard_char", "key": "M" },
+      { "input_method": "keyboard_code", "key": "m", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_E" }
     ]
   },
   {
@@ -8482,32 +4094,14 @@
     "id": "MOVE_ALL_ITEMS",
     "category": "ADVANCED_INVENTORY",
     "name": "Move all items",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": ","
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "," }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_SE" } ]
   },
   {
     "type": "keybinding",
     "id": "CATEGORY_SELECTION",
     "category": "ADVANCED_INVENTORY",
     "name": "Toggle category selection mode",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "t"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_S"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "t" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_S" } ]
   },
   {
     "type": "keybinding",
@@ -8515,25 +4109,10 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Toggle item as favorite",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "*"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MULTIPLY"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "8",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SW"
-      }
+      { "input_method": "keyboard_char", "key": "*" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
+      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_SW" }
     ]
   },
   {
@@ -8542,22 +4121,10 @@
     "category": "INVENTORY",
     "name": "Select/unselect highlighted item",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "l"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "RIGHT"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "6"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_6"
-      }
+      { "input_method": "keyboard_any", "key": "l" },
+      { "input_method": "keyboard_any", "key": "RIGHT" },
+      { "input_method": "keyboard_any", "key": "6" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_6" }
     ]
   },
   {
@@ -8566,22 +4133,10 @@
     "category": "INVENTORY",
     "name": "Increase selected amount for the highlighted item",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "="
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "+"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_PLUS"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
-      }
+      { "input_method": "keyboard_any", "key": "=" },
+      { "input_method": "keyboard_char", "key": "+" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" }
     ]
   },
   {
@@ -8589,32 +4144,14 @@
     "id": "AUTO_BALANCE",
     "category": "INVENTORY",
     "name": "Auto balance trade using highlighted item",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "F1"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "F1" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_NE" } ]
   },
   {
     "type": "keybinding",
     "id": "BANK_BALANCE",
     "category": "INVENTORY",
     "name": "Auto balance trade using bank account",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "F2"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_E"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "F2" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_E" } ]
   },
   {
     "type": "keybinding",
@@ -8622,18 +4159,9 @@
     "category": "INVENTORY",
     "name": "Decrease selected amount for the highlighted item",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "-"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MINUS"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_S"
-      }
+      { "input_method": "keyboard_any", "key": "-" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_S" }
     ]
   },
   {
@@ -8642,26 +4170,11 @@
     "category": "INVENTORY",
     "name": "Next column",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "h"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "LEFT"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "4"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_4"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_LEFT"
-      }
+      { "input_method": "keyboard_any", "key": "h" },
+      { "input_method": "keyboard_any", "key": "LEFT" },
+      { "input_method": "keyboard_any", "key": "4" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_4" },
+      { "input_method": "gamepad", "key": "JOY_LEFT" }
     ]
   },
   {
@@ -8670,17 +4183,8 @@
     "category": "INVENTORY",
     "name": "Previous column",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "BACKTAB"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "TAB",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_char", "key": "BACKTAB" },
+      { "input_method": "keyboard_code", "key": "TAB", "mod": [ "shift" ] }
     ]
   },
   {
@@ -8688,175 +4192,77 @@
     "id": "TOGGLE_NON_FAVORITE",
     "category": "INVENTORY",
     "name": "Select/unselect non-favorite items in multidrop menu",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": ","
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "," } ]
   },
   {
     "type": "keybinding",
     "id": "MARK_WITH_COUNT",
     "category": "INVENTORY",
     "name": "Select a specific amount of highlighted item",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "!"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "1",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "!" }, { "input_method": "keyboard_code", "key": "1", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "ITEMS_NW",
     "category": "ADVANCED_INVENTORY",
     "name": "Select items at northwest",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "7"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_7"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "7" }, { "input_method": "keyboard_code", "key": "KEYPAD_7" } ]
   },
   {
     "type": "keybinding",
     "id": "ITEMS_N",
     "category": "ADVANCED_INVENTORY",
     "name": "Select items at north",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "8"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_8"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "8" }, { "input_method": "keyboard_code", "key": "KEYPAD_8" } ]
   },
   {
     "type": "keybinding",
     "id": "ITEMS_NE",
     "category": "ADVANCED_INVENTORY",
     "name": "Select items at northeast",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "9"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_9"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "9" }, { "input_method": "keyboard_code", "key": "KEYPAD_9" } ]
   },
   {
     "type": "keybinding",
     "id": "ITEMS_W",
     "category": "ADVANCED_INVENTORY",
     "name": "Select items at west",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "4"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_4"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "4" }, { "input_method": "keyboard_code", "key": "KEYPAD_4" } ]
   },
   {
     "type": "keybinding",
     "id": "ITEMS_CE",
     "category": "ADVANCED_INVENTORY",
     "name": "Select items at center",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "5"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_5"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "5" }, { "input_method": "keyboard_code", "key": "KEYPAD_5" } ]
   },
   {
     "type": "keybinding",
     "id": "ITEMS_E",
     "category": "ADVANCED_INVENTORY",
     "name": "Select items at east",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "6"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_6"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "6" }, { "input_method": "keyboard_code", "key": "KEYPAD_6" } ]
   },
   {
     "type": "keybinding",
     "id": "ITEMS_SW",
     "category": "ADVANCED_INVENTORY",
     "name": "Select items at southwest",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "1"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_1"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "1" }, { "input_method": "keyboard_code", "key": "KEYPAD_1" } ]
   },
   {
     "type": "keybinding",
     "id": "ITEMS_S",
     "category": "ADVANCED_INVENTORY",
     "name": "Select items at south",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "2"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_2"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "2" }, { "input_method": "keyboard_code", "key": "KEYPAD_2" } ]
   },
   {
     "type": "keybinding",
     "id": "ITEMS_SE",
     "category": "ADVANCED_INVENTORY",
     "name": "Select items at southeast",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "3"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_3"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "3" }, { "input_method": "keyboard_code", "key": "KEYPAD_3" } ]
   },
   {
     "type": "keybinding",
@@ -8864,29 +4270,11 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Select items in inventory",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "i"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "I"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "i",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "0"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_0"
-      }
+      { "input_method": "keyboard_any", "key": "i" },
+      { "input_method": "keyboard_char", "key": "I" },
+      { "input_method": "keyboard_code", "key": "i", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "0" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_0" }
     ]
   },
   {
@@ -8895,21 +4283,9 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Select items at all 9 tiles",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "a"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "A"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "a",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_any", "key": "a" },
+      { "input_method": "keyboard_char", "key": "A" },
+      { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] }
     ]
   },
   {
@@ -8918,21 +4294,9 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Select items in dragged vehicle",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "d"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "D"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "d",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_any", "key": "d" },
+      { "input_method": "keyboard_char", "key": "D" },
+      { "input_method": "keyboard_code", "key": "d", "mod": [ "shift" ] }
     ]
   },
   {
@@ -8940,28 +4304,14 @@
     "id": "EXAMINE_CONTENTS",
     "category": "ADVANCED_INVENTORY",
     "name": "Examine items in container",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "o"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "o" } ]
   },
   {
     "type": "keybinding",
     "id": "UNLOAD_CONTAINER",
     "category": "ADVANCED_INVENTORY",
     "name": "Unload item from container",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "u"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "U"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "u" }, { "input_method": "keyboard_any", "key": "U" } ]
   },
   {
     "type": "keybinding",
@@ -8969,21 +4319,9 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Select items in container",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "c"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "C"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "c",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_any", "key": "c" },
+      { "input_method": "keyboard_char", "key": "C" },
+      { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] }
     ]
   },
   {
@@ -8992,21 +4330,9 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Exit container to parent",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "x"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "X"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "x",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_any", "key": "x" },
+      { "input_method": "keyboard_char", "key": "X" },
+      { "input_method": "keyboard_code", "key": "x", "mod": [ "shift" ] }
     ]
   },
   {
@@ -9015,21 +4341,9 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Select items currently worn",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "w"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "W"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "w",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_any", "key": "w" },
+      { "input_method": "keyboard_char", "key": "W" },
+      { "input_method": "keyboard_code", "key": "w", "mod": [ "shift" ] }
     ]
   },
   {
@@ -9049,45 +4363,25 @@
     "id": "repair_fabric",
     "category": "ITEM_ACTIONS",
     "name": "Sew",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "s"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "s" } ]
   },
   {
     "type": "keybinding",
     "id": "repair_metal",
     "category": "ITEM_ACTIONS",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "w"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "w" } ]
   },
   {
     "type": "keybinding",
     "id": "firestarter",
     "category": "ITEM_ACTIONS",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "f"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "f" } ]
   },
   {
     "type": "keybinding",
     "id": "holster",
     "category": "ITEM_ACTIONS",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "h"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "h" } ]
   },
   {
     "type": "keybinding",
@@ -9095,21 +4389,9 @@
     "category": "COLORS",
     "name": "Remove custom color",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "r"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "R"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "r",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_any", "key": "r" },
+      { "input_method": "keyboard_char", "key": "R" },
+      { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] }
     ]
   },
   {
@@ -9118,21 +4400,9 @@
     "category": "COLORS",
     "name": "Load color template",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "t"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "T"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "t",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_any", "key": "t" },
+      { "input_method": "keyboard_char", "key": "T" },
+      { "input_method": "keyboard_code", "key": "t", "mod": [ "shift" ] }
     ]
   },
   {
@@ -9141,21 +4411,9 @@
     "category": "COLORS",
     "name": "Load base colors",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "c"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "C"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "c",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_any", "key": "c" },
+      { "input_method": "keyboard_char", "key": "C" },
+      { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] }
     ]
   },
   {
@@ -9164,33 +4422,12 @@
     "category": "COLORS",
     "name": "Quit",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "ESC"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "q"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "Q"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "q",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "SPACE"
-      },
-      {
-        "input_method": "mouse",
-        "key": "MOUSE_RIGHT"
-      }
+      { "input_method": "keyboard_any", "key": "ESC" },
+      { "input_method": "keyboard_any", "key": "q" },
+      { "input_method": "keyboard_char", "key": "Q" },
+      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "SPACE" },
+      { "input_method": "mouse", "key": "MOUSE_RIGHT" }
     ]
   },
   {
@@ -9199,25 +4436,10 @@
     "category": "YESNO",
     "name": "Yes",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "Y"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "y",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "y"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
-      }
+      { "input_method": "keyboard_char", "key": "Y" },
+      { "input_method": "keyboard_code", "key": "y", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "y" },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" }
     ]
   },
   {
@@ -9226,29 +4448,11 @@
     "category": "YESNO",
     "name": "No",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "N"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "n",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "n"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "ESC"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_S"
-      }
+      { "input_method": "keyboard_char", "key": "N" },
+      { "input_method": "keyboard_code", "key": "n", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "n" },
+      { "input_method": "keyboard_any", "key": "ESC" },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_S" }
     ]
   },
   {
@@ -9257,25 +4461,10 @@
     "category": "FRIENDS_ME_CANCEL",
     "name": "With friends",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "F"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "f",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "f"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_E"
-      }
+      { "input_method": "keyboard_char", "key": "F" },
+      { "input_method": "keyboard_code", "key": "f", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "f" },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_E" }
     ]
   },
   {
@@ -9284,25 +4473,10 @@
     "category": "FRIENDS_ME_CANCEL",
     "name": "Just me",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "M"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "m",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "m"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_W"
-      }
+      { "input_method": "keyboard_char", "key": "M" },
+      { "input_method": "keyboard_code", "key": "m", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "m" },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_W" }
     ]
   },
   {
@@ -9311,29 +4485,11 @@
     "category": "FRIENDS_ME_CANCEL",
     "name": "Cancel",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "C"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "c",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "c"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "ESC"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NW"
-      }
+      { "input_method": "keyboard_char", "key": "C" },
+      { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "c" },
+      { "input_method": "keyboard_any", "key": "ESC" },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_NW" }
     ]
   },
   {
@@ -9342,21 +4498,9 @@
     "category": "LOAD_DELETE_CANCEL",
     "name": "Load",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "L"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "l",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "l"
-      }
+      { "input_method": "keyboard_char", "key": "L" },
+      { "input_method": "keyboard_code", "key": "l", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "l" }
     ]
   },
   {
@@ -9365,21 +4509,9 @@
     "category": "LOAD_DELETE_CANCEL",
     "name": "Delete",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "D"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "d",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "d"
-      }
+      { "input_method": "keyboard_char", "key": "D" },
+      { "input_method": "keyboard_code", "key": "d", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "d" }
     ]
   },
   {
@@ -9388,21 +4520,9 @@
     "category": "LOAD_DELETE_CANCEL",
     "name": "Cancel",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "C"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "c",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "c"
-      }
+      { "input_method": "keyboard_char", "key": "C" },
+      { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "c" }
     ]
   },
   {
@@ -9411,21 +4531,9 @@
     "category": "YESNOQUIT",
     "name": "Yes",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "Y"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "y",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "y"
-      }
+      { "input_method": "keyboard_char", "key": "Y" },
+      { "input_method": "keyboard_code", "key": "y", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "y" }
     ]
   },
   {
@@ -9434,21 +4542,9 @@
     "category": "YESNOQUIT",
     "name": "No",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "N"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "n",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "n"
-      }
+      { "input_method": "keyboard_char", "key": "N" },
+      { "input_method": "keyboard_code", "key": "n", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "n" }
     ]
   },
   {
@@ -9457,25 +4553,10 @@
     "category": "YESNOQUIT",
     "name": "Cancel",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "Q"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "q",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "q"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "ESC"
-      }
+      { "input_method": "keyboard_char", "key": "Q" },
+      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "q" },
+      { "input_method": "keyboard_any", "key": "ESC" }
     ]
   },
   {
@@ -9484,21 +4565,9 @@
     "category": "CANCEL_ACTIVITY_OR_IGNORE_QUERY",
     "name": "Yes",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "Y"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "y",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "y"
-      }
+      { "input_method": "keyboard_char", "key": "Y" },
+      { "input_method": "keyboard_code", "key": "y", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "y" }
     ]
   },
   {
@@ -9507,25 +4576,10 @@
     "category": "CANCEL_ACTIVITY_OR_IGNORE_QUERY",
     "name": "No",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "N"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "n",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "n"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "ESC"
-      }
+      { "input_method": "keyboard_char", "key": "N" },
+      { "input_method": "keyboard_code", "key": "n", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "n" },
+      { "input_method": "keyboard_any", "key": "ESC" }
     ]
   },
   {
@@ -9534,21 +4588,9 @@
     "category": "CANCEL_ACTIVITY_OR_IGNORE_QUERY",
     "name": "Ignore this distraction and continue",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "I"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "i",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "i"
-      }
+      { "input_method": "keyboard_char", "key": "I" },
+      { "input_method": "keyboard_code", "key": "i", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "i" }
     ]
   },
   {
@@ -9557,21 +4599,9 @@
     "category": "CANCEL_ACTIVITY_OR_IGNORE_QUERY",
     "name": "Open manager",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "M"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "m",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "m"
-      }
+      { "input_method": "keyboard_char", "key": "M" },
+      { "input_method": "keyboard_code", "key": "m", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "m" }
     ]
   },
   {
@@ -9580,21 +4610,9 @@
     "category": "YES_QUERY",
     "name": "Yes, I will!",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "Y"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "y",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "y"
-      }
+      { "input_method": "keyboard_char", "key": "Y" },
+      { "input_method": "keyboard_code", "key": "y", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "y" }
     ]
   },
   {
@@ -9603,21 +4621,9 @@
     "category": "YES_QUERY",
     "name": "Yes, I must!",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "Y"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "y",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "y"
-      }
+      { "input_method": "keyboard_char", "key": "Y" },
+      { "input_method": "keyboard_code", "key": "y", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "y" }
     ]
   },
   {
@@ -9626,21 +4632,9 @@
     "category": "YES_QUERY",
     "name": "Yes, I shall!",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "Y"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "y",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "y"
-      }
+      { "input_method": "keyboard_char", "key": "Y" },
+      { "input_method": "keyboard_code", "key": "y", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "y" }
     ]
   },
   {
@@ -9649,27 +4643,9 @@
     "category": "YES_NO_ALWAYS_NEVER",
     "name": "Yes",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": [
-          "Y"
-        ]
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": [
-          "y"
-        ],
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": [
-          "y"
-        ]
-      }
+      { "input_method": "keyboard_char", "key": [ "Y" ] },
+      { "input_method": "keyboard_code", "key": [ "y" ], "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": [ "y" ] }
     ]
   },
   {
@@ -9678,33 +4654,10 @@
     "category": "YES_NO_ALWAYS_NEVER",
     "name": "No",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": [
-          "N"
-        ]
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": [
-          "n"
-        ],
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": [
-          "n"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": [
-          "ESC"
-        ]
-      }
+      { "input_method": "keyboard_char", "key": [ "N" ] },
+      { "input_method": "keyboard_code", "key": [ "n" ], "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": [ "n" ] },
+      { "input_method": "keyboard_any", "key": [ "ESC" ] }
     ]
   },
   {
@@ -9713,27 +4666,9 @@
     "category": "YES_NO_ALWAYS_NEVER",
     "name": "Always",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": [
-          "A"
-        ]
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": [
-          "a"
-        ],
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": [
-          "a"
-        ]
-      }
+      { "input_method": "keyboard_char", "key": [ "A" ] },
+      { "input_method": "keyboard_code", "key": [ "a" ], "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": [ "a" ] }
     ]
   },
   {
@@ -9742,27 +4677,9 @@
     "category": "YES_NO_ALWAYS_NEVER",
     "name": "Never",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": [
-          "E"
-        ]
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": [
-          "e"
-        ],
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": [
-          "e"
-        ]
-      }
+      { "input_method": "keyboard_char", "key": [ "E" ] },
+      { "input_method": "keyboard_code", "key": [ "e" ], "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": [ "e" ] }
     ]
   },
   {
@@ -9771,26 +4688,11 @@
     "category": "POPUP_WAIT",
     "name": "Cancel popup",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "ESC"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "SPACE"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "RETURN"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "KEYPAD_ENTER"
-      },
-      {
-        "input_method": "mouse",
-        "key": "MOUSE_RIGHT"
-      }
+      { "input_method": "keyboard_any", "key": "ESC" },
+      { "input_method": "keyboard_any", "key": "SPACE" },
+      { "input_method": "keyboard_any", "key": "RETURN" },
+      { "input_method": "keyboard_any", "key": "KEYPAD_ENTER" },
+      { "input_method": "mouse", "key": "MOUSE_RIGHT" }
     ]
   },
   {
@@ -9798,273 +4700,119 @@
     "id": "CREATURE",
     "category": "EXTENDED_DESCRIPTION",
     "name": "Describe creature",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "c"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "c" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" } ]
   },
   {
     "type": "keybinding",
     "id": "FURNITURE",
     "category": "EXTENDED_DESCRIPTION",
     "name": "Describe furniture",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "f"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "f" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_NE" } ]
   },
   {
     "type": "keybinding",
     "id": "TERRAIN",
     "category": "EXTENDED_DESCRIPTION",
     "name": "Describe terrain",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "t"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_E"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "t" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_E" } ]
   },
   {
     "type": "keybinding",
     "id": "VEHICLE",
     "category": "EXTENDED_DESCRIPTION",
     "name": "Describe vehicle/appliance",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "v"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "v" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_SE" } ]
   },
   {
     "type": "keybinding",
     "id": "SWITCH_LISTS",
     "category": "INVENTORY",
     "name": "Switch lists",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "TAB"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_N"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "TAB" }, { "input_method": "gamepad", "key": "JOY_RADIAL_R_N" } ]
   },
   {
     "type": "keybinding",
     "id": "FAV_PRIORITY",
     "category": "INVENTORY",
     "name": "Set priority",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "p"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_NE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "p" }, { "input_method": "gamepad", "key": "JOY_RADIAL_R_NE" } ]
   },
   {
     "type": "keybinding",
     "id": "FAV_AUTO_PICKUP",
     "category": "INVENTORY",
     "name": "Toggle auto pickup",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "d"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_E"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "d" }, { "input_method": "gamepad", "key": "JOY_RADIAL_R_E" } ]
   },
   {
     "type": "keybinding",
     "id": "FAV_AUTO_UNLOAD",
     "category": "INVENTORY",
     "name": "Toggle auto unload",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "u"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_SE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "u" }, { "input_method": "gamepad", "key": "JOY_RADIAL_R_SE" } ]
   },
   {
     "type": "keybinding",
     "id": "FAV_ITEM",
     "category": "INVENTORY",
     "name": "Whitelist/blacklist item",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "i"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_S"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "i" }, { "input_method": "gamepad", "key": "JOY_RADIAL_R_S" } ]
   },
   {
     "type": "keybinding",
     "id": "FAV_CATEGORY",
     "category": "INVENTORY",
     "name": "Whitelist/blacklist category",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "c"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_SW"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "c" }, { "input_method": "gamepad", "key": "JOY_RADIAL_R_SW" } ]
   },
   {
     "type": "keybinding",
     "id": "FAV_WHITELIST",
     "category": "INVENTORY",
     "name": "Switch to modifying whitelist",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "w"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_W"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "w" }, { "input_method": "gamepad", "key": "JOY_RADIAL_R_W" } ]
   },
   {
     "type": "keybinding",
     "id": "FAV_BLACKLIST",
     "category": "INVENTORY",
     "name": "Switch to modifying blacklist",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "b"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_R_NW"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "b" }, { "input_method": "gamepad", "key": "JOY_RADIAL_R_NW" } ]
   },
   {
     "type": "keybinding",
     "id": "FAV_SAVE_PRESET",
     "category": "INVENTORY",
     "name": "Save preset",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "S"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "s",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "S" }, { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "FAV_APPLY_PRESET",
     "category": "INVENTORY",
     "name": "Apply preset",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "A"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "a",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "A" }, { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "FAV_DEL_PRESET",
     "category": "INVENTORY",
     "name": "Delete preset",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "D"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "d",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "D" }, { "input_method": "keyboard_code", "key": "d", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "FAV_CLEAR",
     "category": "INVENTORY",
     "name": "Clear entries",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "x"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "x" } ]
   },
   {
     "type": "keybinding",
     "id": "FAV_MOVE_ITEM",
     "category": "INVENTORY",
     "name": "Move item",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "m"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "m" } ]
   },
   {
     "type": "keybinding",
@@ -10072,18 +4820,9 @@
     "category": "INVENTORY",
     "name": "Open context menu",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "RETURN"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "KEYPAD_ENTER"
-      },
-      {
-        "input_method": "mouse",
-        "key": "MOUSE_LEFT"
-      }
+      { "input_method": "keyboard_any", "key": "RETURN" },
+      { "input_method": "keyboard_any", "key": "KEYPAD_ENTER" },
+      { "input_method": "mouse", "key": "MOUSE_LEFT" }
     ]
   },
   {
@@ -10091,21 +4830,9 @@
     "id": "CHANGE_PROFESSION_NAME",
     "name": "Change profession name",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "*"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MULTIPLY"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "8",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_char", "key": "*" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
+      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] }
     ]
   },
   {
@@ -10113,336 +4840,147 @@
     "id": "SCROLL_MISSION_INFO_UP",
     "category": "FACTIONS",
     "name": "Scroll camp mission info up",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "["
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "[" } ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_MISSION_INFO_DOWN",
     "category": "FACTIONS",
     "name": "Scroll camp mission info down",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "]"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "]" } ]
   },
   {
     "type": "keybinding",
     "category": "PLAYER_INFO",
     "id": "VIEW_PROFICIENCIES",
     "name": "View character proficiencies",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "p"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "p" } ]
   },
   {
     "type": "keybinding",
     "category": "PLAYER_INFO",
     "id": "VIEW_BODYSTAT",
     "name": "View character's body status",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "s"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "s" } ]
   },
   {
     "type": "keybinding",
     "name": "View character's morale",
     "category": "PLAYER_INFO",
     "id": "morale",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "m"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "m" } ]
   },
   {
     "type": "keybinding",
     "id": "CHANGE_ARMOR_SPRITE",
     "category": "PLAYER_INFO",
     "name": "Change armor sprite",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "W"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "w",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "W" }, { "input_method": "keyboard_code", "key": "w", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "category": "PLAYER_INFO",
     "id": "SELECT_STATS_TAB",
     "name": "Select stats tab",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "w"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "w" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" } ]
   },
   {
     "type": "keybinding",
     "category": "PLAYER_INFO",
     "id": "SELECT_ENCUMBRANCE_TAB",
     "name": "Select encumbrance tab",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "e"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "e" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_NE" } ]
   },
   {
     "type": "keybinding",
     "category": "PLAYER_INFO",
     "id": "SELECT_SKILLS_TAB",
     "name": "Select skills tab",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "r"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_E"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "r" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_E" } ]
   },
   {
     "type": "keybinding",
     "category": "PLAYER_INFO",
     "id": "SELECT_TRAITS_TAB",
     "name": "Select traits tab",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "t"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "t" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_SE" } ]
   },
   {
     "type": "keybinding",
     "category": "PLAYER_INFO",
     "id": "SELECT_BIONICS_TAB",
     "name": "Select bionics tab",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "x"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_S"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "x" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_S" } ]
   },
   {
     "type": "keybinding",
     "category": "PLAYER_INFO",
     "id": "SELECT_EFFECTS_TAB",
     "name": "Select effects tab",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "c"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SW"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "c" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_SW" } ]
   },
   {
     "type": "keybinding",
     "category": "PLAYER_INFO",
     "id": "SELECT_PROFICIENCIES_TAB",
     "name": "Select proficiencies tab",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "v"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_W"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "v" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_W" } ]
   },
   {
     "type": "keybinding",
     "category": "WISH_ITEM",
     "id": "CONTAINER",
     "name": "Toggle spawning item with container",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "f"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "f" } ]
   },
   {
     "type": "keybinding",
     "category": "WISH_ITEM",
     "id": "FLAG",
     "name": "Add flags to spawned items",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "F"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "f",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "F" }, { "input_method": "keyboard_code", "key": "f", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "category": "WISH_ITEM",
     "id": "EVERYTHING",
     "name": "Toggle spawning everything",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "E"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "e",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "E" }, { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "category": "WISH_ITEM",
     "id": "SNIPPET",
     "name": "Choose snippet",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "S"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "s",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "S" }, { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "category": "WISH_ITEM",
     "id": "SCROLL_DESC_UP",
     "name": "Scroll item description up",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "<"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ",",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "<" }, { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "category": "WISH_ITEM",
     "id": "SCROLL_DESC_DOWN",
     "name": "Scroll item description down",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": ">"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ".",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": ">" }, { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_ITEM_INFO_UP",
     "category": "VENDING_MACHINE",
     "name": "Scroll item info up",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "<"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ",",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "<" }, { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_ITEM_INFO_DOWN",
     "category": "VENDING_MACHINE",
     "name": "Scroll item info down",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": ">"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ".",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": ">" }, { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
@@ -10450,21 +4988,9 @@
     "id": "LOOK_AT",
     "name": "Look at",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "L"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "l",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
-      }
+      { "input_method": "keyboard_char", "key": "L" },
+      { "input_method": "keyboard_code", "key": "l", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" }
     ]
   },
   {
@@ -10473,21 +4999,9 @@
     "id": "SIZE_UP_STATS",
     "name": "Size up stats",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "S"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "s",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_NE"
-      }
+      { "input_method": "keyboard_char", "key": "S" },
+      { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_NE" }
     ]
   },
   {
@@ -10496,21 +5010,9 @@
     "id": "ASSESS_PERSONALITY",
     "name": "Assess personality",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "A"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "a",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_E"
-      }
+      { "input_method": "keyboard_char", "key": "A" },
+      { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_E" }
     ]
   },
   {
@@ -10519,21 +5021,9 @@
     "id": "YELL",
     "name": "Yell",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "Y"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "y",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_SE"
-      }
+      { "input_method": "keyboard_char", "key": "Y" },
+      { "input_method": "keyboard_code", "key": "y", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_SE" }
     ]
   },
   {
@@ -10542,21 +5032,9 @@
     "id": "CHECK_OPINION",
     "name": "Check opinion",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "O"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "o",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_S"
-      }
+      { "input_method": "keyboard_char", "key": "O" },
+      { "input_method": "keyboard_code", "key": "o", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_S" }
     ]
   },
   {
@@ -10564,317 +5042,158 @@
     "category": "FACTION_MANAGER",
     "id": "INSPECT_NPC",
     "name": "Inspect NPC",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "i"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "i" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" } ]
   },
   {
     "type": "keybinding",
     "id": "SORT",
     "category": "NEW_CHAR_TRAITS",
     "name": "Sort traits list",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "s"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "JOY_RADIAL_L_N"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "s" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" } ]
   },
   {
     "type": "keybinding",
     "id": "SELECT_TRAIT_VARIANT",
     "name": "Select variant for trait",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "S"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "s",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "S" }, { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "DELETE PAGE",
     "name": "Delete page",
     "category": "DIARY",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "mod": [],
-        "key": [
-          "d"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "mod": [  ], "key": [ "d" ] } ]
   },
   {
     "type": "keybinding",
     "id": "EXPORT_DIARY",
     "name": "Export diary to .txt",
     "category": "DIARY",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "mod": [],
-        "key": [
-          "e"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "mod": [  ], "key": [ "e" ] } ]
   },
   {
     "type": "keybinding",
     "id": "NEW_PAGE",
     "name": "Add new page",
     "category": "DIARY",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "mod": [],
-        "key": [
-          "n"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "mod": [  ], "key": [ "n" ] } ]
   },
   {
     "type": "keybinding",
     "name": "View achievements, scores, and kills",
     "category": "DIARY",
     "id": "VIEW_SCORES",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "mod": [],
-        "key": [
-          "v"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "mod": [  ], "key": [ "v" ] } ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.QUIT",
     "name": "Cancel text input",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "ESC"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "ESC" } ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.CONFIRM",
     "name": "Confirm text input",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "RETURN"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "KEYPAD_ENTER"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "RETURN" }, { "input_method": "keyboard_any", "key": "KEYPAD_ENTER" } ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.UP",
     "name": "Move cursor up",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "UP"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "UP" } ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.DOWN",
     "name": "Move cursor down",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "DOWN"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "DOWN" } ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.LEFT",
     "name": "Move cursor left",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "LEFT"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "LEFT" } ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.RIGHT",
     "name": "Move cursor right",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "RIGHT"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "RIGHT" } ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.PAGE_UP",
     "name": "Move cursor to previous page",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "PPAGE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "PPAGE" } ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.PAGE_DOWN",
     "name": "Move cursor to next page",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "NPAGE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "NPAGE" } ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.CLEAR",
     "name": "Clear text",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "CTRL+U"
-      },
-      {
-        "input_method": "keyboard_code",
-        "mod": [
-          "ctrl"
-        ],
-        "key": "u"
-      }
+      { "input_method": "keyboard_char", "key": "CTRL+U" },
+      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "u" }
     ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.BACKSPACE",
     "name": "Remove previous character",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "BACKSPACE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "BACKSPACE" } ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.HOME",
     "name": "Move cursor to start",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "HOME"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "HOME" } ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.END",
     "name": "Move cursor to end",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "END"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "END" } ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.DELETE",
     "name": "Remove current character",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "DELETE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "DELETE" } ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.PASTE",
     "name": "Paste from clipboard",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "CTRL+V"
-      },
-      {
-        "input_method": "keyboard_code",
-        "mod": [
-          "ctrl"
-        ],
-        "key": "v"
-      }
+      { "input_method": "keyboard_char", "key": "CTRL+V" },
+      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "v" }
     ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.INPUT_FROM_FILE",
     "name": "Input text from file",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "F2"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "F2" } ]
   },
   {
     "type": "keybinding",
     "id": "HISTORY_UP",
     "name": "Show previous history",
     "category": "STRING_INPUT",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "UP"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "UP" } ]
   },
   {
     "type": "keybinding",
     "id": "HISTORY_DOWN",
     "name": "Show next history",
     "category": "STRING_INPUT",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "DOWN"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "DOWN" } ]
   },
   {
     "type": "keybinding",
@@ -10882,12 +5201,7 @@
     "name": "Display keybindings menu",
     "category": "STRING_INPUT",
     "//": "'?' is treated as text input, so a different key is used.",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "F1"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "F1" } ]
   },
   {
     "type": "keybinding",
@@ -10897,28 +5211,10 @@
     "//": "RETURN is treated as text input, so use a different keybinding",
     "//2": "CTRL+S is not available on curses, so add CTRL+Y as an alternative",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "CTRL+S"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "CTRL+Y"
-      },
-      {
-        "input_method": "keyboard_code",
-        "mod": [
-          "ctrl"
-        ],
-        "key": "s"
-      },
-      {
-        "input_method": "keyboard_code",
-        "mod": [
-          "ctrl"
-        ],
-        "key": "y"
-      }
+      { "input_method": "keyboard_char", "key": "CTRL+S" },
+      { "input_method": "keyboard_char", "key": "CTRL+Y" },
+      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "s" },
+      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "y" }
     ]
   },
   {
@@ -10926,72 +5222,42 @@
     "id": "TOGGLE_MONSTER_GROUP",
     "category": "SCORES_UI",
     "name": "Toggle monster group",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "m"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "m" } ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_NPC_GROUP",
     "category": "SCORES_UI",
     "name": "Toggle NPC group",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "n"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "n" } ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_GENERAL_INFO_GROUP",
     "category": "MA_DETAILS_UI",
     "name": "Toggle general info group",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "g"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "g" } ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_BUFFS_GROUP",
     "category": "MA_DETAILS_UI",
     "name": "Toggle buffs group",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "b"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "b" } ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_TECHNIQUES_GROUP",
     "category": "MA_DETAILS_UI",
     "name": "Toggle techniques group",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "t"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "t" } ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_WEAPONS_GROUP",
     "category": "MA_DETAILS_UI",
     "name": "Toggle weapons group",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "w"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "w" } ]
   },
   {
     "type": "keybinding",
@@ -10999,11 +5265,6 @@
     "name": "Display keybindings menu",
     "category": "STRING_EDITOR",
     "//": "'?' is treated as text input, so a different key is used.",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "F1"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "F1" } ]
   }
 ]

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -4,9 +4,22 @@
     "id": "UILIST.UP",
     "name": "Pan up",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "UP" },
-      { "input_method": "keyboard_any", "key": "8" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_8" }
+      {
+        "input_method": "keyboard_any",
+        "key": "UP"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "8"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_8"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_R_UP"
+      }
     ]
   },
   {
@@ -14,9 +27,22 @@
     "id": "UILIST.DOWN",
     "name": "Pan down",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "DOWN" },
-      { "input_method": "keyboard_any", "key": "2" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_2" }
+      {
+        "input_method": "keyboard_any",
+        "key": "DOWN"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "2"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_2"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_R_DOWN"
+      }
     ]
   },
   {
@@ -24,9 +50,22 @@
     "id": "UILIST.LEFT",
     "name": "Pan left",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "LEFT" },
-      { "input_method": "keyboard_any", "key": "4" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_4" }
+      {
+        "input_method": "keyboard_any",
+        "key": "LEFT"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "4"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_4"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_R_LEFT"
+      }
     ]
   },
   {
@@ -34,40 +73,87 @@
     "id": "UILIST.RIGHT",
     "name": "Pan right",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "RIGHT" },
-      { "input_method": "keyboard_any", "key": "6" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_6" }
+      {
+        "input_method": "keyboard_any",
+        "key": "RIGHT"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "6"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_6"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_R_RIGHT"
+      }
     ]
   },
   {
     "type": "keybinding",
     "id": "UILIST.FILTER",
     "name": "Filter",
-    "bindings": [ { "input_method": "keyboard_any", "key": "/" }, { "input_method": "keyboard_code", "key": "KEYPAD_DIVIDE" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "/"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_DIVIDE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "UILIST.QUIT",
     "name": "Cancel menu",
-    "bindings": [ { "input_method": "keyboard_any", "key": "ESC" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "ESC"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SHOW_DESCRIPTION",
     "category": "MELEE_STYLE_PICKER",
     "name": "Show description of melee style",
-    "bindings": [ { "input_method": "keyboard_any", "key": "d" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "d"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "UP",
     "name": "Pan up",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "k" },
-      { "input_method": "keyboard_any", "key": "UP" },
-      { "input_method": "keyboard_any", "key": "8" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_8" },
-      { "input_method": "gamepad", "key": "JOY_L_UP" }
+      {
+        "input_method": "keyboard_any",
+        "key": "k"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "UP"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "8"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_8"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_L_UP"
+      }
     ]
   },
   {
@@ -75,11 +161,26 @@
     "id": "DOWN",
     "name": "Pan down",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "j" },
-      { "input_method": "keyboard_any", "key": "DOWN" },
-      { "input_method": "keyboard_any", "key": "2" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_2" },
-      { "input_method": "gamepad", "key": "JOY_L_DOWN" }
+      {
+        "input_method": "keyboard_any",
+        "key": "j"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "DOWN"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "2"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_2"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_L_DOWN"
+      }
     ]
   },
   {
@@ -87,11 +188,26 @@
     "id": "LEFT",
     "name": "Pan left",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "h" },
-      { "input_method": "keyboard_any", "key": "LEFT" },
-      { "input_method": "keyboard_any", "key": "4" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_4" },
-      { "input_method": "gamepad", "key": "JOY_L_LEFT" }
+      {
+        "input_method": "keyboard_any",
+        "key": "h"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "LEFT"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "4"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_4"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_L_LEFT"
+      }
     ]
   },
   {
@@ -99,11 +215,26 @@
     "id": "RIGHT",
     "name": "Pan right",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "l" },
-      { "input_method": "keyboard_any", "key": "RIGHT" },
-      { "input_method": "keyboard_any", "key": "6" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_6" },
-      { "input_method": "gamepad", "key": "JOY_L_RIGHT" }
+      {
+        "input_method": "keyboard_any",
+        "key": "l"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "RIGHT"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "6"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_6"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_L_RIGHT"
+      }
     ]
   },
   {
@@ -111,10 +242,22 @@
     "id": "LEFTUP",
     "name": "Pan up-left",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "y" },
-      { "input_method": "keyboard_any", "key": "7" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_7" },
-      { "input_method": "gamepad", "key": "JOY_L_LEFTUP" }
+      {
+        "input_method": "keyboard_any",
+        "key": "y"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "7"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_7"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_L_LEFTUP"
+      }
     ]
   },
   {
@@ -122,10 +265,22 @@
     "id": "RIGHTUP",
     "name": "Pan up-right",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "u" },
-      { "input_method": "keyboard_any", "key": "9" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_9" },
-      { "input_method": "gamepad", "key": "JOY_L_RIGHTUP" }
+      {
+        "input_method": "keyboard_any",
+        "key": "u"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "9"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_9"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_L_RIGHTUP"
+      }
     ]
   },
   {
@@ -133,10 +288,22 @@
     "id": "LEFTDOWN",
     "name": "Pan down-left",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "b" },
-      { "input_method": "keyboard_any", "key": "1" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_1" },
-      { "input_method": "gamepad", "key": "JOY_L_LEFTDOWN" }
+      {
+        "input_method": "keyboard_any",
+        "key": "b"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "1"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_1"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_L_LEFTDOWN"
+      }
     ]
   },
   {
@@ -144,68 +311,147 @@
     "id": "RIGHTDOWN",
     "name": "Pan down-right",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "n" },
-      { "input_method": "keyboard_any", "key": "3" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_3" },
-      { "input_method": "gamepad", "key": "JOY_L_RIGHTDOWN" }
+      {
+        "input_method": "keyboard_any",
+        "key": "n"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "3"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_3"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_L_RIGHTDOWN"
+      }
     ]
   },
   {
     "type": "keybinding",
     "id": "HOME",
     "name": "Home",
-    "bindings": [ { "input_method": "keyboard_any", "key": "HOME" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "HOME"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "END",
     "name": "End",
-    "bindings": [ { "input_method": "keyboard_any", "key": "END" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "END"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "PAGE_UP",
     "name": "Page up",
-    "bindings": [ { "input_method": "keyboard_any", "key": "PPAGE" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "PPAGE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "PAGE_DOWN",
     "name": "Page down",
-    "bindings": [ { "input_method": "keyboard_any", "key": "NPAGE" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "NPAGE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_UP",
     "name": "Scroll up",
-    "bindings": [ { "input_method": "mouse", "key": "SCROLL_UP" } ]
+    "bindings": [
+      {
+        "input_method": "mouse",
+        "key": "SCROLL_UP"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_DOWN",
     "name": "Scroll down",
-    "bindings": [ { "input_method": "mouse", "key": "SCROLL_DOWN" } ]
+    "bindings": [
+      {
+        "input_method": "mouse",
+        "key": "SCROLL_DOWN"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SELECT_ALL",
     "category": "PICKUP",
     "name": "Select all",
-    "bindings": [ { "input_method": "keyboard_any", "key": "," } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": ","
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_ITEM_INFO_UP",
     "category": "PICKUP",
     "name": "Scroll item info up",
-    "bindings": [ { "input_method": "keyboard_char", "key": "<" }, { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "<"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ",",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_R_UP"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_ITEM_INFO_DOWN",
     "category": "PICKUP",
     "name": "Scroll item info down",
-    "bindings": [ { "input_method": "keyboard_char", "key": ">" }, { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": ">"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ".",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_R_DOWN"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -213,9 +459,18 @@
     "category": "PICKUP",
     "name": "Previous item",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "k" },
-      { "input_method": "keyboard_any", "key": "UP" },
-      { "input_method": "gamepad", "key": "JOY_UP" }
+      {
+        "input_method": "keyboard_any",
+        "key": "k"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "UP"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_UP"
+      }
     ]
   },
   {
@@ -224,9 +479,18 @@
     "category": "PICKUP",
     "name": "Next item",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "j" },
-      { "input_method": "keyboard_any", "key": "DOWN" },
-      { "input_method": "gamepad", "key": "JOY_DOWN" }
+      {
+        "input_method": "keyboard_any",
+        "key": "j"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "DOWN"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_DOWN"
+      }
     ]
   },
   {
@@ -235,9 +499,18 @@
     "category": "PICKUP",
     "name": "Unmark selected item",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "h" },
-      { "input_method": "keyboard_any", "key": "LEFT" },
-      { "input_method": "gamepad", "key": "JOY_LEFT" }
+      {
+        "input_method": "keyboard_any",
+        "key": "h"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "LEFT"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_LEFT"
+      }
     ]
   },
   {
@@ -245,7 +518,16 @@
     "id": "RIGHT",
     "category": "PICKUP",
     "name": "Mark selected item",
-    "bindings": [ { "input_method": "keyboard_any", "key": "l" }, { "input_method": "keyboard_any", "key": "RIGHT" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "l"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "RIGHT"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -253,9 +535,21 @@
     "category": "AUTO_NOTES",
     "name": "Enable auto notes for map extras",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "e" },
-      { "input_method": "keyboard_char", "key": "E" },
-      { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "e"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "E"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "e",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -264,9 +558,21 @@
     "category": "AUTO_NOTES",
     "name": "Toggle auto notes option",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "s" },
-      { "input_method": "keyboard_char", "key": "S" },
-      { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "s"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "S"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "s",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -275,9 +581,21 @@
     "category": "AUTO_NOTES",
     "name": "Disable auto notes for map extras",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "d" },
-      { "input_method": "keyboard_char", "key": "D" },
-      { "input_method": "keyboard_code", "key": "d", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "d"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "D"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "d",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -285,35 +603,89 @@
     "id": "CHANGE_MAPEXTRA_CHARACTER",
     "category": "AUTO_NOTES",
     "name": "Change a symbol for map extra",
-    "bindings": [ { "input_method": "keyboard_any", "key": "=" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "="
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CHOOSE_INVLET",
     "category": "SPELL_MENU",
     "name": "Choose a hotkey for a spell",
-    "bindings": [ { "input_method": "keyboard_any", "key": "=" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "="
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CAST_IGNORE",
     "category": "SPELL_MENU",
     "name": "Toggle ignore distractions",
-    "bindings": [ { "input_method": "keyboard_char", "key": "I" }, { "input_method": "keyboard_code", "key": "i", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "I"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "i",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_UP_SPELL_MENU",
     "category": "SPELL_MENU",
     "name": "Scroll up spell info",
-    "bindings": [ { "input_method": "keyboard_char", "key": "<" }, { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "<"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ",",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_R_UP"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_DOWN_SPELL_MENU",
     "category": "SPELL_MENU",
     "name": "Scroll down spell info",
-    "bindings": [ { "input_method": "keyboard_char", "key": ">" }, { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": ">"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ".",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_R_DOWN"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -321,9 +693,21 @@
     "category": "SPELL_MENU",
     "name": "Toggle spell as favorite",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "*" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
-      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_char",
+        "key": "*"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MULTIPLY"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "8",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -332,9 +716,21 @@
     "category": "AUTO_PICKUP",
     "name": "Add rule",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "a" },
-      { "input_method": "keyboard_char", "key": "A" },
-      { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "a"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "A"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "a",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -343,9 +739,21 @@
     "category": "AUTO_PICKUP",
     "name": "Remove rule",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "r" },
-      { "input_method": "keyboard_char", "key": "R" },
-      { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "r"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "R"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "r",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -354,9 +762,21 @@
     "category": "AUTO_PICKUP",
     "name": "Copy rule",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "c" },
-      { "input_method": "keyboard_char", "key": "C" },
-      { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "c"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "C"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "c",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -365,9 +785,21 @@
     "category": "AUTO_PICKUP",
     "name": "Move rule global <-> character",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "m" },
-      { "input_method": "keyboard_char", "key": "M" },
-      { "input_method": "keyboard_code", "key": "m", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "m"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "M"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "m",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -376,9 +808,21 @@
     "category": "AUTO_PICKUP",
     "name": "Enable rule",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "e" },
-      { "input_method": "keyboard_char", "key": "E" },
-      { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "e"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "E"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "e",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -387,9 +831,21 @@
     "category": "AUTO_PICKUP",
     "name": "Disable rule",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "d" },
-      { "input_method": "keyboard_char", "key": "D" },
-      { "input_method": "keyboard_code", "key": "d", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "d"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "D"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "d",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -398,9 +854,18 @@
     "category": "AUTO_PICKUP",
     "name": "Move rule up",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "=" },
-      { "input_method": "keyboard_char", "key": "+" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" }
+      {
+        "input_method": "keyboard_any",
+        "key": "="
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "+"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_PLUS"
+      }
     ]
   },
   {
@@ -408,7 +873,16 @@
     "id": "MOVE_RULE_DOWN",
     "category": "AUTO_PICKUP",
     "name": "Move rule down",
-    "bindings": [ { "input_method": "keyboard_any", "key": "-" }, { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "-"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MINUS"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -416,9 +890,21 @@
     "category": "AUTO_PICKUP",
     "name": "Test rule",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "t" },
-      { "input_method": "keyboard_char", "key": "T" },
-      { "input_method": "keyboard_code", "key": "t", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "t"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "T"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "t",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -427,9 +913,21 @@
     "category": "AUTO_PICKUP",
     "name": "Enable auto pickup option",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "s" },
-      { "input_method": "keyboard_char", "key": "S" },
-      { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "s"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "S"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "s",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -438,12 +936,33 @@
     "category": "AUTO_PICKUP",
     "name": "Quit",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "ESC" },
-      { "input_method": "keyboard_any", "key": "q" },
-      { "input_method": "keyboard_char", "key": "Q" },
-      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "SPACE" },
-      { "input_method": "mouse", "key": "MOUSE_RIGHT" }
+      {
+        "input_method": "keyboard_any",
+        "key": "ESC"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "q"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "Q"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "q",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "SPACE"
+      },
+      {
+        "input_method": "mouse",
+        "key": "MOUSE_RIGHT"
+      }
     ]
   },
   {
@@ -452,9 +971,21 @@
     "category": "SAFEMODE",
     "name": "Add default ruleset",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "~" },
-      { "input_method": "keyboard_code", "key": "`", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" }
+      {
+        "input_method": "keyboard_char",
+        "key": "~"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "`",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
     ]
   },
   {
@@ -463,10 +994,25 @@
     "category": "SAFEMODE",
     "name": "Add rule",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "a" },
-      { "input_method": "keyboard_char", "key": "A" },
-      { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_NE" }
+      {
+        "input_method": "keyboard_any",
+        "key": "a"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "A"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "a",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NE"
+      }
     ]
   },
   {
@@ -475,10 +1021,25 @@
     "category": "SAFEMODE",
     "name": "Remove rule",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "r" },
-      { "input_method": "keyboard_char", "key": "R" },
-      { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_E" }
+      {
+        "input_method": "keyboard_any",
+        "key": "r"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "R"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "r",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_E"
+      }
     ]
   },
   {
@@ -487,10 +1048,25 @@
     "category": "SAFEMODE",
     "name": "Copy rule",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "c" },
-      { "input_method": "keyboard_char", "key": "C" },
-      { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_SE" }
+      {
+        "input_method": "keyboard_any",
+        "key": "c"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "C"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "c",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SE"
+      }
     ]
   },
   {
@@ -499,10 +1075,25 @@
     "category": "SAFEMODE",
     "name": "Move rule global <-> character",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "m" },
-      { "input_method": "keyboard_char", "key": "M" },
-      { "input_method": "keyboard_code", "key": "m", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_S" }
+      {
+        "input_method": "keyboard_any",
+        "key": "m"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "M"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "m",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_S"
+      }
     ]
   },
   {
@@ -511,10 +1102,25 @@
     "category": "SAFEMODE",
     "name": "Enable rule",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "e" },
-      { "input_method": "keyboard_char", "key": "E" },
-      { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_SW" }
+      {
+        "input_method": "keyboard_any",
+        "key": "e"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "E"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "e",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SW"
+      }
     ]
   },
   {
@@ -523,10 +1129,25 @@
     "category": "SAFEMODE",
     "name": "Disable rule",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "d" },
-      { "input_method": "keyboard_char", "key": "D" },
-      { "input_method": "keyboard_code", "key": "d", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_W" }
+      {
+        "input_method": "keyboard_any",
+        "key": "d"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "D"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "d",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_W"
+      }
     ]
   },
   {
@@ -535,10 +1156,22 @@
     "category": "SAFEMODE",
     "name": "Move rule up",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "=" },
-      { "input_method": "keyboard_char", "key": "+" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" },
-      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_UP" }
+      {
+        "input_method": "keyboard_any",
+        "key": "="
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "+"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_PLUS"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_DPAD_UP"
+      }
     ]
   },
   {
@@ -547,9 +1180,18 @@
     "category": "SAFEMODE",
     "name": "Move rule down",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "-" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" },
-      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_DOWN" }
+      {
+        "input_method": "keyboard_any",
+        "key": "-"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MINUS"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_DPAD_DOWN"
+      }
     ]
   },
   {
@@ -558,10 +1200,25 @@
     "category": "SAFEMODE",
     "name": "Test rule",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "t" },
-      { "input_method": "keyboard_char", "key": "T" },
-      { "input_method": "keyboard_code", "key": "t", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_NW" }
+      {
+        "input_method": "keyboard_any",
+        "key": "t"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "T"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "t",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NW"
+      }
     ]
   },
   {
@@ -570,10 +1227,25 @@
     "category": "SAFEMODE",
     "name": "Enable safemode option",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "s" },
-      { "input_method": "keyboard_char", "key": "S" },
-      { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_R_N" }
+      {
+        "input_method": "keyboard_any",
+        "key": "s"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "S"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "s",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_N"
+      }
     ]
   },
   {
@@ -582,12 +1254,33 @@
     "category": "SAFEMODE",
     "name": "Quit",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "ESC" },
-      { "input_method": "keyboard_any", "key": "q" },
-      { "input_method": "keyboard_char", "key": "Q" },
-      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "SPACE" },
-      { "input_method": "mouse", "key": "MOUSE_RIGHT" }
+      {
+        "input_method": "keyboard_any",
+        "key": "ESC"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "q"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "Q"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "q",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "SPACE"
+      },
+      {
+        "input_method": "mouse",
+        "key": "MOUSE_RIGHT"
+      }
     ]
   },
   {
@@ -595,7 +1288,12 @@
     "id": "USAGE_HELP",
     "category": "SORT_ARMOR",
     "name": "Display usage help",
-    "bindings": [ { "input_method": "keyboard_any", "key": "F1" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "F1"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -603,9 +1301,18 @@
     "category": "SORT_ARMOR",
     "name": "Select armor for moving",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "s" },
-      { "input_method": "keyboard_any", "key": "RETURN" },
-      { "input_method": "keyboard_any", "key": "KEYPAD_ENTER" }
+      {
+        "input_method": "keyboard_any",
+        "key": "s"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "RETURN"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "KEYPAD_ENTER"
+      }
     ]
   },
   {
@@ -614,9 +1321,18 @@
     "category": "PANEL_MGMT",
     "name": "Select panel for moving",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "s" },
-      { "input_method": "keyboard_any", "key": "RETURN" },
-      { "input_method": "keyboard_any", "key": "KEYPAD_ENTER" }
+      {
+        "input_method": "keyboard_any",
+        "key": "s"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "RETURN"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "KEYPAD_ENTER"
+      }
     ]
   },
   {
@@ -624,14 +1340,28 @@
     "id": "TOGGLE_PANEL",
     "category": "PANEL_MGMT",
     "name": "Toggle panel off",
-    "bindings": [ { "input_method": "keyboard_any", "key": "TAB" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "TAB"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CHANGE_SIDE",
     "category": "SORT_ARMOR",
     "name": "Change side armor is worn on",
-    "bindings": [ { "input_method": "keyboard_any", "key": "c" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "c"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -639,9 +1369,21 @@
     "category": "SORT_ARMOR",
     "name": "Toggle armor visibility on character sprite",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "H" },
-      { "input_method": "keyboard_code", "key": "h", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_NE" }
+      {
+        "input_method": "keyboard_char",
+        "key": "H"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "h",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NE"
+      }
     ]
   },
   {
@@ -649,7 +1391,16 @@
     "id": "ASSIGN_INVLETS",
     "category": "SORT_ARMOR",
     "name": "Assign invlets to armor",
-    "bindings": [ { "input_method": "keyboard_any", "key": "r" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_E" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "r"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_E"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -657,9 +1408,21 @@
     "category": "SORT_ARMOR",
     "name": "Sort armor into natural layer order",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "S" },
-      { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_SE" }
+      {
+        "input_method": "keyboard_char",
+        "key": "S"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "s",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SE"
+      }
     ]
   },
   {
@@ -667,21 +1430,62 @@
     "id": "SCROLL_ITEM_INFO_UP",
     "category": "SORT_ARMOR",
     "name": "Scroll item info up",
-    "bindings": [ { "input_method": "keyboard_char", "key": "<" }, { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "<"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ",",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_R_UP"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_ITEM_INFO_DOWN",
     "category": "SORT_ARMOR",
     "name": "Scroll item info down",
-    "bindings": [ { "input_method": "keyboard_char", "key": ">" }, { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": ">"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ".",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_R_DOWN"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "EQUIP_ARMOR",
     "category": "SORT_ARMOR",
     "name": "Equip armor from inventory",
-    "bindings": [ { "input_method": "keyboard_any", "key": "e" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_S" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "e"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_S"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -689,9 +1493,21 @@
     "category": "SORT_ARMOR",
     "name": "Equip armor from inventory at this position",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "E" },
-      { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_SW" }
+      {
+        "input_method": "keyboard_char",
+        "key": "E"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "e",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SW"
+      }
     ]
   },
   {
@@ -699,24 +1515,63 @@
     "id": "REMOVE_ARMOR",
     "category": "SORT_ARMOR",
     "name": "Unequip selected armor",
-    "bindings": [ { "input_method": "keyboard_any", "key": "u" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_W" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "u"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_W"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "HELP_KEYBINDINGS",
     "name": "Display keybindings menu",
-    "bindings": [ { "input_method": "keyboard_char", "key": "?" }, { "input_method": "keyboard_code", "key": "/", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "?"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "/",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "FILTER",
     "name": "Filter",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "f" },
-      { "input_method": "keyboard_char", "key": "F" },
-      { "input_method": "keyboard_code", "key": "f", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "/" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_DIVIDE" }
+      {
+        "input_method": "keyboard_any",
+        "key": "f"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "F"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "f",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "/"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_DIVIDE"
+      }
     ]
   },
   {
@@ -724,9 +1579,21 @@
     "id": "RESET_FILTER",
     "name": "Reset filter",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "r" },
-      { "input_method": "keyboard_char", "key": "R" },
-      { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "r"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "R"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "r",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -734,14 +1601,24 @@
     "id": "SCROLL_RECIPE_INFO_UP",
     "category": "CRAFTING",
     "name": "Scroll recipe info up",
-    "bindings": [ { "input_method": "keyboard_any", "key": "[" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "["
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_RECIPE_INFO_DOWN",
     "category": "CRAFTING",
     "name": "Scroll recipe info down",
-    "bindings": [ { "input_method": "keyboard_any", "key": "]" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "]"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -749,9 +1626,21 @@
     "category": "CRAFTING",
     "name": "Show recipe result",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "e" },
-      { "input_method": "keyboard_char", "key": "E" },
-      { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "e"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "E"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "e",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -765,7 +1654,16 @@
     "id": "TOGGLE_RECIPE_UNREAD",
     "category": "CRAFTING",
     "name": "Toggle read/unread",
-    "bindings": [ { "input_method": "keyboard_any", "key": "v" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "v"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -773,9 +1671,21 @@
     "category": "CRAFTING",
     "name": "Mark all recipes as read",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "V" },
-      { "input_method": "keyboard_code", "key": "v", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_NE" }
+      {
+        "input_method": "keyboard_char",
+        "key": "V"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "v",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NE"
+      }
     ]
   },
   {
@@ -783,21 +1693,50 @@
     "id": "TOGGLE_UNREAD_RECIPES_FIRST",
     "category": "CRAFTING",
     "name": "Show unread recipes on top",
-    "bindings": [ { "input_method": "keyboard_any", "key": "u" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_E" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "u"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_E"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CHOOSE_CRAFTER",
     "category": "CRAFTING",
     "name": "Choose crafter",
-    "bindings": [ { "input_method": "keyboard_any", "key": "c" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_SE" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "c"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CYCLE_BATCH",
     "category": "CRAFTING",
     "name": "Batch crafting",
-    "bindings": [ { "input_method": "keyboard_any", "key": [ "b" ] }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_S" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": [
+          "b"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_S"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -805,9 +1744,21 @@
     "category": "CRAFTING",
     "name": "Scroll item info up",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "<" },
-      { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_UP" }
+      {
+        "input_method": "keyboard_char",
+        "key": "<"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ",",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_R_UP"
+      }
     ]
   },
   {
@@ -816,9 +1767,21 @@
     "category": "CRAFTING",
     "name": "Scroll item info down",
     "bindings": [
-      { "input_method": "keyboard_char", "key": ">" },
-      { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_DOWN" }
+      {
+        "input_method": "keyboard_char",
+        "key": ">"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ".",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_R_DOWN"
+      }
     ]
   },
   {
@@ -827,9 +1790,21 @@
     "category": "CRAFTING",
     "name": "Related recipes",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "L" },
-      { "input_method": "keyboard_code", "key": "l", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_R_SW" }
+      {
+        "input_method": "keyboard_char",
+        "key": "L"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "l",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_SW"
+      }
     ]
   },
   {
@@ -838,10 +1813,25 @@
     "category": "CRAFTING",
     "name": "Toggle recipes to be shown in favorite tab",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "*" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
-      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_W" }
+      {
+        "input_method": "keyboard_char",
+        "key": "*"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MULTIPLY"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "8",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_W"
+      }
     ]
   },
   {
@@ -850,9 +1840,21 @@
     "category": "CRAFTING",
     "name": "Compare recipe to item in inventory",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "I" },
-      { "input_method": "keyboard_code", "key": "i", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_NW" }
+      {
+        "input_method": "keyboard_char",
+        "key": "I"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "i",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NW"
+      }
     ]
   },
   {
@@ -860,10 +1862,25 @@
     "id": "LEVEL_UP",
     "name": "Go up",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "PPAGE" },
-      { "input_method": "keyboard_char", "key": "<" },
-      { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_UP" }
+      {
+        "input_method": "keyboard_any",
+        "key": "PPAGE"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "<"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ",",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_DPAD_UP"
+      }
     ]
   },
   {
@@ -871,10 +1888,25 @@
     "id": "LEVEL_DOWN",
     "name": "Go down",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "NPAGE" },
-      { "input_method": "keyboard_char", "key": ">" },
-      { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_DOWN" }
+      {
+        "input_method": "keyboard_any",
+        "key": "NPAGE"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": ">"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ".",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_DPAD_DOWN"
+      }
     ]
   },
   {
@@ -883,10 +1915,22 @@
     "category": "SOKOBAN",
     "name": "Next level",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "=" },
-      { "input_method": "keyboard_char", "key": "+" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" }
+      {
+        "input_method": "keyboard_any",
+        "key": "="
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "+"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_PLUS"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
     ]
   },
   {
@@ -895,9 +1939,18 @@
     "category": "SOKOBAN",
     "name": "Previous level",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "-" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_NE" }
+      {
+        "input_method": "keyboard_any",
+        "key": "-"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MINUS"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NE"
+      }
     ]
   },
   {
@@ -905,35 +1958,80 @@
     "id": "RESET",
     "category": "SOKOBAN",
     "name": "Reset level",
-    "bindings": [ { "input_method": "keyboard_any", "key": "r" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_E" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "r"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_E"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "UNDO",
     "category": "SOKOBAN",
     "name": "Undo move",
-    "bindings": [ { "input_method": "keyboard_any", "key": "u" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_SE" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "u"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "NEW",
     "category": "MINESWEEPER",
     "name": "Create new level",
-    "bindings": [ { "input_method": "keyboard_any", "key": "n" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "n"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "FLAG",
     "category": "MINESWEEPER",
     "name": "Toggle flag",
-    "bindings": [ { "input_method": "keyboard_any", "key": "f" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_NE" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "f"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_SPACE",
     "category": "LIGHTSON",
     "name": "Toggle lights",
-    "bindings": [ { "input_method": "keyboard_any", "key": " " }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": " "
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -941,9 +2039,18 @@
     "category": "LIGHTSON",
     "name": "Toggle lights",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "5" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_5" },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_NE" }
+      {
+        "input_method": "keyboard_any",
+        "key": "5"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_5"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NE"
+      }
     ]
   },
   {
@@ -951,33 +2058,74 @@
     "id": "RESET",
     "category": "LIGHTSON",
     "name": "Reset level",
-    "bindings": [ { "input_method": "keyboard_any", "key": "r" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_E" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "r"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_E"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CONFIRM",
     "name": "Confirm choice",
-    "bindings": [ { "input_method": "keyboard_any", "key": "RETURN" }, { "input_method": "keyboard_any", "key": "KEYPAD_ENTER" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "RETURN"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "KEYPAD_ENTER"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CONFIRM_MULTIPLE",
     "name": "Confirm and continue",
-    "bindings": [ { "input_method": "keyboard_any", "key": "SPACE" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "SPACE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SAVE_DEFAULT_MODS",
     "category": "MODMANAGER_DIALOG",
     "name": "Save mods as default",
-    "bindings": [ { "input_method": "keyboard_any", "key": "s" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "s"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "VIEW_MOD_DESCRIPTION",
     "category": "MODMANAGER_DIALOG",
     "name": "View full mod description",
-    "bindings": [ { "input_method": "keyboard_any", "key": "v" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "v"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NE"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -985,9 +2133,22 @@
     "category": "MODMANAGER_DIALOG",
     "name": "Move selected mod down",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "=" },
-      { "input_method": "keyboard_char", "key": "+" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" }
+      {
+        "input_method": "keyboard_any",
+        "key": "="
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "+"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_PLUS"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_E"
+      }
     ]
   },
   {
@@ -995,21 +2156,66 @@
     "id": "MOVE_MOD_UP",
     "category": "MODMANAGER_DIALOG",
     "name": "Move selected mod up",
-    "bindings": [ { "input_method": "keyboard_any", "key": "-" }, { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "-"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MINUS"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "NEXT_CATEGORY_TAB",
     "category": "MODMANAGER_DIALOG",
     "name": "Move to next category tab",
-    "bindings": [ { "input_method": "keyboard_char", "key": ">" }, { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": ">"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ".",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "TAB"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "PREV_CATEGORY_TAB",
     "category": "MODMANAGER_DIALOG",
     "name": "Move to previous category tab",
-    "bindings": [ { "input_method": "keyboard_char", "key": "<" }, { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "<"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ",",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "BACKTAB"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -1017,12 +2223,33 @@
     "category": "MODMANAGER_DIALOG",
     "name": "Quit",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "ESC" },
-      { "input_method": "keyboard_any", "key": "q" },
-      { "input_method": "keyboard_char", "key": "Q" },
-      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "SPACE" },
-      { "input_method": "mouse", "key": "MOUSE_RIGHT" }
+      {
+        "input_method": "keyboard_any",
+        "key": "ESC"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "q"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "Q"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "q",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "SPACE"
+      },
+      {
+        "input_method": "mouse",
+        "key": "MOUSE_RIGHT"
+      }
     ]
   },
   {
@@ -1031,12 +2258,33 @@
     "category": "OPTIONS",
     "name": "Quit",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "ESC" },
-      { "input_method": "keyboard_any", "key": "q" },
-      { "input_method": "keyboard_char", "key": "Q" },
-      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "SPACE" },
-      { "input_method": "mouse", "key": "MOUSE_RIGHT" }
+      {
+        "input_method": "keyboard_any",
+        "key": "ESC"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "q"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "Q"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "q",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "SPACE"
+      },
+      {
+        "input_method": "mouse",
+        "key": "MOUSE_RIGHT"
+      }
     ]
   },
   {
@@ -1045,9 +2293,21 @@
     "category": "STRING_INPUT",
     "name": "Pick random world name",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "*" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
-      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_char",
+        "key": "*"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MULTIPLY"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "8",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -1056,9 +2316,25 @@
     "category": "WORLDGEN_CONFIRM_DIALOG",
     "name": "Pick random world name",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "*" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
-      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_char",
+        "key": "*"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MULTIPLY"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "8",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
     ]
   },
   {
@@ -1068,12 +2344,33 @@
     "category": "WORLDGEN_CONFIRM_DIALOG",
     "name": "Exit worldgen screen",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "ESC" },
-      { "input_method": "keyboard_any", "key": "q" },
-      { "input_method": "keyboard_char", "key": "Q" },
-      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "SPACE" },
-      { "input_method": "mouse", "key": "MOUSE_RIGHT" }
+      {
+        "input_method": "keyboard_any",
+        "key": "ESC"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "q"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "Q"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "q",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "SPACE"
+      },
+      {
+        "input_method": "mouse",
+        "key": "MOUSE_RIGHT"
+      }
     ]
   },
   {
@@ -1082,9 +2379,25 @@
     "category": "WORLDGEN_CONFIRM_DIALOG",
     "name": "View mod manager",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "m" },
-      { "input_method": "keyboard_char", "key": "M" },
-      { "input_method": "keyboard_code", "key": "m", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "m"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "M"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "m",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NE"
+      }
     ]
   },
   {
@@ -1093,9 +2406,25 @@
     "category": "WORLDGEN_CONFIRM_DIALOG",
     "name": "View advanced world settings",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "s" },
-      { "input_method": "keyboard_char", "key": "S" },
-      { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "s"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "S"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "s",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_E"
+      }
     ]
   },
   {
@@ -1104,9 +2433,25 @@
     "category": "WORLDGEN_CONFIRM_DIALOG",
     "name": "Finalize world creation",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "f" },
-      { "input_method": "keyboard_char", "key": "F" },
-      { "input_method": "keyboard_code", "key": "f", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "f"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "F"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "f",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SE"
+      }
     ]
   },
   {
@@ -1115,9 +2460,25 @@
     "category": "WORLDGEN_CONFIRM_DIALOG",
     "name": "Randomize world settings",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "a" },
-      { "input_method": "keyboard_char", "key": "A" },
-      { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "a"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "A"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "a",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_S"
+      }
     ]
   },
   {
@@ -1126,9 +2487,25 @@
     "category": "WORLDGEN_CONFIRM_DIALOG",
     "name": "Reset world settings and mods",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "r" },
-      { "input_method": "keyboard_char", "key": "R" },
-      { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "r"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "R"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "r",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SW"
+      }
     ]
   },
   {
@@ -1137,12 +2514,33 @@
     "category": "DISPLAY_HELP",
     "name": "Quit",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "ESC" },
-      { "input_method": "keyboard_any", "key": "q" },
-      { "input_method": "keyboard_char", "key": "Q" },
-      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "SPACE" },
-      { "input_method": "mouse", "key": "MOUSE_RIGHT" }
+      {
+        "input_method": "keyboard_any",
+        "key": "ESC"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "q"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "Q"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "q",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "SPACE"
+      },
+      {
+        "input_method": "mouse",
+        "key": "MOUSE_RIGHT"
+      }
     ]
   },
   {
@@ -1151,12 +2549,33 @@
     "category": "SCROLLABLE_TEXT",
     "name": "Quit",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "ESC" },
-      { "input_method": "keyboard_any", "key": "q" },
-      { "input_method": "keyboard_char", "key": "Q" },
-      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "SPACE" },
-      { "input_method": "mouse", "key": "MOUSE_RIGHT" }
+      {
+        "input_method": "keyboard_any",
+        "key": "ESC"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "q"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "Q"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "q",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "SPACE"
+      },
+      {
+        "input_method": "mouse",
+        "key": "MOUSE_RIGHT"
+      }
     ]
   },
   {
@@ -1164,119 +2583,309 @@
     "id": "DELETE_NOTE",
     "category": "OVERMAP_NOTES",
     "name": "Delete note",
-    "bindings": [ { "input_method": "keyboard_char", "key": "D" }, { "input_method": "keyboard_code", "key": "d", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "D"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "d",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "EDIT_NOTE",
     "category": "OVERMAP_NOTES",
     "name": "Edit note",
-    "bindings": [ { "input_method": "keyboard_char", "key": "E" }, { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "E"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "e",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "MARK_DANGER",
     "category": "OVERMAP_NOTES",
     "name": "Mark danger",
-    "bindings": [ { "input_method": "keyboard_char", "key": "R" }, { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "R"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "r",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "look",
     "category": "OVERMAP",
     "name": "Look around",
-    "bindings": [ { "input_method": "keyboard_any", "key": ";" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": ";"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "DELETE_NOTE",
     "category": "OVERMAP",
     "name": "Delete note",
-    "bindings": [ { "input_method": "keyboard_char", "key": "D" }, { "input_method": "keyboard_code", "key": "d", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "D"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "d",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CREATE_NOTE",
     "category": "OVERMAP",
     "name": "Create/edit note",
-    "bindings": [ { "input_method": "keyboard_char", "key": "N" }, { "input_method": "keyboard_code", "key": "n", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "N"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "n",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "MARK_DANGER",
     "category": "OVERMAP",
     "name": "Mark danger",
-    "bindings": [ { "input_method": "keyboard_char", "key": "R" }, { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "R"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "r",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "LIST_NOTES",
     "category": "OVERMAP",
     "name": "List notes",
-    "bindings": [ { "input_method": "keyboard_char", "key": "L" }, { "input_method": "keyboard_code", "key": "l", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "L"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "l",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_BLINKING",
     "category": "OVERMAP",
     "name": "Toggle blinking",
-    "bindings": [ { "input_method": "keyboard_char", "key": "B" }, { "input_method": "keyboard_code", "key": "b", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "B"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "b",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_OVERLAYS",
     "category": "OVERMAP",
     "name": "Toggle overlays",
-    "bindings": [ { "input_method": "keyboard_char", "key": "O" }, { "input_method": "keyboard_code", "key": "o", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "O"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "o",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_LAND_USE_CODES",
     "category": "OVERMAP",
     "name": "Toggle land use codes",
-    "bindings": [ { "input_method": "keyboard_char", "key": "A" }, { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "A"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "a",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_MAP_NOTES",
     "category": "OVERMAP",
     "name": "Toggle map notes",
-    "bindings": [ { "input_method": "keyboard_char", "key": "G" }, { "input_method": "keyboard_code", "key": "g", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "G"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "g",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_CITY_LABELS",
     "category": "OVERMAP",
     "name": "Toggle city labels",
-    "bindings": [ { "input_method": "keyboard_char", "key": "C" }, { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "C"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "c",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_MAP_REVEALS",
     "category": "OVERMAP",
     "name": "Toggle highlighting map reveals",
-    "bindings": [ { "input_method": "keyboard_char", "key": "V" }, { "input_method": "keyboard_code", "key": "v", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "V"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "v",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_HORDES",
     "category": "OVERMAP",
     "name": "Toggle hordes",
-    "bindings": [ { "input_method": "keyboard_char", "key": "H" }, { "input_method": "keyboard_code", "key": "h", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "H"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "h",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_OVERMAP_WEATHER",
     "category": "OVERMAP",
     "name": "Toggle visible weather",
-    "bindings": [ { "input_method": "keyboard_any", "key": "w" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "w"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_FOREST_TRAILS",
     "category": "OVERMAP",
     "name": "Toggle forest trails",
-    "bindings": [ { "input_method": "keyboard_char", "key": "T" }, { "input_method": "keyboard_code", "key": "t", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "T"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "t",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -1284,9 +2893,21 @@
     "category": "OVERMAP",
     "name": "Toggle fast travel",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "x" },
-      { "input_method": "keyboard_code", "key": "x", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" }
+      {
+        "input_method": "keyboard_char",
+        "key": "x"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "x",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
     ]
   },
   {
@@ -1294,14 +2915,24 @@
     "id": "COLLAPSE_OVERMAP_SIDEBAR_HEADERS",
     "category": "OVERMAP",
     "name": "Collapse all overmap sidebar headers",
-    "bindings": [ { "input_method": "keyboard_char", "key": "{" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "{"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "EXPAND_OVERMAP_SIDEBAR_HEADERS",
     "category": "OVERMAP",
     "name": "Expand all overmap sidebar headers",
-    "bindings": [ { "input_method": "keyboard_char", "key": "}" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "}"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -1309,9 +2940,21 @@
     "category": "OVERMAP",
     "name": "Toggle explored",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "E" },
-      { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_NE" }
+      {
+        "input_method": "keyboard_char",
+        "key": "E"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "e",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NE"
+      }
     ]
   },
   {
@@ -1319,76 +2962,149 @@
     "id": "PLACE_TERRAIN",
     "category": "OVERMAP",
     "name": "Place overmap terrain",
-    "bindings": [ { "input_method": "keyboard_any", "key": "t" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "t"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "PLACE_SPECIAL",
     "category": "OVERMAP",
     "name": "Place overmap special",
-    "bindings": [ { "input_method": "keyboard_any", "key": "s" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "s"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SET_SPECIAL_ARGS",
     "category": "OVERMAP",
     "name": "Set overmap special arguments",
-    "bindings": [ { "input_method": "keyboard_any", "key": "a" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "a"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "LONG_TELEPORT",
     "category": "OVERMAP",
     "name": "Teleport to cursor",
-    "bindings": [ { "input_method": "keyboard_any", "key": "d" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "d"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "REVEAL_MAP",
     "category": "OVERMAP",
     "name": "Reveal map",
-    "bindings": [ { "input_method": "keyboard_any", "key": "r" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "r"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "MODIFY_HORDE",
     "category": "OVERMAP",
     "name": "Modify existing horde or place new one",
-    "bindings": [ { "input_method": "keyboard_any", "key": "p" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "p"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "PRINT_NOISE_MAPS",
     "category": "OVERMAP",
     "name": "Print noise maps",
-    "bindings": [ { "input_method": "keyboard_any", "key": "," } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": ","
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "View missions",
     "category": "OVERMAP",
     "id": "MISSIONS",
-    "bindings": [ { "input_method": "keyboard_char", "key": "M" }, { "input_method": "keyboard_code", "key": "m", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "M"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "m",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Define Point of Interest",
     "category": "OVERMAP",
     "id": "CREATE_POINT_OF_INTEREST",
-    "bindings": [ { "input_method": "keyboard_char", "key": "P" }, { "input_method": "keyboard_code", "key": "p", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "P"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "p",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "ROTATE",
     "category": "OVERMAP_EDITOR",
     "name": "Rotate",
-    "bindings": [ { "input_method": "keyboard_any", "key": "r" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "r"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SEARCH",
     "name": "Search",
-    "bindings": [ { "input_method": "keyboard_any", "key": "/" }, { "input_method": "keyboard_code", "key": "KEYPAD_DIVIDE" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "/"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_DIVIDE"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -1396,12 +3112,33 @@
     "name": "Close map",
     "category": "OVERMAP",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "m" },
-      { "input_method": "keyboard_any", "key": "ESC" },
-      { "input_method": "keyboard_any", "key": "q" },
-      { "input_method": "keyboard_char", "key": "Q" },
-      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "SPACE" }
+      {
+        "input_method": "keyboard_any",
+        "key": "m"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "ESC"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "q"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "Q"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "q",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "SPACE"
+      }
     ]
   },
   {
@@ -1409,30 +3146,70 @@
     "id": "QUIT",
     "name": "Exit screen",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "ESC" },
-      { "input_method": "keyboard_any", "key": "q" },
-      { "input_method": "keyboard_char", "key": "Q" },
-      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "SPACE" }
+      {
+        "input_method": "keyboard_any",
+        "key": "ESC"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "q"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "Q"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "q",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "SPACE"
+      }
     ]
   },
   {
     "type": "keybinding",
     "id": "CHOOSE_DESTINATION",
     "name": "Choose destination",
-    "bindings": [ { "input_method": "keyboard_char", "key": "W" }, { "input_method": "keyboard_code", "key": "w", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "W"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "w",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "GO_TO_DESTINATION",
     "name": "Go to destination",
-    "bindings": [ { "input_method": "keyboard_any", "key": "g" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "g"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CENTER_ON_DESTINATION",
     "name": "Center on destination",
-    "bindings": [ { "input_method": "keyboard_any", "key": "c" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "c"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -1440,10 +3217,22 @@
     "category": "TARGET",
     "name": "Fire weapon",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "f" },
-      { "input_method": "keyboard_any", "key": "RETURN" },
-      { "input_method": "keyboard_any", "key": "KEYPAD_ENTER" },
-      { "input_method": "mouse", "key": "MOUSE_RIGHT" }
+      {
+        "input_method": "keyboard_any",
+        "key": "f"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "RETURN"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "KEYPAD_ENTER"
+      },
+      {
+        "input_method": "mouse",
+        "key": "MOUSE_RIGHT"
+      }
     ]
   },
   {
@@ -1452,11 +3241,29 @@
     "category": "TARGET",
     "name": "Previous target",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "BACKTAB" },
-      { "input_method": "keyboard_code", "key": "TAB", "mod": [ "shift" ] },
-      { "input_method": "mouse", "key": "SCROLL_UP" },
-      { "input_method": "keyboard_any", "key": "PPAGE" },
-      { "input_method": "gamepad", "key": "JOY_LB" }
+      {
+        "input_method": "keyboard_char",
+        "key": "BACKTAB"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "TAB",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "mouse",
+        "key": "SCROLL_UP"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "PPAGE"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_LB"
+      }
     ]
   },
   {
@@ -1465,10 +3272,22 @@
     "category": "TARGET",
     "name": "Next target",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "TAB" },
-      { "input_method": "mouse", "key": "SCROLL_DOWN" },
-      { "input_method": "keyboard_any", "key": "NPAGE" },
-      { "input_method": "gamepad", "key": "JOY_RB" }
+      {
+        "input_method": "keyboard_any",
+        "key": "TAB"
+      },
+      {
+        "input_method": "mouse",
+        "key": "SCROLL_DOWN"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "NPAGE"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RB"
+      }
     ]
   },
   {
@@ -1477,11 +3296,26 @@
     "category": "TARGET",
     "name": "Aim",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "." },
-      { "input_method": "keyboard_code", "key": "KEYPAD_PERIOD" },
-      { "input_method": "keyboard_any", "key": "5" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_5" },
-      { "input_method": "gamepad", "key": "JOY_RT" }
+      {
+        "input_method": "keyboard_any",
+        "key": "."
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_PERIOD"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "5"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_5"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RT"
+      }
     ]
   },
   {
@@ -1489,35 +3323,76 @@
     "id": "STOPAIM",
     "category": "TARGET",
     "name": "Stop Aiming",
-    "bindings": [ { "input_method": "keyboard_any", "key": "," } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": ","
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "AIMED_SHOT",
     "category": "TARGET",
     "name": "Aimed shot",
-    "bindings": [ { "input_method": "keyboard_any", "key": "a" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "a"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CAREFUL_SHOT",
     "category": "TARGET",
     "name": "Careful shot",
-    "bindings": [ { "input_method": "keyboard_any", "key": "c" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_NE" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "c"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "PRECISE_SHOT",
     "category": "TARGET",
     "name": "Precise shot",
-    "bindings": [ { "input_method": "keyboard_any", "key": "p" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_E" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "p"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_E"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SWITCH_AMMO",
     "category": "TARGET",
     "name": "Switch ammo",
-    "bindings": [ { "input_method": "keyboard_any", "key": "o" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_SE" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "o"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SE"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -1525,10 +3400,25 @@
     "category": "TARGET",
     "name": "Switch firing modes",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "s" },
-      { "input_method": "keyboard_char", "key": "F" },
-      { "input_method": "keyboard_code", "key": "f", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_S" }
+      {
+        "input_method": "keyboard_any",
+        "key": "s"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "F"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "f",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_S"
+      }
     ]
   },
   {
@@ -1536,14 +3426,28 @@
     "id": "TOGGLE_TURRET_LINES",
     "category": "TARGET",
     "name": "Toggle turret lines",
-    "bindings": [ { "input_method": "keyboard_any", "key": "t" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "t"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_UNLOAD_RAS_WEAPON",
     "category": "TARGET",
     "name": "Whether to unload your bow etc after canceling a shot",
-    "bindings": [ { "input_method": "keyboard_any", "key": "-" }, { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "-"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MINUS"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -1551,10 +3455,25 @@
     "category": "TARGET",
     "name": "Toggle snap-to-target",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "*" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
-      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_S" }
+      {
+        "input_method": "keyboard_char",
+        "key": "*"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MULTIPLY"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "8",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_S"
+      }
     ]
   },
   {
@@ -1562,31 +3481,60 @@
     "id": "TOGGLE_MOVE_CURSOR_VIEW",
     "category": "TARGET",
     "name": "Toggle shift view / move cursor",
-    "bindings": [ { "input_method": "keyboard_any", "key": "v" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_SW" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "v"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SW"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SELECT",
     "name": "Select with mouse",
-    "bindings": [ { "input_method": "mouse", "key": "MOUSE_LEFT" } ]
+    "bindings": [
+      {
+        "input_method": "mouse",
+        "key": "MOUSE_LEFT"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CLICK_AND_DRAG",
     "name": "Click and drag with mouse",
-    "bindings": [ { "input_method": "mouse", "key": "MOUSE_LEFT_PRESSED" } ]
+    "bindings": [
+      {
+        "input_method": "mouse",
+        "key": "MOUSE_LEFT_PRESSED"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SEC_SELECT",
     "name": "Secondary select",
-    "bindings": [ { "input_method": "mouse", "key": "MOUSE_RIGHT" } ]
+    "bindings": [
+      {
+        "input_method": "mouse",
+        "key": "MOUSE_RIGHT"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "MOUSE_MOVE",
     "name": "Mouse move",
-    "bindings": [ { "input_method": "mouse", "key": "MOUSE_MOVE" } ]
+    "bindings": [
+      {
+        "input_method": "mouse",
+        "key": "MOUSE_MOVE"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -1594,93 +3542,225 @@
     "category": "PICK_WORLD_DIALOG",
     "name": "Quit",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "ESC" },
-      { "input_method": "keyboard_any", "key": "q" },
-      { "input_method": "keyboard_char", "key": "Q" },
-      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "SPACE" },
-      { "input_method": "mouse", "key": "MOUSE_RIGHT" }
+      {
+        "input_method": "keyboard_any",
+        "key": "ESC"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "q"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "Q"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "q",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "SPACE"
+      },
+      {
+        "input_method": "mouse",
+        "key": "MOUSE_RIGHT"
+      }
     ]
   },
   {
     "type": "keybinding",
     "id": "NEXT_TAB",
     "name": "Go to next tab",
-    "bindings": [ { "input_method": "keyboard_any", "key": "TAB" }, { "input_method": "gamepad", "key": "JOY_RB" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "TAB"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RB"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "PREV_TAB",
     "name": "Go to previous tab",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "BACKTAB" },
-      { "input_method": "keyboard_code", "key": "TAB", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_LB" }
+      {
+        "input_method": "keyboard_char",
+        "key": "BACKTAB"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "TAB",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_LB"
+      }
     ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_FAST_SCROLL",
     "name": "Toggle fast scroll",
-    "bindings": [ { "input_method": "keyboard_any", "key": "f" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "f"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "EXTENDED_DESCRIPTION",
     "name": "Show extended description",
-    "bindings": [ { "input_method": "keyboard_any", "key": "e" }, { "input_method": "gamepad", "key": "JOY_RS" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "e"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RS"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CHANGE_MONSTER_NAME",
     "name": "Change monster name",
-    "bindings": [ { "input_method": "keyboard_any", "key": "c" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "c"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TRAVEL_TO",
     "name": "Travel to destination",
-    "bindings": [ { "input_method": "keyboard_char", "key": "T" }, { "input_method": "keyboard_code", "key": "t", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "T"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "t",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CENTER",
     "name": "Center on character",
-    "bindings": [ { "input_method": "keyboard_any", "key": "0" }, { "input_method": "keyboard_code", "key": "KEYPAD_0" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "0"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_0"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "HELP",
     "category": "CARAVAN",
     "name": "Display help",
-    "bindings": [ { "input_method": "keyboard_any", "key": "0" }, { "input_method": "keyboard_code", "key": "KEYPAD_0" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "0"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_0"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CHANGE_GENDER",
     "name": "Change gender",
-    "bindings": [ { "input_method": "keyboard_char", "key": "@" }, { "input_method": "keyboard_code", "key": "2", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "@"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "2",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CHANGE_OUTFIT",
     "name": "Change outfit",
-    "bindings": [ { "input_method": "keyboard_char", "key": "$" }, { "input_method": "keyboard_code", "key": "4", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "$"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "4",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SWITCH_GENDER",
     "name": "Customize character",
-    "bindings": [ { "input_method": "keyboard_any", "key": "y" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "y"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "MEDICAL_MENU",
     "name": "Open medical menu",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "@" },
-      { "input_method": "keyboard_code", "key": "2", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_R_NE" }
+      {
+        "input_method": "keyboard_char",
+        "key": "@"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "2",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_NE"
+      }
     ]
   },
   {
@@ -1688,49 +3768,119 @@
     "id": "SAVE_TEMPLATE",
     "category": "DEFENSE_SETUP",
     "name": "Save template",
-    "bindings": [ { "input_method": "keyboard_char", "key": "!" }, { "input_method": "keyboard_code", "key": "1", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "!"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "1",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "START",
     "category": "DEFENSE_SETUP",
     "name": "Start",
-    "bindings": [ { "input_method": "keyboard_char", "key": "S" }, { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "S"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "s",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "DELETE_TEMPLATE",
     "category": "MAIN_MENU",
     "name": "Delete template",
-    "bindings": [ { "input_method": "keyboard_any", "key": "d" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "d"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SAVE_TEMPLATE",
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Save template",
-    "bindings": [ { "input_method": "keyboard_char", "key": "!" }, { "input_method": "keyboard_code", "key": "1", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "!"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "1",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "REROLL_CHARACTER",
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Reroll random character",
-    "bindings": [ { "input_method": "keyboard_char", "key": "%" }, { "input_method": "keyboard_code", "key": "5", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "%"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "5",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "REROLL_CHARACTER_WITH_SCENARIO",
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Reroll random character with scenario",
-    "bindings": [ { "input_method": "keyboard_char", "key": "^" }, { "input_method": "keyboard_code", "key": "6", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "^"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "6",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "RANDOMIZE_CHAR_NAME",
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Pick random character name",
-    "bindings": [ { "input_method": "keyboard_any", "key": "n" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "n"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -1738,9 +3888,21 @@
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Pick random character description",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "*" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
-      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_char",
+        "key": "*"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MULTIPLY"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "8",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -1748,35 +3910,92 @@
     "id": "CHANGE_START_OF_CATACLYSM",
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Change Cataclysm start date",
-    "bindings": [ { "input_method": "keyboard_char", "key": "#" }, { "input_method": "keyboard_code", "key": "3", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "#"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "3",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CHANGE_START_OF_GAME",
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Change game start date",
-    "bindings": [ { "input_method": "keyboard_char", "key": "&" }, { "input_method": "keyboard_code", "key": "7", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "&"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "7",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "RESET_CALENDAR",
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Reset scenario calendar",
-    "bindings": [ { "input_method": "keyboard_char", "key": "~" }, { "input_method": "keyboard_code", "key": "`", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "~"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "`",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CHOOSE_CITY",
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Choose character starting city",
-    "bindings": [ { "input_method": "keyboard_char", "key": "C" }, { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "C"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "c",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CHOOSE_LOCATION",
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Choose character starting location",
-    "bindings": [ { "input_method": "keyboard_any", "key": "/" }, { "input_method": "keyboard_code", "key": "KEYPAD_DIVIDE" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "/"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_DIVIDE"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -1784,14 +4003,24 @@
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Exit new character screen",
     "//": "separate entry, because the global entry also has 'q' and 'Q' listed, which conflicts with the character name entry feature of this dialog",
-    "bindings": [ { "input_method": "keyboard_any", "key": "ESC" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "ESC"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SORT",
     "category": "NEW_CHAR_PROFESSIONS",
     "name": "Toggle sorting order",
-    "bindings": [ { "input_method": "keyboard_any", "key": "s" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "s"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -1799,9 +4028,21 @@
     "category": "NEW_CHAR_PROFESSIONS",
     "name": "Randomize profession",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "*" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
-      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_char",
+        "key": "*"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MULTIPLY"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "8",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -1810,9 +4051,21 @@
     "category": "NEW_CHAR_TRAITS",
     "name": "Randomize trait",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "*" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
-      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_char",
+        "key": "*"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MULTIPLY"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "8",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -1821,9 +4074,21 @@
     "category": "NEW_CHAR_SCENARIOS",
     "name": "Randomize scenario",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "*" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
-      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_char",
+        "key": "*"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MULTIPLY"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "8",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -1831,201 +4096,493 @@
     "id": "SORT",
     "category": "NEW_CHAR_SCENARIOS",
     "name": "Toggle sorting order",
-    "bindings": [ { "input_method": "keyboard_any", "key": "s" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "s"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CHANGE_START_OF_CATACLYSM",
     "category": "NEW_CHAR_SCENARIOS",
     "name": "Change cataclysm start date",
-    "bindings": [ { "input_method": "keyboard_char", "key": "#" }, { "input_method": "keyboard_code", "key": "3", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "#"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "3",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CHANGE_START_OF_GAME",
     "category": "NEW_CHAR_SCENARIOS",
     "name": "Change game start date",
-    "bindings": [ { "input_method": "keyboard_char", "key": "&" }, { "input_method": "keyboard_code", "key": "7", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "&"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "7",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "RESET_CALENDAR",
     "category": "NEW_CHAR_SCENARIOS",
     "name": "Reset scenario calendar",
-    "bindings": [ { "input_method": "keyboard_char", "key": "~" }, { "input_method": "keyboard_code", "key": "`", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "~"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "`",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_SKILL_INFO_UP",
     "category": "NEW_CHAR_SKILLS",
     "name": "Scroll description up",
-    "bindings": [ { "input_method": "keyboard_char", "key": "<" }, { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "<"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ",",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_SKILL_INFO_DOWN",
     "category": "NEW_CHAR_SKILLS",
     "name": "Scroll description down",
-    "bindings": [ { "input_method": "keyboard_char", "key": ">" }, { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": ">"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ".",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_R_DOWN"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_INFOBOX_UP",
     "name": "Scroll description up",
-    "bindings": [ { "input_method": "keyboard_char", "key": "<" }, { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "<"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ",",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_R_UP"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_INFOBOX_DOWN",
     "name": "Scroll description down",
-    "bindings": [ { "input_method": "keyboard_char", "key": ">" }, { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": ">"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ".",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_R_DOWN"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "PREV_CATEGORY",
     "category": "PROFICIENCY_WINDOW",
     "name": "Previous proficiency category",
-    "bindings": [ { "input_method": "keyboard_char", "key": "<" }, { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "<"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ",",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "NEXT_CATEGORY",
     "category": "PROFICIENCY_WINDOW",
     "name": "Next proficiency category",
-    "bindings": [ { "input_method": "keyboard_char", "key": ">" }, { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": ">"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ".",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "REFILL",
     "category": "APP_INTERACT",
     "name": "Refill tank/battery",
-    "bindings": [ { "input_method": "keyboard_any", "key": "f" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "f"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SIPHON",
     "category": "APP_INTERACT",
     "name": "Siphon from tank",
-    "bindings": [ { "input_method": "keyboard_any", "key": "s" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_NE" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "s"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "RENAME",
     "category": "APP_INTERACT",
     "name": "Rename appliance",
-    "bindings": [ { "input_method": "keyboard_any", "key": "e" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_E" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "e"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_E"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "REMOVE",
     "category": "APP_INTERACT",
     "name": "Take down appliance",
-    "bindings": [ { "input_method": "keyboard_any", "key": "r" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_SE" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "r"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "PLUG",
     "category": "APP_INTERACT",
     "name": "Plug in appliance",
-    "bindings": [ { "input_method": "keyboard_any", "key": "g" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_S" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "g"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_S"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "DISCONNECT_GRID",
     "category": "APP_INTERACT",
     "name": "Separate from power grid",
-    "bindings": [ { "input_method": "keyboard_any", "key": "c" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_SW" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "c"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SW"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "INSTALL",
     "category": "VEH_INTERACT",
     "name": "Install part",
-    "bindings": [ { "input_method": "keyboard_any", "key": "i" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "i"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "REPAIR",
     "category": "VEH_INTERACT",
     "name": "Repair part",
-    "bindings": [ { "input_method": "keyboard_any", "key": "r" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_NE" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "r"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "MEND",
     "category": "VEH_INTERACT",
     "name": "Mend part",
-    "bindings": [ { "input_method": "keyboard_any", "key": "m" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_E" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "m"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_E"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "REFILL",
     "category": "VEH_INTERACT",
     "name": "Refill tank/battery",
-    "bindings": [ { "input_method": "keyboard_any", "key": "f" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_SE" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "f"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "UNLOAD",
     "category": "VEH_INTERACT",
     "name": "Unload fuel bunker",
-    "bindings": [ { "input_method": "keyboard_any", "key": "d" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_S" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "d"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_S"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "REMOVE",
     "category": "VEH_INTERACT",
     "name": "Remove part",
-    "bindings": [ { "input_method": "keyboard_any", "key": "o" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_SW" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "o"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SW"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "RENAME",
     "category": "VEH_INTERACT",
     "name": "Rename vehicle",
-    "bindings": [ { "input_method": "keyboard_any", "key": "e" }, { "input_method": "gamepad", "key": "JOY_RADIAL_R_N" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "e"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_N"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SIPHON",
     "category": "VEH_INTERACT",
     "name": "Siphon from tank",
-    "bindings": [ { "input_method": "keyboard_any", "key": "s" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_W" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "s"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_W"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TIRE_CHANGE",
     "category": "VEH_INTERACT",
     "name": "Change tire",
-    "bindings": [ { "input_method": "keyboard_any", "key": "c" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_NW" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "c"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NW"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CHANGE_SHAPE",
     "category": "VEH_INTERACT",
     "name": "Change part shape",
-    "bindings": [ { "input_method": "keyboard_any", "key": "p" }, { "input_method": "gamepad", "key": "JOY_RADIAL_R_NE" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "p"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_NE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "ASSIGN_CREW",
     "category": "VEH_INTERACT",
     "name": "Assign crew",
-    "bindings": [ { "input_method": "keyboard_any", "key": "w" }, { "input_method": "gamepad", "key": "JOY_RADIAL_R_E" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "w"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_E"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "RELABEL",
     "category": "VEH_INTERACT",
     "name": "Relabel a portion of a vehicle",
-    "bindings": [ { "input_method": "keyboard_any", "key": "a" }, { "input_method": "gamepad", "key": "JOY_RADIAL_R_SE" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "a"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_SE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "NEXT_TAB",
     "category": "VEH_INTERACT",
     "name": "Go to next tab",
-    "bindings": [ { "input_method": "keyboard_any", "key": "TAB" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "TAB"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -2033,8 +4590,17 @@
     "category": "VEH_INTERACT",
     "name": "Go to previous tab",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "BACKTAB" },
-      { "input_method": "keyboard_code", "key": "TAB", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_char",
+        "key": "BACKTAB"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "TAB",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -2042,14 +4608,32 @@
     "id": "FUEL_LIST_UP",
     "category": "VEH_INTERACT",
     "name": "Scroll up through fuel list",
-    "bindings": [ { "input_method": "keyboard_any", "key": "[" }, { "input_method": "gamepad", "key": "JOY_ALT_DPAD_UP" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "["
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_DPAD_UP"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "FUEL_LIST_DOWN",
     "category": "VEH_INTERACT",
     "name": "Scroll down through fuel list",
-    "bindings": [ { "input_method": "keyboard_any", "key": "]" }, { "input_method": "gamepad", "key": "JOY_ALT_DPAD_DOWN" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "]"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_DPAD_DOWN"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -2057,9 +4641,21 @@
     "category": "VEH_INTERACT",
     "name": "Scroll up through vehicle part descriptions",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "<" },
-      { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_UP" }
+      {
+        "input_method": "keyboard_char",
+        "key": "<"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ",",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_DPAD_UP"
+      }
     ]
   },
   {
@@ -2068,9 +4664,21 @@
     "category": "VEH_INTERACT",
     "name": "Scroll down through vehicle part descriptions",
     "bindings": [
-      { "input_method": "keyboard_char", "key": ">" },
-      { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_DOWN" }
+      {
+        "input_method": "keyboard_char",
+        "key": ">"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ".",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_R_DOWN"
+      }
     ]
   },
   {
@@ -2079,9 +4687,21 @@
     "category": "VEH_INTERACT",
     "name": "Scroll up through vehicle overview",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "{" },
-      { "input_method": "keyboard_code", "key": "[", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_UP" }
+      {
+        "input_method": "keyboard_char",
+        "key": "{"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "[",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_R_UP"
+      }
     ]
   },
   {
@@ -2090,9 +4710,21 @@
     "category": "VEH_INTERACT",
     "name": "Scroll down through vehicle overview",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "}" },
-      { "input_method": "keyboard_code", "key": "]", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_DOWN" }
+      {
+        "input_method": "keyboard_char",
+        "key": "}"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "]",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_DPAD_DOWN"
+      }
     ]
   },
   {
@@ -2100,7 +4732,16 @@
     "id": "TOGGLE_UNAVAILABLE_CONSTRUCTIONS",
     "category": "CONSTRUCTION",
     "name": "Toggle unavailable constructions",
-    "bindings": [ { "input_method": "keyboard_any", "key": ";" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": ";"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -2108,9 +4749,21 @@
     "category": "CONSTRUCTION",
     "name": "Scroll to previous stage",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "<" },
-      { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_DOWN" }
+      {
+        "input_method": "keyboard_char",
+        "key": "<"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ",",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_DPAD_DOWN"
+      }
     ]
   },
   {
@@ -2119,16 +4772,33 @@
     "category": "CONSTRUCTION",
     "name": "Scroll to next stage",
     "bindings": [
-      { "input_method": "keyboard_char", "key": ">" },
-      { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_UP" }
+      {
+        "input_method": "keyboard_char",
+        "key": ">"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ".",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_DPAD_UP"
+      }
     ]
   },
   {
     "type": "keybinding",
     "id": "EDITMAP_SHOW_ALL",
     "name": "Show all",
-    "bindings": [ { "input_method": "keyboard_any", "key": "v" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "v"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -2136,9 +4806,18 @@
     "category": "EDITMAP_FEATURE",
     "name": "Confirm and quit",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "e" },
-      { "input_method": "keyboard_any", "key": "r" },
-      { "input_method": "keyboard_any", "key": "t" }
+      {
+        "input_method": "keyboard_any",
+        "key": "e"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "r"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "t"
+      }
     ]
   },
   {
@@ -2146,145 +4825,283 @@
     "id": "RESIZE",
     "category": "EDITMAP_SHAPE",
     "name": "Resize",
-    "bindings": [ { "input_method": "keyboard_any", "key": "s" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "s"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "START",
     "category": "EDITMAP_SHAPE",
     "name": "To start",
-    "bindings": [ { "input_method": "keyboard_any", "key": "z" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "z"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SWAP",
     "category": "EDITMAP_SHAPE",
     "name": "Swap origin and target",
-    "bindings": [ { "input_method": "keyboard_any", "key": "y" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "y"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "EDITMAP_MOVE",
     "name": "Move shape",
-    "bindings": [ { "input_method": "keyboard_any", "key": "m" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "m"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "EDITMAP_TOGGLE_POST_PROCESS_GENERATORS",
     "name": "Toggle post-process generators",
-    "bindings": [ { "input_method": "keyboard_any", "key": "p" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "p"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "EDITMAP_TAB",
     "name": "Switch to move point / confirm",
-    "bindings": [ { "input_method": "keyboard_any", "key": "TAB" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "TAB"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "EDIT_TRAPS",
     "category": "EDITMAP",
     "name": "Edit traps",
-    "bindings": [ { "input_method": "keyboard_any", "key": "t" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "t"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "EDIT_FIELDS",
     "category": "EDITMAP",
     "name": "Edit fields",
-    "bindings": [ { "input_method": "keyboard_any", "key": "f" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "f"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "EDIT_RADS",
     "category": "EDITMAP",
     "name": "Edit radiation",
-    "bindings": [ { "input_method": "keyboard_any", "key": "a" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "a"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "EDIT_TERRAIN",
     "category": "EDITMAP",
     "name": "Edit terrain",
-    "bindings": [ { "input_method": "keyboard_any", "key": "e" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "e"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "EDIT_FURNITURE",
     "category": "EDITMAP",
     "name": "Edit furniture",
-    "bindings": [ { "input_method": "keyboard_any", "key": "r" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "r"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "EDIT_OVERMAP",
     "category": "EDITMAP",
     "name": "Edit overmap/mapgen",
-    "bindings": [ { "input_method": "keyboard_any", "key": "o" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "o"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "EDIT_ITEMS",
     "category": "EDITMAP",
     "name": "Edit items",
-    "bindings": [ { "input_method": "keyboard_any", "key": "i" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "i"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "EDIT_MONSTER",
     "category": "EDITMAP",
     "name": "Edit creatures",
-    "bindings": [ { "input_method": "keyboard_any", "key": "m" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "m"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SHOW_ALL",
     "category": "EDITMAP",
     "name": "Show whole map",
-    "bindings": [ { "input_method": "keyboard_any", "key": "v" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "v"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "LEFT_WIDE",
     "name": "Wide move left",
-    "bindings": [ { "input_method": "keyboard_char", "key": "H" }, { "input_method": "keyboard_code", "key": "h", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "H"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "h",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "RIGHT_WIDE",
     "name": "Wide move right",
-    "bindings": [ { "input_method": "keyboard_char", "key": "L" }, { "input_method": "keyboard_code", "key": "l", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "L"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "l",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "UP_WIDE",
     "name": "Wide move up",
-    "bindings": [ { "input_method": "keyboard_char", "key": "K" }, { "input_method": "keyboard_code", "key": "k", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "K"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "k",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "DOWN_WIDE",
     "name": "Wide move down",
-    "bindings": [ { "input_method": "keyboard_char", "key": "J" }, { "input_method": "keyboard_code", "key": "j", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "J"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "j",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CATEGORY_SELECTION",
     "category": "INVENTORY",
     "name": "Toggle category selection mode",
-    "bindings": [ { "input_method": "keyboard_any", "key": "t" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "t"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "VIEW_CATEGORY_MODE",
     "name": "Toggle inventory view to show item categories",
-    "bindings": [ { "input_method": "keyboard_any", "key": ";" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": ";"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_NUMPAD_NAVIGATION",
     "name": "Toggle navigation with numpad numbers",
-    "bindings": [ { "input_method": "keyboard_any", "key": "F5" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "F5"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -2292,9 +5109,18 @@
     "category": "INVENTORY",
     "name": "Set item filter",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "/" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_DIVIDE" },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_SW" }
+      {
+        "input_method": "keyboard_any",
+        "key": "/"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_DIVIDE"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SW"
+      }
     ]
   },
   {
@@ -2302,14 +5128,32 @@
     "id": "EXAMINE",
     "category": "INVENTORY",
     "name": "Examine",
-    "bindings": [ { "input_method": "keyboard_any", "key": "e" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "e"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "WIELD",
     "category": "INVENTORY",
     "name": "Wield",
-    "bindings": [ { "input_method": "keyboard_any", "key": "w" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_E" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "w"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_E"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -2317,9 +5161,21 @@
     "category": "INVENTORY",
     "name": "Wear",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "W" },
-      { "input_method": "keyboard_code", "key": "w", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_W" }
+      {
+        "input_method": "keyboard_char",
+        "key": "W"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "w",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_W"
+      }
     ]
   },
   {
@@ -2327,14 +5183,32 @@
     "id": "EXAMINE_CONTENTS",
     "category": "INVENTORY",
     "name": "Examine contents",
-    "bindings": [ { "input_method": "keyboard_any", "key": "o" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_NE" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "o"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "ORGANIZE_MENU",
     "category": "INVENTORY",
     "name": "Organize contents",
-    "bindings": [ { "input_method": "keyboard_any", "key": "i" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_SE" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "i"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SE"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -2342,10 +5216,25 @@
     "category": "INVENTORY",
     "name": "Toggle item as favorite",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "*" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
-      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_NW" }
+      {
+        "input_method": "keyboard_char",
+        "key": "*"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MULTIPLY"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "8",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NW"
+      }
     ]
   },
   {
@@ -2354,9 +5243,21 @@
     "category": "INVENTORY",
     "name": "Show/hide contents",
     "bindings": [
-      { "input_method": "keyboard_char", "key": ">" },
-      { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_S" }
+      {
+        "input_method": "keyboard_char",
+        "key": ">"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ".",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_S"
+      }
     ]
   },
   {
@@ -2376,7 +5277,19 @@
     "id": "CONTAIN_MODE",
     "category": "INVENTORY",
     "name": "Toggle contain mode for unloaded items",
-    "bindings": [ { "input_method": "keyboard_char", "key": "U" }, { "input_method": "keyboard_code", "key": "u", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "U"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "u",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -2384,9 +5297,21 @@
     "category": "BIONICS",
     "name": "Toggle activate/examine",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "!" },
-      { "input_method": "keyboard_code", "key": "1", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" }
+      {
+        "input_method": "keyboard_char",
+        "key": "!"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "1",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
     ]
   },
   {
@@ -2395,9 +5320,21 @@
     "category": "BIONICS",
     "name": "Toggle safe fuel mod",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "S" },
-      { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_NE" }
+      {
+        "input_method": "keyboard_char",
+        "key": "S"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "s",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NE"
+      }
     ]
   },
   {
@@ -2406,9 +5343,21 @@
     "category": "BIONICS",
     "name": "Toggle sprite",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "H" },
-      { "input_method": "keyboard_code", "key": "h", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_E" }
+      {
+        "input_method": "keyboard_char",
+        "key": "H"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "h",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_E"
+      }
     ]
   },
   {
@@ -2417,9 +5366,21 @@
     "category": "BIONICS",
     "name": "Open refuel menu",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "R" },
-      { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_SE" }
+      {
+        "input_method": "keyboard_char",
+        "key": "R"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "r",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SE"
+      }
     ]
   },
   {
@@ -2428,9 +5389,21 @@
     "category": "BIONICS",
     "name": "Toggle auto start mod",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "A" },
-      { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_S" }
+      {
+        "input_method": "keyboard_char",
+        "key": "A"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "a",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_S"
+      }
     ]
   },
   {
@@ -2438,7 +5411,16 @@
     "id": "SORT",
     "category": "BIONICS",
     "name": "Sort bionics list",
-    "bindings": [ { "input_method": "keyboard_any", "key": "s" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_SW" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "s"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SW"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -2446,9 +5428,21 @@
     "category": "MUTATIONS",
     "name": "Toggle activate/examine",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "!" },
-      { "input_method": "keyboard_code", "key": "1", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" }
+      {
+        "input_method": "keyboard_char",
+        "key": "!"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "1",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
     ]
   },
   {
@@ -2456,14 +5450,46 @@
     "id": "SCROLL_TRAIT_INFO_UP",
     "category": "MUTATIONS",
     "name": "Scroll mutation info up",
-    "bindings": [ { "input_method": "keyboard_char", "key": "<" }, { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "<"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ",",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_R_UP"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_TRAIT_INFO_DOWN",
     "category": "MUTATIONS",
     "name": "Scroll mutation info down",
-    "bindings": [ { "input_method": "keyboard_char", "key": ">" }, { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": ">"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ".",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_R_DOWN"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -2471,9 +5497,21 @@
     "category": "MEDICAL",
     "name": "Use item",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "A" },
-      { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" }
+      {
+        "input_method": "keyboard_char",
+        "key": "A"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "a",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
     ]
   },
   {
@@ -2482,11 +5520,26 @@
     "category": "DEFAULTMODE",
     "id": "pause",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "." },
-      { "input_method": "keyboard_code", "key": "KEYPAD_PERIOD" },
-      { "input_method": "keyboard_any", "key": "5" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_5" },
-      { "input_method": "gamepad", "key": "JOY_RT" }
+      {
+        "input_method": "keyboard_any",
+        "key": "."
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_PERIOD"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "5"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_5"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RT"
+      }
     ]
   },
   {
@@ -2505,70 +5558,119 @@
     "name": "Center view",
     "category": "DEFAULTMODE",
     "id": "center",
-    "bindings": [  ]
+    "bindings": []
   },
   {
     "type": "keybinding",
     "name": "Move view north",
     "category": "DEFAULTMODE",
     "id": "shift_n",
-    "bindings": [ { "input_method": "gamepad", "key": "JOY_R_UP" } ]
+    "bindings": [
+      {
+        "input_method": "gamepad",
+        "key": "JOY_R_UP"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Move view east",
     "category": "DEFAULTMODE",
     "id": "shift_e",
-    "bindings": [ { "input_method": "gamepad", "key": "JOY_R_RIGHT" } ]
+    "bindings": [
+      {
+        "input_method": "gamepad",
+        "key": "JOY_R_RIGHT"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Move view south",
     "category": "DEFAULTMODE",
     "id": "shift_s",
-    "bindings": [ { "input_method": "gamepad", "key": "JOY_R_DOWN" } ]
+    "bindings": [
+      {
+        "input_method": "gamepad",
+        "key": "JOY_R_DOWN"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Move view west",
     "category": "DEFAULTMODE",
     "id": "shift_w",
-    "bindings": [ { "input_method": "gamepad", "key": "JOY_R_LEFT" } ]
+    "bindings": [
+      {
+        "input_method": "gamepad",
+        "key": "JOY_R_LEFT"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Open door",
     "category": "DEFAULTMODE",
     "id": "open",
-    "bindings": [ { "input_method": "keyboard_any", "key": "o" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "o"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Close door",
     "category": "DEFAULTMODE",
     "id": "close",
-    "bindings": [ { "input_method": "keyboard_any", "key": "c" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "c"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Smash nearby terrain",
     "category": "DEFAULTMODE",
     "id": "smash",
-    "bindings": [ { "input_method": "keyboard_any", "key": "s" }, { "input_method": "gamepad", "key": "JOY_ALT_X" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "s"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_X"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Examine nearby terrain or furniture",
     "category": "DEFAULTMODE",
     "id": "examine",
-    "bindings": [ { "input_method": "keyboard_any", "key": "e" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "e"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Examine nearby terrain, furniture, and items",
     "category": "DEFAULTMODE",
     "id": "examine_and_pickup",
-    "bindings": [ { "input_method": "gamepad", "key": "JOY_X" } ]
+    "bindings": [
+      {
+        "input_method": "gamepad",
+        "key": "JOY_X"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -2576,9 +5678,18 @@
     "category": "DEFAULTMODE",
     "id": "advinv",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "/" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_DIVIDE" },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_R_SE" }
+      {
+        "input_method": "keyboard_any",
+        "key": "/"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_DIVIDE"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_SE"
+      }
     ]
   },
   {
@@ -2586,7 +5697,12 @@
     "name": "Pick up items from one nearby tile",
     "category": "DEFAULTMODE",
     "id": "pickup",
-    "bindings": [ { "input_method": "keyboard_any", "key": "g" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "g"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -2600,9 +5716,21 @@
     "category": "DEFAULTMODE",
     "id": "grab",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "G" },
-      { "input_method": "keyboard_code", "key": "g", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_B" }
+      {
+        "input_method": "keyboard_char",
+        "key": "G"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "g",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_B"
+      }
     ]
   },
   {
@@ -2610,7 +5738,16 @@
     "name": "Haul items along the ground",
     "category": "DEFAULTMODE",
     "id": "haul",
-    "bindings": [ { "input_method": "keyboard_any", "key": "\\" }, { "input_method": "gamepad", "key": "JOY_ALT_B" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "\\"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_B"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -2623,7 +5760,19 @@
     "name": "Zone activities",
     "category": "DEFAULTMODE",
     "id": "loot",
-    "bindings": [ { "input_method": "keyboard_char", "key": "O" }, { "input_method": "keyboard_code", "key": "o", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "O"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "o",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -2631,9 +5780,21 @@
     "category": "DEFAULTMODE",
     "id": "butcher",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "B" },
-      { "input_method": "keyboard_code", "key": "b", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_E" }
+      {
+        "input_method": "keyboard_char",
+        "key": "B"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "b",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_E"
+      }
     ]
   },
   {
@@ -2641,14 +5802,35 @@
     "name": "Chat with NPC",
     "category": "DEFAULTMODE",
     "id": "chat",
-    "bindings": [ { "input_method": "keyboard_char", "key": "C" }, { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "C"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "c",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Look around",
     "category": "DEFAULTMODE",
     "id": "look",
-    "bindings": [ { "input_method": "keyboard_any", "key": ";" }, { "input_method": "keyboard_any", "key": "x" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": ";"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "x"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -2662,9 +5844,21 @@
     "category": "DEFAULTMODE",
     "id": "peek",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "X" },
-      { "input_method": "keyboard_code", "key": "x", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_ALT_RS" }
+      {
+        "input_method": "keyboard_char",
+        "key": "X"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "x",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_RS"
+      }
     ]
   },
   {
@@ -2673,9 +5867,21 @@
     "category": "DEFAULTMODE",
     "id": "listitems",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "V" },
-      { "input_method": "keyboard_code", "key": "v", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RS" }
+      {
+        "input_method": "keyboard_char",
+        "key": "V"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "v",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RS"
+      }
     ]
   },
   {
@@ -2683,35 +5889,78 @@
     "name": "Zones manager",
     "category": "DEFAULTMODE",
     "id": "zones",
-    "bindings": [ { "input_method": "keyboard_char", "key": "Y" }, { "input_method": "keyboard_code", "key": "y", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "Y"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "y",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Open inventory",
     "category": "DEFAULTMODE",
     "id": "inventory",
-    "bindings": [ { "input_method": "keyboard_any", "key": "i" }, { "input_method": "gamepad", "key": "JOY_RADIAL_R_S" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "i"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_S"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Compare two items",
     "category": "DEFAULTMODE",
     "id": "compare",
-    "bindings": [ { "input_method": "keyboard_char", "key": "I" }, { "input_method": "keyboard_code", "key": "i", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "I"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "i",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Swap inventory letters",
     "category": "DEFAULTMODE",
     "id": "organize",
-    "bindings": [ { "input_method": "keyboard_any", "key": "=" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "="
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Use item",
     "category": "DEFAULTMODE",
     "id": "apply",
-    "bindings": [ { "input_method": "keyboard_any", "key": "a" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "a"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -2719,9 +5968,21 @@
     "category": "DEFAULTMODE",
     "id": "apply_wielded",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "A" },
-      { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_RIGHT" }
+      {
+        "input_method": "keyboard_char",
+        "key": "A"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "a",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_DPAD_RIGHT"
+      }
     ]
   },
   {
@@ -2730,9 +5991,21 @@
     "category": "DEFAULTMODE",
     "id": "wear",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "W" },
-      { "input_method": "keyboard_code", "key": "w", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_DPAD_LEFT" }
+      {
+        "input_method": "keyboard_char",
+        "key": "W"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "w",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_DPAD_LEFT"
+      }
     ]
   },
   {
@@ -2741,9 +6014,21 @@
     "category": "DEFAULTMODE",
     "id": "take_off",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "T" },
-      { "input_method": "keyboard_code", "key": "t", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_LEFT" }
+      {
+        "input_method": "keyboard_char",
+        "key": "T"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "t",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_DPAD_LEFT"
+      }
     ]
   },
   {
@@ -2752,9 +6037,21 @@
     "category": "DEFAULTMODE",
     "id": "eat",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "E" },
-      { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_DPAD_UP" }
+      {
+        "input_method": "keyboard_char",
+        "key": "E"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "e",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_DPAD_UP"
+      }
     ]
   },
   {
@@ -2769,9 +6066,21 @@
     "category": "DEFAULTMODE",
     "id": "read",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "R" },
-      { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_NE" }
+      {
+        "input_method": "keyboard_char",
+        "key": "R"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "r",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NE"
+      }
     ]
   },
   {
@@ -2779,7 +6088,16 @@
     "name": "Wield",
     "category": "DEFAULTMODE",
     "id": "wield",
-    "bindings": [ { "input_method": "keyboard_any", "key": "w" }, { "input_method": "gamepad", "key": "JOY_DPAD_RIGHT" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "w"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_DPAD_RIGHT"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -2787,9 +6105,21 @@
     "category": "DEFAULTMODE",
     "id": "pick_style",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "_" },
-      { "input_method": "keyboard_code", "key": "-", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_ALT_RB" }
+      {
+        "input_method": "keyboard_char",
+        "key": "_"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "-",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_RB"
+      }
     ]
   },
   {
@@ -2809,21 +6139,47 @@
     "name": "Insert item",
     "category": "DEFAULTMODE",
     "id": "insert",
-    "bindings": [ { "input_method": "keyboard_any", "key": "v" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "v"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Unload item",
     "category": "DEFAULTMODE",
     "id": "unload",
-    "bindings": [ { "input_method": "keyboard_char", "key": "U" }, { "input_method": "keyboard_code", "key": "u", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "U"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "u",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Throw item",
     "category": "DEFAULTMODE",
     "id": "throw",
-    "bindings": [ { "input_method": "keyboard_any", "key": "t" }, { "input_method": "gamepad", "key": "JOY_Y" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "t"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_Y"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -2836,7 +6192,12 @@
     "name": "Blind throw item",
     "category": "LOOK",
     "id": "throw_blind",
-    "bindings": [ { "input_method": "keyboard_any", "key": "t" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "t"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -2849,28 +6210,63 @@
     "name": "Fire wielded item",
     "category": "DEFAULTMODE",
     "id": "fire",
-    "bindings": [ { "input_method": "keyboard_any", "key": "f" }, { "input_method": "gamepad", "key": "JOY_LB" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "f"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_LB"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Toggle attack mode of wielded item",
     "category": "DEFAULTMODE",
     "id": "select_fire_mode",
-    "bindings": [ { "input_method": "keyboard_char", "key": "F" }, { "input_method": "keyboard_code", "key": "f", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "F"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "f",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Select default ammo for wielded weapon which do not use a magazine",
     "category": "DEFAULTMODE",
     "id": "select_default_ammo",
-    "bindings": [ { "input_method": "keyboard_any", "key": "F3" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "F3"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Drop item",
     "category": "DEFAULTMODE",
     "id": "drop",
-    "bindings": [ { "input_method": "keyboard_any", "key": "d" }, { "input_method": "gamepad", "key": "JOY_DPAD_DOWN" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "d"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_DPAD_DOWN"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -2883,21 +6279,43 @@
     "name": "Drop item to adjacent tile",
     "category": "DEFAULTMODE",
     "id": "drop_adj",
-    "bindings": [ { "input_method": "keyboard_char", "key": "D" }, { "input_method": "keyboard_code", "key": "d", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "D"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "d",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "View/activate bionics",
     "category": "DEFAULTMODE",
     "id": "bionics",
-    "bindings": [ { "input_method": "keyboard_any", "key": "p" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "p"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "View/activate mutations",
     "category": "DEFAULTMODE",
     "id": "mutations",
-    "bindings": [ { "input_method": "keyboard_any", "key": "[" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "["
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -2905,9 +6323,21 @@
     "category": "DEFAULTMODE",
     "id": "medical",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "N" },
-      { "input_method": "keyboard_code", "key": "n", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_R_NE" }
+      {
+        "input_method": "keyboard_char",
+        "key": "N"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "n",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_NE"
+      }
     ]
   },
   {
@@ -2916,9 +6346,21 @@
     "category": "DEFAULTMODE",
     "id": "bodystatus",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "{" },
-      { "input_method": "keyboard_code", "key": "[", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_R_SW" }
+      {
+        "input_method": "keyboard_char",
+        "key": "{"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "[",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_SW"
+      }
     ]
   },
   {
@@ -2927,9 +6369,21 @@
     "category": "DEFAULTMODE",
     "id": "sort_armor",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "+" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" },
-      { "input_method": "keyboard_code", "key": "=", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_char",
+        "key": "+"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_PLUS"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "=",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -2938,9 +6392,21 @@
     "category": "DEFAULTMODE",
     "id": "wait",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "|" },
-      { "input_method": "keyboard_code", "key": "\\", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_SE" }
+      {
+        "input_method": "keyboard_char",
+        "key": "|"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "\\",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SE"
+      }
     ]
   },
   {
@@ -2949,9 +6415,21 @@
     "category": "DEFAULTMODE",
     "id": "craft",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "&" },
-      { "input_method": "keyboard_code", "key": "7", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" }
+      {
+        "input_method": "keyboard_char",
+        "key": "&"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "7",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
     ]
   },
   {
@@ -2960,9 +6438,18 @@
     "category": "DEFAULTMODE",
     "id": "recraft",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "-" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_NW" }
+      {
+        "input_method": "keyboard_any",
+        "key": "-"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MINUS"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NW"
+      }
     ]
   },
   {
@@ -2971,10 +6458,25 @@
     "category": "DEFAULTMODE",
     "id": "construct",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "*" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
-      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_S" }
+      {
+        "input_method": "keyboard_char",
+        "key": "*"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MULTIPLY"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "8",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_S"
+      }
     ]
   },
   {
@@ -2983,9 +6485,21 @@
     "category": "DEFAULTMODE",
     "id": "disassemble",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "(" },
-      { "input_method": "keyboard_code", "key": "9", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_W" }
+      {
+        "input_method": "keyboard_char",
+        "key": "("
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "9",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_W"
+      }
     ]
   },
   {
@@ -2994,9 +6508,21 @@
     "category": "DEFAULTMODE",
     "id": "sleep",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "$" },
-      { "input_method": "keyboard_code", "key": "4", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_SW" }
+      {
+        "input_method": "keyboard_char",
+        "key": "$"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "4",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SW"
+      }
     ]
   },
   {
@@ -3010,7 +6536,19 @@
     "name": "Control vehicle",
     "category": "DEFAULTMODE",
     "id": "control_vehicle",
-    "bindings": [ { "input_method": "keyboard_char", "key": "^" }, { "input_method": "keyboard_code", "key": "6", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "^"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "6",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -3024,9 +6562,21 @@
     "category": "DEFAULTMODE",
     "id": "safemode",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "!" },
-      { "input_method": "keyboard_code", "key": "1", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_ALT_LS" }
+      {
+        "input_method": "keyboard_char",
+        "key": "!"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "1",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_LS"
+      }
     ]
   },
   {
@@ -3034,21 +6584,54 @@
     "name": "Ignore nearby enemy",
     "category": "DEFAULTMODE",
     "id": "ignore_enemy",
-    "bindings": [ { "input_method": "keyboard_any", "key": "'" }, { "input_method": "gamepad", "key": "JOY_LS" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "'"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_LS"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Whitelist enemy",
     "category": "DEFAULTMODE",
     "id": "whitelist_enemy",
-    "bindings": [ { "input_method": "keyboard_char", "key": "~" }, { "input_method": "keyboard_code", "key": "`", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "~"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "`",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Save and quit",
     "category": "DEFAULTMODE",
     "id": "save",
-    "bindings": [ { "input_method": "keyboard_char", "key": "S" }, { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "S"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "s",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -3062,9 +6645,21 @@
     "category": "DEFAULTMODE",
     "id": "player_data",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "@" },
-      { "input_method": "keyboard_code", "key": "2", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_R_N" }
+      {
+        "input_method": "keyboard_char",
+        "key": "@"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "2",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_N"
+      }
     ]
   },
   {
@@ -3072,13 +6667,27 @@
     "name": "View map",
     "category": "DEFAULTMODE",
     "id": "map",
-    "bindings": [ { "input_method": "keyboard_any", "key": "m" }, { "input_method": "gamepad", "key": "JOY_BACK" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "m"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_BACK"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "View map",
     "id": "map",
-    "bindings": [ { "input_method": "keyboard_any", "key": ";" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": ";"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -3092,9 +6701,21 @@
     "category": "DEFAULTMODE",
     "id": "missions",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "M" },
-      { "input_method": "keyboard_code", "key": "m", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_R_W" }
+      {
+        "input_method": "keyboard_char",
+        "key": "M"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "m",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_W"
+      }
     ]
   },
   {
@@ -3103,9 +6724,21 @@
     "category": "DEFAULTMODE",
     "id": "factions",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "#" },
-      { "input_method": "keyboard_code", "key": "3", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_R_E" }
+      {
+        "input_method": "keyboard_char",
+        "key": "#"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "3",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_E"
+      }
     ]
   },
   {
@@ -3113,36 +6746,83 @@
     "name": "View character's morale",
     "category": "DEFAULTMODE",
     "id": "morale",
-    "bindings": [ { "input_method": "gamepad", "key": "JOY_RADIAL_R_NW" } ]
+    "bindings": [
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_NW"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "View message log",
     "category": "DEFAULTMODE",
     "id": "messages",
-    "bindings": [ { "input_method": "keyboard_char", "key": "P" }, { "input_method": "keyboard_code", "key": "p", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "P"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "p",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "View help",
     "category": "DEFAULTMODE",
     "id": "help",
-    "bindings": [ { "input_method": "keyboard_any", "key": "0" }, { "input_method": "keyboard_code", "key": "KEYPAD_0" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "0"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_0"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Zoom in",
     "id": "zoom_in",
-    "bindings": [ { "input_method": "keyboard_any", "key": "z" }, { "input_method": "gamepad", "key": "JOY_ALT_START" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "z"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_START"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Zoom out",
     "id": "zoom_out",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "Z" },
-      { "input_method": "keyboard_code", "key": "z", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_ALT_BACK" }
+      {
+        "input_method": "keyboard_char",
+        "key": "Z"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "z",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_BACK"
+      }
     ]
   },
   {
@@ -3162,8 +6842,17 @@
     "id": "DEBUG_DIALOGUE_DL_CONDITIONAL",
     "name": "Toggle debug dialogue dynamic_line conditionals",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "CTRL+C" },
-      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "c" }
+      {
+        "input_method": "keyboard_char",
+        "key": "CTRL+C"
+      },
+      {
+        "input_method": "keyboard_code",
+        "mod": [
+          "ctrl"
+        ],
+        "key": "c"
+      }
     ]
   },
   {
@@ -3171,8 +6860,17 @@
     "id": "DEBUG_DIALOGUE_RESP_CONDITIONAL",
     "name": "Toggle debug dialogue response conditionals",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "CTRL+D" },
-      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "d" }
+      {
+        "input_method": "keyboard_char",
+        "key": "CTRL+D"
+      },
+      {
+        "input_method": "keyboard_code",
+        "mod": [
+          "ctrl"
+        ],
+        "key": "d"
+      }
     ]
   },
   {
@@ -3180,8 +6878,17 @@
     "id": "DEBUG_DIALOGUE_DL_EFFECT",
     "name": "Toggle debug dialogue dynamic_line effects",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "CTRL+T" },
-      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "t" }
+      {
+        "input_method": "keyboard_char",
+        "key": "CTRL+T"
+      },
+      {
+        "input_method": "keyboard_code",
+        "mod": [
+          "ctrl"
+        ],
+        "key": "t"
+      }
     ]
   },
   {
@@ -3189,8 +6896,17 @@
     "id": "DEBUG_DIALOGUE_RESP_EFFECT",
     "name": "Toggle debug dialogue response effects",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "CTRL+Y" },
-      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "y" }
+      {
+        "input_method": "keyboard_char",
+        "key": "CTRL+Y"
+      },
+      {
+        "input_method": "keyboard_code",
+        "mod": [
+          "ctrl"
+        ],
+        "key": "y"
+      }
     ]
   },
   {
@@ -3198,8 +6914,17 @@
     "id": "DEBUG_DIALOGUE_SHOW_ALL_RESPONSE",
     "name": "Toggle debug dialogue show hidden responses",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "CTRL+R" },
-      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "r" }
+      {
+        "input_method": "keyboard_char",
+        "key": "CTRL+R"
+      },
+      {
+        "input_method": "keyboard_code",
+        "mod": [
+          "ctrl"
+        ],
+        "key": "r"
+      }
     ]
   },
   {
@@ -3208,9 +6933,21 @@
     "category": "CALENDAR_UI",
     "name": "Reset time point to initial value",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "r" },
-      { "input_method": "keyboard_char", "key": "R" },
-      { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "r"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "R"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "r",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -3224,21 +6961,36 @@
     "category": "DEBUG_SPELLS",
     "id": "TOGGLE_ALL_SPELL",
     "name": "Toggle all spells",
-    "bindings": [ { "input_method": "keyboard_any", "key": "t" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "t"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "category": "DEBUG_SPELLS",
     "id": "UNLEARN_SPELL",
     "name": "Unlearn a spell",
-    "bindings": [ { "input_method": "keyboard_any", "key": "u" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "u"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "category": "DEBUG_SPELLS",
     "id": "SHOW_ONLY_LEARNED",
     "name": "Show only learned",
-    "bindings": [ { "input_method": "keyboard_any", "key": "a" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "a"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -3268,7 +7020,16 @@
     "name": "Reload item",
     "category": "DEFAULTMODE",
     "id": "reload_item",
-    "bindings": [ { "input_method": "keyboard_any", "key": "r" }, { "input_method": "gamepad", "key": "JOY_ALT_LB" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "r"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_LB"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -3318,9 +7079,18 @@
     "category": "DEFAULTMODE",
     "id": "action_menu",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "RETURN" },
-      { "input_method": "keyboard_any", "key": "KEYPAD_ENTER" },
-      { "input_method": "gamepad", "key": "JOY_A" }
+      {
+        "input_method": "keyboard_any",
+        "key": "RETURN"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "KEYPAD_ENTER"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_A"
+      }
     ]
   },
   {
@@ -3329,9 +7099,21 @@
     "category": "DEFAULTMODE",
     "id": "item_action_menu",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "%" },
-      { "input_method": "keyboard_code", "key": "5", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_ALT_A" }
+      {
+        "input_method": "keyboard_char",
+        "key": "%"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "5",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_A"
+      }
     ]
   },
   {
@@ -3351,28 +7133,48 @@
     "name": "Move view northeast",
     "category": "DEFAULTMODE",
     "id": "shift_ne",
-    "bindings": [ { "input_method": "gamepad", "key": "JOY_R_RIGHTUP" } ]
+    "bindings": [
+      {
+        "input_method": "gamepad",
+        "key": "JOY_R_RIGHTUP"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Move view southeast",
     "category": "DEFAULTMODE",
     "id": "shift_se",
-    "bindings": [ { "input_method": "gamepad", "key": "JOY_R_RIGHTDOWN" } ]
+    "bindings": [
+      {
+        "input_method": "gamepad",
+        "key": "JOY_R_RIGHTDOWN"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Move view southwest",
     "category": "DEFAULTMODE",
     "id": "shift_sw",
-    "bindings": [ { "input_method": "gamepad", "key": "JOY_R_LEFTDOWN" } ]
+    "bindings": [
+      {
+        "input_method": "gamepad",
+        "key": "JOY_R_LEFTDOWN"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Move view northwest",
     "category": "DEFAULTMODE",
     "id": "shift_nw",
-    "bindings": [ { "input_method": "gamepad", "key": "JOY_R_LEFTUP" } ]
+    "bindings": [
+      {
+        "input_method": "gamepad",
+        "key": "JOY_R_LEFTUP"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -3397,14 +7199,32 @@
     "name": "Autoattack",
     "category": "DEFAULTMODE",
     "id": "autoattack",
-    "bindings": [ { "input_method": "keyboard_any", "key": "TAB" }, { "input_method": "gamepad", "key": "JOY_RB" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "TAB"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RB"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Main menu",
     "category": "DEFAULTMODE",
     "id": "main_menu",
-    "bindings": [ { "input_method": "keyboard_any", "key": "ESC" }, { "input_method": "gamepad", "key": "JOY_START" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "ESC"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_START"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -3453,7 +7273,7 @@
     "name": "Cycle movement mode",
     "category": "DEFAULTMODE",
     "id": "cycle_move",
-    "bindings": [  ]
+    "bindings": []
   },
   {
     "type": "keybinding",
@@ -3491,9 +7311,21 @@
     "category": "DEFAULTMODE",
     "id": "open_movement",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "\"" },
-      { "input_method": "keyboard_code", "key": "'", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_ALT_RT" }
+      {
+        "input_method": "keyboard_char",
+        "key": "\""
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "'",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_RT"
+      }
     ]
   },
   {
@@ -3501,7 +7333,16 @@
     "id": "cast_spell",
     "name": "Supernatural abilities",
     "category": "DEFAULTMODE",
-    "bindings": [ { "input_method": "keyboard_any", "key": "]" }, { "input_method": "gamepad", "key": "JOY_ALT_Y" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "]"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_Y"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -3514,7 +7355,19 @@
     "id": "diary",
     "name": "Open diary / achievements / scores",
     "category": "DEFAULTMODE",
-    "bindings": [ { "input_method": "keyboard_char", "key": ")" }, { "input_method": "keyboard_code", "key": "0", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": ")"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "0",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -3522,9 +7375,21 @@
     "category": "LIST_ITEMS",
     "name": "Scroll item info up",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "<" },
-      { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_UP" }
+      {
+        "input_method": "keyboard_char",
+        "key": "<"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ",",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_R_UP"
+      }
     ]
   },
   {
@@ -3533,9 +7398,21 @@
     "category": "LIST_ITEMS",
     "name": "Scroll item info down",
     "bindings": [
-      { "input_method": "keyboard_char", "key": ">" },
-      { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_DOWN" }
+      {
+        "input_method": "keyboard_char",
+        "key": ">"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ".",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_R_DOWN"
+      }
     ]
   },
   {
@@ -3544,12 +7421,36 @@
     "category": "LIST_ITEMS",
     "name": "Compare",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "I" },
-      { "input_method": "keyboard_code", "key": "i", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "c" },
-      { "input_method": "keyboard_char", "key": "C" },
-      { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_NE" }
+      {
+        "input_method": "keyboard_char",
+        "key": "I"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "i",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "c"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "C"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "c",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NE"
+      }
     ]
   },
   {
@@ -3558,10 +7459,25 @@
     "category": "LIST_ITEMS",
     "name": "Examine",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "e" },
-      { "input_method": "keyboard_char", "key": "E" },
-      { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" }
+      {
+        "input_method": "keyboard_any",
+        "key": "e"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "E"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "e",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
     ]
   },
   {
@@ -3570,10 +7486,22 @@
     "category": "LIST_ITEMS",
     "name": "Increase priority",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "=" },
-      { "input_method": "keyboard_char", "key": "+" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_E" }
+      {
+        "input_method": "keyboard_any",
+        "key": "="
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "+"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_PLUS"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_E"
+      }
     ]
   },
   {
@@ -3582,9 +7510,18 @@
     "category": "LIST_ITEMS",
     "name": "Decrease priority",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "-" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_W" }
+      {
+        "input_method": "keyboard_any",
+        "key": "-"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MINUS"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_W"
+      }
     ]
   },
   {
@@ -3593,10 +7530,25 @@
     "category": "LIST_ITEMS",
     "name": "Change sort order",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "s" },
-      { "input_method": "keyboard_char", "key": "S" },
-      { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_SE" }
+      {
+        "input_method": "keyboard_any",
+        "key": "s"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "S"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "s",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SE"
+      }
     ]
   },
   {
@@ -3604,28 +7556,67 @@
     "id": "SAFEMODE_BLACKLIST_ADD",
     "category": "LIST_MONSTERS",
     "name": "Add to safe mode blacklist",
-    "bindings": [ { "input_method": "keyboard_any", "key": "a" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "a"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SAFEMODE_BLACKLIST_REMOVE",
     "category": "LIST_MONSTERS",
     "name": "Remove from safe mode blacklist",
-    "bindings": [ { "input_method": "keyboard_any", "key": "r" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_S" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "r"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_S"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "look",
     "category": "LIST_MONSTERS",
     "name": "Look around",
-    "bindings": [ { "input_method": "keyboard_any", "key": "x" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_E" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "x"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_E"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "fire",
     "category": "LIST_MONSTERS",
-    "name": { "ctxt": "verb", "str": "Fire" },
-    "bindings": [ { "input_method": "keyboard_any", "key": "f" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_W" } ]
+    "name": {
+      "ctxt": "verb",
+      "str": "Fire"
+    },
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "f"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_W"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -3633,9 +7624,21 @@
     "category": "LOOK",
     "name": "List items and monsters",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "V" },
-      { "input_method": "keyboard_code", "key": "v", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RS" }
+      {
+        "input_method": "keyboard_char",
+        "key": "V"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "v",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RS"
+      }
     ]
   },
   {
@@ -3643,7 +7646,12 @@
     "id": "REASSIGN",
     "category": "BIONICS",
     "name": "Reassign inventory letter",
-    "bindings": [ { "input_method": "keyboard_any", "key": "=" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "="
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -3651,10 +7659,22 @@
     "category": "BIONICS",
     "name": "Move cursor up",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "8" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_8" },
-      { "input_method": "keyboard_any", "key": "UP" },
-      { "input_method": "gamepad", "key": "JOY_UP" }
+      {
+        "input_method": "keyboard_any",
+        "key": "8"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_8"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "UP"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_UP"
+      }
     ]
   },
   {
@@ -3663,10 +7683,22 @@
     "category": "BIONICS",
     "name": "Move cursor down",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "DOWN" },
-      { "input_method": "keyboard_any", "key": "2" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_2" },
-      { "input_method": "gamepad", "key": "JOY_DOWN" }
+      {
+        "input_method": "keyboard_any",
+        "key": "DOWN"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "2"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_2"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_DOWN"
+      }
     ]
   },
   {
@@ -3674,14 +7706,24 @@
     "id": "REASSIGN",
     "category": "MUTATIONS",
     "name": "Reassign inventory letter",
-    "bindings": [ { "input_method": "keyboard_any", "key": "=" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "="
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_SPRITE",
     "category": "MUTATIONS",
     "name": "Toggle sprite",
-    "bindings": [ { "input_method": "keyboard_any", "key": "," } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": ","
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -3689,10 +7731,22 @@
     "category": "MUTATIONS",
     "name": "Pan up",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "8" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_8" },
-      { "input_method": "keyboard_any", "key": "UP" },
-      { "input_method": "gamepad", "key": "JOY_UP" }
+      {
+        "input_method": "keyboard_any",
+        "key": "8"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_8"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "UP"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_UP"
+      }
     ]
   },
   {
@@ -3701,10 +7755,22 @@
     "category": "MUTATIONS",
     "name": "Pan down",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "DOWN" },
-      { "input_method": "keyboard_any", "key": "2" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_2" },
-      { "input_method": "gamepad", "key": "JOY_DOWN" }
+      {
+        "input_method": "keyboard_any",
+        "key": "DOWN"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "2"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_2"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_DOWN"
+      }
     ]
   },
   {
@@ -3713,28 +7779,52 @@
     "category": "HELP_KEYBINDINGS",
     "name": "Exit this keybinding screen",
     "//": "separate entry, because the global entry also has 'q', 'Q' and space listed, which conflicts with the search text input",
-    "bindings": [ { "input_method": "keyboard_any", "key": "ESC" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "ESC"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "UP",
     "category": "HELP_KEYBINDINGS",
     "name": "Pan up",
-    "bindings": [ { "input_method": "keyboard_any", "key": "UP" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "UP"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "DOWN",
     "category": "HELP_KEYBINDINGS",
     "name": "Pan down",
-    "bindings": [ { "input_method": "keyboard_any", "key": "DOWN" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "DOWN"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "REMOVE",
     "category": "HELP_KEYBINDINGS",
     "name": "Remove keybinding",
-    "bindings": [ { "input_method": "keyboard_any", "key": "-" }, { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "-"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MINUS"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -3742,9 +7832,21 @@
     "category": "HELP_KEYBINDINGS",
     "name": "Reset keybinding",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "*" },
-      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] },
-      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" }
+      {
+        "input_method": "keyboard_char",
+        "key": "*"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "8",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MULTIPLY"
+      }
     ]
   },
   {
@@ -3753,9 +7855,21 @@
     "category": "HELP_KEYBINDINGS",
     "name": "Add local keybinding",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "+" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" },
-      { "input_method": "keyboard_code", "key": "=", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_char",
+        "key": "+"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_PLUS"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "=",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -3763,14 +7877,28 @@
     "id": "ADD_GLOBAL",
     "category": "HELP_KEYBINDINGS",
     "name": "Add global keybinding",
-    "bindings": [ { "input_method": "keyboard_any", "key": "=" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "="
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "EXECUTE",
     "category": "HELP_KEYBINDINGS",
     "name": "Execute action keybinding",
-    "bindings": [ { "input_method": "keyboard_any", "key": "." }, { "input_method": "keyboard_code", "key": "KEYPAD_PERIOD" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "."
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_PERIOD"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -3778,10 +7906,25 @@
     "category": "ZONES_MANAGER",
     "name": "Add zone",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "a" },
-      { "input_method": "keyboard_char", "key": "A" },
-      { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" }
+      {
+        "input_method": "keyboard_any",
+        "key": "a"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "A"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "a",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
     ]
   },
   {
@@ -3790,10 +7933,25 @@
     "category": "ZONES_MANAGER",
     "name": "Add personal zone",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "p" },
-      { "input_method": "keyboard_char", "key": "P" },
-      { "input_method": "keyboard_code", "key": "p", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_NE" }
+      {
+        "input_method": "keyboard_any",
+        "key": "p"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "P"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "p",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NE"
+      }
     ]
   },
   {
@@ -3802,10 +7960,25 @@
     "category": "ZONES_MANAGER",
     "name": "Remove zone",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "r" },
-      { "input_method": "keyboard_char", "key": "R" },
-      { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_E" }
+      {
+        "input_method": "keyboard_any",
+        "key": "r"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "R"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "r",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_E"
+      }
     ]
   },
   {
@@ -3814,10 +7987,22 @@
     "category": "ZONES_MANAGER",
     "name": "Move zone up",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "=" },
-      { "input_method": "keyboard_char", "key": "+" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" },
-      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_UP" }
+      {
+        "input_method": "keyboard_any",
+        "key": "="
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "+"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_PLUS"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_DPAD_UP"
+      }
     ]
   },
   {
@@ -3826,9 +8011,18 @@
     "category": "ZONES_MANAGER",
     "name": "Move zone down",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "-" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" },
-      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_DOWN" }
+      {
+        "input_method": "keyboard_any",
+        "key": "-"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MINUS"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_DPAD_DOWN"
+      }
     ]
   },
   {
@@ -3837,10 +8031,25 @@
     "category": "ZONES_MANAGER",
     "name": "Show zone on map",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "m" },
-      { "input_method": "keyboard_char", "key": "M" },
-      { "input_method": "keyboard_code", "key": "m", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_SE" }
+      {
+        "input_method": "keyboard_any",
+        "key": "m"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "M"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "m",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SE"
+      }
     ]
   },
   {
@@ -3849,10 +8058,25 @@
     "category": "ZONES_MANAGER",
     "name": "Toggle display of zone markers",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "t" },
-      { "input_method": "keyboard_char", "key": "T" },
-      { "input_method": "keyboard_code", "key": "t", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_S" }
+      {
+        "input_method": "keyboard_any",
+        "key": "t"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "T"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "t",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_S"
+      }
     ]
   },
   {
@@ -3861,10 +8085,25 @@
     "category": "ZONES_MANAGER",
     "name": "Enable zone",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "e" },
-      { "input_method": "keyboard_char", "key": "E" },
-      { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_SW" }
+      {
+        "input_method": "keyboard_any",
+        "key": "e"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "E"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "e",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SW"
+      }
     ]
   },
   {
@@ -3873,10 +8112,25 @@
     "category": "ZONES_MANAGER",
     "name": "Disable zone",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "d" },
-      { "input_method": "keyboard_char", "key": "D" },
-      { "input_method": "keyboard_code", "key": "d", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_W" }
+      {
+        "input_method": "keyboard_any",
+        "key": "d"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "D"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "d",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_W"
+      }
     ]
   },
   {
@@ -3885,10 +8139,25 @@
     "category": "ZONES_MANAGER",
     "name": "Enable personal zones",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "z" },
-      { "input_method": "keyboard_char", "key": "Z" },
-      { "input_method": "keyboard_code", "key": "z", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_NW" }
+      {
+        "input_method": "keyboard_any",
+        "key": "z"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "Z"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "z",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NW"
+      }
     ]
   },
   {
@@ -3897,10 +8166,25 @@
     "category": "ZONES_MANAGER",
     "name": "Disable personal zones",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "x" },
-      { "input_method": "keyboard_char", "key": "X" },
-      { "input_method": "keyboard_code", "key": "x", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_R_N" }
+      {
+        "input_method": "keyboard_any",
+        "key": "x"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "X"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "x",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_N"
+      }
     ]
   },
   {
@@ -3909,10 +8193,25 @@
     "category": "ZONES_MANAGER",
     "name": "Enable vehicle zones",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "c" },
-      { "input_method": "keyboard_char", "key": "C" },
-      { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_R_NE" }
+      {
+        "input_method": "keyboard_any",
+        "key": "c"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "C"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "c",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_NE"
+      }
     ]
   },
   {
@@ -3921,10 +8220,25 @@
     "category": "ZONES_MANAGER",
     "name": "Disable vehicle zones",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "v" },
-      { "input_method": "keyboard_char", "key": "V" },
-      { "input_method": "keyboard_code", "key": "v", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_R_E" }
+      {
+        "input_method": "keyboard_any",
+        "key": "v"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "V"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "v",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_E"
+      }
     ]
   },
   {
@@ -3933,10 +8247,25 @@
     "category": "ZONES_MANAGER",
     "name": "Show all zones / hide distant zones",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "s" },
-      { "input_method": "keyboard_char", "key": "S" },
-      { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_R_SE" }
+      {
+        "input_method": "keyboard_any",
+        "key": "s"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "S"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "s",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_SE"
+      }
     ]
   },
   {
@@ -3945,9 +8274,21 @@
     "category": "ZONES_MANAGER",
     "name": "Change shown faction",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "F" },
-      { "input_method": "keyboard_code", "key": "f", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_R_S" }
+      {
+        "input_method": "keyboard_char",
+        "key": "F"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "f",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_S"
+      }
     ]
   },
   {
@@ -3956,10 +8297,25 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Page down",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "NPAGE" },
-      { "input_method": "keyboard_char", "key": ">" },
-      { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_DOWN" }
+      {
+        "input_method": "keyboard_any",
+        "key": "NPAGE"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": ">"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ".",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_DPAD_DOWN"
+      }
     ]
   },
   {
@@ -3968,10 +8324,25 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Page up",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "PPAGE" },
-      { "input_method": "keyboard_char", "key": "<" },
-      { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_UP" }
+      {
+        "input_method": "keyboard_any",
+        "key": "PPAGE"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "<"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ",",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_DPAD_UP"
+      }
     ]
   },
   {
@@ -3980,9 +8351,18 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Pan up",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "k" },
-      { "input_method": "keyboard_any", "key": "UP" },
-      { "input_method": "gamepad", "key": "JOY_UP" }
+      {
+        "input_method": "keyboard_any",
+        "key": "k"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "UP"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_UP"
+      }
     ]
   },
   {
@@ -3991,9 +8371,18 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Pan down",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "j" },
-      { "input_method": "keyboard_any", "key": "DOWN" },
-      { "input_method": "gamepad", "key": "JOY_DOWN" }
+      {
+        "input_method": "keyboard_any",
+        "key": "j"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "DOWN"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_DOWN"
+      }
     ]
   },
   {
@@ -4002,9 +8391,18 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Select left inventory",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "h" },
-      { "input_method": "keyboard_any", "key": "LEFT" },
-      { "input_method": "gamepad", "key": "JOY_LEFT" }
+      {
+        "input_method": "keyboard_any",
+        "key": "h"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "LEFT"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_LEFT"
+      }
     ]
   },
   {
@@ -4012,14 +8410,28 @@
     "id": "RIGHT",
     "category": "ADVANCED_INVENTORY",
     "name": "Select right inventory",
-    "bindings": [ { "input_method": "keyboard_any", "key": "l" }, { "input_method": "keyboard_any", "key": "RIGHT" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "l"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "RIGHT"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_TAB",
     "category": "ADVANCED_INVENTORY",
     "name": "Toggle tab",
-    "bindings": [ { "input_method": "keyboard_any", "key": "TAB" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "TAB"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -4027,10 +8439,25 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Toggle vehicle",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "v" },
-      { "input_method": "keyboard_char", "key": "V" },
-      { "input_method": "keyboard_code", "key": "v", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_NW" }
+      {
+        "input_method": "keyboard_any",
+        "key": "v"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "V"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "v",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NW"
+      }
     ]
   },
   {
@@ -4038,7 +8465,16 @@
     "id": "TOGGLE_AUTO_PICKUP",
     "category": "ADVANCED_INVENTORY",
     "name": "Toggle auto pickup for item",
-    "bindings": [ { "input_method": "keyboard_any", "key": "p" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_W" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "p"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_W"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -4046,10 +8482,25 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Examine",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "e" },
-      { "input_method": "keyboard_char", "key": "E" },
-      { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RS" }
+      {
+        "input_method": "keyboard_any",
+        "key": "e"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "E"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "e",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RS"
+      }
     ]
   },
   {
@@ -4058,10 +8509,25 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Change sorting mode",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "s" },
-      { "input_method": "keyboard_char", "key": "S" },
-      { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" }
+      {
+        "input_method": "keyboard_any",
+        "key": "s"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "S"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "s",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
     ]
   },
   {
@@ -4069,14 +8535,32 @@
     "id": "MOVE_SINGLE_ITEM",
     "category": "ADVANCED_INVENTORY",
     "name": "Move a single item",
-    "bindings": [ { "input_method": "keyboard_any", "key": "RETURN" }, { "input_method": "keyboard_any", "key": "KEYPAD_ENTER" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "RETURN"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "KEYPAD_ENTER"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "MOVE_VARIABLE_ITEM",
     "category": "ADVANCED_INVENTORY",
     "name": "Move some items",
-    "bindings": [ { "input_method": "keyboard_any", "key": "m" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_NE" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "m"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NE"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -4084,9 +8568,21 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Move item stack",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "M" },
-      { "input_method": "keyboard_code", "key": "m", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_E" }
+      {
+        "input_method": "keyboard_char",
+        "key": "M"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "m",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_E"
+      }
     ]
   },
   {
@@ -4094,14 +8590,32 @@
     "id": "MOVE_ALL_ITEMS",
     "category": "ADVANCED_INVENTORY",
     "name": "Move all items",
-    "bindings": [ { "input_method": "keyboard_any", "key": "," }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_SE" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": ","
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CATEGORY_SELECTION",
     "category": "ADVANCED_INVENTORY",
     "name": "Toggle category selection mode",
-    "bindings": [ { "input_method": "keyboard_any", "key": "t" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_S" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "t"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_S"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -4109,10 +8623,25 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Toggle item as favorite",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "*" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
-      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_SW" }
+      {
+        "input_method": "keyboard_char",
+        "key": "*"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MULTIPLY"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "8",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SW"
+      }
     ]
   },
   {
@@ -4121,10 +8650,22 @@
     "category": "INVENTORY",
     "name": "Select/unselect highlighted item",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "l" },
-      { "input_method": "keyboard_any", "key": "RIGHT" },
-      { "input_method": "keyboard_any", "key": "6" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_6" }
+      {
+        "input_method": "keyboard_any",
+        "key": "l"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "RIGHT"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "6"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_6"
+      }
     ]
   },
   {
@@ -4133,10 +8674,22 @@
     "category": "INVENTORY",
     "name": "Increase selected amount for the highlighted item",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "=" },
-      { "input_method": "keyboard_char", "key": "+" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" }
+      {
+        "input_method": "keyboard_any",
+        "key": "="
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "+"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_PLUS"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
     ]
   },
   {
@@ -4144,14 +8697,32 @@
     "id": "AUTO_BALANCE",
     "category": "INVENTORY",
     "name": "Auto balance trade using highlighted item",
-    "bindings": [ { "input_method": "keyboard_any", "key": "F1" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_NE" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "F1"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "BANK_BALANCE",
     "category": "INVENTORY",
     "name": "Auto balance trade using bank account",
-    "bindings": [ { "input_method": "keyboard_any", "key": "F2" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_E" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "F2"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_E"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -4159,9 +8730,18 @@
     "category": "INVENTORY",
     "name": "Decrease selected amount for the highlighted item",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "-" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_S" }
+      {
+        "input_method": "keyboard_any",
+        "key": "-"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MINUS"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_S"
+      }
     ]
   },
   {
@@ -4170,11 +8750,26 @@
     "category": "INVENTORY",
     "name": "Next column",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "h" },
-      { "input_method": "keyboard_any", "key": "LEFT" },
-      { "input_method": "keyboard_any", "key": "4" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_4" },
-      { "input_method": "gamepad", "key": "JOY_LEFT" }
+      {
+        "input_method": "keyboard_any",
+        "key": "h"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "LEFT"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "4"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_4"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_LEFT"
+      }
     ]
   },
   {
@@ -4183,8 +8778,17 @@
     "category": "INVENTORY",
     "name": "Previous column",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "BACKTAB" },
-      { "input_method": "keyboard_code", "key": "TAB", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_char",
+        "key": "BACKTAB"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "TAB",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -4192,77 +8796,175 @@
     "id": "TOGGLE_NON_FAVORITE",
     "category": "INVENTORY",
     "name": "Select/unselect non-favorite items in multidrop menu",
-    "bindings": [ { "input_method": "keyboard_any", "key": "," } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": ","
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "MARK_WITH_COUNT",
     "category": "INVENTORY",
     "name": "Select a specific amount of highlighted item",
-    "bindings": [ { "input_method": "keyboard_char", "key": "!" }, { "input_method": "keyboard_code", "key": "1", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "!"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "1",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "ITEMS_NW",
     "category": "ADVANCED_INVENTORY",
     "name": "Select items at northwest",
-    "bindings": [ { "input_method": "keyboard_any", "key": "7" }, { "input_method": "keyboard_code", "key": "KEYPAD_7" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "7"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_7"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "ITEMS_N",
     "category": "ADVANCED_INVENTORY",
     "name": "Select items at north",
-    "bindings": [ { "input_method": "keyboard_any", "key": "8" }, { "input_method": "keyboard_code", "key": "KEYPAD_8" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "8"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_8"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "ITEMS_NE",
     "category": "ADVANCED_INVENTORY",
     "name": "Select items at northeast",
-    "bindings": [ { "input_method": "keyboard_any", "key": "9" }, { "input_method": "keyboard_code", "key": "KEYPAD_9" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "9"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_9"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "ITEMS_W",
     "category": "ADVANCED_INVENTORY",
     "name": "Select items at west",
-    "bindings": [ { "input_method": "keyboard_any", "key": "4" }, { "input_method": "keyboard_code", "key": "KEYPAD_4" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "4"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_4"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "ITEMS_CE",
     "category": "ADVANCED_INVENTORY",
     "name": "Select items at center",
-    "bindings": [ { "input_method": "keyboard_any", "key": "5" }, { "input_method": "keyboard_code", "key": "KEYPAD_5" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "5"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_5"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "ITEMS_E",
     "category": "ADVANCED_INVENTORY",
     "name": "Select items at east",
-    "bindings": [ { "input_method": "keyboard_any", "key": "6" }, { "input_method": "keyboard_code", "key": "KEYPAD_6" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "6"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_6"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "ITEMS_SW",
     "category": "ADVANCED_INVENTORY",
     "name": "Select items at southwest",
-    "bindings": [ { "input_method": "keyboard_any", "key": "1" }, { "input_method": "keyboard_code", "key": "KEYPAD_1" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "1"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_1"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "ITEMS_S",
     "category": "ADVANCED_INVENTORY",
     "name": "Select items at south",
-    "bindings": [ { "input_method": "keyboard_any", "key": "2" }, { "input_method": "keyboard_code", "key": "KEYPAD_2" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "2"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_2"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "ITEMS_SE",
     "category": "ADVANCED_INVENTORY",
     "name": "Select items at southeast",
-    "bindings": [ { "input_method": "keyboard_any", "key": "3" }, { "input_method": "keyboard_code", "key": "KEYPAD_3" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "3"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_3"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -4270,11 +8972,29 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Select items in inventory",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "i" },
-      { "input_method": "keyboard_char", "key": "I" },
-      { "input_method": "keyboard_code", "key": "i", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "0" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_0" }
+      {
+        "input_method": "keyboard_any",
+        "key": "i"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "I"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "i",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "0"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_0"
+      }
     ]
   },
   {
@@ -4283,9 +9003,21 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Select items at all 9 tiles",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "a" },
-      { "input_method": "keyboard_char", "key": "A" },
-      { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "a"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "A"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "a",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -4294,9 +9026,21 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Select items in dragged vehicle",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "d" },
-      { "input_method": "keyboard_char", "key": "D" },
-      { "input_method": "keyboard_code", "key": "d", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "d"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "D"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "d",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -4304,14 +9048,28 @@
     "id": "EXAMINE_CONTENTS",
     "category": "ADVANCED_INVENTORY",
     "name": "Examine items in container",
-    "bindings": [ { "input_method": "keyboard_any", "key": "o" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "o"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "UNLOAD_CONTAINER",
     "category": "ADVANCED_INVENTORY",
     "name": "Unload item from container",
-    "bindings": [ { "input_method": "keyboard_any", "key": "u" }, { "input_method": "keyboard_any", "key": "U" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "u"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "U"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -4319,9 +9077,21 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Select items in container",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "c" },
-      { "input_method": "keyboard_char", "key": "C" },
-      { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "c"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "C"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "c",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -4330,9 +9100,21 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Exit container to parent",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "x" },
-      { "input_method": "keyboard_char", "key": "X" },
-      { "input_method": "keyboard_code", "key": "x", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "x"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "X"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "x",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -4341,9 +9123,21 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Select items currently worn",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "w" },
-      { "input_method": "keyboard_char", "key": "W" },
-      { "input_method": "keyboard_code", "key": "w", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "w"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "W"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "w",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -4363,25 +9157,45 @@
     "id": "repair_fabric",
     "category": "ITEM_ACTIONS",
     "name": "Sew",
-    "bindings": [ { "input_method": "keyboard_any", "key": "s" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "s"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "repair_metal",
     "category": "ITEM_ACTIONS",
-    "bindings": [ { "input_method": "keyboard_any", "key": "w" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "w"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "firestarter",
     "category": "ITEM_ACTIONS",
-    "bindings": [ { "input_method": "keyboard_any", "key": "f" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "f"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "holster",
     "category": "ITEM_ACTIONS",
-    "bindings": [ { "input_method": "keyboard_any", "key": "h" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "h"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -4389,9 +9203,21 @@
     "category": "COLORS",
     "name": "Remove custom color",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "r" },
-      { "input_method": "keyboard_char", "key": "R" },
-      { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "r"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "R"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "r",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -4400,9 +9226,21 @@
     "category": "COLORS",
     "name": "Load color template",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "t" },
-      { "input_method": "keyboard_char", "key": "T" },
-      { "input_method": "keyboard_code", "key": "t", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "t"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "T"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "t",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -4411,9 +9249,21 @@
     "category": "COLORS",
     "name": "Load base colors",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "c" },
-      { "input_method": "keyboard_char", "key": "C" },
-      { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "c"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "C"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "c",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -4422,12 +9272,33 @@
     "category": "COLORS",
     "name": "Quit",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "ESC" },
-      { "input_method": "keyboard_any", "key": "q" },
-      { "input_method": "keyboard_char", "key": "Q" },
-      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "SPACE" },
-      { "input_method": "mouse", "key": "MOUSE_RIGHT" }
+      {
+        "input_method": "keyboard_any",
+        "key": "ESC"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "q"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "Q"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "q",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "SPACE"
+      },
+      {
+        "input_method": "mouse",
+        "key": "MOUSE_RIGHT"
+      }
     ]
   },
   {
@@ -4436,10 +9307,25 @@
     "category": "YESNO",
     "name": "Yes",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "Y" },
-      { "input_method": "keyboard_code", "key": "y", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "y" },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" }
+      {
+        "input_method": "keyboard_char",
+        "key": "Y"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "y",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "y"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
     ]
   },
   {
@@ -4448,11 +9334,29 @@
     "category": "YESNO",
     "name": "No",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "N" },
-      { "input_method": "keyboard_code", "key": "n", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "n" },
-      { "input_method": "keyboard_any", "key": "ESC" },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_S" }
+      {
+        "input_method": "keyboard_char",
+        "key": "N"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "n",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "n"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "ESC"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_S"
+      }
     ]
   },
   {
@@ -4461,10 +9365,25 @@
     "category": "FRIENDS_ME_CANCEL",
     "name": "With friends",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "F" },
-      { "input_method": "keyboard_code", "key": "f", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "f" },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_E" }
+      {
+        "input_method": "keyboard_char",
+        "key": "F"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "f",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "f"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_E"
+      }
     ]
   },
   {
@@ -4473,10 +9392,25 @@
     "category": "FRIENDS_ME_CANCEL",
     "name": "Just me",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "M" },
-      { "input_method": "keyboard_code", "key": "m", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "m" },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_W" }
+      {
+        "input_method": "keyboard_char",
+        "key": "M"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "m",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "m"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_W"
+      }
     ]
   },
   {
@@ -4485,11 +9419,29 @@
     "category": "FRIENDS_ME_CANCEL",
     "name": "Cancel",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "C" },
-      { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "c" },
-      { "input_method": "keyboard_any", "key": "ESC" },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_NW" }
+      {
+        "input_method": "keyboard_char",
+        "key": "C"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "c",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "c"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "ESC"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NW"
+      }
     ]
   },
   {
@@ -4498,9 +9450,25 @@
     "category": "LOAD_DELETE_CANCEL",
     "name": "Load",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "L" },
-      { "input_method": "keyboard_code", "key": "l", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "l" }
+      {
+        "input_method": "keyboard_char",
+        "key": "L"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "l",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "l"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
     ]
   },
   {
@@ -4509,9 +9477,25 @@
     "category": "LOAD_DELETE_CANCEL",
     "name": "Delete",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "D" },
-      { "input_method": "keyboard_code", "key": "d", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "d" }
+      {
+        "input_method": "keyboard_char",
+        "key": "D"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "d",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "d"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_E"
+      }
     ]
   },
   {
@@ -4520,9 +9504,25 @@
     "category": "LOAD_DELETE_CANCEL",
     "name": "Cancel",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "C" },
-      { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "c" }
+      {
+        "input_method": "keyboard_char",
+        "key": "C"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "c",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "c"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_W"
+      }
     ]
   },
   {
@@ -4531,9 +9531,25 @@
     "category": "YESNOQUIT",
     "name": "Yes",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "Y" },
-      { "input_method": "keyboard_code", "key": "y", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "y" }
+      {
+        "input_method": "keyboard_char",
+        "key": "Y"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "y",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "y"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
     ]
   },
   {
@@ -4542,9 +9558,25 @@
     "category": "YESNOQUIT",
     "name": "No",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "N" },
-      { "input_method": "keyboard_code", "key": "n", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "n" }
+      {
+        "input_method": "keyboard_char",
+        "key": "N"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "n",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "n"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_S"
+      }
     ]
   },
   {
@@ -4553,10 +9585,25 @@
     "category": "YESNOQUIT",
     "name": "Cancel",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "Q" },
-      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "q" },
-      { "input_method": "keyboard_any", "key": "ESC" }
+      {
+        "input_method": "keyboard_char",
+        "key": "Q"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "q",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "q"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "ESC"
+      }
     ]
   },
   {
@@ -4565,9 +9612,25 @@
     "category": "CANCEL_ACTIVITY_OR_IGNORE_QUERY",
     "name": "Yes",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "Y" },
-      { "input_method": "keyboard_code", "key": "y", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "y" }
+      {
+        "input_method": "keyboard_char",
+        "key": "Y"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "y",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "y"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
     ]
   },
   {
@@ -4576,10 +9639,29 @@
     "category": "CANCEL_ACTIVITY_OR_IGNORE_QUERY",
     "name": "No",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "N" },
-      { "input_method": "keyboard_code", "key": "n", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "n" },
-      { "input_method": "keyboard_any", "key": "ESC" }
+      {
+        "input_method": "keyboard_char",
+        "key": "N"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "n",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "n"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "ESC"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_S"
+      }
     ]
   },
   {
@@ -4588,9 +9670,25 @@
     "category": "CANCEL_ACTIVITY_OR_IGNORE_QUERY",
     "name": "Ignore this distraction and continue",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "I" },
-      { "input_method": "keyboard_code", "key": "i", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "i" }
+      {
+        "input_method": "keyboard_char",
+        "key": "I"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "i",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "i"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_E"
+      }
     ]
   },
   {
@@ -4599,9 +9697,21 @@
     "category": "CANCEL_ACTIVITY_OR_IGNORE_QUERY",
     "name": "Open manager",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "M" },
-      { "input_method": "keyboard_code", "key": "m", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "m" }
+      {
+        "input_method": "keyboard_char",
+        "key": "M"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "m",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "m"
+      }
     ]
   },
   {
@@ -4610,9 +9720,25 @@
     "category": "YES_QUERY",
     "name": "Yes, I will!",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "Y" },
-      { "input_method": "keyboard_code", "key": "y", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "y" }
+      {
+        "input_method": "keyboard_char",
+        "key": "Y"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "y",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "y"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
     ]
   },
   {
@@ -4621,9 +9747,25 @@
     "category": "YES_QUERY",
     "name": "Yes, I must!",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "Y" },
-      { "input_method": "keyboard_code", "key": "y", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "y" }
+      {
+        "input_method": "keyboard_char",
+        "key": "Y"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "y",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "y"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NE"
+      }
     ]
   },
   {
@@ -4632,9 +9774,25 @@
     "category": "YES_QUERY",
     "name": "Yes, I shall!",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "Y" },
-      { "input_method": "keyboard_code", "key": "y", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "y" }
+      {
+        "input_method": "keyboard_char",
+        "key": "Y"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "y",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "y"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_E"
+      }
     ]
   },
   {
@@ -4643,9 +9801,31 @@
     "category": "YES_NO_ALWAYS_NEVER",
     "name": "Yes",
     "bindings": [
-      { "input_method": "keyboard_char", "key": [ "Y" ] },
-      { "input_method": "keyboard_code", "key": [ "y" ], "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": [ "y" ] }
+      {
+        "input_method": "keyboard_char",
+        "key": [
+          "Y"
+        ]
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": [
+          "y"
+        ],
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": [
+          "y"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
     ]
   },
   {
@@ -4654,10 +9834,37 @@
     "category": "YES_NO_ALWAYS_NEVER",
     "name": "No",
     "bindings": [
-      { "input_method": "keyboard_char", "key": [ "N" ] },
-      { "input_method": "keyboard_code", "key": [ "n" ], "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": [ "n" ] },
-      { "input_method": "keyboard_any", "key": [ "ESC" ] }
+      {
+        "input_method": "keyboard_char",
+        "key": [
+          "N"
+        ]
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": [
+          "n"
+        ],
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": [
+          "n"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": [
+          "ESC"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_S"
+      }
     ]
   },
   {
@@ -4666,9 +9873,31 @@
     "category": "YES_NO_ALWAYS_NEVER",
     "name": "Always",
     "bindings": [
-      { "input_method": "keyboard_char", "key": [ "A" ] },
-      { "input_method": "keyboard_code", "key": [ "a" ], "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": [ "a" ] }
+      {
+        "input_method": "keyboard_char",
+        "key": [
+          "A"
+        ]
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": [
+          "a"
+        ],
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": [
+          "a"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_E"
+      }
     ]
   },
   {
@@ -4677,9 +9906,31 @@
     "category": "YES_NO_ALWAYS_NEVER",
     "name": "Never",
     "bindings": [
-      { "input_method": "keyboard_char", "key": [ "E" ] },
-      { "input_method": "keyboard_code", "key": [ "e" ], "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": [ "e" ] }
+      {
+        "input_method": "keyboard_char",
+        "key": [
+          "E"
+        ]
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": [
+          "e"
+        ],
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": [
+          "e"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_W"
+      }
     ]
   },
   {
@@ -4688,11 +9939,26 @@
     "category": "POPUP_WAIT",
     "name": "Cancel popup",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "ESC" },
-      { "input_method": "keyboard_any", "key": "SPACE" },
-      { "input_method": "keyboard_any", "key": "RETURN" },
-      { "input_method": "keyboard_any", "key": "KEYPAD_ENTER" },
-      { "input_method": "mouse", "key": "MOUSE_RIGHT" }
+      {
+        "input_method": "keyboard_any",
+        "key": "ESC"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "SPACE"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "RETURN"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "KEYPAD_ENTER"
+      },
+      {
+        "input_method": "mouse",
+        "key": "MOUSE_RIGHT"
+      }
     ]
   },
   {
@@ -4700,119 +9966,273 @@
     "id": "CREATURE",
     "category": "EXTENDED_DESCRIPTION",
     "name": "Describe creature",
-    "bindings": [ { "input_method": "keyboard_any", "key": "c" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "c"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "FURNITURE",
     "category": "EXTENDED_DESCRIPTION",
     "name": "Describe furniture",
-    "bindings": [ { "input_method": "keyboard_any", "key": "f" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_NE" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "f"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TERRAIN",
     "category": "EXTENDED_DESCRIPTION",
     "name": "Describe terrain",
-    "bindings": [ { "input_method": "keyboard_any", "key": "t" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_E" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "t"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_E"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "VEHICLE",
     "category": "EXTENDED_DESCRIPTION",
     "name": "Describe vehicle/appliance",
-    "bindings": [ { "input_method": "keyboard_any", "key": "v" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_SE" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "v"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SWITCH_LISTS",
     "category": "INVENTORY",
     "name": "Switch lists",
-    "bindings": [ { "input_method": "keyboard_any", "key": "TAB" }, { "input_method": "gamepad", "key": "JOY_RADIAL_R_N" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "TAB"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_N"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "FAV_PRIORITY",
     "category": "INVENTORY",
     "name": "Set priority",
-    "bindings": [ { "input_method": "keyboard_any", "key": "p" }, { "input_method": "gamepad", "key": "JOY_RADIAL_R_NE" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "p"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_NE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "FAV_AUTO_PICKUP",
     "category": "INVENTORY",
     "name": "Toggle auto pickup",
-    "bindings": [ { "input_method": "keyboard_any", "key": "d" }, { "input_method": "gamepad", "key": "JOY_RADIAL_R_E" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "d"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_E"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "FAV_AUTO_UNLOAD",
     "category": "INVENTORY",
     "name": "Toggle auto unload",
-    "bindings": [ { "input_method": "keyboard_any", "key": "u" }, { "input_method": "gamepad", "key": "JOY_RADIAL_R_SE" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "u"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_SE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "FAV_ITEM",
     "category": "INVENTORY",
     "name": "Whitelist/blacklist item",
-    "bindings": [ { "input_method": "keyboard_any", "key": "i" }, { "input_method": "gamepad", "key": "JOY_RADIAL_R_S" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "i"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_S"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "FAV_CATEGORY",
     "category": "INVENTORY",
     "name": "Whitelist/blacklist category",
-    "bindings": [ { "input_method": "keyboard_any", "key": "c" }, { "input_method": "gamepad", "key": "JOY_RADIAL_R_SW" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "c"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_SW"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "FAV_WHITELIST",
     "category": "INVENTORY",
     "name": "Switch to modifying whitelist",
-    "bindings": [ { "input_method": "keyboard_any", "key": "w" }, { "input_method": "gamepad", "key": "JOY_RADIAL_R_W" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "w"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_W"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "FAV_BLACKLIST",
     "category": "INVENTORY",
     "name": "Switch to modifying blacklist",
-    "bindings": [ { "input_method": "keyboard_any", "key": "b" }, { "input_method": "gamepad", "key": "JOY_RADIAL_R_NW" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "b"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_NW"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "FAV_SAVE_PRESET",
     "category": "INVENTORY",
     "name": "Save preset",
-    "bindings": [ { "input_method": "keyboard_char", "key": "S" }, { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "S"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "s",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "FAV_APPLY_PRESET",
     "category": "INVENTORY",
     "name": "Apply preset",
-    "bindings": [ { "input_method": "keyboard_char", "key": "A" }, { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "A"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "a",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "FAV_DEL_PRESET",
     "category": "INVENTORY",
     "name": "Delete preset",
-    "bindings": [ { "input_method": "keyboard_char", "key": "D" }, { "input_method": "keyboard_code", "key": "d", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "D"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "d",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "FAV_CLEAR",
     "category": "INVENTORY",
     "name": "Clear entries",
-    "bindings": [ { "input_method": "keyboard_any", "key": "x" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "x"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "FAV_MOVE_ITEM",
     "category": "INVENTORY",
     "name": "Move item",
-    "bindings": [ { "input_method": "keyboard_any", "key": "m" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "m"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -4820,9 +10240,18 @@
     "category": "INVENTORY",
     "name": "Open context menu",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "RETURN" },
-      { "input_method": "keyboard_any", "key": "KEYPAD_ENTER" },
-      { "input_method": "mouse", "key": "MOUSE_LEFT" }
+      {
+        "input_method": "keyboard_any",
+        "key": "RETURN"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "KEYPAD_ENTER"
+      },
+      {
+        "input_method": "mouse",
+        "key": "MOUSE_LEFT"
+      }
     ]
   },
   {
@@ -4830,9 +10259,21 @@
     "id": "CHANGE_PROFESSION_NAME",
     "name": "Change profession name",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "*" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
-      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_char",
+        "key": "*"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MULTIPLY"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "8",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -4840,147 +10281,324 @@
     "id": "SCROLL_MISSION_INFO_UP",
     "category": "FACTIONS",
     "name": "Scroll camp mission info up",
-    "bindings": [ { "input_method": "keyboard_any", "key": "[" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "["
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_MISSION_INFO_DOWN",
     "category": "FACTIONS",
     "name": "Scroll camp mission info down",
-    "bindings": [ { "input_method": "keyboard_any", "key": "]" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "]"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "category": "PLAYER_INFO",
     "id": "VIEW_PROFICIENCIES",
     "name": "View character proficiencies",
-    "bindings": [ { "input_method": "keyboard_any", "key": "p" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "p"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "category": "PLAYER_INFO",
     "id": "VIEW_BODYSTAT",
     "name": "View character's body status",
-    "bindings": [ { "input_method": "keyboard_any", "key": "s" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "s"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "View character's morale",
     "category": "PLAYER_INFO",
     "id": "morale",
-    "bindings": [ { "input_method": "keyboard_any", "key": "m" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "m"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CHANGE_ARMOR_SPRITE",
     "category": "PLAYER_INFO",
     "name": "Change armor sprite",
-    "bindings": [ { "input_method": "keyboard_char", "key": "W" }, { "input_method": "keyboard_code", "key": "w", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "W"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "w",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "category": "PLAYER_INFO",
     "id": "SELECT_STATS_TAB",
     "name": "Select stats tab",
-    "bindings": [ { "input_method": "keyboard_any", "key": "w" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "w"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "category": "PLAYER_INFO",
     "id": "SELECT_ENCUMBRANCE_TAB",
     "name": "Select encumbrance tab",
-    "bindings": [ { "input_method": "keyboard_any", "key": "e" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_NE" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "e"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "category": "PLAYER_INFO",
     "id": "SELECT_SKILLS_TAB",
     "name": "Select skills tab",
-    "bindings": [ { "input_method": "keyboard_any", "key": "r" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_E" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "r"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "category": "PLAYER_INFO",
     "id": "SELECT_TRAITS_TAB",
     "name": "Select traits tab",
-    "bindings": [ { "input_method": "keyboard_any", "key": "t" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_SE" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "t"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "category": "PLAYER_INFO",
     "id": "SELECT_BIONICS_TAB",
     "name": "Select bionics tab",
-    "bindings": [ { "input_method": "keyboard_any", "key": "x" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_S" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "x"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "category": "PLAYER_INFO",
     "id": "SELECT_EFFECTS_TAB",
     "name": "Select effects tab",
-    "bindings": [ { "input_method": "keyboard_any", "key": "c" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_SW" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "c"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "category": "PLAYER_INFO",
     "id": "SELECT_PROFICIENCIES_TAB",
     "name": "Select proficiencies tab",
-    "bindings": [ { "input_method": "keyboard_any", "key": "v" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_W" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "v"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "category": "WISH_ITEM",
     "id": "CONTAINER",
     "name": "Toggle spawning item with container",
-    "bindings": [ { "input_method": "keyboard_any", "key": "f" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "f"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "category": "WISH_ITEM",
     "id": "FLAG",
     "name": "Add flags to spawned items",
-    "bindings": [ { "input_method": "keyboard_char", "key": "F" }, { "input_method": "keyboard_code", "key": "f", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "F"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "f",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "category": "WISH_ITEM",
     "id": "EVERYTHING",
     "name": "Toggle spawning everything",
-    "bindings": [ { "input_method": "keyboard_char", "key": "E" }, { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "E"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "e",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "category": "WISH_ITEM",
     "id": "SNIPPET",
     "name": "Choose snippet",
-    "bindings": [ { "input_method": "keyboard_char", "key": "S" }, { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "S"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "s",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "category": "WISH_ITEM",
     "id": "SCROLL_DESC_UP",
     "name": "Scroll item description up",
-    "bindings": [ { "input_method": "keyboard_char", "key": "<" }, { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "<"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ",",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_R_UP"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "category": "WISH_ITEM",
     "id": "SCROLL_DESC_DOWN",
     "name": "Scroll item description down",
-    "bindings": [ { "input_method": "keyboard_char", "key": ">" }, { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": ">"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ".",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_R_DOWN"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_ITEM_INFO_UP",
     "category": "VENDING_MACHINE",
     "name": "Scroll item info up",
-    "bindings": [ { "input_method": "keyboard_char", "key": "<" }, { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "<"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ",",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_R_UP"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_ITEM_INFO_DOWN",
     "category": "VENDING_MACHINE",
     "name": "Scroll item info down",
-    "bindings": [ { "input_method": "keyboard_char", "key": ">" }, { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": ">"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ".",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_R_DOWN"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -4988,9 +10606,21 @@
     "id": "LOOK_AT",
     "name": "Look at",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "L" },
-      { "input_method": "keyboard_code", "key": "l", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" }
+      {
+        "input_method": "keyboard_char",
+        "key": "L"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "l",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
     ]
   },
   {
@@ -4999,9 +10629,21 @@
     "id": "SIZE_UP_STATS",
     "name": "Size up stats",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "S" },
-      { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_NE" }
+      {
+        "input_method": "keyboard_char",
+        "key": "S"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "s",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NE"
+      }
     ]
   },
   {
@@ -5010,9 +10652,21 @@
     "id": "ASSESS_PERSONALITY",
     "name": "Assess personality",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "A" },
-      { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_E" }
+      {
+        "input_method": "keyboard_char",
+        "key": "A"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "a",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_E"
+      }
     ]
   },
   {
@@ -5021,9 +10675,21 @@
     "id": "YELL",
     "name": "Yell",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "Y" },
-      { "input_method": "keyboard_code", "key": "y", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_SE" }
+      {
+        "input_method": "keyboard_char",
+        "key": "Y"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "y",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SE"
+      }
     ]
   },
   {
@@ -5032,9 +10698,21 @@
     "id": "CHECK_OPINION",
     "name": "Check opinion",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "O" },
-      { "input_method": "keyboard_code", "key": "o", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_S" }
+      {
+        "input_method": "keyboard_char",
+        "key": "O"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "o",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_S"
+      }
     ]
   },
   {
@@ -5042,158 +10720,317 @@
     "category": "FACTION_MANAGER",
     "id": "INSPECT_NPC",
     "name": "Inspect NPC",
-    "bindings": [ { "input_method": "keyboard_any", "key": "i" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "i"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SORT",
     "category": "NEW_CHAR_TRAITS",
     "name": "Sort traits list",
-    "bindings": [ { "input_method": "keyboard_any", "key": "s" }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "s"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SELECT_TRAIT_VARIANT",
     "name": "Select variant for trait",
-    "bindings": [ { "input_method": "keyboard_char", "key": "S" }, { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "S"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "s",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "DELETE PAGE",
     "name": "Delete page",
     "category": "DIARY",
-    "bindings": [ { "input_method": "keyboard_any", "mod": [  ], "key": [ "d" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "mod": [],
+        "key": [
+          "d"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "EXPORT_DIARY",
     "name": "Export diary to .txt",
     "category": "DIARY",
-    "bindings": [ { "input_method": "keyboard_any", "mod": [  ], "key": [ "e" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "mod": [],
+        "key": [
+          "e"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "NEW_PAGE",
     "name": "Add new page",
     "category": "DIARY",
-    "bindings": [ { "input_method": "keyboard_any", "mod": [  ], "key": [ "n" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "mod": [],
+        "key": [
+          "n"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "View achievements, scores, and kills",
     "category": "DIARY",
     "id": "VIEW_SCORES",
-    "bindings": [ { "input_method": "keyboard_any", "mod": [  ], "key": [ "v" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "mod": [],
+        "key": [
+          "v"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.QUIT",
     "name": "Cancel text input",
-    "bindings": [ { "input_method": "keyboard_any", "key": "ESC" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "ESC"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.CONFIRM",
     "name": "Confirm text input",
-    "bindings": [ { "input_method": "keyboard_any", "key": "RETURN" }, { "input_method": "keyboard_any", "key": "KEYPAD_ENTER" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "RETURN"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "KEYPAD_ENTER"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.UP",
     "name": "Move cursor up",
-    "bindings": [ { "input_method": "keyboard_any", "key": "UP" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "UP"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.DOWN",
     "name": "Move cursor down",
-    "bindings": [ { "input_method": "keyboard_any", "key": "DOWN" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "DOWN"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.LEFT",
     "name": "Move cursor left",
-    "bindings": [ { "input_method": "keyboard_any", "key": "LEFT" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "LEFT"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.RIGHT",
     "name": "Move cursor right",
-    "bindings": [ { "input_method": "keyboard_any", "key": "RIGHT" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "RIGHT"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.PAGE_UP",
     "name": "Move cursor to previous page",
-    "bindings": [ { "input_method": "keyboard_any", "key": "PPAGE" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "PPAGE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.PAGE_DOWN",
     "name": "Move cursor to next page",
-    "bindings": [ { "input_method": "keyboard_any", "key": "NPAGE" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "NPAGE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.CLEAR",
     "name": "Clear text",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "CTRL+U" },
-      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "u" }
+      {
+        "input_method": "keyboard_char",
+        "key": "CTRL+U"
+      },
+      {
+        "input_method": "keyboard_code",
+        "mod": [
+          "ctrl"
+        ],
+        "key": "u"
+      }
     ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.BACKSPACE",
     "name": "Remove previous character",
-    "bindings": [ { "input_method": "keyboard_any", "key": "BACKSPACE" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "BACKSPACE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.HOME",
     "name": "Move cursor to start",
-    "bindings": [ { "input_method": "keyboard_any", "key": "HOME" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "HOME"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.END",
     "name": "Move cursor to end",
-    "bindings": [ { "input_method": "keyboard_any", "key": "END" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "END"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.DELETE",
     "name": "Remove current character",
-    "bindings": [ { "input_method": "keyboard_any", "key": "DELETE" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "DELETE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.PASTE",
     "name": "Paste from clipboard",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "CTRL+V" },
-      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "v" }
+      {
+        "input_method": "keyboard_char",
+        "key": "CTRL+V"
+      },
+      {
+        "input_method": "keyboard_code",
+        "mod": [
+          "ctrl"
+        ],
+        "key": "v"
+      }
     ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.INPUT_FROM_FILE",
     "name": "Input text from file",
-    "bindings": [ { "input_method": "keyboard_any", "key": "F2" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "F2"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "HISTORY_UP",
     "name": "Show previous history",
     "category": "STRING_INPUT",
-    "bindings": [ { "input_method": "keyboard_any", "key": "UP" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "UP"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "HISTORY_DOWN",
     "name": "Show next history",
     "category": "STRING_INPUT",
-    "bindings": [ { "input_method": "keyboard_any", "key": "DOWN" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "DOWN"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -5201,7 +11038,12 @@
     "name": "Display keybindings menu",
     "category": "STRING_INPUT",
     "//": "'?' is treated as text input, so a different key is used.",
-    "bindings": [ { "input_method": "keyboard_any", "key": "F1" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "F1"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -5211,10 +11053,28 @@
     "//": "RETURN is treated as text input, so use a different keybinding",
     "//2": "CTRL+S is not available on curses, so add CTRL+Y as an alternative",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "CTRL+S" },
-      { "input_method": "keyboard_char", "key": "CTRL+Y" },
-      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "s" },
-      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "y" }
+      {
+        "input_method": "keyboard_char",
+        "key": "CTRL+S"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "CTRL+Y"
+      },
+      {
+        "input_method": "keyboard_code",
+        "mod": [
+          "ctrl"
+        ],
+        "key": "s"
+      },
+      {
+        "input_method": "keyboard_code",
+        "mod": [
+          "ctrl"
+        ],
+        "key": "y"
+      }
     ]
   },
   {
@@ -5222,42 +11082,72 @@
     "id": "TOGGLE_MONSTER_GROUP",
     "category": "SCORES_UI",
     "name": "Toggle monster group",
-    "bindings": [ { "input_method": "keyboard_any", "key": "m" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "m"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_NPC_GROUP",
     "category": "SCORES_UI",
     "name": "Toggle NPC group",
-    "bindings": [ { "input_method": "keyboard_any", "key": "n" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "n"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_GENERAL_INFO_GROUP",
     "category": "MA_DETAILS_UI",
     "name": "Toggle general info group",
-    "bindings": [ { "input_method": "keyboard_any", "key": "g" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "g"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_BUFFS_GROUP",
     "category": "MA_DETAILS_UI",
     "name": "Toggle buffs group",
-    "bindings": [ { "input_method": "keyboard_any", "key": "b" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "b"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_TECHNIQUES_GROUP",
     "category": "MA_DETAILS_UI",
     "name": "Toggle techniques group",
-    "bindings": [ { "input_method": "keyboard_any", "key": "t" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "t"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_WEAPONS_GROUP",
     "category": "MA_DETAILS_UI",
     "name": "Toggle weapons group",
-    "bindings": [ { "input_method": "keyboard_any", "key": "w" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "w"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -5265,6 +11155,11 @@
     "name": "Display keybindings menu",
     "category": "STRING_EDITOR",
     "//": "'?' is treated as text input, so a different key is used.",
-    "bindings": [ { "input_method": "keyboard_any", "key": "F1" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "F1"
+      }
+    ]
   }
 ]

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -4,9 +4,18 @@
     "id": "UILIST.UP",
     "name": "Pan up",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "UP" },
-      { "input_method": "keyboard_any", "key": "8" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_8" }
+      {
+        "input_method": "keyboard_any",
+        "key": "UP"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "8"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_8"
+      }
     ]
   },
   {
@@ -14,9 +23,18 @@
     "id": "UILIST.DOWN",
     "name": "Pan down",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "DOWN" },
-      { "input_method": "keyboard_any", "key": "2" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_2" }
+      {
+        "input_method": "keyboard_any",
+        "key": "DOWN"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "2"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_2"
+      }
     ]
   },
   {
@@ -24,9 +42,18 @@
     "id": "UILIST.LEFT",
     "name": "Pan left",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "LEFT" },
-      { "input_method": "keyboard_any", "key": "4" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_4" }
+      {
+        "input_method": "keyboard_any",
+        "key": "LEFT"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "4"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_4"
+      }
     ]
   },
   {
@@ -34,40 +61,83 @@
     "id": "UILIST.RIGHT",
     "name": "Pan right",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "RIGHT" },
-      { "input_method": "keyboard_any", "key": "6" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_6" }
+      {
+        "input_method": "keyboard_any",
+        "key": "RIGHT"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "6"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_6"
+      }
     ]
   },
   {
     "type": "keybinding",
     "id": "UILIST.FILTER",
     "name": "Filter",
-    "bindings": [ { "input_method": "keyboard_any", "key": "/" }, { "input_method": "keyboard_code", "key": "KEYPAD_DIVIDE" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "/"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_DIVIDE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "UILIST.QUIT",
     "name": "Cancel menu",
-    "bindings": [ { "input_method": "keyboard_any", "key": "ESC" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "ESC"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SHOW_DESCRIPTION",
     "category": "MELEE_STYLE_PICKER",
     "name": "Show description of melee style",
-    "bindings": [ { "input_method": "keyboard_any", "key": "d" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "d"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "UP",
     "name": "Pan up",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "k" },
-      { "input_method": "keyboard_any", "key": "UP" },
-      { "input_method": "keyboard_any", "key": "8" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_8" },
-      { "input_method": "gamepad", "key": "JOY_L_UP" }
+      {
+        "input_method": "keyboard_any",
+        "key": "k"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "UP"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "8"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_8"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_L_UP"
+      }
     ]
   },
   {
@@ -75,11 +145,26 @@
     "id": "DOWN",
     "name": "Pan down",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "j" },
-      { "input_method": "keyboard_any", "key": "DOWN" },
-      { "input_method": "keyboard_any", "key": "2" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_2" },
-      { "input_method": "gamepad", "key": "JOY_L_DOWN" }
+      {
+        "input_method": "keyboard_any",
+        "key": "j"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "DOWN"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "2"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_2"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_L_DOWN"
+      }
     ]
   },
   {
@@ -87,11 +172,26 @@
     "id": "LEFT",
     "name": "Pan left",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "h" },
-      { "input_method": "keyboard_any", "key": "LEFT" },
-      { "input_method": "keyboard_any", "key": "4" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_4" },
-      { "input_method": "gamepad", "key": "JOY_L_LEFT" }
+      {
+        "input_method": "keyboard_any",
+        "key": "h"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "LEFT"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "4"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_4"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_L_LEFT"
+      }
     ]
   },
   {
@@ -99,11 +199,26 @@
     "id": "RIGHT",
     "name": "Pan right",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "l" },
-      { "input_method": "keyboard_any", "key": "RIGHT" },
-      { "input_method": "keyboard_any", "key": "6" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_6" },
-      { "input_method": "gamepad", "key": "JOY_L_RIGHT" }
+      {
+        "input_method": "keyboard_any",
+        "key": "l"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "RIGHT"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "6"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_6"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_L_RIGHT"
+      }
     ]
   },
   {
@@ -111,10 +226,22 @@
     "id": "LEFTUP",
     "name": "Pan up-left",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "y" },
-      { "input_method": "keyboard_any", "key": "7" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_7" },
-      { "input_method": "gamepad", "key": "JOY_L_LEFTUP" }
+      {
+        "input_method": "keyboard_any",
+        "key": "y"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "7"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_7"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_L_LEFTUP"
+      }
     ]
   },
   {
@@ -122,10 +249,22 @@
     "id": "RIGHTUP",
     "name": "Pan up-right",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "u" },
-      { "input_method": "keyboard_any", "key": "9" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_9" },
-      { "input_method": "gamepad", "key": "JOY_L_RIGHTUP" }
+      {
+        "input_method": "keyboard_any",
+        "key": "u"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "9"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_9"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_L_RIGHTUP"
+      }
     ]
   },
   {
@@ -133,10 +272,22 @@
     "id": "LEFTDOWN",
     "name": "Pan down-left",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "b" },
-      { "input_method": "keyboard_any", "key": "1" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_1" },
-      { "input_method": "gamepad", "key": "JOY_L_LEFTDOWN" }
+      {
+        "input_method": "keyboard_any",
+        "key": "b"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "1"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_1"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_L_LEFTDOWN"
+      }
     ]
   },
   {
@@ -144,68 +295,139 @@
     "id": "RIGHTDOWN",
     "name": "Pan down-right",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "n" },
-      { "input_method": "keyboard_any", "key": "3" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_3" },
-      { "input_method": "gamepad", "key": "JOY_L_RIGHTDOWN" }
+      {
+        "input_method": "keyboard_any",
+        "key": "n"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "3"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_3"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_L_RIGHTDOWN"
+      }
     ]
   },
   {
     "type": "keybinding",
     "id": "HOME",
     "name": "Home",
-    "bindings": [ { "input_method": "keyboard_any", "key": "HOME" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "HOME"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "END",
     "name": "End",
-    "bindings": [ { "input_method": "keyboard_any", "key": "END" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "END"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "PAGE_UP",
     "name": "Page up",
-    "bindings": [ { "input_method": "keyboard_any", "key": "PPAGE" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "PPAGE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "PAGE_DOWN",
     "name": "Page down",
-    "bindings": [ { "input_method": "keyboard_any", "key": "NPAGE" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "NPAGE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_UP",
     "name": "Scroll up",
-    "bindings": [ { "input_method": "mouse", "key": "SCROLL_UP" } ]
+    "bindings": [
+      {
+        "input_method": "mouse",
+        "key": "SCROLL_UP"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_DOWN",
     "name": "Scroll down",
-    "bindings": [ { "input_method": "mouse", "key": "SCROLL_DOWN" } ]
+    "bindings": [
+      {
+        "input_method": "mouse",
+        "key": "SCROLL_DOWN"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SELECT_ALL",
     "category": "PICKUP",
     "name": "Select all",
-    "bindings": [ { "input_method": "keyboard_any", "key": "," } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": ","
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_ITEM_INFO_UP",
     "category": "PICKUP",
     "name": "Scroll item info up",
-    "bindings": [ { "input_method": "keyboard_char", "key": "<" }, { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "<"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ",",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_ITEM_INFO_DOWN",
     "category": "PICKUP",
     "name": "Scroll item info down",
-    "bindings": [ { "input_method": "keyboard_char", "key": ">" }, { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": ">"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ".",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -213,9 +435,18 @@
     "category": "PICKUP",
     "name": "Previous item",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "k" },
-      { "input_method": "keyboard_any", "key": "UP" },
-      { "input_method": "gamepad", "key": "JOY_UP" }
+      {
+        "input_method": "keyboard_any",
+        "key": "k"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "UP"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_UP"
+      }
     ]
   },
   {
@@ -224,9 +455,18 @@
     "category": "PICKUP",
     "name": "Next item",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "j" },
-      { "input_method": "keyboard_any", "key": "DOWN" },
-      { "input_method": "gamepad", "key": "JOY_DOWN" }
+      {
+        "input_method": "keyboard_any",
+        "key": "j"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "DOWN"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_DOWN"
+      }
     ]
   },
   {
@@ -235,9 +475,18 @@
     "category": "PICKUP",
     "name": "Unmark selected item",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "h" },
-      { "input_method": "keyboard_any", "key": "LEFT" },
-      { "input_method": "gamepad", "key": "JOY_LEFT" }
+      {
+        "input_method": "keyboard_any",
+        "key": "h"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "LEFT"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_LEFT"
+      }
     ]
   },
   {
@@ -246,8 +495,14 @@
     "category": "PICKUP",
     "name": "Mark selected item",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "l" },
-      { "input_method": "keyboard_any", "key": "RIGHT" }
+      {
+        "input_method": "keyboard_any",
+        "key": "l"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "RIGHT"
+      }
     ]
   },
   {
@@ -256,9 +511,21 @@
     "category": "AUTO_NOTES",
     "name": "Enable auto notes for map extras",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "e" },
-      { "input_method": "keyboard_char", "key": "E" },
-      { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "e"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "E"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "e",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -267,9 +534,21 @@
     "category": "AUTO_NOTES",
     "name": "Toggle auto notes option",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "s" },
-      { "input_method": "keyboard_char", "key": "S" },
-      { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "s"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "S"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "s",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -278,9 +557,21 @@
     "category": "AUTO_NOTES",
     "name": "Disable auto notes for map extras",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "d" },
-      { "input_method": "keyboard_char", "key": "D" },
-      { "input_method": "keyboard_code", "key": "d", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "d"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "D"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "d",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -288,35 +579,81 @@
     "id": "CHANGE_MAPEXTRA_CHARACTER",
     "category": "AUTO_NOTES",
     "name": "Change a symbol for map extra",
-    "bindings": [ { "input_method": "keyboard_any", "key": "=" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "="
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CHOOSE_INVLET",
     "category": "SPELL_MENU",
     "name": "Choose a hotkey for a spell",
-    "bindings": [ { "input_method": "keyboard_any", "key": "=" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "="
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CAST_IGNORE",
     "category": "SPELL_MENU",
     "name": "Toggle ignore distractions",
-    "bindings": [ { "input_method": "keyboard_char", "key": "I" }, { "input_method": "keyboard_code", "key": "i", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "I"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "i",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_UP_SPELL_MENU",
     "category": "SPELL_MENU",
     "name": "Scroll up spell info",
-    "bindings": [ { "input_method": "keyboard_char", "key": "<" }, { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "<"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ",",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_DOWN_SPELL_MENU",
     "category": "SPELL_MENU",
     "name": "Scroll down spell info",
-    "bindings": [ { "input_method": "keyboard_char", "key": ">" }, { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": ">"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ".",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -324,9 +661,21 @@
     "category": "SPELL_MENU",
     "name": "Toggle spell as favorite",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "*" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
-      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_char",
+        "key": "*"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MULTIPLY"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "8",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -335,9 +684,21 @@
     "category": "AUTO_PICKUP",
     "name": "Add rule",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "a" },
-      { "input_method": "keyboard_char", "key": "A" },
-      { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "a"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "A"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "a",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -346,9 +707,21 @@
     "category": "AUTO_PICKUP",
     "name": "Remove rule",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "r" },
-      { "input_method": "keyboard_char", "key": "R" },
-      { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "r"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "R"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "r",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -357,9 +730,21 @@
     "category": "AUTO_PICKUP",
     "name": "Copy rule",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "c" },
-      { "input_method": "keyboard_char", "key": "C" },
-      { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "c"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "C"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "c",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -368,9 +753,21 @@
     "category": "AUTO_PICKUP",
     "name": "Move rule global <-> character",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "m" },
-      { "input_method": "keyboard_char", "key": "M" },
-      { "input_method": "keyboard_code", "key": "m", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "m"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "M"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "m",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -379,9 +776,21 @@
     "category": "AUTO_PICKUP",
     "name": "Enable rule",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "e" },
-      { "input_method": "keyboard_char", "key": "E" },
-      { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "e"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "E"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "e",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -390,9 +799,21 @@
     "category": "AUTO_PICKUP",
     "name": "Disable rule",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "d" },
-      { "input_method": "keyboard_char", "key": "D" },
-      { "input_method": "keyboard_code", "key": "d", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "d"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "D"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "d",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -401,9 +822,18 @@
     "category": "AUTO_PICKUP",
     "name": "Move rule up",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "=" },
-      { "input_method": "keyboard_char", "key": "+" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" }
+      {
+        "input_method": "keyboard_any",
+        "key": "="
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "+"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_PLUS"
+      }
     ]
   },
   {
@@ -411,7 +841,16 @@
     "id": "MOVE_RULE_DOWN",
     "category": "AUTO_PICKUP",
     "name": "Move rule down",
-    "bindings": [ { "input_method": "keyboard_any", "key": "-" }, { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "-"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MINUS"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -419,9 +858,21 @@
     "category": "AUTO_PICKUP",
     "name": "Test rule",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "t" },
-      { "input_method": "keyboard_char", "key": "T" },
-      { "input_method": "keyboard_code", "key": "t", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "t"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "T"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "t",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -430,9 +881,21 @@
     "category": "AUTO_PICKUP",
     "name": "Enable auto pickup option",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "s" },
-      { "input_method": "keyboard_char", "key": "S" },
-      { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "s"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "S"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "s",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -441,12 +904,33 @@
     "category": "AUTO_PICKUP",
     "name": "Quit",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "ESC" },
-      { "input_method": "keyboard_any", "key": "q" },
-      { "input_method": "keyboard_char", "key": "Q" },
-      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "SPACE" },
-      { "input_method": "mouse", "key": "MOUSE_RIGHT" }
+      {
+        "input_method": "keyboard_any",
+        "key": "ESC"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "q"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "Q"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "q",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "SPACE"
+      },
+      {
+        "input_method": "mouse",
+        "key": "MOUSE_RIGHT"
+      }
     ]
   },
   {
@@ -454,7 +938,23 @@
     "id": "ADD_DEFAULT_RULESET",
     "category": "SAFEMODE",
     "name": "Add default ruleset",
-    "bindings": [ { "input_method": "keyboard_char", "key": "~" }, { "input_method": "keyboard_code", "key": "`", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "~"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "`",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -462,9 +962,25 @@
     "category": "SAFEMODE",
     "name": "Add rule",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "a" },
-      { "input_method": "keyboard_char", "key": "A" },
-      { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "a"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "A"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "a",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NE"
+      }
     ]
   },
   {
@@ -473,9 +989,25 @@
     "category": "SAFEMODE",
     "name": "Remove rule",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "r" },
-      { "input_method": "keyboard_char", "key": "R" },
-      { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "r"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "R"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "r",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_E"
+      }
     ]
   },
   {
@@ -484,9 +1016,25 @@
     "category": "SAFEMODE",
     "name": "Copy rule",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "c" },
-      { "input_method": "keyboard_char", "key": "C" },
-      { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "c"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "C"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "c",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SE"
+      }
     ]
   },
   {
@@ -495,9 +1043,25 @@
     "category": "SAFEMODE",
     "name": "Move rule global <-> character",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "m" },
-      { "input_method": "keyboard_char", "key": "M" },
-      { "input_method": "keyboard_code", "key": "m", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "m"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "M"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "m",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_S"
+      }
     ]
   },
   {
@@ -506,9 +1070,25 @@
     "category": "SAFEMODE",
     "name": "Enable rule",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "e" },
-      { "input_method": "keyboard_char", "key": "E" },
-      { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "e"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "E"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "e",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SW"
+      }
     ]
   },
   {
@@ -517,9 +1097,25 @@
     "category": "SAFEMODE",
     "name": "Disable rule",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "d" },
-      { "input_method": "keyboard_char", "key": "D" },
-      { "input_method": "keyboard_code", "key": "d", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "d"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "D"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "d",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_W"
+      }
     ]
   },
   {
@@ -528,9 +1124,22 @@
     "category": "SAFEMODE",
     "name": "Move rule up",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "=" },
-      { "input_method": "keyboard_char", "key": "+" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" }
+      {
+        "input_method": "keyboard_any",
+        "key": "="
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "+"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_PLUS"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_DPAD_UP"
+      }
     ]
   },
   {
@@ -538,7 +1147,20 @@
     "id": "MOVE_RULE_DOWN",
     "category": "SAFEMODE",
     "name": "Move rule down",
-    "bindings": [ { "input_method": "keyboard_any", "key": "-" }, { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "-"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MINUS"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_DPAD_DOWN"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -546,9 +1168,25 @@
     "category": "SAFEMODE",
     "name": "Test rule",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "t" },
-      { "input_method": "keyboard_char", "key": "T" },
-      { "input_method": "keyboard_code", "key": "t", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "t"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "T"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "t",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NW"
+      }
     ]
   },
   {
@@ -557,9 +1195,25 @@
     "category": "SAFEMODE",
     "name": "Enable safemode option",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "s" },
-      { "input_method": "keyboard_char", "key": "S" },
-      { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "s"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "S"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "s",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_N"
+      }
     ]
   },
   {
@@ -568,12 +1222,33 @@
     "category": "SAFEMODE",
     "name": "Quit",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "ESC" },
-      { "input_method": "keyboard_any", "key": "q" },
-      { "input_method": "keyboard_char", "key": "Q" },
-      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "SPACE" },
-      { "input_method": "mouse", "key": "MOUSE_RIGHT" }
+      {
+        "input_method": "keyboard_any",
+        "key": "ESC"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "q"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "Q"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "q",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "SPACE"
+      },
+      {
+        "input_method": "mouse",
+        "key": "MOUSE_RIGHT"
+      }
     ]
   },
   {
@@ -581,7 +1256,12 @@
     "id": "USAGE_HELP",
     "category": "SORT_ARMOR",
     "name": "Display usage help",
-    "bindings": [ { "input_method": "keyboard_any", "key": "F1" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "F1"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -589,9 +1269,18 @@
     "category": "SORT_ARMOR",
     "name": "Select armor for moving",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "s" },
-      { "input_method": "keyboard_any", "key": "RETURN" },
-      { "input_method": "keyboard_any", "key": "KEYPAD_ENTER" }
+      {
+        "input_method": "keyboard_any",
+        "key": "s"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "RETURN"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "KEYPAD_ENTER"
+      }
     ]
   },
   {
@@ -600,9 +1289,18 @@
     "category": "PANEL_MGMT",
     "name": "Select panel for moving",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "s" },
-      { "input_method": "keyboard_any", "key": "RETURN" },
-      { "input_method": "keyboard_any", "key": "KEYPAD_ENTER" }
+      {
+        "input_method": "keyboard_any",
+        "key": "s"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "RETURN"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "KEYPAD_ENTER"
+      }
     ]
   },
   {
@@ -610,87 +1308,230 @@
     "id": "TOGGLE_PANEL",
     "category": "PANEL_MGMT",
     "name": "Toggle panel off",
-    "bindings": [ { "input_method": "keyboard_any", "key": "TAB" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "TAB"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CHANGE_SIDE",
     "category": "SORT_ARMOR",
     "name": "Change side armor is worn on",
-    "bindings": [ { "input_method": "keyboard_any", "key": "c" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "c"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_CLOTH",
     "category": "SORT_ARMOR",
     "name": "Toggle armor visibility on character sprite",
-    "bindings": [ { "input_method": "keyboard_char", "key": "H" }, { "input_method": "keyboard_code", "key": "h", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "H"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "h",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "ASSIGN_INVLETS",
     "category": "SORT_ARMOR",
     "name": "Assign invlets to armor",
-    "bindings": [ { "input_method": "keyboard_any", "key": "r" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "r"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_E"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SORT_ARMOR",
     "category": "SORT_ARMOR",
     "name": "Sort armor into natural layer order",
-    "bindings": [ { "input_method": "keyboard_char", "key": "S" }, { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "S"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "s",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_ITEM_INFO_UP",
     "category": "SORT_ARMOR",
     "name": "Scroll item info up",
-    "bindings": [ { "input_method": "keyboard_char", "key": "<" }, { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "<"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ",",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_ITEM_INFO_DOWN",
     "category": "SORT_ARMOR",
     "name": "Scroll item info down",
-    "bindings": [ { "input_method": "keyboard_char", "key": ">" }, { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": ">"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ".",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "EQUIP_ARMOR",
     "category": "SORT_ARMOR",
     "name": "Equip armor from inventory",
-    "bindings": [ { "input_method": "keyboard_any", "key": "e" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "e"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_S"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "EQUIP_ARMOR_HERE",
     "category": "SORT_ARMOR",
     "name": "Equip armor from inventory at this position",
-    "bindings": [ { "input_method": "keyboard_char", "key": "E" }, { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "E"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "e",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SW"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "REMOVE_ARMOR",
     "category": "SORT_ARMOR",
     "name": "Unequip selected armor",
-    "bindings": [ { "input_method": "keyboard_any", "key": "u" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "u"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_W"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "HELP_KEYBINDINGS",
     "name": "Display keybindings menu",
-    "bindings": [ { "input_method": "keyboard_char", "key": "?" }, { "input_method": "keyboard_code", "key": "/", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "?"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "/",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "FILTER",
     "name": "Filter",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "f" },
-      { "input_method": "keyboard_char", "key": "F" },
-      { "input_method": "keyboard_code", "key": "f", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "/" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_DIVIDE" }
+      {
+        "input_method": "keyboard_any",
+        "key": "f"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "F"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "f",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "/"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_DIVIDE"
+      }
     ]
   },
   {
@@ -698,9 +1539,21 @@
     "id": "RESET_FILTER",
     "name": "Reset filter",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "r" },
-      { "input_method": "keyboard_char", "key": "R" },
-      { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "r"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "R"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "r",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -708,14 +1561,24 @@
     "id": "SCROLL_RECIPE_INFO_UP",
     "category": "CRAFTING",
     "name": "Scroll recipe info up",
-    "bindings": [ { "input_method": "keyboard_any", "key": "[" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "["
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_RECIPE_INFO_DOWN",
     "category": "CRAFTING",
     "name": "Scroll recipe info down",
-    "bindings": [ { "input_method": "keyboard_any", "key": "]" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "]"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -723,9 +1586,21 @@
     "category": "CRAFTING",
     "name": "Show recipe result",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "e" },
-      { "input_method": "keyboard_char", "key": "E" },
-      { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "e"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "E"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "e",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -739,56 +1614,158 @@
     "id": "TOGGLE_RECIPE_UNREAD",
     "category": "CRAFTING",
     "name": "Toggle read/unread",
-    "bindings": [ { "input_method": "keyboard_any", "key": "v" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "v"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "MARK_ALL_RECIPES_READ",
     "category": "CRAFTING",
     "name": "Mark all recipes as read",
-    "bindings": [ { "input_method": "keyboard_char", "key": "V" }, { "input_method": "keyboard_code", "key": "v", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "V"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "v",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_UNREAD_RECIPES_FIRST",
     "category": "CRAFTING",
     "name": "Show unread recipes on top",
-    "bindings": [ { "input_method": "keyboard_any", "key": "u" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "u"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_E"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CHOOSE_CRAFTER",
     "category": "CRAFTING",
     "name": "Choose crafter",
-    "bindings": [ { "input_method": "keyboard_any", "key": "c" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "c"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CYCLE_BATCH",
     "category": "CRAFTING",
     "name": "Batch crafting",
-    "bindings": [ { "input_method": "keyboard_any", "key": [ "b" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": [
+          "b"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_S"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_ITEM_INFO_UP",
     "category": "CRAFTING",
     "name": "Scroll item info up",
-    "bindings": [ { "input_method": "keyboard_char", "key": "<" }, { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "<"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ",",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_DPAD_UP"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_ITEM_INFO_DOWN",
     "category": "CRAFTING",
     "name": "Scroll item info down",
-    "bindings": [ { "input_method": "keyboard_char", "key": ">" }, { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": ">"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ".",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_DPAD_DOWN"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "RELATED_RECIPES",
     "category": "CRAFTING",
     "name": "Related recipes",
-    "bindings": [ { "input_method": "keyboard_char", "key": "L" }, { "input_method": "keyboard_code", "key": "l", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "L"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "l",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_SW"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -796,9 +1773,25 @@
     "category": "CRAFTING",
     "name": "Toggle recipes to be shown in favorite tab",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "*" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
-      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_char",
+        "key": "*"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MULTIPLY"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "8",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_W"
+      }
     ]
   },
   {
@@ -806,17 +1799,48 @@
     "id": "COMPARE",
     "category": "CRAFTING",
     "name": "Compare recipe to item in inventory",
-    "bindings": [ { "input_method": "keyboard_char", "key": "I" }, { "input_method": "keyboard_code", "key": "i", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "I"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "i",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NW"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "LEVEL_UP",
     "name": "Go up",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "PPAGE" },
-      { "input_method": "keyboard_char", "key": "<" },
-      { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_UP" }
+      {
+        "input_method": "keyboard_any",
+        "key": "PPAGE"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "<"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ",",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_DPAD_UP"
+      }
     ]
   },
   {
@@ -824,10 +1848,25 @@
     "id": "LEVEL_DOWN",
     "name": "Go down",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "NPAGE" },
-      { "input_method": "keyboard_char", "key": ">" },
-      { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_DOWN" }
+      {
+        "input_method": "keyboard_any",
+        "key": "NPAGE"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": ">"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ".",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_DPAD_DOWN"
+      }
     ]
   },
   {
@@ -836,10 +1875,22 @@
     "category": "SOKOBAN",
     "name": "Next level",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "=" },
-      { "input_method": "keyboard_char", "key": "+" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" },
-      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_RIGHT" }
+      {
+        "input_method": "keyboard_any",
+        "key": "="
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "+"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_PLUS"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
     ]
   },
   {
@@ -847,10 +1898,19 @@
     "id": "PREV",
     "category": "SOKOBAN",
     "name": "Previous level",
-    "bindings": [ 
-      { "input_method": "keyboard_any", "key": "-" }, 
-      { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" }, 
-      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_LEFT" } 
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "-"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MINUS"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NE"
+      }
     ]
   },
   {
@@ -858,75 +1918,166 @@
     "id": "RESET",
     "category": "SOKOBAN",
     "name": "Reset level",
-    "bindings": [ { "input_method": "keyboard_any", "key": "r" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "r"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_E"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "UNDO",
     "category": "SOKOBAN",
     "name": "Undo move",
-    "bindings": [ { "input_method": "keyboard_any", "key": "u" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "u"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "NEW",
     "category": "MINESWEEPER",
     "name": "Create new level",
-    "bindings": [ { "input_method": "keyboard_any", "key": "n" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "n"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "FLAG",
     "category": "MINESWEEPER",
     "name": "Toggle flag",
-    "bindings": [ { "input_method": "keyboard_any", "key": "f" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "f"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_SPACE",
     "category": "LIGHTSON",
     "name": "Toggle lights",
-    "bindings": [ { "input_method": "keyboard_any", "key": " " } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": " "
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_5",
     "category": "LIGHTSON",
     "name": "Toggle lights",
-    "bindings": [ { "input_method": "keyboard_any", "key": "5" }, { "input_method": "keyboard_code", "key": "KEYPAD_5" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "5"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_5"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "RESET",
     "category": "LIGHTSON",
     "name": "Reset level",
-    "bindings": [ { "input_method": "keyboard_any", "key": "r" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "r"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_E"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CONFIRM",
     "name": "Confirm choice",
-    "bindings": [ { "input_method": "keyboard_any", "key": "RETURN" }, { "input_method": "keyboard_any", "key": "KEYPAD_ENTER" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "RETURN"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "KEYPAD_ENTER"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CONFIRM_MULTIPLE",
     "name": "Confirm and continue",
-    "bindings": [ { "input_method": "keyboard_any", "key": "SPACE" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "SPACE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SAVE_DEFAULT_MODS",
     "category": "MODMANAGER_DIALOG",
     "name": "Save mods as default",
-    "bindings": [ { "input_method": "keyboard_any", "key": "s" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "s"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "VIEW_MOD_DESCRIPTION",
     "category": "MODMANAGER_DIALOG",
     "name": "View full mod description",
-    "bindings": [ { "input_method": "keyboard_any", "key": "v" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "v"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -934,9 +2085,18 @@
     "category": "MODMANAGER_DIALOG",
     "name": "Move selected mod down",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "=" },
-      { "input_method": "keyboard_char", "key": "+" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" }
+      {
+        "input_method": "keyboard_any",
+        "key": "="
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "+"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_PLUS"
+      }
     ]
   },
   {
@@ -944,21 +2104,54 @@
     "id": "MOVE_MOD_UP",
     "category": "MODMANAGER_DIALOG",
     "name": "Move selected mod up",
-    "bindings": [ { "input_method": "keyboard_any", "key": "-" }, { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "-"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MINUS"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "NEXT_CATEGORY_TAB",
     "category": "MODMANAGER_DIALOG",
     "name": "Move to next category tab",
-    "bindings": [ { "input_method": "keyboard_char", "key": ">" }, { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": ">"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ".",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "PREV_CATEGORY_TAB",
     "category": "MODMANAGER_DIALOG",
     "name": "Move to previous category tab",
-    "bindings": [ { "input_method": "keyboard_char", "key": "<" }, { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "<"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ",",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -966,12 +2159,33 @@
     "category": "MODMANAGER_DIALOG",
     "name": "Quit",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "ESC" },
-      { "input_method": "keyboard_any", "key": "q" },
-      { "input_method": "keyboard_char", "key": "Q" },
-      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "SPACE" },
-      { "input_method": "mouse", "key": "MOUSE_RIGHT" }
+      {
+        "input_method": "keyboard_any",
+        "key": "ESC"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "q"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "Q"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "q",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "SPACE"
+      },
+      {
+        "input_method": "mouse",
+        "key": "MOUSE_RIGHT"
+      }
     ]
   },
   {
@@ -980,12 +2194,33 @@
     "category": "OPTIONS",
     "name": "Quit",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "ESC" },
-      { "input_method": "keyboard_any", "key": "q" },
-      { "input_method": "keyboard_char", "key": "Q" },
-      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "SPACE" },
-      { "input_method": "mouse", "key": "MOUSE_RIGHT" }
+      {
+        "input_method": "keyboard_any",
+        "key": "ESC"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "q"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "Q"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "q",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "SPACE"
+      },
+      {
+        "input_method": "mouse",
+        "key": "MOUSE_RIGHT"
+      }
     ]
   },
   {
@@ -994,9 +2229,21 @@
     "category": "STRING_INPUT",
     "name": "Pick random world name",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "*" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
-      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_char",
+        "key": "*"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MULTIPLY"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "8",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -1005,9 +2252,21 @@
     "category": "WORLDGEN_CONFIRM_DIALOG",
     "name": "Pick random world name",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "*" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
-      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_char",
+        "key": "*"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MULTIPLY"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "8",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -1017,12 +2276,33 @@
     "category": "WORLDGEN_CONFIRM_DIALOG",
     "name": "Exit worldgen screen",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "ESC" },
-      { "input_method": "keyboard_any", "key": "q" },
-      { "input_method": "keyboard_char", "key": "Q" },
-      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "SPACE" },
-      { "input_method": "mouse", "key": "MOUSE_RIGHT" }
+      {
+        "input_method": "keyboard_any",
+        "key": "ESC"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "q"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "Q"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "q",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "SPACE"
+      },
+      {
+        "input_method": "mouse",
+        "key": "MOUSE_RIGHT"
+      }
     ]
   },
   {
@@ -1031,9 +2311,21 @@
     "category": "WORLDGEN_CONFIRM_DIALOG",
     "name": "View mod manager",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "m" },
-      { "input_method": "keyboard_char", "key": "M" },
-      { "input_method": "keyboard_code", "key": "m", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "m"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "M"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "m",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -1042,9 +2334,21 @@
     "category": "WORLDGEN_CONFIRM_DIALOG",
     "name": "View advanced world settings",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "s" },
-      { "input_method": "keyboard_char", "key": "S" },
-      { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "s"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "S"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "s",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -1053,9 +2357,21 @@
     "category": "WORLDGEN_CONFIRM_DIALOG",
     "name": "Finalize world creation",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "f" },
-      { "input_method": "keyboard_char", "key": "F" },
-      { "input_method": "keyboard_code", "key": "f", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "f"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "F"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "f",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -1064,9 +2380,21 @@
     "category": "WORLDGEN_CONFIRM_DIALOG",
     "name": "Randomize world settings",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "a" },
-      { "input_method": "keyboard_char", "key": "A" },
-      { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "a"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "A"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "a",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -1075,9 +2403,21 @@
     "category": "WORLDGEN_CONFIRM_DIALOG",
     "name": "Reset world settings and mods",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "r" },
-      { "input_method": "keyboard_char", "key": "R" },
-      { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "r"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "R"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "r",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -1086,12 +2426,33 @@
     "category": "DISPLAY_HELP",
     "name": "Quit",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "ESC" },
-      { "input_method": "keyboard_any", "key": "q" },
-      { "input_method": "keyboard_char", "key": "Q" },
-      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "SPACE" },
-      { "input_method": "mouse", "key": "MOUSE_RIGHT" }
+      {
+        "input_method": "keyboard_any",
+        "key": "ESC"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "q"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "Q"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "q",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "SPACE"
+      },
+      {
+        "input_method": "mouse",
+        "key": "MOUSE_RIGHT"
+      }
     ]
   },
   {
@@ -1100,12 +2461,33 @@
     "category": "SCROLLABLE_TEXT",
     "name": "Quit",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "ESC" },
-      { "input_method": "keyboard_any", "key": "q" },
-      { "input_method": "keyboard_char", "key": "Q" },
-      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "SPACE" },
-      { "input_method": "mouse", "key": "MOUSE_RIGHT" }
+      {
+        "input_method": "keyboard_any",
+        "key": "ESC"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "q"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "Q"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "q",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "SPACE"
+      },
+      {
+        "input_method": "mouse",
+        "key": "MOUSE_RIGHT"
+      }
     ]
   },
   {
@@ -1113,223 +2495,528 @@
     "id": "DELETE_NOTE",
     "category": "OVERMAP_NOTES",
     "name": "Delete note",
-    "bindings": [ { "input_method": "keyboard_char", "key": "D" }, { "input_method": "keyboard_code", "key": "d", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "D"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "d",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "EDIT_NOTE",
     "category": "OVERMAP_NOTES",
     "name": "Edit note",
-    "bindings": [ { "input_method": "keyboard_char", "key": "E" }, { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "E"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "e",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "MARK_DANGER",
     "category": "OVERMAP_NOTES",
     "name": "Mark danger",
-    "bindings": [ { "input_method": "keyboard_char", "key": "R" }, { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "R"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "r",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "look",
     "category": "OVERMAP",
     "name": "Look around",
-    "bindings": [ { "input_method": "keyboard_any", "key": ";" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": ";"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "DELETE_NOTE",
     "category": "OVERMAP",
     "name": "Delete note",
-    "bindings": [ { "input_method": "keyboard_char", "key": "D" }, { "input_method": "keyboard_code", "key": "d", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "D"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "d",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CREATE_NOTE",
     "category": "OVERMAP",
     "name": "Create/edit note",
-    "bindings": [ { "input_method": "keyboard_char", "key": "N" }, { "input_method": "keyboard_code", "key": "n", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "N"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "n",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "MARK_DANGER",
     "category": "OVERMAP",
     "name": "Mark danger",
-    "bindings": [ { "input_method": "keyboard_char", "key": "R" }, { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "R"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "r",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "LIST_NOTES",
     "category": "OVERMAP",
     "name": "List notes",
-    "bindings": [ { "input_method": "keyboard_char", "key": "L" }, { "input_method": "keyboard_code", "key": "l", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "L"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "l",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_BLINKING",
     "category": "OVERMAP",
     "name": "Toggle blinking",
-    "bindings": [ { "input_method": "keyboard_char", "key": "B" }, { "input_method": "keyboard_code", "key": "b", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "B"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "b",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_OVERLAYS",
     "category": "OVERMAP",
     "name": "Toggle overlays",
-    "bindings": [ { "input_method": "keyboard_char", "key": "O" }, { "input_method": "keyboard_code", "key": "o", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "O"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "o",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_LAND_USE_CODES",
     "category": "OVERMAP",
     "name": "Toggle land use codes",
-    "bindings": [ { "input_method": "keyboard_char", "key": "A" }, { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "A"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "a",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_MAP_NOTES",
     "category": "OVERMAP",
     "name": "Toggle map notes",
-    "bindings": [ { "input_method": "keyboard_char", "key": "G" }, { "input_method": "keyboard_code", "key": "g", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "G"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "g",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_CITY_LABELS",
     "category": "OVERMAP",
     "name": "Toggle city labels",
-    "bindings": [ { "input_method": "keyboard_char", "key": "C" }, { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "C"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "c",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_MAP_REVEALS",
     "category": "OVERMAP",
     "name": "Toggle highlighting map reveals",
-    "bindings": [ { "input_method": "keyboard_char", "key": "V" }, { "input_method": "keyboard_code", "key": "v", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "V"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "v",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_HORDES",
     "category": "OVERMAP",
     "name": "Toggle hordes",
-    "bindings": [ { "input_method": "keyboard_char", "key": "H" }, { "input_method": "keyboard_code", "key": "h", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "H"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "h",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_OVERMAP_WEATHER",
     "category": "OVERMAP",
     "name": "Toggle visible weather",
-    "bindings": [ { "input_method": "keyboard_any", "key": "w" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "w"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_FOREST_TRAILS",
     "category": "OVERMAP",
     "name": "Toggle forest trails",
-    "bindings": [ { "input_method": "keyboard_char", "key": "T" }, { "input_method": "keyboard_code", "key": "t", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "T"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "t",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_FAST_TRAVEL",
     "category": "OVERMAP",
     "name": "Toggle fast travel",
-    "bindings": [ { "input_method": "keyboard_char", "key": "x" }, { "input_method": "keyboard_code", "key": "x", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "x"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "x",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "COLLAPSE_OVERMAP_SIDEBAR_HEADERS",
     "category": "OVERMAP",
     "name": "Collapse all overmap sidebar headers",
-    "bindings": [ { "input_method": "keyboard_char", "key": "{" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "{"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "EXPAND_OVERMAP_SIDEBAR_HEADERS",
     "category": "OVERMAP",
     "name": "Expand all overmap sidebar headers",
-    "bindings": [ { "input_method": "keyboard_char", "key": "}" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "}"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_EXPLORED",
     "category": "OVERMAP",
     "name": "Toggle explored",
-    "bindings": [ { "input_method": "keyboard_char", "key": "E" }, { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "E"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "e",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "PLACE_TERRAIN",
     "category": "OVERMAP",
     "name": "Place overmap terrain",
-    "bindings": [ { "input_method": "keyboard_any", "key": "t" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "t"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "PLACE_SPECIAL",
     "category": "OVERMAP",
     "name": "Place overmap special",
-    "bindings": [ { "input_method": "keyboard_any", "key": "s" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "s"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SET_SPECIAL_ARGS",
     "category": "OVERMAP",
     "name": "Set overmap special arguments",
-    "bindings": [ { "input_method": "keyboard_any", "key": "a" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "a"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "LONG_TELEPORT",
     "category": "OVERMAP",
     "name": "Teleport to cursor",
-    "bindings": [ { "input_method": "keyboard_any", "key": "d" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "d"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "REVEAL_MAP",
     "category": "OVERMAP",
     "name": "Reveal map",
-    "bindings": [ { "input_method": "keyboard_any", "key": "r" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "r"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "MODIFY_HORDE",
     "category": "OVERMAP",
     "name": "Modify existing horde or place new one",
-    "bindings": [ { "input_method": "keyboard_any", "key": "p" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "p"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "PRINT_NOISE_MAPS",
     "category": "OVERMAP",
     "name": "Print noise maps",
-    "bindings": [ { "input_method": "keyboard_any", "key": "," } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": ","
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "View missions",
     "category": "OVERMAP",
     "id": "MISSIONS",
-    "bindings": [ { "input_method": "keyboard_char", "key": "M" }, { "input_method": "keyboard_code", "key": "m", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "M"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "m",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Define Point of Interest",
     "category": "OVERMAP",
     "id": "CREATE_POINT_OF_INTEREST",
-    "bindings": [ { "input_method": "keyboard_char", "key": "P" }, { "input_method": "keyboard_code", "key": "p", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "P"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "p",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "ROTATE",
     "category": "OVERMAP_EDITOR",
     "name": "Rotate",
-    "bindings": [ { "input_method": "keyboard_any", "key": "r" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "r"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SEARCH",
     "name": "Search",
-    "bindings": [ { "input_method": "keyboard_any", "key": "/" }, { "input_method": "keyboard_code", "key": "KEYPAD_DIVIDE" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "/"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_DIVIDE"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -1337,12 +3024,33 @@
     "name": "Close map",
     "category": "OVERMAP",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "m" },
-      { "input_method": "keyboard_any", "key": "ESC" },
-      { "input_method": "keyboard_any", "key": "q" },
-      { "input_method": "keyboard_char", "key": "Q" },
-      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "SPACE" }
+      {
+        "input_method": "keyboard_any",
+        "key": "m"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "ESC"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "q"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "Q"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "q",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "SPACE"
+      }
     ]
   },
   {
@@ -1350,30 +3058,70 @@
     "id": "QUIT",
     "name": "Exit screen",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "ESC" },
-      { "input_method": "keyboard_any", "key": "q" },
-      { "input_method": "keyboard_char", "key": "Q" },
-      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "SPACE" }
+      {
+        "input_method": "keyboard_any",
+        "key": "ESC"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "q"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "Q"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "q",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "SPACE"
+      }
     ]
   },
   {
     "type": "keybinding",
     "id": "CHOOSE_DESTINATION",
     "name": "Choose destination",
-    "bindings": [ { "input_method": "keyboard_char", "key": "W" }, { "input_method": "keyboard_code", "key": "w", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "W"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "w",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "GO_TO_DESTINATION",
     "name": "Go to destination",
-    "bindings": [ { "input_method": "keyboard_any", "key": "g" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "g"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CENTER_ON_DESTINATION",
     "name": "Center on destination",
-    "bindings": [ { "input_method": "keyboard_any", "key": "c" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "c"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -1381,10 +3129,22 @@
     "category": "TARGET",
     "name": "Fire weapon",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "f" },
-      { "input_method": "keyboard_any", "key": "RETURN" },
-      { "input_method": "keyboard_any", "key": "KEYPAD_ENTER" },
-      { "input_method": "mouse", "key": "MOUSE_RIGHT" }
+      {
+        "input_method": "keyboard_any",
+        "key": "f"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "RETURN"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "KEYPAD_ENTER"
+      },
+      {
+        "input_method": "mouse",
+        "key": "MOUSE_RIGHT"
+      }
     ]
   },
   {
@@ -1393,11 +3153,29 @@
     "category": "TARGET",
     "name": "Previous target",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "BACKTAB" },
-      { "input_method": "keyboard_code", "key": "TAB", "mod": [ "shift" ] },
-      { "input_method": "mouse", "key": "SCROLL_UP" },
-      { "input_method": "keyboard_any", "key": "PPAGE" },
-      { "input_method": "gamepad", "key": "JOY_LB" }
+      {
+        "input_method": "keyboard_char",
+        "key": "BACKTAB"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "TAB",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "mouse",
+        "key": "SCROLL_UP"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "PPAGE"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_LB"
+      }
     ]
   },
   {
@@ -1406,10 +3184,22 @@
     "category": "TARGET",
     "name": "Next target",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "TAB" },
-      { "input_method": "mouse", "key": "SCROLL_DOWN" },
-      { "input_method": "keyboard_any", "key": "NPAGE" },
-      { "input_method": "gamepad", "key": "JOY_RB" }
+      {
+        "input_method": "keyboard_any",
+        "key": "TAB"
+      },
+      {
+        "input_method": "mouse",
+        "key": "SCROLL_DOWN"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "NPAGE"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RB"
+      }
     ]
   },
   {
@@ -1418,11 +3208,26 @@
     "category": "TARGET",
     "name": "Aim",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "." },
-      { "input_method": "keyboard_code", "key": "KEYPAD_PERIOD" },
-      { "input_method": "keyboard_any", "key": "5" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_5" },
-      { "input_method": "gamepad", "key": "JOY_RT" }
+      {
+        "input_method": "keyboard_any",
+        "key": "."
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_PERIOD"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "5"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_5"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RT"
+      }
     ]
   },
   {
@@ -1430,35 +3235,76 @@
     "id": "STOPAIM",
     "category": "TARGET",
     "name": "Stop Aiming",
-    "bindings": [ { "input_method": "keyboard_any", "key": "," } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": ","
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "AIMED_SHOT",
     "category": "TARGET",
     "name": "Aimed shot",
-    "bindings": [ { "input_method": "keyboard_any", "key": "a" }, { "input_method": "gamepad", "key": "JOY_ALT_A" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "a"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CAREFUL_SHOT",
     "category": "TARGET",
     "name": "Careful shot",
-    "bindings": [ { "input_method": "keyboard_any", "key": "c" }, { "input_method": "gamepad", "key": "JOY_X" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "c"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "PRECISE_SHOT",
     "category": "TARGET",
     "name": "Precise shot",
-    "bindings": [ { "input_method": "keyboard_any", "key": "p" }, { "input_method": "gamepad", "key": "JOY_ALT_X" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "p"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_E"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SWITCH_AMMO",
     "category": "TARGET",
     "name": "Switch ammo",
-    "bindings": [ { "input_method": "keyboard_any", "key": "o" }, { "input_method": "gamepad", "key": "JOY_ALT_LB" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "o"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SE"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -1466,10 +3312,25 @@
     "category": "TARGET",
     "name": "Switch firing modes",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "s" },
-      { "input_method": "keyboard_char", "key": "F" },
-      { "input_method": "keyboard_code", "key": "f", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_Y" }
+      {
+        "input_method": "keyboard_any",
+        "key": "s"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "F"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "f",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_S"
+      }
     ]
   },
   {
@@ -1477,14 +3338,28 @@
     "id": "TOGGLE_TURRET_LINES",
     "category": "TARGET",
     "name": "Toggle turret lines",
-    "bindings": [ { "input_method": "keyboard_any", "key": "t" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "t"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_UNLOAD_RAS_WEAPON",
     "category": "TARGET",
     "name": "Whether to unload your bow etc after canceling a shot",
-    "bindings": [ { "input_method": "keyboard_any", "key": "-" }, { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "-"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MINUS"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -1492,9 +3367,25 @@
     "category": "TARGET",
     "name": "Toggle snap-to-target",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "*" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
-      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_char",
+        "key": "*"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MULTIPLY"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "8",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_S"
+      }
     ]
   },
   {
@@ -1502,31 +3393,60 @@
     "id": "TOGGLE_MOVE_CURSOR_VIEW",
     "category": "TARGET",
     "name": "Toggle shift view / move cursor",
-    "bindings": [ { "input_method": "keyboard_any", "key": "v" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "v"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SW"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SELECT",
     "name": "Select with mouse",
-    "bindings": [ { "input_method": "mouse", "key": "MOUSE_LEFT" } ]
+    "bindings": [
+      {
+        "input_method": "mouse",
+        "key": "MOUSE_LEFT"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CLICK_AND_DRAG",
     "name": "Click and drag with mouse",
-    "bindings": [ { "input_method": "mouse", "key": "MOUSE_LEFT_PRESSED" } ]
+    "bindings": [
+      {
+        "input_method": "mouse",
+        "key": "MOUSE_LEFT_PRESSED"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SEC_SELECT",
     "name": "Secondary select",
-    "bindings": [ { "input_method": "mouse", "key": "MOUSE_RIGHT" } ]
+    "bindings": [
+      {
+        "input_method": "mouse",
+        "key": "MOUSE_RIGHT"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "MOUSE_MOVE",
     "name": "Mouse move",
-    "bindings": [ { "input_method": "mouse", "key": "MOUSE_MOVE" } ]
+    "bindings": [
+      {
+        "input_method": "mouse",
+        "key": "MOUSE_MOVE"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -1534,143 +3454,345 @@
     "category": "PICK_WORLD_DIALOG",
     "name": "Quit",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "ESC" },
-      { "input_method": "keyboard_any", "key": "q" },
-      { "input_method": "keyboard_char", "key": "Q" },
-      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "SPACE" },
-      { "input_method": "mouse", "key": "MOUSE_RIGHT" }
+      {
+        "input_method": "keyboard_any",
+        "key": "ESC"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "q"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "Q"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "q",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "SPACE"
+      },
+      {
+        "input_method": "mouse",
+        "key": "MOUSE_RIGHT"
+      }
     ]
   },
   {
     "type": "keybinding",
     "id": "NEXT_TAB",
     "name": "Go to next tab",
-    "bindings": [ { "input_method": "keyboard_any", "key": "TAB" }, { "input_method": "gamepad", "key": "JOY_RB" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "TAB"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RB"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "PREV_TAB",
     "name": "Go to previous tab",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "BACKTAB" },
-      { "input_method": "keyboard_code", "key": "TAB", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_LB" }
+      {
+        "input_method": "keyboard_char",
+        "key": "BACKTAB"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "TAB",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_LB"
+      }
     ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_FAST_SCROLL",
     "name": "Toggle fast scroll",
-    "bindings": [ { "input_method": "keyboard_any", "key": "f" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "f"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "EXTENDED_DESCRIPTION",
     "name": "Show extended description",
-    "bindings": [ { "input_method": "keyboard_any", "key": "e" }, { "input_method": "gamepad", "key": "JOY_RS" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "e"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RS"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CHANGE_MONSTER_NAME",
     "name": "Change monster name",
-    "bindings": [ { "input_method": "keyboard_any", "key": "c" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "c"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TRAVEL_TO",
     "name": "Travel to destination",
-    "bindings": [ { "input_method": "keyboard_char", "key": "T" }, { "input_method": "keyboard_code", "key": "t", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "T"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "t",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CENTER",
     "name": "Center on character",
-    "bindings": [ { "input_method": "keyboard_any", "key": "0" }, { "input_method": "keyboard_code", "key": "KEYPAD_0" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "0"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_0"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "HELP",
     "category": "CARAVAN",
     "name": "Display help",
-    "bindings": [ { "input_method": "keyboard_any", "key": "0" }, { "input_method": "keyboard_code", "key": "KEYPAD_0" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "0"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_0"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CHANGE_GENDER",
     "name": "Change gender",
-    "bindings": [ { "input_method": "keyboard_char", "key": "@" }, { "input_method": "keyboard_code", "key": "2", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "@"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "2",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CHANGE_OUTFIT",
     "name": "Change outfit",
-    "bindings": [ { "input_method": "keyboard_char", "key": "$" }, { "input_method": "keyboard_code", "key": "4", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "$"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "4",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SWITCH_GENDER",
     "name": "Customize character",
-    "bindings": [ { "input_method": "keyboard_any", "key": "y" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "y"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "MEDICAL_MENU",
     "name": "Open medical menu",
-    "bindings": [ 
-      { "input_method": "keyboard_char", "key": "@" }, 
-      { "input_method": "keyboard_code", "key": "2", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_R_NE" }
-     ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "@"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "2",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_NE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SAVE_TEMPLATE",
     "category": "DEFENSE_SETUP",
     "name": "Save template",
-    "bindings": [ { "input_method": "keyboard_char", "key": "!" }, { "input_method": "keyboard_code", "key": "1", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "!"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "1",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "START",
     "category": "DEFENSE_SETUP",
     "name": "Start",
-    "bindings": [ { "input_method": "keyboard_char", "key": "S" }, { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "S"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "s",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "DELETE_TEMPLATE",
     "category": "MAIN_MENU",
     "name": "Delete template",
-    "bindings": [ { "input_method": "keyboard_any", "key": "d" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "d"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SAVE_TEMPLATE",
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Save template",
-    "bindings": [ { "input_method": "keyboard_char", "key": "!" }, { "input_method": "keyboard_code", "key": "1", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "!"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "1",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "REROLL_CHARACTER",
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Reroll random character",
-    "bindings": [ { "input_method": "keyboard_char", "key": "%" }, { "input_method": "keyboard_code", "key": "5", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "%"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "5",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "REROLL_CHARACTER_WITH_SCENARIO",
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Reroll random character with scenario",
-    "bindings": [ { "input_method": "keyboard_char", "key": "^" }, { "input_method": "keyboard_code", "key": "6", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "^"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "6",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "RANDOMIZE_CHAR_NAME",
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Pick random character name",
-    "bindings": [ { "input_method": "keyboard_any", "key": "n" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "n"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -1678,9 +3800,21 @@
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Pick random character description",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "*" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
-      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_char",
+        "key": "*"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MULTIPLY"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "8",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -1688,35 +3822,92 @@
     "id": "CHANGE_START_OF_CATACLYSM",
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Change Cataclysm start date",
-    "bindings": [ { "input_method": "keyboard_char", "key": "#" }, { "input_method": "keyboard_code", "key": "3", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "#"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "3",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CHANGE_START_OF_GAME",
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Change game start date",
-    "bindings": [ { "input_method": "keyboard_char", "key": "&" }, { "input_method": "keyboard_code", "key": "7", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "&"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "7",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "RESET_CALENDAR",
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Reset scenario calendar",
-    "bindings": [ { "input_method": "keyboard_char", "key": "~" }, { "input_method": "keyboard_code", "key": "`", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "~"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "`",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CHOOSE_CITY",
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Choose character starting city",
-    "bindings": [ { "input_method": "keyboard_char", "key": "C" }, { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "C"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "c",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CHOOSE_LOCATION",
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Choose character starting location",
-    "bindings": [ { "input_method": "keyboard_any", "key": "/" }, { "input_method": "keyboard_code", "key": "KEYPAD_DIVIDE" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "/"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_DIVIDE"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -1724,14 +3915,24 @@
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Exit new character screen",
     "//": "separate entry, because the global entry also has 'q' and 'Q' listed, which conflicts with the character name entry feature of this dialog",
-    "bindings": [ { "input_method": "keyboard_any", "key": "ESC" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "ESC"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SORT",
     "category": "NEW_CHAR_PROFESSIONS",
     "name": "Toggle sorting order",
-    "bindings": [ { "input_method": "keyboard_any", "key": "s" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "s"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -1739,9 +3940,21 @@
     "category": "NEW_CHAR_PROFESSIONS",
     "name": "Randomize profession",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "*" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
-      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_char",
+        "key": "*"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MULTIPLY"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "8",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -1750,9 +3963,21 @@
     "category": "NEW_CHAR_TRAITS",
     "name": "Randomize trait",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "*" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
-      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_char",
+        "key": "*"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MULTIPLY"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "8",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -1761,9 +3986,21 @@
     "category": "NEW_CHAR_SCENARIOS",
     "name": "Randomize scenario",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "*" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
-      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_char",
+        "key": "*"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MULTIPLY"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "8",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -1771,201 +4008,481 @@
     "id": "SORT",
     "category": "NEW_CHAR_SCENARIOS",
     "name": "Toggle sorting order",
-    "bindings": [ { "input_method": "keyboard_any", "key": "s" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "s"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CHANGE_START_OF_CATACLYSM",
     "category": "NEW_CHAR_SCENARIOS",
     "name": "Change cataclysm start date",
-    "bindings": [ { "input_method": "keyboard_char", "key": "#" }, { "input_method": "keyboard_code", "key": "3", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "#"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "3",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CHANGE_START_OF_GAME",
     "category": "NEW_CHAR_SCENARIOS",
     "name": "Change game start date",
-    "bindings": [ { "input_method": "keyboard_char", "key": "&" }, { "input_method": "keyboard_code", "key": "7", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "&"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "7",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "RESET_CALENDAR",
     "category": "NEW_CHAR_SCENARIOS",
     "name": "Reset scenario calendar",
-    "bindings": [ { "input_method": "keyboard_char", "key": "~" }, { "input_method": "keyboard_code", "key": "`", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "~"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "`",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_SKILL_INFO_UP",
     "category": "NEW_CHAR_SKILLS",
     "name": "Scroll description up",
-    "bindings": [ { "input_method": "keyboard_char", "key": "<" }, { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "<"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ",",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_SKILL_INFO_DOWN",
     "category": "NEW_CHAR_SKILLS",
     "name": "Scroll description down",
-    "bindings": [ { "input_method": "keyboard_char", "key": ">" }, { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": ">"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ".",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_INFOBOX_UP",
     "name": "Scroll description up",
-    "bindings": [ { "input_method": "keyboard_char", "key": "<" }, { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "<"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ",",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_INFOBOX_DOWN",
     "name": "Scroll description down",
-    "bindings": [ { "input_method": "keyboard_char", "key": ">" }, { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": ">"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ".",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "PREV_CATEGORY",
     "category": "PROFICIENCY_WINDOW",
     "name": "Previous proficiency category",
-    "bindings": [ { "input_method": "keyboard_char", "key": "<" }, { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "<"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ",",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "NEXT_CATEGORY",
     "category": "PROFICIENCY_WINDOW",
     "name": "Next proficiency category",
-    "bindings": [ { "input_method": "keyboard_char", "key": ">" }, { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": ">"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ".",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "REFILL",
     "category": "APP_INTERACT",
     "name": "Refill tank/battery",
-    "bindings": [ { "input_method": "keyboard_any", "key": "f" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "f"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SIPHON",
     "category": "APP_INTERACT",
     "name": "Siphon from tank",
-    "bindings": [ { "input_method": "keyboard_any", "key": "s" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "s"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "RENAME",
     "category": "APP_INTERACT",
     "name": "Rename appliance",
-    "bindings": [ { "input_method": "keyboard_any", "key": "e" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "e"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_E"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "REMOVE",
     "category": "APP_INTERACT",
     "name": "Take down appliance",
-    "bindings": [ { "input_method": "keyboard_any", "key": "r" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "r"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "PLUG",
     "category": "APP_INTERACT",
     "name": "Plug in appliance",
-    "bindings": [ { "input_method": "keyboard_any", "key": "g" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "g"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_S"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "DISCONNECT_GRID",
     "category": "APP_INTERACT",
     "name": "Separate from power grid",
-    "bindings": [ { "input_method": "keyboard_any", "key": "c" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "c"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SW"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "INSTALL",
     "category": "VEH_INTERACT",
     "name": "Install part",
-    "bindings": [ { "input_method": "keyboard_any", "key": "i" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "i"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "REPAIR",
     "category": "VEH_INTERACT",
     "name": "Repair part",
-    "bindings": [ { "input_method": "keyboard_any", "key": "r" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "r"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "MEND",
     "category": "VEH_INTERACT",
     "name": "Mend part",
-    "bindings": [ { "input_method": "keyboard_any", "key": "m" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "m"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_E"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "REFILL",
     "category": "VEH_INTERACT",
     "name": "Refill tank/battery",
-    "bindings": [ { "input_method": "keyboard_any", "key": "f" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "f"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "UNLOAD",
     "category": "VEH_INTERACT",
     "name": "Unload fuel bunker",
-    "bindings": [ { "input_method": "keyboard_any", "key": "d" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "d"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_S"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "REMOVE",
     "category": "VEH_INTERACT",
     "name": "Remove part",
-    "bindings": [ { "input_method": "keyboard_any", "key": "o" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "o"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SW"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "RENAME",
     "category": "VEH_INTERACT",
     "name": "Rename vehicle",
-    "bindings": [ { "input_method": "keyboard_any", "key": "e" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "e"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_N"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SIPHON",
     "category": "VEH_INTERACT",
     "name": "Siphon from tank",
-    "bindings": [ { "input_method": "keyboard_any", "key": "s" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "s"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_W"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TIRE_CHANGE",
     "category": "VEH_INTERACT",
     "name": "Change tire",
-    "bindings": [ { "input_method": "keyboard_any", "key": "c" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "c"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NW"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CHANGE_SHAPE",
     "category": "VEH_INTERACT",
     "name": "Change part shape",
-    "bindings": [ { "input_method": "keyboard_any", "key": "p" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "p"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_NE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "ASSIGN_CREW",
     "category": "VEH_INTERACT",
     "name": "Assign crew",
-    "bindings": [ { "input_method": "keyboard_any", "key": "w" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "w"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_E"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "RELABEL",
     "category": "VEH_INTERACT",
     "name": "Relabel a portion of a vehicle",
-    "bindings": [ { "input_method": "keyboard_any", "key": "a" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "a"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_SE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "NEXT_TAB",
     "category": "VEH_INTERACT",
     "name": "Go to next tab",
-    "bindings": [ { "input_method": "keyboard_any", "key": "TAB" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "TAB"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -1973,8 +4490,17 @@
     "category": "VEH_INTERACT",
     "name": "Go to previous tab",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "BACKTAB" },
-      { "input_method": "keyboard_code", "key": "TAB", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_char",
+        "key": "BACKTAB"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "TAB",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -1982,69 +4508,197 @@
     "id": "FUEL_LIST_UP",
     "category": "VEH_INTERACT",
     "name": "Scroll up through fuel list",
-    "bindings": [ { "input_method": "keyboard_any", "key": "[" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "["
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_DPAD_UP"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "FUEL_LIST_DOWN",
     "category": "VEH_INTERACT",
     "name": "Scroll down through fuel list",
-    "bindings": [ { "input_method": "keyboard_any", "key": "]" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "]"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_DPAD_DOWN"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "DESC_LIST_UP",
     "category": "VEH_INTERACT",
     "name": "Scroll up through vehicle part descriptions",
-    "bindings": [ { "input_method": "keyboard_char", "key": "<" }, { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "<"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ",",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_DPAD_UP"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "DESC_LIST_DOWN",
     "category": "VEH_INTERACT",
     "name": "Scroll down through vehicle part descriptions",
-    "bindings": [ { "input_method": "keyboard_char", "key": ">" }, { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": ">"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ".",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_DPAD_DOWN"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "OVERVIEW_UP",
     "category": "VEH_INTERACT",
     "name": "Scroll up through vehicle overview",
-    "bindings": [ { "input_method": "keyboard_char", "key": "{" }, { "input_method": "keyboard_code", "key": "[", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "{"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "[",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_DPAD_UP"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "OVERVIEW_DOWN",
     "category": "VEH_INTERACT",
     "name": "Scroll down through vehicle overview",
-    "bindings": [ { "input_method": "keyboard_char", "key": "}" }, { "input_method": "keyboard_code", "key": "]", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "}"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "]",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_DPAD_DOWN"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_UNAVAILABLE_CONSTRUCTIONS",
     "category": "CONSTRUCTION",
     "name": "Toggle unavailable constructions",
-    "bindings": [ { "input_method": "keyboard_any", "key": ";" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": ";"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_STAGE_UP",
     "category": "CONSTRUCTION",
     "name": "Scroll to previous stage",
-    "bindings": [ { "input_method": "keyboard_char", "key": "<" }, { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "<"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ",",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_DPAD_DOWN"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_STAGE_DOWN",
     "category": "CONSTRUCTION",
     "name": "Scroll to next stage",
-    "bindings": [ { "input_method": "keyboard_char", "key": ">" }, { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": ">"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ".",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_DPAD_UP"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "EDITMAP_SHOW_ALL",
     "name": "Show all",
-    "bindings": [ { "input_method": "keyboard_any", "key": "v" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "v"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -2052,9 +4706,18 @@
     "category": "EDITMAP_FEATURE",
     "name": "Confirm and quit",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "e" },
-      { "input_method": "keyboard_any", "key": "r" },
-      { "input_method": "keyboard_any", "key": "t" }
+      {
+        "input_method": "keyboard_any",
+        "key": "e"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "r"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "t"
+      }
     ]
   },
   {
@@ -2062,191 +4725,390 @@
     "id": "RESIZE",
     "category": "EDITMAP_SHAPE",
     "name": "Resize",
-    "bindings": [ { "input_method": "keyboard_any", "key": "s" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "s"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "START",
     "category": "EDITMAP_SHAPE",
     "name": "To start",
-    "bindings": [ { "input_method": "keyboard_any", "key": "z" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "z"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SWAP",
     "category": "EDITMAP_SHAPE",
     "name": "Swap origin and target",
-    "bindings": [ { "input_method": "keyboard_any", "key": "y" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "y"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "EDITMAP_MOVE",
     "name": "Move shape",
-    "bindings": [ { "input_method": "keyboard_any", "key": "m" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "m"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "EDITMAP_TOGGLE_POST_PROCESS_GENERATORS",
     "name": "Toggle post-process generators",
-    "bindings": [ { "input_method": "keyboard_any", "key": "p" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "p"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "EDITMAP_TAB",
     "name": "Switch to move point / confirm",
-    "bindings": [ { "input_method": "keyboard_any", "key": "TAB" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "TAB"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "EDIT_TRAPS",
     "category": "EDITMAP",
     "name": "Edit traps",
-    "bindings": [ { "input_method": "keyboard_any", "key": "t" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "t"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "EDIT_FIELDS",
     "category": "EDITMAP",
     "name": "Edit fields",
-    "bindings": [ { "input_method": "keyboard_any", "key": "f" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "f"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "EDIT_RADS",
     "category": "EDITMAP",
     "name": "Edit radiation",
-    "bindings": [ { "input_method": "keyboard_any", "key": "a" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "a"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "EDIT_TERRAIN",
     "category": "EDITMAP",
     "name": "Edit terrain",
-    "bindings": [ { "input_method": "keyboard_any", "key": "e" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "e"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "EDIT_FURNITURE",
     "category": "EDITMAP",
     "name": "Edit furniture",
-    "bindings": [ { "input_method": "keyboard_any", "key": "r" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "r"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "EDIT_OVERMAP",
     "category": "EDITMAP",
     "name": "Edit overmap/mapgen",
-    "bindings": [ { "input_method": "keyboard_any", "key": "o" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "o"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "EDIT_ITEMS",
     "category": "EDITMAP",
     "name": "Edit items",
-    "bindings": [ { "input_method": "keyboard_any", "key": "i" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "i"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "EDIT_MONSTER",
     "category": "EDITMAP",
     "name": "Edit creatures",
-    "bindings": [ { "input_method": "keyboard_any", "key": "m" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "m"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SHOW_ALL",
     "category": "EDITMAP",
     "name": "Show whole map",
-    "bindings": [ { "input_method": "keyboard_any", "key": "v" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "v"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "LEFT_WIDE",
     "name": "Wide move left",
-    "bindings": [ { "input_method": "keyboard_char", "key": "H" }, { "input_method": "keyboard_code", "key": "h", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "H"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "h",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "RIGHT_WIDE",
     "name": "Wide move right",
-    "bindings": [ { "input_method": "keyboard_char", "key": "L" }, { "input_method": "keyboard_code", "key": "l", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "L"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "l",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "UP_WIDE",
     "name": "Wide move up",
-    "bindings": [ { "input_method": "keyboard_char", "key": "K" }, { "input_method": "keyboard_code", "key": "k", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "K"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "k",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "DOWN_WIDE",
     "name": "Wide move down",
-    "bindings": [ { "input_method": "keyboard_char", "key": "J" }, { "input_method": "keyboard_code", "key": "j", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "J"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "j",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CATEGORY_SELECTION",
     "category": "INVENTORY",
     "name": "Toggle category selection mode",
-    "bindings": [ { "input_method": "keyboard_any", "key": "t" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "t"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "VIEW_CATEGORY_MODE",
     "name": "Toggle inventory view to show item categories",
-    "bindings": [ { "input_method": "keyboard_any", "key": ";" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": ";"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_NUMPAD_NAVIGATION",
     "name": "Toggle navigation with numpad numbers",
-    "bindings": [ { "input_method": "keyboard_any", "key": "F5" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "F5"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "INVENTORY_FILTER",
     "category": "INVENTORY",
     "name": "Set item filter",
-    "bindings": [ { "input_method": "keyboard_any", "key": "/" }, { "input_method": "keyboard_code", "key": "KEYPAD_DIVIDE" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "/"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_DIVIDE"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SW"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "EXAMINE",
     "category": "INVENTORY",
     "name": "Examine",
-    "bindings": [ { "input_method": "keyboard_any", "key": "e" }, { "input_method": "gamepad", "key": "JOY_RS" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "e"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "WIELD",
     "category": "INVENTORY",
     "name": "Wield",
-    "bindings": [ { "input_method": "keyboard_any", "key": "w" }, { "input_method": "gamepad", "key": "JOY_X" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "w"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_E"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "WEAR",
     "category": "INVENTORY",
     "name": "Wear",
-    "bindings": [ 
-      { "input_method": "keyboard_char", "key": "W" }, 
-      { "input_method": "keyboard_code", "key": "w", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_Y" }
-   ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "W"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "w",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_W"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "EXAMINE_CONTENTS",
     "category": "INVENTORY",
     "name": "Examine contents",
-    "bindings": [ { "input_method": "keyboard_any", "key": "o" }, { "input_method": "gamepad", "key": "JOY_Y" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "o"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "ORGANIZE_MENU",
     "category": "INVENTORY",
     "name": "Organize contents",
-    "bindings": [ { "input_method": "keyboard_any", "key": "i" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "i"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SE"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -2254,9 +5116,25 @@
     "category": "INVENTORY",
     "name": "Toggle item as favorite",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "*" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
-      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_char",
+        "key": "*"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MULTIPLY"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "8",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NW"
+      }
     ]
   },
   {
@@ -2264,7 +5142,23 @@
     "id": "SHOW_HIDE_CONTENTS",
     "category": "INVENTORY",
     "name": "Show/hide contents",
-    "bindings": [ { "input_method": "keyboard_char", "key": ">" }, { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": ">"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ".",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_S"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -2283,77 +5177,234 @@
     "id": "CONTAIN_MODE",
     "category": "INVENTORY",
     "name": "Toggle contain mode for unloaded items",
-    "bindings": [ { "input_method": "keyboard_char", "key": "U" }, { "input_method": "keyboard_code", "key": "u", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "U"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "u",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_EXAMINE",
     "category": "BIONICS",
     "name": "Toggle activate/examine",
-    "bindings": [ { "input_method": "keyboard_char", "key": "!" }, { "input_method": "keyboard_code", "key": "1", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "!"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "1",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_SAFE_FUEL",
     "category": "BIONICS",
     "name": "Toggle safe fuel mod",
-    "bindings": [ { "input_method": "keyboard_char", "key": "S" }, { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "S"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "s",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_SPRITE",
     "category": "BIONICS",
     "name": "Toggle sprite",
-    "bindings": [ { "input_method": "keyboard_char", "key": "H" }, { "input_method": "keyboard_code", "key": "h", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "H"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "h",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_E"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "REFUEL",
     "category": "BIONICS",
     "name": "Open refuel menu",
-    "bindings": [ { "input_method": "keyboard_char", "key": "R" }, { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "R"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "r",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_AUTO_START",
     "category": "BIONICS",
     "name": "Toggle auto start mod",
-    "bindings": [ { "input_method": "keyboard_char", "key": "A" }, { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "A"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "a",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_S"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SORT",
     "category": "BIONICS",
     "name": "Sort bionics list",
-    "bindings": [ { "input_method": "keyboard_any", "key": "s" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "s"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SW"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_EXAMINE",
     "category": "MUTATIONS",
     "name": "Toggle activate/examine",
-    "bindings": [ { "input_method": "keyboard_char", "key": "!" }, { "input_method": "keyboard_code", "key": "1", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "!"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "1",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_TRAIT_INFO_UP",
     "category": "MUTATIONS",
     "name": "Scroll mutation info up",
-    "bindings": [ { "input_method": "keyboard_char", "key": "<" }, { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "<"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ",",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_TRAIT_INFO_DOWN",
     "category": "MUTATIONS",
     "name": "Scroll mutation info down",
-    "bindings": [ { "input_method": "keyboard_char", "key": ">" }, { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": ">"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ".",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "APPLY",
     "category": "MEDICAL",
     "name": "Use item",
-    "bindings": [ { "input_method": "keyboard_char", "key": "A" }, { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "A"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "a",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -2361,11 +5412,26 @@
     "category": "DEFAULTMODE",
     "id": "pause",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "." },
-      { "input_method": "keyboard_code", "key": "KEYPAD_PERIOD" },
-      { "input_method": "keyboard_any", "key": "5" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_5" },
-      { "input_method": "gamepad", "key": "JOY_RT" }
+      {
+        "input_method": "keyboard_any",
+        "key": "."
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_PERIOD"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "5"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_5"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RT"
+      }
     ]
   },
   {
@@ -2384,70 +5450,119 @@
     "name": "Center view",
     "category": "DEFAULTMODE",
     "id": "center",
-    "bindings": [ ]
+    "bindings": []
   },
   {
     "type": "keybinding",
     "name": "Move view north",
     "category": "DEFAULTMODE",
     "id": "shift_n",
-    "bindings": [ { "input_method": "gamepad", "key": "JOY_R_UP" } ]
+    "bindings": [
+      {
+        "input_method": "gamepad",
+        "key": "JOY_R_UP"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Move view east",
     "category": "DEFAULTMODE",
     "id": "shift_e",
-    "bindings": [ { "input_method": "gamepad", "key": "JOY_R_RIGHT" } ]
+    "bindings": [
+      {
+        "input_method": "gamepad",
+        "key": "JOY_R_RIGHT"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Move view south",
     "category": "DEFAULTMODE",
     "id": "shift_s",
-    "bindings": [ { "input_method": "gamepad", "key": "JOY_R_DOWN" } ]
+    "bindings": [
+      {
+        "input_method": "gamepad",
+        "key": "JOY_R_DOWN"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Move view west",
     "category": "DEFAULTMODE",
     "id": "shift_w",
-    "bindings": [ { "input_method": "gamepad", "key": "JOY_R_LEFT" } ]
+    "bindings": [
+      {
+        "input_method": "gamepad",
+        "key": "JOY_R_LEFT"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Open door",
     "category": "DEFAULTMODE",
     "id": "open",
-    "bindings": [ { "input_method": "keyboard_any", "key": "o" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "o"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Close door",
     "category": "DEFAULTMODE",
     "id": "close",
-    "bindings": [ { "input_method": "keyboard_any", "key": "c" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "c"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Smash nearby terrain",
     "category": "DEFAULTMODE",
     "id": "smash",
-    "bindings": [ { "input_method": "keyboard_any", "key": "s" }, { "input_method": "gamepad", "key": "JOY_ALT_X" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "s"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_X"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Examine nearby terrain or furniture",
     "category": "DEFAULTMODE",
     "id": "examine",
-    "bindings": [ { "input_method": "keyboard_any", "key": "e" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "e"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Examine nearby terrain, furniture, and items",
     "category": "DEFAULTMODE",
     "id": "examine_and_pickup",
-    "bindings": [ { "input_method": "gamepad", "key": "JOY_X" } ]
+    "bindings": [
+      {
+        "input_method": "gamepad",
+        "key": "JOY_X"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -2455,9 +5570,18 @@
     "category": "DEFAULTMODE",
     "id": "advinv",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "/" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_DIVIDE" },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_R_SE" }
+      {
+        "input_method": "keyboard_any",
+        "key": "/"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_DIVIDE"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_SE"
+      }
     ]
   },
   {
@@ -2465,7 +5589,12 @@
     "name": "Pick up items from one nearby tile",
     "category": "DEFAULTMODE",
     "id": "pickup",
-    "bindings": [ { "input_method": "keyboard_any", "key": "g" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "g"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -2479,9 +5608,21 @@
     "category": "DEFAULTMODE",
     "id": "grab",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "G" },
-      { "input_method": "keyboard_code", "key": "g", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_B" }
+      {
+        "input_method": "keyboard_char",
+        "key": "G"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "g",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_B"
+      }
     ]
   },
   {
@@ -2489,7 +5630,16 @@
     "name": "Haul items along the ground",
     "category": "DEFAULTMODE",
     "id": "haul",
-    "bindings": [ { "input_method": "keyboard_any", "key": "\\" }, { "input_method": "gamepad", "key": "JOY_ALT_B" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "\\"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_B"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -2502,21 +5652,61 @@
     "name": "Zone activities",
     "category": "DEFAULTMODE",
     "id": "loot",
-    "bindings": [ { "input_method": "keyboard_char", "key": "O" }, { "input_method": "keyboard_code", "key": "o", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "O"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "o",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Butcher",
     "category": "DEFAULTMODE",
     "id": "butcher",
-    "bindings": [ { "input_method": "keyboard_char", "key": "B" }, { "input_method": "keyboard_code", "key": "b", "mod": [ "shift" ] }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_E" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "B"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "b",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_E"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Chat with NPC",
     "category": "DEFAULTMODE",
     "id": "chat",
-    "bindings": [ { "input_method": "keyboard_char", "key": "C" }, { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "C"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "c",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -2524,8 +5714,14 @@
     "category": "DEFAULTMODE",
     "id": "look",
     "bindings": [
-      { "input_method": "keyboard_any", "key": ";" },
-      { "input_method": "keyboard_any", "key": "x" }
+      {
+        "input_method": "keyboard_any",
+        "key": ";"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "x"
+      }
     ]
   },
   {
@@ -2539,17 +5735,45 @@
     "name": "Peek around corners",
     "category": "DEFAULTMODE",
     "id": "peek",
-    "bindings": [ { "input_method": "keyboard_char", "key": "X" }, { "input_method": "keyboard_code", "key": "x", "mod": [ "shift" ] }, { "input_method": "gamepad", "key": "JOY_ALT_RS" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "X"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "x",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_RS"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "List all items around the player",
     "category": "DEFAULTMODE",
     "id": "listitems",
-    "bindings": [ 
-      { "input_method": "keyboard_char", "key": "V" }, 
-      { "input_method": "keyboard_code", "key": "v", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RS" }
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "V"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "v",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RS"
+      }
     ]
   },
   {
@@ -2557,23 +5781,53 @@
     "name": "Zones manager",
     "category": "DEFAULTMODE",
     "id": "zones",
-    "bindings": [ { "input_method": "keyboard_char", "key": "Y" }, { "input_method": "keyboard_code", "key": "y", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "Y"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "y",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Open inventory",
     "category": "DEFAULTMODE",
     "id": "inventory",
-    "bindings": [ { "input_method": "keyboard_any", "key": "i" }, { "input_method": "gamepad", "key": "JOY_RADIAL_R_S" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "i"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_S"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Compare two items",
     "category": "DEFAULTMODE",
     "id": "compare",
-    "bindings": [ 
-      { "input_method": "keyboard_char", "key": "I" }, 
-      { "input_method": "keyboard_code", "key": "i", "mod": [ "shift" ] }
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "I"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "i",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -2581,24 +5835,46 @@
     "name": "Swap inventory letters",
     "category": "DEFAULTMODE",
     "id": "organize",
-    "bindings": [ { "input_method": "keyboard_any", "key": "=" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "="
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Use item",
     "category": "DEFAULTMODE",
     "id": "apply",
-    "bindings": [ { "input_method": "keyboard_any", "key": "a" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "a"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Use wielded item",
     "category": "DEFAULTMODE",
     "id": "apply_wielded",
-    "bindings": [ 
-      { "input_method": "keyboard_char", "key": "A" }, 
-      { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_RIGHT" }
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "A"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "a",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_DPAD_RIGHT"
+      }
     ]
   },
   {
@@ -2606,10 +5882,22 @@
     "name": "Wear item",
     "category": "DEFAULTMODE",
     "id": "wear",
-    "bindings": [ 
-      { "input_method": "keyboard_char", "key": "W" }, 
-      { "input_method": "keyboard_code", "key": "w", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_DPAD_LEFT" }
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "W"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "w",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_DPAD_LEFT"
+      }
     ]
   },
   {
@@ -2617,10 +5905,22 @@
     "name": "Take off worn item",
     "category": "DEFAULTMODE",
     "id": "take_off",
-    "bindings": [ 
-      { "input_method": "keyboard_char", "key": "T" }, 
-      { "input_method": "keyboard_code", "key": "t", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_LEFT" }
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "T"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "t",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_DPAD_LEFT"
+      }
     ]
   },
   {
@@ -2628,10 +5928,22 @@
     "name": "Consume item (all items)",
     "category": "DEFAULTMODE",
     "id": "eat",
-    "bindings": [ 
-      { "input_method": "keyboard_char", "key": "E" }, 
-      { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_DPAD_UP" }
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "E"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "e",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_DPAD_UP"
+      }
     ]
   },
   {
@@ -2645,10 +5957,22 @@
     "name": "Read",
     "category": "DEFAULTMODE",
     "id": "read",
-    "bindings": [ 
-      { "input_method": "keyboard_char", "key": "R" }, 
-      { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_NE" }
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "R"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "r",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NE"
+      }
     ]
   },
   {
@@ -2656,17 +5980,38 @@
     "name": "Wield",
     "category": "DEFAULTMODE",
     "id": "wield",
-    "bindings": [ { "input_method": "keyboard_any", "key": "w" }, { "input_method": "gamepad", "key": "JOY_DPAD_RIGHT" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "w"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_DPAD_RIGHT"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Select martial arts style",
     "category": "DEFAULTMODE",
     "id": "pick_style",
-    "bindings": [ 
-      { "input_method": "keyboard_char", "key": "_" }, 
-      { "input_method": "keyboard_code", "key": "-", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_ALT_RB" }
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "_"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "-",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_RB"
+      }
     ]
   },
   {
@@ -2686,21 +6031,47 @@
     "name": "Insert item",
     "category": "DEFAULTMODE",
     "id": "insert",
-    "bindings": [ { "input_method": "keyboard_any", "key": "v" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "v"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Unload item",
     "category": "DEFAULTMODE",
     "id": "unload",
-    "bindings": [ { "input_method": "keyboard_char", "key": "U" }, { "input_method": "keyboard_code", "key": "u", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "U"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "u",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Throw item",
     "category": "DEFAULTMODE",
     "id": "throw",
-    "bindings": [ { "input_method": "keyboard_any", "key": "t" }, { "input_method": "gamepad", "key": "JOY_Y" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "t"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_Y"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -2713,7 +6084,12 @@
     "name": "Blind throw item",
     "category": "LOOK",
     "id": "throw_blind",
-    "bindings": [ { "input_method": "keyboard_any", "key": "t" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "t"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -2726,28 +6102,63 @@
     "name": "Fire wielded item",
     "category": "DEFAULTMODE",
     "id": "fire",
-    "bindings": [ { "input_method": "keyboard_any", "key": "f" }, { "input_method": "gamepad", "key": "JOY_LB" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "f"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_LB"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Toggle attack mode of wielded item",
     "category": "DEFAULTMODE",
     "id": "select_fire_mode",
-    "bindings": [ { "input_method": "keyboard_char", "key": "F" }, { "input_method": "keyboard_code", "key": "f", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "F"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "f",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Select default ammo for wielded weapon which do not use a magazine",
     "category": "DEFAULTMODE",
     "id": "select_default_ammo",
-    "bindings": [ { "input_method": "keyboard_any", "key": "F3" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "F3"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Drop item",
     "category": "DEFAULTMODE",
     "id": "drop",
-    "bindings": [ { "input_method": "keyboard_any", "key": "d" }, { "input_method": "gamepad", "key": "JOY_DPAD_DOWN" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "d"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_DPAD_DOWN"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -2760,31 +6171,65 @@
     "name": "Drop item to adjacent tile",
     "category": "DEFAULTMODE",
     "id": "drop_adj",
-    "bindings": [ { "input_method": "keyboard_char", "key": "D" }, { "input_method": "keyboard_code", "key": "d", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "D"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "d",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "View/activate bionics",
     "category": "DEFAULTMODE",
     "id": "bionics",
-    "bindings": [ { "input_method": "keyboard_any", "key": "p" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "p"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "View/activate mutations",
     "category": "DEFAULTMODE",
     "id": "mutations",
-    "bindings": [ { "input_method": "keyboard_any", "key": "[" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "["
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "View medical",
     "category": "DEFAULTMODE",
     "id": "medical",
-    "bindings": [ 
-      { "input_method": "keyboard_char", "key": "N" }, 
-      { "input_method": "keyboard_code", "key": "n", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_R_NE" }
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "N"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "n",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_NE"
+      }
     ]
   },
   {
@@ -2792,10 +6237,22 @@
     "name": "View body status",
     "category": "DEFAULTMODE",
     "id": "bodystatus",
-    "bindings": [ 
-      { "input_method": "keyboard_char", "key": "{" }, 
-      { "input_method": "keyboard_code", "key": "[", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_R_SW" }
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "{"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "[",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_SW"
+      }
     ]
   },
   {
@@ -2804,9 +6261,21 @@
     "category": "DEFAULTMODE",
     "id": "sort_armor",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "+" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" },
-      { "input_method": "keyboard_code", "key": "=", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_char",
+        "key": "+"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_PLUS"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "=",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -2815,9 +6284,21 @@
     "category": "DEFAULTMODE",
     "id": "wait",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "|" },
-      { "input_method": "keyboard_code", "key": "\\", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_SE" }
+      {
+        "input_method": "keyboard_char",
+        "key": "|"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "\\",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SE"
+      }
     ]
   },
   {
@@ -2825,10 +6306,22 @@
     "name": "Craft items",
     "category": "DEFAULTMODE",
     "id": "craft",
-    "bindings": [ 
-      { "input_method": "keyboard_char", "key": "&" }, 
-      { "input_method": "keyboard_code", "key": "7", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" }
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "&"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "7",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
     ]
   },
   {
@@ -2836,10 +6329,19 @@
     "name": "Recraft last recipe",
     "category": "DEFAULTMODE",
     "id": "recraft",
-    "bindings": [ 
-      { "input_method": "keyboard_any", "key": "-" }, 
-      { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_NW" }
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "-"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MINUS"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NW"
+      }
     ]
   },
   {
@@ -2848,10 +6350,25 @@
     "category": "DEFAULTMODE",
     "id": "construct",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "*" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
-      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_S" }
+      {
+        "input_method": "keyboard_char",
+        "key": "*"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MULTIPLY"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "8",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_S"
+      }
     ]
   },
   {
@@ -2859,10 +6376,22 @@
     "name": "Disassemble items",
     "category": "DEFAULTMODE",
     "id": "disassemble",
-    "bindings": [ 
-      { "input_method": "keyboard_char", "key": "(" }, 
-      { "input_method": "keyboard_code", "key": "9", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_W" }
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "("
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "9",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_W"
+      }
     ]
   },
   {
@@ -2870,10 +6399,22 @@
     "name": "Sleep",
     "category": "DEFAULTMODE",
     "id": "sleep",
-    "bindings": [ 
-      { "input_method": "keyboard_char", "key": "$" }, 
-      { "input_method": "keyboard_code", "key": "4", "mod": [ "shift" ] }, 
-      { "input_method": "gamepad", "key": "JOY_RADIAL_L_SW" }
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "$"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "4",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SW"
+      }
     ]
   },
   {
@@ -2887,7 +6428,19 @@
     "name": "Control vehicle",
     "category": "DEFAULTMODE",
     "id": "control_vehicle",
-    "bindings": [ { "input_method": "keyboard_char", "key": "^" }, { "input_method": "keyboard_code", "key": "6", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "^"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "6",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -2901,9 +6454,21 @@
     "category": "DEFAULTMODE",
     "id": "safemode",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "!" },
-      { "input_method": "keyboard_code", "key": "1", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_ALT_LS" }
+      {
+        "input_method": "keyboard_char",
+        "key": "!"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "1",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_LS"
+      }
     ]
   },
   {
@@ -2911,21 +6476,54 @@
     "name": "Ignore nearby enemy",
     "category": "DEFAULTMODE",
     "id": "ignore_enemy",
-    "bindings": [ { "input_method": "keyboard_any", "key": "'" }, { "input_method": "gamepad", "key": "JOY_LS" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "'"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_LS"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Whitelist enemy",
     "category": "DEFAULTMODE",
     "id": "whitelist_enemy",
-    "bindings": [ { "input_method": "keyboard_char", "key": "~" }, { "input_method": "keyboard_code", "key": "`", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "~"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "`",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Save and quit",
     "category": "DEFAULTMODE",
     "id": "save",
-    "bindings": [ { "input_method": "keyboard_char", "key": "S" }, { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "S"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "s",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -2938,20 +6536,50 @@
     "name": "View player info",
     "category": "DEFAULTMODE",
     "id": "player_data",
-    "bindings": [ { "input_method": "keyboard_char", "key": "@" }, { "input_method": "keyboard_code", "key": "2", "mod": [ "shift" ] }, { "input_method": "gamepad", "key": "JOY_RADIAL_R_N" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "@"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "2",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_N"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "View map",
     "category": "DEFAULTMODE",
     "id": "map",
-    "bindings": [ { "input_method": "keyboard_any", "key": "m" }, { "input_method": "gamepad", "key": "JOY_BACK" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "m"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_BACK"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "View map",
     "id": "map",
-    "bindings": [ { "input_method": "keyboard_any", "key": ";" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": ";"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -2964,10 +6592,22 @@
     "name": "View missions",
     "category": "DEFAULTMODE",
     "id": "missions",
-    "bindings": [ 
-      { "input_method": "keyboard_char", "key": "M" }, 
-      { "input_method": "keyboard_code", "key": "m", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_R_W" }
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "M"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "m",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_W"
+      }
     ]
   },
   {
@@ -2975,10 +6615,22 @@
     "name": "View factions",
     "category": "DEFAULTMODE",
     "id": "factions",
-    "bindings": [ 
-      { "input_method": "keyboard_char", "key": "#" }, 
-      { "input_method": "keyboard_code", "key": "3", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_RADIAL_R_E" }
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "#"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "3",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_E"
+      }
     ]
   },
   {
@@ -2986,8 +6638,11 @@
     "name": "View character's morale",
     "category": "DEFAULTMODE",
     "id": "morale",
-    "bindings": [ 
-      { "input_method": "gamepad", "key": "JOY_RADIAL_R_NW" }
+    "bindings": [
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_NW"
+      }
     ]
   },
   {
@@ -2995,9 +6650,18 @@
     "name": "View message log",
     "category": "DEFAULTMODE",
     "id": "messages",
-    "bindings": [ 
-      { "input_method": "keyboard_char", "key": "P" }, 
-      { "input_method": "keyboard_code", "key": "p", "mod": [ "shift" ] }
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "P"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "p",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -3006,24 +6670,51 @@
     "category": "DEFAULTMODE",
     "id": "help",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "0" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_0" }
+      {
+        "input_method": "keyboard_any",
+        "key": "0"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_0"
+      }
     ]
   },
   {
     "type": "keybinding",
     "name": "Zoom in",
     "id": "zoom_in",
-    "bindings": [ { "input_method": "keyboard_any", "key": "z" }, { "input_method": "gamepad", "key": "JOY_ALT_START" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "z"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_START"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Zoom out",
     "id": "zoom_out",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "Z" },
-      { "input_method": "keyboard_code", "key": "z", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_ALT_BACK" }
+      {
+        "input_method": "keyboard_char",
+        "key": "Z"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "z",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_BACK"
+      }
     ]
   },
   {
@@ -3043,8 +6734,17 @@
     "id": "DEBUG_DIALOGUE_DL_CONDITIONAL",
     "name": "Toggle debug dialogue dynamic_line conditionals",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "CTRL+C" },
-      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "c" }
+      {
+        "input_method": "keyboard_char",
+        "key": "CTRL+C"
+      },
+      {
+        "input_method": "keyboard_code",
+        "mod": [
+          "ctrl"
+        ],
+        "key": "c"
+      }
     ]
   },
   {
@@ -3052,8 +6752,17 @@
     "id": "DEBUG_DIALOGUE_RESP_CONDITIONAL",
     "name": "Toggle debug dialogue response conditionals",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "CTRL+D" },
-      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "d" }
+      {
+        "input_method": "keyboard_char",
+        "key": "CTRL+D"
+      },
+      {
+        "input_method": "keyboard_code",
+        "mod": [
+          "ctrl"
+        ],
+        "key": "d"
+      }
     ]
   },
   {
@@ -3061,8 +6770,17 @@
     "id": "DEBUG_DIALOGUE_DL_EFFECT",
     "name": "Toggle debug dialogue dynamic_line effects",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "CTRL+T" },
-      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "t" }
+      {
+        "input_method": "keyboard_char",
+        "key": "CTRL+T"
+      },
+      {
+        "input_method": "keyboard_code",
+        "mod": [
+          "ctrl"
+        ],
+        "key": "t"
+      }
     ]
   },
   {
@@ -3070,8 +6788,17 @@
     "id": "DEBUG_DIALOGUE_RESP_EFFECT",
     "name": "Toggle debug dialogue response effects",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "CTRL+Y" },
-      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "y" }
+      {
+        "input_method": "keyboard_char",
+        "key": "CTRL+Y"
+      },
+      {
+        "input_method": "keyboard_code",
+        "mod": [
+          "ctrl"
+        ],
+        "key": "y"
+      }
     ]
   },
   {
@@ -3079,8 +6806,17 @@
     "id": "DEBUG_DIALOGUE_SHOW_ALL_RESPONSE",
     "name": "Toggle debug dialogue show hidden responses",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "CTRL+R" },
-      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "r" }
+      {
+        "input_method": "keyboard_char",
+        "key": "CTRL+R"
+      },
+      {
+        "input_method": "keyboard_code",
+        "mod": [
+          "ctrl"
+        ],
+        "key": "r"
+      }
     ]
   },
   {
@@ -3089,9 +6825,21 @@
     "category": "CALENDAR_UI",
     "name": "Reset time point to initial value",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "r" },
-      { "input_method": "keyboard_char", "key": "R" },
-      { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "r"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "R"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "r",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -3105,21 +6853,36 @@
     "category": "DEBUG_SPELLS",
     "id": "TOGGLE_ALL_SPELL",
     "name": "Toggle all spells",
-    "bindings": [ { "input_method": "keyboard_any", "key": "t" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "t"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "category": "DEBUG_SPELLS",
     "id": "UNLEARN_SPELL",
     "name": "Unlearn a spell",
-    "bindings": [ { "input_method": "keyboard_any", "key": "u" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "u"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "category": "DEBUG_SPELLS",
     "id": "SHOW_ONLY_LEARNED",
     "name": "Show only learned",
-    "bindings": [ { "input_method": "keyboard_any", "key": "a" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "a"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -3149,7 +6912,16 @@
     "name": "Reload item",
     "category": "DEFAULTMODE",
     "id": "reload_item",
-    "bindings": [ { "input_method": "keyboard_any", "key": "r" }, { "input_method": "gamepad", "key": "JOY_ALT_LB" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "r"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_LB"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -3198,10 +6970,19 @@
     "name": "Action menu",
     "category": "DEFAULTMODE",
     "id": "action_menu",
-    "bindings": [ 
-      { "input_method": "keyboard_any", "key": "RETURN" }, 
-      { "input_method": "keyboard_any", "key": "KEYPAD_ENTER" },
-      { "input_method": "gamepad", "key": "JOY_A" }
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "RETURN"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "KEYPAD_ENTER"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_A"
+      }
     ]
   },
   {
@@ -3210,9 +6991,21 @@
     "category": "DEFAULTMODE",
     "id": "item_action_menu",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "%" },
-      { "input_method": "keyboard_code", "key": "5", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_ALT_A" }
+      {
+        "input_method": "keyboard_char",
+        "key": "%"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "5",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_A"
+      }
     ]
   },
   {
@@ -3232,28 +7025,48 @@
     "name": "Move view northeast",
     "category": "DEFAULTMODE",
     "id": "shift_ne",
-    "bindings": [ { "input_method": "gamepad", "key": "JOY_R_RIGHTUP" } ]
+    "bindings": [
+      {
+        "input_method": "gamepad",
+        "key": "JOY_R_RIGHTUP"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Move view southeast",
     "category": "DEFAULTMODE",
     "id": "shift_se",
-    "bindings": [ { "input_method": "gamepad", "key": "JOY_R_RIGHTDOWN" } ]
+    "bindings": [
+      {
+        "input_method": "gamepad",
+        "key": "JOY_R_RIGHTDOWN"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Move view southwest",
     "category": "DEFAULTMODE",
     "id": "shift_sw",
-    "bindings": [ { "input_method": "gamepad", "key": "JOY_R_LEFTDOWN" } ]
+    "bindings": [
+      {
+        "input_method": "gamepad",
+        "key": "JOY_R_LEFTDOWN"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Move view northwest",
     "category": "DEFAULTMODE",
     "id": "shift_nw",
-    "bindings": [ { "input_method": "gamepad", "key": "JOY_R_LEFTUP" } ]
+    "bindings": [
+      {
+        "input_method": "gamepad",
+        "key": "JOY_R_LEFTUP"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -3278,14 +7091,32 @@
     "name": "Autoattack",
     "category": "DEFAULTMODE",
     "id": "autoattack",
-    "bindings": [ { "input_method": "keyboard_any", "key": "TAB" }, { "input_method": "gamepad", "key": "JOY_RB" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "TAB"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RB"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Main menu",
     "category": "DEFAULTMODE",
     "id": "main_menu",
-    "bindings": [ { "input_method": "keyboard_any", "key": "ESC" }, { "input_method": "gamepad", "key": "JOY_START" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "ESC"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_START"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -3334,7 +7165,7 @@
     "name": "Cycle movement mode",
     "category": "DEFAULTMODE",
     "id": "cycle_move",
-    "bindings": [ ]
+    "bindings": []
   },
   {
     "type": "keybinding",
@@ -3372,9 +7203,21 @@
     "category": "DEFAULTMODE",
     "id": "open_movement",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "\"" },
-      { "input_method": "keyboard_code", "key": "'", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_ALT_RT" }
+      {
+        "input_method": "keyboard_char",
+        "key": "\""
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "'",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_RT"
+      }
     ]
   },
   {
@@ -3382,7 +7225,16 @@
     "id": "cast_spell",
     "name": "Supernatural abilities",
     "category": "DEFAULTMODE",
-    "bindings": [ { "input_method": "keyboard_any", "key": "]" }, { "input_method": "gamepad", "key": "JOY_ALT_Y" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "]"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_Y"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -3395,21 +7247,65 @@
     "id": "diary",
     "name": "Open diary / achievements / scores",
     "category": "DEFAULTMODE",
-    "bindings": [ { "input_method": "keyboard_char", "key": ")" }, { "input_method": "keyboard_code", "key": "0", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": ")"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "0",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_ITEM_INFO_UP",
     "category": "LIST_ITEMS",
     "name": "Scroll item info up",
-    "bindings": [ { "input_method": "keyboard_char", "key": "<" }, { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "<"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ",",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_DPAD_UP"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_ITEM_INFO_DOWN",
     "category": "LIST_ITEMS",
     "name": "Scroll item info down",
-    "bindings": [ { "input_method": "keyboard_char", "key": ">" }, { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": ">"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ".",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_DPAD_DOWN"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -3417,11 +7313,36 @@
     "category": "LIST_ITEMS",
     "name": "Compare",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "I" },
-      { "input_method": "keyboard_code", "key": "i", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "c" },
-      { "input_method": "keyboard_char", "key": "C" },
-      { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_char",
+        "key": "I"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "i",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "c"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "C"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "c",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NE"
+      }
     ]
   },
   {
@@ -3430,9 +7351,25 @@
     "category": "LIST_ITEMS",
     "name": "Examine",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "e" },
-      { "input_method": "keyboard_char", "key": "E" },
-      { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "e"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "E"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "e",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
     ]
   },
   {
@@ -3441,9 +7378,22 @@
     "category": "LIST_ITEMS",
     "name": "Increase priority",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "=" },
-      { "input_method": "keyboard_char", "key": "+" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" }
+      {
+        "input_method": "keyboard_any",
+        "key": "="
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "+"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_PLUS"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_E"
+      }
     ]
   },
   {
@@ -3451,7 +7401,20 @@
     "id": "PRIORITY_DECREASE",
     "category": "LIST_ITEMS",
     "name": "Decrease priority",
-    "bindings": [ { "input_method": "keyboard_any", "key": "-" }, { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "-"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MINUS"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_W"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -3459,9 +7422,25 @@
     "category": "LIST_ITEMS",
     "name": "Change sort order",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "s" },
-      { "input_method": "keyboard_char", "key": "S" },
-      { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "s"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "S"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "s",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SE"
+      }
     ]
   },
   {
@@ -3469,38 +7448,89 @@
     "id": "SAFEMODE_BLACKLIST_ADD",
     "category": "LIST_MONSTERS",
     "name": "Add to safe mode blacklist",
-    "bindings": [ { "input_method": "keyboard_any", "key": "a" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "a"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SAFEMODE_BLACKLIST_REMOVE",
     "category": "LIST_MONSTERS",
     "name": "Remove from safe mode blacklist",
-    "bindings": [ { "input_method": "keyboard_any", "key": "r" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "r"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_S"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "look",
     "category": "LIST_MONSTERS",
     "name": "Look around",
-    "bindings": [ { "input_method": "keyboard_any", "key": "x" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "x"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_E"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "fire",
     "category": "LIST_MONSTERS",
-    "name": { "ctxt": "verb", "str": "Fire" },
-    "bindings": [ { "input_method": "keyboard_any", "key": "f" } ]
+    "name": {
+      "ctxt": "verb",
+      "str": "Fire"
+    },
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "f"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_W"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "LIST_ITEMS",
     "category": "LOOK",
     "name": "List items and monsters",
-    "bindings": [ 
-      { "input_method": "keyboard_char", "key": "V" }, 
-      { "input_method": "keyboard_code", "key": "v", "mod": [ "shift" ] }, 
-      { "input_method": "gamepad", "key": "JOY_RS" } 
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "V"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "v",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RS"
+      }
     ]
   },
   {
@@ -3508,7 +7538,12 @@
     "id": "REASSIGN",
     "category": "BIONICS",
     "name": "Reassign inventory letter",
-    "bindings": [ { "input_method": "keyboard_any", "key": "=" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "="
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -3516,10 +7551,22 @@
     "category": "BIONICS",
     "name": "Move cursor up",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "8" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_8" },
-      { "input_method": "keyboard_any", "key": "UP" },
-      { "input_method": "gamepad", "key": "JOY_UP" }
+      {
+        "input_method": "keyboard_any",
+        "key": "8"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_8"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "UP"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_UP"
+      }
     ]
   },
   {
@@ -3528,10 +7575,22 @@
     "category": "BIONICS",
     "name": "Move cursor down",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "DOWN" },
-      { "input_method": "keyboard_any", "key": "2" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_2" },
-      { "input_method": "gamepad", "key": "JOY_DOWN" }
+      {
+        "input_method": "keyboard_any",
+        "key": "DOWN"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "2"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_2"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_DOWN"
+      }
     ]
   },
   {
@@ -3539,14 +7598,24 @@
     "id": "REASSIGN",
     "category": "MUTATIONS",
     "name": "Reassign inventory letter",
-    "bindings": [ { "input_method": "keyboard_any", "key": "=" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "="
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_SPRITE",
     "category": "MUTATIONS",
     "name": "Toggle sprite",
-    "bindings": [ { "input_method": "keyboard_any", "key": "," } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": ","
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -3554,10 +7623,22 @@
     "category": "MUTATIONS",
     "name": "Pan up",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "8" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_8" },
-      { "input_method": "keyboard_any", "key": "UP" },
-      { "input_method": "gamepad", "key": "JOY_UP" }
+      {
+        "input_method": "keyboard_any",
+        "key": "8"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_8"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "UP"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_UP"
+      }
     ]
   },
   {
@@ -3566,10 +7647,22 @@
     "category": "MUTATIONS",
     "name": "Pan down",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "DOWN" },
-      { "input_method": "keyboard_any", "key": "2" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_2" },
-      { "input_method": "gamepad", "key": "JOY_DOWN" }
+      {
+        "input_method": "keyboard_any",
+        "key": "DOWN"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "2"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_2"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_DOWN"
+      }
     ]
   },
   {
@@ -3578,28 +7671,52 @@
     "category": "HELP_KEYBINDINGS",
     "name": "Exit this keybinding screen",
     "//": "separate entry, because the global entry also has 'q', 'Q' and space listed, which conflicts with the search text input",
-    "bindings": [ { "input_method": "keyboard_any", "key": "ESC" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "ESC"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "UP",
     "category": "HELP_KEYBINDINGS",
     "name": "Pan up",
-    "bindings": [ { "input_method": "keyboard_any", "key": "UP" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "UP"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "DOWN",
     "category": "HELP_KEYBINDINGS",
     "name": "Pan down",
-    "bindings": [ { "input_method": "keyboard_any", "key": "DOWN" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "DOWN"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "REMOVE",
     "category": "HELP_KEYBINDINGS",
     "name": "Remove keybinding",
-    "bindings": [ { "input_method": "keyboard_any", "key": "-" }, { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "-"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MINUS"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -3607,9 +7724,21 @@
     "category": "HELP_KEYBINDINGS",
     "name": "Reset keybinding",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "*" },
-      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] },
-      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" }
+      {
+        "input_method": "keyboard_char",
+        "key": "*"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "8",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MULTIPLY"
+      }
     ]
   },
   {
@@ -3618,9 +7747,21 @@
     "category": "HELP_KEYBINDINGS",
     "name": "Add local keybinding",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "+" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" },
-      { "input_method": "keyboard_code", "key": "=", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_char",
+        "key": "+"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_PLUS"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "=",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -3628,14 +7769,28 @@
     "id": "ADD_GLOBAL",
     "category": "HELP_KEYBINDINGS",
     "name": "Add global keybinding",
-    "bindings": [ { "input_method": "keyboard_any", "key": "=" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "="
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "EXECUTE",
     "category": "HELP_KEYBINDINGS",
     "name": "Execute action keybinding",
-    "bindings": [ { "input_method": "keyboard_any", "key": "." }, { "input_method": "keyboard_code", "key": "KEYPAD_PERIOD" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "."
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_PERIOD"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -3643,9 +7798,25 @@
     "category": "ZONES_MANAGER",
     "name": "Add zone",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "a" },
-      { "input_method": "keyboard_char", "key": "A" },
-      { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "a"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "A"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "a",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
     ]
   },
   {
@@ -3654,9 +7825,25 @@
     "category": "ZONES_MANAGER",
     "name": "Add personal zone",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "p" },
-      { "input_method": "keyboard_char", "key": "P" },
-      { "input_method": "keyboard_code", "key": "p", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "p"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "P"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "p",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NE"
+      }
     ]
   },
   {
@@ -3665,9 +7852,25 @@
     "category": "ZONES_MANAGER",
     "name": "Remove zone",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "r" },
-      { "input_method": "keyboard_char", "key": "R" },
-      { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "r"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "R"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "r",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_E"
+      }
     ]
   },
   {
@@ -3676,9 +7879,22 @@
     "category": "ZONES_MANAGER",
     "name": "Move zone up",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "=" },
-      { "input_method": "keyboard_char", "key": "+" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" }
+      {
+        "input_method": "keyboard_any",
+        "key": "="
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "+"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_PLUS"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_DPAD_UP"
+      }
     ]
   },
   {
@@ -3686,7 +7902,20 @@
     "id": "MOVE_ZONE_DOWN",
     "category": "ZONES_MANAGER",
     "name": "Move zone down",
-    "bindings": [ { "input_method": "keyboard_any", "key": "-" }, { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "-"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MINUS"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_DPAD_DOWN"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -3694,9 +7923,25 @@
     "category": "ZONES_MANAGER",
     "name": "Show zone on map",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "m" },
-      { "input_method": "keyboard_char", "key": "M" },
-      { "input_method": "keyboard_code", "key": "m", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "m"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "M"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "m",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SE"
+      }
     ]
   },
   {
@@ -3705,9 +7950,25 @@
     "category": "ZONES_MANAGER",
     "name": "Toggle display of zone markers",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "t" },
-      { "input_method": "keyboard_char", "key": "T" },
-      { "input_method": "keyboard_code", "key": "t", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "t"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "T"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "t",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_S"
+      }
     ]
   },
   {
@@ -3716,9 +7977,25 @@
     "category": "ZONES_MANAGER",
     "name": "Enable zone",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "e" },
-      { "input_method": "keyboard_char", "key": "E" },
-      { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "e"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "E"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "e",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SW"
+      }
     ]
   },
   {
@@ -3727,9 +8004,25 @@
     "category": "ZONES_MANAGER",
     "name": "Disable zone",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "d" },
-      { "input_method": "keyboard_char", "key": "D" },
-      { "input_method": "keyboard_code", "key": "d", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "d"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "D"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "d",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_W"
+      }
     ]
   },
   {
@@ -3738,9 +8031,25 @@
     "category": "ZONES_MANAGER",
     "name": "Enable personal zones",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "z" },
-      { "input_method": "keyboard_char", "key": "Z" },
-      { "input_method": "keyboard_code", "key": "z", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "z"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "Z"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "z",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NW"
+      }
     ]
   },
   {
@@ -3749,9 +8058,25 @@
     "category": "ZONES_MANAGER",
     "name": "Disable personal zones",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "x" },
-      { "input_method": "keyboard_char", "key": "X" },
-      { "input_method": "keyboard_code", "key": "x", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "x"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "X"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "x",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_N"
+      }
     ]
   },
   {
@@ -3760,9 +8085,25 @@
     "category": "ZONES_MANAGER",
     "name": "Enable vehicle zones",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "c" },
-      { "input_method": "keyboard_char", "key": "C" },
-      { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "c"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "C"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "c",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_NE"
+      }
     ]
   },
   {
@@ -3771,9 +8112,25 @@
     "category": "ZONES_MANAGER",
     "name": "Disable vehicle zones",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "v" },
-      { "input_method": "keyboard_char", "key": "V" },
-      { "input_method": "keyboard_code", "key": "v", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "v"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "V"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "v",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_E"
+      }
     ]
   },
   {
@@ -3782,9 +8139,25 @@
     "category": "ZONES_MANAGER",
     "name": "Show all zones / hide distant zones",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "s" },
-      { "input_method": "keyboard_char", "key": "S" },
-      { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "s"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "S"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "s",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_SE"
+      }
     ]
   },
   {
@@ -3792,7 +8165,23 @@
     "id": "CHANGE_FACTION",
     "category": "ZONES_MANAGER",
     "name": "Change shown faction",
-    "bindings": [ { "input_method": "keyboard_char", "key": "F" }, { "input_method": "keyboard_code", "key": "f", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "F"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "f",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_S"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -3800,10 +8189,25 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Page down",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "NPAGE" },
-      { "input_method": "keyboard_char", "key": ">" },
-      { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_DOWN" }
+      {
+        "input_method": "keyboard_any",
+        "key": "NPAGE"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": ">"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ".",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_DPAD_DOWN"
+      }
     ]
   },
   {
@@ -3812,10 +8216,25 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Page up",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "PPAGE" },
-      { "input_method": "keyboard_char", "key": "<" },
-      { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_UP" }
+      {
+        "input_method": "keyboard_any",
+        "key": "PPAGE"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "<"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ",",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_ALT_DPAD_UP"
+      }
     ]
   },
   {
@@ -3824,9 +8243,18 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Pan up",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "k" },
-      { "input_method": "keyboard_any", "key": "UP" },
-      { "input_method": "gamepad", "key": "JOY_UP" }
+      {
+        "input_method": "keyboard_any",
+        "key": "k"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "UP"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_UP"
+      }
     ]
   },
   {
@@ -3835,9 +8263,18 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Pan down",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "j" },
-      { "input_method": "keyboard_any", "key": "DOWN" },
-      { "input_method": "gamepad", "key": "JOY_DOWN" }
+      {
+        "input_method": "keyboard_any",
+        "key": "j"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "DOWN"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_DOWN"
+      }
     ]
   },
   {
@@ -3846,9 +8283,18 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Select left inventory",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "h" },
-      { "input_method": "keyboard_any", "key": "LEFT" },
-      { "input_method": "gamepad", "key": "JOY_LEFT" }
+      {
+        "input_method": "keyboard_any",
+        "key": "h"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "LEFT"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_LEFT"
+      }
     ]
   },
   {
@@ -3857,8 +8303,14 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Select right inventory",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "l" },
-      { "input_method": "keyboard_any", "key": "RIGHT" }
+      {
+        "input_method": "keyboard_any",
+        "key": "l"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "RIGHT"
+      }
     ]
   },
   {
@@ -3866,7 +8318,12 @@
     "id": "TOGGLE_TAB",
     "category": "ADVANCED_INVENTORY",
     "name": "Toggle tab",
-    "bindings": [ { "input_method": "keyboard_any", "key": "TAB" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "TAB"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -3874,9 +8331,25 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Toggle vehicle",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "v" },
-      { "input_method": "keyboard_char", "key": "V" },
-      { "input_method": "keyboard_code", "key": "v", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "v"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "V"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "v",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NW"
+      }
     ]
   },
   {
@@ -3884,7 +8357,16 @@
     "id": "TOGGLE_AUTO_PICKUP",
     "category": "ADVANCED_INVENTORY",
     "name": "Toggle auto pickup for item",
-    "bindings": [ { "input_method": "keyboard_any", "key": "p" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "p"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_W"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -3892,9 +8374,25 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Examine",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "e" },
-      { "input_method": "keyboard_char", "key": "E" },
-      { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "e"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "E"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "e",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RS"
+      }
     ]
   },
   {
@@ -3903,9 +8401,25 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Change sorting mode",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "s" },
-      { "input_method": "keyboard_char", "key": "S" },
-      { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "s"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "S"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "s",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
     ]
   },
   {
@@ -3913,35 +8427,87 @@
     "id": "MOVE_SINGLE_ITEM",
     "category": "ADVANCED_INVENTORY",
     "name": "Move a single item",
-    "bindings": [ { "input_method": "keyboard_any", "key": "RETURN" }, { "input_method": "keyboard_any", "key": "KEYPAD_ENTER" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "RETURN"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "KEYPAD_ENTER"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "MOVE_VARIABLE_ITEM",
     "category": "ADVANCED_INVENTORY",
     "name": "Move some items",
-    "bindings": [ { "input_method": "keyboard_any", "key": "m" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "m"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "MOVE_ITEM_STACK",
     "category": "ADVANCED_INVENTORY",
     "name": "Move item stack",
-    "bindings": [ { "input_method": "keyboard_char", "key": "M" }, { "input_method": "keyboard_code", "key": "m", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "M"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "m",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_E"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "MOVE_ALL_ITEMS",
     "category": "ADVANCED_INVENTORY",
     "name": "Move all items",
-    "bindings": [ { "input_method": "keyboard_any", "key": "," } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": ","
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CATEGORY_SELECTION",
     "category": "ADVANCED_INVENTORY",
     "name": "Toggle category selection mode",
-    "bindings": [ { "input_method": "keyboard_any", "key": "t" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "t"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_S"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -3949,9 +8515,25 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Toggle item as favorite",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "*" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
-      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_char",
+        "key": "*"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MULTIPLY"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "8",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SW"
+      }
     ]
   },
   {
@@ -3960,10 +8542,22 @@
     "category": "INVENTORY",
     "name": "Select/unselect highlighted item",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "l" },
-      { "input_method": "keyboard_any", "key": "RIGHT" },
-      { "input_method": "keyboard_any", "key": "6" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_6" }
+      {
+        "input_method": "keyboard_any",
+        "key": "l"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "RIGHT"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "6"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_6"
+      }
     ]
   },
   {
@@ -3972,9 +8566,22 @@
     "category": "INVENTORY",
     "name": "Increase selected amount for the highlighted item",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "=" },
-      { "input_method": "keyboard_char", "key": "+" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" }
+      {
+        "input_method": "keyboard_any",
+        "key": "="
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "+"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_PLUS"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
     ]
   },
   {
@@ -3982,21 +8589,52 @@
     "id": "AUTO_BALANCE",
     "category": "INVENTORY",
     "name": "Auto balance trade using highlighted item",
-    "bindings": [ { "input_method": "keyboard_any", "key": "F1" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "F1"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "BANK_BALANCE",
     "category": "INVENTORY",
     "name": "Auto balance trade using bank account",
-    "bindings": [ { "input_method": "keyboard_any", "key": "F2" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "F2"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_E"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "DECREASE_COUNT",
     "category": "INVENTORY",
     "name": "Decrease selected amount for the highlighted item",
-    "bindings": [ { "input_method": "keyboard_any", "key": "-" }, { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "-"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MINUS"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_S"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -4004,11 +8642,26 @@
     "category": "INVENTORY",
     "name": "Next column",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "h" },
-      { "input_method": "keyboard_any", "key": "LEFT" },
-      { "input_method": "keyboard_any", "key": "4" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_4" },
-      { "input_method": "gamepad", "key": "JOY_LEFT" }
+      {
+        "input_method": "keyboard_any",
+        "key": "h"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "LEFT"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "4"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_4"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_LEFT"
+      }
     ]
   },
   {
@@ -4017,8 +8670,17 @@
     "category": "INVENTORY",
     "name": "Previous column",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "BACKTAB" },
-      { "input_method": "keyboard_code", "key": "TAB", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_char",
+        "key": "BACKTAB"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "TAB",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -4026,77 +8688,175 @@
     "id": "TOGGLE_NON_FAVORITE",
     "category": "INVENTORY",
     "name": "Select/unselect non-favorite items in multidrop menu",
-    "bindings": [ { "input_method": "keyboard_any", "key": "," } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": ","
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "MARK_WITH_COUNT",
     "category": "INVENTORY",
     "name": "Select a specific amount of highlighted item",
-    "bindings": [ { "input_method": "keyboard_char", "key": "!" }, { "input_method": "keyboard_code", "key": "1", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "!"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "1",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "ITEMS_NW",
     "category": "ADVANCED_INVENTORY",
     "name": "Select items at northwest",
-    "bindings": [ { "input_method": "keyboard_any", "key": "7" }, { "input_method": "keyboard_code", "key": "KEYPAD_7" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "7"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_7"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "ITEMS_N",
     "category": "ADVANCED_INVENTORY",
     "name": "Select items at north",
-    "bindings": [ { "input_method": "keyboard_any", "key": "8" }, { "input_method": "keyboard_code", "key": "KEYPAD_8" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "8"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_8"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "ITEMS_NE",
     "category": "ADVANCED_INVENTORY",
     "name": "Select items at northeast",
-    "bindings": [ { "input_method": "keyboard_any", "key": "9" }, { "input_method": "keyboard_code", "key": "KEYPAD_9" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "9"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_9"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "ITEMS_W",
     "category": "ADVANCED_INVENTORY",
     "name": "Select items at west",
-    "bindings": [ { "input_method": "keyboard_any", "key": "4" }, { "input_method": "keyboard_code", "key": "KEYPAD_4" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "4"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_4"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "ITEMS_CE",
     "category": "ADVANCED_INVENTORY",
     "name": "Select items at center",
-    "bindings": [ { "input_method": "keyboard_any", "key": "5" }, { "input_method": "keyboard_code", "key": "KEYPAD_5" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "5"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_5"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "ITEMS_E",
     "category": "ADVANCED_INVENTORY",
     "name": "Select items at east",
-    "bindings": [ { "input_method": "keyboard_any", "key": "6" }, { "input_method": "keyboard_code", "key": "KEYPAD_6" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "6"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_6"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "ITEMS_SW",
     "category": "ADVANCED_INVENTORY",
     "name": "Select items at southwest",
-    "bindings": [ { "input_method": "keyboard_any", "key": "1" }, { "input_method": "keyboard_code", "key": "KEYPAD_1" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "1"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_1"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "ITEMS_S",
     "category": "ADVANCED_INVENTORY",
     "name": "Select items at south",
-    "bindings": [ { "input_method": "keyboard_any", "key": "2" }, { "input_method": "keyboard_code", "key": "KEYPAD_2" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "2"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_2"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "ITEMS_SE",
     "category": "ADVANCED_INVENTORY",
     "name": "Select items at southeast",
-    "bindings": [ { "input_method": "keyboard_any", "key": "3" }, { "input_method": "keyboard_code", "key": "KEYPAD_3" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "3"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_3"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -4104,11 +8864,29 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Select items in inventory",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "i" },
-      { "input_method": "keyboard_char", "key": "I" },
-      { "input_method": "keyboard_code", "key": "i", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "0" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_0" }
+      {
+        "input_method": "keyboard_any",
+        "key": "i"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "I"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "i",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "0"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_0"
+      }
     ]
   },
   {
@@ -4117,9 +8895,21 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Select items at all 9 tiles",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "a" },
-      { "input_method": "keyboard_char", "key": "A" },
-      { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "a"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "A"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "a",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -4128,9 +8918,21 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Select items in dragged vehicle",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "d" },
-      { "input_method": "keyboard_char", "key": "D" },
-      { "input_method": "keyboard_code", "key": "d", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "d"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "D"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "d",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -4138,14 +8940,28 @@
     "id": "EXAMINE_CONTENTS",
     "category": "ADVANCED_INVENTORY",
     "name": "Examine items in container",
-    "bindings": [ { "input_method": "keyboard_any", "key": "o" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "o"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "UNLOAD_CONTAINER",
     "category": "ADVANCED_INVENTORY",
     "name": "Unload item from container",
-    "bindings": [ { "input_method": "keyboard_any", "key": "u" }, { "input_method": "keyboard_any", "key": "U" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "u"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "U"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -4153,9 +8969,21 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Select items in container",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "c" },
-      { "input_method": "keyboard_char", "key": "C" },
-      { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "c"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "C"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "c",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -4164,9 +8992,21 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Exit container to parent",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "x" },
-      { "input_method": "keyboard_char", "key": "X" },
-      { "input_method": "keyboard_code", "key": "x", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "x"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "X"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "x",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -4175,9 +9015,21 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Select items currently worn",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "w" },
-      { "input_method": "keyboard_char", "key": "W" },
-      { "input_method": "keyboard_code", "key": "w", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "w"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "W"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "w",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -4197,25 +9049,45 @@
     "id": "repair_fabric",
     "category": "ITEM_ACTIONS",
     "name": "Sew",
-    "bindings": [ { "input_method": "keyboard_any", "key": "s" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "s"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "repair_metal",
     "category": "ITEM_ACTIONS",
-    "bindings": [ { "input_method": "keyboard_any", "key": "w" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "w"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "firestarter",
     "category": "ITEM_ACTIONS",
-    "bindings": [ { "input_method": "keyboard_any", "key": "f" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "f"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "holster",
     "category": "ITEM_ACTIONS",
-    "bindings": [ { "input_method": "keyboard_any", "key": "h" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "h"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -4223,9 +9095,21 @@
     "category": "COLORS",
     "name": "Remove custom color",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "r" },
-      { "input_method": "keyboard_char", "key": "R" },
-      { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "r"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "R"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "r",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -4234,9 +9118,21 @@
     "category": "COLORS",
     "name": "Load color template",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "t" },
-      { "input_method": "keyboard_char", "key": "T" },
-      { "input_method": "keyboard_code", "key": "t", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "t"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "T"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "t",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -4245,9 +9141,21 @@
     "category": "COLORS",
     "name": "Load base colors",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "c" },
-      { "input_method": "keyboard_char", "key": "C" },
-      { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_any",
+        "key": "c"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "C"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "c",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -4256,12 +9164,33 @@
     "category": "COLORS",
     "name": "Quit",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "ESC" },
-      { "input_method": "keyboard_any", "key": "q" },
-      { "input_method": "keyboard_char", "key": "Q" },
-      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "SPACE" },
-      { "input_method": "mouse", "key": "MOUSE_RIGHT" }
+      {
+        "input_method": "keyboard_any",
+        "key": "ESC"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "q"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "Q"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "q",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "SPACE"
+      },
+      {
+        "input_method": "mouse",
+        "key": "MOUSE_RIGHT"
+      }
     ]
   },
   {
@@ -4270,9 +9199,25 @@
     "category": "YESNO",
     "name": "Yes",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "Y" },
-      { "input_method": "keyboard_code", "key": "y", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "y" }
+      {
+        "input_method": "keyboard_char",
+        "key": "Y"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "y",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "y"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
     ]
   },
   {
@@ -4281,10 +9226,29 @@
     "category": "YESNO",
     "name": "No",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "N" },
-      { "input_method": "keyboard_code", "key": "n", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "n" },
-      { "input_method": "keyboard_any", "key": "ESC" }
+      {
+        "input_method": "keyboard_char",
+        "key": "N"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "n",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "n"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "ESC"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_S"
+      }
     ]
   },
   {
@@ -4293,9 +9257,25 @@
     "category": "FRIENDS_ME_CANCEL",
     "name": "With friends",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "F" },
-      { "input_method": "keyboard_code", "key": "f", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "f" }
+      {
+        "input_method": "keyboard_char",
+        "key": "F"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "f",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "f"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_E"
+      }
     ]
   },
   {
@@ -4304,9 +9284,25 @@
     "category": "FRIENDS_ME_CANCEL",
     "name": "Just me",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "M" },
-      { "input_method": "keyboard_code", "key": "m", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "m" }
+      {
+        "input_method": "keyboard_char",
+        "key": "M"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "m",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "m"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_W"
+      }
     ]
   },
   {
@@ -4315,10 +9311,29 @@
     "category": "FRIENDS_ME_CANCEL",
     "name": "Cancel",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "C" },
-      { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "c" },
-      { "input_method": "keyboard_any", "key": "ESC" }
+      {
+        "input_method": "keyboard_char",
+        "key": "C"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "c",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "c"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "ESC"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NW"
+      }
     ]
   },
   {
@@ -4327,9 +9342,21 @@
     "category": "LOAD_DELETE_CANCEL",
     "name": "Load",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "L" },
-      { "input_method": "keyboard_code", "key": "l", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "l" }
+      {
+        "input_method": "keyboard_char",
+        "key": "L"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "l",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "l"
+      }
     ]
   },
   {
@@ -4338,9 +9365,21 @@
     "category": "LOAD_DELETE_CANCEL",
     "name": "Delete",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "D" },
-      { "input_method": "keyboard_code", "key": "d", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "d" }
+      {
+        "input_method": "keyboard_char",
+        "key": "D"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "d",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "d"
+      }
     ]
   },
   {
@@ -4349,9 +9388,21 @@
     "category": "LOAD_DELETE_CANCEL",
     "name": "Cancel",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "C" },
-      { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "c" }
+      {
+        "input_method": "keyboard_char",
+        "key": "C"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "c",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "c"
+      }
     ]
   },
   {
@@ -4360,9 +9411,21 @@
     "category": "YESNOQUIT",
     "name": "Yes",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "Y" },
-      { "input_method": "keyboard_code", "key": "y", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "y" }
+      {
+        "input_method": "keyboard_char",
+        "key": "Y"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "y",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "y"
+      }
     ]
   },
   {
@@ -4371,9 +9434,21 @@
     "category": "YESNOQUIT",
     "name": "No",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "N" },
-      { "input_method": "keyboard_code", "key": "n", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "n" }
+      {
+        "input_method": "keyboard_char",
+        "key": "N"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "n",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "n"
+      }
     ]
   },
   {
@@ -4382,10 +9457,25 @@
     "category": "YESNOQUIT",
     "name": "Cancel",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "Q" },
-      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "q" },
-      { "input_method": "keyboard_any", "key": "ESC" }
+      {
+        "input_method": "keyboard_char",
+        "key": "Q"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "q",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "q"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "ESC"
+      }
     ]
   },
   {
@@ -4394,9 +9484,21 @@
     "category": "CANCEL_ACTIVITY_OR_IGNORE_QUERY",
     "name": "Yes",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "Y" },
-      { "input_method": "keyboard_code", "key": "y", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "y" }
+      {
+        "input_method": "keyboard_char",
+        "key": "Y"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "y",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "y"
+      }
     ]
   },
   {
@@ -4405,10 +9507,25 @@
     "category": "CANCEL_ACTIVITY_OR_IGNORE_QUERY",
     "name": "No",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "N" },
-      { "input_method": "keyboard_code", "key": "n", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "n" },
-      { "input_method": "keyboard_any", "key": "ESC" }
+      {
+        "input_method": "keyboard_char",
+        "key": "N"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "n",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "n"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "ESC"
+      }
     ]
   },
   {
@@ -4417,9 +9534,21 @@
     "category": "CANCEL_ACTIVITY_OR_IGNORE_QUERY",
     "name": "Ignore this distraction and continue",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "I" },
-      { "input_method": "keyboard_code", "key": "i", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "i" }
+      {
+        "input_method": "keyboard_char",
+        "key": "I"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "i",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "i"
+      }
     ]
   },
   {
@@ -4428,9 +9557,21 @@
     "category": "CANCEL_ACTIVITY_OR_IGNORE_QUERY",
     "name": "Open manager",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "M" },
-      { "input_method": "keyboard_code", "key": "m", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "m" }
+      {
+        "input_method": "keyboard_char",
+        "key": "M"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "m",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "m"
+      }
     ]
   },
   {
@@ -4439,9 +9580,21 @@
     "category": "YES_QUERY",
     "name": "Yes, I will!",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "Y" },
-      { "input_method": "keyboard_code", "key": "y", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "y" }
+      {
+        "input_method": "keyboard_char",
+        "key": "Y"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "y",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "y"
+      }
     ]
   },
   {
@@ -4450,9 +9603,21 @@
     "category": "YES_QUERY",
     "name": "Yes, I must!",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "Y" },
-      { "input_method": "keyboard_code", "key": "y", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "y" }
+      {
+        "input_method": "keyboard_char",
+        "key": "Y"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "y",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "y"
+      }
     ]
   },
   {
@@ -4461,9 +9626,21 @@
     "category": "YES_QUERY",
     "name": "Yes, I shall!",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "Y" },
-      { "input_method": "keyboard_code", "key": "y", "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": "y" }
+      {
+        "input_method": "keyboard_char",
+        "key": "Y"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "y",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "y"
+      }
     ]
   },
   {
@@ -4472,9 +9649,27 @@
     "category": "YES_NO_ALWAYS_NEVER",
     "name": "Yes",
     "bindings": [
-      { "input_method": "keyboard_char", "key": [ "Y" ] },
-      { "input_method": "keyboard_code", "key": [ "y" ], "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": [ "y" ] }
+      {
+        "input_method": "keyboard_char",
+        "key": [
+          "Y"
+        ]
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": [
+          "y"
+        ],
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": [
+          "y"
+        ]
+      }
     ]
   },
   {
@@ -4483,10 +9678,33 @@
     "category": "YES_NO_ALWAYS_NEVER",
     "name": "No",
     "bindings": [
-      { "input_method": "keyboard_char", "key": [ "N" ] },
-      { "input_method": "keyboard_code", "key": [ "n" ], "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": [ "n" ] },
-      { "input_method": "keyboard_any", "key": [ "ESC" ] }
+      {
+        "input_method": "keyboard_char",
+        "key": [
+          "N"
+        ]
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": [
+          "n"
+        ],
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": [
+          "n"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": [
+          "ESC"
+        ]
+      }
     ]
   },
   {
@@ -4495,9 +9713,27 @@
     "category": "YES_NO_ALWAYS_NEVER",
     "name": "Always",
     "bindings": [
-      { "input_method": "keyboard_char", "key": [ "A" ] },
-      { "input_method": "keyboard_code", "key": [ "a" ], "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": [ "a" ] }
+      {
+        "input_method": "keyboard_char",
+        "key": [
+          "A"
+        ]
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": [
+          "a"
+        ],
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": [
+          "a"
+        ]
+      }
     ]
   },
   {
@@ -4506,9 +9742,27 @@
     "category": "YES_NO_ALWAYS_NEVER",
     "name": "Never",
     "bindings": [
-      { "input_method": "keyboard_char", "key": [ "E" ] },
-      { "input_method": "keyboard_code", "key": [ "e" ], "mod": [ "shift" ] },
-      { "input_method": "keyboard_any", "key": [ "e" ] }
+      {
+        "input_method": "keyboard_char",
+        "key": [
+          "E"
+        ]
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": [
+          "e"
+        ],
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": [
+          "e"
+        ]
+      }
     ]
   },
   {
@@ -4517,11 +9771,26 @@
     "category": "POPUP_WAIT",
     "name": "Cancel popup",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "ESC" },
-      { "input_method": "keyboard_any", "key": "SPACE" },
-      { "input_method": "keyboard_any", "key": "RETURN" },
-      { "input_method": "keyboard_any", "key": "KEYPAD_ENTER" },
-      { "input_method": "mouse", "key": "MOUSE_RIGHT" }
+      {
+        "input_method": "keyboard_any",
+        "key": "ESC"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "SPACE"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "RETURN"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "KEYPAD_ENTER"
+      },
+      {
+        "input_method": "mouse",
+        "key": "MOUSE_RIGHT"
+      }
     ]
   },
   {
@@ -4529,119 +9798,273 @@
     "id": "CREATURE",
     "category": "EXTENDED_DESCRIPTION",
     "name": "Describe creature",
-    "bindings": [ { "input_method": "keyboard_any", "key": "c" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "c"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "FURNITURE",
     "category": "EXTENDED_DESCRIPTION",
     "name": "Describe furniture",
-    "bindings": [ { "input_method": "keyboard_any", "key": "f" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "f"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TERRAIN",
     "category": "EXTENDED_DESCRIPTION",
     "name": "Describe terrain",
-    "bindings": [ { "input_method": "keyboard_any", "key": "t" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "t"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_E"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "VEHICLE",
     "category": "EXTENDED_DESCRIPTION",
     "name": "Describe vehicle/appliance",
-    "bindings": [ { "input_method": "keyboard_any", "key": "v" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "v"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SWITCH_LISTS",
     "category": "INVENTORY",
     "name": "Switch lists",
-    "bindings": [ { "input_method": "keyboard_any", "key": "TAB" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "TAB"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_N"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "FAV_PRIORITY",
     "category": "INVENTORY",
     "name": "Set priority",
-    "bindings": [ { "input_method": "keyboard_any", "key": "p" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "p"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_NE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "FAV_AUTO_PICKUP",
     "category": "INVENTORY",
     "name": "Toggle auto pickup",
-    "bindings": [ { "input_method": "keyboard_any", "key": "d" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "d"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_E"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "FAV_AUTO_UNLOAD",
     "category": "INVENTORY",
     "name": "Toggle auto unload",
-    "bindings": [ { "input_method": "keyboard_any", "key": "u" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "u"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_SE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "FAV_ITEM",
     "category": "INVENTORY",
     "name": "Whitelist/blacklist item",
-    "bindings": [ { "input_method": "keyboard_any", "key": "i" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "i"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_S"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "FAV_CATEGORY",
     "category": "INVENTORY",
     "name": "Whitelist/blacklist category",
-    "bindings": [ { "input_method": "keyboard_any", "key": "c" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "c"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_SW"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "FAV_WHITELIST",
     "category": "INVENTORY",
     "name": "Switch to modifying whitelist",
-    "bindings": [ { "input_method": "keyboard_any", "key": "w" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "w"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_W"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "FAV_BLACKLIST",
     "category": "INVENTORY",
     "name": "Switch to modifying blacklist",
-    "bindings": [ { "input_method": "keyboard_any", "key": "b" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "b"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_R_NW"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "FAV_SAVE_PRESET",
     "category": "INVENTORY",
     "name": "Save preset",
-    "bindings": [ { "input_method": "keyboard_char", "key": "S" }, { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "S"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "s",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "FAV_APPLY_PRESET",
     "category": "INVENTORY",
     "name": "Apply preset",
-    "bindings": [ { "input_method": "keyboard_char", "key": "A" }, { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "A"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "a",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "FAV_DEL_PRESET",
     "category": "INVENTORY",
     "name": "Delete preset",
-    "bindings": [ { "input_method": "keyboard_char", "key": "D" }, { "input_method": "keyboard_code", "key": "d", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "D"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "d",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "FAV_CLEAR",
     "category": "INVENTORY",
     "name": "Clear entries",
-    "bindings": [ { "input_method": "keyboard_any", "key": "x" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "x"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "FAV_MOVE_ITEM",
     "category": "INVENTORY",
     "name": "Move item",
-    "bindings": [ { "input_method": "keyboard_any", "key": "m" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "m"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -4649,9 +10072,18 @@
     "category": "INVENTORY",
     "name": "Open context menu",
     "bindings": [
-      { "input_method": "keyboard_any", "key": "RETURN" },
-      { "input_method": "keyboard_any", "key": "KEYPAD_ENTER" },
-      { "input_method": "mouse", "key": "MOUSE_LEFT" }
+      {
+        "input_method": "keyboard_any",
+        "key": "RETURN"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "KEYPAD_ENTER"
+      },
+      {
+        "input_method": "mouse",
+        "key": "MOUSE_LEFT"
+      }
     ]
   },
   {
@@ -4659,9 +10091,21 @@
     "id": "CHANGE_PROFESSION_NAME",
     "name": "Change profession name",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "*" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
-      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] }
+      {
+        "input_method": "keyboard_char",
+        "key": "*"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "KEYPAD_MULTIPLY"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "8",
+        "mod": [
+          "shift"
+        ]
+      }
     ]
   },
   {
@@ -4669,158 +10113,358 @@
     "id": "SCROLL_MISSION_INFO_UP",
     "category": "FACTIONS",
     "name": "Scroll camp mission info up",
-    "bindings": [ { "input_method": "keyboard_any", "key": "[" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "["
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_MISSION_INFO_DOWN",
     "category": "FACTIONS",
     "name": "Scroll camp mission info down",
-    "bindings": [ { "input_method": "keyboard_any", "key": "]" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "]"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "category": "PLAYER_INFO",
     "id": "VIEW_PROFICIENCIES",
     "name": "View character proficiencies",
-    "bindings": [ { "input_method": "keyboard_any", "key": "p" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "p"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "category": "PLAYER_INFO",
     "id": "VIEW_BODYSTAT",
     "name": "View character's body status",
-    "bindings": [ { "input_method": "keyboard_any", "key": "s" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "s"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "View character's morale",
     "category": "PLAYER_INFO",
     "id": "morale",
-    "bindings": [ { "input_method": "keyboard_any", "key": "m" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "m"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "CHANGE_ARMOR_SPRITE",
     "category": "PLAYER_INFO",
     "name": "Change armor sprite",
-    "bindings": [ { "input_method": "keyboard_char", "key": "W" }, { "input_method": "keyboard_code", "key": "w", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "W"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "w",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "category": "PLAYER_INFO",
     "id": "SELECT_STATS_TAB",
     "name": "Select stats tab",
-    "bindings": [ { "input_method": "keyboard_any", "key": "w" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "w"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "category": "PLAYER_INFO",
     "id": "SELECT_ENCUMBRANCE_TAB",
     "name": "Select encumbrance tab",
-    "bindings": [ { "input_method": "keyboard_any", "key": "e" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "e"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "category": "PLAYER_INFO",
     "id": "SELECT_SKILLS_TAB",
     "name": "Select skills tab",
-    "bindings": [ { "input_method": "keyboard_any", "key": "r" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "r"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_E"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "category": "PLAYER_INFO",
     "id": "SELECT_TRAITS_TAB",
     "name": "Select traits tab",
-    "bindings": [ { "input_method": "keyboard_any", "key": "t" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "t"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "category": "PLAYER_INFO",
     "id": "SELECT_BIONICS_TAB",
     "name": "Select bionics tab",
-    "bindings": [ { "input_method": "keyboard_any", "key": "x" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "x"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_S"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "category": "PLAYER_INFO",
     "id": "SELECT_EFFECTS_TAB",
     "name": "Select effects tab",
-    "bindings": [ { "input_method": "keyboard_any", "key": "c" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "c"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SW"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "category": "PLAYER_INFO",
     "id": "SELECT_PROFICIENCIES_TAB",
     "name": "Select proficiencies tab",
-    "bindings": [ { "input_method": "keyboard_any", "key": "v" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "v"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_W"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "category": "WISH_ITEM",
     "id": "CONTAINER",
     "name": "Toggle spawning item with container",
-    "bindings": [ { "input_method": "keyboard_any", "key": "f" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "f"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "category": "WISH_ITEM",
     "id": "FLAG",
     "name": "Add flags to spawned items",
-    "bindings": [ { "input_method": "keyboard_char", "key": "F" }, { "input_method": "keyboard_code", "key": "f", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "F"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "f",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "category": "WISH_ITEM",
     "id": "EVERYTHING",
     "name": "Toggle spawning everything",
-    "bindings": [ { "input_method": "keyboard_char", "key": "E" }, { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "E"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "e",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "category": "WISH_ITEM",
     "id": "SNIPPET",
     "name": "Choose snippet",
-    "bindings": [ { "input_method": "keyboard_char", "key": "S" }, { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "S"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "s",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "category": "WISH_ITEM",
     "id": "SCROLL_DESC_UP",
     "name": "Scroll item description up",
-    "bindings": [ { "input_method": "keyboard_char", "key": "<" }, { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "<"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ",",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "category": "WISH_ITEM",
     "id": "SCROLL_DESC_DOWN",
     "name": "Scroll item description down",
-    "bindings": [ { "input_method": "keyboard_char", "key": ">" }, { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": ">"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ".",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_ITEM_INFO_UP",
     "category": "VENDING_MACHINE",
     "name": "Scroll item info up",
-    "bindings": [ { "input_method": "keyboard_char", "key": "<" }, { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "<"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ",",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_ITEM_INFO_DOWN",
     "category": "VENDING_MACHINE",
     "name": "Scroll item info down",
-    "bindings": [ { "input_method": "keyboard_char", "key": ">" }, { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": ">"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": ".",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "category": "DIALOGUE_CHOOSE_RESPONSE",
     "id": "LOOK_AT",
     "name": "Look at",
-    "bindings": [ 
-      { "input_method": "keyboard_char", "key": "L" }, 
-      { "input_method": "keyboard_code", "key": "l", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_X" }
-
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "L"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "l",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
     ]
   },
   {
@@ -4828,10 +10472,22 @@
     "category": "DIALOGUE_CHOOSE_RESPONSE",
     "id": "SIZE_UP_STATS",
     "name": "Size up stats",
-    "bindings": [ 
-      { "input_method": "keyboard_char", "key": "S" }, 
-      { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_Y" }
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "S"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "s",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_NE"
+      }
     ]
   },
   {
@@ -4839,10 +10495,22 @@
     "category": "DIALOGUE_CHOOSE_RESPONSE",
     "id": "ASSESS_PERSONALITY",
     "name": "Assess personality",
-    "bindings": [ 
-      { "input_method": "keyboard_char", "key": "A" }, 
-      { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_B" }
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "A"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "a",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_E"
+      }
     ]
   },
   {
@@ -4850,10 +10518,22 @@
     "category": "DIALOGUE_CHOOSE_RESPONSE",
     "id": "YELL",
     "name": "Yell",
-    "bindings": [ 
-      { "input_method": "keyboard_char", "key": "Y" }, 
-      { "input_method": "keyboard_code", "key": "y", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_ALT_X" }
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "Y"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "y",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_SE"
+      }
     ]
   },
   {
@@ -4861,10 +10541,22 @@
     "category": "DIALOGUE_CHOOSE_RESPONSE",
     "id": "CHECK_OPINION",
     "name": "Check opinion",
-    "bindings": [ 
-      { "input_method": "keyboard_char", "key": "O" }, 
-      { "input_method": "keyboard_code", "key": "o", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_ALT_Y" }
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "O"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "o",
+        "mod": [
+          "shift"
+        ]
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_S"
+      }
     ]
   },
   {
@@ -4872,158 +10564,317 @@
     "category": "FACTION_MANAGER",
     "id": "INSPECT_NPC",
     "name": "Inspect NPC",
-    "bindings": [ { "input_method": "keyboard_any", "key": "i" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "i"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SORT",
     "category": "NEW_CHAR_TRAITS",
     "name": "Sort traits list",
-    "bindings": [ { "input_method": "keyboard_any", "key": "s" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "s"
+      },
+      {
+        "input_method": "gamepad",
+        "key": "JOY_RADIAL_L_N"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "SELECT_TRAIT_VARIANT",
     "name": "Select variant for trait",
-    "bindings": [ { "input_method": "keyboard_char", "key": "S" }, { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_char",
+        "key": "S"
+      },
+      {
+        "input_method": "keyboard_code",
+        "key": "s",
+        "mod": [
+          "shift"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "DELETE PAGE",
     "name": "Delete page",
     "category": "DIARY",
-    "bindings": [ { "input_method": "keyboard_any", "mod": [  ], "key": [ "d" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "mod": [],
+        "key": [
+          "d"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "EXPORT_DIARY",
     "name": "Export diary to .txt",
     "category": "DIARY",
-    "bindings": [ { "input_method": "keyboard_any", "mod": [  ], "key": [ "e" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "mod": [],
+        "key": [
+          "e"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "NEW_PAGE",
     "name": "Add new page",
     "category": "DIARY",
-    "bindings": [ { "input_method": "keyboard_any", "mod": [  ], "key": [ "n" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "mod": [],
+        "key": [
+          "n"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "name": "View achievements, scores, and kills",
     "category": "DIARY",
     "id": "VIEW_SCORES",
-    "bindings": [ { "input_method": "keyboard_any", "mod": [  ], "key": [ "v" ] } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "mod": [],
+        "key": [
+          "v"
+        ]
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.QUIT",
     "name": "Cancel text input",
-    "bindings": [ { "input_method": "keyboard_any", "key": "ESC" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "ESC"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.CONFIRM",
     "name": "Confirm text input",
-    "bindings": [ { "input_method": "keyboard_any", "key": "RETURN" }, { "input_method": "keyboard_any", "key": "KEYPAD_ENTER" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "RETURN"
+      },
+      {
+        "input_method": "keyboard_any",
+        "key": "KEYPAD_ENTER"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.UP",
     "name": "Move cursor up",
-    "bindings": [ { "input_method": "keyboard_any", "key": "UP" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "UP"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.DOWN",
     "name": "Move cursor down",
-    "bindings": [ { "input_method": "keyboard_any", "key": "DOWN" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "DOWN"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.LEFT",
     "name": "Move cursor left",
-    "bindings": [ { "input_method": "keyboard_any", "key": "LEFT" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "LEFT"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.RIGHT",
     "name": "Move cursor right",
-    "bindings": [ { "input_method": "keyboard_any", "key": "RIGHT" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "RIGHT"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.PAGE_UP",
     "name": "Move cursor to previous page",
-    "bindings": [ { "input_method": "keyboard_any", "key": "PPAGE" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "PPAGE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.PAGE_DOWN",
     "name": "Move cursor to next page",
-    "bindings": [ { "input_method": "keyboard_any", "key": "NPAGE" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "NPAGE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.CLEAR",
     "name": "Clear text",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "CTRL+U" },
-      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "u" }
+      {
+        "input_method": "keyboard_char",
+        "key": "CTRL+U"
+      },
+      {
+        "input_method": "keyboard_code",
+        "mod": [
+          "ctrl"
+        ],
+        "key": "u"
+      }
     ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.BACKSPACE",
     "name": "Remove previous character",
-    "bindings": [ { "input_method": "keyboard_any", "key": "BACKSPACE" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "BACKSPACE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.HOME",
     "name": "Move cursor to start",
-    "bindings": [ { "input_method": "keyboard_any", "key": "HOME" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "HOME"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.END",
     "name": "Move cursor to end",
-    "bindings": [ { "input_method": "keyboard_any", "key": "END" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "END"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.DELETE",
     "name": "Remove current character",
-    "bindings": [ { "input_method": "keyboard_any", "key": "DELETE" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "DELETE"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.PASTE",
     "name": "Paste from clipboard",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "CTRL+V" },
-      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "v" }
+      {
+        "input_method": "keyboard_char",
+        "key": "CTRL+V"
+      },
+      {
+        "input_method": "keyboard_code",
+        "mod": [
+          "ctrl"
+        ],
+        "key": "v"
+      }
     ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.INPUT_FROM_FILE",
     "name": "Input text from file",
-    "bindings": [ { "input_method": "keyboard_any", "key": "F2" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "F2"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "HISTORY_UP",
     "name": "Show previous history",
     "category": "STRING_INPUT",
-    "bindings": [ { "input_method": "keyboard_any", "key": "UP" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "UP"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "HISTORY_DOWN",
     "name": "Show next history",
     "category": "STRING_INPUT",
-    "bindings": [ { "input_method": "keyboard_any", "key": "DOWN" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "DOWN"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -5031,7 +10882,12 @@
     "name": "Display keybindings menu",
     "category": "STRING_INPUT",
     "//": "'?' is treated as text input, so a different key is used.",
-    "bindings": [ { "input_method": "keyboard_any", "key": "F1" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "F1"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -5041,10 +10897,28 @@
     "//": "RETURN is treated as text input, so use a different keybinding",
     "//2": "CTRL+S is not available on curses, so add CTRL+Y as an alternative",
     "bindings": [
-      { "input_method": "keyboard_char", "key": "CTRL+S" },
-      { "input_method": "keyboard_char", "key": "CTRL+Y" },
-      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "s" },
-      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "y" }
+      {
+        "input_method": "keyboard_char",
+        "key": "CTRL+S"
+      },
+      {
+        "input_method": "keyboard_char",
+        "key": "CTRL+Y"
+      },
+      {
+        "input_method": "keyboard_code",
+        "mod": [
+          "ctrl"
+        ],
+        "key": "s"
+      },
+      {
+        "input_method": "keyboard_code",
+        "mod": [
+          "ctrl"
+        ],
+        "key": "y"
+      }
     ]
   },
   {
@@ -5052,42 +10926,72 @@
     "id": "TOGGLE_MONSTER_GROUP",
     "category": "SCORES_UI",
     "name": "Toggle monster group",
-    "bindings": [ { "input_method": "keyboard_any", "key": "m" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "m"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_NPC_GROUP",
     "category": "SCORES_UI",
     "name": "Toggle NPC group",
-    "bindings": [ { "input_method": "keyboard_any", "key": "n" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "n"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_GENERAL_INFO_GROUP",
     "category": "MA_DETAILS_UI",
     "name": "Toggle general info group",
-    "bindings": [ { "input_method": "keyboard_any", "key": "g" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "g"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_BUFFS_GROUP",
     "category": "MA_DETAILS_UI",
     "name": "Toggle buffs group",
-    "bindings": [ { "input_method": "keyboard_any", "key": "b" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "b"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_TECHNIQUES_GROUP",
     "category": "MA_DETAILS_UI",
     "name": "Toggle techniques group",
-    "bindings": [ { "input_method": "keyboard_any", "key": "t" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "t"
+      }
+    ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_WEAPONS_GROUP",
     "category": "MA_DETAILS_UI",
     "name": "Toggle weapons group",
-    "bindings": [ { "input_method": "keyboard_any", "key": "w" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "w"
+      }
+    ]
   },
   {
     "type": "keybinding",
@@ -5095,6 +10999,11 @@
     "name": "Display keybindings menu",
     "category": "STRING_EDITOR",
     "//": "'?' is treated as text input, so a different key is used.",
-    "bindings": [ { "input_method": "keyboard_any", "key": "F1" } ]
+    "bindings": [
+      {
+        "input_method": "keyboard_any",
+        "key": "F1"
+      }
+    ]
   }
 ]

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -67,7 +67,7 @@
       { "input_method": "keyboard_any", "key": "UP" },
       { "input_method": "keyboard_any", "key": "8" },
       { "input_method": "keyboard_code", "key": "KEYPAD_8" },
-      { "input_method": "gamepad", "key": "JOY_UP" }
+      { "input_method": "gamepad", "key": "JOY_L_UP" }
     ]
   },
   {
@@ -79,7 +79,7 @@
       { "input_method": "keyboard_any", "key": "DOWN" },
       { "input_method": "keyboard_any", "key": "2" },
       { "input_method": "keyboard_code", "key": "KEYPAD_2" },
-      { "input_method": "gamepad", "key": "JOY_DOWN" }
+      { "input_method": "gamepad", "key": "JOY_L_DOWN" }
     ]
   },
   {
@@ -91,7 +91,7 @@
       { "input_method": "keyboard_any", "key": "LEFT" },
       { "input_method": "keyboard_any", "key": "4" },
       { "input_method": "keyboard_code", "key": "KEYPAD_4" },
-      { "input_method": "gamepad", "key": "JOY_LEFT" }
+      { "input_method": "gamepad", "key": "JOY_L_LEFT" }
     ]
   },
   {
@@ -103,7 +103,7 @@
       { "input_method": "keyboard_any", "key": "RIGHT" },
       { "input_method": "keyboard_any", "key": "6" },
       { "input_method": "keyboard_code", "key": "KEYPAD_6" },
-      { "input_method": "gamepad", "key": "JOY_RIGHT" }
+      { "input_method": "gamepad", "key": "JOY_L_RIGHT" }
     ]
   },
   {
@@ -114,7 +114,7 @@
       { "input_method": "keyboard_any", "key": "y" },
       { "input_method": "keyboard_any", "key": "7" },
       { "input_method": "keyboard_code", "key": "KEYPAD_7" },
-      { "input_method": "gamepad", "key": "JOY_LEFTUP" }
+      { "input_method": "gamepad", "key": "JOY_L_LEFTUP" }
     ]
   },
   {
@@ -125,7 +125,7 @@
       { "input_method": "keyboard_any", "key": "u" },
       { "input_method": "keyboard_any", "key": "9" },
       { "input_method": "keyboard_code", "key": "KEYPAD_9" },
-      { "input_method": "gamepad", "key": "JOY_RIGHTUP" }
+      { "input_method": "gamepad", "key": "JOY_L_RIGHTUP" }
     ]
   },
   {
@@ -136,7 +136,7 @@
       { "input_method": "keyboard_any", "key": "b" },
       { "input_method": "keyboard_any", "key": "1" },
       { "input_method": "keyboard_code", "key": "KEYPAD_1" },
-      { "input_method": "gamepad", "key": "JOY_LEFTDOWN" }
+      { "input_method": "gamepad", "key": "JOY_L_LEFTDOWN" }
     ]
   },
   {
@@ -147,7 +147,7 @@
       { "input_method": "keyboard_any", "key": "n" },
       { "input_method": "keyboard_any", "key": "3" },
       { "input_method": "keyboard_code", "key": "KEYPAD_3" },
-      { "input_method": "gamepad", "key": "JOY_RIGHTDOWN" }
+      { "input_method": "gamepad", "key": "JOY_L_RIGHTDOWN" }
     ]
   },
   {
@@ -247,8 +247,7 @@
     "name": "Mark selected item",
     "bindings": [
       { "input_method": "keyboard_any", "key": "l" },
-      { "input_method": "keyboard_any", "key": "RIGHT" },
-      { "input_method": "gamepad", "key": "JOY_RIGHT" }
+      { "input_method": "keyboard_any", "key": "RIGHT" }
     ]
   },
   {
@@ -816,7 +815,8 @@
     "bindings": [
       { "input_method": "keyboard_any", "key": "PPAGE" },
       { "input_method": "keyboard_char", "key": "<" },
-      { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] }
+      { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_UP" }
     ]
   },
   {
@@ -826,7 +826,8 @@
     "bindings": [
       { "input_method": "keyboard_any", "key": "NPAGE" },
       { "input_method": "keyboard_char", "key": ">" },
-      { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] }
+      { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_DOWN" }
     ]
   },
   {
@@ -837,7 +838,8 @@
     "bindings": [
       { "input_method": "keyboard_any", "key": "=" },
       { "input_method": "keyboard_char", "key": "+" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" }
+      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" },
+      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_RIGHT" }
     ]
   },
   {
@@ -845,7 +847,11 @@
     "id": "PREV",
     "category": "SOKOBAN",
     "name": "Previous level",
-    "bindings": [ { "input_method": "keyboard_any", "key": "-" }, { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" } ]
+    "bindings": [ 
+      { "input_method": "keyboard_any", "key": "-" }, 
+      { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" }, 
+      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_LEFT" } 
+    ]
   },
   {
     "type": "keybinding",
@@ -1390,7 +1396,8 @@
       { "input_method": "keyboard_char", "key": "BACKTAB" },
       { "input_method": "keyboard_code", "key": "TAB", "mod": [ "shift" ] },
       { "input_method": "mouse", "key": "SCROLL_UP" },
-      { "input_method": "keyboard_any", "key": "PPAGE" }
+      { "input_method": "keyboard_any", "key": "PPAGE" },
+      { "input_method": "gamepad", "key": "JOY_LB" }
     ]
   },
   {
@@ -1401,7 +1408,8 @@
     "bindings": [
       { "input_method": "keyboard_any", "key": "TAB" },
       { "input_method": "mouse", "key": "SCROLL_DOWN" },
-      { "input_method": "keyboard_any", "key": "NPAGE" }
+      { "input_method": "keyboard_any", "key": "NPAGE" },
+      { "input_method": "gamepad", "key": "JOY_RB" }
     ]
   },
   {
@@ -1413,7 +1421,8 @@
       { "input_method": "keyboard_any", "key": "." },
       { "input_method": "keyboard_code", "key": "KEYPAD_PERIOD" },
       { "input_method": "keyboard_any", "key": "5" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_5" }
+      { "input_method": "keyboard_code", "key": "KEYPAD_5" },
+      { "input_method": "gamepad", "key": "JOY_RT" }
     ]
   },
   {
@@ -1428,28 +1437,28 @@
     "id": "AIMED_SHOT",
     "category": "TARGET",
     "name": "Aimed shot",
-    "bindings": [ { "input_method": "keyboard_any", "key": "a" } ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "a" }, { "input_method": "gamepad", "key": "JOY_ALT_A" } ]
   },
   {
     "type": "keybinding",
     "id": "CAREFUL_SHOT",
     "category": "TARGET",
     "name": "Careful shot",
-    "bindings": [ { "input_method": "keyboard_any", "key": "c" } ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "c" }, { "input_method": "gamepad", "key": "JOY_X" } ]
   },
   {
     "type": "keybinding",
     "id": "PRECISE_SHOT",
     "category": "TARGET",
     "name": "Precise shot",
-    "bindings": [ { "input_method": "keyboard_any", "key": "p" } ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "p" }, { "input_method": "gamepad", "key": "JOY_ALT_X" } ]
   },
   {
     "type": "keybinding",
     "id": "SWITCH_AMMO",
     "category": "TARGET",
     "name": "Switch ammo",
-    "bindings": [ { "input_method": "keyboard_any", "key": "o" } ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "o" }, { "input_method": "gamepad", "key": "JOY_ALT_LB" } ]
   },
   {
     "type": "keybinding",
@@ -1459,7 +1468,8 @@
     "bindings": [
       { "input_method": "keyboard_any", "key": "s" },
       { "input_method": "keyboard_char", "key": "F" },
-      { "input_method": "keyboard_code", "key": "f", "mod": [ "shift" ] }
+      { "input_method": "keyboard_code", "key": "f", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_Y" }
     ]
   },
   {
@@ -1536,7 +1546,7 @@
     "type": "keybinding",
     "id": "NEXT_TAB",
     "name": "Go to next tab",
-    "bindings": [ { "input_method": "keyboard_any", "key": "TAB" } ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "TAB" }, { "input_method": "gamepad", "key": "JOY_RB" } ]
   },
   {
     "type": "keybinding",
@@ -1544,7 +1554,8 @@
     "name": "Go to previous tab",
     "bindings": [
       { "input_method": "keyboard_char", "key": "BACKTAB" },
-      { "input_method": "keyboard_code", "key": "TAB", "mod": [ "shift" ] }
+      { "input_method": "keyboard_code", "key": "TAB", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_LB" }
     ]
   },
   {
@@ -1557,7 +1568,7 @@
     "type": "keybinding",
     "id": "EXTENDED_DESCRIPTION",
     "name": "Show extended description",
-    "bindings": [ { "input_method": "keyboard_any", "key": "e" } ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "e" }, { "input_method": "gamepad", "key": "JOY_RS" } ]
   },
   {
     "type": "keybinding",
@@ -1606,7 +1617,11 @@
     "type": "keybinding",
     "id": "MEDICAL_MENU",
     "name": "Open medical menu",
-    "bindings": [ { "input_method": "keyboard_char", "key": "@" }, { "input_method": "keyboard_code", "key": "2", "mod": [ "shift" ] } ]
+    "bindings": [ 
+      { "input_method": "keyboard_char", "key": "@" }, 
+      { "input_method": "keyboard_code", "key": "2", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_R_NE" }
+     ]
   },
   {
     "type": "keybinding",
@@ -2199,28 +2214,32 @@
     "id": "EXAMINE",
     "category": "INVENTORY",
     "name": "Examine",
-    "bindings": [ { "input_method": "keyboard_any", "key": "e" } ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "e" }, { "input_method": "gamepad", "key": "JOY_RS" } ]
   },
   {
     "type": "keybinding",
     "id": "WIELD",
     "category": "INVENTORY",
     "name": "Wield",
-    "bindings": [ { "input_method": "keyboard_any", "key": "w" } ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "w" }, { "input_method": "gamepad", "key": "JOY_X" } ]
   },
   {
     "type": "keybinding",
     "id": "WEAR",
     "category": "INVENTORY",
     "name": "Wear",
-    "bindings": [ { "input_method": "keyboard_char", "key": "W" }, { "input_method": "keyboard_code", "key": "w", "mod": [ "shift" ] } ]
+    "bindings": [ 
+      { "input_method": "keyboard_char", "key": "W" }, 
+      { "input_method": "keyboard_code", "key": "w", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_Y" }
+   ]
   },
   {
     "type": "keybinding",
     "id": "EXAMINE_CONTENTS",
     "category": "INVENTORY",
     "name": "Examine contents",
-    "bindings": [ { "input_method": "keyboard_any", "key": "o" } ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "o" }, { "input_method": "gamepad", "key": "JOY_Y" } ]
   },
   {
     "type": "keybinding",
@@ -2346,7 +2365,7 @@
       { "input_method": "keyboard_code", "key": "KEYPAD_PERIOD" },
       { "input_method": "keyboard_any", "key": "5" },
       { "input_method": "keyboard_code", "key": "KEYPAD_5" },
-      { "input_method": "gamepad", "key": "JOY_7" }
+      { "input_method": "gamepad", "key": "JOY_RT" }
     ]
   },
   {
@@ -2365,35 +2384,35 @@
     "name": "Center view",
     "category": "DEFAULTMODE",
     "id": "center",
-    "bindings": [ { "input_method": "gamepad", "key": "JOY_8" } ]
+    "bindings": [ ]
   },
   {
     "type": "keybinding",
     "name": "Move view north",
     "category": "DEFAULTMODE",
     "id": "shift_n",
-    "bindings": [ { "input_method": "gamepad", "key": "JOY_21" } ]
+    "bindings": [ { "input_method": "gamepad", "key": "JOY_R_UP" } ]
   },
   {
     "type": "keybinding",
     "name": "Move view east",
     "category": "DEFAULTMODE",
     "id": "shift_e",
-    "bindings": [ { "input_method": "gamepad", "key": "JOY_22" } ]
+    "bindings": [ { "input_method": "gamepad", "key": "JOY_R_RIGHT" } ]
   },
   {
     "type": "keybinding",
     "name": "Move view south",
     "category": "DEFAULTMODE",
     "id": "shift_s",
-    "bindings": [ { "input_method": "gamepad", "key": "JOY_23" } ]
+    "bindings": [ { "input_method": "gamepad", "key": "JOY_R_DOWN" } ]
   },
   {
     "type": "keybinding",
     "name": "Move view west",
     "category": "DEFAULTMODE",
     "id": "shift_w",
-    "bindings": [ { "input_method": "gamepad", "key": "JOY_24" } ]
+    "bindings": [ { "input_method": "gamepad", "key": "JOY_R_LEFT" } ]
   },
   {
     "type": "keybinding",
@@ -2414,7 +2433,7 @@
     "name": "Smash nearby terrain",
     "category": "DEFAULTMODE",
     "id": "smash",
-    "bindings": [ { "input_method": "keyboard_any", "key": "s" } ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "s" }, { "input_method": "gamepad", "key": "JOY_ALT_X" } ]
   },
   {
     "type": "keybinding",
@@ -2428,14 +2447,18 @@
     "name": "Examine nearby terrain, furniture, and items",
     "category": "DEFAULTMODE",
     "id": "examine_and_pickup",
-    "bindings": [ { "input_method": "gamepad", "key": "JOY_2" } ]
+    "bindings": [ { "input_method": "gamepad", "key": "JOY_X" } ]
   },
   {
     "type": "keybinding",
     "name": "Advanced Inventory Manager",
     "category": "DEFAULTMODE",
     "id": "advinv",
-    "bindings": [ { "input_method": "keyboard_any", "key": "/" }, { "input_method": "keyboard_code", "key": "KEYPAD_DIVIDE" } ]
+    "bindings": [
+      { "input_method": "keyboard_any", "key": "/" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_DIVIDE" },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_R_SE" }
+    ]
   },
   {
     "type": "keybinding",
@@ -2455,14 +2478,18 @@
     "name": "Grab something nearby",
     "category": "DEFAULTMODE",
     "id": "grab",
-    "bindings": [ { "input_method": "keyboard_char", "key": "G" }, { "input_method": "keyboard_code", "key": "g", "mod": [ "shift" ] } ]
+    "bindings": [
+      { "input_method": "keyboard_char", "key": "G" },
+      { "input_method": "keyboard_code", "key": "g", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_B" }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Haul items along the ground",
     "category": "DEFAULTMODE",
     "id": "haul",
-    "bindings": [ { "input_method": "keyboard_any", "key": "\\" } ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "\\" }, { "input_method": "gamepad", "key": "JOY_ALT_B" } ]
   },
   {
     "type": "keybinding",
@@ -2482,7 +2509,7 @@
     "name": "Butcher",
     "category": "DEFAULTMODE",
     "id": "butcher",
-    "bindings": [ { "input_method": "keyboard_char", "key": "B" }, { "input_method": "keyboard_code", "key": "b", "mod": [ "shift" ] } ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "B" }, { "input_method": "keyboard_code", "key": "b", "mod": [ "shift" ] }, { "input_method": "gamepad", "key": "JOY_RADIAL_L_E" } ]
   },
   {
     "type": "keybinding",
@@ -2498,8 +2525,7 @@
     "id": "look",
     "bindings": [
       { "input_method": "keyboard_any", "key": ";" },
-      { "input_method": "keyboard_any", "key": "x" },
-      { "input_method": "gamepad", "key": "JOY_0" }
+      { "input_method": "keyboard_any", "key": "x" }
     ]
   },
   {
@@ -2513,14 +2539,18 @@
     "name": "Peek around corners",
     "category": "DEFAULTMODE",
     "id": "peek",
-    "bindings": [ { "input_method": "keyboard_char", "key": "X" }, { "input_method": "keyboard_code", "key": "x", "mod": [ "shift" ] } ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "X" }, { "input_method": "keyboard_code", "key": "x", "mod": [ "shift" ] }, { "input_method": "gamepad", "key": "JOY_ALT_RS" } ]
   },
   {
     "type": "keybinding",
     "name": "List all items around the player",
     "category": "DEFAULTMODE",
     "id": "listitems",
-    "bindings": [ { "input_method": "keyboard_char", "key": "V" }, { "input_method": "keyboard_code", "key": "v", "mod": [ "shift" ] } ]
+    "bindings": [ 
+      { "input_method": "keyboard_char", "key": "V" }, 
+      { "input_method": "keyboard_code", "key": "v", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RS" }
+    ]
   },
   {
     "type": "keybinding",
@@ -2534,14 +2564,17 @@
     "name": "Open inventory",
     "category": "DEFAULTMODE",
     "id": "inventory",
-    "bindings": [ { "input_method": "keyboard_any", "key": "i" }, { "input_method": "gamepad", "key": "JOY_5" } ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "i" }, { "input_method": "gamepad", "key": "JOY_RADIAL_R_S" } ]
   },
   {
     "type": "keybinding",
     "name": "Compare two items",
     "category": "DEFAULTMODE",
     "id": "compare",
-    "bindings": [ { "input_method": "keyboard_char", "key": "I" }, { "input_method": "keyboard_code", "key": "i", "mod": [ "shift" ] } ]
+    "bindings": [ 
+      { "input_method": "keyboard_char", "key": "I" }, 
+      { "input_method": "keyboard_code", "key": "i", "mod": [ "shift" ] }
+    ]
   },
   {
     "type": "keybinding",
@@ -2562,28 +2595,44 @@
     "name": "Use wielded item",
     "category": "DEFAULTMODE",
     "id": "apply_wielded",
-    "bindings": [ { "input_method": "keyboard_char", "key": "A" }, { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] } ]
+    "bindings": [ 
+      { "input_method": "keyboard_char", "key": "A" }, 
+      { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_RIGHT" }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Wear item",
     "category": "DEFAULTMODE",
     "id": "wear",
-    "bindings": [ { "input_method": "keyboard_char", "key": "W" }, { "input_method": "keyboard_code", "key": "w", "mod": [ "shift" ] } ]
+    "bindings": [ 
+      { "input_method": "keyboard_char", "key": "W" }, 
+      { "input_method": "keyboard_code", "key": "w", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_DPAD_LEFT" }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Take off worn item",
     "category": "DEFAULTMODE",
     "id": "take_off",
-    "bindings": [ { "input_method": "keyboard_char", "key": "T" }, { "input_method": "keyboard_code", "key": "t", "mod": [ "shift" ] } ]
+    "bindings": [ 
+      { "input_method": "keyboard_char", "key": "T" }, 
+      { "input_method": "keyboard_code", "key": "t", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_LEFT" }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Consume item (all items)",
     "category": "DEFAULTMODE",
     "id": "eat",
-    "bindings": [ { "input_method": "keyboard_char", "key": "E" }, { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] } ]
+    "bindings": [ 
+      { "input_method": "keyboard_char", "key": "E" }, 
+      { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_DPAD_UP" }
+    ]
   },
   {
     "type": "keybinding",
@@ -2596,21 +2645,29 @@
     "name": "Read",
     "category": "DEFAULTMODE",
     "id": "read",
-    "bindings": [ { "input_method": "keyboard_char", "key": "R" }, { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] } ]
+    "bindings": [ 
+      { "input_method": "keyboard_char", "key": "R" }, 
+      { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_NE" }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Wield",
     "category": "DEFAULTMODE",
     "id": "wield",
-    "bindings": [ { "input_method": "keyboard_any", "key": "w" } ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "w" }, { "input_method": "gamepad", "key": "JOY_DPAD_RIGHT" } ]
   },
   {
     "type": "keybinding",
     "name": "Select martial arts style",
     "category": "DEFAULTMODE",
     "id": "pick_style",
-    "bindings": [ { "input_method": "keyboard_char", "key": "_" }, { "input_method": "keyboard_code", "key": "-", "mod": [ "shift" ] } ]
+    "bindings": [ 
+      { "input_method": "keyboard_char", "key": "_" }, 
+      { "input_method": "keyboard_code", "key": "-", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_ALT_RB" }
+    ]
   },
   {
     "type": "keybinding",
@@ -2643,7 +2700,7 @@
     "name": "Throw item",
     "category": "DEFAULTMODE",
     "id": "throw",
-    "bindings": [ { "input_method": "keyboard_any", "key": "t" } ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "t" }, { "input_method": "gamepad", "key": "JOY_Y" } ]
   },
   {
     "type": "keybinding",
@@ -2669,7 +2726,7 @@
     "name": "Fire wielded item",
     "category": "DEFAULTMODE",
     "id": "fire",
-    "bindings": [ { "input_method": "keyboard_any", "key": "f" }, { "input_method": "gamepad", "key": "JOY_3" } ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "f" }, { "input_method": "gamepad", "key": "JOY_LB" } ]
   },
   {
     "type": "keybinding",
@@ -2690,7 +2747,7 @@
     "name": "Drop item",
     "category": "DEFAULTMODE",
     "id": "drop",
-    "bindings": [ { "input_method": "keyboard_any", "key": "d" } ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "d" }, { "input_method": "gamepad", "key": "JOY_DPAD_DOWN" } ]
   },
   {
     "type": "keybinding",
@@ -2724,14 +2781,22 @@
     "name": "View medical",
     "category": "DEFAULTMODE",
     "id": "medical",
-    "bindings": [ { "input_method": "keyboard_char", "key": "N" }, { "input_method": "keyboard_code", "key": "n", "mod": [ "shift" ] } ]
+    "bindings": [ 
+      { "input_method": "keyboard_char", "key": "N" }, 
+      { "input_method": "keyboard_code", "key": "n", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_R_NE" }
+    ]
   },
   {
     "type": "keybinding",
     "name": "View body status",
     "category": "DEFAULTMODE",
     "id": "bodystatus",
-    "bindings": [ { "input_method": "keyboard_char", "key": "{" }, { "input_method": "keyboard_code", "key": "[", "mod": [ "shift" ] } ]
+    "bindings": [ 
+      { "input_method": "keyboard_char", "key": "{" }, 
+      { "input_method": "keyboard_code", "key": "[", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_R_SW" }
+    ]
   },
   {
     "type": "keybinding",
@@ -2751,7 +2816,8 @@
     "id": "wait",
     "bindings": [
       { "input_method": "keyboard_char", "key": "|" },
-      { "input_method": "keyboard_code", "key": "\\", "mod": [ "shift" ] }
+      { "input_method": "keyboard_code", "key": "\\", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_SE" }
     ]
   },
   {
@@ -2759,14 +2825,22 @@
     "name": "Craft items",
     "category": "DEFAULTMODE",
     "id": "craft",
-    "bindings": [ { "input_method": "keyboard_char", "key": "&" }, { "input_method": "keyboard_code", "key": "7", "mod": [ "shift" ] } ]
+    "bindings": [ 
+      { "input_method": "keyboard_char", "key": "&" }, 
+      { "input_method": "keyboard_code", "key": "7", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_N" }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Recraft last recipe",
     "category": "DEFAULTMODE",
     "id": "recraft",
-    "bindings": [ { "input_method": "keyboard_any", "key": "-" }, { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" } ]
+    "bindings": [ 
+      { "input_method": "keyboard_any", "key": "-" }, 
+      { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_NW" }
+    ]
   },
   {
     "type": "keybinding",
@@ -2776,7 +2850,8 @@
     "bindings": [
       { "input_method": "keyboard_char", "key": "*" },
       { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
-      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] }
+      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_S" }
     ]
   },
   {
@@ -2784,14 +2859,22 @@
     "name": "Disassemble items",
     "category": "DEFAULTMODE",
     "id": "disassemble",
-    "bindings": [ { "input_method": "keyboard_char", "key": "(" }, { "input_method": "keyboard_code", "key": "9", "mod": [ "shift" ] } ]
+    "bindings": [ 
+      { "input_method": "keyboard_char", "key": "(" }, 
+      { "input_method": "keyboard_code", "key": "9", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_W" }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Sleep",
     "category": "DEFAULTMODE",
     "id": "sleep",
-    "bindings": [ { "input_method": "keyboard_char", "key": "$" }, { "input_method": "keyboard_code", "key": "4", "mod": [ "shift" ] } ]
+    "bindings": [ 
+      { "input_method": "keyboard_char", "key": "$" }, 
+      { "input_method": "keyboard_code", "key": "4", "mod": [ "shift" ] }, 
+      { "input_method": "gamepad", "key": "JOY_RADIAL_L_SW" }
+    ]
   },
   {
     "type": "keybinding",
@@ -2820,7 +2903,7 @@
     "bindings": [
       { "input_method": "keyboard_char", "key": "!" },
       { "input_method": "keyboard_code", "key": "1", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_29" }
+      { "input_method": "gamepad", "key": "JOY_ALT_LS" }
     ]
   },
   {
@@ -2828,7 +2911,7 @@
     "name": "Ignore nearby enemy",
     "category": "DEFAULTMODE",
     "id": "ignore_enemy",
-    "bindings": [ { "input_method": "keyboard_any", "key": "'" } ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "'" }, { "input_method": "gamepad", "key": "JOY_LS" } ]
   },
   {
     "type": "keybinding",
@@ -2855,14 +2938,14 @@
     "name": "View player info",
     "category": "DEFAULTMODE",
     "id": "player_data",
-    "bindings": [ { "input_method": "keyboard_char", "key": "@" }, { "input_method": "keyboard_code", "key": "2", "mod": [ "shift" ] } ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "@" }, { "input_method": "keyboard_code", "key": "2", "mod": [ "shift" ] }, { "input_method": "gamepad", "key": "JOY_RADIAL_R_N" } ]
   },
   {
     "type": "keybinding",
     "name": "View map",
     "category": "DEFAULTMODE",
     "id": "map",
-    "bindings": [ { "input_method": "keyboard_any", "key": "m" } ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "m" }, { "input_method": "gamepad", "key": "JOY_BACK" } ]
   },
   {
     "type": "keybinding",
@@ -2881,46 +2964,67 @@
     "name": "View missions",
     "category": "DEFAULTMODE",
     "id": "missions",
-    "bindings": [ { "input_method": "keyboard_char", "key": "M" }, { "input_method": "keyboard_code", "key": "m", "mod": [ "shift" ] } ]
+    "bindings": [ 
+      { "input_method": "keyboard_char", "key": "M" }, 
+      { "input_method": "keyboard_code", "key": "m", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_R_W" }
+    ]
   },
   {
     "type": "keybinding",
     "name": "View factions",
     "category": "DEFAULTMODE",
     "id": "factions",
-    "bindings": [ { "input_method": "keyboard_char", "key": "#" }, { "input_method": "keyboard_code", "key": "3", "mod": [ "shift" ] } ]
+    "bindings": [ 
+      { "input_method": "keyboard_char", "key": "#" }, 
+      { "input_method": "keyboard_code", "key": "3", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_RADIAL_R_E" }
+    ]
   },
   {
     "type": "keybinding",
     "name": "View character's morale",
     "category": "DEFAULTMODE",
-    "id": "morale"
+    "id": "morale",
+    "bindings": [ 
+      { "input_method": "gamepad", "key": "JOY_RADIAL_R_NW" }
+    ]
   },
   {
     "type": "keybinding",
     "name": "View message log",
     "category": "DEFAULTMODE",
     "id": "messages",
-    "bindings": [ { "input_method": "keyboard_char", "key": "P" }, { "input_method": "keyboard_code", "key": "p", "mod": [ "shift" ] } ]
+    "bindings": [ 
+      { "input_method": "keyboard_char", "key": "P" }, 
+      { "input_method": "keyboard_code", "key": "p", "mod": [ "shift" ] }
+    ]
   },
   {
     "type": "keybinding",
     "name": "View help",
     "category": "DEFAULTMODE",
     "id": "help",
-    "bindings": [ { "input_method": "keyboard_any", "key": "0" }, { "input_method": "keyboard_code", "key": "KEYPAD_0" } ]
+    "bindings": [
+      { "input_method": "keyboard_any", "key": "0" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_0" }
+    ]
   },
   {
     "type": "keybinding",
     "name": "Zoom in",
     "id": "zoom_in",
-    "bindings": [ { "input_method": "keyboard_any", "key": "z" }, { "input_method": "gamepad", "key": "JOY_30" } ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "z" }, { "input_method": "gamepad", "key": "JOY_ALT_START" } ]
   },
   {
     "type": "keybinding",
     "name": "Zoom out",
     "id": "zoom_out",
-    "bindings": [ { "input_method": "keyboard_char", "key": "Z" }, { "input_method": "keyboard_code", "key": "z", "mod": [ "shift" ] } ]
+    "bindings": [
+      { "input_method": "keyboard_char", "key": "Z" },
+      { "input_method": "keyboard_code", "key": "z", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_ALT_BACK" }
+    ]
   },
   {
     "type": "keybinding",
@@ -3045,7 +3149,7 @@
     "name": "Reload item",
     "category": "DEFAULTMODE",
     "id": "reload_item",
-    "bindings": [ { "input_method": "keyboard_any", "key": "r" } ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "r" }, { "input_method": "gamepad", "key": "JOY_ALT_LB" } ]
   },
   {
     "type": "keybinding",
@@ -3094,7 +3198,11 @@
     "name": "Action menu",
     "category": "DEFAULTMODE",
     "id": "action_menu",
-    "bindings": [ { "input_method": "keyboard_any", "key": "RETURN" }, { "input_method": "keyboard_any", "key": "KEYPAD_ENTER" } ]
+    "bindings": [ 
+      { "input_method": "keyboard_any", "key": "RETURN" }, 
+      { "input_method": "keyboard_any", "key": "KEYPAD_ENTER" },
+      { "input_method": "gamepad", "key": "JOY_A" }
+    ]
   },
   {
     "type": "keybinding",
@@ -3104,7 +3212,7 @@
     "bindings": [
       { "input_method": "keyboard_char", "key": "%" },
       { "input_method": "keyboard_code", "key": "5", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "JOY_9" }
+      { "input_method": "gamepad", "key": "JOY_ALT_A" }
     ]
   },
   {
@@ -3124,28 +3232,28 @@
     "name": "Move view northeast",
     "category": "DEFAULTMODE",
     "id": "shift_ne",
-    "bindings": [ { "input_method": "gamepad", "key": "JOY_25" } ]
+    "bindings": [ { "input_method": "gamepad", "key": "JOY_R_RIGHTUP" } ]
   },
   {
     "type": "keybinding",
     "name": "Move view southeast",
     "category": "DEFAULTMODE",
     "id": "shift_se",
-    "bindings": [ { "input_method": "gamepad", "key": "JOY_26" } ]
+    "bindings": [ { "input_method": "gamepad", "key": "JOY_R_RIGHTDOWN" } ]
   },
   {
     "type": "keybinding",
     "name": "Move view southwest",
     "category": "DEFAULTMODE",
     "id": "shift_sw",
-    "bindings": [ { "input_method": "gamepad", "key": "JOY_27" } ]
+    "bindings": [ { "input_method": "gamepad", "key": "JOY_R_LEFTDOWN" } ]
   },
   {
     "type": "keybinding",
     "name": "Move view northwest",
     "category": "DEFAULTMODE",
     "id": "shift_nw",
-    "bindings": [ { "input_method": "gamepad", "key": "JOY_28" } ]
+    "bindings": [ { "input_method": "gamepad", "key": "JOY_R_LEFTUP" } ]
   },
   {
     "type": "keybinding",
@@ -3170,14 +3278,14 @@
     "name": "Autoattack",
     "category": "DEFAULTMODE",
     "id": "autoattack",
-    "bindings": [ { "input_method": "keyboard_any", "key": "TAB" }, { "input_method": "gamepad", "key": "JOY_1" } ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "TAB" }, { "input_method": "gamepad", "key": "JOY_RB" } ]
   },
   {
     "type": "keybinding",
     "name": "Main menu",
     "category": "DEFAULTMODE",
     "id": "main_menu",
-    "bindings": [ { "input_method": "keyboard_any", "key": "ESC" } ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "ESC" }, { "input_method": "gamepad", "key": "JOY_START" } ]
   },
   {
     "type": "keybinding",
@@ -3226,7 +3334,7 @@
     "name": "Cycle movement mode",
     "category": "DEFAULTMODE",
     "id": "cycle_move",
-    "bindings": [ { "input_method": "gamepad", "key": "JOY_10" } ]
+    "bindings": [ ]
   },
   {
     "type": "keybinding",
@@ -3265,7 +3373,8 @@
     "id": "open_movement",
     "bindings": [
       { "input_method": "keyboard_char", "key": "\"" },
-      { "input_method": "keyboard_code", "key": "'", "mod": [ "shift" ] }
+      { "input_method": "keyboard_code", "key": "'", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_ALT_RT" }
     ]
   },
   {
@@ -3273,7 +3382,7 @@
     "id": "cast_spell",
     "name": "Supernatural abilities",
     "category": "DEFAULTMODE",
-    "bindings": [ { "input_method": "keyboard_any", "key": "]" } ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "]" }, { "input_method": "gamepad", "key": "JOY_ALT_Y" } ]
   },
   {
     "type": "keybinding",
@@ -3388,7 +3497,11 @@
     "id": "LIST_ITEMS",
     "category": "LOOK",
     "name": "List items and monsters",
-    "bindings": [ { "input_method": "keyboard_char", "key": "V" }, { "input_method": "keyboard_code", "key": "v", "mod": [ "shift" ] } ]
+    "bindings": [ 
+      { "input_method": "keyboard_char", "key": "V" }, 
+      { "input_method": "keyboard_code", "key": "v", "mod": [ "shift" ] }, 
+      { "input_method": "gamepad", "key": "JOY_RS" } 
+    ]
   },
   {
     "type": "keybinding",
@@ -3689,7 +3802,8 @@
     "bindings": [
       { "input_method": "keyboard_any", "key": "NPAGE" },
       { "input_method": "keyboard_char", "key": ">" },
-      { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] }
+      { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_DOWN" }
     ]
   },
   {
@@ -3700,7 +3814,8 @@
     "bindings": [
       { "input_method": "keyboard_any", "key": "PPAGE" },
       { "input_method": "keyboard_char", "key": "<" },
-      { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] }
+      { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_ALT_DPAD_UP" }
     ]
   },
   {
@@ -3743,8 +3858,7 @@
     "name": "Select right inventory",
     "bindings": [
       { "input_method": "keyboard_any", "key": "l" },
-      { "input_method": "keyboard_any", "key": "RIGHT" },
-      { "input_method": "gamepad", "key": "JOY_RIGHT" }
+      { "input_method": "keyboard_any", "key": "RIGHT" }
     ]
   },
   {
@@ -3849,8 +3963,7 @@
       { "input_method": "keyboard_any", "key": "l" },
       { "input_method": "keyboard_any", "key": "RIGHT" },
       { "input_method": "keyboard_any", "key": "6" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_6" },
-      { "input_method": "gamepad", "key": "JOY_RIGHT" }
+      { "input_method": "keyboard_code", "key": "KEYPAD_6" }
     ]
   },
   {
@@ -4703,35 +4816,56 @@
     "category": "DIALOGUE_CHOOSE_RESPONSE",
     "id": "LOOK_AT",
     "name": "Look at",
-    "bindings": [ { "input_method": "keyboard_char", "key": "L" }, { "input_method": "keyboard_code", "key": "l", "mod": [ "shift" ] } ]
+    "bindings": [ 
+      { "input_method": "keyboard_char", "key": "L" }, 
+      { "input_method": "keyboard_code", "key": "l", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_X" }
+
+    ]
   },
   {
     "type": "keybinding",
     "category": "DIALOGUE_CHOOSE_RESPONSE",
     "id": "SIZE_UP_STATS",
     "name": "Size up stats",
-    "bindings": [ { "input_method": "keyboard_char", "key": "S" }, { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] } ]
+    "bindings": [ 
+      { "input_method": "keyboard_char", "key": "S" }, 
+      { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_Y" }
+    ]
   },
   {
     "type": "keybinding",
     "category": "DIALOGUE_CHOOSE_RESPONSE",
     "id": "ASSESS_PERSONALITY",
     "name": "Assess personality",
-    "bindings": [ { "input_method": "keyboard_char", "key": "A" }, { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] } ]
+    "bindings": [ 
+      { "input_method": "keyboard_char", "key": "A" }, 
+      { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_B" }
+    ]
   },
   {
     "type": "keybinding",
     "category": "DIALOGUE_CHOOSE_RESPONSE",
     "id": "YELL",
     "name": "Yell",
-    "bindings": [ { "input_method": "keyboard_char", "key": "Y" }, { "input_method": "keyboard_code", "key": "y", "mod": [ "shift" ] } ]
+    "bindings": [ 
+      { "input_method": "keyboard_char", "key": "Y" }, 
+      { "input_method": "keyboard_code", "key": "y", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_ALT_X" }
+    ]
   },
   {
     "type": "keybinding",
     "category": "DIALOGUE_CHOOSE_RESPONSE",
     "id": "CHECK_OPINION",
     "name": "Check opinion",
-    "bindings": [ { "input_method": "keyboard_char", "key": "O" }, { "input_method": "keyboard_code", "key": "o", "mod": [ "shift" ] } ]
+    "bindings": [ 
+      { "input_method": "keyboard_char", "key": "O" }, 
+      { "input_method": "keyboard_code", "key": "o", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "JOY_ALT_Y" }
+    ]
   },
   {
     "type": "keybinding",

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -4,22 +4,10 @@
     "id": "UILIST.UP",
     "name": "Pan up",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "UP"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "8"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_8"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "RS_UP"
-      }
+      { "input_method": "keyboard_any", "key": "UP" },
+      { "input_method": "keyboard_any", "key": "8" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_8" },
+      { "input_method": "gamepad", "key": "RS_UP" }
     ]
   },
   {
@@ -27,22 +15,10 @@
     "id": "UILIST.DOWN",
     "name": "Pan down",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "DOWN"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "2"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_2"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "RS_DOWN"
-      }
+      { "input_method": "keyboard_any", "key": "DOWN" },
+      { "input_method": "keyboard_any", "key": "2" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_2" },
+      { "input_method": "gamepad", "key": "RS_DOWN" }
     ]
   },
   {
@@ -50,22 +26,10 @@
     "id": "UILIST.LEFT",
     "name": "Pan left",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "LEFT"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "4"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_4"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "RS_LEFT"
-      }
+      { "input_method": "keyboard_any", "key": "LEFT" },
+      { "input_method": "keyboard_any", "key": "4" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_4" },
+      { "input_method": "gamepad", "key": "RS_LEFT" }
     ]
   },
   {
@@ -73,87 +37,41 @@
     "id": "UILIST.RIGHT",
     "name": "Pan right",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "RIGHT"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "6"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_6"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "RS_RIGHT"
-      }
+      { "input_method": "keyboard_any", "key": "RIGHT" },
+      { "input_method": "keyboard_any", "key": "6" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_6" },
+      { "input_method": "gamepad", "key": "RS_RIGHT" }
     ]
   },
   {
     "type": "keybinding",
     "id": "UILIST.FILTER",
     "name": "Filter",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "/"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_DIVIDE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "/" }, { "input_method": "keyboard_code", "key": "KEYPAD_DIVIDE" } ]
   },
   {
     "type": "keybinding",
     "id": "UILIST.QUIT",
     "name": "Cancel menu",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "ESC"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "ESC" } ]
   },
   {
     "type": "keybinding",
     "id": "SHOW_DESCRIPTION",
     "category": "MELEE_STYLE_PICKER",
     "name": "Show description of melee style",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "d"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "d" } ]
   },
   {
     "type": "keybinding",
     "id": "UP",
     "name": "Pan up",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "k"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "UP"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "8"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_8"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "LS_UP"
-      }
+      { "input_method": "keyboard_any", "key": "k" },
+      { "input_method": "keyboard_any", "key": "UP" },
+      { "input_method": "keyboard_any", "key": "8" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_8" },
+      { "input_method": "gamepad", "key": "LS_UP" }
     ]
   },
   {
@@ -161,26 +79,11 @@
     "id": "DOWN",
     "name": "Pan down",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "j"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "DOWN"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "2"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_2"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "LS_DOWN"
-      }
+      { "input_method": "keyboard_any", "key": "j" },
+      { "input_method": "keyboard_any", "key": "DOWN" },
+      { "input_method": "keyboard_any", "key": "2" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_2" },
+      { "input_method": "gamepad", "key": "LS_DOWN" }
     ]
   },
   {
@@ -188,26 +91,11 @@
     "id": "LEFT",
     "name": "Pan left",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "h"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "LEFT"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "4"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_4"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "LS_LEFT"
-      }
+      { "input_method": "keyboard_any", "key": "h" },
+      { "input_method": "keyboard_any", "key": "LEFT" },
+      { "input_method": "keyboard_any", "key": "4" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_4" },
+      { "input_method": "gamepad", "key": "LS_LEFT" }
     ]
   },
   {
@@ -215,26 +103,11 @@
     "id": "RIGHT",
     "name": "Pan right",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "l"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "RIGHT"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "6"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_6"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "LS_RIGHT"
-      }
+      { "input_method": "keyboard_any", "key": "l" },
+      { "input_method": "keyboard_any", "key": "RIGHT" },
+      { "input_method": "keyboard_any", "key": "6" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_6" },
+      { "input_method": "gamepad", "key": "LS_RIGHT" }
     ]
   },
   {
@@ -242,22 +115,10 @@
     "id": "LEFTUP",
     "name": "Pan up-left",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "y"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "7"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_7"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "LS_UP_LEFT"
-      }
+      { "input_method": "keyboard_any", "key": "y" },
+      { "input_method": "keyboard_any", "key": "7" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_7" },
+      { "input_method": "gamepad", "key": "LS_UP_LEFT" }
     ]
   },
   {
@@ -265,22 +126,10 @@
     "id": "RIGHTUP",
     "name": "Pan up-right",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "u"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "9"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_9"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "LS_UP_RIGHT"
-      }
+      { "input_method": "keyboard_any", "key": "u" },
+      { "input_method": "keyboard_any", "key": "9" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_9" },
+      { "input_method": "gamepad", "key": "LS_UP_RIGHT" }
     ]
   },
   {
@@ -288,22 +137,10 @@
     "id": "LEFTDOWN",
     "name": "Pan down-left",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "b"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "1"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_1"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "LS_DOWN_LEFT"
-      }
+      { "input_method": "keyboard_any", "key": "b" },
+      { "input_method": "keyboard_any", "key": "1" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_1" },
+      { "input_method": "gamepad", "key": "LS_DOWN_LEFT" }
     ]
   },
   {
@@ -311,101 +148,54 @@
     "id": "RIGHTDOWN",
     "name": "Pan down-right",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "n"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "3"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_3"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "LS_DOWN_RIGHT"
-      }
+      { "input_method": "keyboard_any", "key": "n" },
+      { "input_method": "keyboard_any", "key": "3" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_3" },
+      { "input_method": "gamepad", "key": "LS_DOWN_RIGHT" }
     ]
   },
   {
     "type": "keybinding",
     "id": "HOME",
     "name": "Home",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "HOME"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "HOME" } ]
   },
   {
     "type": "keybinding",
     "id": "END",
     "name": "End",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "END"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "END" } ]
   },
   {
     "type": "keybinding",
     "id": "PAGE_UP",
     "name": "Page up",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "PPAGE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "PPAGE" } ]
   },
   {
     "type": "keybinding",
     "id": "PAGE_DOWN",
     "name": "Page down",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "NPAGE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "NPAGE" } ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_UP",
     "name": "Scroll up",
-    "bindings": [
-      {
-        "input_method": "mouse",
-        "key": "SCROLL_UP"
-      }
-    ]
+    "bindings": [ { "input_method": "mouse", "key": "SCROLL_UP" } ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_DOWN",
     "name": "Scroll down",
-    "bindings": [
-      {
-        "input_method": "mouse",
-        "key": "SCROLL_DOWN"
-      }
-    ]
+    "bindings": [ { "input_method": "mouse", "key": "SCROLL_DOWN" } ]
   },
   {
     "type": "keybinding",
     "id": "SELECT_ALL",
     "category": "PICKUP",
     "name": "Select all",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": ","
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "," } ]
   },
   {
     "type": "keybinding",
@@ -413,21 +203,9 @@
     "category": "PICKUP",
     "name": "Scroll item info up",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "<"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ",",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_UP"
-      }
+      { "input_method": "keyboard_char", "key": "<" },
+      { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "ALT_UP" }
     ]
   },
   {
@@ -436,21 +214,9 @@
     "category": "PICKUP",
     "name": "Scroll item info down",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": ">"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ".",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_DOWN"
-      }
+      { "input_method": "keyboard_char", "key": ">" },
+      { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "ALT_DOWN" }
     ]
   },
   {
@@ -459,18 +225,9 @@
     "category": "PICKUP",
     "name": "Previous item",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "k"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "UP"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "UP"
-      }
+      { "input_method": "keyboard_any", "key": "k" },
+      { "input_method": "keyboard_any", "key": "UP" },
+      { "input_method": "gamepad", "key": "UP" }
     ]
   },
   {
@@ -479,18 +236,9 @@
     "category": "PICKUP",
     "name": "Next item",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "j"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "DOWN"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "DOWN"
-      }
+      { "input_method": "keyboard_any", "key": "j" },
+      { "input_method": "keyboard_any", "key": "DOWN" },
+      { "input_method": "gamepad", "key": "DOWN" }
     ]
   },
   {
@@ -499,18 +247,9 @@
     "category": "PICKUP",
     "name": "Unmark selected item",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "h"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "LEFT"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "LEFT"
-      }
+      { "input_method": "keyboard_any", "key": "h" },
+      { "input_method": "keyboard_any", "key": "LEFT" },
+      { "input_method": "gamepad", "key": "LEFT" }
     ]
   },
   {
@@ -518,16 +257,7 @@
     "id": "RIGHT",
     "category": "PICKUP",
     "name": "Mark selected item",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "l"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "RIGHT"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "l" }, { "input_method": "keyboard_any", "key": "RIGHT" } ]
   },
   {
     "type": "keybinding",
@@ -535,21 +265,9 @@
     "category": "AUTO_NOTES",
     "name": "Enable auto notes for map extras",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "e"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "E"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "e",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_any", "key": "e" },
+      { "input_method": "keyboard_char", "key": "E" },
+      { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] }
     ]
   },
   {
@@ -558,21 +276,9 @@
     "category": "AUTO_NOTES",
     "name": "Toggle auto notes option",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "s"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "S"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "s",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_any", "key": "s" },
+      { "input_method": "keyboard_char", "key": "S" },
+      { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] }
     ]
   },
   {
@@ -581,21 +287,9 @@
     "category": "AUTO_NOTES",
     "name": "Disable auto notes for map extras",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "d"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "D"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "d",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_any", "key": "d" },
+      { "input_method": "keyboard_char", "key": "D" },
+      { "input_method": "keyboard_code", "key": "d", "mod": [ "shift" ] }
     ]
   },
   {
@@ -603,43 +297,21 @@
     "id": "CHANGE_MAPEXTRA_CHARACTER",
     "category": "AUTO_NOTES",
     "name": "Change a symbol for map extra",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "="
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "=" } ]
   },
   {
     "type": "keybinding",
     "id": "CHOOSE_INVLET",
     "category": "SPELL_MENU",
     "name": "Choose a hotkey for a spell",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "="
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "=" } ]
   },
   {
     "type": "keybinding",
     "id": "CAST_IGNORE",
     "category": "SPELL_MENU",
     "name": "Toggle ignore distractions",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "I"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "i",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "I" }, { "input_method": "keyboard_code", "key": "i", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
@@ -647,21 +319,9 @@
     "category": "SPELL_MENU",
     "name": "Scroll up spell info",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "<"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ",",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_UP"
-      }
+      { "input_method": "keyboard_char", "key": "<" },
+      { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "ALT_UP" }
     ]
   },
   {
@@ -670,21 +330,9 @@
     "category": "SPELL_MENU",
     "name": "Scroll down spell info",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": ">"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ".",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_DOWN"
-      }
+      { "input_method": "keyboard_char", "key": ">" },
+      { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "ALT_DOWN" }
     ]
   },
   {
@@ -693,21 +341,9 @@
     "category": "SPELL_MENU",
     "name": "Toggle spell as favorite",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "*"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MULTIPLY"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "8",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_char", "key": "*" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
+      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] }
     ]
   },
   {
@@ -716,21 +352,9 @@
     "category": "AUTO_PICKUP",
     "name": "Add rule",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "a"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "A"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "a",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_any", "key": "a" },
+      { "input_method": "keyboard_char", "key": "A" },
+      { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] }
     ]
   },
   {
@@ -739,21 +363,9 @@
     "category": "AUTO_PICKUP",
     "name": "Remove rule",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "r"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "R"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "r",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_any", "key": "r" },
+      { "input_method": "keyboard_char", "key": "R" },
+      { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] }
     ]
   },
   {
@@ -762,21 +374,9 @@
     "category": "AUTO_PICKUP",
     "name": "Copy rule",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "c"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "C"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "c",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_any", "key": "c" },
+      { "input_method": "keyboard_char", "key": "C" },
+      { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] }
     ]
   },
   {
@@ -785,21 +385,9 @@
     "category": "AUTO_PICKUP",
     "name": "Move rule global <-> character",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "m"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "M"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "m",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_any", "key": "m" },
+      { "input_method": "keyboard_char", "key": "M" },
+      { "input_method": "keyboard_code", "key": "m", "mod": [ "shift" ] }
     ]
   },
   {
@@ -808,21 +396,9 @@
     "category": "AUTO_PICKUP",
     "name": "Enable rule",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "e"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "E"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "e",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_any", "key": "e" },
+      { "input_method": "keyboard_char", "key": "E" },
+      { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] }
     ]
   },
   {
@@ -831,21 +407,9 @@
     "category": "AUTO_PICKUP",
     "name": "Disable rule",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "d"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "D"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "d",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_any", "key": "d" },
+      { "input_method": "keyboard_char", "key": "D" },
+      { "input_method": "keyboard_code", "key": "d", "mod": [ "shift" ] }
     ]
   },
   {
@@ -854,18 +418,9 @@
     "category": "AUTO_PICKUP",
     "name": "Move rule up",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "="
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "+"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_PLUS"
-      }
+      { "input_method": "keyboard_any", "key": "=" },
+      { "input_method": "keyboard_char", "key": "+" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" }
     ]
   },
   {
@@ -873,16 +428,7 @@
     "id": "MOVE_RULE_DOWN",
     "category": "AUTO_PICKUP",
     "name": "Move rule down",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "-"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MINUS"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "-" }, { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" } ]
   },
   {
     "type": "keybinding",
@@ -890,21 +436,9 @@
     "category": "AUTO_PICKUP",
     "name": "Test rule",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "t"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "T"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "t",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_any", "key": "t" },
+      { "input_method": "keyboard_char", "key": "T" },
+      { "input_method": "keyboard_code", "key": "t", "mod": [ "shift" ] }
     ]
   },
   {
@@ -913,21 +447,9 @@
     "category": "AUTO_PICKUP",
     "name": "Enable auto pickup option",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "s"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "S"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "s",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_any", "key": "s" },
+      { "input_method": "keyboard_char", "key": "S" },
+      { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] }
     ]
   },
   {
@@ -936,33 +458,12 @@
     "category": "AUTO_PICKUP",
     "name": "Quit",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "ESC"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "q"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "Q"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "q",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "SPACE"
-      },
-      {
-        "input_method": "mouse",
-        "key": "MOUSE_RIGHT"
-      }
+      { "input_method": "keyboard_any", "key": "ESC" },
+      { "input_method": "keyboard_any", "key": "q" },
+      { "input_method": "keyboard_char", "key": "Q" },
+      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "SPACE" },
+      { "input_method": "mouse", "key": "MOUSE_RIGHT" }
     ]
   },
   {
@@ -971,21 +472,9 @@
     "category": "SAFEMODE",
     "name": "Add default ruleset",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "~"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "`",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_N"
-      }
+      { "input_method": "keyboard_char", "key": "~" },
+      { "input_method": "keyboard_code", "key": "`", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_N" }
     ]
   },
   {
@@ -994,25 +483,10 @@
     "category": "SAFEMODE",
     "name": "Add rule",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "a"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "A"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "a",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_NE"
-      }
+      { "input_method": "keyboard_any", "key": "a" },
+      { "input_method": "keyboard_char", "key": "A" },
+      { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_NE" }
     ]
   },
   {
@@ -1021,25 +495,10 @@
     "category": "SAFEMODE",
     "name": "Remove rule",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "r"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "R"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "r",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_E"
-      }
+      { "input_method": "keyboard_any", "key": "r" },
+      { "input_method": "keyboard_char", "key": "R" },
+      { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_E" }
     ]
   },
   {
@@ -1048,25 +507,10 @@
     "category": "SAFEMODE",
     "name": "Copy rule",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "c"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "C"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "c",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_SE"
-      }
+      { "input_method": "keyboard_any", "key": "c" },
+      { "input_method": "keyboard_char", "key": "C" },
+      { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_SE" }
     ]
   },
   {
@@ -1075,25 +519,10 @@
     "category": "SAFEMODE",
     "name": "Move rule global <-> character",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "m"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "M"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "m",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_S"
-      }
+      { "input_method": "keyboard_any", "key": "m" },
+      { "input_method": "keyboard_char", "key": "M" },
+      { "input_method": "keyboard_code", "key": "m", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_S" }
     ]
   },
   {
@@ -1102,25 +531,10 @@
     "category": "SAFEMODE",
     "name": "Enable rule",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "e"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "E"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "e",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_SW"
-      }
+      { "input_method": "keyboard_any", "key": "e" },
+      { "input_method": "keyboard_char", "key": "E" },
+      { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_SW" }
     ]
   },
   {
@@ -1129,25 +543,10 @@
     "category": "SAFEMODE",
     "name": "Disable rule",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "d"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "D"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "d",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_W"
-      }
+      { "input_method": "keyboard_any", "key": "d" },
+      { "input_method": "keyboard_char", "key": "D" },
+      { "input_method": "keyboard_code", "key": "d", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_W" }
     ]
   },
   {
@@ -1156,22 +555,10 @@
     "category": "SAFEMODE",
     "name": "Move rule up",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "="
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "+"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_PLUS"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_UP"
-      }
+      { "input_method": "keyboard_any", "key": "=" },
+      { "input_method": "keyboard_char", "key": "+" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" },
+      { "input_method": "gamepad", "key": "ALT_UP" }
     ]
   },
   {
@@ -1180,18 +567,9 @@
     "category": "SAFEMODE",
     "name": "Move rule down",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "-"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MINUS"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_DOWN"
-      }
+      { "input_method": "keyboard_any", "key": "-" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" },
+      { "input_method": "gamepad", "key": "ALT_DOWN" }
     ]
   },
   {
@@ -1200,25 +578,10 @@
     "category": "SAFEMODE",
     "name": "Test rule",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "t"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "T"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "t",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_NW"
-      }
+      { "input_method": "keyboard_any", "key": "t" },
+      { "input_method": "keyboard_char", "key": "T" },
+      { "input_method": "keyboard_code", "key": "t", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_NW" }
     ]
   },
   {
@@ -1227,25 +590,10 @@
     "category": "SAFEMODE",
     "name": "Enable safemode option",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "s"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "S"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "s",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "R_RADIAL_N"
-      }
+      { "input_method": "keyboard_any", "key": "s" },
+      { "input_method": "keyboard_char", "key": "S" },
+      { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "R_RADIAL_N" }
     ]
   },
   {
@@ -1254,33 +602,12 @@
     "category": "SAFEMODE",
     "name": "Quit",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "ESC"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "q"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "Q"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "q",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "SPACE"
-      },
-      {
-        "input_method": "mouse",
-        "key": "MOUSE_RIGHT"
-      }
+      { "input_method": "keyboard_any", "key": "ESC" },
+      { "input_method": "keyboard_any", "key": "q" },
+      { "input_method": "keyboard_char", "key": "Q" },
+      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "SPACE" },
+      { "input_method": "mouse", "key": "MOUSE_RIGHT" }
     ]
   },
   {
@@ -1288,12 +615,7 @@
     "id": "USAGE_HELP",
     "category": "SORT_ARMOR",
     "name": "Display usage help",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "F1"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "F1" } ]
   },
   {
     "type": "keybinding",
@@ -1301,18 +623,9 @@
     "category": "SORT_ARMOR",
     "name": "Select armor for moving",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "s"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "RETURN"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "KEYPAD_ENTER"
-      }
+      { "input_method": "keyboard_any", "key": "s" },
+      { "input_method": "keyboard_any", "key": "RETURN" },
+      { "input_method": "keyboard_any", "key": "KEYPAD_ENTER" }
     ]
   },
   {
@@ -1321,18 +634,9 @@
     "category": "PANEL_MGMT",
     "name": "Select panel for moving",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "s"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "RETURN"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "KEYPAD_ENTER"
-      }
+      { "input_method": "keyboard_any", "key": "s" },
+      { "input_method": "keyboard_any", "key": "RETURN" },
+      { "input_method": "keyboard_any", "key": "KEYPAD_ENTER" }
     ]
   },
   {
@@ -1340,28 +644,14 @@
     "id": "TOGGLE_PANEL",
     "category": "PANEL_MGMT",
     "name": "Toggle panel off",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "TAB"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "TAB" } ]
   },
   {
     "type": "keybinding",
     "id": "CHANGE_SIDE",
     "category": "SORT_ARMOR",
     "name": "Change side armor is worn on",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "c"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_N"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "c" }, { "input_method": "gamepad", "key": "L_RADIAL_N" } ]
   },
   {
     "type": "keybinding",
@@ -1369,21 +659,9 @@
     "category": "SORT_ARMOR",
     "name": "Toggle armor visibility on character sprite",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "H"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "h",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_NE"
-      }
+      { "input_method": "keyboard_char", "key": "H" },
+      { "input_method": "keyboard_code", "key": "h", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_NE" }
     ]
   },
   {
@@ -1391,16 +669,7 @@
     "id": "ASSIGN_INVLETS",
     "category": "SORT_ARMOR",
     "name": "Assign invlets to armor",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "r"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_E"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "r" }, { "input_method": "gamepad", "key": "L_RADIAL_E" } ]
   },
   {
     "type": "keybinding",
@@ -1408,21 +677,9 @@
     "category": "SORT_ARMOR",
     "name": "Sort armor into natural layer order",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "S"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "s",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_SE"
-      }
+      { "input_method": "keyboard_char", "key": "S" },
+      { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_SE" }
     ]
   },
   {
@@ -1431,21 +688,9 @@
     "category": "SORT_ARMOR",
     "name": "Scroll item info up",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "<"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ",",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_UP"
-      }
+      { "input_method": "keyboard_char", "key": "<" },
+      { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "ALT_UP" }
     ]
   },
   {
@@ -1454,21 +699,9 @@
     "category": "SORT_ARMOR",
     "name": "Scroll item info down",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": ">"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ".",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_DOWN"
-      }
+      { "input_method": "keyboard_char", "key": ">" },
+      { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "ALT_DOWN" }
     ]
   },
   {
@@ -1476,16 +709,7 @@
     "id": "EQUIP_ARMOR",
     "category": "SORT_ARMOR",
     "name": "Equip armor from inventory",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "e"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_S"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "e" }, { "input_method": "gamepad", "key": "L_RADIAL_S" } ]
   },
   {
     "type": "keybinding",
@@ -1493,21 +717,9 @@
     "category": "SORT_ARMOR",
     "name": "Equip armor from inventory at this position",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "E"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "e",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_SW"
-      }
+      { "input_method": "keyboard_char", "key": "E" },
+      { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_SW" }
     ]
   },
   {
@@ -1515,63 +727,24 @@
     "id": "REMOVE_ARMOR",
     "category": "SORT_ARMOR",
     "name": "Unequip selected armor",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "u"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_W"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "u" }, { "input_method": "gamepad", "key": "L_RADIAL_W" } ]
   },
   {
     "type": "keybinding",
     "id": "HELP_KEYBINDINGS",
     "name": "Display keybindings menu",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "?"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "/",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "?" }, { "input_method": "keyboard_code", "key": "/", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "FILTER",
     "name": "Filter",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "f"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "F"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "f",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "/"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_DIVIDE"
-      }
+      { "input_method": "keyboard_any", "key": "f" },
+      { "input_method": "keyboard_char", "key": "F" },
+      { "input_method": "keyboard_code", "key": "f", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "/" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_DIVIDE" }
     ]
   },
   {
@@ -1579,21 +752,9 @@
     "id": "RESET_FILTER",
     "name": "Reset filter",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "r"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "R"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "r",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_any", "key": "r" },
+      { "input_method": "keyboard_char", "key": "R" },
+      { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] }
     ]
   },
   {
@@ -1601,24 +762,14 @@
     "id": "SCROLL_RECIPE_INFO_UP",
     "category": "CRAFTING",
     "name": "Scroll recipe info up",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "["
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "[" } ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_RECIPE_INFO_DOWN",
     "category": "CRAFTING",
     "name": "Scroll recipe info down",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "]"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "]" } ]
   },
   {
     "type": "keybinding",
@@ -1626,21 +777,9 @@
     "category": "CRAFTING",
     "name": "Show recipe result",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "e"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "E"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "e",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_any", "key": "e" },
+      { "input_method": "keyboard_char", "key": "E" },
+      { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] }
     ]
   },
   {
@@ -1654,16 +793,7 @@
     "id": "TOGGLE_RECIPE_UNREAD",
     "category": "CRAFTING",
     "name": "Toggle read/unread",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "v"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_N"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "v" }, { "input_method": "gamepad", "key": "L_RADIAL_N" } ]
   },
   {
     "type": "keybinding",
@@ -1671,21 +801,9 @@
     "category": "CRAFTING",
     "name": "Mark all recipes as read",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "V"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "v",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_NE"
-      }
+      { "input_method": "keyboard_char", "key": "V" },
+      { "input_method": "keyboard_code", "key": "v", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_NE" }
     ]
   },
   {
@@ -1693,50 +811,21 @@
     "id": "TOGGLE_UNREAD_RECIPES_FIRST",
     "category": "CRAFTING",
     "name": "Show unread recipes on top",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "u"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_E"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "u" }, { "input_method": "gamepad", "key": "L_RADIAL_E" } ]
   },
   {
     "type": "keybinding",
     "id": "CHOOSE_CRAFTER",
     "category": "CRAFTING",
     "name": "Choose crafter",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "c"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_SE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "c" }, { "input_method": "gamepad", "key": "L_RADIAL_SE" } ]
   },
   {
     "type": "keybinding",
     "id": "CYCLE_BATCH",
     "category": "CRAFTING",
     "name": "Batch crafting",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": [
-          "b"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_S"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": [ "b" ] }, { "input_method": "gamepad", "key": "L_RADIAL_S" } ]
   },
   {
     "type": "keybinding",
@@ -1744,21 +833,9 @@
     "category": "CRAFTING",
     "name": "Scroll item info up",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "<"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ",",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_UP"
-      }
+      { "input_method": "keyboard_char", "key": "<" },
+      { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "ALT_UP" }
     ]
   },
   {
@@ -1767,21 +844,9 @@
     "category": "CRAFTING",
     "name": "Scroll item info down",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": ">"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ".",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_DOWN"
-      }
+      { "input_method": "keyboard_char", "key": ">" },
+      { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "ALT_DOWN" }
     ]
   },
   {
@@ -1790,21 +855,9 @@
     "category": "CRAFTING",
     "name": "Related recipes",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "L"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "l",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "R_RADIAL_SW"
-      }
+      { "input_method": "keyboard_char", "key": "L" },
+      { "input_method": "keyboard_code", "key": "l", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "R_RADIAL_SW" }
     ]
   },
   {
@@ -1813,25 +866,10 @@
     "category": "CRAFTING",
     "name": "Toggle recipes to be shown in favorite tab",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "*"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MULTIPLY"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "8",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_SW"
-      }
+      { "input_method": "keyboard_char", "key": "*" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
+      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_SW" }
     ]
   },
   {
@@ -1840,21 +878,9 @@
     "category": "CRAFTING",
     "name": "Compare recipe to item in inventory",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "I"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "i",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_NW"
-      }
+      { "input_method": "keyboard_char", "key": "I" },
+      { "input_method": "keyboard_code", "key": "i", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_NW" }
     ]
   },
   {
@@ -1862,25 +888,10 @@
     "id": "LEVEL_UP",
     "name": "Go up",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "PPAGE"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "<"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ",",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_UP"
-      }
+      { "input_method": "keyboard_any", "key": "PPAGE" },
+      { "input_method": "keyboard_char", "key": "<" },
+      { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "ALT_UP" }
     ]
   },
   {
@@ -1888,25 +899,10 @@
     "id": "LEVEL_DOWN",
     "name": "Go down",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "NPAGE"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": ">"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ".",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_DOWN"
-      }
+      { "input_method": "keyboard_any", "key": "NPAGE" },
+      { "input_method": "keyboard_char", "key": ">" },
+      { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "ALT_DOWN" }
     ]
   },
   {
@@ -1915,22 +911,10 @@
     "category": "SOKOBAN",
     "name": "Next level",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "="
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "+"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_PLUS"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_N"
-      }
+      { "input_method": "keyboard_any", "key": "=" },
+      { "input_method": "keyboard_char", "key": "+" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" },
+      { "input_method": "gamepad", "key": "L_RADIAL_N" }
     ]
   },
   {
@@ -1939,18 +923,9 @@
     "category": "SOKOBAN",
     "name": "Previous level",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "-"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MINUS"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_NE"
-      }
+      { "input_method": "keyboard_any", "key": "-" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" },
+      { "input_method": "gamepad", "key": "L_RADIAL_NE" }
     ]
   },
   {
@@ -1958,80 +933,35 @@
     "id": "RESET",
     "category": "SOKOBAN",
     "name": "Reset level",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "r"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_E"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "r" }, { "input_method": "gamepad", "key": "L_RADIAL_E" } ]
   },
   {
     "type": "keybinding",
     "id": "UNDO",
     "category": "SOKOBAN",
     "name": "Undo move",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "u"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_SE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "u" }, { "input_method": "gamepad", "key": "L_RADIAL_SE" } ]
   },
   {
     "type": "keybinding",
     "id": "NEW",
     "category": "MINESWEEPER",
     "name": "Create new level",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "n"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_N"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "n" }, { "input_method": "gamepad", "key": "L_RADIAL_N" } ]
   },
   {
     "type": "keybinding",
     "id": "FLAG",
     "category": "MINESWEEPER",
     "name": "Toggle flag",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "f"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_NE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "f" }, { "input_method": "gamepad", "key": "L_RADIAL_NE" } ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_SPACE",
     "category": "LIGHTSON",
     "name": "Toggle lights",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": " "
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_N"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": " " }, { "input_method": "gamepad", "key": "L_RADIAL_N" } ]
   },
   {
     "type": "keybinding",
@@ -2039,18 +969,9 @@
     "category": "LIGHTSON",
     "name": "Toggle lights",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "5"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_5"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_NE"
-      }
+      { "input_method": "keyboard_any", "key": "5" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_5" },
+      { "input_method": "gamepad", "key": "L_RADIAL_NE" }
     ]
   },
   {
@@ -2058,74 +979,33 @@
     "id": "RESET",
     "category": "LIGHTSON",
     "name": "Reset level",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "r"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_E"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "r" }, { "input_method": "gamepad", "key": "L_RADIAL_E" } ]
   },
   {
     "type": "keybinding",
     "id": "CONFIRM",
     "name": "Confirm choice",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "RETURN"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "KEYPAD_ENTER"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "RETURN" }, { "input_method": "keyboard_any", "key": "KEYPAD_ENTER" } ]
   },
   {
     "type": "keybinding",
     "id": "CONFIRM_MULTIPLE",
     "name": "Confirm and continue",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "SPACE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "SPACE" } ]
   },
   {
     "type": "keybinding",
     "id": "SAVE_DEFAULT_MODS",
     "category": "MODMANAGER_DIALOG",
     "name": "Save mods as default",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "s"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_N"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "s" }, { "input_method": "gamepad", "key": "L_RADIAL_N" } ]
   },
   {
     "type": "keybinding",
     "id": "VIEW_MOD_DESCRIPTION",
     "category": "MODMANAGER_DIALOG",
     "name": "View full mod description",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "v"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_NE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "v" }, { "input_method": "gamepad", "key": "L_RADIAL_NE" } ]
   },
   {
     "type": "keybinding",
@@ -2133,22 +1013,10 @@
     "category": "MODMANAGER_DIALOG",
     "name": "Move selected mod down",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "="
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "+"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_PLUS"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_E"
-      }
+      { "input_method": "keyboard_any", "key": "=" },
+      { "input_method": "keyboard_char", "key": "+" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" },
+      { "input_method": "gamepad", "key": "L_RADIAL_E" }
     ]
   },
   {
@@ -2157,18 +1025,9 @@
     "category": "MODMANAGER_DIALOG",
     "name": "Move selected mod up",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "-"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MINUS"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_SE"
-      }
+      { "input_method": "keyboard_any", "key": "-" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" },
+      { "input_method": "gamepad", "key": "L_RADIAL_SE" }
     ]
   },
   {
@@ -2177,21 +1036,9 @@
     "category": "MODMANAGER_DIALOG",
     "name": "Move to next category tab",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": ">"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ".",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "TAB"
-      }
+      { "input_method": "keyboard_char", "key": ">" },
+      { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] },
+      { "input_method": "keyboard_char", "key": "TAB" }
     ]
   },
   {
@@ -2200,21 +1047,9 @@
     "category": "MODMANAGER_DIALOG",
     "name": "Move to previous category tab",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "<"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ",",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "BACKTAB"
-      }
+      { "input_method": "keyboard_char", "key": "<" },
+      { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] },
+      { "input_method": "keyboard_char", "key": "BACKTAB" }
     ]
   },
   {
@@ -2223,33 +1058,12 @@
     "category": "MODMANAGER_DIALOG",
     "name": "Quit",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "ESC"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "q"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "Q"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "q",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "SPACE"
-      },
-      {
-        "input_method": "mouse",
-        "key": "MOUSE_RIGHT"
-      }
+      { "input_method": "keyboard_any", "key": "ESC" },
+      { "input_method": "keyboard_any", "key": "q" },
+      { "input_method": "keyboard_char", "key": "Q" },
+      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "SPACE" },
+      { "input_method": "mouse", "key": "MOUSE_RIGHT" }
     ]
   },
   {
@@ -2258,33 +1072,12 @@
     "category": "OPTIONS",
     "name": "Quit",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "ESC"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "q"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "Q"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "q",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "SPACE"
-      },
-      {
-        "input_method": "mouse",
-        "key": "MOUSE_RIGHT"
-      }
+      { "input_method": "keyboard_any", "key": "ESC" },
+      { "input_method": "keyboard_any", "key": "q" },
+      { "input_method": "keyboard_char", "key": "Q" },
+      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "SPACE" },
+      { "input_method": "mouse", "key": "MOUSE_RIGHT" }
     ]
   },
   {
@@ -2293,21 +1086,9 @@
     "category": "STRING_INPUT",
     "name": "Pick random world name",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "*"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MULTIPLY"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "8",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_char", "key": "*" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
+      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] }
     ]
   },
   {
@@ -2316,25 +1097,10 @@
     "category": "WORLDGEN_CONFIRM_DIALOG",
     "name": "Pick random world name",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "*"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MULTIPLY"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "8",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_N"
-      }
+      { "input_method": "keyboard_char", "key": "*" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
+      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_N" }
     ]
   },
   {
@@ -2344,33 +1110,12 @@
     "category": "WORLDGEN_CONFIRM_DIALOG",
     "name": "Exit worldgen screen",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "ESC"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "q"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "Q"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "q",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "SPACE"
-      },
-      {
-        "input_method": "mouse",
-        "key": "MOUSE_RIGHT"
-      }
+      { "input_method": "keyboard_any", "key": "ESC" },
+      { "input_method": "keyboard_any", "key": "q" },
+      { "input_method": "keyboard_char", "key": "Q" },
+      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "SPACE" },
+      { "input_method": "mouse", "key": "MOUSE_RIGHT" }
     ]
   },
   {
@@ -2379,25 +1124,10 @@
     "category": "WORLDGEN_CONFIRM_DIALOG",
     "name": "View mod manager",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "m"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "M"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "m",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_NE"
-      }
+      { "input_method": "keyboard_any", "key": "m" },
+      { "input_method": "keyboard_char", "key": "M" },
+      { "input_method": "keyboard_code", "key": "m", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_NE" }
     ]
   },
   {
@@ -2406,25 +1136,10 @@
     "category": "WORLDGEN_CONFIRM_DIALOG",
     "name": "View advanced world settings",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "s"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "S"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "s",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_E"
-      }
+      { "input_method": "keyboard_any", "key": "s" },
+      { "input_method": "keyboard_char", "key": "S" },
+      { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_E" }
     ]
   },
   {
@@ -2433,25 +1148,10 @@
     "category": "WORLDGEN_CONFIRM_DIALOG",
     "name": "Finalize world creation",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "f"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "F"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "f",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_SE"
-      }
+      { "input_method": "keyboard_any", "key": "f" },
+      { "input_method": "keyboard_char", "key": "F" },
+      { "input_method": "keyboard_code", "key": "f", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_SE" }
     ]
   },
   {
@@ -2460,25 +1160,10 @@
     "category": "WORLDGEN_CONFIRM_DIALOG",
     "name": "Randomize world settings",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "a"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "A"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "a",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_S"
-      }
+      { "input_method": "keyboard_any", "key": "a" },
+      { "input_method": "keyboard_char", "key": "A" },
+      { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_S" }
     ]
   },
   {
@@ -2487,25 +1172,10 @@
     "category": "WORLDGEN_CONFIRM_DIALOG",
     "name": "Reset world settings and mods",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "r"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "R"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "r",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_SW"
-      }
+      { "input_method": "keyboard_any", "key": "r" },
+      { "input_method": "keyboard_char", "key": "R" },
+      { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_SW" }
     ]
   },
   {
@@ -2514,33 +1184,12 @@
     "category": "DISPLAY_HELP",
     "name": "Quit",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "ESC"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "q"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "Q"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "q",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "SPACE"
-      },
-      {
-        "input_method": "mouse",
-        "key": "MOUSE_RIGHT"
-      }
+      { "input_method": "keyboard_any", "key": "ESC" },
+      { "input_method": "keyboard_any", "key": "q" },
+      { "input_method": "keyboard_char", "key": "Q" },
+      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "SPACE" },
+      { "input_method": "mouse", "key": "MOUSE_RIGHT" }
     ]
   },
   {
@@ -2549,33 +1198,12 @@
     "category": "SCROLLABLE_TEXT",
     "name": "Quit",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "ESC"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "q"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "Q"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "q",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "SPACE"
-      },
-      {
-        "input_method": "mouse",
-        "key": "MOUSE_RIGHT"
-      }
+      { "input_method": "keyboard_any", "key": "ESC" },
+      { "input_method": "keyboard_any", "key": "q" },
+      { "input_method": "keyboard_char", "key": "Q" },
+      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "SPACE" },
+      { "input_method": "mouse", "key": "MOUSE_RIGHT" }
     ]
   },
   {
@@ -2583,107 +1211,42 @@
     "id": "DELETE_NOTE",
     "category": "OVERMAP_NOTES",
     "name": "Delete note",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "D"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "d",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "D" }, { "input_method": "keyboard_code", "key": "d", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "EDIT_NOTE",
     "category": "OVERMAP_NOTES",
     "name": "Edit note",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "E"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "e",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "E" }, { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "MARK_DANGER",
     "category": "OVERMAP_NOTES",
     "name": "Mark danger",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "R"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "r",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "R" }, { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "look",
     "category": "OVERMAP",
     "name": "Look around",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": ";"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": ";" } ]
   },
   {
     "type": "keybinding",
     "id": "DELETE_NOTE",
     "category": "OVERMAP",
     "name": "Delete note",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "D"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "d",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "D" }, { "input_method": "keyboard_code", "key": "d", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "CREATE_NOTE",
     "category": "OVERMAP",
     "name": "Create/edit note",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "N"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "n",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "N" }, { "input_method": "keyboard_code", "key": "n", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
@@ -2691,21 +1254,9 @@
     "category": "OVERMAP",
     "name": "Mark danger",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "R"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "r",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_SW"
-      }
+      { "input_method": "keyboard_char", "key": "R" },
+      { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_SW" }
     ]
   },
   {
@@ -2714,21 +1265,9 @@
     "category": "OVERMAP",
     "name": "List notes",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "L"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "l",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_W"
-      }
+      { "input_method": "keyboard_char", "key": "L" },
+      { "input_method": "keyboard_code", "key": "l", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_W" }
     ]
   },
   {
@@ -2736,19 +1275,7 @@
     "id": "TOGGLE_BLINKING",
     "category": "OVERMAP",
     "name": "Toggle blinking",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "B"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "b",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "B" }, { "input_method": "keyboard_code", "key": "b", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
@@ -2756,21 +1283,9 @@
     "category": "OVERMAP",
     "name": "Toggle overlays",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "O"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "o",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "R_RADIAL_N"
-      }
+      { "input_method": "keyboard_char", "key": "O" },
+      { "input_method": "keyboard_code", "key": "o", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "R_RADIAL_N" }
     ]
   },
   {
@@ -2779,21 +1294,9 @@
     "category": "OVERMAP",
     "name": "Toggle land use codes",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "A"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "a",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "R_RADIAL_NE"
-      }
+      { "input_method": "keyboard_char", "key": "A" },
+      { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "R_RADIAL_NE" }
     ]
   },
   {
@@ -2802,21 +1305,9 @@
     "category": "OVERMAP",
     "name": "Toggle map notes",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "G"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "g",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "R_RADIAL_E"
-      }
+      { "input_method": "keyboard_char", "key": "G" },
+      { "input_method": "keyboard_code", "key": "g", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "R_RADIAL_E" }
     ]
   },
   {
@@ -2825,21 +1316,9 @@
     "category": "OVERMAP",
     "name": "Toggle city labels",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "C"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "c",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "R_RADIAL_SE"
-      }
+      { "input_method": "keyboard_char", "key": "C" },
+      { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "R_RADIAL_SE" }
     ]
   },
   {
@@ -2848,21 +1327,9 @@
     "category": "OVERMAP",
     "name": "Toggle highlighting map reveals",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "V"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "v",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "R_RADIAL_S"
-      }
+      { "input_method": "keyboard_char", "key": "V" },
+      { "input_method": "keyboard_code", "key": "v", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "R_RADIAL_S" }
     ]
   },
   {
@@ -2871,21 +1338,9 @@
     "category": "OVERMAP",
     "name": "Toggle hordes",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "H"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "h",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "R_RADIAL_SW"
-      }
+      { "input_method": "keyboard_char", "key": "H" },
+      { "input_method": "keyboard_code", "key": "h", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "R_RADIAL_SW" }
     ]
   },
   {
@@ -2893,16 +1348,7 @@
     "id": "TOGGLE_OVERMAP_WEATHER",
     "category": "OVERMAP",
     "name": "Toggle visible weather",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "w"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "R_RADIAL_W"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "w" }, { "input_method": "gamepad", "key": "R_RADIAL_W" } ]
   },
   {
     "type": "keybinding",
@@ -2910,21 +1356,9 @@
     "category": "OVERMAP",
     "name": "Toggle forest trails",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "T"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "t",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "R_RADIAL_NW"
-      }
+      { "input_method": "keyboard_char", "key": "T" },
+      { "input_method": "keyboard_code", "key": "t", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "R_RADIAL_NW" }
     ]
   },
   {
@@ -2933,21 +1367,9 @@
     "category": "OVERMAP",
     "name": "Toggle fast travel",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "x"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "x",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_S"
-      }
+      { "input_method": "keyboard_char", "key": "x" },
+      { "input_method": "keyboard_code", "key": "x", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_S" }
     ]
   },
   {
@@ -2955,24 +1377,14 @@
     "id": "COLLAPSE_OVERMAP_SIDEBAR_HEADERS",
     "category": "OVERMAP",
     "name": "Collapse all overmap sidebar headers",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "{"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "{" } ]
   },
   {
     "type": "keybinding",
     "id": "EXPAND_OVERMAP_SIDEBAR_HEADERS",
     "category": "OVERMAP",
     "name": "Expand all overmap sidebar headers",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "}"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "}" } ]
   },
   {
     "type": "keybinding",
@@ -2980,21 +1392,9 @@
     "category": "OVERMAP",
     "name": "Toggle explored",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "E"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "e",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_NE"
-      }
+      { "input_method": "keyboard_char", "key": "E" },
+      { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_NE" }
     ]
   },
   {
@@ -3002,103 +1402,56 @@
     "id": "PLACE_TERRAIN",
     "category": "OVERMAP",
     "name": "Place overmap terrain",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "t"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "t" } ]
   },
   {
     "type": "keybinding",
     "id": "PLACE_SPECIAL",
     "category": "OVERMAP",
     "name": "Place overmap special",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "s"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "s" } ]
   },
   {
     "type": "keybinding",
     "id": "SET_SPECIAL_ARGS",
     "category": "OVERMAP",
     "name": "Set overmap special arguments",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "a"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "a" } ]
   },
   {
     "type": "keybinding",
     "id": "LONG_TELEPORT",
     "category": "OVERMAP",
     "name": "Teleport to cursor",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "d"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "d" } ]
   },
   {
     "type": "keybinding",
     "id": "REVEAL_MAP",
     "category": "OVERMAP",
     "name": "Reveal map",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "r"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "r" } ]
   },
   {
     "type": "keybinding",
     "id": "MODIFY_HORDE",
     "category": "OVERMAP",
     "name": "Modify existing horde or place new one",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "p"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "p" } ]
   },
   {
     "type": "keybinding",
     "id": "PRINT_NOISE_MAPS",
     "category": "OVERMAP",
     "name": "Print noise maps",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": ","
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "," } ]
   },
   {
     "type": "keybinding",
     "name": "View missions",
     "category": "OVERMAP",
     "id": "MISSIONS",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "M"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "m",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "M" }, { "input_method": "keyboard_code", "key": "m", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
@@ -3106,21 +1459,9 @@
     "category": "OVERMAP",
     "id": "CREATE_POINT_OF_INTEREST",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "P"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "p",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_SW"
-      }
+      { "input_method": "keyboard_char", "key": "P" },
+      { "input_method": "keyboard_code", "key": "p", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_SW" }
     ]
   },
   {
@@ -3128,27 +1469,13 @@
     "id": "ROTATE",
     "category": "OVERMAP_EDITOR",
     "name": "Rotate",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "r"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "r" } ]
   },
   {
     "type": "keybinding",
     "id": "SEARCH",
     "name": "Search",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "/"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_DIVIDE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "/" }, { "input_method": "keyboard_code", "key": "KEYPAD_DIVIDE" } ]
   },
   {
     "type": "keybinding",
@@ -3156,33 +1483,12 @@
     "name": "Close map",
     "category": "OVERMAP",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "m"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "ESC"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "q"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "Q"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "q",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "SPACE"
-      }
+      { "input_method": "keyboard_any", "key": "m" },
+      { "input_method": "keyboard_any", "key": "ESC" },
+      { "input_method": "keyboard_any", "key": "q" },
+      { "input_method": "keyboard_char", "key": "Q" },
+      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "SPACE" }
     ]
   },
   {
@@ -3190,29 +1496,11 @@
     "id": "QUIT",
     "name": "Exit screen",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "ESC"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "q"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "Q"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "q",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "SPACE"
-      }
+      { "input_method": "keyboard_any", "key": "ESC" },
+      { "input_method": "keyboard_any", "key": "q" },
+      { "input_method": "keyboard_char", "key": "Q" },
+      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "SPACE" }
     ]
   },
   {
@@ -3220,52 +1508,22 @@
     "id": "CHOOSE_DESTINATION",
     "name": "Choose destination",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "W"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "w",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_N"
-      }
+      { "input_method": "keyboard_char", "key": "W" },
+      { "input_method": "keyboard_code", "key": "w", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_N" }
     ]
   },
   {
     "type": "keybinding",
     "id": "GO_TO_DESTINATION",
     "name": "Go to destination",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "g"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_NE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "g" }, { "input_method": "gamepad", "key": "L_RADIAL_NE" } ]
   },
   {
     "type": "keybinding",
     "id": "CENTER_ON_DESTINATION",
     "name": "Center on destination",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "c"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_E"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "c" }, { "input_method": "gamepad", "key": "L_RADIAL_E" } ]
   },
   {
     "type": "keybinding",
@@ -3273,22 +1531,10 @@
     "category": "TARGET",
     "name": "Fire weapon",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "f"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "RETURN"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "KEYPAD_ENTER"
-      },
-      {
-        "input_method": "mouse",
-        "key": "MOUSE_RIGHT"
-      }
+      { "input_method": "keyboard_any", "key": "f" },
+      { "input_method": "keyboard_any", "key": "RETURN" },
+      { "input_method": "keyboard_any", "key": "KEYPAD_ENTER" },
+      { "input_method": "mouse", "key": "MOUSE_RIGHT" }
     ]
   },
   {
@@ -3297,29 +1543,11 @@
     "category": "TARGET",
     "name": "Previous target",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "BACKTAB"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "TAB",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "mouse",
-        "key": "SCROLL_UP"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "PPAGE"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "LB"
-      }
+      { "input_method": "keyboard_char", "key": "BACKTAB" },
+      { "input_method": "keyboard_code", "key": "TAB", "mod": [ "shift" ] },
+      { "input_method": "mouse", "key": "SCROLL_UP" },
+      { "input_method": "keyboard_any", "key": "PPAGE" },
+      { "input_method": "gamepad", "key": "LB" }
     ]
   },
   {
@@ -3328,22 +1556,10 @@
     "category": "TARGET",
     "name": "Next target",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "TAB"
-      },
-      {
-        "input_method": "mouse",
-        "key": "SCROLL_DOWN"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "NPAGE"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "RB"
-      }
+      { "input_method": "keyboard_any", "key": "TAB" },
+      { "input_method": "mouse", "key": "SCROLL_DOWN" },
+      { "input_method": "keyboard_any", "key": "NPAGE" },
+      { "input_method": "gamepad", "key": "RB" }
     ]
   },
   {
@@ -3352,26 +1568,11 @@
     "category": "TARGET",
     "name": "Aim",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "."
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_PERIOD"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "5"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_5"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "RT"
-      }
+      { "input_method": "keyboard_any", "key": "." },
+      { "input_method": "keyboard_code", "key": "KEYPAD_PERIOD" },
+      { "input_method": "keyboard_any", "key": "5" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_5" },
+      { "input_method": "gamepad", "key": "RT" }
     ]
   },
   {
@@ -3379,76 +1580,35 @@
     "id": "STOPAIM",
     "category": "TARGET",
     "name": "Stop Aiming",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": ","
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "," } ]
   },
   {
     "type": "keybinding",
     "id": "AIMED_SHOT",
     "category": "TARGET",
     "name": "Aimed shot",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "a"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_N"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "a" }, { "input_method": "gamepad", "key": "L_RADIAL_N" } ]
   },
   {
     "type": "keybinding",
     "id": "CAREFUL_SHOT",
     "category": "TARGET",
     "name": "Careful shot",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "c"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_NE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "c" }, { "input_method": "gamepad", "key": "L_RADIAL_NE" } ]
   },
   {
     "type": "keybinding",
     "id": "PRECISE_SHOT",
     "category": "TARGET",
     "name": "Precise shot",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "p"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_E"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "p" }, { "input_method": "gamepad", "key": "L_RADIAL_E" } ]
   },
   {
     "type": "keybinding",
     "id": "SWITCH_AMMO",
     "category": "TARGET",
     "name": "Switch ammo",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "o"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_SE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "o" }, { "input_method": "gamepad", "key": "L_RADIAL_SE" } ]
   },
   {
     "type": "keybinding",
@@ -3456,25 +1616,10 @@
     "category": "TARGET",
     "name": "Switch firing modes",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "s"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "F"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "f",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_S"
-      }
+      { "input_method": "keyboard_any", "key": "s" },
+      { "input_method": "keyboard_char", "key": "F" },
+      { "input_method": "keyboard_code", "key": "f", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_S" }
     ]
   },
   {
@@ -3482,28 +1627,14 @@
     "id": "TOGGLE_TURRET_LINES",
     "category": "TARGET",
     "name": "Toggle turret lines",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "t"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "t" } ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_UNLOAD_RAS_WEAPON",
     "category": "TARGET",
     "name": "Whether to unload your bow etc after canceling a shot",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "-"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MINUS"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "-" }, { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" } ]
   },
   {
     "type": "keybinding",
@@ -3511,25 +1642,10 @@
     "category": "TARGET",
     "name": "Toggle snap-to-target",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "*"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MULTIPLY"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "8",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_S"
-      }
+      { "input_method": "keyboard_char", "key": "*" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
+      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_S" }
     ]
   },
   {
@@ -3537,60 +1653,31 @@
     "id": "TOGGLE_MOVE_CURSOR_VIEW",
     "category": "TARGET",
     "name": "Toggle shift view / move cursor",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "v"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_SW"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "v" }, { "input_method": "gamepad", "key": "L_RADIAL_SW" } ]
   },
   {
     "type": "keybinding",
     "id": "SELECT",
     "name": "Select with mouse",
-    "bindings": [
-      {
-        "input_method": "mouse",
-        "key": "MOUSE_LEFT"
-      }
-    ]
+    "bindings": [ { "input_method": "mouse", "key": "MOUSE_LEFT" } ]
   },
   {
     "type": "keybinding",
     "id": "CLICK_AND_DRAG",
     "name": "Click and drag with mouse",
-    "bindings": [
-      {
-        "input_method": "mouse",
-        "key": "MOUSE_LEFT_PRESSED"
-      }
-    ]
+    "bindings": [ { "input_method": "mouse", "key": "MOUSE_LEFT_PRESSED" } ]
   },
   {
     "type": "keybinding",
     "id": "SEC_SELECT",
     "name": "Secondary select",
-    "bindings": [
-      {
-        "input_method": "mouse",
-        "key": "MOUSE_RIGHT"
-      }
-    ]
+    "bindings": [ { "input_method": "mouse", "key": "MOUSE_RIGHT" } ]
   },
   {
     "type": "keybinding",
     "id": "MOUSE_MOVE",
     "name": "Mouse move",
-    "bindings": [
-      {
-        "input_method": "mouse",
-        "key": "MOUSE_MOVE"
-      }
-    ]
+    "bindings": [ { "input_method": "mouse", "key": "MOUSE_MOVE" } ]
   },
   {
     "type": "keybinding",
@@ -3598,225 +1685,93 @@
     "category": "PICK_WORLD_DIALOG",
     "name": "Quit",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "ESC"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "q"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "Q"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "q",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "SPACE"
-      },
-      {
-        "input_method": "mouse",
-        "key": "MOUSE_RIGHT"
-      }
+      { "input_method": "keyboard_any", "key": "ESC" },
+      { "input_method": "keyboard_any", "key": "q" },
+      { "input_method": "keyboard_char", "key": "Q" },
+      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "SPACE" },
+      { "input_method": "mouse", "key": "MOUSE_RIGHT" }
     ]
   },
   {
     "type": "keybinding",
     "id": "NEXT_TAB",
     "name": "Go to next tab",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "TAB"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "RB"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "TAB" }, { "input_method": "gamepad", "key": "RB" } ]
   },
   {
     "type": "keybinding",
     "id": "PREV_TAB",
     "name": "Go to previous tab",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "BACKTAB"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "TAB",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "LB"
-      }
+      { "input_method": "keyboard_char", "key": "BACKTAB" },
+      { "input_method": "keyboard_code", "key": "TAB", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "LB" }
     ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_FAST_SCROLL",
     "name": "Toggle fast scroll",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "f"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "f" } ]
   },
   {
     "type": "keybinding",
     "id": "EXTENDED_DESCRIPTION",
     "name": "Show extended description",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "e"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "RS"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "e" }, { "input_method": "gamepad", "key": "RS" } ]
   },
   {
     "type": "keybinding",
     "id": "CHANGE_MONSTER_NAME",
     "name": "Change monster name",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "c"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "c" } ]
   },
   {
     "type": "keybinding",
     "id": "TRAVEL_TO",
     "name": "Travel to destination",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "T"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "t",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "T" }, { "input_method": "keyboard_code", "key": "t", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "CENTER",
     "name": "Center on character",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "0"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_0"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "0" }, { "input_method": "keyboard_code", "key": "KEYPAD_0" } ]
   },
   {
     "type": "keybinding",
     "id": "HELP",
     "category": "CARAVAN",
     "name": "Display help",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "0"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_0"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "0" }, { "input_method": "keyboard_code", "key": "KEYPAD_0" } ]
   },
   {
     "type": "keybinding",
     "id": "CHANGE_GENDER",
     "name": "Change gender",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "@"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "2",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "@" }, { "input_method": "keyboard_code", "key": "2", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "CHANGE_OUTFIT",
     "name": "Change outfit",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "$"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "4",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "$" }, { "input_method": "keyboard_code", "key": "4", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "SWITCH_GENDER",
     "name": "Customize character",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "y"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "y" } ]
   },
   {
     "type": "keybinding",
     "id": "MEDICAL_MENU",
     "name": "Open medical menu",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "@"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "2",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "R_RADIAL_NE"
-      }
+      { "input_method": "keyboard_char", "key": "@" },
+      { "input_method": "keyboard_code", "key": "2", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "R_RADIAL_NE" }
     ]
   },
   {
@@ -3824,119 +1779,49 @@
     "id": "SAVE_TEMPLATE",
     "category": "DEFENSE_SETUP",
     "name": "Save template",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "!"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "1",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "!" }, { "input_method": "keyboard_code", "key": "1", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "START",
     "category": "DEFENSE_SETUP",
     "name": "Start",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "S"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "s",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "S" }, { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "DELETE_TEMPLATE",
     "category": "MAIN_MENU",
     "name": "Delete template",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "d"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "d" } ]
   },
   {
     "type": "keybinding",
     "id": "SAVE_TEMPLATE",
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Save template",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "!"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "1",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "!" }, { "input_method": "keyboard_code", "key": "1", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "REROLL_CHARACTER",
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Reroll random character",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "%"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "5",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "%" }, { "input_method": "keyboard_code", "key": "5", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "REROLL_CHARACTER_WITH_SCENARIO",
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Reroll random character with scenario",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "^"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "6",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "^" }, { "input_method": "keyboard_code", "key": "6", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "RANDOMIZE_CHAR_NAME",
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Pick random character name",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "n"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "n" } ]
   },
   {
     "type": "keybinding",
@@ -3944,21 +1829,9 @@
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Pick random character description",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "*"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MULTIPLY"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "8",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_char", "key": "*" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
+      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] }
     ]
   },
   {
@@ -3966,92 +1839,35 @@
     "id": "CHANGE_START_OF_CATACLYSM",
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Change Cataclysm start date",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "#"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "3",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "#" }, { "input_method": "keyboard_code", "key": "3", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "CHANGE_START_OF_GAME",
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Change game start date",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "&"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "7",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "&" }, { "input_method": "keyboard_code", "key": "7", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "RESET_CALENDAR",
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Reset scenario calendar",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "~"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "`",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "~" }, { "input_method": "keyboard_code", "key": "`", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "CHOOSE_CITY",
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Choose character starting city",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "C"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "c",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "C" }, { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "CHOOSE_LOCATION",
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Choose character starting location",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "/"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_DIVIDE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "/" }, { "input_method": "keyboard_code", "key": "KEYPAD_DIVIDE" } ]
   },
   {
     "type": "keybinding",
@@ -4059,24 +1875,14 @@
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Exit new character screen",
     "//": "separate entry, because the global entry also has 'q' and 'Q' listed, which conflicts with the character name entry feature of this dialog",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "ESC"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "ESC" } ]
   },
   {
     "type": "keybinding",
     "id": "SORT",
     "category": "NEW_CHAR_PROFESSIONS",
     "name": "Toggle sorting order",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "s"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "s" } ]
   },
   {
     "type": "keybinding",
@@ -4084,21 +1890,9 @@
     "category": "NEW_CHAR_PROFESSIONS",
     "name": "Randomize profession",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "*"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MULTIPLY"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "8",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_char", "key": "*" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
+      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] }
     ]
   },
   {
@@ -4107,21 +1901,9 @@
     "category": "NEW_CHAR_TRAITS",
     "name": "Randomize trait",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "*"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MULTIPLY"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "8",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_char", "key": "*" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
+      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] }
     ]
   },
   {
@@ -4130,21 +1912,9 @@
     "category": "NEW_CHAR_SCENARIOS",
     "name": "Randomize scenario",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "*"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MULTIPLY"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "8",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_char", "key": "*" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
+      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] }
     ]
   },
   {
@@ -4152,88 +1922,35 @@
     "id": "SORT",
     "category": "NEW_CHAR_SCENARIOS",
     "name": "Toggle sorting order",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "s"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "s" } ]
   },
   {
     "type": "keybinding",
     "id": "CHANGE_START_OF_CATACLYSM",
     "category": "NEW_CHAR_SCENARIOS",
     "name": "Change cataclysm start date",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "#"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "3",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "#" }, { "input_method": "keyboard_code", "key": "3", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "CHANGE_START_OF_GAME",
     "category": "NEW_CHAR_SCENARIOS",
     "name": "Change game start date",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "&"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "7",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "&" }, { "input_method": "keyboard_code", "key": "7", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "RESET_CALENDAR",
     "category": "NEW_CHAR_SCENARIOS",
     "name": "Reset scenario calendar",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "~"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "`",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "~" }, { "input_method": "keyboard_code", "key": "`", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_SKILL_INFO_UP",
     "category": "NEW_CHAR_SKILLS",
     "name": "Scroll description up",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "<"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ",",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "<" }, { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
@@ -4241,21 +1958,9 @@
     "category": "NEW_CHAR_SKILLS",
     "name": "Scroll description down",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": ">"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ".",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "RS_DOWN"
-      }
+      { "input_method": "keyboard_char", "key": ">" },
+      { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "RS_DOWN" }
     ]
   },
   {
@@ -4263,21 +1968,9 @@
     "id": "SCROLL_INFOBOX_UP",
     "name": "Scroll description up",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "<"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ",",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_UP"
-      }
+      { "input_method": "keyboard_char", "key": "<" },
+      { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "ALT_UP" }
     ]
   },
   {
@@ -4285,21 +1978,9 @@
     "id": "SCROLL_INFOBOX_DOWN",
     "name": "Scroll description down",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": ">"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ".",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_DOWN"
-      }
+      { "input_method": "keyboard_char", "key": ">" },
+      { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "ALT_DOWN" }
     ]
   },
   {
@@ -4307,338 +1988,147 @@
     "id": "PREV_CATEGORY",
     "category": "PROFICIENCY_WINDOW",
     "name": "Previous proficiency category",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "<"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ",",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "<" }, { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "NEXT_CATEGORY",
     "category": "PROFICIENCY_WINDOW",
     "name": "Next proficiency category",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": ">"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ".",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": ">" }, { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "REFILL",
     "category": "APP_INTERACT",
     "name": "Refill tank/battery",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "f"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_N"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "f" }, { "input_method": "gamepad", "key": "L_RADIAL_N" } ]
   },
   {
     "type": "keybinding",
     "id": "SIPHON",
     "category": "APP_INTERACT",
     "name": "Siphon from tank",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "s"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_NE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "s" }, { "input_method": "gamepad", "key": "L_RADIAL_NE" } ]
   },
   {
     "type": "keybinding",
     "id": "RENAME",
     "category": "APP_INTERACT",
     "name": "Rename appliance",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "e"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_E"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "e" }, { "input_method": "gamepad", "key": "L_RADIAL_E" } ]
   },
   {
     "type": "keybinding",
     "id": "REMOVE",
     "category": "APP_INTERACT",
     "name": "Take down appliance",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "r"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_SE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "r" }, { "input_method": "gamepad", "key": "L_RADIAL_SE" } ]
   },
   {
     "type": "keybinding",
     "id": "PLUG",
     "category": "APP_INTERACT",
     "name": "Plug in appliance",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "g"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_S"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "g" }, { "input_method": "gamepad", "key": "L_RADIAL_S" } ]
   },
   {
     "type": "keybinding",
     "id": "DISCONNECT_GRID",
     "category": "APP_INTERACT",
     "name": "Separate from power grid",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "c"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_SW"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "c" }, { "input_method": "gamepad", "key": "L_RADIAL_SW" } ]
   },
   {
     "type": "keybinding",
     "id": "INSTALL",
     "category": "VEH_INTERACT",
     "name": "Install part",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "i"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_N"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "i" }, { "input_method": "gamepad", "key": "L_RADIAL_N" } ]
   },
   {
     "type": "keybinding",
     "id": "REPAIR",
     "category": "VEH_INTERACT",
     "name": "Repair part",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "r"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_NE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "r" }, { "input_method": "gamepad", "key": "L_RADIAL_NE" } ]
   },
   {
     "type": "keybinding",
     "id": "MEND",
     "category": "VEH_INTERACT",
     "name": "Mend part",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "m"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_E"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "m" }, { "input_method": "gamepad", "key": "L_RADIAL_E" } ]
   },
   {
     "type": "keybinding",
     "id": "REFILL",
     "category": "VEH_INTERACT",
     "name": "Refill tank/battery",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "f"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_SE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "f" }, { "input_method": "gamepad", "key": "L_RADIAL_SE" } ]
   },
   {
     "type": "keybinding",
     "id": "UNLOAD",
     "category": "VEH_INTERACT",
     "name": "Unload fuel bunker",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "d"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_S"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "d" }, { "input_method": "gamepad", "key": "L_RADIAL_S" } ]
   },
   {
     "type": "keybinding",
     "id": "REMOVE",
     "category": "VEH_INTERACT",
     "name": "Remove part",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "o"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_SW"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "o" }, { "input_method": "gamepad", "key": "L_RADIAL_SW" } ]
   },
   {
     "type": "keybinding",
     "id": "RENAME",
     "category": "VEH_INTERACT",
     "name": "Rename vehicle",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "e"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "R_RADIAL_N"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "e" }, { "input_method": "gamepad", "key": "R_RADIAL_N" } ]
   },
   {
     "type": "keybinding",
     "id": "SIPHON",
     "category": "VEH_INTERACT",
     "name": "Siphon from tank",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "s"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_W"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "s" }, { "input_method": "gamepad", "key": "L_RADIAL_W" } ]
   },
   {
     "type": "keybinding",
     "id": "TIRE_CHANGE",
     "category": "VEH_INTERACT",
     "name": "Change tire",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "c"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_NW"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "c" }, { "input_method": "gamepad", "key": "L_RADIAL_NW" } ]
   },
   {
     "type": "keybinding",
     "id": "CHANGE_SHAPE",
     "category": "VEH_INTERACT",
     "name": "Change part shape",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "p"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "R_RADIAL_NE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "p" }, { "input_method": "gamepad", "key": "R_RADIAL_NE" } ]
   },
   {
     "type": "keybinding",
     "id": "ASSIGN_CREW",
     "category": "VEH_INTERACT",
     "name": "Assign crew",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "w"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "R_RADIAL_E"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "w" }, { "input_method": "gamepad", "key": "R_RADIAL_E" } ]
   },
   {
     "type": "keybinding",
     "id": "RELABEL",
     "category": "VEH_INTERACT",
     "name": "Relabel a portion of a vehicle",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "a"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "R_RADIAL_SE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "a" }, { "input_method": "gamepad", "key": "R_RADIAL_SE" } ]
   },
   {
     "type": "keybinding",
     "id": "NEXT_TAB",
     "category": "VEH_INTERACT",
     "name": "Go to next tab",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "TAB"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "TAB" } ]
   },
   {
     "type": "keybinding",
@@ -4646,17 +2136,8 @@
     "category": "VEH_INTERACT",
     "name": "Go to previous tab",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "BACKTAB"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "TAB",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_char", "key": "BACKTAB" },
+      { "input_method": "keyboard_code", "key": "TAB", "mod": [ "shift" ] }
     ]
   },
   {
@@ -4664,32 +2145,14 @@
     "id": "FUEL_LIST_UP",
     "category": "VEH_INTERACT",
     "name": "Scroll up through fuel list",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "["
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_UP"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "[" }, { "input_method": "gamepad", "key": "ALT_UP" } ]
   },
   {
     "type": "keybinding",
     "id": "FUEL_LIST_DOWN",
     "category": "VEH_INTERACT",
     "name": "Scroll down through fuel list",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "]"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_DOWN"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "]" }, { "input_method": "gamepad", "key": "ALT_DOWN" } ]
   },
   {
     "type": "keybinding",
@@ -4697,21 +2160,9 @@
     "category": "VEH_INTERACT",
     "name": "Scroll up through vehicle part descriptions",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "<"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ",",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_UP"
-      }
+      { "input_method": "keyboard_char", "key": "<" },
+      { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "ALT_UP" }
     ]
   },
   {
@@ -4720,21 +2171,9 @@
     "category": "VEH_INTERACT",
     "name": "Scroll down through vehicle part descriptions",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": ">"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ".",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_DOWN"
-      }
+      { "input_method": "keyboard_char", "key": ">" },
+      { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "ALT_DOWN" }
     ]
   },
   {
@@ -4743,21 +2182,9 @@
     "category": "VEH_INTERACT",
     "name": "Scroll up through vehicle overview",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "{"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "[",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_UP"
-      }
+      { "input_method": "keyboard_char", "key": "{" },
+      { "input_method": "keyboard_code", "key": "[", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "ALT_UP" }
     ]
   },
   {
@@ -4766,21 +2193,9 @@
     "category": "VEH_INTERACT",
     "name": "Scroll down through vehicle overview",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "}"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "]",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_DOWN"
-      }
+      { "input_method": "keyboard_char", "key": "}" },
+      { "input_method": "keyboard_code", "key": "]", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "ALT_DOWN" }
     ]
   },
   {
@@ -4788,16 +2203,7 @@
     "id": "TOGGLE_UNAVAILABLE_CONSTRUCTIONS",
     "category": "CONSTRUCTION",
     "name": "Toggle unavailable constructions",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": ";"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_N"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": ";" }, { "input_method": "gamepad", "key": "L_RADIAL_N" } ]
   },
   {
     "type": "keybinding",
@@ -4805,21 +2211,9 @@
     "category": "CONSTRUCTION",
     "name": "Scroll to previous stage",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "<"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ",",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_DOWN"
-      }
+      { "input_method": "keyboard_char", "key": "<" },
+      { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "ALT_DOWN" }
     ]
   },
   {
@@ -4828,33 +2222,16 @@
     "category": "CONSTRUCTION",
     "name": "Scroll to next stage",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": ">"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ".",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_UP"
-      }
+      { "input_method": "keyboard_char", "key": ">" },
+      { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "ALT_UP" }
     ]
   },
   {
     "type": "keybinding",
     "id": "EDITMAP_SHOW_ALL",
     "name": "Show all",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "v"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "v" } ]
   },
   {
     "type": "keybinding",
@@ -4862,18 +2239,9 @@
     "category": "EDITMAP_FEATURE",
     "name": "Confirm and quit",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "e"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "r"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "t"
-      }
+      { "input_method": "keyboard_any", "key": "e" },
+      { "input_method": "keyboard_any", "key": "r" },
+      { "input_method": "keyboard_any", "key": "t" }
     ]
   },
   {
@@ -4881,283 +2249,145 @@
     "id": "RESIZE",
     "category": "EDITMAP_SHAPE",
     "name": "Resize",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "s"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "s" } ]
   },
   {
     "type": "keybinding",
     "id": "START",
     "category": "EDITMAP_SHAPE",
     "name": "To start",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "z"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "z" } ]
   },
   {
     "type": "keybinding",
     "id": "SWAP",
     "category": "EDITMAP_SHAPE",
     "name": "Swap origin and target",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "y"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "y" } ]
   },
   {
     "type": "keybinding",
     "id": "EDITMAP_MOVE",
     "name": "Move shape",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "m"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "m" } ]
   },
   {
     "type": "keybinding",
     "id": "EDITMAP_TOGGLE_POST_PROCESS_GENERATORS",
     "name": "Toggle post-process generators",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "p"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "p" } ]
   },
   {
     "type": "keybinding",
     "id": "EDITMAP_TAB",
     "name": "Switch to move point / confirm",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "TAB"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "TAB" } ]
   },
   {
     "type": "keybinding",
     "id": "EDIT_TRAPS",
     "category": "EDITMAP",
     "name": "Edit traps",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "t"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "t" } ]
   },
   {
     "type": "keybinding",
     "id": "EDIT_FIELDS",
     "category": "EDITMAP",
     "name": "Edit fields",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "f"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "f" } ]
   },
   {
     "type": "keybinding",
     "id": "EDIT_RADS",
     "category": "EDITMAP",
     "name": "Edit radiation",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "a"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "a" } ]
   },
   {
     "type": "keybinding",
     "id": "EDIT_TERRAIN",
     "category": "EDITMAP",
     "name": "Edit terrain",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "e"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "e" } ]
   },
   {
     "type": "keybinding",
     "id": "EDIT_FURNITURE",
     "category": "EDITMAP",
     "name": "Edit furniture",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "r"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "r" } ]
   },
   {
     "type": "keybinding",
     "id": "EDIT_OVERMAP",
     "category": "EDITMAP",
     "name": "Edit overmap/mapgen",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "o"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "o" } ]
   },
   {
     "type": "keybinding",
     "id": "EDIT_ITEMS",
     "category": "EDITMAP",
     "name": "Edit items",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "i"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "i" } ]
   },
   {
     "type": "keybinding",
     "id": "EDIT_MONSTER",
     "category": "EDITMAP",
     "name": "Edit creatures",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "m"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "m" } ]
   },
   {
     "type": "keybinding",
     "id": "SHOW_ALL",
     "category": "EDITMAP",
     "name": "Show whole map",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "v"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "v" } ]
   },
   {
     "type": "keybinding",
     "id": "LEFT_WIDE",
     "name": "Wide move left",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "H"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "h",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "H" }, { "input_method": "keyboard_code", "key": "h", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "RIGHT_WIDE",
     "name": "Wide move right",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "L"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "l",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "L" }, { "input_method": "keyboard_code", "key": "l", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "UP_WIDE",
     "name": "Wide move up",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "K"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "k",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "K" }, { "input_method": "keyboard_code", "key": "k", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "DOWN_WIDE",
     "name": "Wide move down",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "J"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "j",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "J" }, { "input_method": "keyboard_code", "key": "j", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "CATEGORY_SELECTION",
     "category": "INVENTORY",
     "name": "Toggle category selection mode",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "t"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "t" } ]
   },
   {
     "type": "keybinding",
     "id": "VIEW_CATEGORY_MODE",
     "name": "Toggle inventory view to show item categories",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": ";"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": ";" } ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_NUMPAD_NAVIGATION",
     "name": "Toggle navigation with numpad numbers",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "F5"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "F5" } ]
   },
   {
     "type": "keybinding",
@@ -5165,18 +2395,9 @@
     "category": "INVENTORY",
     "name": "Set item filter",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "/"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_DIVIDE"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_SW"
-      }
+      { "input_method": "keyboard_any", "key": "/" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_DIVIDE" },
+      { "input_method": "gamepad", "key": "L_RADIAL_SW" }
     ]
   },
   {
@@ -5184,32 +2405,14 @@
     "id": "EXAMINE",
     "category": "INVENTORY",
     "name": "Examine",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "e"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_N"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "e" }, { "input_method": "gamepad", "key": "L_RADIAL_N" } ]
   },
   {
     "type": "keybinding",
     "id": "WIELD",
     "category": "INVENTORY",
     "name": "Wield",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "w"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_E"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "w" }, { "input_method": "gamepad", "key": "L_RADIAL_E" } ]
   },
   {
     "type": "keybinding",
@@ -5217,21 +2420,9 @@
     "category": "INVENTORY",
     "name": "Wear",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "W"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "w",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_W"
-      }
+      { "input_method": "keyboard_char", "key": "W" },
+      { "input_method": "keyboard_code", "key": "w", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_W" }
     ]
   },
   {
@@ -5239,32 +2430,14 @@
     "id": "EXAMINE_CONTENTS",
     "category": "INVENTORY",
     "name": "Examine contents",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "o"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_NE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "o" }, { "input_method": "gamepad", "key": "L_RADIAL_NE" } ]
   },
   {
     "type": "keybinding",
     "id": "ORGANIZE_MENU",
     "category": "INVENTORY",
     "name": "Organize contents",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "i"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_SE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "i" }, { "input_method": "gamepad", "key": "L_RADIAL_SE" } ]
   },
   {
     "type": "keybinding",
@@ -5272,25 +2445,10 @@
     "category": "INVENTORY",
     "name": "Toggle item as favorite",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "*"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MULTIPLY"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "8",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_NW"
-      }
+      { "input_method": "keyboard_char", "key": "*" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
+      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_NW" }
     ]
   },
   {
@@ -5299,21 +2457,9 @@
     "category": "INVENTORY",
     "name": "Show/hide contents",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": ">"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ".",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_S"
-      }
+      { "input_method": "keyboard_char", "key": ">" },
+      { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_S" }
     ]
   },
   {
@@ -5333,19 +2479,7 @@
     "id": "CONTAIN_MODE",
     "category": "INVENTORY",
     "name": "Toggle contain mode for unloaded items",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "U"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "u",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "U" }, { "input_method": "keyboard_code", "key": "u", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
@@ -5353,21 +2487,9 @@
     "category": "BIONICS",
     "name": "Toggle activate/examine",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "!"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "1",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_N"
-      }
+      { "input_method": "keyboard_char", "key": "!" },
+      { "input_method": "keyboard_code", "key": "1", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_N" }
     ]
   },
   {
@@ -5376,21 +2498,9 @@
     "category": "BIONICS",
     "name": "Toggle safe fuel mod",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "S"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "s",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_NE"
-      }
+      { "input_method": "keyboard_char", "key": "S" },
+      { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_NE" }
     ]
   },
   {
@@ -5399,21 +2509,9 @@
     "category": "BIONICS",
     "name": "Toggle sprite",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "H"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "h",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_E"
-      }
+      { "input_method": "keyboard_char", "key": "H" },
+      { "input_method": "keyboard_code", "key": "h", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_E" }
     ]
   },
   {
@@ -5422,21 +2520,9 @@
     "category": "BIONICS",
     "name": "Open refuel menu",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "R"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "r",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_SE"
-      }
+      { "input_method": "keyboard_char", "key": "R" },
+      { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_SE" }
     ]
   },
   {
@@ -5445,21 +2531,9 @@
     "category": "BIONICS",
     "name": "Toggle auto start mod",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "A"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "a",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_S"
-      }
+      { "input_method": "keyboard_char", "key": "A" },
+      { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_S" }
     ]
   },
   {
@@ -5467,16 +2541,7 @@
     "id": "SORT",
     "category": "BIONICS",
     "name": "Sort bionics list",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "s"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_SW"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "s" }, { "input_method": "gamepad", "key": "L_RADIAL_SW" } ]
   },
   {
     "type": "keybinding",
@@ -5484,21 +2549,9 @@
     "category": "MUTATIONS",
     "name": "Toggle activate/examine",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "!"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "1",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_N"
-      }
+      { "input_method": "keyboard_char", "key": "!" },
+      { "input_method": "keyboard_code", "key": "1", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_N" }
     ]
   },
   {
@@ -5507,21 +2560,9 @@
     "category": "MUTATIONS",
     "name": "Scroll mutation info up",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "<"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ",",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_UP"
-      }
+      { "input_method": "keyboard_char", "key": "<" },
+      { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "ALT_UP" }
     ]
   },
   {
@@ -5530,21 +2571,9 @@
     "category": "MUTATIONS",
     "name": "Scroll mutation info down",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": ">"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ".",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_DOWN"
-      }
+      { "input_method": "keyboard_char", "key": ">" },
+      { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "ALT_DOWN" }
     ]
   },
   {
@@ -5553,21 +2582,9 @@
     "category": "MEDICAL",
     "name": "Use item",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "A"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "a",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_N"
-      }
+      { "input_method": "keyboard_char", "key": "A" },
+      { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_N" }
     ]
   },
   {
@@ -5576,26 +2593,11 @@
     "category": "DEFAULTMODE",
     "id": "pause",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "."
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_PERIOD"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "5"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_5"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "RT"
-      }
+      { "input_method": "keyboard_any", "key": "." },
+      { "input_method": "keyboard_code", "key": "KEYPAD_PERIOD" },
+      { "input_method": "keyboard_any", "key": "5" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_5" },
+      { "input_method": "gamepad", "key": "RT" }
     ]
   },
   {
@@ -5614,119 +2616,70 @@
     "name": "Center view",
     "category": "DEFAULTMODE",
     "id": "center",
-    "bindings": []
+    "bindings": [  ]
   },
   {
     "type": "keybinding",
     "name": "Move view north",
     "category": "DEFAULTMODE",
     "id": "shift_n",
-    "bindings": [
-      {
-        "input_method": "gamepad",
-        "key": "RS_UP"
-      }
-    ]
+    "bindings": [ { "input_method": "gamepad", "key": "RS_UP" } ]
   },
   {
     "type": "keybinding",
     "name": "Move view east",
     "category": "DEFAULTMODE",
     "id": "shift_e",
-    "bindings": [
-      {
-        "input_method": "gamepad",
-        "key": "RS_RIGHT"
-      }
-    ]
+    "bindings": [ { "input_method": "gamepad", "key": "RS_RIGHT" } ]
   },
   {
     "type": "keybinding",
     "name": "Move view south",
     "category": "DEFAULTMODE",
     "id": "shift_s",
-    "bindings": [
-      {
-        "input_method": "gamepad",
-        "key": "RS_DOWN"
-      }
-    ]
+    "bindings": [ { "input_method": "gamepad", "key": "RS_DOWN" } ]
   },
   {
     "type": "keybinding",
     "name": "Move view west",
     "category": "DEFAULTMODE",
     "id": "shift_w",
-    "bindings": [
-      {
-        "input_method": "gamepad",
-        "key": "RS_LEFT"
-      }
-    ]
+    "bindings": [ { "input_method": "gamepad", "key": "RS_LEFT" } ]
   },
   {
     "type": "keybinding",
     "name": "Open door",
     "category": "DEFAULTMODE",
     "id": "open",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "o"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "o" } ]
   },
   {
     "type": "keybinding",
     "name": "Close door",
     "category": "DEFAULTMODE",
     "id": "close",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "c"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "c" } ]
   },
   {
     "type": "keybinding",
     "name": "Smash nearby terrain",
     "category": "DEFAULTMODE",
     "id": "smash",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "s"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_X"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "s" }, { "input_method": "gamepad", "key": "ALT_X" } ]
   },
   {
     "type": "keybinding",
     "name": "Examine nearby terrain or furniture",
     "category": "DEFAULTMODE",
     "id": "examine",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "e"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "e" } ]
   },
   {
     "type": "keybinding",
     "name": "Examine nearby terrain, furniture, and items",
     "category": "DEFAULTMODE",
     "id": "examine_and_pickup",
-    "bindings": [
-      {
-        "input_method": "gamepad",
-        "key": "X"
-      }
-    ]
+    "bindings": [ { "input_method": "gamepad", "key": "X" } ]
   },
   {
     "type": "keybinding",
@@ -5734,18 +2687,9 @@
     "category": "DEFAULTMODE",
     "id": "advinv",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "/"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_DIVIDE"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "R_RADIAL_SE"
-      }
+      { "input_method": "keyboard_any", "key": "/" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_DIVIDE" },
+      { "input_method": "gamepad", "key": "R_RADIAL_SE" }
     ]
   },
   {
@@ -5753,12 +2697,7 @@
     "name": "Pick up items from one nearby tile",
     "category": "DEFAULTMODE",
     "id": "pickup",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "g"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "g" } ]
   },
   {
     "type": "keybinding",
@@ -5772,21 +2711,9 @@
     "category": "DEFAULTMODE",
     "id": "grab",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "G"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "g",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "B"
-      }
+      { "input_method": "keyboard_char", "key": "G" },
+      { "input_method": "keyboard_code", "key": "g", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "B" }
     ]
   },
   {
@@ -5794,16 +2721,7 @@
     "name": "Haul items along the ground",
     "category": "DEFAULTMODE",
     "id": "haul",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "\\"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_B"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "\\" }, { "input_method": "gamepad", "key": "ALT_B" } ]
   },
   {
     "type": "keybinding",
@@ -5816,38 +2734,14 @@
     "name": "Zone activities",
     "category": "DEFAULTMODE",
     "id": "loot",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "O"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "o",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "O" }, { "input_method": "keyboard_code", "key": "o", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "name": "Butcher",
     "category": "DEFAULTMODE",
     "id": "butcher",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "B"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "b",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "B" }, { "input_method": "keyboard_code", "key": "b", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
@@ -5855,21 +2749,9 @@
     "category": "DEFAULTMODE",
     "id": "chat",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "C"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "c",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_E"
-      }
+      { "input_method": "keyboard_char", "key": "C" },
+      { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_E" }
     ]
   },
   {
@@ -5877,16 +2759,7 @@
     "name": "Look around",
     "category": "DEFAULTMODE",
     "id": "look",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": ";"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "x"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": ";" }, { "input_method": "keyboard_any", "key": "x" } ]
   },
   {
     "type": "keybinding",
@@ -5900,21 +2773,9 @@
     "category": "DEFAULTMODE",
     "id": "peek",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "X"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "x",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_RS"
-      }
+      { "input_method": "keyboard_char", "key": "X" },
+      { "input_method": "keyboard_code", "key": "x", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "ALT_RS" }
     ]
   },
   {
@@ -5923,21 +2784,9 @@
     "category": "DEFAULTMODE",
     "id": "listitems",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "V"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "v",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "RS"
-      }
+      { "input_method": "keyboard_char", "key": "V" },
+      { "input_method": "keyboard_code", "key": "v", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "RS" }
     ]
   },
   {
@@ -5945,78 +2794,35 @@
     "name": "Zones manager",
     "category": "DEFAULTMODE",
     "id": "zones",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "Y"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "y",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "Y" }, { "input_method": "keyboard_code", "key": "y", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "name": "Open inventory",
     "category": "DEFAULTMODE",
     "id": "inventory",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "i"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "R_RADIAL_S"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "i" }, { "input_method": "gamepad", "key": "R_RADIAL_S" } ]
   },
   {
     "type": "keybinding",
     "name": "Compare two items",
     "category": "DEFAULTMODE",
     "id": "compare",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "I"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "i",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "I" }, { "input_method": "keyboard_code", "key": "i", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "name": "Swap inventory letters",
     "category": "DEFAULTMODE",
     "id": "organize",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "="
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "=" } ]
   },
   {
     "type": "keybinding",
     "name": "Use item",
     "category": "DEFAULTMODE",
     "id": "apply",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "a"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "a" } ]
   },
   {
     "type": "keybinding",
@@ -6024,21 +2830,9 @@
     "category": "DEFAULTMODE",
     "id": "apply_wielded",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "A"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "a",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_RIGHT"
-      }
+      { "input_method": "keyboard_char", "key": "A" },
+      { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "ALT_RIGHT" }
     ]
   },
   {
@@ -6047,21 +2841,9 @@
     "category": "DEFAULTMODE",
     "id": "wear",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "W"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "w",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "LEFT"
-      }
+      { "input_method": "keyboard_char", "key": "W" },
+      { "input_method": "keyboard_code", "key": "w", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "LEFT" }
     ]
   },
   {
@@ -6070,21 +2852,9 @@
     "category": "DEFAULTMODE",
     "id": "take_off",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "T"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "t",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_LEFT"
-      }
+      { "input_method": "keyboard_char", "key": "T" },
+      { "input_method": "keyboard_code", "key": "t", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "ALT_LEFT" }
     ]
   },
   {
@@ -6093,21 +2863,9 @@
     "category": "DEFAULTMODE",
     "id": "eat",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "E"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "e",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "UP"
-      }
+      { "input_method": "keyboard_char", "key": "E" },
+      { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "UP" }
     ]
   },
   {
@@ -6122,21 +2880,9 @@
     "category": "DEFAULTMODE",
     "id": "read",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "R"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "r",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_NE"
-      }
+      { "input_method": "keyboard_char", "key": "R" },
+      { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_NE" }
     ]
   },
   {
@@ -6144,16 +2890,7 @@
     "name": "Wield",
     "category": "DEFAULTMODE",
     "id": "wield",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "w"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "RIGHT"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "w" }, { "input_method": "gamepad", "key": "RIGHT" } ]
   },
   {
     "type": "keybinding",
@@ -6161,21 +2898,9 @@
     "category": "DEFAULTMODE",
     "id": "pick_style",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "_"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "-",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_RB"
-      }
+      { "input_method": "keyboard_char", "key": "_" },
+      { "input_method": "keyboard_code", "key": "-", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "ALT_RB" }
     ]
   },
   {
@@ -6195,12 +2920,7 @@
     "name": "Insert item",
     "category": "DEFAULTMODE",
     "id": "insert",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "v"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "v" } ]
   },
   {
     "type": "keybinding",
@@ -6208,21 +2928,9 @@
     "category": "DEFAULTMODE",
     "id": "unload",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "U"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "u",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_NW"
-      }
+      { "input_method": "keyboard_char", "key": "U" },
+      { "input_method": "keyboard_code", "key": "u", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_NW" }
     ]
   },
   {
@@ -6230,16 +2938,7 @@
     "name": "Throw item",
     "category": "DEFAULTMODE",
     "id": "throw",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "t"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "Y"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "t" }, { "input_method": "gamepad", "key": "Y" } ]
   },
   {
     "type": "keybinding",
@@ -6252,12 +2951,7 @@
     "name": "Blind throw item",
     "category": "LOOK",
     "id": "throw_blind",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "t"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "t" } ]
   },
   {
     "type": "keybinding",
@@ -6270,63 +2964,28 @@
     "name": "Fire wielded item",
     "category": "DEFAULTMODE",
     "id": "fire",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "f"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "LB"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "f" }, { "input_method": "gamepad", "key": "LB" } ]
   },
   {
     "type": "keybinding",
     "name": "Toggle attack mode of wielded item",
     "category": "DEFAULTMODE",
     "id": "select_fire_mode",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "F"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "f",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "F" }, { "input_method": "keyboard_code", "key": "f", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "name": "Select default ammo for wielded weapon which do not use a magazine",
     "category": "DEFAULTMODE",
     "id": "select_default_ammo",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "F3"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "F3" } ]
   },
   {
     "type": "keybinding",
     "name": "Drop item",
     "category": "DEFAULTMODE",
     "id": "drop",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "d"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "DOWN"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "d" }, { "input_method": "gamepad", "key": "DOWN" } ]
   },
   {
     "type": "keybinding",
@@ -6339,43 +2998,21 @@
     "name": "Drop item to adjacent tile",
     "category": "DEFAULTMODE",
     "id": "drop_adj",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "D"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "d",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "D" }, { "input_method": "keyboard_code", "key": "d", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "name": "View/activate bionics",
     "category": "DEFAULTMODE",
     "id": "bionics",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "p"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "p" } ]
   },
   {
     "type": "keybinding",
     "name": "View/activate mutations",
     "category": "DEFAULTMODE",
     "id": "mutations",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "["
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "[" } ]
   },
   {
     "type": "keybinding",
@@ -6383,21 +3020,9 @@
     "category": "DEFAULTMODE",
     "id": "medical",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "N"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "n",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "R_RADIAL_NE"
-      }
+      { "input_method": "keyboard_char", "key": "N" },
+      { "input_method": "keyboard_code", "key": "n", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "R_RADIAL_NE" }
     ]
   },
   {
@@ -6406,21 +3031,9 @@
     "category": "DEFAULTMODE",
     "id": "bodystatus",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "{"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "[",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "R_RADIAL_SW"
-      }
+      { "input_method": "keyboard_char", "key": "{" },
+      { "input_method": "keyboard_code", "key": "[", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "R_RADIAL_SW" }
     ]
   },
   {
@@ -6429,21 +3042,9 @@
     "category": "DEFAULTMODE",
     "id": "sort_armor",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "+"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_PLUS"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "=",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_char", "key": "+" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" },
+      { "input_method": "keyboard_code", "key": "=", "mod": [ "shift" ] }
     ]
   },
   {
@@ -6452,21 +3053,9 @@
     "category": "DEFAULTMODE",
     "id": "wait",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "|"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "\\",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_SE"
-      }
+      { "input_method": "keyboard_char", "key": "|" },
+      { "input_method": "keyboard_code", "key": "\\", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_SE" }
     ]
   },
   {
@@ -6475,21 +3064,9 @@
     "category": "DEFAULTMODE",
     "id": "craft",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "&"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "7",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_N"
-      }
+      { "input_method": "keyboard_char", "key": "&" },
+      { "input_method": "keyboard_code", "key": "7", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_N" }
     ]
   },
   {
@@ -6497,16 +3074,7 @@
     "name": "Recraft last recipe",
     "category": "DEFAULTMODE",
     "id": "recraft",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "-"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MINUS"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "-" }, { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" } ]
   },
   {
     "type": "keybinding",
@@ -6514,25 +3082,10 @@
     "category": "DEFAULTMODE",
     "id": "construct",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "*"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MULTIPLY"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "8",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_S"
-      }
+      { "input_method": "keyboard_char", "key": "*" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
+      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_S" }
     ]
   },
   {
@@ -6541,21 +3094,9 @@
     "category": "DEFAULTMODE",
     "id": "disassemble",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "("
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "9",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_W"
-      }
+      { "input_method": "keyboard_char", "key": "(" },
+      { "input_method": "keyboard_code", "key": "9", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_W" }
     ]
   },
   {
@@ -6564,21 +3105,9 @@
     "category": "DEFAULTMODE",
     "id": "sleep",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "$"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "4",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_SW"
-      }
+      { "input_method": "keyboard_char", "key": "$" },
+      { "input_method": "keyboard_code", "key": "4", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_SW" }
     ]
   },
   {
@@ -6592,19 +3121,7 @@
     "name": "Control vehicle",
     "category": "DEFAULTMODE",
     "id": "control_vehicle",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "^"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "6",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "^" }, { "input_method": "keyboard_code", "key": "6", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
@@ -6618,21 +3135,9 @@
     "category": "DEFAULTMODE",
     "id": "safemode",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "!"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "1",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_LS"
-      }
+      { "input_method": "keyboard_char", "key": "!" },
+      { "input_method": "keyboard_code", "key": "1", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "ALT_LS" }
     ]
   },
   {
@@ -6640,54 +3145,21 @@
     "name": "Ignore nearby enemy",
     "category": "DEFAULTMODE",
     "id": "ignore_enemy",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "'"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "LS"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "'" }, { "input_method": "gamepad", "key": "LS" } ]
   },
   {
     "type": "keybinding",
     "name": "Whitelist enemy",
     "category": "DEFAULTMODE",
     "id": "whitelist_enemy",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "~"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "`",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "~" }, { "input_method": "keyboard_code", "key": "`", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "name": "Save and quit",
     "category": "DEFAULTMODE",
     "id": "save",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "S"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "s",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "S" }, { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
@@ -6701,21 +3173,9 @@
     "category": "DEFAULTMODE",
     "id": "player_data",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "@"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "2",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "R_RADIAL_N"
-      }
+      { "input_method": "keyboard_char", "key": "@" },
+      { "input_method": "keyboard_code", "key": "2", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "R_RADIAL_N" }
     ]
   },
   {
@@ -6723,27 +3183,13 @@
     "name": "View map",
     "category": "DEFAULTMODE",
     "id": "map",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "m"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "BACK"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "m" }, { "input_method": "gamepad", "key": "BACK" } ]
   },
   {
     "type": "keybinding",
     "name": "View map",
     "id": "map",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": ";"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": ";" } ]
   },
   {
     "type": "keybinding",
@@ -6757,21 +3203,9 @@
     "category": "DEFAULTMODE",
     "id": "missions",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "M"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "m",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "R_RADIAL_W"
-      }
+      { "input_method": "keyboard_char", "key": "M" },
+      { "input_method": "keyboard_code", "key": "m", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "R_RADIAL_W" }
     ]
   },
   {
@@ -6780,21 +3214,9 @@
     "category": "DEFAULTMODE",
     "id": "factions",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "#"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "3",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "R_RADIAL_E"
-      }
+      { "input_method": "keyboard_char", "key": "#" },
+      { "input_method": "keyboard_code", "key": "3", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "R_RADIAL_E" }
     ]
   },
   {
@@ -6802,83 +3224,36 @@
     "name": "View character's morale",
     "category": "DEFAULTMODE",
     "id": "morale",
-    "bindings": [
-      {
-        "input_method": "gamepad",
-        "key": "R_RADIAL_NW"
-      }
-    ]
+    "bindings": [ { "input_method": "gamepad", "key": "R_RADIAL_NW" } ]
   },
   {
     "type": "keybinding",
     "name": "View message log",
     "category": "DEFAULTMODE",
     "id": "messages",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "P"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "p",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "P" }, { "input_method": "keyboard_code", "key": "p", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "name": "View help",
     "category": "DEFAULTMODE",
     "id": "help",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "0"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_0"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "0" }, { "input_method": "keyboard_code", "key": "KEYPAD_0" } ]
   },
   {
     "type": "keybinding",
     "name": "Zoom in",
     "id": "zoom_in",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "z"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_START"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "z" }, { "input_method": "gamepad", "key": "ALT_START" } ]
   },
   {
     "type": "keybinding",
     "name": "Zoom out",
     "id": "zoom_out",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "Z"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "z",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_BACK"
-      }
+      { "input_method": "keyboard_char", "key": "Z" },
+      { "input_method": "keyboard_code", "key": "z", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "ALT_BACK" }
     ]
   },
   {
@@ -6898,17 +3273,8 @@
     "id": "DEBUG_DIALOGUE_DL_CONDITIONAL",
     "name": "Toggle debug dialogue dynamic_line conditionals",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "CTRL+C"
-      },
-      {
-        "input_method": "keyboard_code",
-        "mod": [
-          "ctrl"
-        ],
-        "key": "c"
-      }
+      { "input_method": "keyboard_char", "key": "CTRL+C" },
+      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "c" }
     ]
   },
   {
@@ -6916,17 +3282,8 @@
     "id": "DEBUG_DIALOGUE_RESP_CONDITIONAL",
     "name": "Toggle debug dialogue response conditionals",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "CTRL+D"
-      },
-      {
-        "input_method": "keyboard_code",
-        "mod": [
-          "ctrl"
-        ],
-        "key": "d"
-      }
+      { "input_method": "keyboard_char", "key": "CTRL+D" },
+      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "d" }
     ]
   },
   {
@@ -6934,17 +3291,8 @@
     "id": "DEBUG_DIALOGUE_DL_EFFECT",
     "name": "Toggle debug dialogue dynamic_line effects",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "CTRL+T"
-      },
-      {
-        "input_method": "keyboard_code",
-        "mod": [
-          "ctrl"
-        ],
-        "key": "t"
-      }
+      { "input_method": "keyboard_char", "key": "CTRL+T" },
+      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "t" }
     ]
   },
   {
@@ -6952,17 +3300,8 @@
     "id": "DEBUG_DIALOGUE_RESP_EFFECT",
     "name": "Toggle debug dialogue response effects",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "CTRL+Y"
-      },
-      {
-        "input_method": "keyboard_code",
-        "mod": [
-          "ctrl"
-        ],
-        "key": "y"
-      }
+      { "input_method": "keyboard_char", "key": "CTRL+Y" },
+      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "y" }
     ]
   },
   {
@@ -6970,17 +3309,8 @@
     "id": "DEBUG_DIALOGUE_SHOW_ALL_RESPONSE",
     "name": "Toggle debug dialogue show hidden responses",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "CTRL+R"
-      },
-      {
-        "input_method": "keyboard_code",
-        "mod": [
-          "ctrl"
-        ],
-        "key": "r"
-      }
+      { "input_method": "keyboard_char", "key": "CTRL+R" },
+      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "r" }
     ]
   },
   {
@@ -6989,21 +3319,9 @@
     "category": "CALENDAR_UI",
     "name": "Reset time point to initial value",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "r"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "R"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "r",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_any", "key": "r" },
+      { "input_method": "keyboard_char", "key": "R" },
+      { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] }
     ]
   },
   {
@@ -7017,36 +3335,21 @@
     "category": "DEBUG_SPELLS",
     "id": "TOGGLE_ALL_SPELL",
     "name": "Toggle all spells",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "t"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "t" } ]
   },
   {
     "type": "keybinding",
     "category": "DEBUG_SPELLS",
     "id": "UNLEARN_SPELL",
     "name": "Unlearn a spell",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "u"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "u" } ]
   },
   {
     "type": "keybinding",
     "category": "DEBUG_SPELLS",
     "id": "SHOW_ONLY_LEARNED",
     "name": "Show only learned",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "a"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "a" } ]
   },
   {
     "type": "keybinding",
@@ -7076,16 +3379,7 @@
     "name": "Reload item",
     "category": "DEFAULTMODE",
     "id": "reload_item",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "r"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_LB"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "r" }, { "input_method": "gamepad", "key": "ALT_LB" } ]
   },
   {
     "type": "keybinding",
@@ -7135,18 +3429,9 @@
     "category": "DEFAULTMODE",
     "id": "action_menu",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "RETURN"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "KEYPAD_ENTER"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "A"
-      }
+      { "input_method": "keyboard_any", "key": "RETURN" },
+      { "input_method": "keyboard_any", "key": "KEYPAD_ENTER" },
+      { "input_method": "gamepad", "key": "A" }
     ]
   },
   {
@@ -7155,21 +3440,9 @@
     "category": "DEFAULTMODE",
     "id": "item_action_menu",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "%"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "5",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_A"
-      }
+      { "input_method": "keyboard_char", "key": "%" },
+      { "input_method": "keyboard_code", "key": "5", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "ALT_A" }
     ]
   },
   {
@@ -7189,48 +3462,28 @@
     "name": "Move view northeast",
     "category": "DEFAULTMODE",
     "id": "shift_ne",
-    "bindings": [
-      {
-        "input_method": "gamepad",
-        "key": "RS_UP_RIGHT"
-      }
-    ]
+    "bindings": [ { "input_method": "gamepad", "key": "RS_UP_RIGHT" } ]
   },
   {
     "type": "keybinding",
     "name": "Move view southeast",
     "category": "DEFAULTMODE",
     "id": "shift_se",
-    "bindings": [
-      {
-        "input_method": "gamepad",
-        "key": "RS_DOWN_RIGHT"
-      }
-    ]
+    "bindings": [ { "input_method": "gamepad", "key": "RS_DOWN_RIGHT" } ]
   },
   {
     "type": "keybinding",
     "name": "Move view southwest",
     "category": "DEFAULTMODE",
     "id": "shift_sw",
-    "bindings": [
-      {
-        "input_method": "gamepad",
-        "key": "RS_DOWN_LEFT"
-      }
-    ]
+    "bindings": [ { "input_method": "gamepad", "key": "RS_DOWN_LEFT" } ]
   },
   {
     "type": "keybinding",
     "name": "Move view northwest",
     "category": "DEFAULTMODE",
     "id": "shift_nw",
-    "bindings": [
-      {
-        "input_method": "gamepad",
-        "key": "RS_UP_LEFT"
-      }
-    ]
+    "bindings": [ { "input_method": "gamepad", "key": "RS_UP_LEFT" } ]
   },
   {
     "type": "keybinding",
@@ -7255,32 +3508,14 @@
     "name": "Autoattack",
     "category": "DEFAULTMODE",
     "id": "autoattack",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "TAB"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "RB"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "TAB" }, { "input_method": "gamepad", "key": "RB" } ]
   },
   {
     "type": "keybinding",
     "name": "Main menu",
     "category": "DEFAULTMODE",
     "id": "main_menu",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "ESC"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "START"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "ESC" }, { "input_method": "gamepad", "key": "START" } ]
   },
   {
     "type": "keybinding",
@@ -7329,7 +3564,7 @@
     "name": "Cycle movement mode",
     "category": "DEFAULTMODE",
     "id": "cycle_move",
-    "bindings": []
+    "bindings": [  ]
   },
   {
     "type": "keybinding",
@@ -7367,21 +3602,9 @@
     "category": "DEFAULTMODE",
     "id": "open_movement",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "\""
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "'",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_RT"
-      }
+      { "input_method": "keyboard_char", "key": "\"" },
+      { "input_method": "keyboard_code", "key": "'", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "ALT_RT" }
     ]
   },
   {
@@ -7389,16 +3612,7 @@
     "id": "cast_spell",
     "name": "Supernatural abilities",
     "category": "DEFAULTMODE",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "]"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_Y"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "]" }, { "input_method": "gamepad", "key": "ALT_Y" } ]
   },
   {
     "type": "keybinding",
@@ -7411,19 +3625,7 @@
     "id": "diary",
     "name": "Open diary / achievements / scores",
     "category": "DEFAULTMODE",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": ")"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "0",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": ")" }, { "input_method": "keyboard_code", "key": "0", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
@@ -7431,21 +3633,9 @@
     "category": "LIST_ITEMS",
     "name": "Scroll item info up",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "<"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ",",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_UP"
-      }
+      { "input_method": "keyboard_char", "key": "<" },
+      { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "ALT_UP" }
     ]
   },
   {
@@ -7454,21 +3644,9 @@
     "category": "LIST_ITEMS",
     "name": "Scroll item info down",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": ">"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ".",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_DOWN"
-      }
+      { "input_method": "keyboard_char", "key": ">" },
+      { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "ALT_DOWN" }
     ]
   },
   {
@@ -7477,36 +3655,12 @@
     "category": "LIST_ITEMS",
     "name": "Compare",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "I"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "i",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "c"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "C"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "c",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_NE"
-      }
+      { "input_method": "keyboard_char", "key": "I" },
+      { "input_method": "keyboard_code", "key": "i", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "c" },
+      { "input_method": "keyboard_char", "key": "C" },
+      { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_NE" }
     ]
   },
   {
@@ -7515,25 +3669,10 @@
     "category": "LIST_ITEMS",
     "name": "Examine",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "e"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "E"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "e",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_N"
-      }
+      { "input_method": "keyboard_any", "key": "e" },
+      { "input_method": "keyboard_char", "key": "E" },
+      { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_N" }
     ]
   },
   {
@@ -7542,22 +3681,10 @@
     "category": "LIST_ITEMS",
     "name": "Increase priority",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "="
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "+"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_PLUS"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_E"
-      }
+      { "input_method": "keyboard_any", "key": "=" },
+      { "input_method": "keyboard_char", "key": "+" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" },
+      { "input_method": "gamepad", "key": "L_RADIAL_E" }
     ]
   },
   {
@@ -7566,18 +3693,9 @@
     "category": "LIST_ITEMS",
     "name": "Decrease priority",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "-"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MINUS"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_W"
-      }
+      { "input_method": "keyboard_any", "key": "-" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" },
+      { "input_method": "gamepad", "key": "L_RADIAL_W" }
     ]
   },
   {
@@ -7586,25 +3704,10 @@
     "category": "LIST_ITEMS",
     "name": "Change sort order",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "s"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "S"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "s",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_SE"
-      }
+      { "input_method": "keyboard_any", "key": "s" },
+      { "input_method": "keyboard_char", "key": "S" },
+      { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_SE" }
     ]
   },
   {
@@ -7612,67 +3715,28 @@
     "id": "SAFEMODE_BLACKLIST_ADD",
     "category": "LIST_MONSTERS",
     "name": "Add to safe mode blacklist",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "a"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_N"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "a" }, { "input_method": "gamepad", "key": "L_RADIAL_N" } ]
   },
   {
     "type": "keybinding",
     "id": "SAFEMODE_BLACKLIST_REMOVE",
     "category": "LIST_MONSTERS",
     "name": "Remove from safe mode blacklist",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "r"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_S"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "r" }, { "input_method": "gamepad", "key": "L_RADIAL_S" } ]
   },
   {
     "type": "keybinding",
     "id": "look",
     "category": "LIST_MONSTERS",
     "name": "Look around",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "x"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_E"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "x" }, { "input_method": "gamepad", "key": "L_RADIAL_E" } ]
   },
   {
     "type": "keybinding",
     "id": "fire",
     "category": "LIST_MONSTERS",
-    "name": {
-      "ctxt": "verb",
-      "str": "Fire"
-    },
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "f"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_W"
-      }
-    ]
+    "name": { "ctxt": "verb", "str": "Fire" },
+    "bindings": [ { "input_method": "keyboard_any", "key": "f" }, { "input_method": "gamepad", "key": "L_RADIAL_W" } ]
   },
   {
     "type": "keybinding",
@@ -7680,21 +3744,9 @@
     "category": "LOOK",
     "name": "List items and monsters",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "V"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "v",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "RS"
-      }
+      { "input_method": "keyboard_char", "key": "V" },
+      { "input_method": "keyboard_code", "key": "v", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "RS" }
     ]
   },
   {
@@ -7702,12 +3754,7 @@
     "id": "REASSIGN",
     "category": "BIONICS",
     "name": "Reassign inventory letter",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "="
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "=" } ]
   },
   {
     "type": "keybinding",
@@ -7715,22 +3762,10 @@
     "category": "BIONICS",
     "name": "Move cursor up",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "8"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_8"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "UP"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "UP"
-      }
+      { "input_method": "keyboard_any", "key": "8" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_8" },
+      { "input_method": "keyboard_any", "key": "UP" },
+      { "input_method": "gamepad", "key": "UP" }
     ]
   },
   {
@@ -7739,22 +3774,10 @@
     "category": "BIONICS",
     "name": "Move cursor down",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "DOWN"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "2"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_2"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "DOWN"
-      }
+      { "input_method": "keyboard_any", "key": "DOWN" },
+      { "input_method": "keyboard_any", "key": "2" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_2" },
+      { "input_method": "gamepad", "key": "DOWN" }
     ]
   },
   {
@@ -7762,24 +3785,14 @@
     "id": "REASSIGN",
     "category": "MUTATIONS",
     "name": "Reassign inventory letter",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "="
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "=" } ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_SPRITE",
     "category": "MUTATIONS",
     "name": "Toggle sprite",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": ","
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "," } ]
   },
   {
     "type": "keybinding",
@@ -7787,22 +3800,10 @@
     "category": "MUTATIONS",
     "name": "Pan up",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "8"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_8"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "UP"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "UP"
-      }
+      { "input_method": "keyboard_any", "key": "8" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_8" },
+      { "input_method": "keyboard_any", "key": "UP" },
+      { "input_method": "gamepad", "key": "UP" }
     ]
   },
   {
@@ -7811,22 +3812,10 @@
     "category": "MUTATIONS",
     "name": "Pan down",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "DOWN"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "2"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_2"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "DOWN"
-      }
+      { "input_method": "keyboard_any", "key": "DOWN" },
+      { "input_method": "keyboard_any", "key": "2" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_2" },
+      { "input_method": "gamepad", "key": "DOWN" }
     ]
   },
   {
@@ -7835,52 +3824,28 @@
     "category": "HELP_KEYBINDINGS",
     "name": "Exit this keybinding screen",
     "//": "separate entry, because the global entry also has 'q', 'Q' and space listed, which conflicts with the search text input",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "ESC"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "ESC" } ]
   },
   {
     "type": "keybinding",
     "id": "UP",
     "category": "HELP_KEYBINDINGS",
     "name": "Pan up",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "UP"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "UP" } ]
   },
   {
     "type": "keybinding",
     "id": "DOWN",
     "category": "HELP_KEYBINDINGS",
     "name": "Pan down",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "DOWN"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "DOWN" } ]
   },
   {
     "type": "keybinding",
     "id": "REMOVE",
     "category": "HELP_KEYBINDINGS",
     "name": "Remove keybinding",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "-"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MINUS"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "-" }, { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" } ]
   },
   {
     "type": "keybinding",
@@ -7888,21 +3853,9 @@
     "category": "HELP_KEYBINDINGS",
     "name": "Reset keybinding",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "*"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "8",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MULTIPLY"
-      }
+      { "input_method": "keyboard_char", "key": "*" },
+      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] },
+      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" }
     ]
   },
   {
@@ -7911,21 +3864,9 @@
     "category": "HELP_KEYBINDINGS",
     "name": "Add local keybinding",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "+"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_PLUS"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "=",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_char", "key": "+" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" },
+      { "input_method": "keyboard_code", "key": "=", "mod": [ "shift" ] }
     ]
   },
   {
@@ -7933,28 +3874,14 @@
     "id": "ADD_GLOBAL",
     "category": "HELP_KEYBINDINGS",
     "name": "Add global keybinding",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "="
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "=" } ]
   },
   {
     "type": "keybinding",
     "id": "EXECUTE",
     "category": "HELP_KEYBINDINGS",
     "name": "Execute action keybinding",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "."
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_PERIOD"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "." }, { "input_method": "keyboard_code", "key": "KEYPAD_PERIOD" } ]
   },
   {
     "type": "keybinding",
@@ -7962,25 +3889,10 @@
     "category": "ZONES_MANAGER",
     "name": "Add zone",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "a"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "A"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "a",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_N"
-      }
+      { "input_method": "keyboard_any", "key": "a" },
+      { "input_method": "keyboard_char", "key": "A" },
+      { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_N" }
     ]
   },
   {
@@ -7989,25 +3901,10 @@
     "category": "ZONES_MANAGER",
     "name": "Add personal zone",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "p"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "P"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "p",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_NE"
-      }
+      { "input_method": "keyboard_any", "key": "p" },
+      { "input_method": "keyboard_char", "key": "P" },
+      { "input_method": "keyboard_code", "key": "p", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_NE" }
     ]
   },
   {
@@ -8016,25 +3913,10 @@
     "category": "ZONES_MANAGER",
     "name": "Remove zone",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "r"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "R"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "r",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_E"
-      }
+      { "input_method": "keyboard_any", "key": "r" },
+      { "input_method": "keyboard_char", "key": "R" },
+      { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_E" }
     ]
   },
   {
@@ -8043,22 +3925,10 @@
     "category": "ZONES_MANAGER",
     "name": "Move zone up",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "="
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "+"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_PLUS"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_UP"
-      }
+      { "input_method": "keyboard_any", "key": "=" },
+      { "input_method": "keyboard_char", "key": "+" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" },
+      { "input_method": "gamepad", "key": "ALT_UP" }
     ]
   },
   {
@@ -8067,18 +3937,9 @@
     "category": "ZONES_MANAGER",
     "name": "Move zone down",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "-"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MINUS"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_DOWN"
-      }
+      { "input_method": "keyboard_any", "key": "-" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" },
+      { "input_method": "gamepad", "key": "ALT_DOWN" }
     ]
   },
   {
@@ -8087,25 +3948,10 @@
     "category": "ZONES_MANAGER",
     "name": "Show zone on map",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "m"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "M"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "m",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_SE"
-      }
+      { "input_method": "keyboard_any", "key": "m" },
+      { "input_method": "keyboard_char", "key": "M" },
+      { "input_method": "keyboard_code", "key": "m", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_SE" }
     ]
   },
   {
@@ -8114,25 +3960,10 @@
     "category": "ZONES_MANAGER",
     "name": "Toggle display of zone markers",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "t"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "T"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "t",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_S"
-      }
+      { "input_method": "keyboard_any", "key": "t" },
+      { "input_method": "keyboard_char", "key": "T" },
+      { "input_method": "keyboard_code", "key": "t", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_S" }
     ]
   },
   {
@@ -8141,25 +3972,10 @@
     "category": "ZONES_MANAGER",
     "name": "Enable zone",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "e"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "E"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "e",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_SW"
-      }
+      { "input_method": "keyboard_any", "key": "e" },
+      { "input_method": "keyboard_char", "key": "E" },
+      { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_SW" }
     ]
   },
   {
@@ -8168,25 +3984,10 @@
     "category": "ZONES_MANAGER",
     "name": "Disable zone",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "d"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "D"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "d",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_W"
-      }
+      { "input_method": "keyboard_any", "key": "d" },
+      { "input_method": "keyboard_char", "key": "D" },
+      { "input_method": "keyboard_code", "key": "d", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_W" }
     ]
   },
   {
@@ -8195,25 +3996,10 @@
     "category": "ZONES_MANAGER",
     "name": "Enable personal zones",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "z"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "Z"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "z",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_NW"
-      }
+      { "input_method": "keyboard_any", "key": "z" },
+      { "input_method": "keyboard_char", "key": "Z" },
+      { "input_method": "keyboard_code", "key": "z", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_NW" }
     ]
   },
   {
@@ -8222,25 +4008,10 @@
     "category": "ZONES_MANAGER",
     "name": "Disable personal zones",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "x"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "X"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "x",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "R_RADIAL_N"
-      }
+      { "input_method": "keyboard_any", "key": "x" },
+      { "input_method": "keyboard_char", "key": "X" },
+      { "input_method": "keyboard_code", "key": "x", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "R_RADIAL_N" }
     ]
   },
   {
@@ -8249,25 +4020,10 @@
     "category": "ZONES_MANAGER",
     "name": "Enable vehicle zones",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "c"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "C"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "c",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "R_RADIAL_NE"
-      }
+      { "input_method": "keyboard_any", "key": "c" },
+      { "input_method": "keyboard_char", "key": "C" },
+      { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "R_RADIAL_NE" }
     ]
   },
   {
@@ -8276,25 +4032,10 @@
     "category": "ZONES_MANAGER",
     "name": "Disable vehicle zones",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "v"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "V"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "v",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "R_RADIAL_E"
-      }
+      { "input_method": "keyboard_any", "key": "v" },
+      { "input_method": "keyboard_char", "key": "V" },
+      { "input_method": "keyboard_code", "key": "v", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "R_RADIAL_E" }
     ]
   },
   {
@@ -8303,25 +4044,10 @@
     "category": "ZONES_MANAGER",
     "name": "Show all zones / hide distant zones",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "s"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "S"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "s",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "R_RADIAL_SE"
-      }
+      { "input_method": "keyboard_any", "key": "s" },
+      { "input_method": "keyboard_char", "key": "S" },
+      { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "R_RADIAL_SE" }
     ]
   },
   {
@@ -8330,21 +4056,9 @@
     "category": "ZONES_MANAGER",
     "name": "Change shown faction",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "F"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "f",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "R_RADIAL_S"
-      }
+      { "input_method": "keyboard_char", "key": "F" },
+      { "input_method": "keyboard_code", "key": "f", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "R_RADIAL_S" }
     ]
   },
   {
@@ -8353,25 +4067,10 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Page down",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "NPAGE"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": ">"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ".",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_DOWN"
-      }
+      { "input_method": "keyboard_any", "key": "NPAGE" },
+      { "input_method": "keyboard_char", "key": ">" },
+      { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "ALT_DOWN" }
     ]
   },
   {
@@ -8380,25 +4079,10 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Page up",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "PPAGE"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "<"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ",",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_UP"
-      }
+      { "input_method": "keyboard_any", "key": "PPAGE" },
+      { "input_method": "keyboard_char", "key": "<" },
+      { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "ALT_UP" }
     ]
   },
   {
@@ -8407,18 +4091,9 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Pan up",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "k"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "UP"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "UP"
-      }
+      { "input_method": "keyboard_any", "key": "k" },
+      { "input_method": "keyboard_any", "key": "UP" },
+      { "input_method": "gamepad", "key": "UP" }
     ]
   },
   {
@@ -8427,18 +4102,9 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Pan down",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "j"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "DOWN"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "DOWN"
-      }
+      { "input_method": "keyboard_any", "key": "j" },
+      { "input_method": "keyboard_any", "key": "DOWN" },
+      { "input_method": "gamepad", "key": "DOWN" }
     ]
   },
   {
@@ -8447,18 +4113,9 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Select left inventory",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "h"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "LEFT"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "LEFT"
-      }
+      { "input_method": "keyboard_any", "key": "h" },
+      { "input_method": "keyboard_any", "key": "LEFT" },
+      { "input_method": "gamepad", "key": "LEFT" }
     ]
   },
   {
@@ -8466,28 +4123,14 @@
     "id": "RIGHT",
     "category": "ADVANCED_INVENTORY",
     "name": "Select right inventory",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "l"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "RIGHT"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "l" }, { "input_method": "keyboard_any", "key": "RIGHT" } ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_TAB",
     "category": "ADVANCED_INVENTORY",
     "name": "Toggle tab",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "TAB"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "TAB" } ]
   },
   {
     "type": "keybinding",
@@ -8495,25 +4138,10 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Toggle vehicle",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "v"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "V"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "v",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_NW"
-      }
+      { "input_method": "keyboard_any", "key": "v" },
+      { "input_method": "keyboard_char", "key": "V" },
+      { "input_method": "keyboard_code", "key": "v", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_NW" }
     ]
   },
   {
@@ -8521,16 +4149,7 @@
     "id": "TOGGLE_AUTO_PICKUP",
     "category": "ADVANCED_INVENTORY",
     "name": "Toggle auto pickup for item",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "p"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_W"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "p" }, { "input_method": "gamepad", "key": "L_RADIAL_W" } ]
   },
   {
     "type": "keybinding",
@@ -8538,25 +4157,10 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Examine",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "e"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "E"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "e",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_N"
-      }
+      { "input_method": "keyboard_any", "key": "e" },
+      { "input_method": "keyboard_char", "key": "E" },
+      { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_N" }
     ]
   },
   {
@@ -8565,25 +4169,10 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Change sorting mode",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "s"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "S"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "s",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_N"
-      }
+      { "input_method": "keyboard_any", "key": "s" },
+      { "input_method": "keyboard_char", "key": "S" },
+      { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_N" }
     ]
   },
   {
@@ -8591,32 +4180,14 @@
     "id": "MOVE_SINGLE_ITEM",
     "category": "ADVANCED_INVENTORY",
     "name": "Move a single item",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "RETURN"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "KEYPAD_ENTER"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "RETURN" }, { "input_method": "keyboard_any", "key": "KEYPAD_ENTER" } ]
   },
   {
     "type": "keybinding",
     "id": "MOVE_VARIABLE_ITEM",
     "category": "ADVANCED_INVENTORY",
     "name": "Move some items",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "m"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_NE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "m" }, { "input_method": "gamepad", "key": "L_RADIAL_NE" } ]
   },
   {
     "type": "keybinding",
@@ -8624,21 +4195,9 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Move item stack",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "M"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "m",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_E"
-      }
+      { "input_method": "keyboard_char", "key": "M" },
+      { "input_method": "keyboard_code", "key": "m", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_E" }
     ]
   },
   {
@@ -8646,32 +4205,14 @@
     "id": "MOVE_ALL_ITEMS",
     "category": "ADVANCED_INVENTORY",
     "name": "Move all items",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": ","
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_SE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "," }, { "input_method": "gamepad", "key": "L_RADIAL_SE" } ]
   },
   {
     "type": "keybinding",
     "id": "CATEGORY_SELECTION",
     "category": "ADVANCED_INVENTORY",
     "name": "Toggle category selection mode",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "t"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_S"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "t" }, { "input_method": "gamepad", "key": "L_RADIAL_S" } ]
   },
   {
     "type": "keybinding",
@@ -8679,25 +4220,10 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Toggle item as favorite",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "*"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MULTIPLY"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "8",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_SW"
-      }
+      { "input_method": "keyboard_char", "key": "*" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
+      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_SW" }
     ]
   },
   {
@@ -8706,22 +4232,10 @@
     "category": "INVENTORY",
     "name": "Select/unselect highlighted item",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "l"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "RIGHT"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "6"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_6"
-      }
+      { "input_method": "keyboard_any", "key": "l" },
+      { "input_method": "keyboard_any", "key": "RIGHT" },
+      { "input_method": "keyboard_any", "key": "6" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_6" }
     ]
   },
   {
@@ -8730,22 +4244,10 @@
     "category": "INVENTORY",
     "name": "Increase selected amount for the highlighted item",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "="
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "+"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_PLUS"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_N"
-      }
+      { "input_method": "keyboard_any", "key": "=" },
+      { "input_method": "keyboard_char", "key": "+" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" },
+      { "input_method": "gamepad", "key": "L_RADIAL_N" }
     ]
   },
   {
@@ -8753,32 +4255,14 @@
     "id": "AUTO_BALANCE",
     "category": "INVENTORY",
     "name": "Auto balance trade using highlighted item",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "F1"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_UP"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "F1" }, { "input_method": "gamepad", "key": "ALT_UP" } ]
   },
   {
     "type": "keybinding",
     "id": "BANK_BALANCE",
     "category": "INVENTORY",
     "name": "Auto balance trade using bank account",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "F2"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_E"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "F2" }, { "input_method": "gamepad", "key": "L_RADIAL_E" } ]
   },
   {
     "type": "keybinding",
@@ -8786,18 +4270,9 @@
     "category": "INVENTORY",
     "name": "Decrease selected amount for the highlighted item",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "-"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MINUS"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_DOWN"
-      }
+      { "input_method": "keyboard_any", "key": "-" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" },
+      { "input_method": "gamepad", "key": "ALT_DOWN" }
     ]
   },
   {
@@ -8806,26 +4281,11 @@
     "category": "INVENTORY",
     "name": "Next column",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "h"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "LEFT"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "4"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_4"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "LEFT"
-      }
+      { "input_method": "keyboard_any", "key": "h" },
+      { "input_method": "keyboard_any", "key": "LEFT" },
+      { "input_method": "keyboard_any", "key": "4" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_4" },
+      { "input_method": "gamepad", "key": "LEFT" }
     ]
   },
   {
@@ -8834,17 +4294,8 @@
     "category": "INVENTORY",
     "name": "Previous column",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "BACKTAB"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "TAB",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_char", "key": "BACKTAB" },
+      { "input_method": "keyboard_code", "key": "TAB", "mod": [ "shift" ] }
     ]
   },
   {
@@ -8852,175 +4303,77 @@
     "id": "TOGGLE_NON_FAVORITE",
     "category": "INVENTORY",
     "name": "Select/unselect non-favorite items in multidrop menu",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": ","
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "," } ]
   },
   {
     "type": "keybinding",
     "id": "MARK_WITH_COUNT",
     "category": "INVENTORY",
     "name": "Select a specific amount of highlighted item",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "!"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "1",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "!" }, { "input_method": "keyboard_code", "key": "1", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "ITEMS_NW",
     "category": "ADVANCED_INVENTORY",
     "name": "Select items at northwest",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "7"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_7"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "7" }, { "input_method": "keyboard_code", "key": "KEYPAD_7" } ]
   },
   {
     "type": "keybinding",
     "id": "ITEMS_N",
     "category": "ADVANCED_INVENTORY",
     "name": "Select items at north",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "8"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_8"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "8" }, { "input_method": "keyboard_code", "key": "KEYPAD_8" } ]
   },
   {
     "type": "keybinding",
     "id": "ITEMS_NE",
     "category": "ADVANCED_INVENTORY",
     "name": "Select items at northeast",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "9"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_9"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "9" }, { "input_method": "keyboard_code", "key": "KEYPAD_9" } ]
   },
   {
     "type": "keybinding",
     "id": "ITEMS_W",
     "category": "ADVANCED_INVENTORY",
     "name": "Select items at west",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "4"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_4"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "4" }, { "input_method": "keyboard_code", "key": "KEYPAD_4" } ]
   },
   {
     "type": "keybinding",
     "id": "ITEMS_CE",
     "category": "ADVANCED_INVENTORY",
     "name": "Select items at center",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "5"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_5"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "5" }, { "input_method": "keyboard_code", "key": "KEYPAD_5" } ]
   },
   {
     "type": "keybinding",
     "id": "ITEMS_E",
     "category": "ADVANCED_INVENTORY",
     "name": "Select items at east",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "6"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_6"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "6" }, { "input_method": "keyboard_code", "key": "KEYPAD_6" } ]
   },
   {
     "type": "keybinding",
     "id": "ITEMS_SW",
     "category": "ADVANCED_INVENTORY",
     "name": "Select items at southwest",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "1"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_1"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "1" }, { "input_method": "keyboard_code", "key": "KEYPAD_1" } ]
   },
   {
     "type": "keybinding",
     "id": "ITEMS_S",
     "category": "ADVANCED_INVENTORY",
     "name": "Select items at south",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "2"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_2"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "2" }, { "input_method": "keyboard_code", "key": "KEYPAD_2" } ]
   },
   {
     "type": "keybinding",
     "id": "ITEMS_SE",
     "category": "ADVANCED_INVENTORY",
     "name": "Select items at southeast",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "3"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_3"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "3" }, { "input_method": "keyboard_code", "key": "KEYPAD_3" } ]
   },
   {
     "type": "keybinding",
@@ -9028,33 +4381,12 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Select items in inventory",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "i"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "I"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "i",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "0"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_0"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "R_RADIAL_NW"
-      }
+      { "input_method": "keyboard_any", "key": "i" },
+      { "input_method": "keyboard_char", "key": "I" },
+      { "input_method": "keyboard_code", "key": "i", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "0" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_0" },
+      { "input_method": "gamepad", "key": "R_RADIAL_NW" }
     ]
   },
   {
@@ -9063,25 +4395,10 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Select items at all 9 tiles",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "a"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "A"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "a",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "R_RADIAL_N"
-      }
+      { "input_method": "keyboard_any", "key": "a" },
+      { "input_method": "keyboard_char", "key": "A" },
+      { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "R_RADIAL_N" }
     ]
   },
   {
@@ -9090,25 +4407,10 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Select items in dragged vehicle",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "d"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "D"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "d",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "R_RADIAL_NE"
-      }
+      { "input_method": "keyboard_any", "key": "d" },
+      { "input_method": "keyboard_char", "key": "D" },
+      { "input_method": "keyboard_code", "key": "d", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "R_RADIAL_NE" }
     ]
   },
   {
@@ -9116,16 +4418,7 @@
     "id": "EXAMINE_CONTENTS",
     "category": "ADVANCED_INVENTORY",
     "name": "Examine items in container",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "o"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "R_RADIAL_E"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "o" }, { "input_method": "gamepad", "key": "R_RADIAL_E" } ]
   },
   {
     "type": "keybinding",
@@ -9133,18 +4426,9 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Unload item from container",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "u"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "U"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "R_RADIAL_SW"
-      }
+      { "input_method": "keyboard_any", "key": "u" },
+      { "input_method": "keyboard_any", "key": "U" },
+      { "input_method": "gamepad", "key": "R_RADIAL_SW" }
     ]
   },
   {
@@ -9153,25 +4437,10 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Select items in container",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "c"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "C"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "c",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "R_RADIAL_SE"
-      }
+      { "input_method": "keyboard_any", "key": "c" },
+      { "input_method": "keyboard_char", "key": "C" },
+      { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "R_RADIAL_SE" }
     ]
   },
   {
@@ -9180,21 +4449,9 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Exit container to parent",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "x"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "X"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "x",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_any", "key": "x" },
+      { "input_method": "keyboard_char", "key": "X" },
+      { "input_method": "keyboard_code", "key": "x", "mod": [ "shift" ] }
     ]
   },
   {
@@ -9203,25 +4460,10 @@
     "category": "ADVANCED_INVENTORY",
     "name": "Select items currently worn",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "w"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "W"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "w",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "R_RADIAL_S"
-      }
+      { "input_method": "keyboard_any", "key": "w" },
+      { "input_method": "keyboard_char", "key": "W" },
+      { "input_method": "keyboard_code", "key": "w", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "R_RADIAL_S" }
     ]
   },
   {
@@ -9241,45 +4483,25 @@
     "id": "repair_fabric",
     "category": "ITEM_ACTIONS",
     "name": "Sew",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "s"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "s" } ]
   },
   {
     "type": "keybinding",
     "id": "repair_metal",
     "category": "ITEM_ACTIONS",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "w"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "w" } ]
   },
   {
     "type": "keybinding",
     "id": "firestarter",
     "category": "ITEM_ACTIONS",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "f"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "f" } ]
   },
   {
     "type": "keybinding",
     "id": "holster",
     "category": "ITEM_ACTIONS",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "h"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "h" } ]
   },
   {
     "type": "keybinding",
@@ -9287,21 +4509,9 @@
     "category": "COLORS",
     "name": "Remove custom color",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "r"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "R"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "r",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_any", "key": "r" },
+      { "input_method": "keyboard_char", "key": "R" },
+      { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] }
     ]
   },
   {
@@ -9310,21 +4520,9 @@
     "category": "COLORS",
     "name": "Load color template",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "t"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "T"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "t",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_any", "key": "t" },
+      { "input_method": "keyboard_char", "key": "T" },
+      { "input_method": "keyboard_code", "key": "t", "mod": [ "shift" ] }
     ]
   },
   {
@@ -9333,21 +4531,9 @@
     "category": "COLORS",
     "name": "Load base colors",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "c"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "C"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "c",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_any", "key": "c" },
+      { "input_method": "keyboard_char", "key": "C" },
+      { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] }
     ]
   },
   {
@@ -9356,33 +4542,12 @@
     "category": "COLORS",
     "name": "Quit",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "ESC"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "q"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "Q"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "q",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "SPACE"
-      },
-      {
-        "input_method": "mouse",
-        "key": "MOUSE_RIGHT"
-      }
+      { "input_method": "keyboard_any", "key": "ESC" },
+      { "input_method": "keyboard_any", "key": "q" },
+      { "input_method": "keyboard_char", "key": "Q" },
+      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "SPACE" },
+      { "input_method": "mouse", "key": "MOUSE_RIGHT" }
     ]
   },
   {
@@ -9391,25 +4556,10 @@
     "category": "YESNO",
     "name": "Yes",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "Y"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "y",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "y"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_N"
-      }
+      { "input_method": "keyboard_char", "key": "Y" },
+      { "input_method": "keyboard_code", "key": "y", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "y" },
+      { "input_method": "gamepad", "key": "L_RADIAL_N" }
     ]
   },
   {
@@ -9418,29 +4568,11 @@
     "category": "YESNO",
     "name": "No",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "N"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "n",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "n"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "ESC"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_S"
-      }
+      { "input_method": "keyboard_char", "key": "N" },
+      { "input_method": "keyboard_code", "key": "n", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "n" },
+      { "input_method": "keyboard_any", "key": "ESC" },
+      { "input_method": "gamepad", "key": "L_RADIAL_S" }
     ]
   },
   {
@@ -9449,25 +4581,10 @@
     "category": "FRIENDS_ME_CANCEL",
     "name": "With friends",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "F"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "f",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "f"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_E"
-      }
+      { "input_method": "keyboard_char", "key": "F" },
+      { "input_method": "keyboard_code", "key": "f", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "f" },
+      { "input_method": "gamepad", "key": "L_RADIAL_E" }
     ]
   },
   {
@@ -9476,25 +4593,10 @@
     "category": "FRIENDS_ME_CANCEL",
     "name": "Just me",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "M"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "m",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "m"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_W"
-      }
+      { "input_method": "keyboard_char", "key": "M" },
+      { "input_method": "keyboard_code", "key": "m", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "m" },
+      { "input_method": "gamepad", "key": "L_RADIAL_W" }
     ]
   },
   {
@@ -9503,29 +4605,11 @@
     "category": "FRIENDS_ME_CANCEL",
     "name": "Cancel",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "C"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "c",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "c"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "ESC"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_NW"
-      }
+      { "input_method": "keyboard_char", "key": "C" },
+      { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "c" },
+      { "input_method": "keyboard_any", "key": "ESC" },
+      { "input_method": "gamepad", "key": "L_RADIAL_NW" }
     ]
   },
   {
@@ -9534,25 +4618,10 @@
     "category": "LOAD_DELETE_CANCEL",
     "name": "Load",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "L"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "l",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "l"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_N"
-      }
+      { "input_method": "keyboard_char", "key": "L" },
+      { "input_method": "keyboard_code", "key": "l", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "l" },
+      { "input_method": "gamepad", "key": "L_RADIAL_N" }
     ]
   },
   {
@@ -9561,25 +4630,10 @@
     "category": "LOAD_DELETE_CANCEL",
     "name": "Delete",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "D"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "d",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "d"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_E"
-      }
+      { "input_method": "keyboard_char", "key": "D" },
+      { "input_method": "keyboard_code", "key": "d", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "d" },
+      { "input_method": "gamepad", "key": "L_RADIAL_E" }
     ]
   },
   {
@@ -9588,25 +4642,10 @@
     "category": "LOAD_DELETE_CANCEL",
     "name": "Cancel",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "C"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "c",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "c"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_W"
-      }
+      { "input_method": "keyboard_char", "key": "C" },
+      { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "c" },
+      { "input_method": "gamepad", "key": "L_RADIAL_W" }
     ]
   },
   {
@@ -9615,25 +4654,10 @@
     "category": "YESNOQUIT",
     "name": "Yes",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "Y"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "y",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "y"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_N"
-      }
+      { "input_method": "keyboard_char", "key": "Y" },
+      { "input_method": "keyboard_code", "key": "y", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "y" },
+      { "input_method": "gamepad", "key": "L_RADIAL_N" }
     ]
   },
   {
@@ -9642,25 +4666,10 @@
     "category": "YESNOQUIT",
     "name": "No",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "N"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "n",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "n"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_S"
-      }
+      { "input_method": "keyboard_char", "key": "N" },
+      { "input_method": "keyboard_code", "key": "n", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "n" },
+      { "input_method": "gamepad", "key": "L_RADIAL_S" }
     ]
   },
   {
@@ -9669,25 +4678,10 @@
     "category": "YESNOQUIT",
     "name": "Cancel",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "Q"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "q",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "q"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "ESC"
-      }
+      { "input_method": "keyboard_char", "key": "Q" },
+      { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "q" },
+      { "input_method": "keyboard_any", "key": "ESC" }
     ]
   },
   {
@@ -9696,25 +4690,10 @@
     "category": "CANCEL_ACTIVITY_OR_IGNORE_QUERY",
     "name": "Yes",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "Y"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "y",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "y"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_N"
-      }
+      { "input_method": "keyboard_char", "key": "Y" },
+      { "input_method": "keyboard_code", "key": "y", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "y" },
+      { "input_method": "gamepad", "key": "L_RADIAL_N" }
     ]
   },
   {
@@ -9723,29 +4702,11 @@
     "category": "CANCEL_ACTIVITY_OR_IGNORE_QUERY",
     "name": "No",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "N"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "n",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "n"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "ESC"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_S"
-      }
+      { "input_method": "keyboard_char", "key": "N" },
+      { "input_method": "keyboard_code", "key": "n", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "n" },
+      { "input_method": "keyboard_any", "key": "ESC" },
+      { "input_method": "gamepad", "key": "L_RADIAL_S" }
     ]
   },
   {
@@ -9754,25 +4715,10 @@
     "category": "CANCEL_ACTIVITY_OR_IGNORE_QUERY",
     "name": "Ignore this distraction and continue",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "I"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "i",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "i"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_E"
-      }
+      { "input_method": "keyboard_char", "key": "I" },
+      { "input_method": "keyboard_code", "key": "i", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "i" },
+      { "input_method": "gamepad", "key": "L_RADIAL_E" }
     ]
   },
   {
@@ -9781,21 +4727,9 @@
     "category": "CANCEL_ACTIVITY_OR_IGNORE_QUERY",
     "name": "Open manager",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "M"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "m",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "m"
-      }
+      { "input_method": "keyboard_char", "key": "M" },
+      { "input_method": "keyboard_code", "key": "m", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "m" }
     ]
   },
   {
@@ -9804,25 +4738,10 @@
     "category": "YES_QUERY",
     "name": "Yes, I will!",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "Y"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "y",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "y"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_N"
-      }
+      { "input_method": "keyboard_char", "key": "Y" },
+      { "input_method": "keyboard_code", "key": "y", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "y" },
+      { "input_method": "gamepad", "key": "L_RADIAL_N" }
     ]
   },
   {
@@ -9831,25 +4750,10 @@
     "category": "YES_QUERY",
     "name": "Yes, I must!",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "Y"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "y",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "y"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_NE"
-      }
+      { "input_method": "keyboard_char", "key": "Y" },
+      { "input_method": "keyboard_code", "key": "y", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "y" },
+      { "input_method": "gamepad", "key": "L_RADIAL_NE" }
     ]
   },
   {
@@ -9858,25 +4762,10 @@
     "category": "YES_QUERY",
     "name": "Yes, I shall!",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "Y"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "y",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "y"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_E"
-      }
+      { "input_method": "keyboard_char", "key": "Y" },
+      { "input_method": "keyboard_code", "key": "y", "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": "y" },
+      { "input_method": "gamepad", "key": "L_RADIAL_E" }
     ]
   },
   {
@@ -9885,31 +4774,10 @@
     "category": "YES_NO_ALWAYS_NEVER",
     "name": "Yes",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": [
-          "Y"
-        ]
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": [
-          "y"
-        ],
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": [
-          "y"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_N"
-      }
+      { "input_method": "keyboard_char", "key": [ "Y" ] },
+      { "input_method": "keyboard_code", "key": [ "y" ], "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": [ "y" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_N" }
     ]
   },
   {
@@ -9918,37 +4786,11 @@
     "category": "YES_NO_ALWAYS_NEVER",
     "name": "No",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": [
-          "N"
-        ]
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": [
-          "n"
-        ],
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": [
-          "n"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": [
-          "ESC"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_S"
-      }
+      { "input_method": "keyboard_char", "key": [ "N" ] },
+      { "input_method": "keyboard_code", "key": [ "n" ], "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": [ "n" ] },
+      { "input_method": "keyboard_any", "key": [ "ESC" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_S" }
     ]
   },
   {
@@ -9957,31 +4799,10 @@
     "category": "YES_NO_ALWAYS_NEVER",
     "name": "Always",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": [
-          "A"
-        ]
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": [
-          "a"
-        ],
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": [
-          "a"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_E"
-      }
+      { "input_method": "keyboard_char", "key": [ "A" ] },
+      { "input_method": "keyboard_code", "key": [ "a" ], "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": [ "a" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_E" }
     ]
   },
   {
@@ -9990,31 +4811,10 @@
     "category": "YES_NO_ALWAYS_NEVER",
     "name": "Never",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": [
-          "E"
-        ]
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": [
-          "e"
-        ],
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": [
-          "e"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_W"
-      }
+      { "input_method": "keyboard_char", "key": [ "E" ] },
+      { "input_method": "keyboard_code", "key": [ "e" ], "mod": [ "shift" ] },
+      { "input_method": "keyboard_any", "key": [ "e" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_W" }
     ]
   },
   {
@@ -10023,26 +4823,11 @@
     "category": "POPUP_WAIT",
     "name": "Cancel popup",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "ESC"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "SPACE"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "RETURN"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "KEYPAD_ENTER"
-      },
-      {
-        "input_method": "mouse",
-        "key": "MOUSE_RIGHT"
-      }
+      { "input_method": "keyboard_any", "key": "ESC" },
+      { "input_method": "keyboard_any", "key": "SPACE" },
+      { "input_method": "keyboard_any", "key": "RETURN" },
+      { "input_method": "keyboard_any", "key": "KEYPAD_ENTER" },
+      { "input_method": "mouse", "key": "MOUSE_RIGHT" }
     ]
   },
   {
@@ -10050,273 +4835,119 @@
     "id": "CREATURE",
     "category": "EXTENDED_DESCRIPTION",
     "name": "Describe creature",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "c"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_N"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "c" }, { "input_method": "gamepad", "key": "L_RADIAL_N" } ]
   },
   {
     "type": "keybinding",
     "id": "FURNITURE",
     "category": "EXTENDED_DESCRIPTION",
     "name": "Describe furniture",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "f"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_NE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "f" }, { "input_method": "gamepad", "key": "L_RADIAL_NE" } ]
   },
   {
     "type": "keybinding",
     "id": "TERRAIN",
     "category": "EXTENDED_DESCRIPTION",
     "name": "Describe terrain",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "t"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_E"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "t" }, { "input_method": "gamepad", "key": "L_RADIAL_E" } ]
   },
   {
     "type": "keybinding",
     "id": "VEHICLE",
     "category": "EXTENDED_DESCRIPTION",
     "name": "Describe vehicle/appliance",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "v"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_SE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "v" }, { "input_method": "gamepad", "key": "L_RADIAL_SE" } ]
   },
   {
     "type": "keybinding",
     "id": "SWITCH_LISTS",
     "category": "INVENTORY",
     "name": "Switch lists",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "TAB"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "R_RADIAL_N"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "TAB" }, { "input_method": "gamepad", "key": "R_RADIAL_N" } ]
   },
   {
     "type": "keybinding",
     "id": "FAV_PRIORITY",
     "category": "INVENTORY",
     "name": "Set priority",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "p"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "R_RADIAL_NE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "p" }, { "input_method": "gamepad", "key": "R_RADIAL_NE" } ]
   },
   {
     "type": "keybinding",
     "id": "FAV_AUTO_PICKUP",
     "category": "INVENTORY",
     "name": "Toggle auto pickup",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "d"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "R_RADIAL_E"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "d" }, { "input_method": "gamepad", "key": "R_RADIAL_E" } ]
   },
   {
     "type": "keybinding",
     "id": "FAV_AUTO_UNLOAD",
     "category": "INVENTORY",
     "name": "Toggle auto unload",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "u"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "R_RADIAL_SE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "u" }, { "input_method": "gamepad", "key": "R_RADIAL_SE" } ]
   },
   {
     "type": "keybinding",
     "id": "FAV_ITEM",
     "category": "INVENTORY",
     "name": "Whitelist/blacklist item",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "i"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "R_RADIAL_S"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "i" }, { "input_method": "gamepad", "key": "R_RADIAL_S" } ]
   },
   {
     "type": "keybinding",
     "id": "FAV_CATEGORY",
     "category": "INVENTORY",
     "name": "Whitelist/blacklist category",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "c"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "R_RADIAL_SW"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "c" }, { "input_method": "gamepad", "key": "R_RADIAL_SW" } ]
   },
   {
     "type": "keybinding",
     "id": "FAV_WHITELIST",
     "category": "INVENTORY",
     "name": "Switch to modifying whitelist",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "w"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "R_RADIAL_W"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "w" }, { "input_method": "gamepad", "key": "R_RADIAL_W" } ]
   },
   {
     "type": "keybinding",
     "id": "FAV_BLACKLIST",
     "category": "INVENTORY",
     "name": "Switch to modifying blacklist",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "b"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "R_RADIAL_NW"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "b" }, { "input_method": "gamepad", "key": "R_RADIAL_NW" } ]
   },
   {
     "type": "keybinding",
     "id": "FAV_SAVE_PRESET",
     "category": "INVENTORY",
     "name": "Save preset",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "S"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "s",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "S" }, { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "FAV_APPLY_PRESET",
     "category": "INVENTORY",
     "name": "Apply preset",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "A"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "a",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "A" }, { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "FAV_DEL_PRESET",
     "category": "INVENTORY",
     "name": "Delete preset",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "D"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "d",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "D" }, { "input_method": "keyboard_code", "key": "d", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "FAV_CLEAR",
     "category": "INVENTORY",
     "name": "Clear entries",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "x"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "x" } ]
   },
   {
     "type": "keybinding",
     "id": "FAV_MOVE_ITEM",
     "category": "INVENTORY",
     "name": "Move item",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "m"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "m" } ]
   },
   {
     "type": "keybinding",
@@ -10324,18 +4955,9 @@
     "category": "INVENTORY",
     "name": "Open context menu",
     "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "RETURN"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "KEYPAD_ENTER"
-      },
-      {
-        "input_method": "mouse",
-        "key": "MOUSE_LEFT"
-      }
+      { "input_method": "keyboard_any", "key": "RETURN" },
+      { "input_method": "keyboard_any", "key": "KEYPAD_ENTER" },
+      { "input_method": "mouse", "key": "MOUSE_LEFT" }
     ]
   },
   {
@@ -10343,21 +4965,9 @@
     "id": "CHANGE_PROFESSION_NAME",
     "name": "Change profession name",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "*"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "KEYPAD_MULTIPLY"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "8",
-        "mod": [
-          "shift"
-        ]
-      }
+      { "input_method": "keyboard_char", "key": "*" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
+      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] }
     ]
   },
   {
@@ -10365,232 +4975,119 @@
     "id": "SCROLL_MISSION_INFO_UP",
     "category": "FACTIONS",
     "name": "Scroll camp mission info up",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "["
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "[" } ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_MISSION_INFO_DOWN",
     "category": "FACTIONS",
     "name": "Scroll camp mission info down",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "]"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "]" } ]
   },
   {
     "type": "keybinding",
     "category": "PLAYER_INFO",
     "id": "VIEW_PROFICIENCIES",
     "name": "View character proficiencies",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "p"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "p" } ]
   },
   {
     "type": "keybinding",
     "category": "PLAYER_INFO",
     "id": "VIEW_BODYSTAT",
     "name": "View character's body status",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "s"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "s" } ]
   },
   {
     "type": "keybinding",
     "name": "View character's morale",
     "category": "PLAYER_INFO",
     "id": "morale",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "m"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "m" } ]
   },
   {
     "type": "keybinding",
     "id": "CHANGE_ARMOR_SPRITE",
     "category": "PLAYER_INFO",
     "name": "Change armor sprite",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "W"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "w",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "W" }, { "input_method": "keyboard_code", "key": "w", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "category": "PLAYER_INFO",
     "id": "SELECT_STATS_TAB",
     "name": "Select stats tab",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "w"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "w" } ]
   },
   {
     "type": "keybinding",
     "category": "PLAYER_INFO",
     "id": "SELECT_ENCUMBRANCE_TAB",
     "name": "Select encumbrance tab",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "e"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "e" } ]
   },
   {
     "type": "keybinding",
     "category": "PLAYER_INFO",
     "id": "SELECT_SKILLS_TAB",
     "name": "Select skills tab",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "r"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "r" } ]
   },
   {
     "type": "keybinding",
     "category": "PLAYER_INFO",
     "id": "SELECT_TRAITS_TAB",
     "name": "Select traits tab",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "t"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "t" } ]
   },
   {
     "type": "keybinding",
     "category": "PLAYER_INFO",
     "id": "SELECT_BIONICS_TAB",
     "name": "Select bionics tab",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "x"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "x" } ]
   },
   {
     "type": "keybinding",
     "category": "PLAYER_INFO",
     "id": "SELECT_EFFECTS_TAB",
     "name": "Select effects tab",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "c"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "c" } ]
   },
   {
     "type": "keybinding",
     "category": "PLAYER_INFO",
     "id": "SELECT_PROFICIENCIES_TAB",
     "name": "Select proficiencies tab",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "v"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "v" } ]
   },
   {
     "type": "keybinding",
     "category": "WISH_ITEM",
     "id": "CONTAINER",
     "name": "Toggle spawning item with container",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "f"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "f" } ]
   },
   {
     "type": "keybinding",
     "category": "WISH_ITEM",
     "id": "FLAG",
     "name": "Add flags to spawned items",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "F"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "f",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "F" }, { "input_method": "keyboard_code", "key": "f", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "category": "WISH_ITEM",
     "id": "EVERYTHING",
     "name": "Toggle spawning everything",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "E"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "e",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "E" }, { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "category": "WISH_ITEM",
     "id": "SNIPPET",
     "name": "Choose snippet",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "S"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "s",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "S" }, { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
@@ -10598,21 +5095,9 @@
     "id": "SCROLL_DESC_UP",
     "name": "Scroll item description up",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "<"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ",",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_UP"
-      }
+      { "input_method": "keyboard_char", "key": "<" },
+      { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "ALT_UP" }
     ]
   },
   {
@@ -10621,21 +5106,9 @@
     "id": "SCROLL_DESC_DOWN",
     "name": "Scroll item description down",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": ">"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ".",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_DOWN"
-      }
+      { "input_method": "keyboard_char", "key": ">" },
+      { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "ALT_DOWN" }
     ]
   },
   {
@@ -10644,21 +5117,9 @@
     "category": "VENDING_MACHINE",
     "name": "Scroll item info up",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "<"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ",",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_UP"
-      }
+      { "input_method": "keyboard_char", "key": "<" },
+      { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "ALT_UP" }
     ]
   },
   {
@@ -10667,21 +5128,9 @@
     "category": "VENDING_MACHINE",
     "name": "Scroll item info down",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": ">"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": ".",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "ALT_DOWN"
-      }
+      { "input_method": "keyboard_char", "key": ">" },
+      { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "ALT_DOWN" }
     ]
   },
   {
@@ -10690,21 +5139,9 @@
     "id": "LOOK_AT",
     "name": "Look at",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "L"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "l",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_N"
-      }
+      { "input_method": "keyboard_char", "key": "L" },
+      { "input_method": "keyboard_code", "key": "l", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_N" }
     ]
   },
   {
@@ -10713,21 +5150,9 @@
     "id": "SIZE_UP_STATS",
     "name": "Size up stats",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "S"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "s",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_NE"
-      }
+      { "input_method": "keyboard_char", "key": "S" },
+      { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_NE" }
     ]
   },
   {
@@ -10736,21 +5161,9 @@
     "id": "ASSESS_PERSONALITY",
     "name": "Assess personality",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "A"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "a",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_E"
-      }
+      { "input_method": "keyboard_char", "key": "A" },
+      { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_E" }
     ]
   },
   {
@@ -10759,21 +5172,9 @@
     "id": "YELL",
     "name": "Yell",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "Y"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "y",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_SE"
-      }
+      { "input_method": "keyboard_char", "key": "Y" },
+      { "input_method": "keyboard_code", "key": "y", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_SE" }
     ]
   },
   {
@@ -10782,21 +5183,9 @@
     "id": "CHECK_OPINION",
     "name": "Check opinion",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "O"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "o",
-        "mod": [
-          "shift"
-        ]
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_S"
-      }
+      { "input_method": "keyboard_char", "key": "O" },
+      { "input_method": "keyboard_code", "key": "o", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_S" }
     ]
   },
   {
@@ -10804,317 +5193,158 @@
     "category": "FACTION_MANAGER",
     "id": "INSPECT_NPC",
     "name": "Inspect NPC",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "i"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_N"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "i" }, { "input_method": "gamepad", "key": "L_RADIAL_N" } ]
   },
   {
     "type": "keybinding",
     "id": "SORT",
     "category": "NEW_CHAR_TRAITS",
     "name": "Sort traits list",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "s"
-      },
-      {
-        "input_method": "gamepad",
-        "key": "L_RADIAL_N"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "s" }, { "input_method": "gamepad", "key": "L_RADIAL_N" } ]
   },
   {
     "type": "keybinding",
     "id": "SELECT_TRAIT_VARIANT",
     "name": "Select variant for trait",
-    "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "S"
-      },
-      {
-        "input_method": "keyboard_code",
-        "key": "s",
-        "mod": [
-          "shift"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "S" }, { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "DELETE PAGE",
     "name": "Delete page",
     "category": "DIARY",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "mod": [],
-        "key": [
-          "d"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "mod": [  ], "key": [ "d" ] } ]
   },
   {
     "type": "keybinding",
     "id": "EXPORT_DIARY",
     "name": "Export diary to .txt",
     "category": "DIARY",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "mod": [],
-        "key": [
-          "e"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "mod": [  ], "key": [ "e" ] } ]
   },
   {
     "type": "keybinding",
     "id": "NEW_PAGE",
     "name": "Add new page",
     "category": "DIARY",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "mod": [],
-        "key": [
-          "n"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "mod": [  ], "key": [ "n" ] } ]
   },
   {
     "type": "keybinding",
     "name": "View achievements, scores, and kills",
     "category": "DIARY",
     "id": "VIEW_SCORES",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "mod": [],
-        "key": [
-          "v"
-        ]
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "mod": [  ], "key": [ "v" ] } ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.QUIT",
     "name": "Cancel text input",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "ESC"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "ESC" } ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.CONFIRM",
     "name": "Confirm text input",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "RETURN"
-      },
-      {
-        "input_method": "keyboard_any",
-        "key": "KEYPAD_ENTER"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "RETURN" }, { "input_method": "keyboard_any", "key": "KEYPAD_ENTER" } ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.UP",
     "name": "Move cursor up",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "UP"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "UP" } ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.DOWN",
     "name": "Move cursor down",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "DOWN"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "DOWN" } ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.LEFT",
     "name": "Move cursor left",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "LEFT"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "LEFT" } ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.RIGHT",
     "name": "Move cursor right",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "RIGHT"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "RIGHT" } ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.PAGE_UP",
     "name": "Move cursor to previous page",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "PPAGE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "PPAGE" } ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.PAGE_DOWN",
     "name": "Move cursor to next page",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "NPAGE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "NPAGE" } ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.CLEAR",
     "name": "Clear text",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "CTRL+U"
-      },
-      {
-        "input_method": "keyboard_code",
-        "mod": [
-          "ctrl"
-        ],
-        "key": "u"
-      }
+      { "input_method": "keyboard_char", "key": "CTRL+U" },
+      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "u" }
     ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.BACKSPACE",
     "name": "Remove previous character",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "BACKSPACE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "BACKSPACE" } ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.HOME",
     "name": "Move cursor to start",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "HOME"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "HOME" } ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.END",
     "name": "Move cursor to end",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "END"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "END" } ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.DELETE",
     "name": "Remove current character",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "DELETE"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "DELETE" } ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.PASTE",
     "name": "Paste from clipboard",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "CTRL+V"
-      },
-      {
-        "input_method": "keyboard_code",
-        "mod": [
-          "ctrl"
-        ],
-        "key": "v"
-      }
+      { "input_method": "keyboard_char", "key": "CTRL+V" },
+      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "v" }
     ]
   },
   {
     "type": "keybinding",
     "id": "TEXT.INPUT_FROM_FILE",
     "name": "Input text from file",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "F2"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "F2" } ]
   },
   {
     "type": "keybinding",
     "id": "HISTORY_UP",
     "name": "Show previous history",
     "category": "STRING_INPUT",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "UP"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "UP" } ]
   },
   {
     "type": "keybinding",
     "id": "HISTORY_DOWN",
     "name": "Show next history",
     "category": "STRING_INPUT",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "DOWN"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "DOWN" } ]
   },
   {
     "type": "keybinding",
@@ -11122,12 +5352,7 @@
     "name": "Display keybindings menu",
     "category": "STRING_INPUT",
     "//": "'?' is treated as text input, so a different key is used.",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "F1"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "F1" } ]
   },
   {
     "type": "keybinding",
@@ -11137,28 +5362,10 @@
     "//": "RETURN is treated as text input, so use a different keybinding",
     "//2": "CTRL+S is not available on curses, so add CTRL+Y as an alternative",
     "bindings": [
-      {
-        "input_method": "keyboard_char",
-        "key": "CTRL+S"
-      },
-      {
-        "input_method": "keyboard_char",
-        "key": "CTRL+Y"
-      },
-      {
-        "input_method": "keyboard_code",
-        "mod": [
-          "ctrl"
-        ],
-        "key": "s"
-      },
-      {
-        "input_method": "keyboard_code",
-        "mod": [
-          "ctrl"
-        ],
-        "key": "y"
-      }
+      { "input_method": "keyboard_char", "key": "CTRL+S" },
+      { "input_method": "keyboard_char", "key": "CTRL+Y" },
+      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "s" },
+      { "input_method": "keyboard_code", "mod": [ "ctrl" ], "key": "y" }
     ]
   },
   {
@@ -11166,72 +5373,42 @@
     "id": "TOGGLE_MONSTER_GROUP",
     "category": "SCORES_UI",
     "name": "Toggle monster group",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "m"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "m" } ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_NPC_GROUP",
     "category": "SCORES_UI",
     "name": "Toggle NPC group",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "n"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "n" } ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_GENERAL_INFO_GROUP",
     "category": "MA_DETAILS_UI",
     "name": "Toggle general info group",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "g"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "g" } ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_BUFFS_GROUP",
     "category": "MA_DETAILS_UI",
     "name": "Toggle buffs group",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "b"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "b" } ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_TECHNIQUES_GROUP",
     "category": "MA_DETAILS_UI",
     "name": "Toggle techniques group",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "t"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "t" } ]
   },
   {
     "type": "keybinding",
     "id": "TOGGLE_WEAPONS_GROUP",
     "category": "MA_DETAILS_UI",
     "name": "Toggle weapons group",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "w"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "w" } ]
   },
   {
     "type": "keybinding",
@@ -11239,11 +5416,6 @@
     "name": "Display keybindings menu",
     "category": "STRING_EDITOR",
     "//": "'?' is treated as text input, so a different key is used.",
-    "bindings": [
-      {
-        "input_method": "keyboard_any",
-        "key": "F1"
-      }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "F1" } ]
   }
 ]

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -60,7 +60,7 @@
     "id": "SHOW_DESCRIPTION",
     "category": "MELEE_STYLE_PICKER",
     "name": "Show description of melee style",
-    "bindings": [ { "input_method": "keyboard_any", "key": "d" } ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "d" }, { "input_method": "gamepad", "key": "L_RADIAL_N" } ]
   },
   {
     "type": "keybinding",
@@ -1731,7 +1731,11 @@
     "type": "keybinding",
     "id": "TRAVEL_TO",
     "name": "Travel to destination",
-    "bindings": [ { "input_method": "keyboard_char", "key": "T" }, { "input_method": "keyboard_code", "key": "t", "mod": [ "shift" ] } ]
+    "bindings": [
+      { "input_method": "keyboard_char", "key": "T" },
+      { "input_method": "keyboard_code", "key": "t", "mod": [ "shift" ] },
+      { "input_method": "gamepad", "key": "L_RADIAL_NW" }
+    ]
   },
   {
     "type": "keybinding",
@@ -2665,7 +2669,7 @@
     "name": "Smash nearby terrain",
     "category": "DEFAULTMODE",
     "id": "smash",
-    "bindings": [ { "input_method": "keyboard_any", "key": "s" }, { "input_method": "gamepad", "key": "ALT_X" } ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "s" }, { "input_method": "gamepad", "key": "X" } ]
   },
   {
     "type": "keybinding",
@@ -2679,7 +2683,7 @@
     "name": "Examine nearby terrain, furniture, and items",
     "category": "DEFAULTMODE",
     "id": "examine_and_pickup",
-    "bindings": [ { "input_method": "gamepad", "key": "X" } ]
+    "bindings": [  ]
   },
   {
     "type": "keybinding",
@@ -2775,7 +2779,7 @@
     "bindings": [
       { "input_method": "keyboard_char", "key": "X" },
       { "input_method": "keyboard_code", "key": "x", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "ALT_RS" }
+      { "input_method": "gamepad", "key": "RS" }
     ]
   },
   {
@@ -2786,7 +2790,7 @@
     "bindings": [
       { "input_method": "keyboard_char", "key": "V" },
       { "input_method": "keyboard_code", "key": "v", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "RS" }
+      { "input_method": "gamepad", "key": "ALT_RS" }
     ]
   },
   {
@@ -3431,8 +3435,15 @@
     "bindings": [
       { "input_method": "keyboard_any", "key": "RETURN" },
       { "input_method": "keyboard_any", "key": "KEYPAD_ENTER" },
-      { "input_method": "gamepad", "key": "A" }
+      { "input_method": "gamepad", "key": "ALT_A" }
     ]
+  },
+  {
+    "type": "keybinding",
+    "name": "Interact",
+    "category": "DEFAULTMODE",
+    "id": "interact",
+    "bindings": [ { "input_method": "gamepad", "key": "A" } ]
   },
   {
     "type": "keybinding",
@@ -3442,7 +3453,7 @@
     "bindings": [
       { "input_method": "keyboard_char", "key": "%" },
       { "input_method": "keyboard_code", "key": "5", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "ALT_A" }
+      { "input_method": "gamepad", "key": "ALT_X" }
     ]
   },
   {

--- a/src/action.h
+++ b/src/action.h
@@ -314,7 +314,7 @@ enum action_id : int {
     ACTION_ZOOM_OUT,
     /** Zoom view out */
     ACTION_ZOOM_IN,
-    /** Open the action menu */
+    /** Open the the action menu */
     ACTION_ACTIONMENU,
     /** Open the item uses menu */
     ACTION_ITEMACTION,
@@ -353,6 +353,8 @@ enum action_id : int {
     ACTION_DISPLAY_NPC_ATTACK_POTENTIAL,
     /** Toggle timing of the game hours */
     ACTION_TOGGLE_HOUR_TIMER,
+    /** Interact with the current or nearby tile */
+    ACTION_INTERACT,
     /** Not an action, serves as count of enumerated actions */
     NUM_ACTIONS
     /**@}*/
@@ -602,6 +604,17 @@ point_rel_ms get_delta_from_movement_action( action_id act, iso_rotate rot );
  * @returns action_id ID of action requested by user at menu.
  */
 action_id handle_action_menu( map &here );
+
+/**
+ * Show a context-sensitive action menu for a specific tile.
+ *
+ * If only one action is possible, it is returned immediately.
+ * If multiple actions are possible, a menu is shown.
+ *
+ * @param pos The tile to perform actions on.
+ * @returns action_id ID of action requested by user, or ACTION_NULL.
+ */
+action_id handle_interact( map &here, const tripoint_bub_ms &pos );
 
 /**
  * Show in-game main menu

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1931,9 +1931,9 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
         }
     } else if( you.view_offset != tripoint_rel_ms::zero && !you.in_vehicle ) {
         // check to see if player is located at ter
-        // draw_from_id_string( "cursor", TILE_CATEGORY::NONE, empty_string,
-        //                      tripoint_bub_ms( g->ter_view_p.xy(), center.z() ), 0, 0, lit_level::LIT,
-        //                      false );
+        draw_from_id_string( "cursor", TILE_CATEGORY::NONE, empty_string,
+                             tripoint_bub_ms( g->ter_view_p.xy(), center.z() ), 0, 0, lit_level::LIT,
+                             false );
     }
     if( you.controlling_vehicle ) {
         std::optional<tripoint_rel_ms> indicator_offset = g->get_veh_dir_indicator_location( true );

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1945,7 +1945,7 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
     }
 
     // Draw gamepad direction indicator
-    if( gamepad::is_active() && !gamepad::is_in_menu() ) {
+    if( gamepad::is_active() ) {
         gamepad::direction dir = gamepad::get_left_stick_direction();
         if( dir != gamepad::direction::NONE ) {
             tripoint offset = gamepad::direction_to_offset( dir );

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -46,6 +46,7 @@
 #include "flexbuffer_json.h"
 #include "game.h"
 #include "input.h"
+#include "sdl_gamepad.h"
 #include "item.h"
 #include "item_factory.h"
 #include "itype.h"
@@ -1930,15 +1931,27 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
         }
     } else if( you.view_offset != tripoint_rel_ms::zero && !you.in_vehicle ) {
         // check to see if player is located at ter
-        draw_from_id_string( "cursor", TILE_CATEGORY::NONE, empty_string,
-                             tripoint_bub_ms( g->ter_view_p.xy(), center.z() ), 0, 0, lit_level::LIT,
-                             false );
+        // draw_from_id_string( "cursor", TILE_CATEGORY::NONE, empty_string,
+        //                      tripoint_bub_ms( g->ter_view_p.xy(), center.z() ), 0, 0, lit_level::LIT,
+        //                      false );
     }
     if( you.controlling_vehicle ) {
         std::optional<tripoint_rel_ms> indicator_offset = g->get_veh_dir_indicator_location( true );
         if( indicator_offset ) {
             draw_from_id_string( "cursor", TILE_CATEGORY::NONE, empty_string,
                                  tripoint_bub_ms( you.pos_bub().xy(), center.z() ) + indicator_offset->xy(),
+                                 0, 0, lit_level::LIT, false );
+        }
+    }
+
+    // Draw gamepad direction indicator
+    if( gamepad::is_active() && !gamepad::is_in_menu() ) {
+        gamepad::direction dir = gamepad::get_left_stick_direction();
+        if( dir != gamepad::direction::NONE ) {
+            tripoint offset = gamepad::direction_to_offset( dir );
+            tripoint_bub_ms indicator_pos = you.pos_bub() + tripoint_rel_ms( offset.x, offset.y, 0 );
+            draw_from_id_string( "cursor", TILE_CATEGORY::NONE, empty_string,
+                                 tripoint_bub_ms( indicator_pos.xy(), center.z() ),
                                  0, 0, lit_level::LIT, false );
         }
     }

--- a/src/game.h
+++ b/src/game.h
@@ -958,7 +958,8 @@ class game
         bool grabbed_move( const tripoint_rel_ms &dp, bool via_ramp );
         bool grabbed_veh_move( const tripoint_rel_ms &dp );
 
-        void control_vehicle(); // Use vehicle controls  '^'
+        void control_vehicle( const std::optional<tripoint_bub_ms> &p =
+                                  std::nullopt ); // Use vehicle controls  '^'
         // Examine nearby terrain 'e', with or without picking up items
         void examine( const tripoint_bub_ms &p, bool with_pickup = false );
         void examine( bool with_pickup = true );
@@ -969,10 +970,11 @@ class game
         // Pick up items from all nearby tiles
         void pickup_all();
 
-        void unload_container(); // Unload a container w/ direction  'd'
+        void unload_container( const std::optional<tripoint_bub_ms> &p =
+                                   std::nullopt ); // Unload a container w/ direction  'd'
         void drop_in_direction( const tripoint_bub_ms &pnt ); // Drop w/ direction  'D'
 
-        void butcher(); // Butcher a corpse  'B'
+        void butcher( const std::optional<tripoint_bub_ms> &p = std::nullopt ); // Butcher a corpse  'B'
 
         void reload( item_location &loc, bool prompt = false, bool empty = true );
     public:
@@ -1013,9 +1015,8 @@ class game
                                     std::vector<std::string> *harmful_stuff = nullptr ) const;
         // Pick up items from the given point
         void pickup( const tripoint_bub_ms &p );
+        void chat( const std::optional<tripoint_bub_ms> &p = std::nullopt ); // Talk to a nearby NPC  'C'
     private:
-
-        void chat(); // Talk to a nearby NPC  'C'
 
         // Internal methods to show "look around" info
         void print_fields_info( const tripoint_bub_ms &lp, const catacurses::window &w_look, int column,

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -3154,10 +3154,6 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             avatar_action::autoattack( player_character, here );
             break;
 
-        case ACTION_INTERACT:
-            // Handled above in handle_action()
-            break;
-
         default:
             break;
     }

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -3241,6 +3241,7 @@ bool game::handle_action()
             }
         }
 
+#if defined(TILES)
         if( gamepad::is_active() ) {
             gamepad::direction dir = gamepad::get_left_stick_direction();
             if( dir != gamepad::direction::NONE ) {
@@ -3254,6 +3255,7 @@ bool game::handle_action()
                 }
             }
         }
+#endif
 
         if( act == ACTION_ACTIONMENU ) {
             if( uquit == QUIT_WATCH ) {

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -629,18 +629,24 @@ void input_manager::init_keycode_mapping()
     add_gamepad_keycode_pair( JOY_L_UP,        translate_marker_context( "key name", "JOY_L_UP" ) );
     add_gamepad_keycode_pair( JOY_L_DOWN,      translate_marker_context( "key name", "JOY_L_DOWN" ) );
     add_gamepad_keycode_pair( JOY_L_LEFTUP,    translate_marker_context( "key name", "JOY_L_LEFTUP" ) );
-    add_gamepad_keycode_pair( JOY_L_LEFTDOWN,  translate_marker_context( "key name", "JOY_L_LEFTDOWN" ) );
-    add_gamepad_keycode_pair( JOY_L_RIGHTUP,   translate_marker_context( "key name", "JOY_L_RIGHTUP" ) );
-    add_gamepad_keycode_pair( JOY_L_RIGHTDOWN, translate_marker_context( "key name", "JOY_L_RIGHTDOWN" ) );
+    add_gamepad_keycode_pair( JOY_L_LEFTDOWN,  translate_marker_context( "key name",
+                              "JOY_L_LEFTDOWN" ) );
+    add_gamepad_keycode_pair( JOY_L_RIGHTUP,   translate_marker_context( "key name",
+                              "JOY_L_RIGHTUP" ) );
+    add_gamepad_keycode_pair( JOY_L_RIGHTDOWN, translate_marker_context( "key name",
+                              "JOY_L_RIGHTDOWN" ) );
 
     add_gamepad_keycode_pair( JOY_R_LEFT,      translate_marker_context( "key name", "JOY_R_LEFT" ) );
     add_gamepad_keycode_pair( JOY_R_RIGHT,     translate_marker_context( "key name", "JOY_R_RIGHT" ) );
     add_gamepad_keycode_pair( JOY_R_UP,        translate_marker_context( "key name", "JOY_R_UP" ) );
     add_gamepad_keycode_pair( JOY_R_DOWN,      translate_marker_context( "key name", "JOY_R_DOWN" ) );
     add_gamepad_keycode_pair( JOY_R_LEFTUP,    translate_marker_context( "key name", "JOY_R_LEFTUP" ) );
-    add_gamepad_keycode_pair( JOY_R_LEFTDOWN,  translate_marker_context( "key name", "JOY_R_LEFTDOWN" ) );
-    add_gamepad_keycode_pair( JOY_R_RIGHTUP,   translate_marker_context( "key name", "JOY_R_RIGHTUP" ) );
-    add_gamepad_keycode_pair( JOY_R_RIGHTDOWN, translate_marker_context( "key name", "JOY_R_RIGHTDOWN" ) );
+    add_gamepad_keycode_pair( JOY_R_LEFTDOWN,  translate_marker_context( "key name",
+                              "JOY_R_LEFTDOWN" ) );
+    add_gamepad_keycode_pair( JOY_R_RIGHTUP,   translate_marker_context( "key name",
+                              "JOY_R_RIGHTUP" ) );
+    add_gamepad_keycode_pair( JOY_R_RIGHTDOWN, translate_marker_context( "key name",
+                              "JOY_R_RIGHTDOWN" ) );
     // Named gamepad buttons
     add_gamepad_keycode_pair( JOY_A,         translate_marker_context( "key name", "JOY_A" ) );
     add_gamepad_keycode_pair( JOY_B,         translate_marker_context( "key name", "JOY_B" ) );
@@ -655,7 +661,8 @@ void input_manager::init_keycode_mapping()
     add_gamepad_keycode_pair( JOY_DPAD_UP,   translate_marker_context( "key name", "JOY_DPAD_UP" ) );
     add_gamepad_keycode_pair( JOY_DPAD_DOWN, translate_marker_context( "key name", "JOY_DPAD_DOWN" ) );
     add_gamepad_keycode_pair( JOY_DPAD_LEFT, translate_marker_context( "key name", "JOY_DPAD_LEFT" ) );
-    add_gamepad_keycode_pair( JOY_DPAD_RIGHT, translate_marker_context( "key name", "JOY_DPAD_RIGHT" ) );
+    add_gamepad_keycode_pair( JOY_DPAD_RIGHT, translate_marker_context( "key name",
+                              "JOY_DPAD_RIGHT" ) );
     add_gamepad_keycode_pair( JOY_START,     translate_marker_context( "key name", "JOY_START" ) );
     add_gamepad_keycode_pair( JOY_BACK,      translate_marker_context( "key name", "JOY_BACK" ) );
 
@@ -669,32 +676,52 @@ void input_manager::init_keycode_mapping()
     add_gamepad_keycode_pair( JOY_ALT_RT,    translate_marker_context( "key name", "JOY_ALT_RT" ) );
     add_gamepad_keycode_pair( JOY_ALT_LS,    translate_marker_context( "key name", "JOY_ALT_LS" ) );
     add_gamepad_keycode_pair( JOY_ALT_RS,    translate_marker_context( "key name", "JOY_ALT_RS" ) );
-    add_gamepad_keycode_pair( JOY_ALT_DPAD_UP, translate_marker_context( "key name", "JOY_ALT_DPAD_UP" ) );
-    add_gamepad_keycode_pair( JOY_ALT_DPAD_DOWN, translate_marker_context( "key name", "JOY_ALT_DPAD_DOWN" ) );
-    add_gamepad_keycode_pair( JOY_ALT_DPAD_LEFT, translate_marker_context( "key name", "JOY_ALT_DPAD_LEFT" ) );
-    add_gamepad_keycode_pair( JOY_ALT_DPAD_RIGHT, translate_marker_context( "key name", "JOY_ALT_DPAD_RIGHT" ) );
+    add_gamepad_keycode_pair( JOY_ALT_DPAD_UP, translate_marker_context( "key name",
+                              "JOY_ALT_DPAD_UP" ) );
+    add_gamepad_keycode_pair( JOY_ALT_DPAD_DOWN, translate_marker_context( "key name",
+                              "JOY_ALT_DPAD_DOWN" ) );
+    add_gamepad_keycode_pair( JOY_ALT_DPAD_LEFT, translate_marker_context( "key name",
+                              "JOY_ALT_DPAD_LEFT" ) );
+    add_gamepad_keycode_pair( JOY_ALT_DPAD_RIGHT, translate_marker_context( "key name",
+                              "JOY_ALT_DPAD_RIGHT" ) );
     add_gamepad_keycode_pair( JOY_ALT_START, translate_marker_context( "key name", "JOY_ALT_START" ) );
     add_gamepad_keycode_pair( JOY_ALT_BACK,  translate_marker_context( "key name", "JOY_ALT_BACK" ) );
 
     // Left radial menu
-    add_gamepad_keycode_pair( JOY_RADIAL_L_N,  translate_marker_context( "key name", "JOY_RADIAL_L_N" ) );
-    add_gamepad_keycode_pair( JOY_RADIAL_L_NE, translate_marker_context( "key name", "JOY_RADIAL_L_NE" ) );
-    add_gamepad_keycode_pair( JOY_RADIAL_L_E,  translate_marker_context( "key name", "JOY_RADIAL_L_E" ) );
-    add_gamepad_keycode_pair( JOY_RADIAL_L_SE, translate_marker_context( "key name", "JOY_RADIAL_L_SE" ) );
-    add_gamepad_keycode_pair( JOY_RADIAL_L_S,  translate_marker_context( "key name", "JOY_RADIAL_L_S" ) );
-    add_gamepad_keycode_pair( JOY_RADIAL_L_SW, translate_marker_context( "key name", "JOY_RADIAL_L_SW" ) );
-    add_gamepad_keycode_pair( JOY_RADIAL_L_W,  translate_marker_context( "key name", "JOY_RADIAL_L_W" ) );
-    add_gamepad_keycode_pair( JOY_RADIAL_L_NW, translate_marker_context( "key name", "JOY_RADIAL_L_NW" ) );
+    add_gamepad_keycode_pair( JOY_RADIAL_L_N,  translate_marker_context( "key name",
+                              "JOY_RADIAL_L_N" ) );
+    add_gamepad_keycode_pair( JOY_RADIAL_L_NE, translate_marker_context( "key name",
+                              "JOY_RADIAL_L_NE" ) );
+    add_gamepad_keycode_pair( JOY_RADIAL_L_E,  translate_marker_context( "key name",
+                              "JOY_RADIAL_L_E" ) );
+    add_gamepad_keycode_pair( JOY_RADIAL_L_SE, translate_marker_context( "key name",
+                              "JOY_RADIAL_L_SE" ) );
+    add_gamepad_keycode_pair( JOY_RADIAL_L_S,  translate_marker_context( "key name",
+                              "JOY_RADIAL_L_S" ) );
+    add_gamepad_keycode_pair( JOY_RADIAL_L_SW, translate_marker_context( "key name",
+                              "JOY_RADIAL_L_SW" ) );
+    add_gamepad_keycode_pair( JOY_RADIAL_L_W,  translate_marker_context( "key name",
+                              "JOY_RADIAL_L_W" ) );
+    add_gamepad_keycode_pair( JOY_RADIAL_L_NW, translate_marker_context( "key name",
+                              "JOY_RADIAL_L_NW" ) );
 
     // Right radial menu
-    add_gamepad_keycode_pair( JOY_RADIAL_R_N,  translate_marker_context( "key name", "JOY_RADIAL_R_N" ) );
-    add_gamepad_keycode_pair( JOY_RADIAL_R_NE, translate_marker_context( "key name", "JOY_RADIAL_R_NE" ) );
-    add_gamepad_keycode_pair( JOY_RADIAL_R_E,  translate_marker_context( "key name", "JOY_RADIAL_R_E" ) );
-    add_gamepad_keycode_pair( JOY_RADIAL_R_SE, translate_marker_context( "key name", "JOY_RADIAL_R_SE" ) );
-    add_gamepad_keycode_pair( JOY_RADIAL_R_S,  translate_marker_context( "key name", "JOY_RADIAL_R_S" ) );
-    add_gamepad_keycode_pair( JOY_RADIAL_R_SW, translate_marker_context( "key name", "JOY_RADIAL_R_SW" ) );
-    add_gamepad_keycode_pair( JOY_RADIAL_R_W,  translate_marker_context( "key name", "JOY_RADIAL_R_W" ) );
-    add_gamepad_keycode_pair( JOY_RADIAL_R_NW, translate_marker_context( "key name", "JOY_RADIAL_R_NW" ) );
+    add_gamepad_keycode_pair( JOY_RADIAL_R_N,  translate_marker_context( "key name",
+                              "JOY_RADIAL_R_N" ) );
+    add_gamepad_keycode_pair( JOY_RADIAL_R_NE, translate_marker_context( "key name",
+                              "JOY_RADIAL_R_NE" ) );
+    add_gamepad_keycode_pair( JOY_RADIAL_R_E,  translate_marker_context( "key name",
+                              "JOY_RADIAL_R_E" ) );
+    add_gamepad_keycode_pair( JOY_RADIAL_R_SE, translate_marker_context( "key name",
+                              "JOY_RADIAL_R_SE" ) );
+    add_gamepad_keycode_pair( JOY_RADIAL_R_S,  translate_marker_context( "key name",
+                              "JOY_RADIAL_R_S" ) );
+    add_gamepad_keycode_pair( JOY_RADIAL_R_SW, translate_marker_context( "key name",
+                              "JOY_RADIAL_R_SW" ) );
+    add_gamepad_keycode_pair( JOY_RADIAL_R_W,  translate_marker_context( "key name",
+                              "JOY_RADIAL_R_W" ) );
+    add_gamepad_keycode_pair( JOY_RADIAL_R_NW, translate_marker_context( "key name",
+                              "JOY_RADIAL_R_NW" ) );
 
     add_mouse_keycode_pair( MouseInput::LeftButtonPressed,
                             translate_marker_context( "key name", "MOUSE_LEFT_PRESSED" ) );

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -591,15 +591,6 @@ void input_manager::init_keycode_mapping()
         add_keyboard_code_keycode_pair( v.first, v.second );
     }
 
-    add_gamepad_keycode_pair( JOY_LEFT,      translate_marker_context( "key name", "JOY_LEFT" ) );
-    add_gamepad_keycode_pair( JOY_RIGHT,     translate_marker_context( "key name", "JOY_RIGHT" ) );
-    add_gamepad_keycode_pair( JOY_UP,        translate_marker_context( "key name", "JOY_UP" ) );
-    add_gamepad_keycode_pair( JOY_DOWN,      translate_marker_context( "key name", "JOY_DOWN" ) );
-    add_gamepad_keycode_pair( JOY_LEFTUP,    translate_marker_context( "key name", "JOY_LEFTUP" ) );
-    add_gamepad_keycode_pair( JOY_LEFTDOWN,  translate_marker_context( "key name", "JOY_LEFTDOWN" ) );
-    add_gamepad_keycode_pair( JOY_RIGHTUP,   translate_marker_context( "key name", "JOY_RIGHTUP" ) );
-    add_gamepad_keycode_pair( JOY_RIGHTDOWN, translate_marker_context( "key name", "JOY_RIGHTDOWN" ) );
-
     add_gamepad_keycode_pair( JOY_0,         translate_marker_context( "key name", "JOY_0" ) );
     add_gamepad_keycode_pair( JOY_1,         translate_marker_context( "key name", "JOY_1" ) );
     add_gamepad_keycode_pair( JOY_2,         translate_marker_context( "key name", "JOY_2" ) );
@@ -631,6 +622,79 @@ void input_manager::init_keycode_mapping()
     add_gamepad_keycode_pair( JOY_28,        translate_marker_context( "key name", "JOY_28" ) );
     add_gamepad_keycode_pair( JOY_29,        translate_marker_context( "key name", "JOY_29" ) );
     add_gamepad_keycode_pair( JOY_30,        translate_marker_context( "key name", "JOY_30" ) );
+
+
+    add_gamepad_keycode_pair( JOY_L_LEFT,      translate_marker_context( "key name", "JOY_L_LEFT" ) );
+    add_gamepad_keycode_pair( JOY_L_RIGHT,     translate_marker_context( "key name", "JOY_L_RIGHT" ) );
+    add_gamepad_keycode_pair( JOY_L_UP,        translate_marker_context( "key name", "JOY_L_UP" ) );
+    add_gamepad_keycode_pair( JOY_L_DOWN,      translate_marker_context( "key name", "JOY_L_DOWN" ) );
+    add_gamepad_keycode_pair( JOY_L_LEFTUP,    translate_marker_context( "key name", "JOY_L_LEFTUP" ) );
+    add_gamepad_keycode_pair( JOY_L_LEFTDOWN,  translate_marker_context( "key name", "JOY_L_LEFTDOWN" ) );
+    add_gamepad_keycode_pair( JOY_L_RIGHTUP,   translate_marker_context( "key name", "JOY_L_RIGHTUP" ) );
+    add_gamepad_keycode_pair( JOY_L_RIGHTDOWN, translate_marker_context( "key name", "JOY_L_RIGHTDOWN" ) );
+
+    add_gamepad_keycode_pair( JOY_R_LEFT,      translate_marker_context( "key name", "JOY_R_LEFT" ) );
+    add_gamepad_keycode_pair( JOY_R_RIGHT,     translate_marker_context( "key name", "JOY_R_RIGHT" ) );
+    add_gamepad_keycode_pair( JOY_R_UP,        translate_marker_context( "key name", "JOY_R_UP" ) );
+    add_gamepad_keycode_pair( JOY_R_DOWN,      translate_marker_context( "key name", "JOY_R_DOWN" ) );
+    add_gamepad_keycode_pair( JOY_R_LEFTUP,    translate_marker_context( "key name", "JOY_R_LEFTUP" ) );
+    add_gamepad_keycode_pair( JOY_R_LEFTDOWN,  translate_marker_context( "key name", "JOY_R_LEFTDOWN" ) );
+    add_gamepad_keycode_pair( JOY_R_RIGHTUP,   translate_marker_context( "key name", "JOY_R_RIGHTUP" ) );
+    add_gamepad_keycode_pair( JOY_R_RIGHTDOWN, translate_marker_context( "key name", "JOY_R_RIGHTDOWN" ) );
+    // Named gamepad buttons
+    add_gamepad_keycode_pair( JOY_A,         translate_marker_context( "key name", "JOY_A" ) );
+    add_gamepad_keycode_pair( JOY_B,         translate_marker_context( "key name", "JOY_B" ) );
+    add_gamepad_keycode_pair( JOY_X,         translate_marker_context( "key name", "JOY_X" ) );
+    add_gamepad_keycode_pair( JOY_Y,         translate_marker_context( "key name", "JOY_Y" ) );
+    add_gamepad_keycode_pair( JOY_LB,        translate_marker_context( "key name", "JOY_LB" ) );
+    add_gamepad_keycode_pair( JOY_RB,        translate_marker_context( "key name", "JOY_RB" ) );
+    add_gamepad_keycode_pair( JOY_LT,        translate_marker_context( "key name", "JOY_LT" ) );
+    add_gamepad_keycode_pair( JOY_RT,        translate_marker_context( "key name", "JOY_RT" ) );
+    add_gamepad_keycode_pair( JOY_LS,        translate_marker_context( "key name", "JOY_LS" ) );
+    add_gamepad_keycode_pair( JOY_RS,        translate_marker_context( "key name", "JOY_RS" ) );
+    add_gamepad_keycode_pair( JOY_DPAD_UP,   translate_marker_context( "key name", "JOY_DPAD_UP" ) );
+    add_gamepad_keycode_pair( JOY_DPAD_DOWN, translate_marker_context( "key name", "JOY_DPAD_DOWN" ) );
+    add_gamepad_keycode_pair( JOY_DPAD_LEFT, translate_marker_context( "key name", "JOY_DPAD_LEFT" ) );
+    add_gamepad_keycode_pair( JOY_DPAD_RIGHT, translate_marker_context( "key name", "JOY_DPAD_RIGHT" ) );
+    add_gamepad_keycode_pair( JOY_START,     translate_marker_context( "key name", "JOY_START" ) );
+    add_gamepad_keycode_pair( JOY_BACK,      translate_marker_context( "key name", "JOY_BACK" ) );
+
+    // ALT variants
+    add_gamepad_keycode_pair( JOY_ALT_A,     translate_marker_context( "key name", "JOY_ALT_A" ) );
+    add_gamepad_keycode_pair( JOY_ALT_B,     translate_marker_context( "key name", "JOY_ALT_B" ) );
+    add_gamepad_keycode_pair( JOY_ALT_X,     translate_marker_context( "key name", "JOY_ALT_X" ) );
+    add_gamepad_keycode_pair( JOY_ALT_Y,     translate_marker_context( "key name", "JOY_ALT_Y" ) );
+    add_gamepad_keycode_pair( JOY_ALT_RB,    translate_marker_context( "key name", "JOY_ALT_RB" ) );
+    add_gamepad_keycode_pair( JOY_ALT_LB,    translate_marker_context( "key name", "JOY_ALT_LB" ) );
+    add_gamepad_keycode_pair( JOY_ALT_RT,    translate_marker_context( "key name", "JOY_ALT_RT" ) );
+    add_gamepad_keycode_pair( JOY_ALT_LS,    translate_marker_context( "key name", "JOY_ALT_LS" ) );
+    add_gamepad_keycode_pair( JOY_ALT_RS,    translate_marker_context( "key name", "JOY_ALT_RS" ) );
+    add_gamepad_keycode_pair( JOY_ALT_DPAD_UP, translate_marker_context( "key name", "JOY_ALT_DPAD_UP" ) );
+    add_gamepad_keycode_pair( JOY_ALT_DPAD_DOWN, translate_marker_context( "key name", "JOY_ALT_DPAD_DOWN" ) );
+    add_gamepad_keycode_pair( JOY_ALT_DPAD_LEFT, translate_marker_context( "key name", "JOY_ALT_DPAD_LEFT" ) );
+    add_gamepad_keycode_pair( JOY_ALT_DPAD_RIGHT, translate_marker_context( "key name", "JOY_ALT_DPAD_RIGHT" ) );
+    add_gamepad_keycode_pair( JOY_ALT_START, translate_marker_context( "key name", "JOY_ALT_START" ) );
+    add_gamepad_keycode_pair( JOY_ALT_BACK,  translate_marker_context( "key name", "JOY_ALT_BACK" ) );
+
+    // Left radial menu
+    add_gamepad_keycode_pair( JOY_RADIAL_L_N,  translate_marker_context( "key name", "JOY_RADIAL_L_N" ) );
+    add_gamepad_keycode_pair( JOY_RADIAL_L_NE, translate_marker_context( "key name", "JOY_RADIAL_L_NE" ) );
+    add_gamepad_keycode_pair( JOY_RADIAL_L_E,  translate_marker_context( "key name", "JOY_RADIAL_L_E" ) );
+    add_gamepad_keycode_pair( JOY_RADIAL_L_SE, translate_marker_context( "key name", "JOY_RADIAL_L_SE" ) );
+    add_gamepad_keycode_pair( JOY_RADIAL_L_S,  translate_marker_context( "key name", "JOY_RADIAL_L_S" ) );
+    add_gamepad_keycode_pair( JOY_RADIAL_L_SW, translate_marker_context( "key name", "JOY_RADIAL_L_SW" ) );
+    add_gamepad_keycode_pair( JOY_RADIAL_L_W,  translate_marker_context( "key name", "JOY_RADIAL_L_W" ) );
+    add_gamepad_keycode_pair( JOY_RADIAL_L_NW, translate_marker_context( "key name", "JOY_RADIAL_L_NW" ) );
+
+    // Right radial menu
+    add_gamepad_keycode_pair( JOY_RADIAL_R_N,  translate_marker_context( "key name", "JOY_RADIAL_R_N" ) );
+    add_gamepad_keycode_pair( JOY_RADIAL_R_NE, translate_marker_context( "key name", "JOY_RADIAL_R_NE" ) );
+    add_gamepad_keycode_pair( JOY_RADIAL_R_E,  translate_marker_context( "key name", "JOY_RADIAL_R_E" ) );
+    add_gamepad_keycode_pair( JOY_RADIAL_R_SE, translate_marker_context( "key name", "JOY_RADIAL_R_SE" ) );
+    add_gamepad_keycode_pair( JOY_RADIAL_R_S,  translate_marker_context( "key name", "JOY_RADIAL_R_S" ) );
+    add_gamepad_keycode_pair( JOY_RADIAL_R_SW, translate_marker_context( "key name", "JOY_RADIAL_R_SW" ) );
+    add_gamepad_keycode_pair( JOY_RADIAL_R_W,  translate_marker_context( "key name", "JOY_RADIAL_R_W" ) );
+    add_gamepad_keycode_pair( JOY_RADIAL_R_NW, translate_marker_context( "key name", "JOY_RADIAL_R_NW" ) );
 
     add_mouse_keycode_pair( MouseInput::LeftButtonPressed,
                             translate_marker_context( "key name", "MOUSE_LEFT_PRESSED" ) );

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -591,137 +591,137 @@ void input_manager::init_keycode_mapping()
         add_keyboard_code_keycode_pair( v.first, v.second );
     }
 
-    add_gamepad_keycode_pair( JOY_0,         translate_marker_context( "key name", "JOY_0" ) );
-    add_gamepad_keycode_pair( JOY_1,         translate_marker_context( "key name", "JOY_1" ) );
-    add_gamepad_keycode_pair( JOY_2,         translate_marker_context( "key name", "JOY_2" ) );
-    add_gamepad_keycode_pair( JOY_3,         translate_marker_context( "key name", "JOY_3" ) );
-    add_gamepad_keycode_pair( JOY_4,         translate_marker_context( "key name", "JOY_4" ) );
-    add_gamepad_keycode_pair( JOY_5,         translate_marker_context( "key name", "JOY_5" ) );
-    add_gamepad_keycode_pair( JOY_6,         translate_marker_context( "key name", "JOY_6" ) );
-    add_gamepad_keycode_pair( JOY_7,         translate_marker_context( "key name", "JOY_7" ) );
-    add_gamepad_keycode_pair( JOY_8,         translate_marker_context( "key name", "JOY_8" ) );
-    add_gamepad_keycode_pair( JOY_9,         translate_marker_context( "key name", "JOY_9" ) );
-    add_gamepad_keycode_pair( JOY_10,        translate_marker_context( "key name", "JOY_10" ) );
-    add_gamepad_keycode_pair( JOY_11,        translate_marker_context( "key name", "JOY_11" ) );
-    add_gamepad_keycode_pair( JOY_12,        translate_marker_context( "key name", "JOY_12" ) );
-    add_gamepad_keycode_pair( JOY_13,        translate_marker_context( "key name", "JOY_13" ) );
-    add_gamepad_keycode_pair( JOY_14,        translate_marker_context( "key name", "JOY_14" ) );
-    add_gamepad_keycode_pair( JOY_15,        translate_marker_context( "key name", "JOY_15" ) );
-    add_gamepad_keycode_pair( JOY_16,        translate_marker_context( "key name", "JOY_16" ) );
-    add_gamepad_keycode_pair( JOY_17,        translate_marker_context( "key name", "JOY_17" ) );
-    add_gamepad_keycode_pair( JOY_18,        translate_marker_context( "key name", "JOY_18" ) );
-    add_gamepad_keycode_pair( JOY_19,        translate_marker_context( "key name", "JOY_19" ) );
-    add_gamepad_keycode_pair( JOY_20,        translate_marker_context( "key name", "JOY_20" ) );
-    add_gamepad_keycode_pair( JOY_21,        translate_marker_context( "key name", "JOY_21" ) );
-    add_gamepad_keycode_pair( JOY_22,        translate_marker_context( "key name", "JOY_22" ) );
-    add_gamepad_keycode_pair( JOY_23,        translate_marker_context( "key name", "JOY_23" ) );
-    add_gamepad_keycode_pair( JOY_24,        translate_marker_context( "key name", "JOY_24" ) );
-    add_gamepad_keycode_pair( JOY_25,        translate_marker_context( "key name", "JOY_25" ) );
-    add_gamepad_keycode_pair( JOY_26,        translate_marker_context( "key name", "JOY_26" ) );
-    add_gamepad_keycode_pair( JOY_27,        translate_marker_context( "key name", "JOY_27" ) );
-    add_gamepad_keycode_pair( JOY_28,        translate_marker_context( "key name", "JOY_28" ) );
-    add_gamepad_keycode_pair( JOY_29,        translate_marker_context( "key name", "JOY_29" ) );
-    add_gamepad_keycode_pair( JOY_30,        translate_marker_context( "key name", "JOY_30" ) );
+    add_gamepad_keycode_pair( JOY_0,         translate_marker_context( "key name", "0" ) );
+    add_gamepad_keycode_pair( JOY_1,         translate_marker_context( "key name", "1" ) );
+    add_gamepad_keycode_pair( JOY_2,         translate_marker_context( "key name", "2" ) );
+    add_gamepad_keycode_pair( JOY_3,         translate_marker_context( "key name", "3" ) );
+    add_gamepad_keycode_pair( JOY_4,         translate_marker_context( "key name", "4" ) );
+    add_gamepad_keycode_pair( JOY_5,         translate_marker_context( "key name", "5" ) );
+    add_gamepad_keycode_pair( JOY_6,         translate_marker_context( "key name", "6" ) );
+    add_gamepad_keycode_pair( JOY_7,         translate_marker_context( "key name", "7" ) );
+    add_gamepad_keycode_pair( JOY_8,         translate_marker_context( "key name", "8" ) );
+    add_gamepad_keycode_pair( JOY_9,         translate_marker_context( "key name", "9" ) );
+    add_gamepad_keycode_pair( JOY_10,        translate_marker_context( "key name", "10" ) );
+    add_gamepad_keycode_pair( JOY_11,        translate_marker_context( "key name", "11" ) );
+    add_gamepad_keycode_pair( JOY_12,        translate_marker_context( "key name", "12" ) );
+    add_gamepad_keycode_pair( JOY_13,        translate_marker_context( "key name", "13" ) );
+    add_gamepad_keycode_pair( JOY_14,        translate_marker_context( "key name", "14" ) );
+    add_gamepad_keycode_pair( JOY_15,        translate_marker_context( "key name", "15" ) );
+    add_gamepad_keycode_pair( JOY_16,        translate_marker_context( "key name", "16" ) );
+    add_gamepad_keycode_pair( JOY_17,        translate_marker_context( "key name", "17" ) );
+    add_gamepad_keycode_pair( JOY_18,        translate_marker_context( "key name", "18" ) );
+    add_gamepad_keycode_pair( JOY_19,        translate_marker_context( "key name", "19" ) );
+    add_gamepad_keycode_pair( JOY_20,        translate_marker_context( "key name", "20" ) );
+    add_gamepad_keycode_pair( JOY_21,        translate_marker_context( "key name", "21" ) );
+    add_gamepad_keycode_pair( JOY_22,        translate_marker_context( "key name", "22" ) );
+    add_gamepad_keycode_pair( JOY_23,        translate_marker_context( "key name", "23" ) );
+    add_gamepad_keycode_pair( JOY_24,        translate_marker_context( "key name", "24" ) );
+    add_gamepad_keycode_pair( JOY_25,        translate_marker_context( "key name", "25" ) );
+    add_gamepad_keycode_pair( JOY_26,        translate_marker_context( "key name", "26" ) );
+    add_gamepad_keycode_pair( JOY_27,        translate_marker_context( "key name", "27" ) );
+    add_gamepad_keycode_pair( JOY_28,        translate_marker_context( "key name", "28" ) );
+    add_gamepad_keycode_pair( JOY_29,        translate_marker_context( "key name", "29" ) );
+    add_gamepad_keycode_pair( JOY_30,        translate_marker_context( "key name", "30" ) );
 
 
-    add_gamepad_keycode_pair( JOY_L_LEFT,      translate_marker_context( "key name", "JOY_L_LEFT" ) );
-    add_gamepad_keycode_pair( JOY_L_RIGHT,     translate_marker_context( "key name", "JOY_L_RIGHT" ) );
-    add_gamepad_keycode_pair( JOY_L_UP,        translate_marker_context( "key name", "JOY_L_UP" ) );
-    add_gamepad_keycode_pair( JOY_L_DOWN,      translate_marker_context( "key name", "JOY_L_DOWN" ) );
-    add_gamepad_keycode_pair( JOY_L_LEFTUP,    translate_marker_context( "key name", "JOY_L_LEFTUP" ) );
-    add_gamepad_keycode_pair( JOY_L_LEFTDOWN,  translate_marker_context( "key name",
-                              "JOY_L_LEFTDOWN" ) );
-    add_gamepad_keycode_pair( JOY_L_RIGHTUP,   translate_marker_context( "key name",
-                              "JOY_L_RIGHTUP" ) );
-    add_gamepad_keycode_pair( JOY_L_RIGHTDOWN, translate_marker_context( "key name",
-                              "JOY_L_RIGHTDOWN" ) );
+    add_gamepad_keycode_pair( JOY_LS_LEFT,      translate_marker_context( "key name", "LS_LEFT" ) );
+    add_gamepad_keycode_pair( JOY_LS_RIGHT,     translate_marker_context( "key name", "LS_RIGHT" ) );
+    add_gamepad_keycode_pair( JOY_LS_UP,        translate_marker_context( "key name", "LS_UP" ) );
+    add_gamepad_keycode_pair( JOY_LS_DOWN,      translate_marker_context( "key name", "LS_DOWN" ) );
+    add_gamepad_keycode_pair( JOY_LS_UP_LEFT,    translate_marker_context( "key name", "LS_UP_LEFT" ) );
+    add_gamepad_keycode_pair( JOY_LS_DOWN_LEFT,  translate_marker_context( "key name",
+                              "LS_DOWN_LEFT" ) );
+    add_gamepad_keycode_pair( JOY_LS_UP_RIGHT,   translate_marker_context( "key name",
+                              "LS_UP_RIGHT" ) );
+    add_gamepad_keycode_pair( JOY_LS_DOWN_RIGHT, translate_marker_context( "key name",
+                              "LS_DOWN_RIGHT" ) );
 
-    add_gamepad_keycode_pair( JOY_R_LEFT,      translate_marker_context( "key name", "JOY_R_LEFT" ) );
-    add_gamepad_keycode_pair( JOY_R_RIGHT,     translate_marker_context( "key name", "JOY_R_RIGHT" ) );
-    add_gamepad_keycode_pair( JOY_R_UP,        translate_marker_context( "key name", "JOY_R_UP" ) );
-    add_gamepad_keycode_pair( JOY_R_DOWN,      translate_marker_context( "key name", "JOY_R_DOWN" ) );
-    add_gamepad_keycode_pair( JOY_R_LEFTUP,    translate_marker_context( "key name", "JOY_R_LEFTUP" ) );
-    add_gamepad_keycode_pair( JOY_R_LEFTDOWN,  translate_marker_context( "key name",
-                              "JOY_R_LEFTDOWN" ) );
-    add_gamepad_keycode_pair( JOY_R_RIGHTUP,   translate_marker_context( "key name",
-                              "JOY_R_RIGHTUP" ) );
-    add_gamepad_keycode_pair( JOY_R_RIGHTDOWN, translate_marker_context( "key name",
-                              "JOY_R_RIGHTDOWN" ) );
+    add_gamepad_keycode_pair( JOY_RS_LEFT,      translate_marker_context( "key name", "RS_LEFT" ) );
+    add_gamepad_keycode_pair( JOY_RS_RIGHT,     translate_marker_context( "key name", "RS_RIGHT" ) );
+    add_gamepad_keycode_pair( JOY_RS_UP,        translate_marker_context( "key name", "RS_UP" ) );
+    add_gamepad_keycode_pair( JOY_RS_DOWN,      translate_marker_context( "key name", "RS_DOWN" ) );
+    add_gamepad_keycode_pair( JOY_RS_UP_LEFT,    translate_marker_context( "key name", "RS_UP_LEFT" ) );
+    add_gamepad_keycode_pair( JOY_RS_DOWN_LEFT,  translate_marker_context( "key name",
+                              "RS_DOWN_LEFT" ) );
+    add_gamepad_keycode_pair( JOY_RS_UP_RIGHT,   translate_marker_context( "key name",
+                              "RS_UP_RIGHT" ) );
+    add_gamepad_keycode_pair( JOY_RS_DOWN_RIGHT, translate_marker_context( "key name",
+                              "RS_DOWN_RIGHT" ) );
     // Named gamepad buttons
-    add_gamepad_keycode_pair( JOY_A,         translate_marker_context( "key name", "JOY_A" ) );
-    add_gamepad_keycode_pair( JOY_B,         translate_marker_context( "key name", "JOY_B" ) );
-    add_gamepad_keycode_pair( JOY_X,         translate_marker_context( "key name", "JOY_X" ) );
-    add_gamepad_keycode_pair( JOY_Y,         translate_marker_context( "key name", "JOY_Y" ) );
-    add_gamepad_keycode_pair( JOY_LB,        translate_marker_context( "key name", "JOY_LB" ) );
-    add_gamepad_keycode_pair( JOY_RB,        translate_marker_context( "key name", "JOY_RB" ) );
-    add_gamepad_keycode_pair( JOY_LT,        translate_marker_context( "key name", "JOY_LT" ) );
-    add_gamepad_keycode_pair( JOY_RT,        translate_marker_context( "key name", "JOY_RT" ) );
-    add_gamepad_keycode_pair( JOY_LS,        translate_marker_context( "key name", "JOY_LS" ) );
-    add_gamepad_keycode_pair( JOY_RS,        translate_marker_context( "key name", "JOY_RS" ) );
-    add_gamepad_keycode_pair( JOY_DPAD_UP,   translate_marker_context( "key name", "JOY_DPAD_UP" ) );
-    add_gamepad_keycode_pair( JOY_DPAD_DOWN, translate_marker_context( "key name", "JOY_DPAD_DOWN" ) );
-    add_gamepad_keycode_pair( JOY_DPAD_LEFT, translate_marker_context( "key name", "JOY_DPAD_LEFT" ) );
-    add_gamepad_keycode_pair( JOY_DPAD_RIGHT, translate_marker_context( "key name",
-                              "JOY_DPAD_RIGHT" ) );
-    add_gamepad_keycode_pair( JOY_START,     translate_marker_context( "key name", "JOY_START" ) );
-    add_gamepad_keycode_pair( JOY_BACK,      translate_marker_context( "key name", "JOY_BACK" ) );
+    add_gamepad_keycode_pair( JOY_A,         translate_marker_context( "key name", "A" ) );
+    add_gamepad_keycode_pair( JOY_B,         translate_marker_context( "key name", "B" ) );
+    add_gamepad_keycode_pair( JOY_X,         translate_marker_context( "key name", "X" ) );
+    add_gamepad_keycode_pair( JOY_Y,         translate_marker_context( "key name", "Y" ) );
+    add_gamepad_keycode_pair( JOY_LB,        translate_marker_context( "key name", "LB" ) );
+    add_gamepad_keycode_pair( JOY_RB,        translate_marker_context( "key name", "RB" ) );
+    add_gamepad_keycode_pair( JOY_LT,        translate_marker_context( "key name", "LT" ) );
+    add_gamepad_keycode_pair( JOY_RT,        translate_marker_context( "key name", "RT" ) );
+    add_gamepad_keycode_pair( JOY_LS,        translate_marker_context( "key name", "LS" ) );
+    add_gamepad_keycode_pair( JOY_RS,        translate_marker_context( "key name", "RS" ) );
+    add_gamepad_keycode_pair( JOY_UP,   translate_marker_context( "key name", "UP" ) );
+    add_gamepad_keycode_pair( JOY_DOWN, translate_marker_context( "key name", "DOWN" ) );
+    add_gamepad_keycode_pair( JOY_LEFT, translate_marker_context( "key name", "LEFT" ) );
+    add_gamepad_keycode_pair( JOY_RIGHT, translate_marker_context( "key name",
+                              "RIGHT" ) );
+    add_gamepad_keycode_pair( JOY_START,     translate_marker_context( "key name", "START" ) );
+    add_gamepad_keycode_pair( JOY_BACK,      translate_marker_context( "key name", "BACK" ) );
 
     // ALT variants
-    add_gamepad_keycode_pair( JOY_ALT_A,     translate_marker_context( "key name", "JOY_ALT_A" ) );
-    add_gamepad_keycode_pair( JOY_ALT_B,     translate_marker_context( "key name", "JOY_ALT_B" ) );
-    add_gamepad_keycode_pair( JOY_ALT_X,     translate_marker_context( "key name", "JOY_ALT_X" ) );
-    add_gamepad_keycode_pair( JOY_ALT_Y,     translate_marker_context( "key name", "JOY_ALT_Y" ) );
-    add_gamepad_keycode_pair( JOY_ALT_RB,    translate_marker_context( "key name", "JOY_ALT_RB" ) );
-    add_gamepad_keycode_pair( JOY_ALT_LB,    translate_marker_context( "key name", "JOY_ALT_LB" ) );
-    add_gamepad_keycode_pair( JOY_ALT_RT,    translate_marker_context( "key name", "JOY_ALT_RT" ) );
-    add_gamepad_keycode_pair( JOY_ALT_LS,    translate_marker_context( "key name", "JOY_ALT_LS" ) );
-    add_gamepad_keycode_pair( JOY_ALT_RS,    translate_marker_context( "key name", "JOY_ALT_RS" ) );
-    add_gamepad_keycode_pair( JOY_ALT_DPAD_UP, translate_marker_context( "key name",
-                              "JOY_ALT_DPAD_UP" ) );
-    add_gamepad_keycode_pair( JOY_ALT_DPAD_DOWN, translate_marker_context( "key name",
-                              "JOY_ALT_DPAD_DOWN" ) );
-    add_gamepad_keycode_pair( JOY_ALT_DPAD_LEFT, translate_marker_context( "key name",
-                              "JOY_ALT_DPAD_LEFT" ) );
-    add_gamepad_keycode_pair( JOY_ALT_DPAD_RIGHT, translate_marker_context( "key name",
-                              "JOY_ALT_DPAD_RIGHT" ) );
-    add_gamepad_keycode_pair( JOY_ALT_START, translate_marker_context( "key name", "JOY_ALT_START" ) );
-    add_gamepad_keycode_pair( JOY_ALT_BACK,  translate_marker_context( "key name", "JOY_ALT_BACK" ) );
+    add_gamepad_keycode_pair( JOY_ALT_A,     translate_marker_context( "key name", "ALT_A" ) );
+    add_gamepad_keycode_pair( JOY_ALT_B,     translate_marker_context( "key name", "ALT_B" ) );
+    add_gamepad_keycode_pair( JOY_ALT_X,     translate_marker_context( "key name", "ALT_X" ) );
+    add_gamepad_keycode_pair( JOY_ALT_Y,     translate_marker_context( "key name", "ALT_Y" ) );
+    add_gamepad_keycode_pair( JOY_ALT_RB,    translate_marker_context( "key name", "ALT_RB" ) );
+    add_gamepad_keycode_pair( JOY_ALT_LB,    translate_marker_context( "key name", "ALT_LB" ) );
+    add_gamepad_keycode_pair( JOY_ALT_RT,    translate_marker_context( "key name", "ALT_RT" ) );
+    add_gamepad_keycode_pair( JOY_ALT_LS,    translate_marker_context( "key name", "ALT_LS" ) );
+    add_gamepad_keycode_pair( JOY_ALT_RS,    translate_marker_context( "key name", "ALT_RS" ) );
+    add_gamepad_keycode_pair( JOY_ALT_UP, translate_marker_context( "key name",
+                              "ALT_UP" ) );
+    add_gamepad_keycode_pair( JOY_ALT_DOWN, translate_marker_context( "key name",
+                              "ALT_DOWN" ) );
+    add_gamepad_keycode_pair( JOY_ALT_LEFT, translate_marker_context( "key name",
+                              "ALT_LEFT" ) );
+    add_gamepad_keycode_pair( JOY_ALT_RIGHT, translate_marker_context( "key name",
+                              "ALT_RIGHT" ) );
+    add_gamepad_keycode_pair( JOY_ALT_START, translate_marker_context( "key name", "ALT_START" ) );
+    add_gamepad_keycode_pair( JOY_ALT_BACK,  translate_marker_context( "key name", "ALT_BACK" ) );
 
     // Left radial menu
-    add_gamepad_keycode_pair( JOY_RADIAL_L_N,  translate_marker_context( "key name",
-                              "JOY_RADIAL_L_N" ) );
-    add_gamepad_keycode_pair( JOY_RADIAL_L_NE, translate_marker_context( "key name",
-                              "JOY_RADIAL_L_NE" ) );
-    add_gamepad_keycode_pair( JOY_RADIAL_L_E,  translate_marker_context( "key name",
-                              "JOY_RADIAL_L_E" ) );
-    add_gamepad_keycode_pair( JOY_RADIAL_L_SE, translate_marker_context( "key name",
-                              "JOY_RADIAL_L_SE" ) );
-    add_gamepad_keycode_pair( JOY_RADIAL_L_S,  translate_marker_context( "key name",
-                              "JOY_RADIAL_L_S" ) );
-    add_gamepad_keycode_pair( JOY_RADIAL_L_SW, translate_marker_context( "key name",
-                              "JOY_RADIAL_L_SW" ) );
-    add_gamepad_keycode_pair( JOY_RADIAL_L_W,  translate_marker_context( "key name",
-                              "JOY_RADIAL_L_W" ) );
-    add_gamepad_keycode_pair( JOY_RADIAL_L_NW, translate_marker_context( "key name",
-                              "JOY_RADIAL_L_NW" ) );
+    add_gamepad_keycode_pair( JOY_L_RADIAL_N,  translate_marker_context( "key name",
+                              "L_RADIAL_N" ) );
+    add_gamepad_keycode_pair( JOY_L_RADIAL_NE, translate_marker_context( "key name",
+                              "L_RADIAL_NE" ) );
+    add_gamepad_keycode_pair( JOY_L_RADIAL_E,  translate_marker_context( "key name",
+                              "L_RADIAL_E" ) );
+    add_gamepad_keycode_pair( JOY_L_RADIAL_SE, translate_marker_context( "key name",
+                              "L_RADIAL_SE" ) );
+    add_gamepad_keycode_pair( JOY_L_RADIAL_S,  translate_marker_context( "key name",
+                              "L_RADIAL_S" ) );
+    add_gamepad_keycode_pair( JOY_L_RADIAL_SW, translate_marker_context( "key name",
+                              "L_RADIAL_SW" ) );
+    add_gamepad_keycode_pair( JOY_L_RADIAL_W,  translate_marker_context( "key name",
+                              "L_RADIAL_W" ) );
+    add_gamepad_keycode_pair( JOY_L_RADIAL_NW, translate_marker_context( "key name",
+                              "L_RADIAL_NW" ) );
 
     // Right radial menu
-    add_gamepad_keycode_pair( JOY_RADIAL_R_N,  translate_marker_context( "key name",
-                              "JOY_RADIAL_R_N" ) );
-    add_gamepad_keycode_pair( JOY_RADIAL_R_NE, translate_marker_context( "key name",
-                              "JOY_RADIAL_R_NE" ) );
-    add_gamepad_keycode_pair( JOY_RADIAL_R_E,  translate_marker_context( "key name",
-                              "JOY_RADIAL_R_E" ) );
-    add_gamepad_keycode_pair( JOY_RADIAL_R_SE, translate_marker_context( "key name",
-                              "JOY_RADIAL_R_SE" ) );
-    add_gamepad_keycode_pair( JOY_RADIAL_R_S,  translate_marker_context( "key name",
-                              "JOY_RADIAL_R_S" ) );
-    add_gamepad_keycode_pair( JOY_RADIAL_R_SW, translate_marker_context( "key name",
-                              "JOY_RADIAL_R_SW" ) );
-    add_gamepad_keycode_pair( JOY_RADIAL_R_W,  translate_marker_context( "key name",
-                              "JOY_RADIAL_R_W" ) );
-    add_gamepad_keycode_pair( JOY_RADIAL_R_NW, translate_marker_context( "key name",
-                              "JOY_RADIAL_R_NW" ) );
+    add_gamepad_keycode_pair( JOY_R_RADIAL_N,  translate_marker_context( "key name",
+                              "R_RADIAL_N" ) );
+    add_gamepad_keycode_pair( JOY_R_RADIAL_NE, translate_marker_context( "key name",
+                              "R_RADIAL_NE" ) );
+    add_gamepad_keycode_pair( JOY_R_RADIAL_E,  translate_marker_context( "key name",
+                              "R_RADIAL_E" ) );
+    add_gamepad_keycode_pair( JOY_R_RADIAL_SE, translate_marker_context( "key name",
+                              "R_RADIAL_SE" ) );
+    add_gamepad_keycode_pair( JOY_R_RADIAL_S,  translate_marker_context( "key name",
+                              "R_RADIAL_S" ) );
+    add_gamepad_keycode_pair( JOY_R_RADIAL_SW, translate_marker_context( "key name",
+                              "R_RADIAL_SW" ) );
+    add_gamepad_keycode_pair( JOY_R_RADIAL_W,  translate_marker_context( "key name",
+                              "R_RADIAL_W" ) );
+    add_gamepad_keycode_pair( JOY_R_RADIAL_NW, translate_marker_context( "key name",
+                              "R_RADIAL_NW" ) );
 
     add_mouse_keycode_pair( MouseInput::LeftButtonPressed,
                             translate_marker_context( "key name", "MOUSE_LEFT_PRESSED" ) );

--- a/src/input.h
+++ b/src/input.h
@@ -179,14 +179,89 @@ constexpr int JOY_28 = 28;
 constexpr int JOY_29 = 29;
 constexpr int JOY_30 = 30;
 
-constexpr int JOY_LEFT      = 256 + 1;
-constexpr int JOY_RIGHT     = 256 + 2;
-constexpr int JOY_UP        = 256 + 3;
-constexpr int JOY_DOWN      = 256 + 4;
-constexpr int JOY_RIGHTUP   = 256 + 5;
-constexpr int JOY_RIGHTDOWN = 256 + 6;
-constexpr int JOY_LEFTUP    = 256 + 7;
-constexpr int JOY_LEFTDOWN  = 256 + 8;
+constexpr int JOY_L_LEFT      = 256 + 1;
+constexpr int JOY_L_RIGHT     = 256 + 2;
+constexpr int JOY_L_UP        = 256 + 3;
+constexpr int JOY_L_DOWN      = 256 + 4;
+constexpr int JOY_L_RIGHTUP   = 256 + 5;
+constexpr int JOY_L_RIGHTDOWN = 256 + 6;
+constexpr int JOY_L_LEFTUP    = 256 + 7;
+constexpr int JOY_L_LEFTDOWN  = 256 + 8;
+
+constexpr int JOY_R_LEFT      = 256 + 9;
+constexpr int JOY_R_RIGHT     = 256 + 10;
+constexpr int JOY_R_UP        = 256 + 11;
+constexpr int JOY_R_DOWN      = 256 + 12;
+constexpr int JOY_R_RIGHTUP   = 256 + 13;
+constexpr int JOY_R_RIGHTDOWN = 256 + 14;
+constexpr int JOY_R_LEFTUP    = 256 + 15;
+constexpr int JOY_R_LEFTDOWN  = 256 + 16;
+
+// Named gamepad buttons (SDL controller mapping)
+// Face buttons (SDL: A=0, B=1, X=2, Y=3)
+constexpr int JOY_A  = 256 + 32;
+constexpr int JOY_B  = 256 + 33;
+constexpr int JOY_X  = 256 + 34;
+constexpr int JOY_Y  = 256 + 35;
+
+// Shoulder buttons
+constexpr int JOY_LB = 256 + 36;  // Left bumper (ALT modifier)
+constexpr int JOY_RB = 256 + 37;  // Right bumper
+
+// Triggers
+constexpr int JOY_LT = 256 + 38;  // Left trigger
+constexpr int JOY_RT = 256 + 39;  // Right trigger (move confirm)
+
+// Stick clicks
+constexpr int JOY_LS = 256 + 40;  // Left stick click
+constexpr int JOY_RS = 256 + 41;  // Right stick click
+
+// D-pad (for gameplay actions, not menu navigation)
+constexpr int JOY_DPAD_UP    = 256 + 42;
+constexpr int JOY_DPAD_DOWN  = 256 + 43;
+constexpr int JOY_DPAD_LEFT  = 256 + 44;
+constexpr int JOY_DPAD_RIGHT = 256 + 45;
+
+// Start/Back
+constexpr int JOY_START = 256 + 46;
+constexpr int JOY_BACK  = 256 + 47;
+
+// ALT variants (when LB is held)
+constexpr int JOY_ALT_A  = 256 + 48;
+constexpr int JOY_ALT_B  = 256 + 49;
+constexpr int JOY_ALT_X  = 256 + 50;
+constexpr int JOY_ALT_Y  = 256 + 51;
+constexpr int JOY_ALT_RB = 256 + 52;
+constexpr int JOY_ALT_LB = 256 + 53;
+constexpr int JOY_ALT_RT = 256 + 55;
+constexpr int JOY_ALT_LS = 256 + 56;
+constexpr int JOY_ALT_RS = 256 + 57;
+constexpr int JOY_ALT_DPAD_UP    = 256 + 58;
+constexpr int JOY_ALT_DPAD_DOWN  = 256 + 59;
+constexpr int JOY_ALT_DPAD_LEFT  = 256 + 60;
+constexpr int JOY_ALT_DPAD_RIGHT = 256 + 61;
+constexpr int JOY_ALT_START = 256 + 62;
+constexpr int JOY_ALT_BACK  = 256 + 63;
+
+// Left radial menu
+constexpr int JOY_RADIAL_L_N  = 256 + 64;
+constexpr int JOY_RADIAL_L_NE = 256 + 65;
+constexpr int JOY_RADIAL_L_E  = 256 + 66;
+constexpr int JOY_RADIAL_L_SE = 256 + 67;
+constexpr int JOY_RADIAL_L_S  = 256 + 68;
+constexpr int JOY_RADIAL_L_SW = 256 + 69;
+constexpr int JOY_RADIAL_L_W  = 256 + 70;
+constexpr int JOY_RADIAL_L_NW = 256 + 71;
+
+// Right radial menu
+constexpr int JOY_RADIAL_R_N  = 256 + 72;
+constexpr int JOY_RADIAL_R_NE = 256 + 73;
+constexpr int JOY_RADIAL_R_E  = 256 + 74;
+constexpr int JOY_RADIAL_R_SE = 256 + 75;
+constexpr int JOY_RADIAL_R_S  = 256 + 76;
+constexpr int JOY_RADIAL_R_SW = 256 + 77;
+constexpr int JOY_RADIAL_R_W  = 256 + 78;
+constexpr int JOY_RADIAL_R_NW = 256 + 79;
 
 
 /**

--- a/src/input.h
+++ b/src/input.h
@@ -179,23 +179,23 @@ constexpr int JOY_28 = 28;
 constexpr int JOY_29 = 29;
 constexpr int JOY_30 = 30;
 
-constexpr int JOY_L_LEFT      = 256 + 1;
-constexpr int JOY_L_RIGHT     = 256 + 2;
-constexpr int JOY_L_UP        = 256 + 3;
-constexpr int JOY_L_DOWN      = 256 + 4;
-constexpr int JOY_L_RIGHTUP   = 256 + 5;
-constexpr int JOY_L_RIGHTDOWN = 256 + 6;
-constexpr int JOY_L_LEFTUP    = 256 + 7;
-constexpr int JOY_L_LEFTDOWN  = 256 + 8;
+constexpr int JOY_LS_LEFT      = 256 + 1;
+constexpr int JOY_LS_RIGHT     = 256 + 2;
+constexpr int JOY_LS_UP        = 256 + 3;
+constexpr int JOY_LS_DOWN      = 256 + 4;
+constexpr int JOY_LS_UP_RIGHT   = 256 + 5;
+constexpr int JOY_LS_DOWN_RIGHT = 256 + 6;
+constexpr int JOY_LS_UP_LEFT    = 256 + 7;
+constexpr int JOY_LS_DOWN_LEFT  = 256 + 8;
 
-constexpr int JOY_R_LEFT      = 256 + 9;
-constexpr int JOY_R_RIGHT     = 256 + 10;
-constexpr int JOY_R_UP        = 256 + 11;
-constexpr int JOY_R_DOWN      = 256 + 12;
-constexpr int JOY_R_RIGHTUP   = 256 + 13;
-constexpr int JOY_R_RIGHTDOWN = 256 + 14;
-constexpr int JOY_R_LEFTUP    = 256 + 15;
-constexpr int JOY_R_LEFTDOWN  = 256 + 16;
+constexpr int JOY_RS_LEFT      = 256 + 9;
+constexpr int JOY_RS_RIGHT     = 256 + 10;
+constexpr int JOY_RS_UP        = 256 + 11;
+constexpr int JOY_RS_DOWN      = 256 + 12;
+constexpr int JOY_RS_UP_RIGHT   = 256 + 13;
+constexpr int JOY_RS_DOWN_RIGHT = 256 + 14;
+constexpr int JOY_RS_UP_LEFT    = 256 + 15;
+constexpr int JOY_RS_DOWN_LEFT  = 256 + 16;
 
 // Named gamepad buttons (SDL controller mapping)
 // Face buttons (SDL: A=0, B=1, X=2, Y=3)
@@ -217,10 +217,10 @@ constexpr int JOY_LS = 256 + 40;  // Left stick click
 constexpr int JOY_RS = 256 + 41;  // Right stick click
 
 // D-pad (for gameplay actions, not menu navigation)
-constexpr int JOY_DPAD_UP    = 256 + 42;
-constexpr int JOY_DPAD_DOWN  = 256 + 43;
-constexpr int JOY_DPAD_LEFT  = 256 + 44;
-constexpr int JOY_DPAD_RIGHT = 256 + 45;
+constexpr int JOY_UP    = 256 + 42;
+constexpr int JOY_DOWN  = 256 + 43;
+constexpr int JOY_LEFT  = 256 + 44;
+constexpr int JOY_RIGHT = 256 + 45;
 
 // Start/Back
 constexpr int JOY_START = 256 + 46;
@@ -236,32 +236,32 @@ constexpr int JOY_ALT_LB = 256 + 53;
 constexpr int JOY_ALT_RT = 256 + 55;
 constexpr int JOY_ALT_LS = 256 + 56;
 constexpr int JOY_ALT_RS = 256 + 57;
-constexpr int JOY_ALT_DPAD_UP    = 256 + 58;
-constexpr int JOY_ALT_DPAD_DOWN  = 256 + 59;
-constexpr int JOY_ALT_DPAD_LEFT  = 256 + 60;
-constexpr int JOY_ALT_DPAD_RIGHT = 256 + 61;
+constexpr int JOY_ALT_UP    = 256 + 58;
+constexpr int JOY_ALT_DOWN  = 256 + 59;
+constexpr int JOY_ALT_LEFT  = 256 + 60;
+constexpr int JOY_ALT_RIGHT = 256 + 61;
 constexpr int JOY_ALT_START = 256 + 62;
 constexpr int JOY_ALT_BACK  = 256 + 63;
 
 // Left radial menu
-constexpr int JOY_RADIAL_L_N  = 256 + 64;
-constexpr int JOY_RADIAL_L_NE = 256 + 65;
-constexpr int JOY_RADIAL_L_E  = 256 + 66;
-constexpr int JOY_RADIAL_L_SE = 256 + 67;
-constexpr int JOY_RADIAL_L_S  = 256 + 68;
-constexpr int JOY_RADIAL_L_SW = 256 + 69;
-constexpr int JOY_RADIAL_L_W  = 256 + 70;
-constexpr int JOY_RADIAL_L_NW = 256 + 71;
+constexpr int JOY_L_RADIAL_N  = 256 + 64;
+constexpr int JOY_L_RADIAL_NE = 256 + 65;
+constexpr int JOY_L_RADIAL_E  = 256 + 66;
+constexpr int JOY_L_RADIAL_SE = 256 + 67;
+constexpr int JOY_L_RADIAL_S  = 256 + 68;
+constexpr int JOY_L_RADIAL_SW = 256 + 69;
+constexpr int JOY_L_RADIAL_W  = 256 + 70;
+constexpr int JOY_L_RADIAL_NW = 256 + 71;
 
 // Right radial menu
-constexpr int JOY_RADIAL_R_N  = 256 + 72;
-constexpr int JOY_RADIAL_R_NE = 256 + 73;
-constexpr int JOY_RADIAL_R_E  = 256 + 74;
-constexpr int JOY_RADIAL_R_SE = 256 + 75;
-constexpr int JOY_RADIAL_R_S  = 256 + 76;
-constexpr int JOY_RADIAL_R_SW = 256 + 77;
-constexpr int JOY_RADIAL_R_W  = 256 + 78;
-constexpr int JOY_RADIAL_R_NW = 256 + 79;
+constexpr int JOY_R_RADIAL_N  = 256 + 72;
+constexpr int JOY_R_RADIAL_NE = 256 + 73;
+constexpr int JOY_R_RADIAL_E  = 256 + 74;
+constexpr int JOY_R_RADIAL_SE = 256 + 75;
+constexpr int JOY_R_RADIAL_S  = 256 + 76;
+constexpr int JOY_R_RADIAL_SW = 256 + 77;
+constexpr int JOY_R_RADIAL_W  = 256 + 78;
+constexpr int JOY_R_RADIAL_NW = 256 + 79;
 
 
 /**

--- a/src/input_context.cpp
+++ b/src/input_context.cpp
@@ -1341,7 +1341,11 @@ bool input_context::is_event_type_enabled( const input_event_t type ) const
         case input_event_t::keyboard_code:
             return input_manager::actual_keyboard_mode( preferred_keyboard_mode ) == keyboard_mode::keycode;
         case input_event_t::gamepad:
+#if defined(TILES)
             return gamepad::is_active();
+#else
+            return false;
+#endif
         case input_event_t::mouse:
             return true;
     }

--- a/src/input_context.cpp
+++ b/src/input_context.cpp
@@ -154,9 +154,11 @@ const std::string &input_context::input_to_action( const input_event &inp ) cons
     return CATA_ERROR;
 }
 
-#if defined(__ANDROID__)
+#if defined(__ANDROID__) || defined(TILES)
 std::list<input_context *> input_context::input_context_stack;
+#endif
 
+#if defined(__ANDROID__)
 void input_context::register_manual_key( manual_key mk )
 {
     // Prevent duplicates

--- a/src/input_context.cpp
+++ b/src/input_context.cpp
@@ -36,6 +36,7 @@
 #include "string_input_popup.h"
 #include "translations.h"
 #include "ui_manager.h"
+#include "sdl_gamepad.h"
 
 enum class kb_menu_status {
     remove, reset, add, add_global, execute, show, filter
@@ -1143,11 +1144,6 @@ input_event input_context::get_raw_input()
 
 #if defined(TUI)
 // Also specify that we don't have a gamepad plugged in.
-bool gamepad_available()
-{
-    return false;
-}
-
 std::optional<tripoint_bub_ms> input_context::get_coordinates( const catacurses::window
         &capture_win, const point &offset, const bool center_cursor ) const
 {
@@ -1345,7 +1341,7 @@ bool input_context::is_event_type_enabled( const input_event_t type ) const
         case input_event_t::keyboard_code:
             return input_manager::actual_keyboard_mode( preferred_keyboard_mode ) == keyboard_mode::keycode;
         case input_event_t::gamepad:
-            return gamepad_available();
+            return gamepad::is_active();
         case input_event_t::mouse:
             return true;
     }

--- a/src/input_context.h
+++ b/src/input_context.h
@@ -8,7 +8,7 @@
 #include <string_view>
 #include <vector>
 
-#if defined(__ANDROID__)
+#if defined(__ANDROID__) || defined(TILES)
 #include <list>
 #endif
 
@@ -41,15 +41,17 @@ class input_context
 {
         friend class keybindings_ui;
     public:
-#if defined(__ANDROID__)
+#if defined(__ANDROID__) || defined(TILES)
         // Whatever's on top is our current input context.
         static std::list<input_context *> input_context_stack;
 #endif
 
         input_context() : registered_any_input( false ), category( "default" ),
             coordinate_input_received( false ), handling_coordinate_input( false ) {
-#if defined(__ANDROID__)
+#if defined(__ANDROID__) || defined(TILES)
             input_context_stack.push_back( this );
+#endif
+#if defined(__ANDROID__)
             allow_text_entry = false;
 #endif
             register_action( "toggle_language_to_en" );
@@ -61,18 +63,22 @@ class input_context
             : registered_any_input( false ), category( category ),
               coordinate_input_received( false ), handling_coordinate_input( false ),
               preferred_keyboard_mode( preferred_keyboard_mode ) {
-#if defined(__ANDROID__)
+#if defined(__ANDROID__) || defined(TILES)
             input_context_stack.push_back( this );
+#endif
+#if defined(__ANDROID__)
             allow_text_entry = false;
 #endif
             register_action( "toggle_language_to_en" );
         }
 
-#if defined(__ANDROID__)
+#if defined(__ANDROID__) || defined(TILES)
         virtual ~input_context() {
             input_context_stack.remove( this );
         }
+#endif
 
+#if defined(__ANDROID__)
         // HACK: hack to allow creating manual keybindings for getch() instances, uilists etc. that don't use an input_context outside of the Android version
         struct manual_key {
             manual_key( int _key, const std::string &_text ) : key( _key ), text( _text ) {}

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1037,7 +1037,7 @@ static void tell_magic_veh_stop_following()
     }
 }
 
-void game::chat()
+void game::chat( const std::optional<tripoint_bub_ms> &p )
 {
     map &here = get_map();
 
@@ -1048,24 +1048,37 @@ void game::chat()
         // TODO: Get rid of the z-level check when z-level vision gets "better"
         return ( guy.is_npc() || ( guy.is_monster() &&
                                    guy.as_monster()->has_flag( mon_flag_CONVERSATION ) &&
-                                   !guy.as_monster()->type->chat_topics.empty() ) ) && u.posz() == guy.posz() &&
-               u.sees( here, guy.pos_bub( here ) ) &&
-               rl_dist( u.pos_abs(), guy.pos_abs() ) <= SEEX * 2;
+                                   !guy.as_monster()->type->chat_topics.empty() ) ) && player_character.posz() == guy.posz() &&
+               player_character.sees( here, guy.pos_bub( here ) ) &&
+               rl_dist( player_character.pos_abs(), guy.pos_abs() ) <= SEEX * 2;
     } );
+
+    if( p.has_value() ) {
+        Creature *target = get_creature_tracker().creature_at( *p );
+        if( target ) {
+            auto it = std::find( available.begin(), available.end(), target );
+            if( it != available.end() ) {
+                get_avatar().talk_to( get_talker_for( **it ) );
+                return;
+            }
+        }
+    }
+
     const int available_count = available.size();
     const std::vector<npc *> followers = get_npcs_if( [&]( const npc & guy ) {
-        return guy.is_player_ally() && guy.is_following() && guy.can_hear( u.pos_bub(), volume );
+        return guy.is_player_ally() && guy.is_following() &&
+               guy.can_hear( player_character.pos_bub(), volume );
     } );
     const int follower_count = followers.size();
     const std::vector<npc *> guards = get_npcs_if( [&]( const npc & guy ) {
         return guy.mission == NPC_MISSION_GUARD_ALLY &&
                guy.companion_mission_role_id != "FACTION_CAMP" &&
-               guy.can_hear( u.pos_bub(), volume );
+               guy.can_hear( player_character.pos_bub(), volume );
     } );
     const int guard_count = guards.size();
 
     const std::vector<npc *> available_for_activities = get_npcs_if( [&]( const npc & guy ) {
-        return guy.is_player_ally() && guy.can_hear( u.pos_bub(), volume ) &&
+        return guy.is_player_ally() && guy.can_hear( player_character.pos_bub(), volume ) &&
                guy.companion_mission_role_id != "FACTION CAMP";
     } );
     const int available_for_activities_count = available_for_activities.size();

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -135,7 +135,7 @@ void overmap_sidebar::draw_sidebar_text( const std::string_view &original_text,
 }
 
 overmap_sidebar::overmap_sidebar( overmap_ui::overmap_draw_data_t &data,
-                                 const input_context &ictxt ) :
+                                  const input_context &ictxt ) :
     cataimgui::window( _( "OVERMAP_SIDEBAR" ),
                        ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoNav ),
     draw_data( data ), ictxt( ictxt )

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -134,10 +134,11 @@ void overmap_sidebar::draw_sidebar_text( const std::string_view &original_text,
     ImGui::NewLine();
 }
 
-overmap_sidebar::overmap_sidebar( overmap_ui::overmap_draw_data_t &data ) :
+overmap_sidebar::overmap_sidebar( overmap_ui::overmap_draw_data_t &data,
+                                 const input_context &ictxt ) :
     cataimgui::window( _( "OVERMAP_SIDEBAR" ),
                        ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoNav ),
-    draw_data( data )
+    draw_data( data ), ictxt( ictxt )
 {
     init();
 }
@@ -184,9 +185,8 @@ void overmap_sidebar::draw_controls()
 
 void overmap_sidebar::print_hint( const std::string &action, nc_color color )
 {
-    const input_context &ctxt = draw_data.ictxt;
     draw_sidebar_text( string_format( _( "%s - %s" ),
-                                      ctxt.get_desc( action ), ctxt.get_action_name( action ) ), color );
+                                      ictxt.get_desc( action ), ictxt.get_action_name( action ) ), color );
 }
 
 void overmap_sidebar::draw_tile_info()
@@ -274,10 +274,9 @@ void overmap_sidebar::draw_settings_info()
 
 void overmap_sidebar::draw_quick_reference()
 {
-    const input_context &ctxt = draw_data.ictxt;
     draw_sidebar_text( _( "Use movement keys to pan." ), c_magenta );
     draw_sidebar_text( string_format( _( "Press %s to preview route." ),
-                                      ctxt.get_desc( "CHOOSE_DESTINATION" ) ), c_magenta );
+                                      ictxt.get_desc( "CHOOSE_DESTINATION" ) ), c_magenta );
     draw_sidebar_text( _( "Press again to confirm." ), c_magenta );
     print_hint( "LEVEL_UP" );
     print_hint( "LEVEL_DOWN" );
@@ -2061,7 +2060,7 @@ static tripoint_abs_omt display()
     tripoint_abs_omt &orig = data.origin_pos;
     std::vector<tripoint_abs_omt> &display_path = data.display_path;
     tripoint_abs_omt &select = data.select;
-    input_context &ictxt = data.ictxt;
+    input_context ictxt( "OVERMAP" );
 
     const int previous_zoom = g->get_zoom();
     g->set_zoom( overmap_zoom_level );
@@ -2076,7 +2075,7 @@ static tripoint_abs_omt display()
     data.ui = std::make_shared<ui_adaptor>();
     std::shared_ptr<ui_adaptor> ui = data.ui;
 
-    overmap_sidebar om_sidebar( data );
+    overmap_sidebar om_sidebar( data, ictxt );
 
     ui->on_screen_resize( []( ui_adaptor & ui ) {
         /**

--- a/src/overmap_ui.h
+++ b/src/overmap_ui.h
@@ -15,12 +15,12 @@
 #include "city.h"
 #include "color.h"
 #include "coordinates.h"
-#include "input_context.h"
 #include "map_scale_constants.h"
 #include "point.h"
 #include "string_id.h"
 
 class ui_adaptor;
+class input_context;
 
 constexpr int RANDOM_CITY_ENTRY = INT_MIN;
 

--- a/src/overmap_ui.h
+++ b/src/overmap_ui.h
@@ -146,11 +146,8 @@ struct overmap_draw_data_t {
     tripoint_abs_omt cursor_pos = tripoint_abs_omt( -1, -1, -1 );
     //the UI adaptor for the overmap; this can keep the overmap displayed while turns are processed
     std::shared_ptr<ui_adaptor> ui;
-    input_context ictxt;
 
-    overmap_draw_data_t() {
-        ictxt = input_context( "OVERMAP" );
-    }
+    overmap_draw_data_t() = default;
 };
 
 #if defined(TILES)
@@ -171,6 +168,7 @@ bool is_generated_omt( const point_abs_omt &omp );
 class overmap_sidebar : public cataimgui::window
 {
         overmap_ui::overmap_draw_data_t &draw_data;
+        const input_context &ictxt;
         //uses input context to print a keybind hint
         void draw_sidebar_text( const std::string_view &original_text, const nc_color &color );
         void print_hint( const std::string &action, nc_color color = c_magenta );
@@ -183,7 +181,7 @@ class overmap_sidebar : public cataimgui::window
     public:
         int width = 0;
         int x_pos = 0;
-        explicit overmap_sidebar( overmap_ui::overmap_draw_data_t &data );
+        overmap_sidebar( overmap_ui::overmap_draw_data_t &data, const input_context &ictxt );
 
         void init();
         void draw_controls() override;

--- a/src/sdl_gamepad.cpp
+++ b/src/sdl_gamepad.cpp
@@ -599,7 +599,7 @@ void handle_button_event( SDL_Event &event )
         // If in a menu, send keyboard arrow keys for navigation
         // If in gameplay, send JOY_* codes for mapped actions
         case SDL_CONTROLLER_BUTTON_DPAD_UP:
-            if( is_in_menu() && !alt_modifier_held) {
+            if( is_in_menu() && !alt_modifier_held ) {
                 joy_code = KEY_UP;
                 input_type = input_event_t::keyboard_char;
             } else {
@@ -607,7 +607,7 @@ void handle_button_event( SDL_Event &event )
             }
             break;
         case SDL_CONTROLLER_BUTTON_DPAD_DOWN:
-            if( is_in_menu() && !alt_modifier_held) {
+            if( is_in_menu() && !alt_modifier_held ) {
                 joy_code = KEY_DOWN;
                 input_type = input_event_t::keyboard_char;
             } else {
@@ -615,7 +615,7 @@ void handle_button_event( SDL_Event &event )
             }
             break;
         case SDL_CONTROLLER_BUTTON_DPAD_LEFT:
-            if( is_in_menu() && !alt_modifier_held) {
+            if( is_in_menu() && !alt_modifier_held ) {
                 joy_code = KEY_LEFT;
                 input_type = input_event_t::keyboard_char;
             } else {
@@ -623,7 +623,7 @@ void handle_button_event( SDL_Event &event )
             }
             break;
         case SDL_CONTROLLER_BUTTON_DPAD_RIGHT:
-            if( is_in_menu() && !alt_modifier_held) {
+            if( is_in_menu() && !alt_modifier_held ) {
                 joy_code = KEY_RIGHT;
                 input_type = input_event_t::keyboard_char;
             } else {

--- a/src/sdl_gamepad.cpp
+++ b/src/sdl_gamepad.cpp
@@ -253,11 +253,11 @@ int direction_to_radial_joy( direction dir, int stick_idx )
 }
 
 // Calculate 8-way direction from raw axis values using angle
-static direction angle_to_direction( int x, int y )
+static direction angle_to_direction( const point &p )
 {
     // atan2 returns angle in radians, with 0 pointing right (East)
     // We want 0 to be North, so we use atan2(x, -y)
-    double angle = std::atan2( static_cast<double>( x ), static_cast<double>( -y ) );
+    double angle = std::atan2( static_cast<double>( p.x ), static_cast<double>( -p.y ) );
 
     // Convert to degrees (0-360, with 0 = North, clockwise)
     double degrees = angle * 180.0 / M_PI;
@@ -405,17 +405,17 @@ bool handle_axis_event( SDL_Event &event )
         int axis_idx = one_of_two( sticks_axis[i], axis );
         if( axis_idx >= 0 ) {
             // Get current values for both axes of this stick
-            int x_val = SDL_GameControllerGetAxis( controller,
-                                                   static_cast<SDL_GameControllerAxis>( sticks_axis[i][0] ) );
-            int y_val = SDL_GameControllerGetAxis( controller,
-                                                   static_cast<SDL_GameControllerAxis>( sticks_axis[i][1] ) );
+            const point val(
+                SDL_GameControllerGetAxis( controller,
+                                           static_cast<SDL_GameControllerAxis>( sticks_axis[i][0] ) ),
+                SDL_GameControllerGetAxis( controller,
+                                           static_cast<SDL_GameControllerAxis>( sticks_axis[i][1] ) ) );
 
             // Calculate magnitude (distance from center)
-            double magnitude = std::sqrt( static_cast<double>( x_val ) * x_val +
-                                          static_cast<double>( y_val ) * y_val );
+            double magnitude = std::sqrt( static_cast<double>( val.x ) * val.x +
+                                          static_cast<double>( val.y ) * val.y );
 
-            direction dir = ( magnitude > sticks_threshold ) ? angle_to_direction( x_val,
-                            y_val ) : direction::NONE;
+            direction dir = ( magnitude > sticks_threshold ) ? angle_to_direction( val ) : direction::NONE;
 
             task_t &stick_task = all_tasks[sticks_task_index + i];
             direction old_dir = ( i == 0 ) ? left_stick_dir : right_stick_dir;
@@ -743,21 +743,21 @@ tripoint direction_to_offset( direction dir )
 {
     switch( dir ) {
         case direction::N:
-            return tripoint( 0, -1, 0 );
+            return tripoint::north;
         case direction::NE:
-            return tripoint( 1, -1, 0 );
+            return tripoint::north_east;
         case direction::E:
-            return tripoint( 1, 0, 0 );
+            return tripoint::east;
         case direction::SE:
-            return tripoint( 1, 1, 0 );
+            return tripoint::south_east;
         case direction::S:
-            return tripoint( 0, 1, 0 );
+            return tripoint::south;
         case direction::SW:
-            return tripoint( -1, 1, 0 );
+            return tripoint::south_west;
         case direction::W:
-            return tripoint( -1, 0, 0 );
+            return tripoint::west;
         case direction::NW:
-            return tripoint( -1, -1, 0 );
+            return tripoint::north_west;
         case direction::NONE:
         default:
             return tripoint::zero;

--- a/src/sdl_gamepad.cpp
+++ b/src/sdl_gamepad.cpp
@@ -162,22 +162,38 @@ static void send_input( int ibtn, input_event_t itype = input_event_t::gamepad )
 static int get_alt_button( int base_code )
 {
     switch( base_code ) {
-        case JOY_A:  return JOY_ALT_A;
-        case JOY_B:  return JOY_ALT_B;
-        case JOY_X:  return JOY_ALT_X;
-        case JOY_Y:  return JOY_ALT_Y;
-        case JOY_LB: return JOY_ALT_LB;
-        case JOY_RB: return JOY_ALT_RB;
-        case JOY_RT: return JOY_ALT_RT;
-        case JOY_LS: return JOY_ALT_LS;
-        case JOY_RS: return JOY_ALT_RS;
-        case JOY_DPAD_UP:    return JOY_ALT_DPAD_UP;
-        case JOY_DPAD_DOWN:  return JOY_ALT_DPAD_DOWN;
-        case JOY_DPAD_LEFT:  return JOY_ALT_DPAD_LEFT;
-        case JOY_DPAD_RIGHT: return JOY_ALT_DPAD_RIGHT;
-        case JOY_START: return JOY_ALT_START;
-        case JOY_BACK:  return JOY_ALT_BACK;
-        default: return base_code;
+        case JOY_A:
+            return JOY_ALT_A;
+        case JOY_B:
+            return JOY_ALT_B;
+        case JOY_X:
+            return JOY_ALT_X;
+        case JOY_Y:
+            return JOY_ALT_Y;
+        case JOY_LB:
+            return JOY_ALT_LB;
+        case JOY_RB:
+            return JOY_ALT_RB;
+        case JOY_RT:
+            return JOY_ALT_RT;
+        case JOY_LS:
+            return JOY_ALT_LS;
+        case JOY_RS:
+            return JOY_ALT_RS;
+        case JOY_DPAD_UP:
+            return JOY_ALT_DPAD_UP;
+        case JOY_DPAD_DOWN:
+            return JOY_ALT_DPAD_DOWN;
+        case JOY_DPAD_LEFT:
+            return JOY_ALT_DPAD_LEFT;
+        case JOY_DPAD_RIGHT:
+            return JOY_ALT_DPAD_RIGHT;
+        case JOY_START:
+            return JOY_ALT_START;
+        case JOY_BACK:
+            return JOY_ALT_BACK;
+        default:
+            return base_code;
     }
 }
 
@@ -185,15 +201,24 @@ static int get_alt_button( int base_code )
 static int direction_to_num_key( direction dir )
 {
     switch( dir ) {
-        case direction::N:  return '8';
-        case direction::NE: return '9';
-        case direction::E:  return '6';
-        case direction::SE: return '3';
-        case direction::S:  return '2';
-        case direction::SW: return '1';
-        case direction::W:  return '4';
-        case direction::NW: return '7';
-        default: return -1;
+        case direction::N:
+            return '8';
+        case direction::NE:
+            return '9';
+        case direction::E:
+            return '6';
+        case direction::SE:
+            return '3';
+        case direction::S:
+            return '2';
+        case direction::SW:
+            return '1';
+        case direction::W:
+            return '4';
+        case direction::NW:
+            return '7';
+        default:
+            return -1;
     }
 }
 
@@ -205,15 +230,24 @@ int direction_to_radial_joy( direction dir, int stick_idx )
     }
     int base = ( stick_idx == 0 ) ? JOY_RADIAL_L_N : JOY_RADIAL_R_N;
     switch( dir ) {
-        case direction::N:  return base + 0;
-        case direction::NE: return base + 1;
-        case direction::E:  return base + 2;
-        case direction::SE: return base + 3;
-        case direction::S:  return base + 4;
-        case direction::SW: return base + 5;
-        case direction::W:  return base + 6;
-        case direction::NW: return base + 7;
-        default: return -1;
+        case direction::N:
+            return base + 0;
+        case direction::NE:
+            return base + 1;
+        case direction::E:
+            return base + 2;
+        case direction::SE:
+            return base + 3;
+        case direction::S:
+            return base + 4;
+        case direction::SW:
+            return base + 5;
+        case direction::W:
+            return base + 6;
+        case direction::NW:
+            return base + 7;
+        default:
+            return -1;
     }
 }
 
@@ -223,13 +257,13 @@ static direction angle_to_direction( int x, int y )
     // atan2 returns angle in radians, with 0 pointing right (East)
     // We want 0 to be North, so we use atan2(x, -y)
     double angle = std::atan2( static_cast<double>( x ), static_cast<double>( -y ) );
-    
+
     // Convert to degrees (0-360, with 0 = North, clockwise)
     double degrees = angle * 180.0 / M_PI;
     if( degrees < 0 ) {
         degrees += 360.0;
     }
-    
+
     // Each direction covers 45 degrees, centered on its cardinal/diagonal
     // N: 337.5 - 22.5, NE: 22.5 - 67.5, E: 67.5 - 112.5, etc.
     if( degrees >= 337.5 || degrees < 22.5 ) {
@@ -257,18 +291,35 @@ static void send_direction_movement()
     if( left_stick_dir == direction::NONE ) {
         return;
     }
-    
+
     // Convert direction to old-style JOY movement for keybinding lookup
     switch( left_stick_dir ) {
-        case direction::N:  send_input( JOY_L_UP ); break;
-        case direction::NE: send_input( JOY_L_RIGHTUP ); break;
-        case direction::E:  send_input( JOY_L_RIGHT ); break;
-        case direction::SE: send_input( JOY_L_RIGHTDOWN ); break;
-        case direction::S:  send_input( JOY_L_DOWN ); break;
-        case direction::SW: send_input( JOY_L_LEFTDOWN ); break;
-        case direction::W:  send_input( JOY_L_LEFT ); break;
-        case direction::NW: send_input( JOY_L_LEFTUP ); break;
-        default: break;
+        case direction::N:
+            send_input( JOY_L_UP );
+            break;
+        case direction::NE:
+            send_input( JOY_L_RIGHTUP );
+            break;
+        case direction::E:
+            send_input( JOY_L_RIGHT );
+            break;
+        case direction::SE:
+            send_input( JOY_L_RIGHTDOWN );
+            break;
+        case direction::S:
+            send_input( JOY_L_DOWN );
+            break;
+        case direction::SW:
+            send_input( JOY_L_LEFTDOWN );
+            break;
+        case direction::W:
+            send_input( JOY_L_LEFT );
+            break;
+        case direction::NW:
+            send_input( JOY_L_LEFTUP );
+            break;
+        default:
+            break;
     }
 }
 
@@ -290,7 +341,7 @@ bool handle_axis_event( SDL_Event &event )
         task_t &task = all_tasks[triggers_task_index + idx];
         bool trigger_pressed = value > triggers_threshold + error_margin;
         bool trigger_released = value < triggers_threshold - error_margin;
-        
+
         if( idx == 1 ) {
             // Right trigger (RT)
             if( !state && trigger_pressed ) {
@@ -354,13 +405,13 @@ bool handle_axis_event( SDL_Event &event )
         if( axis_idx >= 0 ) {
             // Get current values for both axes of this stick
             int x_val = SDL_GameControllerGetAxis( controller,
-                        static_cast<SDL_GameControllerAxis>( sticks_axis[i][0] ) );
+                                                   static_cast<SDL_GameControllerAxis>( sticks_axis[i][0] ) );
             int y_val = SDL_GameControllerGetAxis( controller,
-                        static_cast<SDL_GameControllerAxis>( sticks_axis[i][1] ) );
+                                                   static_cast<SDL_GameControllerAxis>( sticks_axis[i][1] ) );
 
             // Calculate magnitude (distance from center)
             double magnitude = std::sqrt( static_cast<double>( x_val ) * x_val +
-                                            static_cast<double>( y_val ) * y_val );
+                                          static_cast<double>( y_val ) * y_val );
 
             direction dir = ( magnitude > sticks_threshold ) ? angle_to_direction( x_val,
                             y_val ) : direction::NONE;
@@ -390,7 +441,7 @@ bool handle_axis_event( SDL_Event &event )
                     if( dir != radial_last ) {
                         radial_last = dir;
                     }
-                } else{
+                } else {
                     // When stick is released just update the UI
                     if( radial_open ) {
                         direction_changed = true;
@@ -405,7 +456,7 @@ bool handle_axis_event( SDL_Event &event )
 
                 if( i == 0 ) {
                     // Left stick (i=0): Map to num keys in menu if the radial menu is not open
-                    if( is_in_menu() && !radial_left_open) {
+                    if( is_in_menu() && !radial_left_open ) {
                         joy_code = direction_to_num_key( dir );
                         itype = input_event_t::keyboard_char;
                     }
@@ -413,21 +464,38 @@ bool handle_axis_event( SDL_Event &event )
                 } else {
                     // Right stick (i=1): Map to num keys in menu if the radial menu is not open, or JOY_R_* in gameplay
                     if( is_in_menu() ) {
-                        if( !radial_right_open) {
+                        if( !radial_right_open ) {
                             joy_code = direction_to_num_key( dir );
                             itype = input_event_t::keyboard_char;
                         }
                     } else {
                         switch( dir ) {
-                            case direction::N:  joy_code = JOY_R_UP; break;
-                            case direction::NE: joy_code = JOY_R_RIGHTUP; break;
-                            case direction::E:  joy_code = JOY_R_RIGHT; break;
-                            case direction::SE: joy_code = JOY_R_RIGHTDOWN; break;
-                            case direction::S:  joy_code = JOY_R_DOWN; break;
-                            case direction::SW: joy_code = JOY_R_LEFTDOWN; break;
-                            case direction::W:  joy_code = JOY_R_LEFT; break;
-                            case direction::NW: joy_code = JOY_R_LEFTUP; break;
-                            default: break;
+                            case direction::N:
+                                joy_code = JOY_R_UP;
+                                break;
+                            case direction::NE:
+                                joy_code = JOY_R_RIGHTUP;
+                                break;
+                            case direction::E:
+                                joy_code = JOY_R_RIGHT;
+                                break;
+                            case direction::SE:
+                                joy_code = JOY_R_RIGHTDOWN;
+                                break;
+                            case direction::S:
+                                joy_code = JOY_R_DOWN;
+                                break;
+                            case direction::SW:
+                                joy_code = JOY_R_LEFTDOWN;
+                                break;
+                            case direction::W:
+                                joy_code = JOY_R_LEFT;
+                                break;
+                            case direction::NW:
+                                joy_code = JOY_R_LEFTUP;
+                                break;
+                            default:
+                                break;
                         }
                     }
                 }

--- a/src/sdl_gamepad.cpp
+++ b/src/sdl_gamepad.cpp
@@ -2,20 +2,24 @@
 #include "sdl_gamepad.h"
 
 #include <array>
+#include <cmath>
 #include <ostream>
 
 #include "debug.h"
 #include "input.h"
 #include "input_enums.h"
+#include "point.h"
+#include "ui_manager.h"
 
-#define dbg(x) DebugLog((x),D_SDL) << __FILE__ << ":" << __LINE__ << ": "
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
 
 namespace gamepad
 {
 
 static constexpr int max_triggers = 2;
 static constexpr int max_sticks = 2;
-//constexpr int max_axis = 6;
 static constexpr int max_buttons = 30;
 
 static std::array<int, max_triggers> triggers_axis = {
@@ -29,37 +33,41 @@ static std::array<std::array<int, 2>, max_sticks> sticks_axis = { {
 };
 
 static std::array<int, max_triggers> triggers_state = {0, 0};
-static std::array<int, max_sticks> sticks_state = {0, 0};
 
 static int triggers_threshold = 16000;
 static int sticks_threshold = 16000;
 static int error_margin = 2000;
-
-static std::array<std::array<int, 16>, max_sticks> sticks_map = {};
-static std::array<int, max_triggers> triggers_map = {0};
-static std::array<int, max_buttons> buttons_map = {0};
 
 struct task_t {
     Uint32 when;
     int button;
     int counter;
     int state;
+    input_event_t type;
 };
 
 static constexpr int max_tasks           = max_buttons + max_sticks + max_triggers + 1;
-//constexpr int buttons_task_index  = 0;
 static constexpr int sticks_task_index   = max_buttons;
 static constexpr int triggers_task_index = max_buttons + max_sticks;
 
 static std::array<task_t, max_tasks> all_tasks;
 
 static int repeat_delay = 400;
-static int repeat_interval = 200;
-static int diagonal_detect_delay = 250;
+static int repeat_interval = 100;
 
 // SDL related stuff
 static SDL_TimerID timer_id;
 static SDL_GameController *controller = nullptr;
+static SDL_JoystickID controller_id = -1;
+
+static direction left_stick_dir = direction::NONE;
+static direction right_stick_dir = direction::NONE;
+static direction radial_left_last_dir = direction::NONE;
+static direction radial_right_last_dir = direction::NONE;
+static bool radial_left_open = false;
+static bool radial_right_open = false;
+static bool alt_modifier_held = false;
+static constexpr Uint32 fast_move_hold_ms = 200;
 
 static Uint32 timer_func( Uint32 interval, void * )
 {
@@ -80,32 +88,6 @@ static Uint32 timer_func( Uint32 interval, void * )
 
 void init()
 {
-    // FIXME maybe stick/trigger "buttons" need their own names?
-    sticks_map[0][0b0001] = JOY_UP;
-    sticks_map[0][0b0010] = JOY_RIGHT;
-    sticks_map[0][0b0100] = JOY_DOWN;
-    sticks_map[0][0b1000] = JOY_LEFT;
-    sticks_map[0][0b0011] = JOY_RIGHTUP;
-    sticks_map[0][0b0110] = JOY_RIGHTDOWN;
-    sticks_map[0][0b1100] = JOY_LEFTDOWN;
-    sticks_map[0][0b1001] = JOY_LEFTUP;
-
-    sticks_map[1][0b0001] = JOY_21;
-    sticks_map[1][0b0010] = JOY_22;
-    sticks_map[1][0b0100] = JOY_23;
-    sticks_map[1][0b1000] = JOY_24;
-    sticks_map[1][0b0011] = JOY_25;
-    sticks_map[1][0b0110] = JOY_26;
-    sticks_map[1][0b1100] = JOY_27;
-    sticks_map[1][0b1001] = JOY_28;
-
-    triggers_map[0] = JOY_29;
-    triggers_map[1] = JOY_30;
-
-    for( int i = 0; i < max_buttons; ++i ) {
-        buttons_map[i] = JOY_0 + i;
-    }
-
     for( gamepad::task_t &task : all_tasks ) {
         task.counter = 0;
     }
@@ -115,21 +97,13 @@ void init()
         printErrorIf( ret != 0, "Init gamecontroller+timer failed" );
         return;
     }
-    int numjoy = SDL_NumJoysticks();
-    if( numjoy >= 1 ) {
-        if( numjoy > 1 ) {
-            dbg( D_WARNING ) <<
-                             "You have more than one gamepads/joysticks plugged in, only the first will be used.";
-        }
+
+    if( SDL_NumJoysticks() > 0 ) {
         controller = SDL_GameControllerOpen( 0 );
-        printErrorIf( controller == nullptr, "SDL_GameControllerOpen failed" );
         if( controller ) {
-            printErrorIf( SDL_GameControllerEventState( SDL_ENABLE ) < 0,
-                          "SDL_GameControllerEventState(SDL_ENABLE) failed" );
+            controller_id = SDL_JoystickInstanceID( SDL_GameControllerGetJoystick( controller ) );
+            SDL_GameControllerEventState( SDL_ENABLE );
         }
-    } else {
-        controller = nullptr;
-        return;
     }
 
     timer_id = SDL_AddTimer( 50, timer_func, nullptr );
@@ -164,12 +138,14 @@ static int one_of_two( const std::array<int, 2> &arr, int val )
     return -1;
 }
 
-static void schedule_task( task_t &task, Uint32 when, int button, int state )
+static void schedule_task( task_t &task, Uint32 when, int button, int state,
+                           input_event_t type = input_event_t::gamepad )
 {
     task.when = when;
     task.button = button;
     task.counter = 1;
     task.state = state;
+    task.type = type;
 }
 
 static void cancel_task( task_t &task )
@@ -182,150 +158,454 @@ static void send_input( int ibtn, input_event_t itype = input_event_t::gamepad )
     last_input = input_event( ibtn, itype );
 }
 
-static void dpad_changes( task_t &task, const std::array<int, 16> &m, Uint32 now, int old_state,
-                          int new_state )
+
+// Helper to get ALT variant of a button code
+static int get_alt_button( int base_code )
 {
-    // get rid of unneeded bits
-    old_state &= 0b1111;
-    new_state &= 0b1111;
-
-    if( old_state == new_state ) {
-        return;
-    }
-
-    switch( new_state ) {
-        case SDL_HAT_LEFTUP:
-        case SDL_HAT_LEFTDOWN:
-        case SDL_HAT_RIGHTUP:
-        case SDL_HAT_RIGHTDOWN:
-            send_input( m[new_state] );
-            schedule_task( task, now + repeat_delay, m[new_state], new_state );
-            break;
-        case SDL_HAT_CENTERED: {
-            if( task.counter == 1 ) {
-                switch( old_state ) {
-                    // detecting quick CENTER -> Left|Up|Right|Down -> CENTER transition
-                    case SDL_HAT_UP:
-                    case SDL_HAT_DOWN:
-                    case SDL_HAT_RIGHT:
-                    case SDL_HAT_LEFT:
-                        send_input( task.button );
-                }
-            }
-            cancel_task( task );
-            break;
-        }
-        case SDL_HAT_UP:
-        case SDL_HAT_DOWN:
-        case SDL_HAT_RIGHT:
-        case SDL_HAT_LEFT:
-            schedule_task( task, now + diagonal_detect_delay, m[new_state], new_state );
-            task.counter += old_state;
-            break;
+    switch( base_code ) {
+        case JOY_A:  return JOY_ALT_A;
+        case JOY_B:  return JOY_ALT_B;
+        case JOY_X:  return JOY_ALT_X;
+        case JOY_Y:  return JOY_ALT_Y;
+        case JOY_LB: return JOY_ALT_LB;
+        case JOY_RB: return JOY_ALT_RB;
+        case JOY_RT: return JOY_ALT_RT;
+        case JOY_LS: return JOY_ALT_LS;
+        case JOY_RS: return JOY_ALT_RS;
+        case JOY_DPAD_UP:    return JOY_ALT_DPAD_UP;
+        case JOY_DPAD_DOWN:  return JOY_ALT_DPAD_DOWN;
+        case JOY_DPAD_LEFT:  return JOY_ALT_DPAD_LEFT;
+        case JOY_DPAD_RIGHT: return JOY_ALT_DPAD_RIGHT;
+        case JOY_START: return JOY_ALT_START;
+        case JOY_BACK:  return JOY_ALT_BACK;
+        default: return base_code;
     }
 }
 
-void handle_axis_event( SDL_Event &event )
+// Convert direction to numpad key ('1'-'9')
+static int direction_to_num_key( direction dir )
+{
+    switch( dir ) {
+        case direction::N:  return '8';
+        case direction::NE: return '9';
+        case direction::E:  return '6';
+        case direction::SE: return '3';
+        case direction::S:  return '2';
+        case direction::SW: return '1';
+        case direction::W:  return '4';
+        case direction::NW: return '7';
+        default: return -1;
+    }
+}
+
+// Convert direction to radial joy event
+int direction_to_radial_joy( direction dir, int stick_idx )
+{
+    if( dir == direction::NONE ) {
+        return -1;
+    }
+    int base = ( stick_idx == 0 ) ? JOY_RADIAL_L_N : JOY_RADIAL_R_N;
+    switch( dir ) {
+        case direction::N:  return base + 0;
+        case direction::NE: return base + 1;
+        case direction::E:  return base + 2;
+        case direction::SE: return base + 3;
+        case direction::S:  return base + 4;
+        case direction::SW: return base + 5;
+        case direction::W:  return base + 6;
+        case direction::NW: return base + 7;
+        default: return -1;
+    }
+}
+
+// Calculate 8-way direction from raw axis values using angle
+static direction angle_to_direction( int x, int y )
+{
+    // atan2 returns angle in radians, with 0 pointing right (East)
+    // We want 0 to be North, so we use atan2(x, -y)
+    double angle = std::atan2( static_cast<double>( x ), static_cast<double>( -y ) );
+    
+    // Convert to degrees (0-360, with 0 = North, clockwise)
+    double degrees = angle * 180.0 / M_PI;
+    if( degrees < 0 ) {
+        degrees += 360.0;
+    }
+    
+    // Each direction covers 45 degrees, centered on its cardinal/diagonal
+    // N: 337.5 - 22.5, NE: 22.5 - 67.5, E: 67.5 - 112.5, etc.
+    if( degrees >= 337.5 || degrees < 22.5 ) {
+        return direction::N;
+    } else if( degrees >= 22.5 && degrees < 67.5 ) {
+        return direction::NE;
+    } else if( degrees >= 67.5 && degrees < 112.5 ) {
+        return direction::E;
+    } else if( degrees >= 112.5 && degrees < 157.5 ) {
+        return direction::SE;
+    } else if( degrees >= 157.5 && degrees < 202.5 ) {
+        return direction::S;
+    } else if( degrees >= 202.5 && degrees < 247.5 ) {
+        return direction::SW;
+    } else if( degrees >= 247.5 && degrees < 292.5 ) {
+        return direction::W;
+    } else {
+        return direction::NW;
+    }
+}
+
+// Helper to send directional movement input
+static void send_direction_movement()
+{
+    if( left_stick_dir == direction::NONE ) {
+        return;
+    }
+    
+    // Convert direction to old-style JOY movement for keybinding lookup
+    switch( left_stick_dir ) {
+        case direction::N:  send_input( JOY_L_UP ); break;
+        case direction::NE: send_input( JOY_L_RIGHTUP ); break;
+        case direction::E:  send_input( JOY_L_RIGHT ); break;
+        case direction::SE: send_input( JOY_L_RIGHTDOWN ); break;
+        case direction::S:  send_input( JOY_L_DOWN ); break;
+        case direction::SW: send_input( JOY_L_LEFTDOWN ); break;
+        case direction::W:  send_input( JOY_L_LEFT ); break;
+        case direction::NW: send_input( JOY_L_LEFTUP ); break;
+        default: break;
+    }
+}
+
+bool handle_axis_event( SDL_Event &event )
 {
     if( event.type != SDL_CONTROLLERAXISMOTION ) {
-        return;
+        return false;
     }
 
     int axis = event.caxis.axis;
     int value = event.caxis.value;
     Uint32 now = event.caxis.timestamp;
+    bool direction_changed = false;
 
     // check triggers
     int idx = one_of_two( triggers_axis, axis );
     if( idx >= 0 ) {
         int state = triggers_state[idx];
-        int button = triggers_map[idx];
         task_t &task = all_tasks[triggers_task_index + idx];
-        if( !state && value > triggers_threshold + error_margin ) {
-            send_input( button );
-            triggers_state[idx] = 1;
-            schedule_task( task, now + repeat_delay, button, 1 );
+        bool trigger_pressed = value > triggers_threshold + error_margin;
+        bool trigger_released = value < triggers_threshold - error_margin;
+        
+            if( idx == 1 ) {
+                // Right trigger (RT)
+                if( !state && trigger_pressed ) {
+                    triggers_state[idx] = 1;
+                    // Check if direction is selected
+                    if( left_stick_dir != direction::NONE ) {
+                        // Move in selected direction
+                        send_direction_movement();
+                        // Schedule repeat for continuous movement
+                        schedule_task( task, now + fast_move_hold_ms, -1, 1 );
+                    } else {
+                        // No direction selected - send JOY_RT event (with ALT if held) and schedule repeat
+                        int joy_code = alt_modifier_held ? get_alt_button( JOY_RT ) : JOY_RT;
+                        send_input( joy_code );
+                        schedule_task( task, now + repeat_delay, joy_code, 1 );
+                    }
+                }
+                if( state && trigger_released ) {
+                    triggers_state[idx] = 0;
+                    cancel_task( task );
+                }
+            } else {
+                // Left trigger (LT)
+                if( !state && trigger_pressed ) {
+                    alt_modifier_held = true;
+                    triggers_state[idx] = 1;
+                }
+                if( state && trigger_released ) {
+                    triggers_state[idx] = 0;
+                    alt_modifier_held = false;
+
+                    // Trigger radial select on Alt release
+                    if( radial_left_open && radial_left_last_dir != direction::NONE ) {
+                        int joy_code = direction_to_radial_joy( radial_left_last_dir, 0 );
+                        if( joy_code != -1 ) {
+                            send_input( joy_code );
+                        }
+                    }
+                    if( radial_right_open && radial_right_last_dir != direction::NONE ) {
+                        int joy_code = direction_to_radial_joy( radial_right_last_dir, 1 );
+                        if( joy_code != -1 ) {
+                            send_input( joy_code );
+                        }
+                    }
+
+                    // Reset radial menu states when LT is released
+                    radial_left_open = false;
+                    radial_right_open = false;
+                    radial_left_last_dir = direction::NONE;
+                    radial_right_last_dir = direction::NONE;
+                }
+            }
+            return false;
         }
-        if( state && value < triggers_threshold - error_margin ) {
-            triggers_state[idx] = 0;
-            cancel_task( task );
+
+        // check sticks
+        for( int i = 0; i < max_sticks; ++i ) {
+            int axis_idx = one_of_two( sticks_axis[i], axis );
+            if( axis_idx >= 0 ) {
+                // Get current values for both axes of this stick
+                int x_val = SDL_GameControllerGetAxis( controller,
+                            static_cast<SDL_GameControllerAxis>( sticks_axis[i][0] ) );
+                int y_val = SDL_GameControllerGetAxis( controller,
+                            static_cast<SDL_GameControllerAxis>( sticks_axis[i][1] ) );
+
+                // Calculate magnitude (distance from center)
+                double magnitude = std::sqrt( static_cast<double>( x_val ) * x_val +
+                                              static_cast<double>( y_val ) * y_val );
+
+                direction dir = ( magnitude > sticks_threshold ) ? angle_to_direction( x_val,
+                                y_val ) : direction::NONE;
+
+                task_t &stick_task = all_tasks[sticks_task_index + i];
+                direction old_dir = ( i == 0 ) ? left_stick_dir : right_stick_dir;
+
+                if( i == 0 ) {
+                    // Left stick (i=0): Update selected direction
+                    left_stick_dir = dir;
+                    // Signal UI refresh needed if direction changed and not in menu
+                    if( old_dir != left_stick_dir && !is_in_menu() ) {
+                        direction_changed = true;
+                    }
+                } else {
+                    right_stick_dir = dir;
+                }
+
+                if( alt_modifier_held ) {
+                    // When LT is held, sticks control radial menu state
+                    direction &radial_last = ( i == 0 ) ? radial_left_last_dir : radial_right_last_dir;
+                    bool &radial_open = ( i == 0 ) ? radial_left_open : radial_right_open;
+                    bool &radial_other = ( i == 0 ) ? radial_right_open : radial_left_open;
+
+                    // Only update direction when stick is deflected beyond threshold
+                    if( dir != direction::NONE ) {
+                        radial_open = true;
+                        radial_other = false; // Mutually exclusive
+                        if( dir != radial_last ) {
+                            radial_last = dir;
+                        }
+                    }
+                    // When stick is in deadzone (released), do nothing - keep last direction
+
+                    // Cancel any existing repeat tasks when entering radial mode
+                    cancel_task( stick_task );
+                } else if( i == 1 ) {
+                    // Right stick: Output num keys in menu, or joy directions in gameplay
+                    if( is_in_menu() ) {
+                        int num_key = direction_to_num_key( dir );
+                        if( num_key != -1 ) {
+                            send_input( num_key, input_event_t::keyboard_char );
+                            schedule_task( stick_task, now + repeat_delay, num_key, 1, input_event_t::keyboard_char );
+                        } else {
+                            cancel_task( stick_task );
+                        }
+                    } else {
+                        // Right stick (i=1) in gameplay: Map to stick JOY_R_* input code and schedule repeat
+                        int joy_code = -1;
+
+                        switch( dir ) {
+                            case direction::N:
+                                joy_code = JOY_R_UP;
+                                break;
+                            case direction::E:
+                                joy_code = JOY_R_RIGHT;
+                                break;
+                            case direction::S:
+                                joy_code = JOY_R_DOWN;
+                                break;
+                            case direction::W:
+                                joy_code = JOY_R_LEFT;
+                                break;
+                            case direction::NE:
+                                joy_code = JOY_R_RIGHTUP;
+                                break;
+                            case direction::SE:
+                                joy_code = JOY_R_RIGHTDOWN;
+                                break;
+                            case direction::SW:
+                                joy_code = JOY_R_LEFTDOWN;
+                                break;
+                            case direction::NW:
+                                joy_code = JOY_R_LEFTUP;
+                                break;
+                            case direction::NONE:
+                                // Cancel repeat when stick returns to neutral
+                                cancel_task( stick_task );
+                                break;
+                        }
+
+                        if( joy_code != -1 ) {
+                            send_input( joy_code );
+                            // Schedule repeat for held direction
+                            schedule_task( stick_task, now + repeat_delay, joy_code, 1 );
+                        }
+                    }
+                } else {
+                    // Left stick (i == 0) and not in radial mode: No direct input or repeat.
+                    // It only updates left_stick_dir (handled above).
+                    cancel_task( stick_task );
+                }
+            }
+        }
+        return direction_changed;
+    }
+
+
+void handle_button_event( SDL_Event &event )
+{
+    int button = event.cbutton.button;
+    Uint32 now = event.cbutton.timestamp;
+
+    if( event.type == SDL_CONTROLLERBUTTONUP ) {
+        // Button released - only handle cleanup/task cancellation
+        if( button < max_buttons ) {
+            cancel_task( all_tasks[button] );
         }
         return;
     }
 
-    // check sticks
-    for( int i = 0; i < max_sticks; ++i ) {
-        int idx = one_of_two( sticks_axis[i], axis );
-        if( idx >= 0 ) {
-            int old_state = sticks_state[i];
-            int new_state = old_state;
-            task_t &task = all_tasks[sticks_task_index + i];
+    // SDL_CONTROLLERBUTTONDOWN:
+    // Button pressed - determine which input to send
+    int joy_code = -1;
+    input_event_t input_type = input_event_t::gamepad;
 
-            // calculate dpad state for the analog sticks, simulating joystick hat state (4 bits)
-            if( idx ) { // vertical stick movement
-                if( !( old_state & 0b0100 ) && value > sticks_threshold + error_margin ) {
-                    new_state |= 0b0100;    // turn on bit _x__
-                } else if( ( old_state & 0b0100 ) && value < sticks_threshold - error_margin ) {
-                    new_state &= 0b1011;    // turn off bit _x__
-                } else if( !( old_state & 0b0001 ) && value < -sticks_threshold - error_margin ) {
-                    new_state |= 0b0001;    // turn on bit ___x
-                } else if( ( old_state & 0b0001 ) && value > -sticks_threshold + error_margin ) {
-                    new_state &= 0b1110;    // turn off bit ___x
-                }
-            } else { // horizontal stick movement
-                if( !( old_state & 0b0010 ) && value > sticks_threshold + error_margin ) {
-                    new_state |= 0b0010;    // turn on bit __x_
-                } else if( ( old_state & 0b0010 ) && value < sticks_threshold - error_margin ) {
-                    new_state &= 0b1101;    // turn off bit __x_
-                } else if( !( old_state & 0b1000 ) && value < -sticks_threshold - error_margin ) {
-                    new_state |= 0b1000;    // turn on bit x___
-                } else if( ( old_state & 0b1000 ) && value > -sticks_threshold + error_margin ) {
-                    new_state &= 0b0111;    // turn off bit x___
-                }
+    switch( button ) {
+        case SDL_CONTROLLER_BUTTON_A:
+            if( is_in_menu() ) {
+                joy_code = '\n';
+                input_type = input_event_t::keyboard_char;
+            } else {
+                joy_code = JOY_A;
             }
+            break;
+        case SDL_CONTROLLER_BUTTON_B:
+            if( is_in_menu() ) {
+                joy_code = KEY_ESCAPE;
+                input_type = input_event_t::keyboard_code;
+            } else {
+                joy_code = JOY_B;
+            }
+            break;
+        case SDL_CONTROLLER_BUTTON_X:
+            joy_code = JOY_X;
+            break;
+        case SDL_CONTROLLER_BUTTON_Y:
+            joy_code = JOY_Y;
+            break;
+        case SDL_CONTROLLER_BUTTON_RIGHTSHOULDER:
+            if( is_in_menu() ) {
+                joy_code = '\t';
+                input_type = input_event_t::keyboard_char;
+            } else {
+                joy_code = JOY_RB;
+            }
+            break;
+        case SDL_CONTROLLER_BUTTON_LEFTSHOULDER:
+            if( is_in_menu() ) {
+                joy_code = KEY_BTAB;
+                input_type = input_event_t::keyboard_char;
+            } else {
+                joy_code = JOY_LB;
+            }
+            break;
+        case SDL_CONTROLLER_BUTTON_LEFTSTICK:
+            joy_code = JOY_LS;
+            break;
+        case SDL_CONTROLLER_BUTTON_RIGHTSTICK:
+            joy_code = JOY_RS;
+            break;
+        case SDL_CONTROLLER_BUTTON_START:
+            if( is_in_menu() ) {
+                joy_code = KEY_ESCAPE;
+                input_type = input_event_t::keyboard_code;
+            } else {
+                joy_code = JOY_START;
+            }
+            break;
+        case SDL_CONTROLLER_BUTTON_BACK:
+            if( is_in_menu() ) {
+                joy_code = KEY_ESCAPE;
+                input_type = input_event_t::keyboard_code;
+            } else {
+                joy_code = JOY_BACK;
+            }
+            break;
 
-            sticks_state[i] = new_state;
-            dpad_changes( task, sticks_map[i], now, old_state, new_state );
+        // D-pad handling
+        // If in a menu, send keyboard arrow keys for navigation
+        // If in gameplay, send JOY_DPAD_* codes for mapped actions
+        case SDL_CONTROLLER_BUTTON_DPAD_UP:
+            if( is_in_menu() ) {
+                joy_code = KEY_UP;
+                input_type = input_event_t::keyboard_char;
+            } else {
+                joy_code = JOY_DPAD_UP;
+            }
+            break;
+        case SDL_CONTROLLER_BUTTON_DPAD_DOWN:
+            if( is_in_menu() ) {
+                joy_code = KEY_DOWN;
+                input_type = input_event_t::keyboard_char;
+            } else {
+                joy_code = JOY_DPAD_DOWN;
+            }
+            break;
+        case SDL_CONTROLLER_BUTTON_DPAD_LEFT:
+            if( is_in_menu() ) {
+                joy_code = KEY_LEFT;
+                input_type = input_event_t::keyboard_char;
+            } else {
+                joy_code = JOY_DPAD_LEFT;
+            }
+            break;
+        case SDL_CONTROLLER_BUTTON_DPAD_RIGHT:
+            if( is_in_menu() ) {
+                joy_code = KEY_RIGHT;
+                input_type = input_event_t::keyboard_char;
+            } else {
+                joy_code = JOY_DPAD_RIGHT;
+            }
+            break;
+
+        default:
+            break;
+    }
+
+    // Apply ALT modifier if held (only for non-keyboard inputs)
+    if( joy_code != -1 && alt_modifier_held && input_type == input_event_t::gamepad ) {
+        joy_code = get_alt_button( joy_code );
+    }
+
+    if( joy_code != -1 ) {
+        send_input( joy_code, input_type );
+        // Only D-pad buttons repeat
+        if( button >= SDL_CONTROLLER_BUTTON_DPAD_UP && button <= SDL_CONTROLLER_BUTTON_DPAD_RIGHT ) {
+            schedule_task( all_tasks[button], now + repeat_delay, joy_code, 1, input_type );
         }
     }
 }
 
-void handle_button_event( SDL_Event &event )
+void handle_device_event( SDL_Event &event )
 {
-    switch( event.type ) {
-        case SDL_CONTROLLERBUTTONDOWN:
-        case SDL_CONTROLLERBUTTONUP: {
-            int button = event.cbutton.button;
-            int state = event.cbutton.state;
-            Uint32 now = event.cbutton.timestamp;
-            task_t &task = all_tasks[button];
-            if( state ) {
-                switch( button ) {
-                    case SDL_CONTROLLER_BUTTON_BACK:    // BACK -> Escape
-                        send_input( KEY_ESCAPE, input_event_t::keyboard_code );
-                        break;
-                    case SDL_CONTROLLER_BUTTON_START:   // START -> Enter
-                        send_input( '\n', input_event_t::keyboard_char );
-                        break;
-                    case SDL_CONTROLLER_BUTTON_DPAD_UP:
-                        send_input( KEY_UP, input_event_t::keyboard_char );
-                        break;
-                    case SDL_CONTROLLER_BUTTON_DPAD_DOWN:
-                        send_input( KEY_DOWN, input_event_t::keyboard_char );
-                        break;
-                    case SDL_CONTROLLER_BUTTON_DPAD_LEFT:
-                        send_input( KEY_LEFT, input_event_t::keyboard_char );
-                        break;
-                    case SDL_CONTROLLER_BUTTON_DPAD_RIGHT:
-                        send_input( KEY_RIGHT, input_event_t::keyboard_char );
-                        break;
-                    default:
-                        send_input( button );
-                        schedule_task( task, now + repeat_delay, buttons_map[button], state );
-                }
-            } else {
-                cancel_task( task );
+    if( event.type == SDL_CONTROLLERDEVICEADDED ) {
+        if( controller == nullptr ) {
+            controller = SDL_GameControllerOpen( event.cdevice.which );
+            if( controller ) {
+                controller_id = SDL_JoystickInstanceID( SDL_GameControllerGetJoystick( controller ) );
             }
+        }
+    } else if( event.type == SDL_CONTROLLERDEVICEREMOVED ) {
+        if( controller != nullptr && event.cdevice.which == controller_id ) {
+            SDL_GameControllerClose( controller );
+            controller = nullptr;
+            controller_id = -1;
         }
     }
 }
@@ -333,12 +613,97 @@ void handle_button_event( SDL_Event &event )
 void handle_scheduler_event( SDL_Event &event )
 {
     Uint32 now = event.user.timestamp;
-    for( gamepad::task_t &task : all_tasks ) {
+    for( size_t i = 0; i < all_tasks.size(); ++i ) {
+        gamepad::task_t &task = all_tasks[i];
         if( task.counter && task.when <= now ) {
-            send_input( task.button );
+            // Check if this is the RT repeat task
+            if( i == triggers_task_index + 1 && left_stick_dir != direction::NONE ) {
+                // RT continuous movement - send direction
+                send_direction_movement();
+            } else if( i >= sticks_task_index && i < triggers_task_index ) {
+                // Stick repeat (sticks_task_index + i where i is stick index)
+                if( task.button != -1 ) {
+                    send_input( task.button, task.type );
+                }
+            } else if( task.button != -1 ) {
+                // Regular button repeat (including RT when no direction is held)
+                send_input( task.button, task.type );
+            }
             task.counter += 1;
             task.when = now + repeat_interval;
         }
+    }
+}
+
+direction get_left_stick_direction()
+{
+    return left_stick_dir;
+}
+
+direction get_right_stick_direction()
+{
+    return right_stick_dir;
+}
+
+direction get_radial_left_direction()
+{
+    return radial_left_last_dir;
+}
+
+direction get_radial_right_direction()
+{
+    return radial_right_last_dir;
+}
+
+bool is_radial_left_open()
+{
+    return radial_left_open;
+}
+
+bool is_radial_right_open()
+{
+    return radial_right_open;
+}
+
+bool is_alt_held()
+{
+    return alt_modifier_held;
+}
+
+bool is_in_menu()
+{
+    // If the UI stack has more than 1 element, it usually means a menu is open
+    // on top of the main game UI.
+    return ui_adaptor::ui_stack_size() > 1;
+}
+
+bool is_active()
+{
+    return controller != nullptr;
+}
+
+tripoint direction_to_offset( direction dir )
+{
+    switch( dir ) {
+        case direction::N:
+            return tripoint( 0, -1, 0 );
+        case direction::NE:
+            return tripoint( 1, -1, 0 );
+        case direction::E:
+            return tripoint( 1, 0, 0 );
+        case direction::SE:
+            return tripoint( 1, 1, 0 );
+        case direction::S:
+            return tripoint( 0, 1, 0 );
+        case direction::SW:
+            return tripoint( -1, 1, 0 );
+        case direction::W:
+            return tripoint( -1, 0, 0 );
+        case direction::NW:
+            return tripoint( -1, -1, 0 );
+        case direction::NONE:
+        default:
+            return tripoint::zero;
     }
 }
 

--- a/src/sdl_gamepad.h
+++ b/src/sdl_gamepad.h
@@ -7,18 +7,51 @@
 
 #define SDL_GAMEPAD_SCHEDULER (SDL_USEREVENT+1)
 
+struct tripoint;
+
 // IWYU pragma: no_forward_declare input_event  // Is valid, but looks silly
 extern input_event last_input;
 
 namespace gamepad
 {
 
+// Direction states for left stick
+enum class direction : int {
+    NONE = 0,
+    N,    // North (up)
+    NE,   // Northeast
+    E,    // East (right)
+    SE,   // Southeast
+    S,    // South (down)
+    SW,   // Southwest
+    W,    // West (left)
+    NW    // Northwest
+};
+
 void init();
 void quit();
-void handle_axis_event( SDL_Event &event );
+// Returns true if the selected direction changed (UI needs refresh)
+bool handle_axis_event( SDL_Event &event );
 void handle_button_event( SDL_Event &event );
+void handle_device_event( SDL_Event &event );
 void handle_scheduler_event( SDL_Event &event );
 SDL_GameController *get_controller();
+
+direction get_left_stick_direction();
+direction get_right_stick_direction();
+direction get_radial_left_direction();
+direction get_radial_right_direction();
+bool is_radial_left_open();
+bool is_radial_right_open();
+bool is_alt_held();
+bool is_in_menu();
+bool is_active();
+
+// Convert direction enum to movement offset
+tripoint direction_to_offset( direction dir );
+
+// Convert direction to radial joy event
+int direction_to_radial_joy( direction dir, int stick_idx );
 
 } // namespace gamepad
 

--- a/src/sdl_geometry.cpp
+++ b/src/sdl_geometry.cpp
@@ -51,6 +51,8 @@ ColorModulatedGeometryRenderer::ColorModulatedGeometryRenderer( const SDL_Render
     tex.reset( SDL_CreateTextureFromSurface( renderer.get(), alt_surf.get() ) );
     alt_surf.reset();
 
+    SetTextureBlendMode( tex, SDL_BLENDMODE_BLEND );
+
     // Test to make sure color modulation is supported by renderer
     bool tex_enable = !SetTextureColorMod( tex, 0, 0, 0 );
     if( !tex_enable ) {
@@ -65,6 +67,7 @@ void ColorModulatedGeometryRenderer::rect( const SDL_Renderer_Ptr &renderer, con
 {
     if( tex ) {
         SetTextureColorMod( tex, color.r, color.g, color.b );
+        SDL_SetTextureAlphaMod( tex.get(), color.a );
         RenderCopy( renderer, tex, nullptr, &rect );
     } else {
         DefaultGeometryRenderer::rect( renderer, rect, color );

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -53,6 +53,7 @@
 #include "hash_utils.h"
 #include "horde_entity.h"
 #include "input.h"
+#include "input_context.h"
 #include "json.h"
 #include "line.h"
 #include "map.h"

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -537,7 +537,7 @@ SDL_Rect get_android_render_rect( float DisplayBufferWidth, float DisplayBufferH
 
 #endif
 
-void draw_gamepad_radial_menu();
+static void draw_gamepad_radial_menu();
 
 void refresh_display()
 {
@@ -2500,7 +2500,7 @@ void draw_virtual_joystick()
 #define M_PI 3.14159265358979323846
 #endif
 
-void draw_gamepad_radial_menu()
+static void draw_gamepad_radial_menu()
 {
     if( !gamepad::is_active() || !gamepad::is_alt_held() ) {
         return;
@@ -2529,7 +2529,8 @@ void draw_gamepad_radial_menu()
         return;
     }
 
-    int w, h;
+    int w;
+    int h;
     SDL_GetRendererOutputSize( renderer.get(), &w, &h );
 
     // Draw a semi-transparent black background over the whole screen
@@ -2537,8 +2538,7 @@ void draw_gamepad_radial_menu()
     geometry->rect( renderer, { 0, 0, w, h }, { 0, 0, 0, 150 } );
     SetRenderDrawBlendMode( renderer, SDL_BLENDMODE_NONE );
 
-    const int center_x = w / 2;
-    const int center_y = h / 2;
+    const point center( w / 2, h / 2 );
     const float radius = h * 0.8f / 2.0f;
 
     // Scale font relative to window height.
@@ -2570,8 +2570,8 @@ void draw_gamepad_radial_menu()
 
         // Angle in radians (0 is North, clockwise)
         float angle = i * ( 2.0f * M_PI / 8.0f );
-        float target_x = center_x + radius * std::sin( angle );
-        float target_y = center_y - radius * std::cos( angle );
+        float target_x = center.x + radius * std::sin( angle );
+        float target_y = center.y - radius * std::cos( angle );
 
         // Convert target screen coords back to scaled coords for font drawing
         int draw_x = static_cast<int>( target_x / text_scale );
@@ -2583,7 +2583,7 @@ void draw_gamepad_radial_menu()
         draw_x -= text_w / 2;
         draw_y -= text_h / 2;
 
-        bool is_selected = ( dir == selected_dir );
+        bool is_selected = dir == selected_dir;
 
         if( is_selected ) {
             // Draw selected item in yellow

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -2531,9 +2531,15 @@ void draw_gamepad_radial_menu()
 
     int w, h;
     SDL_GetRendererOutputSize( renderer.get(), &w, &h );
+
+    // Draw a semi-transparent black background over the whole screen
+    SetRenderDrawBlendMode( renderer, SDL_BLENDMODE_BLEND );
+    geometry->rect( renderer, { 0, 0, w, h }, { 0, 0, 0, 150 } );
+    SetRenderDrawBlendMode( renderer, SDL_BLENDMODE_NONE );
+
     const int center_x = w / 2;
     const int center_y = h / 2;
-    const float radius = h / 3.0f;
+    const float radius = h * 0.8f / 2.0f;
 
     // Scale font relative to window height.
     // Base scale 1.0 at 720p, for labels to be legible.
@@ -2578,9 +2584,6 @@ void draw_gamepad_radial_menu()
         draw_y -= text_h / 2;
 
         bool is_selected = ( dir == selected_dir );
-
-        // Draw shadow
-        font->OutputChar( renderer, geometry, label, point( draw_x + 1, draw_y + 1 ), 0, 0.8f );
 
         if( is_selected ) {
             // Draw selected item in yellow
@@ -2661,10 +2664,10 @@ void handle_finger_input( uint32_t ticks )
                 } else if( std::abs( delta_y ) < delta_x * 2.0f ) {
                     if( delta_y < 0 ) {
                         // swipe up-right
-                        last_input = input_event( JOY_RIGHTUP, input_event_t::gamepad );
+                        last_input = input_event( JOY_UP_RIGHT, input_event_t::gamepad );
                     } else {
                         // swipe down-right
-                        last_input = input_event( JOY_RIGHTDOWN, input_event_t::gamepad );
+                        last_input = input_event( JOY_DOWN_RIGHT, input_event_t::gamepad );
                     }
                 } else {
                     if( delta_y < 0 ) {
@@ -2682,11 +2685,11 @@ void handle_finger_input( uint32_t ticks )
                 } else if( std::abs( delta_y ) < -delta_x * 2.0f ) {
                     if( delta_y < 0 ) {
                         // swipe up-left
-                        last_input = input_event( JOY_LEFTUP, input_event_t::gamepad );
+                        last_input = input_event( JOY_UP_LEFT, input_event_t::gamepad );
 
                     } else {
                         // swipe down-left
-                        last_input = input_event( JOY_LEFTDOWN, input_event_t::gamepad );
+                        last_input = input_event( JOY_DOWN_LEFT, input_event_t::gamepad );
                     }
                 } else {
                     if( delta_y < 0 ) {
@@ -3359,6 +3362,7 @@ static void CheckMessages()
                 if( gamepad::handle_axis_event( ev ) ) {
                     // Direction indicator changed, need to redraw
                     needupdate = true;
+                    ui_manager::redraw_invalidated();
                 }
                 break;
             case SDL_CONTROLLERDEVICEADDED:

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -2574,7 +2574,8 @@ static void draw_gamepad_radial_menu()
         float target_y = center.y - radius * std::cos( angle );
 
         // Convert target screen coords back to scaled coords for font drawing
-        const point draw( static_cast<int>( target_x / text_scale ) - ( font->width * utf8_width( label ) / 2 ),
+        const point draw( static_cast<int>( target_x / text_scale ) - ( font->width * utf8_width(
+                              label ) / 2 ),
                           static_cast<int>( target_y / text_scale ) - ( font->height / 2 ) );
 
         bool is_selected = dir == selected_dir;

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -537,6 +537,8 @@ SDL_Rect get_android_render_rect( float DisplayBufferWidth, float DisplayBufferH
 
 #endif
 
+void draw_gamepad_radial_menu();
+
 void refresh_display()
 {
     needupdate = false;
@@ -565,6 +567,7 @@ void refresh_display()
     }
     draw_virtual_joystick();
 #endif
+    draw_gamepad_radial_menu();
     SDL_RenderPresent( renderer.get() );
     SetRenderTarget( renderer, display_buffer );
 }
@@ -2491,7 +2494,109 @@ void draw_virtual_joystick()
     RenderCopy( renderer, touch_joystick, NULL, &dstrect );
 
 }
+#endif
 
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+void draw_gamepad_radial_menu()
+{
+    if( !gamepad::is_active() || !gamepad::is_alt_held() ) {
+        return;
+    }
+
+    int stick_idx = -1;
+    gamepad::direction selected_dir = gamepad::direction::NONE;
+    if( gamepad::is_radial_left_open() ) {
+        stick_idx = 0;
+        selected_dir = gamepad::get_radial_left_direction();
+    } else if( gamepad::is_radial_right_open() ) {
+        stick_idx = 1;
+        selected_dir = gamepad::get_radial_right_direction();
+    }
+
+    if( stick_idx == -1 ) {
+        return;
+    }
+
+    if( input_context::input_context_stack.empty() ) {
+        return;
+    }
+
+    input_context *ctxt = input_context::input_context_stack.back();
+    if( !ctxt ) {
+        return;
+    }
+
+    int w, h;
+    SDL_GetRendererOutputSize( renderer.get(), &w, &h );
+    const int center_x = w / 2;
+    const int center_y = h / 2;
+    const float radius = h / 3.0f;
+
+    // Scale font relative to window height.
+    // Base scale 1.0 at 720p, for labels to be legible.
+    float text_scale = static_cast<float>( h ) / 720.0f * 1.0f;
+    SDL_RenderSetScale( renderer.get(), text_scale, text_scale );
+
+    static const std::vector<gamepad::direction> directions = {
+        gamepad::direction::N, gamepad::direction::NE, gamepad::direction::E,
+        gamepad::direction::SE, gamepad::direction::S, gamepad::direction::SW,
+        gamepad::direction::W, gamepad::direction::NW
+    };
+
+    for( size_t i = 0; i < directions.size(); ++i ) {
+        gamepad::direction dir = directions[i];
+        int joy_code = gamepad::direction_to_radial_joy( dir, stick_idx );
+        input_event event( joy_code, input_event_t::gamepad );
+        const std::string &action = ctxt->input_to_action( event );
+
+        std::string label;
+        if( action == "ERROR" ) {
+            label = "None";
+        } else {
+            label = ctxt->get_action_name( action );
+            if( label.empty() ) {
+                label = "None";
+            }
+        }
+
+        // Angle in radians (0 is North, clockwise)
+        float angle = i * ( 2.0f * M_PI / 8.0f );
+        float target_x = center_x + radius * std::sin( angle );
+        float target_y = center_y - radius * std::cos( angle );
+
+        // Convert target screen coords back to scaled coords for font drawing
+        int draw_x = static_cast<int>( target_x / text_scale );
+        int draw_y = static_cast<int>( target_y / text_scale );
+
+        // Center the text in scaled space
+        int text_w = font->width * utf8_width( label );
+        int text_h = font->height;
+        draw_x -= text_w / 2;
+        draw_y -= text_h / 2;
+
+        bool is_selected = ( dir == selected_dir );
+
+        // Draw shadow
+        font->OutputChar( renderer, geometry, label, point( draw_x + 1, draw_y + 1 ), 0, 0.8f );
+
+        if( is_selected ) {
+            // Draw selected item in yellow 
+            font->OutputChar( renderer, geometry, label, point( draw_x, draw_y ),
+                              11, 1.0f );
+        } else {
+            font->OutputChar( renderer, geometry, label, point( draw_x, draw_y ),
+                              15, 1.0f );
+        }
+    }
+
+    // Restore scale
+    SDL_RenderSetScale( renderer.get(), 1.0f, 1.0f );
+}
+
+#if defined(__ANDROID__)
 void update_finger_repeat_delay()
 {
     float delta_x = finger_curr_x - finger_down_x;
@@ -3251,7 +3356,14 @@ static void CheckMessages()
                 gamepad::handle_button_event( ev );
                 break;
             case SDL_CONTROLLERAXISMOTION:
-                gamepad::handle_axis_event( ev );
+                if( gamepad::handle_axis_event( ev ) ) {
+                    // Direction indicator changed, need to redraw
+                    needupdate = true;
+                }
+                break;
+            case SDL_CONTROLLERDEVICEADDED:
+            case SDL_CONTROLLERDEVICEREMOVED:
+                gamepad::handle_device_event( ev );
                 break;
             case SDL_GAMEPAD_SCHEDULER:
                 gamepad::handle_scheduler_event( ev );

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -2660,10 +2660,10 @@ void handle_finger_input( uint32_t ticks )
                 } else if( std::abs( delta_y ) < delta_x * 2.0f ) {
                     if( delta_y < 0 ) {
                         // swipe up-right
-                        last_input = input_event( JOY_UP_RIGHT, input_event_t::gamepad );
+                        last_input = input_event( JOY_LS_UP_RIGHT, input_event_t::gamepad );
                     } else {
                         // swipe down-right
-                        last_input = input_event( JOY_DOWN_RIGHT, input_event_t::gamepad );
+                        last_input = input_event( JOY_LS_DOWN_RIGHT, input_event_t::gamepad );
                     }
                 } else {
                     if( delta_y < 0 ) {
@@ -2681,11 +2681,11 @@ void handle_finger_input( uint32_t ticks )
                 } else if( std::abs( delta_y ) < -delta_x * 2.0f ) {
                     if( delta_y < 0 ) {
                         // swipe up-left
-                        last_input = input_event( JOY_UP_LEFT, input_event_t::gamepad );
+                        last_input = input_event( JOY_LS_UP_LEFT, input_event_t::gamepad );
 
                     } else {
                         // swipe down-left
-                        last_input = input_event( JOY_DOWN_LEFT, input_event_t::gamepad );
+                        last_input = input_event( JOY_LS_DOWN_LEFT, input_event_t::gamepad );
                     }
                 } else {
                     if( delta_y < 0 ) {

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -2583,7 +2583,7 @@ void draw_gamepad_radial_menu()
         font->OutputChar( renderer, geometry, label, point( draw_x + 1, draw_y + 1 ), 0, 0.8f );
 
         if( is_selected ) {
-            // Draw selected item in yellow 
+            // Draw selected item in yellow
             font->OutputChar( renderer, geometry, label, point( draw_x, draw_y ),
                               11, 1.0f );
         } else {

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -2574,23 +2574,17 @@ static void draw_gamepad_radial_menu()
         float target_y = center.y - radius * std::cos( angle );
 
         // Convert target screen coords back to scaled coords for font drawing
-        int draw_x = static_cast<int>( target_x / text_scale );
-        int draw_y = static_cast<int>( target_y / text_scale );
-
-        // Center the text in scaled space
-        int text_w = font->width * utf8_width( label );
-        int text_h = font->height;
-        draw_x -= text_w / 2;
-        draw_y -= text_h / 2;
+        const point draw( static_cast<int>( target_x / text_scale ) - ( font->width * utf8_width( label ) / 2 ),
+                          static_cast<int>( target_y / text_scale ) - ( font->height / 2 ) );
 
         bool is_selected = dir == selected_dir;
 
         if( is_selected ) {
             // Draw selected item in yellow
-            font->OutputChar( renderer, geometry, label, point( draw_x, draw_y ),
+            font->OutputChar( renderer, geometry, label, draw,
                               11, 1.0f );
         } else {
-            font->OutputChar( renderer, geometry, label, point( draw_x, draw_y ),
+            font->OutputChar( renderer, geometry, label, draw,
                               15, 1.0f );
         }
     }

--- a/src/ui_manager.cpp
+++ b/src/ui_manager.cpp
@@ -232,6 +232,11 @@ static bool overlap( const rectangle<point> &lhs, const rectangle<point> &rhs )
            rhs.p_min.x < lhs.p_max.x && rhs.p_min.y < lhs.p_max.y;
 }
 
+size_t ui_adaptor::ui_stack_size()
+{
+    return ui_stack.size();
+}
+
 // This function does two things:
 // 1. Ensure that any UI that would be overwritten by redrawing a lower invalidated
 //    UI also gets redrawn.

--- a/src/ui_manager.h
+++ b/src/ui_manager.h
@@ -231,6 +231,7 @@ class ui_adaptor
         static void redraw();
         static void redraw_invalidated();
         static void screen_resized();
+        static size_t ui_stack_size();
     private:
         static void invalidation_consistency_and_optimization();
 

--- a/src/ui_manager.h
+++ b/src/ui_manager.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_UI_MANAGER_H
 #define CATA_SRC_UI_MANAGER_H
 
+#include <stddef.h>
 #include <functional>
 #include <memory>
 


### PR DESCRIPTION
#### Summary
Interface "Improved controller support to add left trigger to switch to alternate buttons, and radial menus"

#### Purpose of change

The game is currently very difficult to play with a controller. There are lots of commands in this game, and the previous controller implementation was outdated. Movement was unpredictable and there was too much menu diving. This change aims to make the game experience much better by following modern roguelike controller patterns, inspired by Caves of Qud, which is very comfortable to play on a controller (I've played 80+ hours) and it has a lot of actions.

#### Describe the solution

1. Added the concept of a "alternate" button layout that is active only while holding left trigger. Similar actions are grouped so that the regular button its alt function are conceptually related.
2. Movement is triggered by holding the direction with the left stick, then confirming the movement with the right trigger. While holding a direction with the left stick, a cursor shows where you will move to when you trigger the movement with RT, making movement much safer and predictable.
3. Added radial menus with actions on the left radial menu and info on the right menu, allowing for quick access to 16 different actions and screens.
4. The change introduces many more JOY_* strings to use in the keymapping.json, so that every button, its alternate and the radial menu options are customizable via the json.
5. Added controller added and removed events so that you can connect or disconnect a controller during play without having to restart the game
6. Added a function to test if the you are in a menu or not, with different navigation functionality. Ideally there'd be a full set of different mappings available for menus, but currently it seems like this isn't the case.

#### Describe alternatives you've considered

Steam input and external mapping tools. The RT-based movement system and radial menus were extremely difficult to implement.

#### Testing

Played for an hour. The controller layout could potentially be improved but it plays pretty well. Tests run and passed.

#### Additional context

Full default layout:

### **Menu Navigation**
*   **Navigate:** Left Stick (`JOY_L_UP`, `DOWN`, `LEFT`, `RIGHT`)
*   **Confirm:** A (`JOY_A`)
*   **Cancel / Back:** B (`JOY_B`)
*   **Filter:** X (`JOY_X`)
*   **Next Tab:** RB (`JOY_RB`)
*   **Prev Tab:** LB (`JOY_LB`)
*   **Page Up / Scroll Up:** Right Stick Up (`JOY_R_UP`)
*   **Page Down / Scroll Down:** Right Stick Down (`JOY_R_DOWN`)
*   **Examine Item:** Right Stick Click (`JOY_RS`)

---

### **Gameplay: Base Layer**
*   **Action Menu:** A (`JOY_A`)
*   **Grab:** B (`JOY_B`)
*   **Examine & Pickup:** X (`JOY_X`)
*   **Throw:** Y (`JOY_Y`)
*   **Fire Weapon:** LB (`JOY_LB`)
*   **Autoattack:** RB (`JOY_RB`)
*   **Wait / Pause:** RT (`JOY_RT`) *(Used with Left Stick for movement logic)*
*   **Ignore Enemy:** L3 (`JOY_LS`)
*   **List Items (V-Menu):** R3 (`JOY_RS`)
*   **Main Menu:** Start (`JOY_START`)
*   **Map:** Select/Back (`JOY_BACK`)
*   **Eat:** D-Pad Up (`JOY_DPAD_UP`)
*   **Drop:** D-Pad Down (`JOY_DPAD_DOWN`)
*   **Wear:** D-Pad Left (`JOY_DPAD_LEFT`)
*   **Wield:** D-Pad Right (`JOY_DPAD_RIGHT`)

---

### **Gameplay: Shift Layer (Holding LT)**
*   **Item Action Menu:** LT + A (`JOY_ALT_A`)
*   **Haul:** LT + B (`JOY_ALT_B`)
*   **Smash:** LT + X (`JOY_ALT_X`)
*   **Cast Spell:** LT + Y (`JOY_ALT_Y`)
*   **Switch Ammo:** LT + LB (`JOY_ALT_LB`)
*   **Select Combat Style:** LT + RB (`JOY_ALT_RB`)
*   **Movement Mode Menu:** LT + RT (`JOY_ALT_RT`)
*   **Toggle Safemode:** LT + L3 (`JOY_ALT_LS`)
*   **Peek:** LT + R3 (`JOY_ALT_RS`)
*   **Zoom In:** LT + Start (`JOY_ALT_START`)
*   **Zoom Out:** LT + Select (`JOY_ALT_BACK`)
*   **Level Up (Stairs):** LT + D-Pad Up (`JOY_ALT_DPAD_UP`)
*   **Level Down (Stairs):** LT + D-Pad Down (`JOY_ALT_DPAD_DOWN`)
*   **Take Off Armor:** LT + D-Pad Left (`JOY_ALT_DPAD_LEFT`)
*   **Apply Wielded Item:** LT + D-Pad Right (`JOY_ALT_DPAD_RIGHT`)

---

### **Radial Menu Left (Survival & Crafting)**
*   **North:** Craft (`JOY_RADIAL_L_N`)
*   **North-East:** Read (`JOY_RADIAL_L_NE`)
*   **East:** Butcher (`JOY_RADIAL_L_E`)
*   **South-East:** Wait Long (`JOY_RADIAL_L_SE`)
*   **South:** Construct (`JOY_RADIAL_L_S`)
*   **South-West:** Sleep (`JOY_RADIAL_L_SW`)
*   **West:** Disassemble (`JOY_RADIAL_L_W`)
*   **North-West:** Recraft (`JOY_RADIAL_L_NW`)

---

### **Radial Menu Right (Info & Inventory)**
*   **North:** Player Data / Character Sheet (`JOY_RADIAL_R_N`)
*   **North-East:** Medical Menu (`JOY_RADIAL_R_NE`)
*   **East:** Factions (`JOY_RADIAL_R_E`)
*   **South-East:** Advanced Inventory (`JOY_RADIAL_R_SE`)
*   **South:** Inventory (`JOY_RADIAL_R_S`)
*   **South-West:** Body Status (`JOY_RADIAL_R_SW`)
*   **West:** Missions (`JOY_RADIAL_R_W`)
*   **North-West:** Morale (`JOY_RADIAL_R_NW`)

Added radial menu bindings for most menus, but they aren't super well thought out. They are at least functional however. You can now do pretty much everything without a keyboard, except for typing (renaming stuff etc).

Heavily inspired by https://github.com/CleverRaven/Cataclysm-DDA/issues/56996
