### PR TITLE
Make barrel damage proportional to amount damage

### DIFF
--- a/src/damage.cpp
+++ b/src/damage.cpp
@@ -578,7 +578,7 @@ bool damage_instance::handle_proportional( const JsonValue &jval )
         prop_damage.unconditional_res_mult *= read_proportional_entry( jo, "constant_armor_multiplier" );
         prop_damage.unconditional_damage_mult *= read_proportional_entry( jo,
                 "constant_damage_multiplier" );
-        float barrel_mult = read_proportional_entry( jo, "barrels" );
+        float barrel_mult = read_proportional_entry( jo, "amount" );
         for( barrel_desc &bd : prop_damage.barrels ) {
             bd.amount *= barrel_mult;
         }


### PR DESCRIPTION
#### Summary
None
#### Purpose of change

proportional damage we use right now is:
```json
"proportional": { "damage": { "damage_type": "bullet", "amount": 0.9 } },
```
But it doesn't work with barrel damage. The author intenion was to use a separate field for it, so json would look like this:
```json
"proportional": { "damage": { "damage_type": "bullet", "amount": 0.9, "barrels": 0.9 } },
```
It would handle both decreasing the damage of single instance, and each barrel length.
But personally i didn't saw a reason why it should be two separate value

Fix #84249
#### Describe the solution

Make so that "amount" is responsible for barrel damage, and not dedicated "barrels"

#### Describe alternatives you've considered
Add "barrels" to every single ammo in the game that uses barrel damage, track it being added to new rounds that might use barrel damage
#### Testing

Before:
<img width="2560" height="734" alt="image" src="https://github.com/user-attachments/assets/2568709f-e9c0-4f8b-89a9-630a979f21e1" />

After:
<img width="2560" height="687" alt="image" src="https://github.com/user-attachments/assets/5e063bd8-415e-4516-8c76-fbdad5af617c" />
