### PR TITLE
Move the lore snippets from the faction to the diary UI

### DIFF
--- a/src/diary.cpp
+++ b/src/diary.cpp
@@ -448,6 +448,14 @@ std::string diary::get_page_text()
     return "";
 }
 
+std::string diary::get_desc_or_page_text( int desc )
+{
+    if( get_page_ptr()->is_summary() ) {
+        return get_desc_map()[desc];
+    }
+    return get_page_text();
+}
+
 std::string diary::get_head_text( bool is_summary )
 {
 

--- a/src/diary.cpp
+++ b/src/diary.cpp
@@ -162,7 +162,7 @@ void diary::changes( Container diary_page::* member, Fn &&get_entry,
     if( !currpage ) {
         return;
     }
-    size_t heading_index;
+    size_t heading_index{};
     int count = 0;
     for( const auto &elem : currpage->*member ) {
         const diary_entry_opt entry = get_entry( elem, prevpage );

--- a/src/diary.cpp
+++ b/src/diary.cpp
@@ -31,6 +31,7 @@
 #include "proficiency.h"
 #include "skill.h"
 #include "string_formatter.h"
+#include "text_snippets.h"
 #include "translation.h"
 #include "translations.h"
 #include "type_id.h"
@@ -134,6 +135,21 @@ void diary::open_summary_page()
     add_to_change_list( string_format( _( "It is currently %s." ), season_name ) );
     add_to_change_list( string_format( _( "%s will last for %d more days." ), season_name,
                                        to_days<int>( calendar::season_length() ) - day_of_season<int>( calendar::turn ) ) );
+    add_to_change_list( "" );
+    auto snippets = get_avatar().get_snippets();
+    if( snippets.empty() ) {
+        add_to_change_list( _( "You haven't learned anything about the world." ) );
+        return;
+    }
+
+    add_to_change_list( string_format( _( "Lore: %1$d entries" ), snippets.size() ) );
+    for( const auto &elem : snippets ) {
+        const std::optional<translation> name = SNIPPET.get_name_by_id( elem );
+        const std::optional<translation> desc = SNIPPET.get_snippet_by_id( elem );
+        if( name.has_value() && desc.has_value() && !name->empty() && !desc->empty() ) {
+            add_to_change_list( name->translated(), desc->translated() );
+        }
+    }
 }
 
 template<typename Container, typename Fn>

--- a/src/diary.cpp
+++ b/src/diary.cpp
@@ -4,6 +4,7 @@
 #include <array>
 #include <fstream>
 #include <optional>
+#include <set>
 #include <string>
 #include <tuple>
 #include <utility>

--- a/src/diary.h
+++ b/src/diary.h
@@ -166,6 +166,8 @@ class diary
         diary_page *get_page_ptr( int offset = 0, bool allow_summary = true );
         /*returns the text of opened page*/
         std::string get_page_text();
+        /*return the text or the selected description if in summary*/
+        std::string get_desc_or_page_text( int desc );
         /*returns text for head of page*/
         std::string get_head_text( bool is_summary = false );
         /*helper functions for *_changes below, adds to change_list with headers, pluralization, etc*/

--- a/src/diary_ui.cpp
+++ b/src/diary_ui.cpp
@@ -226,7 +226,8 @@ void diary::show_diary_ui( diary *c_diary )
 
         print_list_scrollable( &w_changes, c_diary->get_change_list(), &selected[window_mode::CHANGE_WIN],
                                currwin == window_mode::CHANGE_WIN, false, report_color_error::yes );
-        print_list_scrollable( &w_text, c_diary->get_page_text(), &selected[window_mode::TEXT_WIN],
+        print_list_scrollable( &w_text, c_diary->get_desc_or_page_text( selected[window_mode::CHANGE_WIN] ),
+                               &selected[window_mode::TEXT_WIN],
                                currwin == window_mode::TEXT_WIN, false, report_color_error::no );
 
         trim_and_print( w_head, point::south_east, getmaxx( w_head ) - 2, c_white,
@@ -311,8 +312,10 @@ void diary::show_diary_ui( diary *c_diary )
         draw_border( w_info );
         center_print( w_info, 0, c_light_gray, string_format( _( "Info" ) ) );
         if( currwin == window_mode::CHANGE_WIN || currwin == window_mode::TEXT_WIN ) {
-            fold_and_print( w_info, point::south_east, getmaxx( w_info ) - 2, c_white,
-                            c_diary->get_desc_map()[ selected[window_mode::CHANGE_WIN] ] );
+            if( !c_diary->get_page_ptr()->is_summary() ) {
+                fold_and_print( w_info, point::south_east, getmaxx( w_info ) - 2, c_white,
+                                c_diary->get_desc_map()[ selected[window_mode::CHANGE_WIN] ] );
+            }
         }
 
         wnoutrefresh( w_info );
@@ -341,7 +344,10 @@ void diary::show_diary_ui( diary *c_diary )
         } else if( navigate_ui_list( action, selected[currwin], 10,
                                      currwin == window_mode::PAGE_WIN ? c_diary->pages.size()
                                      : currwin == window_mode::CHANGE_WIN ? c_diary->change_list.size()
-                                     : text_to_list_scrollable( w_text, c_diary->get_page_text(), false ).size(), true ) ) {
+                                     : text_to_list_scrollable( w_text,
+                                             c_diary->get_desc_or_page_text( selected[window_mode::CHANGE_WIN] ),
+                                             false ).size(),
+                                     true ) ) {
             // size in navigate_ui_list above is redundant with print_list_scrollable's wrapping effect during redraw
             if( currwin == window_mode::PAGE_WIN ) {
                 selected[window_mode::CHANGE_WIN] = 0;

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -35,7 +35,7 @@
 #include "point.h"
 #include "skill.h"
 #include "string_formatter.h"
-#include "talker.h"
+#include "talker.h"  // IWYU pragma: keep
 #include "translations.h"
 #include "type_id.h"
 #include "uilist.h"

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -5,6 +5,7 @@
 #include <map>
 #include <memory>
 #include <optional>
+#include <set>
 #include <string>
 #include <utility>
 

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -5,7 +5,6 @@
 #include <map>
 #include <memory>
 #include <optional>
-#include <set>
 #include <string>
 #include <utility>
 
@@ -35,7 +34,7 @@
 #include "point.h"
 #include "skill.h"
 #include "string_formatter.h"
-#include "text_snippets.h"
+#include "talker.h"
 #include "translations.h"
 #include "type_id.h"
 #include "uilist.h"

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -921,7 +921,6 @@ void faction_manager::display() const
     basecamp *camp = nullptr;
     std::vector<basecamp *> camps;
     size_t active_vec_size = 0;
-    std::pair<snippet_id, std::string> *snippet = nullptr;
     std::vector<mtype_id> creatures; // Creatures we've recorded
     mtype_id cur_creature = mtype_id::NULL_ID();
 
@@ -1054,7 +1053,6 @@ void faction_manager::display() const
         }
         guy = nullptr;
         cur_fac = nullptr;
-        snippet = nullptr;
         cur_creature = mtype_id::NULL_ID();
         interactable = false;
         radio_interactable = false;
@@ -1073,11 +1071,6 @@ void faction_manager::display() const
             }
             camps.push_back( temp_camp );
         }
-        auto compare_second =
-            []( const std::pair<snippet_id, std::string> &a,
-        const std::pair<snippet_id, std::string> &b ) {
-            return localized_compare( a.second, b.second );
-        };
         if( tab < tab_mode::FIRST_TAB || tab >= tab_mode::NUM_TABS ) {
             debugmsg( "The sanity check failed because tab=%d", static_cast<int>( tab ) );
             tab = tab_mode::FIRST_TAB;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Interface "Move the lore snippets from the faction to the diary UI"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #83338
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
<img width="1364" height="738" alt="image" src="https://github.com/user-attachments/assets/a7793d5d-889b-49b5-996c-51354140bdeb" />

<img width="1112" height="569" alt="image" src="https://github.com/user-attachments/assets/6cf72737-a6d8-434f-840b-4eaaf1abe79d" />

The summary page in the diary now lists the lore snippets. By moving the cursor over them, the diary page shows the text lore as previously in the faction UI. The major difference is now you can scroll the text in the page to read it further.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
With less changes it would have shown the `desc` for the lore in the info box below, which also has no scrolling.
Another alternative would be to add an additional "Summary" only for the lore.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Built the Window version, run in a debug world, spawned some newspapers, screenshots.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Maybe the "Creatures" should also go in the diary?
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
