### PR TITLE
Fix zzip_stack cold compaction & flush after compaction

### DIFF
--- a/src/mmap_file.cpp
+++ b/src/mmap_file.cpp
@@ -268,7 +268,7 @@ struct file_impl : mmap_file::impl {
         }
 #endif
 
-        if( !map_view() ) {
+        if( desired_size != 0 && !map_view() ) {
             return false;
         }
         return true;

--- a/src/zzip.cpp
+++ b/src/zzip.cpp
@@ -1166,13 +1166,15 @@ bool zzip::compact_to( std::filesystem::path const &dest, double bloat_factor )
     return compact_to( std::move( compacted_file ) );
 }
 
-bool zzip::compact_to( std::shared_ptr<mmap_file> dest ) const
+bool zzip::compact_to( std::shared_ptr<mmap_file> const &dest ) const
 {
-    std::optional<zzip> new_zip = zzip::load( std::move( dest ) );
+    std::optional<zzip> new_zip = zzip::load( dest );
     if( !new_zip ) {
         return false;
     }
-    return new_zip->copy_files( get_entries(), *this, /* shrink_to_fit = */ true );
+    bool success = new_zip->copy_files( get_entries(), *this, /* shrink_to_fit = */ true );
+    dest->flush();
+    return success;
 }
 
 bool zzip::clear()

--- a/src/zzip.h
+++ b/src/zzip.h
@@ -165,7 +165,7 @@ class zzip
          * Writes a copy of the live/most recent contents of this zzip into the given file.
          * Returns true on success, false on error.
          */
-        bool compact_to( std::shared_ptr<mmap_file> dest ) const;
+        bool compact_to( std::shared_ptr<mmap_file> const &dest ) const;
 
         /**
          * Removes all contents and resets to a default initialized empty zzip.

--- a/src/zzip_stack.cpp
+++ b/src/zzip_stack.cpp
@@ -112,9 +112,8 @@ std::shared_ptr<zzip_stack> zzip_stack::create_from_folder( std::filesystem::pat
     if( !assure_dir_exist( path ) ) {
         return nullptr;
     }
-    std::filesystem::path zzip_filename = path.filename();
     // Default everything to cold.
-    zzip_filename += kColdSuffix; // NOLINT(cata-u8-path)
+    std::filesystem::path zzip_filename = filename_of_temp( path, file_temp::cold );
     std::optional<zzip> z = zzip::create_from_folder( path / zzip_filename, folder, dictionary );
     if( !z ) {
         return nullptr;
@@ -132,8 +131,8 @@ std::shared_ptr<zzip_stack> zzip_stack::create_from_folder_with_files(
     if( !assure_dir_exist( path ) ) {
         return nullptr;
     }
-    std::filesystem::path zzip_filename = path.filename();
-    zzip_filename += kColdSuffix; // NOLINT(cata-u8-path)
+    // Default everything to cold.
+    std::filesystem::path zzip_filename = filename_of_temp( path, file_temp::cold );
     std::optional<zzip> z = zzip::create_from_folder_with_files( path / zzip_filename, folder, files,
                             total_file_size, dictionary );
     if( !z ) {
@@ -239,9 +238,12 @@ bool zzip_stack::compact( double bloat_factor )
     }
 
     // Finally normal compact on cold.
-    std::filesystem::path tmp_path = path_ / "cold.zzip.tmp"; // NOLINT(cata-u8-path)
+    std::filesystem::path cold_path = path_ / filename_of_temp( path_, file_temp::cold );
+    std::filesystem::path tmp_path = cold_path;
+    tmp_path.concat( ".tmp" ); // NOLINT(cata-u8-path)
     if( cold_->compact_to( tmp_path, std::max( bloat_factor / 2.0, 1.0 ) ) ) {
-        return rename_file( tmp_path, path_ / kColdSuffix ); // NOLINT(cata-u8-path)
+        cold_.reset();
+        return rename_file( tmp_path, cold_path );
     }
     return true;
 }
@@ -309,13 +311,10 @@ zzip &zzip_stack::zzip_of_temp( zzip_stack::file_temp temp ) const
     }
 }
 
-std::optional<zzip> zzip_stack::load_temp( file_temp temp ) const
+std::filesystem::path zzip_stack::filename_of_temp( std::filesystem::path const &folder,
+        file_temp temp )
 {
-    if( temp == file_temp::unknown ) {
-        // default unknown to hot
-        temp = file_temp::hot;
-    }
-    std::filesystem::path zzip_path = path_.filename();
+    std::filesystem::path zzip_path = folder.filename();
     std::string_view file_suffix;
     switch( temp ) {
         case file_temp::cold:
@@ -331,6 +330,18 @@ std::optional<zzip> zzip_stack::load_temp( file_temp temp ) const
 
     }
     zzip_path += file_suffix; // NOLINT(cata-u8-path)
+    return zzip_path;
+}
+
+std::optional<zzip> zzip_stack::load_temp( file_temp temp ) const
+{
+    if( temp == file_temp::unknown ) {
+        // default unknown to hot
+        temp = file_temp::hot;
+    }
+
+    std::filesystem::path zzip_path = filename_of_temp( path_, temp );
+
     std::optional<zzip> z = zzip::load( path_ / zzip_path, dictionary_ );
     if( !z ) {
         return z;

--- a/src/zzip_stack.h
+++ b/src/zzip_stack.h
@@ -149,6 +149,8 @@ class zzip_stack
         mutable std::unordered_map<std::filesystem::path, file_temp, std_fs_path_hash> path_temp_map_;
         file_temp temp_of_file( std::filesystem::path const &zzip_relative_path ) const;
 
+        static std::filesystem::path filename_of_temp( std::filesystem::path const &folder,
+                file_temp temp );
         zzip &zzip_of_temp( file_temp temp ) const;
         std::optional<zzip> load_temp( file_temp temp ) const;
 };


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I noticed that there was a bare `.cold.zzip` file being created in the memory map folder. The code was not computing the proper filename to replace the compacted contents with. This meant the cold memory map file could grow forever instead of staying bounded. Also fix resize_file returning failure when truncating writeable files, even when it succeeds, because that was making hot->warm file compaction fail also which could possibly lead to internal data inconsistencies when trying to look up map memory files later before a restart.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Fix the rename logic to correctly overwrite the old .cold.zzip file. Also sneak in a change to flush newly written compacted zzips for extra file integrity safety. Detect when truncating mmap_file's and don't spuriously return failure when it succeeds.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Saved my game, stepped through the function to verify compaction happens and check no random files are written or left behind.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
