### PR TITLE
Allow overriding in snippets definitions

### DIFF
--- a/src/text_snippets.cpp
+++ b/src/text_snippets.cpp
@@ -22,6 +22,11 @@ void snippet_library::load_snippet( const JsonObject &jsobj, const std::string &
     }
     hash_to_id_migration = std::nullopt;
     const std::string category = jsobj.get_string( "category" );
+    if( jsobj.has_member( "override" ) && jsobj.get_bool( "override" ) ) {
+        snippets_by_category[category].ids.clear();
+        snippets_by_category[category].no_id.clear();
+
+    }
     if( jsobj.has_array( "text" ) ) {
         add_snippets_from_json( category, jsobj.get_array( "text" ), src );
     } else {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Infrastructure "Allow overriding in snippets definitions"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Some things are dependent on the snippet system currently, like for example npc names. This means that mods can't "replace" the base pool of names, only add to it.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Allow snippet type objects with the same category as already existing snippet objects to define an `override` field as true so that the snippets within properly replace the base ones instead of adding to them.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Maybe there are some issues with that solution in the long term but I don't care much for it since I need this now and ehughsbaird thought it was fine enough I'm assuming it probably is.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Added a new `<male_full_name>` category snippet with the override field as true and the npc that spawned with me was called "MaleName" as newly defined there.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Code entirely authored by @ehughsbaird, I'm just submitting the PR. I'm expecting the name test to possibly be an issue but we'll see.

Thought I'd add an example of it in use:
```json
  {
    "type": "snippet",
    "category": "<male_full_name>",
    "override": true,
    "text": [ "AltMaleName" ]
  },
```
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
