### PR TITLE
Getting hurt is bad for your long-term health

### DIFF
--- a/src/character_health.cpp
+++ b/src/character_health.cpp
@@ -1215,6 +1215,9 @@ void Character::regen( int rate_multiplier )
         int healing_apply = roll_remainder( healing );
         mod_part_healed_total( bp, healing_apply );
         heal( bp, healing_apply );
+        // Consume 1 "health" for every Hit Point healed via medicine healing.
+        // This has a significant effect on long-term healing.
+        mod_daily_health( -healing_apply, -200 );
         if( get_part_damage_bandaged( bp ) > 0 ) {
             mod_part_damage_bandaged( bp, -healing_apply );
             if( get_part_damage_bandaged( bp ) <= 0 ) {


### PR DESCRIPTION
#### Summary
Balance "Getting hurt is bad for your long-term health"

#### Purpose of change
There has been a long-standing consensus that the rate of healing is simply **too goddamn fast**. You can shrug off bullet wounds overnight. You can shrug off *lots* of bullet wounds overnight.

There is a second long-standing consensus that properly stretching out the healing time to take weeks (or even months!) will require more automation and less friction in the "day to day" processes, to avoid bad injuries being effectively the same thing as death (the player stops playing the game)

*But* we can stretch it... a little bit, right? Make it a little more interesting, fun, and spicy. And not just instahealing everyone and everything overnight.

#### Describe the solution
Storm dropped this absolute banger on the development discord, in the help channel of all places.
<img width="1549" height="168" alt="image" src="https://github.com/user-attachments/assets/6b0b14d1-5222-48a7-97e1-94d62ed30129" />

I really like this idea. At +200 you still bounce back overnight, but the second night? The third night?

Health does not accumulate that quickly, and this will drag you really hard if you're getting shot to pieces every day.

But very conveniently, health also affects your healing rate! So it's self-stabilizing, it won't drag you straight to -200 and keep you there. The further towards -200 you get, the less it can chip away at your health (because you're healing less).


#### Describe alternatives you've considered
A ton of automation and stuff to just crank the healing rates down in general

#### Testing
Not tested - throwing it up to see how the tests like it. (I expect they will not.)

#### Additional context

