### PR TITLE
[MoM] fix photokinetic_light_image max_damage

### DIFF
--- a/data/mods/MindOverMatter/powers/photokinesis.json
+++ b/data/mods/MindOverMatter/powers/photokinesis.json
@@ -522,7 +522,7 @@
     "min_damage": 1,
     "max_damage": {
       "math": [
-        " (u_spell_level('photokinetic_light_beam') / 3) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
+        " (u_spell_level('photokinetic_light_image') / 3) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
       ]
     },
     "min_duration": {


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Tracking some another bug, found photokinetic_light_image spell incorrectly scales off photokinetic_light_beam spell
#### Describe the solution
Fix
