### PR TITLE
Fix repeat words and typos

### DIFF
--- a/build-scripts/Dockerfile.debian-build
+++ b/build-scripts/Dockerfile.debian-build
@@ -64,7 +64,7 @@ WORKDIR /home/cdda
 COPY --chown=cdda:cdda . .
 
 # we build in build dirs rather than at the repo root
-# TODO: move build dirs to a directory ABOVE the source so we can Docker mount in the source dir for 'live' builds of code you're hacking on on the host
+# TODO: move build dirs to a directory ABOVE the source so we can Docker mount in the source dir for 'live' builds of code you're hacking on the host
 RUN mkdir cmake-build-debug cmake-build-debug-tiles
 
 WORKDIR /home/cdda/cmake-build-debug

--- a/data/json/npcs/Backgrounds/grad_student_1.json
+++ b/data/json/npcs/Backgrounds/grad_student_1.json
@@ -31,7 +31,7 @@
     "id": "BGSS_GRAD_STUDENT_1_STORY3",
     "type": "talk_topic",
     "dynamic_line": {
-      "gendered_line": "Yes.  Simple hunger.  The vending machines sold only peanuts and biscuits.  I wasn't about to rely on that for survival.  I stayed long enough to realize no one was going to come for me, then packed up what I could and drove off.  Eventually my car was caught in a downpour of acid rain that stripped the tires and left me to carry on on foot, living the life of a hunter gatherer.  Honestly, I think I eat better this way than I did as a grad student.",
+      "gendered_line": "Yes.  Simple hunger.  The vending machines sold only peanuts and biscuits.  I wasn't about to rely on that for survival.  I stayed long enough to realize no one was going to come for me, then packed up what I could and drove off.  Eventually my car was caught in a downpour of acid rain that stripped the tires and left me to carry on foot, living the life of a hunter gatherer.  Honestly, I think I eat better this way than I did as a grad student.",
       "relevant_genders": [ "npc" ]
     },
     "responses": [

--- a/data/mods/Xedra_Evolved/design_doc_spoilers.md
+++ b/data/mods/Xedra_Evolved/design_doc_spoilers.md
@@ -4,7 +4,7 @@ These documents are for the lore basis and mechnical assumptions behind some of 
 
 ## The Principle of Supernatural Exclusivity
 
-Xedra Evolved has more types of playable supernatural with their own magic than any other CDDA mod, and it's a general principle that these are all exclusive. You cannot have a werewolf chronomancer, or a changeling mad genius, or a a gracken lilit. Most magickal powers require starting as having that power to develop it, and those who start with non-human power sources cannot learn human dream magick.
+Xedra Evolved has more types of playable supernatural with their own magic than any other CDDA mod, and it's a general principle that these are all exclusive. You cannot have a werewolf chronomancer, or a changeling mad genius, or a gracken lilit. Most magickal powers require starting as having that power to develop it, and those who start with non-human power sources cannot learn human dream magick.
 
 The exception to this is vampirism. Since vampirism is an infection, anyone can theoretically develop it (barring lilin or dhampirs who are immune), but becoming a vampire locks out previous supernatural powers. The lower tiers merely cannot learn new powers, but making the choice to become a full vampire removes all previous supernatural powers as the blood overwhelms everything.
 
@@ -21,13 +21,13 @@ TBD
 Cryptids are an assortment of unique beings and creatures that share a single thing: how hard they are to encounter.  Their abilities and motives are as unique as they are, and their origin is unclear.
 
 There are three ways to encounter a cryptid:
-- Find and examinate their tracks to locate that cryptid's lair.
+- Find and examine their tracks to locate that cryptid's lair.
 - Start as a cryptid hunter to get a map to a random cryptid.
 - Stumble upon their lair by pure chance.
 
 Guidelines to add a new cryptid:
 - All cryptids must be unique.  The player cannot encounter the same cryptid twice in the same world.
-- Adding a cryptid includes the addition of a lair terrain where they can be found, and a track terrain where the player can get directions to the lair by examinating a special tile.
+- Adding a cryptid includes the addition of a lair terrain where they can be found, and a track terrain where the player can get directions to the lair by examining a special tile.
 - The cryptid's lair is globally unique, while the track overmap cannot be found more than once per overmap.
 - Each cryptid have their own track and lair.  They do not share them.
 - There is no need for them to have loot.  You can make your new cryptid drop something, but it is not required.
@@ -149,7 +149,7 @@ Each Paraclesian has their own design sensibilities:
 - Arvore: Arvore powers relate to plants, nature, and growing things. Their magic allows them to become more plantlike, encourage plant growth, draw sustenance from soil and sunlight, and so on. While Arvore do have damaging spells, they mostly only affect plants and zombies, and then not generally in a magical bolt instant-damage fashion, since damage-over-time is much more similar to how nature works. Arvore deliberately have no powers that affect animals. The mortal need Arvore can overcome is requiring food and drink.
 - Homullus: Homullus powers relate to humanity, tools, cities and knowledge.  They have abilities related to managing humans and formerly human creatures such as ferals, renfields, etc.  Currently not implemented but they should be incredibly effective at dealing with cyborgs and some abilities related to interacting with robots (as tools created by humans).  They have the ability to install CBMs or even choose to limit their Paraclesian abilities by pursuing a mutation path created by humans.  The mortal need that Homullus can overcome is anything that limits their ability to make choices such as mind control. Homullus are also, uniquely, not bothered by iron.
 - Ierde: Ierde powers relate to resilience, preservation, and the manipulation of earth and stone. They are designed less to destroy their enemies with magick and more to slow them, redirect them, and simply outlast them (though since only the player has stamina this works less well than it could). The mortal need Ierde can overcome is sensitivity to pain and tiredness (stamina, not sleepiness). 
-- Salamander: Salamanders are the most innately destructive of the Paraclesians, though their magick also invokes the way forests regrow after a forest fire. Their magick allows them to move quickly and set everything on fire (though they are deliberately designed without an "I cast fireball" equivalent), with some associatons with the heat of the forge and with light. The mortal need Salamander can overcome is need for water or sleep, though part of their design is that they need much more extra food (as fuel, so to speak)
+- Salamander: Salamanders are the most innately destructive of the Paraclesians, though their magick also invokes the way forests regrow after a forest fire. Their magick allows them to move quickly and set everything on fire (though they are deliberately designed without an "I cast fireball" equivalent), with some associations with the heat of the forge and with light. The mortal need Salamander can overcome is need for water or sleep, though part of their design is that they need much more extra food (as fuel, so to speak)
 - Sylph: Sylph powers relate to wind, lightning, and the weather (weather currently unimplemented). Their powers allow them to breathe without air, affect the morale of enemies and friends, conjure up blasts of lightning, and control the air around them. The mortal need Sylphs can overcome is being tied down, in both the literal gravity sense and the metaphorical snares or entanglements sense.
 - Undine: Undine powers relate to water and acid, as well as the transformation of liquids.  Undines are slightly different because by default they do not need to drink water and heal when in water, but many of their powers have a thirst cost so they can become thirsty by using their magic. They can also regain thirst automatically when underwater, so the push-pull of Undine powers is making sure to never be so far from water that they can't top up when necessary.
 
@@ -159,7 +159,7 @@ Paraclesians gain their powers by spending time in their native environments, th
 
 Changelings are originally the offspring of pairings between mortals and elemental fae in the unremembered past, which occurred often enough that their descendants formed a new stable population. While they do sometimes still swap mortal babies for fae babies, the name "changeling" as a collective is used for convenience and most changelings are born and grow up Under the Hill.
 
-The Fair Folk make a habit of making offers to mortals to come back to the Elflands with them, especially on worlds that have undergone or are about to undergo a Cataclysm. The reason for this is that changeling magic relies on mortal dreams for power, which means they need mortals on hand to dream for them. The degree to which they are willing to coerce mortals into this arragement varies based on the individual changeling but the temptation is always there. They will not bring anyone to the Elflands who has not sworn some sort of agreement with them, and for this reason the Exodii are wary to antagonistic towards them. 
+The Fair Folk make a habit of making offers to mortals to come back to the Elflands with them, especially on worlds that have undergone or are about to undergo a Cataclysm. The reason for this is that changeling magic relies on mortal dreams for power, which means they need mortals on hand to dream for them. The degree to which they are willing to coerce mortals into this arrangement varies based on the individual changeling but the temptation is always there. They will not bring anyone to the Elflands who has not sworn some sort of agreement with them, and for this reason the Exodii are wary to antagonistic towards them. 
 
 Changelings are divided into two great courts, the Summer (or Seelie) Court and the Winter (or Unseelie) Court. The Summer Court is more benevolent to mortals (Lady Boann is Summer Court), but that does not mean they are nice. Changelings are also divided into two broad types, nobles and commoners. Nobles are more magically powerful, but commoners have individual tricks that the nobles cannot copy with their magic, such as the selkies' facility with weather control or brownies' ability to speed crafting when unobserved.
 
@@ -173,7 +173,7 @@ The following types of changelings exist or are planned:
 - Selkies: Based on the seal-folk of Northern Europe. They can control the weather and exist without penalty in water, and are beguiling to mortals.
 - Trow: Based on coblyns and knockers. Their abilities relate to the earth and mining.
 
-Currently, changelings gain their powers in a steady drip of 1 per 8-10 days. There are a small number of various deeds that each changeling can accomplish to gain more powers, which will be expanded over time. Deeds should generally be in-theme, such as how pooka deeds invovle the wilderness, trow deeds involve mining and the underground, etc. Repeatable deeds are possible, but should be tasks that require effort: the only currently repeatable deeds are killing a March Lord and closing a shadow wound.
+Currently, changelings gain their powers in a steady drip of 1 per 8-10 days. There are a small number of various deeds that each changeling can accomplish to gain more powers, which will be expanded over time. Deeds should generally be in-theme, such as how pooka deeds involve the wilderness, trow deeds involve mining and the underground, etc. Repeatable deeds are possible, but should be tasks that require effort: the only currently repeatable deeds are killing a March Lord and closing a shadow wound.
 
 #### Seasonal Magick
 
@@ -210,7 +210,7 @@ Principles of lilin powers:
 - Lilin can use their ruach to weave beautiful illusions around themselves (at night), but they need to use their own words to persuade.
 - Like Blood Arts, lilin powers that turn on and remain on until turned off should be implemented as activatable mutations, and powers which create an instant or temporary effect should be implemented as spells in the Supernatural Powers menu.
 
-Lilin gain new powers by dedicating some ruach to power reseach. They can only possibly gain new powers when outside under the moonlight (currently implemented as just outside at night), where periodic power-gaining rolls are made. 
+Lilin gain new powers by dedicating some ruach to power research. They can only possibly gain new powers when outside under the moonlight (currently implemented as just outside at night), where periodic power-gaining rolls are made. 
 
 ## Gracken
 

--- a/data/mods/aftershock_exoplanet/doc/lore/factions.md
+++ b/data/mods/aftershock_exoplanet/doc/lore/factions.md
@@ -22,7 +22,7 @@ Besides ample money and stipends they can offer:
 
 ### Bases
 
-UICA administers the Salus IV spaceport, which is is the principal world hub for most starting scenarios. This is the main faction hq.
+UICA administers the Salus IV spaceport, which is the principal world hub for most starting scenarios. This is the main faction hq.
 Valid locations that could be added:
 - Small military outposts out in the frozen wastes.
 - Manned infrastructure buildings. (Power plants, radar stations, planetary defenses, smaller spaceports)

--- a/doc/JSON/ITEM_CRAFT_AND_DISASSEMBLY.md
+++ b/doc/JSON/ITEM_CRAFT_AND_DISASSEMBLY.md
@@ -83,7 +83,7 @@ Crafting recipes are defined as a JSON object with the following fields:
   "BLIND_EASY",
   "ANOTHERFLAG"
 ],
-"result_eocs": [ {"id": "TEST", "effect": { "u_message": "You feel Test" } } // List of inline effect_on_conditions or effect_on_condition ids that attempt to activate when this recipe is successfully finished.  If a value is provided a result becomes optional, though a name and id will be needed it it is missing.  If no result is provided and a description is present, "description" will be displayed as the result on the crafting gui.
+"result_eocs": [ {"id": "TEST", "effect": { "u_message": "You feel Test" } } // List of inline effect_on_conditions or effect_on_condition ids that attempt to activate when this recipe is successfully finished.  If a value is provided a result becomes optional, though a name and id will be needed if it is missing.  If no result is provided and a description is present, "description" will be displayed as the result on the crafting gui.
 ], 
 "name" : "%s with quern", // optional string to further describe recipe where %s is the recipe result name. Example if the result name is "flour", the final name will be "flour with quern". Especially useful for recipes with "id_suffix" that produce the same result as other recipes.
 "description": "foobar.  your name is <u_name>" // if crafting result is not an item, this text will be shown. Support color and NPC tags

--- a/doc/JSON/JSON_INFO.md
+++ b/doc/JSON/JSON_INFO.md
@@ -2528,8 +2528,8 @@ it is present to help catch errors.
 
 | Field                      | Purpose |
 | ---                        | ---     |
-| `name`                     | Name of the skill as displayed in the the character info screen. |
-| `description`              | Description of the skill as displayed in the the character info screen. |
+| `name`                     | Name of the skill as displayed in the character info screen. |
+| `description`              | Description of the skill as displayed in the character info screen. |
 | `tags`                     | Identifies special cases. Currently valid tags are: "combat_skill" and "contextual_skill". |
 | `time_to_attack`           | Object used to calculate the movecost for firing a gun. |
 | `display_category`         | Category in the character info screen where this skill is displayed. |

--- a/doc/JSON/JSON_STYLE.md
+++ b/doc/JSON/JSON_STYLE.md
@@ -103,4 +103,4 @@ position of your command in the list (e.g. `Tools.ExternalCommand1` if it's the
 top item in the list) and then assign shortcut keys to it.
 
 ### Visual Studio Code
-If you install the recommended extensions you should have access to the the cdda-toys.cdda-json-formatter which will auto format your json.
+If you install the recommended extensions you should have access to the cdda-toys.cdda-json-formatter which will auto format your json.

--- a/doc/JSON/MONSTERS.md
+++ b/doc/JSON/MONSTERS.md
@@ -419,7 +419,7 @@ Field              | Description
 `is_good`          | marks mutation, that is beneficial for you to hit (like headshot); false means it is a bad weakpoint for you to hit (like thick piece of armor); default true;
 `is_head`          | determines whether this weakpoint is part of the monster's head and can trigger a headshot; Only functions when `is_good` is also true, default false;
 `coverage_mult`    | object mapping weapon types to constant coverage multipliers.
-`difficulty`       | object mapping weapon types to difficulty values. Difficulty acts as soft "gate" on the attacker's skill. If the the attacker has skill equal to the difficulty, coverage is reduced to 50%. For bad weakpoint, attacker's skill will reduce the chance of hitting it.
+`difficulty`       | object mapping weapon types to difficulty values. Difficulty acts as soft "gate" on the attacker's skill. If the attacker has skill equal to the difficulty, coverage is reduced to 50%. For bad weakpoint, attacker's skill will reduce the chance of hitting it.
 `armor_mult`       | object mapping damage types to multipliers on the monster's base protection, when hitting the weakpoint.
 `armor_penalty`    | object mapping damage types to flat penalties on the monster's protection, applied after the multiplier.
 `damage_mult`      | object mapping damage types to multipliers on the post-armor damage, when hitting the weakpoint.

--- a/doc/JSON/REGION_SETTINGS.md
+++ b/doc/JSON/REGION_SETTINGS.md
@@ -368,7 +368,7 @@ The **overmap_connection_settings** section defines the `overmap_connection_id`s
 | `inter_city_road_connection` | overmap_connection id used between cities. Should include locations for the intra city terrains.   |
 | `trail_connection`           | overmap_connection id used for forest trails.                                                      |
 | `sewer_connection`           | overmap_connection id used for sewer connections.                                                  |
-| `subway_connection`          | overmap_connection id used for for both z-2 and z-4 subway connections.                            |
+| `subway_connection`          | overmap_connection id used for both z-2 and z-4 subway connections.                            |
 | `rail_connection`            | overmap_connection id used for rail connections. ( Unused in vanilla as of 0.H )                   |
 
 ### Example

--- a/doc/PLAYER_ACTIVITY.md
+++ b/doc/PLAYER_ACTIVITY.md
@@ -152,7 +152,7 @@ satisfied:
 
 - The `player_activity::moves_left` is decreased in `do_turn`
 
-- The the activity is stopped in `do_turn`  (see 'Termination' above)
+- The activity is stopped in `do_turn`  (see 'Termination' above)
 
 For example, `move_items_activity_actor::do_turn` will either move as
 many items as possible given the character's current moves or, if there

--- a/doc/WIDGETS.md
+++ b/doc/WIDGETS.md
@@ -567,7 +567,7 @@ See [Text widgets](#text-widgets) for a variety of predefined text widgets you c
 ## label
 
 The "label" is the word or phrase that appears in the UI to identify this widget. For "number",
-"graph", or "text" widgets, the label is shown to the left of the the value unless the
+"graph", or "text" widgets, the label is shown to the left of the value unless the
 `W_LABEL_NONE` [flag](#flags) is given. For "layout" widgets, the label may appear as the name of a
 section within the sidebar.
 

--- a/src/item.h
+++ b/src/item.h
@@ -426,7 +426,7 @@ class item : public visitable
         nc_color color() const;
         /**
          * Returns the color of the item depending on usefulness for the player character,
-         * e.g. differently if it its an unread book or a spoiling food item etc.
+         * e.g. differently if it is an unread book or a spoiling food item etc.
          * This should only be used for displaying data, it should not affect game play.
          */
         nc_color color_in_inventory( const Character *ch = nullptr ) const;

--- a/src/mission_companion.cpp
+++ b/src/mission_companion.cpp
@@ -1424,7 +1424,7 @@ void talk_function::caravan_return( npc &p, const std::string &dest, const missi
             popup( _( "A bandit party approaches the caravan in the open!" ) );
             force_on_force( caravan_party, "caravan", bandit_party, "band", 1 );
         } else if( one_in( 3 ) ) {
-            popup( _( "A bandit party attacks the caravan while it it's camped!" ) );
+            popup( _( "A bandit party attacks the caravan while it's camped!" ) );
             force_on_force( caravan_party, "caravan", bandit_party, "band", 2 );
         } else {
             popup( _( "The caravan walks into a bandit ambush!" ) );

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -2291,7 +2291,7 @@ bool overmapbuffer::place_special( const overmap_special_id &special_id,
         specials.push_back( &special );
         overmap_special_batch batch( om->pos(), specials );
 
-        // Filter the sectors to those which are in in range of our center point, so
+        // Filter the sectors to those which are in range of our center point, so
         // that we don't end up creating specials in areas that are outside of our radius,
         // since the whole point is to create a special that is within the parameters.
         std::vector<point_om_omt> sector_points_in_range;

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1585,7 +1585,7 @@ dealt_projectile_attack Character::throw_item( const tripoint_bub_ms &target, co
     }
 
     // Throw from the player's position, unless we're blind throwing, in which case
-    // throw from the the blind throw position instead.
+    // throw from the blind throw position instead.
     const tripoint_bub_ms throw_from = blind_throw_from_pos ? *blind_throw_from_pos : pos_bub();
 
     float range = rl_dist( throw_from, target );

--- a/tools/palettize.py
+++ b/tools/palettize.py
@@ -58,7 +58,7 @@ args = argparse.ArgumentParser(
     description="Read all the terrain and furniture definitions from a "
                 "mapgen .json file and move them into a palette file.  "
                 "Symbols with multiple definitions put the most common "
-                "definition in the the palette and leave the others in "
+                "definition in the palette and leave the others in "
                 "the mapgen file.")
 args.add_argument("mapgen_source", action="store",
                   help="specify json file to convert to palette.")


### PR DESCRIPTION
#### Summary
Bugfixes "Fix repeat words and typos"

#### Purpose of change

Came across a few incorrectly repeated words and typos in in-game dialogue, code comments and documentation.

#### Describe the solution
Deleted repeated words and fixed typos as I saw them.


#### Describe alternatives you've considered
Rewrite some dialogue. Taking the time to write detailed code comments for the comments I understand.

#### Testing

GitHub automated tests. Did not compile. In-game dialogue should be reviewed for rendering/appearance in a perfect world.

#### Additional context

Xedra Evolved documentation could use quite a bit of revision and improvement.
