### PR TITLE
Allow power producing bionics to stay on when empty (#80950)

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -2282,6 +2282,13 @@
   },
   {
     "type": "keybinding",
+    "id": "TOGGLE_SHUTDOWN",
+    "category": "BIONICS",
+    "name": "Toggle automatic shutdown on empty fuel",
+    "bindings": [ { "input_method": "keyboard_char", "key": "P" }, { "input_method": "keyboard_code", "key": "p", "mod": [ "shift" ] } ]
+  },
+  {
+    "type": "keybinding",
     "id": "TOGGLE_SPRITE",
     "category": "BIONICS",
     "name": "Toggle sprite",

--- a/src/bionics.h
+++ b/src/bionics.h
@@ -201,6 +201,7 @@ struct bionic {
         char        invlet  = 'a';
         bool        powered = false;
         bool        show_sprite = true;
+        bool        auto_shutdown = true;
         /* An amount of time during which this bionic has been rendered inoperative. */
         time_duration        incapacitated_time;
 

--- a/tests/bionics_test.cpp
+++ b/tests/bionics_test.cpp
@@ -392,14 +392,13 @@ TEST_CASE( "fueled_bionics", "[bionics] [item]" )
         bionic &bio = *dummy.find_bionic_by_uid( dummy.add_bionic( bio_fuel_cell_gasoline ) ).value();
         item_location gasoline_tank = dummy.top_items_loc().front();
 
-        // There should be no fuel available, can turn bionic on and off but no power is produced
+        // There should be no fuel available, can't turn bionic on and no power is produced
         CHECK( dummy.get_bionic_fuels( bio.id ).empty() );
         CHECK( dummy.get_cable_ups().empty() );
         CHECK( dummy.get_cable_solar().empty() );
         CHECK( dummy.get_cable_vehicle().empty() );
-        CHECK( dummy.activate_bionic( bio ) );
+        CHECK_FALSE( dummy.activate_bionic( bio ) );
         dummy.suffer();
-        CHECK( dummy.deactivate_bionic( bio ) );
         REQUIRE( !dummy.has_power() );
 
         // Add fuel. Now it turns on and generates power.
@@ -418,28 +417,26 @@ TEST_CASE( "fueled_bionics", "[bionics] [item]" )
         CHECK( units::to_joule( dummy.get_power_level() ) == 17100 );
         CHECK( gasoline_tank->empty_container() );
 
-        // Run out of fuel. Bionic stays on and can be deactivated manually.
+        // Run out of fuel
         dummy.suffer();
         CHECK( units::to_joule( dummy.get_power_level() ) == 17100 );
-        CHECK( dummy.deactivate_bionic( bio ) );
     }
 
     SECTION( "bio_batteries" ) {
         bionic &bio = *dummy.find_bionic_by_uid( dummy.add_bionic( bio_batteries ) ).value();
         item_location bat_compartment = dummy.top_items_loc().front();
 
-        // There should be no fuel available, can turn bionic on and off but no power is produced
+        // There should be no fuel available, can't turn bionic on and no power is produced
         REQUIRE( bat_compartment->ammo_remaining( ) == 0 );
         CHECK( dummy.get_bionic_fuels( bio.id ).empty() );
         CHECK( dummy.get_cable_ups().empty() );
         CHECK( dummy.get_cable_solar().empty() );
         CHECK( dummy.get_cable_vehicle().empty() );
-        CHECK( dummy.activate_bionic( bio ) );
+        CHECK_FALSE( dummy.activate_bionic( bio ) );
         dummy.suffer();
-        CHECK( dummy.deactivate_bionic( bio ) );
         REQUIRE( !dummy.has_power() );
 
-        // Add empty battery. Still won't produce power
+        // Add empty battery. Still won't work
         item battery = item( itype_light_battery_cell );
         CHECK( bat_compartment->can_reload_with( battery, true ) );
         bat_compartment->put_in( battery, pocket_type::MAGAZINE_WELL );
@@ -448,9 +445,8 @@ TEST_CASE( "fueled_bionics", "[bionics] [item]" )
         CHECK( dummy.get_cable_ups().empty() );
         CHECK( dummy.get_cable_solar().empty() );
         CHECK( dummy.get_cable_vehicle().empty() );
-        CHECK( dummy.activate_bionic( bio ) );
+        CHECK_FALSE( dummy.activate_bionic( bio ) );
         dummy.suffer();
-        CHECK( dummy.deactivate_bionic( bio ) );
         REQUIRE( !dummy.has_power() );
 
         // Add fuel. Now it turns on and generates power.
@@ -466,26 +462,24 @@ TEST_CASE( "fueled_bionics", "[bionics] [item]" )
         CHECK( units::to_joule( dummy.get_power_level() ) == 2000 );
         CHECK( bat_compartment->ammo_remaining( ) == 0 );
 
-        // Run out of ammo. Bionic stays on and can be deactivated manually.
+        // Run out of ammo
         dummy.suffer();
         CHECK( units::to_joule( dummy.get_power_level() ) == 2000 );
-        CHECK( dummy.deactivate_bionic( bio ) );
     }
 
     SECTION( "bio_cable ups" ) {
         bionic &bio = *dummy.find_bionic_by_uid( dummy.add_bionic( bio_cable ) ).value();
 
-        // There should be no fuel available, can turn bionic on and off but no power is produced
+        // There should be no fuel available, can't turn bionic on and no power is produced
         CHECK( dummy.get_bionic_fuels( bio.id ).empty() );
         CHECK( dummy.get_cable_ups().empty() );
         CHECK( dummy.get_cable_solar().empty() );
         CHECK( dummy.get_cable_vehicle().empty() );
-        CHECK( dummy.activate_bionic( bio ) );
+        CHECK_FALSE( dummy.activate_bionic( bio ) );
         dummy.suffer();
-        CHECK( dummy.deactivate_bionic( bio ) );
         REQUIRE( !dummy.has_power() );
 
-        // Connect to empty ups. Bionic shouldn't produce power
+        // Connect to empty ups. Bionic shouldn't work
         dummy.worn.wear_item( dummy, item( itype_backpack ), false, false );
         item_location ups = dummy.i_add( item( itype_UPS_ON ) );
         item_location cable = dummy.i_add( item( itype_jumper_cable ) );
@@ -499,19 +493,17 @@ TEST_CASE( "fueled_bionics", "[bionics] [item]" )
         CHECK( dummy.get_cable_ups().empty() );
         CHECK( dummy.get_cable_solar().empty() );
         CHECK( dummy.get_cable_vehicle().empty() );
-        CHECK( dummy.activate_bionic( bio ) );
+        CHECK_FALSE( dummy.activate_bionic( bio ) );
         dummy.suffer();
-        CHECK( dummy.deactivate_bionic( bio ) );
         REQUIRE( !dummy.has_power() );
 
-        // Put empty battery into ups. Still produces no power.
+        // Put empty battery into ups. Still does not work.
         item ups_mag( ups->magazine_default() );
         ups->put_in( ups_mag, pocket_type::MAGAZINE_WELL );
         REQUIRE( ups->ammo_remaining( ) == 0 );
         CHECK( dummy.get_bionic_fuels( bio.id ).empty() );
-        CHECK( dummy.activate_bionic( bio ) );
+        CHECK_FALSE( dummy.activate_bionic( bio ) );
         dummy.suffer();
-        CHECK( dummy.deactivate_bionic( bio ) );
         REQUIRE( !dummy.has_power() );
 
         // Fill the battery. Works now.
@@ -527,10 +519,9 @@ TEST_CASE( "fueled_bionics", "[bionics] [item]" )
         CHECK( ups->ammo_remaining( ) == 0 );
         CHECK( units::to_joule( dummy.get_power_level() ) == 2000 );
 
-        // Run out of fuel. Bionic stays on and can be deactivated manually.
+        // Run out of fuel
         dummy.suffer();
         CHECK( units::to_joule( dummy.get_power_level() ) == 2000 );
-        CHECK( dummy.deactivate_bionic( bio ) );
     }
 
     SECTION( "bio_wood_burner" ) {
@@ -540,11 +531,10 @@ TEST_CASE( "fueled_bionics", "[bionics] [item]" )
         // Turn safe fuel off since log produces too much energy
         bio.set_safe_fuel_thresh( -1.0f );
 
-        // There should be no fuel available, can turn bionic on and off but no power is produced
+        // There should be no fuel available, can't turn bionic on and no power is produced
         CHECK( dummy.get_bionic_fuels( bio.id ).empty() );
-        CHECK( dummy.activate_bionic( bio ) );
+        CHECK_FALSE( dummy.activate_bionic( bio ) );
         dummy.suffer();
-        CHECK( dummy.deactivate_bionic( bio ) );
         REQUIRE( !dummy.has_power() );
 
         // Add two splints. Now it turns on and generates power.
@@ -564,13 +554,12 @@ TEST_CASE( "fueled_bionics", "[bionics] [item]" )
         CHECK( units::to_joule( dummy.get_power_level() ) == 125000 );
         CHECK( woodshed->empty_container() );
 
-        // Run out of fuel. Bionic stays on and can be deactivated manually.
+        // Run out of fuel
         dummy.suffer();
         CHECK( units::to_joule( dummy.get_power_level() ) == 125000 );
-        CHECK( dummy.deactivate_bionic( bio ) );
     }
 
-    SECTION( "bio_batteries" ) {
+    SECTION( "bio_metabolics" ) {
         bionic &bio = *dummy.find_bionic_by_uid( dummy.add_bionic( bio_metabolics ) ).value();
 
         // Set stored energy below safe threshold (80%)
@@ -607,5 +596,42 @@ TEST_CASE( "fueled_bionics", "[bionics] [item]" )
         // Stored energy goes below safe level. Bionic turns off for safety.
         dummy.suffer();
         CHECK_FALSE( dummy.deactivate_bionic( bio ) );
+    }
+
+    SECTION( "bio_fuel_cell_gasoline_no_shutdown" ) {
+        bionic &bio = *dummy.find_bionic_by_uid( dummy.add_bionic( bio_fuel_cell_gasoline ) ).value();
+        item_location gasoline_tank = dummy.top_items_loc().front();
+        bio.auto_shutdown = false;
+
+        // There should be no fuel available, can turn bionic on and off but no power is produced
+        CHECK( dummy.get_bionic_fuels( bio.id ).empty() );
+        CHECK( dummy.get_cable_ups().empty() );
+        CHECK( dummy.get_cable_solar().empty() );
+        CHECK( dummy.get_cable_vehicle().empty() );
+        CHECK( dummy.activate_bionic( bio ) );
+        dummy.suffer();
+        CHECK( dummy.deactivate_bionic( bio ) );
+        REQUIRE( !dummy.has_power() );
+
+        // Add fuel. Now it turns on and generates power.
+        item gasoline = item( fuel_type_gasoline );
+        gasoline.charges = 2;
+        CHECK( gasoline_tank->can_reload_with( gasoline, true ) );
+        gasoline_tank->put_in( gasoline, pocket_type::CONTAINER );
+        REQUIRE( gasoline_tank->only_item().charges == 2 );
+        CHECK( dummy.activate_bionic( bio ) );
+        CHECK_FALSE( dummy.get_bionic_fuels( bio.id ).empty() );
+        dummy.suffer();
+        CHECK( units::to_joule( dummy.get_power_level() ) == 8550 );
+        CHECK( gasoline_tank->only_item().charges == 1 );
+
+        dummy.suffer();
+        CHECK( units::to_joule( dummy.get_power_level() ) == 17100 );
+        CHECK( gasoline_tank->empty_container() );
+
+        // Run out of fuel. Bionic stays on and can be deactivated manually.
+        dummy.suffer();
+        CHECK( units::to_joule( dummy.get_power_level() ) == 17100 );
+        CHECK( dummy.deactivate_bionic( bio ) );
     }
 }

--- a/tests/bionics_test.cpp
+++ b/tests/bionics_test.cpp
@@ -22,7 +22,6 @@
 #include "type_id.h"
 #include "units.h"
 
-static const bionic_id bio_metabolics( "bio_metabolics" );
 static const bionic_id bio_batteries( "bio_batteries" );
 // Change to some other weapon CBM if bio_blade is ever removed
 static const bionic_id bio_blade( "bio_blade" );
@@ -31,6 +30,7 @@ static const bionic_id bio_earplugs( "bio_earplugs" );
 static const bionic_id bio_ears( "bio_ears" );
 static const bionic_id bio_fuel_cell_gasoline( "bio_fuel_cell_gasoline" );
 static const bionic_id bio_fuel_wood( "bio_fuel_wood" );
+static const bionic_id bio_metabolics( "bio_metabolics" );
 static const bionic_id bio_power_storage( "bio_power_storage" );
 // Change to some other weapon CBM if bio_surgical_razor is ever removed
 static const bionic_id bio_surgical_razor( "bio_surgical_razor" );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Balance "Allow power producing bionics to be turned on and stay on when empty"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
To reduce amount of repetitive actions required while dealing with power producing bionics.
Closes #80950
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Allow power producing bionics to be turned on an stay on while empty without producing energy. Metabolic interchange is a sole exception since you can actually kill your character with it.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Keep reactivating them manually.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Installed power producing bionics on a fresh character one by one and tried to turn them on and off with and without a power source.
Metabolic interchange refuses to work on low calories, and if it was on - stops on reaching low calories. Everything else turns on without a charge while providing a message about it. When bionics run out of fuel they provide a message about it, stay on and produce no energy. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
An original threshold of 80% of healthy calories on the metabolic interchange is a bit to high maybe? Getting somewhat starved may be preferable in a dire situation.
Previously due to a bug threshold was never triggered at all - XS character was drained to death in ~6hours without metabolic interchange ever stopping.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
