### PR TITLE
Fix --world on empty worlds

### DIFF
--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -641,13 +641,32 @@ bool main_menu::opening_screen()
     ui.mark_resize();
 
     if( !queued_world_to_load.empty() ) {
-        save_t const &save_to_load = queued_save_id_to_load.empty() ? world_generator->get_world(
-                                         queued_world_to_load )->world_saves.front() : save_t::from_save_id( queued_save_id_to_load );
-        start = main_menu::load_game( queued_world_to_load, save_to_load );
-        queued_world_to_load.clear();
-        queued_save_id_to_load.clear();
-        if( start ) {
-            load_game = true;
+        WORLD* world_to_load{};
+        try {
+            save_t const &save_to_load = [&](){
+                if (queued_save_id_to_load.empty()) {
+                    world_to_load = world_generator->get_world(queued_world_to_load);
+                    const std::vector<save_t>& world_saves = world_to_load->world_saves;
+                    if (world_saves.empty()) {
+                        throw false;
+                    }
+                    return world_saves.front();
+                }
+                return save_t::from_save_id(
+                    queued_save_id_to_load
+                );
+            }();
+            start = main_menu::load_game( queued_world_to_load, save_to_load );
+            queued_world_to_load.clear();
+            queued_save_id_to_load.clear();
+            if( start ) {
+                load_game = true;
+            }
+        } catch (bool has_save) {
+            load_game = has_save;
+            if (world_to_load) {
+                popup( _( "%s has no characters to load!" ), world_to_load->world_name );
+            }
         }
     }
 

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -641,30 +641,29 @@ bool main_menu::opening_screen()
     ui.mark_resize();
 
     if( !queued_world_to_load.empty() ) {
-        WORLD* world_to_load{};
+        WORLD *world_to_load{};
         try {
-            save_t const &save_to_load = [&](){
-                if (queued_save_id_to_load.empty()) {
-                    world_to_load = world_generator->get_world(queued_world_to_load);
-                    const std::vector<save_t>& world_saves = world_to_load->world_saves;
-                    if (world_saves.empty()) {
+            save_t const &save_to_load = [&]() {
+                if( queued_save_id_to_load.empty() ) {
+                    world_to_load = world_generator->get_world( queued_world_to_load );
+                    const std::vector<save_t> &world_saves = world_to_load->world_saves;
+                    if ( world_saves.empty() ) {
                         throw false;
                     }
                     return world_saves.front();
                 }
-                return save_t::from_save_id(
-                    queued_save_id_to_load
-                );
-            }();
+                return save_t::from_save_id( queued_save_id_to_load );
+            }
+            ();
             start = main_menu::load_game( queued_world_to_load, save_to_load );
             queued_world_to_load.clear();
             queued_save_id_to_load.clear();
             if( start ) {
                 load_game = true;
             }
-        } catch (bool has_save) {
+        } catch( bool has_save ) {
             load_game = has_save;
-            if (world_to_load) {
+            if( world_to_load ) {
                 popup( _( "%s has no characters to load!" ), world_to_load->world_name );
             }
         }

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -647,7 +647,7 @@ bool main_menu::opening_screen()
                 if( queued_save_id_to_load.empty() ) {
                     world_to_load = world_generator->get_world( queued_world_to_load );
                     const std::vector<save_t> &world_saves = world_to_load->world_saves;
-                    if ( world_saves.empty() ) {
+                    if( world_saves.empty() ) {
                         throw false;
                     }
                     return world_saves.front();


### PR DESCRIPTION
Rewrite the ternary as lambda to keep save_to_load a const ref Display the same error dialog as from interactive menu

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Fix --world on empty worlds"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
We use `--world` to load a world on startup. However, if the world is empty the game crashes because the vector of saves is empty, and the code calls `.front()` on it.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Wrap the ternary in a lambda and a try/catch to keep save_to_load a const reference. Also, show the same dialog error at start-up.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not catch a bool, but why not?
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Run with and without `--world` on a world with and without characters
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
It happens when debugging using `--world` and resetting that world
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
