### PR TITLE
Significantly reduce the flammability of cotton

### DIFF
--- a/data/json/materials.json
+++ b/data/json/materials.json
@@ -600,7 +600,7 @@
   {
     "type": "material",
     "id": "cotton",
-    "name": "Cotton",
+    "name": "Cotton Blend",
     "density": 0.5,
     "specific_heat_liquid": 0.02,
     "specific_heat_solid": 0.02,
@@ -615,9 +615,9 @@
     "bash_dmg_verb": "ripped",
     "cut_dmg_verb": "cut",
     "burn_data": [
-      { "fuel": 1, "smoke": 1, "burn": 0.02 },
-      { "fuel": 2, "smoke": 1, "burn": 0.04 },
-      { "fuel": 3, "smoke": 1, "burn": 0.06 }
+      { "fuel": 0.05, "smoke": 1, "burn": 0.015 },
+      { "fuel": 0.1, "smoke": 1, "burn": 0.04 },
+      { "fuel": 0.2, "smoke": 1, "burn": 0.06 }
     ],
     "resist": { "bash": 1, "cut": 1, "acid": 3, "heat": 0, "bullet": 1 },
     "repair_difficulty": 1


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Basically a followup to #65536

I've come to realize that "Cotton" ingame burns extremely well, making it the worst (but not only!) offender which turns a pile of clothes into a raging inferno if you just drop a match on it.

The thing is, that's just not how it works! First of all, cotton isn't that flammable. Secondly, [there's laws about this!](https://www.ecfr.gov/current/title-16/chapter-II/subchapter-D/part-1610) And third, basically nothing is pure 100% cotton anymore, because synthetic fabrics are *great*.

For the viewers that have seen videos of people burning flags... well, you probably have a pretty good idea of how difficult it can be to burn fabrics.

#### Describe the solution
Take a multi-pronged approach to solving all of those issues.

First, rename "Cotton" to "Cotton-Polyester". Polyesters are the most common thing for Cotton to be blended with. (There's also Cotton-Spandex, Cotton-Silk, and pretty much any other kind of blend you can imagine.)

Second, significantly reduce the flammability and generally muck with the burn data. The Consumer Product Safety Commission(government) standards linked up above provide baseline data, but nothing that directly translates to how fast a pile of clothes should burn.

So, I've kind of winged it. These are numbers which "feel right", and went through a few tests (see below) until they performed to expectations.

#### Describe alternatives you've considered
Instead of changing "Cotton" to "Cotton-Polyester" we could instead change the material %s for all clothes already made of cotton to be part "Cotton", part "Synthetic Fabric"... but that is a massive amount of effort and churn.

That also wouldn't be very accurate - since that depicts different parts or patches of the item being made of different materials. A cotton-polyester blend is a *blend*, you physically cannot distinguish where the polyester starts and where it ends. It would be like making any item made of Bronze and changing it to be part copper, part tin. Technically, kind of correct, but bizarrely inaccurate!

#### Testing
Spawned some piles of zombie clothes.

Cotton-Polyester--> Can't be lit on its own

Pile of random clothes --> Burns, but takes upwards of 5-10 minutes before it gets beyond a small fire

Repeated the test with spawned zombies which were debug killed and unloaded into a pile. (The corpses themselves were not added to the pile.) Same results as the pile of random clothes.

Some fuzzing shows that wool is now the main contributor to piles of clothes becoming infernos. Pure wool *is* quite flammable, but I'm less sure on how wool blends or where it falls into the above regulations. Guess I'll keep checking my clothes tags...

#### Additional context

Known issues:
This does mean that grown cotton is technically now "Cotton-Polyester" right after it's come of the ground, which is a bit weird. But since most clothes were *already* made out of Cotton-Polyester (we just didn't represent this properly) it's just a minor graphical issue.