### PR TITLE
[MoM] Add speech snippets for PHAVIAN scientists

### DIFF
--- a/data/mods/MindOverMatter/monsters/zombies.json
+++ b/data/mods/MindOverMatter/monsters/zombies.json
@@ -125,6 +125,8 @@
     "emit_fields": [ { "emit_id": "emit_anti_psi", "delay": "1 s" } ],
     "grab_strength": 30,
     "special_attacks": [
+      [ "PARROT", 400 ],
+      [ "PARROT_AT_DANGER", 0 ],
       { "id": "grab", "cooldown": { "math": [ "5 + rand(10)" ] } },
       { "id": "bite_humanoid", "cooldown": { "math": [ "2 + rand(4)" ] } },
       {

--- a/data/mods/MindOverMatter/monsters/zombies.json
+++ b/data/mods/MindOverMatter/monsters/zombies.json
@@ -59,6 +59,7 @@
     "emit_fields": [ { "emit_id": "emit_anti_psi", "delay": "1 s" } ],
     "grab_strength": 40,
     "special_attacks": [
+      [ "PARROT", 400 ],
       { "id": "grab", "cooldown": { "math": [ "5 + rand(10)" ] } },
       { "id": "bite_humanoid", "cooldown": { "math": [ "2 + rand(4)" ] } },
       {
@@ -185,6 +186,7 @@
     "emit_fields": [ { "emit_id": "emit_anti_psi_void", "delay": "1 s" } ],
     "grab_strength": 50,
     "special_attacks": [
+      [ "PARROT", 400 ],
       { "id": "ranged_pull", "range": 3, "cooldown": { "math": [ "2 + rand(4)" ] }, "no_adjacent": true },
       { "id": "grab_drag", "cooldown": { "math": [ "2 + rand(4)" ] } },
       { "id": "drag_followup" },

--- a/data/mods/MindOverMatter/snippets/speech.json
+++ b/data/mods/MindOverMatter/snippets/speech.json
@@ -1,6 +1,42 @@
 [
   {
     "type": "speech",
+    "speaker": [ "mon_zombie_scientist_phavian" ],
+    "sound": "wheezing.",
+    "volume": 10
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_zombie_scientist_phavian" ],
+    "sound": "moaning.",
+    "volume": 20
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_zombie_scientist_phavian" ],
+    "sound": "gargling.",
+    "volume": 10
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_zombie_scientist_phavian" ],
+    "sound": "growling.",
+    "volume": 15
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_zombie_scientist_phavian" ],
+    "sound": "grunting.",
+    "volume": 10
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_zombie_scientist_phavian" ],
+    "sound": "gasping.",
+    "volume": 5
+  },
+  {
+    "type": "speech",
     "speaker": [ "mon_feral_human_pyrokin3", "mon_feral_human_pyrokin2", "mon_civilian_pyrokinetic" ],
     "sound": "the crackle of flames.",
     "volume": 10

--- a/data/mods/MindOverMatter/snippets/speech.json
+++ b/data/mods/MindOverMatter/snippets/speech.json
@@ -1,37 +1,37 @@
 [
   {
     "type": "speech",
-    "speaker": [ "mon_zombie_scientist_phavian" ],
+    "speaker": [ "mon_zombie_scientist_phavian", "mon_zombie_blank", "mon_zombie_concentration_ender" ],
     "sound": "wheezing.",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "mon_zombie_scientist_phavian" ],
+    "speaker": [ "mon_zombie_scientist_phavian", "mon_zombie_blank", "mon_zombie_concentration_ender" ],
     "sound": "moaning.",
     "volume": 20
   },
   {
     "type": "speech",
-    "speaker": [ "mon_zombie_scientist_phavian" ],
+    "speaker": [ "mon_zombie_scientist_phavian", "mon_zombie_blank", "mon_zombie_concentration_ender" ],
     "sound": "gargling.",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "mon_zombie_scientist_phavian" ],
+    "speaker": [ "mon_zombie_scientist_phavian", "mon_zombie_blank", "mon_zombie_concentration_ender" ],
     "sound": "growling.",
     "volume": 15
   },
   {
     "type": "speech",
-    "speaker": [ "mon_zombie_scientist_phavian" ],
+    "speaker": [ "mon_zombie_scientist_phavian", "mon_zombie_blank", "mon_zombie_concentration_ender" ],
     "sound": "grunting.",
     "volume": 10
   },
   {
     "type": "speech",
-    "speaker": [ "mon_zombie_scientist_phavian" ],
+    "speaker": [ "mon_zombie_scientist_phavian", "mon_zombie_blank", "mon_zombie_concentration_ender" ],
     "sound": "gasping.",
     "volume": 5
   },
@@ -49,7 +49,7 @@
   },
   {
     "type": "speech",
-    "speaker": [ "mon_feral_human_teep2" ],
+    "speaker": [ "mon_feral_human_teep2", "mon_zombie_concentration_ender", "mon_zombie_nullpsi", "mon_zombie_psi_void" ],
     "sound": "a low droning hum inside your head.",
     "volume": 10
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "[MoM] Add speech snippets for PHAVIAN scientists"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Speech snippets are not inherited, they go strictly off id
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the various zombie noises to PHAVIAN scientists so they have something to `PARROT`. Also do the same for the `zombie blank` and the `zombie breaker.`

For the `zombie null` and the `nether-void`, add them for the snippet that runs 

> a low droning hum inside your head

And give them the PARROT attack
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
