### PR TITLE
Fix zone sorting (again) (for real) (final) (v4)

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -10208,7 +10208,6 @@ bool zone_sort_activity_actor::stage_think( player_activity &act, Character &you
     // iterate over zone positions and look for items to move
     for( const tripoint_abs_ms &src : src_sorted ) {
         placement = src;
-        coord_set.erase( src );
 
         const tripoint_bub_ms src_bub = here.get_bub( src );
         if( !here.inbounds( src_bub ) ) {


### PR DESCRIPTION
#### Summary
Bugfixes "Properly fixed zone sorting this time, probably."

#### Purpose of change
* Fixes #84282 (although this report was really for the first issue, not the current one)

After moving the first item in non-adjacent destinations it realizes the current turn is "done" (because we're out of moves) and sets the activity back to thinking.

The problem is: The first time we "thought" about how to do the sorting we actually burned the bridges and threw everything out. So we *can't* think about it again.

#### Describe the solution
Just don't do that. Don't erase our sorting coordinates until we're actually done and they naturally go out of scope.

This lets it loop naturally between thinking and doing until the task actually is done.

#### Describe alternatives you've considered
Reverting most of the anvilmancy fix. Ehhhh, sure we could do that but we want sorting to work this way anyway. And this was not difficult.

#### Testing
Loaded saves from both #83745 and #83746 and couldn't reproduce those. (The last time that line of code was changed was to fix those two). Admittedly, the former I let it sit for a good 10 IRL minutes before declaring it "works fine" (did not finish sorting).... they have a lot to sort. The latter is an absolute mess, and while I cannot tell if anything was sorted it did not *freeze*.

Loaded saves from #84260 and #84271, both sorted.

Sorted from a vehicle:

https://github.com/user-attachments/assets/a41cb1c8-fdd8-4ea5-8eb1-7882d3473376


#### Additional context

Now, I will openly say that I do not understand why that line of code was there.

I blamed it all the way back to 99705f8b0e529029c2c8b149b448c483f51e2be5, and everything since then has just been passing it along.