### PR TITLE
Remove MXE from release, fix clang on macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,6 @@ jobs:
             artifact: windows-with-graphics-x64
             arch: x64
             os: windows-2022
-            mxe: none
             ext: zip
             content: application/zip
             tiles: 1
@@ -79,14 +78,12 @@ jobs:
             artifact: windows-with-graphics-and-sounds-x64
             arch: x64
             os: windows-2022
-            mxe: none
             ext: zip
             content: application/zip
             tiles: 1
             sound: 1
           - name: Linux Tiles x64
             os: ubuntu-22.04
-            mxe: none
             android: none
             libbacktrace: 1
             tiles: 1
@@ -96,7 +93,6 @@ jobs:
             content: application/gzip
           - name: Linux Tiles Sounds x64
             os: ubuntu-22.04
-            mxe: none
             android: none
             libbacktrace: 1
             tiles: 1
@@ -106,7 +102,6 @@ jobs:
             content: application/gzip
           - name: Linux Curses x64
             os: ubuntu-22.04
-            mxe: none
             android: none
             libbacktrace: 1
             tiles: 0
@@ -116,7 +111,6 @@ jobs:
             content: application/gzip
           - name: macOS Curses Universal Binary (x64 and arm64)
             os: macos-15
-            mxe: none
             tiles: 0
             sound: 0
             artifact: osx-terminal-only-universal
@@ -124,7 +118,6 @@ jobs:
             content: application/x-apple-diskimage
           - name: macOS Tiles Universal Binary (x64 and arm64)
             os: macos-15
-            mxe: none
             tiles: 1
             sound: 0
             artifact: osx-with-graphics-universal
@@ -132,7 +125,6 @@ jobs:
             content: application/x-apple-diskimage
           - name: Android x64
             os: ubuntu-latest
-            mxe: none
             tiles: 1
             android: arm64
             artifact: android-x64
@@ -140,7 +132,6 @@ jobs:
             content: application/apk
           - name: Android x32
             os: ubuntu-latest
-            mxe: none
             tiles: 1
             android: arm32
             artifact: android-x32
@@ -148,7 +139,6 @@ jobs:
             content: application/apk 
           #- name: WebAssembly Bundle
           #  os: ubuntu-latest
-          #  mxe: none
           #  artifact: wasm
           #  ext: zip
           #  content: application/zip
@@ -180,12 +170,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: translations
-      - name: Install dependencies (windows msvc) (0/4)
-        if: runner.os == 'Windows'
-        uses: lukka/get-cmake@latest
-        with:
-          # 4.0.0 has issues compiling old packages in vcpkg
-          cmakeVersion: 3.31.6
       - name: Install dependencies (windows msvc) (1/4)
         if: runner.os == 'Windows'
         uses: microsoft/setup-msbuild@v2
@@ -208,22 +192,8 @@ jobs:
           install: >-
             gettext
             make
-      - name: Install dependencies (windows mxe)
-        if: matrix.mxe != 'none'
-        run: |
-          sudo apt install gettext
-      - name: Install MXE
-        if: matrix.mxe != 'none'
-        run: |
-          curl -L -o mxe-${{ matrix.mxe }}.tar.xz https://github.com/BrettDong/MXE-GCC/releases/download/mxe-sdl-2-0-20/mxe-${{ matrix.mxe }}.tar.xz
-          curl -L -o mxe-${{ matrix.mxe }}.tar.xz.sha256 https://github.com/BrettDong/MXE-GCC/releases/download/mxe-sdl-2-0-20/mxe-${{ matrix.mxe }}.tar.xz.sha256
-          shasum -a 256 -c ./mxe-${{ matrix.mxe }}.tar.xz.sha256
-          sudo tar xJf mxe-${{ matrix.mxe }}.tar.xz -C /opt
-          curl -L -o SDL2-devel-2.26.2-mingw.tar.gz https://github.com/libsdl-org/SDL/releases/download/release-2.26.2/SDL2-devel-2.26.2-mingw.tar.gz
-          shasum -a 256 -c ./build-scripts/SDL2-devel-2.26.2-mingw.tar.gz.sha256
-          sudo tar -xzf SDL2-devel-2.26.2-mingw.tar.gz -C /opt/mxe/usr/${{ matrix.mxe }}-w64-mingw32.static.gcc12 --strip-components=2 SDL2-2.26.2/${{ matrix.mxe }}-w64-mingw32
       - name: Install dependencies (Linux)
-        if: runner.os == 'Linux' && matrix.mxe == 'none' && matrix.android == 'none' && !matrix.wasm
+        if: runner.os == 'Linux' && matrix.android == 'none' && !matrix.wasm
         run: |
           sudo apt-get update
           sudo apt-get install libsdl2-dev
@@ -285,7 +255,7 @@ jobs:
           cp LICENSE ${{ github.workspace }}/LICENSE-libbacktrace.txt
           sudo make install
       - name: Build CDDA (linux)
-        if: runner.os == 'Linux' && matrix.mxe == 'none' && matrix.android == 'none' && !matrix.wasm
+        if: runner.os == 'Linux' && matrix.android == 'none' && !matrix.wasm
         run: |
           make -j$((`nproc`+0)) TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=1 LIBBACKTRACE=${{ matrix.libbacktrace }} WARN_STALE_DATA=1 PCH=0 bindist
           mv cataclysmdda-0.J.tar.gz cdda-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.tar.gz
@@ -295,13 +265,6 @@ jobs:
           ./build-scripts/build-emscripten.sh
           ./build-scripts/prepare-web.sh
           (cd build && zip ../cdda-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.${{ matrix.ext }} *)
-      - name: Build CDDA (windows mxe)
-        if: matrix.mxe != 'none'
-        env:
-          PLATFORM: /opt/mxe/usr/bin/${{ matrix.mxe }}-w64-mingw32.static.gcc12-
-        run: |
-          make -j$((`nproc`+0)) CROSS="${PLATFORM}" TILES=1 SOUND=1 RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=1 LIBBACKTRACE=${{ matrix.libbacktrace }} WARN_STALE_DATA=1 PCH=0 bindist
-          mv cataclysmdda-0.J.zip cdda-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.zip
       - name: Build CDDA (windows msvc)
         if: runner.os == 'Windows'
         env:
@@ -319,18 +282,18 @@ jobs:
           make -j3 TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=0 PCH=0 USE_HOME_DIR=1 FRAMEWORK=1 UNIVERSAL_BINARY=1 WARN_STALE_DATA=1 dmgdist
           mv Cataclysm.dmg cdda-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.dmg
       - name: Set up JDK 8 (android)
-        if: runner.os == 'Linux' && matrix.android != 'none' && matrix.mxe == 'none'
+        if: runner.os == 'Linux' && matrix.android != 'none'
         uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'adopt'   
       - name: Setup Build and Dependencies (android)
-        if: runner.os == 'Linux' && matrix.android != 'none' && matrix.mxe == 'none'
+        if: runner.os == 'Linux' && matrix.android != 'none'
         run: |
           sudo apt-get update
           sudo apt-get install gettext          
       - name: Build CDDA (android)
-        if: runner.os == 'Linux' && matrix.android != 'none' && matrix.mxe == 'none'
+        if: runner.os == 'Linux' && matrix.android != 'none'
         working-directory: ./android
         run: |
           echo "${{ secrets.KEYSTORE }}" > release.keystore.asc   

--- a/Makefile
+++ b/Makefile
@@ -260,7 +260,6 @@ endif
 
 ifneq (,$(findstring clang,$(COMPILER)))
   CLANG = $(COMPILER)
-  CXX_WARNINGS += -Wno-unknown-warning-option
 endif
 
 # Windows sets the OS environment variable so we can cheaply test for it.
@@ -386,6 +385,7 @@ ifneq ($(CLANG), 0)
     CXX = $(CROSS)$(CLANGCMD)
     LD  = $(CROSS)$(CLANGCMD)
   endif
+  CXX_WARNINGS += -Wno-unknown-warning-option
 else
   # Compiler version & target machine - used later for MXE ICE workaround
   ifdef CROSS


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Build "Remove MXE from release, fix clang on macOS"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
MXE is not used in the GHA release matrix workflow so I removed the logic around it.

Also fix the macOS build by using clang's `-Wno-unknown-warning-option` properly (fixed by @akrieger).

Also remove forcing cmake v3 workaround after vcpkg baseline upgrade.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
As above
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
None
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested the CI workflow on my fork.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I have (finally) enabled GHA on my fork.
- Why `workflow_dispatch` must run on the default branch?
- Will GHA use my workflow or the `master` one?
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
