### PR TITLE
Fix installed gunmods appearing in multidrop

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8096,12 +8096,27 @@ void game::reload( item_location &loc, bool prompt, bool empty )
     }
 }
 
+
+class reload_selector_preset : public inventory_selector_preset
+{
+    public:
+        explicit reload_selector_preset() : inventory_selector_preset( ), you( get_avatar() ) {
+            _pk_type = { pocket_type::CONTAINER, pocket_type::MOD };
+        }
+        bool is_shown( const item_location &location ) const override {
+            return !location.is_invisible_installed_gunmod( ) &&
+                   you.rate_action_reload( *location ) == hint_rating::good;
+        }
+    private:
+        const Character &you;
+};
+
 // Reload something.
 void game::reload_item()
 {
-    item_location item_loc = inv_map_splice( [&]( const item & it ) {
-        return u.rate_action_reload( it ) == hint_rating::good;
-    }, _( "Reload item" ), 1, _( "You have nothing to reload." ) );
+    const reload_selector_preset preset;
+    item_location item_loc = inv_map_splice( preset,
+                             _( "Reload item" ), 1, _( "You have nothing to reload." ) );
 
     if( !item_loc ) {
         add_msg( _( "Never mind." ) );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8100,7 +8100,7 @@ void game::reload( item_location &loc, bool prompt, bool empty )
 class reload_selector_preset : public inventory_selector_preset
 {
     public:
-        explicit reload_selector_preset() : inventory_selector_preset( ), you( get_avatar() ) {
+        explicit reload_selector_preset() : you( get_avatar() ) {
             _pk_type = { pocket_type::CONTAINER, pocket_type::MOD };
         }
         bool is_shown( const item_location &location ) const override {

--- a/src/game.h
+++ b/src/game.h
@@ -26,6 +26,7 @@
 #include "cursesdef.h"
 #include "enums.h"
 #include "global_vars.h"
+#include "inventory_ui.h"
 #include "item_location.h"
 #include "map_scale_constants.h"
 #include "memory_fast.h"
@@ -764,6 +765,8 @@ class game
         /** Custom-filtered menu for inventory and nearby items and those that within specified radius */
         item_location inv_map_splice( const item_filter &filter, const std::string &title, int radius = 0,
                                       const std::string &none_message = "" );
+        item_location inv_map_splice( const inventory_selector_preset &preset, const std::string &title,
+                                      int radius = 0, const std::string &none_message = "" );
         item_location inv_map_splice( const item_location_filter &filter, const std::string &title,
                                       int radius = 0, const std::string &none_message = "" );
 

--- a/src/game.h
+++ b/src/game.h
@@ -26,7 +26,6 @@
 #include "cursesdef.h"
 #include "enums.h"
 #include "global_vars.h"
-#include "inventory_ui.h"
 #include "item_location.h"
 #include "map_scale_constants.h"
 #include "memory_fast.h"
@@ -76,6 +75,7 @@ class eoc_events;
 class event_bus;
 class faction_manager;
 class field_entry;
+class inventory_selector_preset;
 class item;
 class kill_tracker;
 class live_view;

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -3025,7 +3025,7 @@ item_location game_menus::inv::change_sprite( Character &you )
 class unload_selector_preset : public inventory_selector_preset
 {
     public:
-        explicit unload_selector_preset() : inventory_selector_preset( ), you( get_avatar() ) {
+        explicit unload_selector_preset() : you( get_avatar() ) {
             _pk_type = { pocket_type::CONTAINER, pocket_type::MOD };
         }
         bool is_shown( const item_location &location ) const override {

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -479,6 +479,13 @@ item_location game::inv_map_splice( const item_filter &filter, const std::string
                          title, radius, none_message );
 }
 
+item_location game::inv_map_splice( const inventory_selector_preset &preset,
+                                    const std::string &title,
+                                    int radius, const std::string &none_message )
+{
+    return inv_internal( u, preset, title, radius, none_message );
+}
+
 item_location game::inv_map_splice( const item_location_filter &filter, const std::string &title,
                                     int radius, const std::string &none_message )
 {
@@ -1108,6 +1115,7 @@ class activatable_inventory_preset : public pickup_inventory_preset
         explicit activatable_inventory_preset() : pickup_inventory_preset( get_avatar() ),
             you( get_avatar() ) {
             _collate_entries = true;
+            _pk_type = { pocket_type::CONTAINER, pocket_type::MOD };
             if( get_option<bool>( "INV_USE_ACTION_NAMES" ) ) {
                 append_cell( [ this ]( const item_location & loc ) {
                     return string_format( "<color_light_green>%s</color>", get_action_name( *loc ) );
@@ -1116,7 +1124,8 @@ class activatable_inventory_preset : public pickup_inventory_preset
         }
 
         bool is_shown( const item_location &loc ) const override {
-            return loc->type->has_use() || loc->has_relic_activation();
+            return !loc.is_invisible_installed_gunmod( )
+                   && ( loc->type->has_use() || loc->has_relic_activation() );
         }
 
         std::string get_denial( const item_location &loc ) const override {
@@ -3013,12 +3022,23 @@ item_location game_menus::inv::change_sprite( Character &you )
                          _( "You have nothing to wear." ) );
 }
 
+class unload_selector_preset : public inventory_selector_preset
+{
+    public:
+        explicit unload_selector_preset() : inventory_selector_preset( ), you( get_avatar() ) {
+            _pk_type = { pocket_type::CONTAINER, pocket_type::MOD };
+        }
+        bool is_shown( const item_location &location ) const override {
+            return !location.is_invisible_installed_gunmod( ) &&
+                   you.rate_action_unload( *location ) == hint_rating::good;
+        }
+    private:
+        const Character &you;
+};
+
 std::pair<item_location, bool> game_menus::inv::unload( Character &you )
 {
-
-    const inventory_filter_preset preset( [&you]( const item_location & location ) {
-        return you.rate_action_unload( *location ) == hint_rating::good;
-    } );
+    const unload_selector_preset preset;
     unload_selector inv_s( you, preset );
 
     inv_s.set_title( _( "Unload item" ) );

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -708,15 +708,8 @@ inventory_selector_preset::inventory_selector_preset()
     } ) );
 }
 
-bool inventory_selector_preset::is_shown( const item_location &loc ) const
+bool inventory_selector_preset::is_shown( const item_location & ) const
 {
-    if( loc->is_gunmod() ) {
-        item_location parent = loc.parent_item();
-        const bool installed = parent && parent->is_gun();
-        if( installed && !loc->type->gunmod->is_visible_when_installed ) {
-            return false;
-        }
-    }
     return true;
 }
 

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -58,7 +58,6 @@
 #include "uistate.h"
 #include "units.h"
 #include "units_utility.h"
-#include "value_ptr.h"
 #include "vehicle.h"
 #include "vehicle_selector.h"
 #include "vpart_position.h"

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -313,7 +313,7 @@ class inventory_selector_preset
         bool _indent_entries = true;
         bool _collate_entries = false;
 
-        std::vector<pocket_type> _pk_type = { pocket_type::CONTAINER, pocket_type::MOD };
+        std::vector<pocket_type> _pk_type = { pocket_type::CONTAINER };
 
     private:
         class cell_t

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -22,6 +22,7 @@
 #include "game_constants.h"
 #include "item.h"
 #include "item_pocket.h"
+#include "itype.h"
 #include "json.h"
 #include "line.h"
 #include "magic_enchantment.h"
@@ -936,6 +937,19 @@ bool item_location::has_parent() const
 bool item_location::is_efile() const
 {
     return parent_item() && parent_item()->is_estorage();
+}
+
+bool item_location::is_invisible_installed_gunmod() const
+{
+    const item_location current_location = *this;
+    if( current_location->is_gunmod() ) {
+        item_location parent = parent_item();
+        const bool installed = parent && parent->is_gun();
+        if( installed && !current_location->type->gunmod->is_visible_when_installed ) {
+            return true;
+        }
+    }
+    return false;
 }
 
 pocket_constraint item_location::get_pocket_constraints_recursive( const item_pocket *pocket ) const

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -38,6 +38,7 @@
 #include "translations.h"
 #include "type_id.h"
 #include "units.h"
+#include "value_ptr.h"
 #include "vehicle.h"
 #include "vehicle_selector.h"
 #include "visitable.h"

--- a/src/item_location.h
+++ b/src/item_location.h
@@ -133,6 +133,12 @@ class item_location
         bool is_efile() const;
 
         /**
+        * Returns true if the item is a gunmod, is installed on a gun
+        * and allowed to be used directly from inventory
+        */
+        bool is_invisible_installed_gunmod() const;
+
+        /**
         * Returns available volume capacity where this item is located.
         */
         units::volume volume_capacity() const;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from Github's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Fix installed gunmods appearing in multidrop"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix installed gunmods appearing in irrelevant places like multidrop selection.
They will only appear for activation, reload and unload.

Fixes #84192
Fixes #83851
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Installed gunmod filtering logic moved from default selector preset to relevant action presets - activate, reload, unload.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
1. Drop the whole "interact with installed gunmods directly from inventory" thing. Quite an intrusive feature for a single corner case. Personally - all for it.
2. Keep installed gunmods in default selector and make multidrop specifically not show them instead. Solves issue at hand but unwanted installed mods may still show up in some other unintended places.
3. Keep dropping your carbine .223 upper receiver and getting annoyed by that

#### Testing
Directly from inventory mounted flashlight on AR-15 can be activated, unloaded and reloaded, but not dropped.
Directly from inventory other mods on AR-15 can not be activated, unloaded, reloaded or dropped.
Other mods still can be activated through gun modding menu - adjustable sling adjusts fine.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
N/A
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
