### PR TITLE
Revert "Restore quick reload"

### DIFF
--- a/data/core/tips.json
+++ b/data/core/tips.json
@@ -140,7 +140,6 @@
       "Feral humans are smarter than zombies.  They throw rocks and can even open doors.  Watch out!",
       "If you want something to stop existing, setting it on fire is a tried and true method.",
       "The higher up you are, the farther you can see on the overmap.",
-      "Reloading allows you to repeat the last keypress to pick the first item in the reloading list.  Paired with the 'Reload weapon' keybind, reloading shotguns can even bring some joy!",
       "Nobody wants to buy filthy underwear.  Wash your clothes to get a better price for them."
     ]
   }

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -43,7 +43,6 @@
 #include "iuse_actor.h"
 #include "map.h"
 #include "mapdata.h"
-#include "math_parser_diag_value.h"
 #include "messages.h"
 #include "npc.h"
 #include "npctrade.h"
@@ -3149,22 +3148,6 @@ class select_ammo_inventory_preset : public inventory_selector_preset
             item_location left = lhs.any_item();
             item_location right = rhs.any_item();
 
-            // if we remember what round we used last time, it's wise to try to use it again
-            // it supposed to be stored elsewhere, potentially in a gun itself, but all item_locations are const here
-            const std::string last_ammo = you.get_value( "last_round_reloaded_id" ).str();
-            if( !last_ammo.empty() ) {
-                if( ( left.get_item()->type->id.str() == last_ammo ) !=
-                    ( right.get_item()->typeId().str() == last_ammo ) ) {
-                    return left.get_item()->typeId().str() == last_ammo;
-                }
-            }
-
-            // if gun already has a round of this type inside, prioritize this type
-            if( ( target.get_item()->ammo_current() == left.get_item()->typeId() ) !=
-                ( target.get_item()->ammo_current() == right.get_item()->typeId() ) ) {
-                return ( target.get_item()->ammo_current() == left.get_item()->typeId() );
-            }
-
             if( left->ammo_remaining( ) == 0 || right->ammo_remaining( ) == 0 ) {
                 return ( left->ammo_remaining( ) != 0 ) > ( right->ammo_remaining( ) != 0 );
             }
@@ -3195,8 +3178,7 @@ item::reload_option game_menus::inv::select_ammo( Character &you, const item_loc
     inv_s.set_title( string_format( loc->is_watertight_container() ? _( "Refill %s" ) :
                                     loc->has_flag( flag_RELOAD_AND_SHOOT ) ? _( "Select ammo for %s" ) : _( "Reload %s" ),
                                     loc->display_name() ) );
-    inv_s.set_hint(
-        _( "Choose ammo to reload\nRepeating the last keybind picks the lastly loaded round" ) );
+    inv_s.set_hint( _( "Choose ammo to reload" ) );
     inv_s.set_display_stats( false );
 
     inv_s.clear_items();
@@ -3228,7 +3210,6 @@ item::reload_option game_menus::inv::select_ammo( Character &you, const item_loc
         }
     }
 
-    you.set_value( "last_round_reloaded_id", selected.first.get_item()->type->id.str() );
     item::reload_option opt( &you, target_loc, selected.first );
     opt.qty( selected.second );
 

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -1641,18 +1641,6 @@ size_t inventory_column::get_entry_indent( const inventory_entry &entry ) const
     return res;
 }
 
-void inventory_column::assign_custom_invlet( int cur_idx, std::string_view pickup_chars )
-{
-    for( inventory_entry &elem : entries ) {
-        elem.custom_invlet =
-            static_cast<uint8_t>(
-                cur_idx < static_cast<int>( pickup_chars.size() ) ?
-                pickup_chars[cur_idx] : '\0'
-            );
-        cur_idx++;
-    }
-}
-
 int inventory_column::reassign_custom_invlets( const Character &p, int min_invlet, int max_invlet )
 {
     int cur_invlet = min_invlet;
@@ -1670,7 +1658,12 @@ int inventory_column::reassign_custom_invlets( int cur_idx, std::string_view pic
     for( inventory_entry &elem : entries ) {
         // Only items on map/in vehicles: those that the player does not possess.
         if( elem.is_selectable() && elem.any_item()->invlet <= '\0' ) {
-            assign_custom_invlet( cur_idx, pickup_chars );
+            elem.custom_invlet =
+                static_cast<uint8_t>(
+                    cur_idx < static_cast<int>( pickup_chars.size() ) ?
+                    pickup_chars[cur_idx] : '\0'
+                );
+            cur_idx++;
         }
     }
     return cur_idx;
@@ -3953,23 +3946,6 @@ void ammo_inventory_selector::set_all_entries_chosen_count()
                 }
             }
         }
-    }
-}
-
-void ammo_inventory_selector::reassign_custom_invlets()
-{
-    bool use_num_invlet = uistate.numpad_navigation ? false : true;
-    // funky bug: if you press any another allowed button (like `>` to show content), this invlet is lost and replaced with this button you just pressed!
-    const char last_key = inp_mngr.get_previously_pressed_key();
-    // 0 is eaten by some magic, then our last_key appear, then and later on are numbers if numpad_navigation is off
-    const std::string invlet_set = std::string( "0" )
-                                   + last_key
-                                   + ( use_num_invlet ? "123456789" : "" );
-    int i = 0;
-    for( inventory_column *elem : columns ) {
-        elem->prepare_paging();
-        elem->assign_custom_invlet( i, invlet_set );
-        ++i;
     }
 }
 

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -465,8 +465,6 @@ class inventory_column
         /** Returns next custom inventory letter. */
         int reassign_custom_invlets( const Character &p, int min_invlet, int max_invlet );
         int reassign_custom_invlets( int cur_idx, std::string_view pickup_chars );
-        // just assign an invlet manually
-        void assign_custom_invlet( int cur_idx, std::string_view pickup_chars );
         /** Reorder entries, repopulate titles, adjust to the new height. */
         virtual void prepare_paging( const std::string &filter = "" );
         /**
@@ -1041,8 +1039,6 @@ class ammo_inventory_selector : public inventory_selector
 
         drop_location execute();
         void set_all_entries_chosen_count();
-    protected:
-        void reassign_custom_invlets() override;
     private:
         void mod_chosen_count( inventory_entry &entry, int val );
         const item_location reload_loc;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Someone reported that not only this PR do not work in many cases (like, for example, it works when i personally use `ctrl + r` as reload weapon keybind, but do not work when i have reload on just `r`), it also breaks a generic reload, because `ammo_inventory_selector::execute()` do not understand such shenanigans
#### Describe the solution
Reverts CleverRaven/Cataclysm-DDA#80740
#### Additional context
I have a different PR in work, that would streamline reloading better, but it was plagued by a ton of weird issues recently