### PR TITLE
[RFC] make flatbuffers lib dynamic

### DIFF
--- a/msvc-full-features/flatbuffers.vcxproj
+++ b/msvc-full-features/flatbuffers.vcxproj
@@ -55,7 +55,7 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <PreferredToolArchitecture>x64</PreferredToolArchitecture>
@@ -126,3 +126,4 @@
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
 </Project>
+


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
The build is breaking because the image size is too large.

#### Describe the solution
Configures the VS build of flatbuffers to emit a dll and reduce the exe size.
Probably will need more configuration to get it to link. 

#### Describe alternatives you've considered
It might be better to find some native dda code with a low call rate to extract to a dll instead because this might have a lot of overhead due to rapid invocation ratesv during serialization.

#### Testing
If it links it's correct,  but needs at least a cursiry perf comparison to make sure there's not a large regression.

#### Additional context
Error first noticed here https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/20500211724/job/58915615291?pr=84316#step:15:2221

D:\a\Cataclysm-DDA\Cataclysm-DDA\msvc-full-features\..\objwin\Release\x64\Cataclysm-lib-vcpkg-static\Cataclysm-lib-vcpkg-static-Release-x64.lib : fatal error LNK1248: image size (100B62605) exceeds maximum allowable size (FFFFFFFF) [D:\a\Cataclysm-DDA\Cataclysm-DDA\msvc-full-features\Cataclysm-lib-vcpkg-static.vcxproj]