### PR TITLE
Allow filling the washing machine with water only.

### DIFF
--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -1486,7 +1486,8 @@
         "rigid": true,
         "watertight": true,
         "max_contains_volume": "135 L",
-        "max_contains_weight": "15 kg"
+        "max_contains_weight": "15 kg",
+        "item_restriction": [ "water", "water_clean" ]
       }
     ],
     "to_hit": { "grip": "bad", "length": "long", "surface": "any", "balance": "clumsy" },


### PR DESCRIPTION
#### Summary
Bugfixes "Allow filling the washing machine with water only."

#### Purpose of change
Fixes #83731.

#### Describe the solution
Added "item_restriction" list to "pocket_data" of "household_washing_machine".