### PR TITLE
add "OVERHEATS" flag to hm12.

### DIFF
--- a/data/json/items/gun/ups.json
+++ b/data/json/items/gun/ups.json
@@ -174,7 +174,7 @@
     "energy_drain": "20 kJ",
     "modes": [ [ "DEFAULT", "semi-auto", 1 ] ],
     "ammo_effects": [ "LASER", "ROBOT_DAZZLE" ],
-    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE", "USE_UPS" ],
+    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE", "USE_UPS", "OVERHEATS" ],
     "valid_mod_locations": [
       [ "grip", 1 ],
       [ "rail", 1 ],

--- a/doc/JSON/JSON_FLAGS.md
+++ b/doc/JSON/JSON_FLAGS.md
@@ -991,7 +991,7 @@ These can be applied to guns or gunmods, adding different effects to the guns.
 - ```NEVER_JAMS``` Never malfunctions.  Unaffected by the `JAMMED_GUN` fault.
 - ```NO_DIRTYING``` Prevents the gun from receiving `fault_gun_dirt` fault.
 - ```NON_FOULING``` Gun does not become dirty or blackpowder fouled.
-- ```OVERHEATS``` Adds informational description that the gun will overheat when fired continuously. Does not actually control any behavior.
+- ```OVERHEATS``` Adds a description stating the gun overheats when fired continuously. Purely informational. Does not affect behavior.
 - ```JAMMED_GUN``` Stops burst fire.  Adds delay on next shot.
 - ```UNLUBRICATED``` Randomly causes screeching noise when firing and applies damage when that happens.
 

--- a/doc/JSON/JSON_FLAGS.md
+++ b/doc/JSON/JSON_FLAGS.md
@@ -991,6 +991,7 @@ These can be applied to guns or gunmods, adding different effects to the guns.
 - ```NEVER_JAMS``` Never malfunctions.  Unaffected by the `JAMMED_GUN` fault.
 - ```NO_DIRTYING``` Prevents the gun from receiving `fault_gun_dirt` fault.
 - ```NON_FOULING``` Gun does not become dirty or blackpowder fouled.
+- ```OVERHEATS``` Adds informational description that the gun will overheat when fired continuously. Does not actually control any behavior.
 - ```JAMMED_GUN``` Stops burst fire.  Adds delay on next shot.
 - ```UNLUBRICATED``` Randomly causes screeching noise when firing and applies damage when that happens.
 


### PR DESCRIPTION
#### Summary
Interface "Show a brief description that the HM12 overheats when fired continuously."

#### Purpose of change
Fill missing information. References #84299.

#### Describe the solution
Add "OVERHEATS" flag to hm12. Document "OVERHEATS" flag in [JSON_FLAGS.md](https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/JSON/JSON_FLAGS.md).
