### PR TITLE
Make an enchantment to modify "free dodges"

### DIFF
--- a/data/json/enchantments.json
+++ b/data/json/enchantments.json
@@ -45,6 +45,12 @@
   },
   {
     "type": "enchantment",
+    "id": "ENCH_DEBUG_FREE_DODGES",
+    "condition": "ALWAYS",
+    "values": [ { "value": "FREE_DODGES", "add": 10 } ]
+  },
+  {
+    "type": "enchantment",
     "id": "SQUEAKY_ANKLES",
     "condition": "ALWAYS",
     "values": [ { "value": "FOOTSTEP_NOISE", "multiply": 3 } ]

--- a/data/json/mutations/debug.json
+++ b/data/json/mutations/debug.json
@@ -277,6 +277,16 @@
   },
   {
     "type": "mutation",
+    "id": "MUT_DEBUG_FREE_DODGES",
+    "name": { "str": "Debug Free Dodges" },
+    "description": "You'll never get tired of testing dodges!",
+    "points": 99,
+    "debug": true,
+    "valid": false,
+    "enchantments": [ "ENCH_DEBUG_FREE_DODGES" ]
+  },
+  {
+    "type": "mutation",
     "id": "DEBUG_TAIL",
     "name": { "str": "Debug Tail" },
     "description": "Gain a tail bodypart.",

--- a/doc/JSON/MAGIC.md
+++ b/doc/JSON/MAGIC.md
@@ -1000,6 +1000,7 @@ Character status value  | Description
 `FAT_TO_MAX_HP`         | Changes the amount of HP, that is given to you by your fat. Formula is `((your_calories/7716.17)/((your_height_in_cm/100)^2))*hitsize_of_all_non_bionic_bodyparts`. Using `add` works just as adding HP, so use `multiply` instead
 `FOOTSTEP_NOISE`        | 
 `FORCEFIELD`            | Chance your character reduces incoming damage to 0. From 0.0 (no chance), to 1.0 (100% chance to avoid attacks).
+`FREE_DODGES`           | Dodges per turn that won't consume stamina. Can be higher than actual amount of dodges, but won't add more dodges.
 `HEALTHY_RATE`          | How much of your health is changed daily. `"multiply": -1` stops any changes in health
 `HEARING_MULT`          | How well you can hear. Remember that increased hearing means you would have a bigger "noise" written in UI; default step noise of 6, multiplied 10 times, would show it as 60
 `HUNGER`                | Affects how fast your hunger level changes. Do not affect actual calorie burn, the `METABOLISM` field is responsible for this

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -99,6 +99,7 @@ namespace io
             case enchant_vals::mod::RANGED_DAMAGE: return "RANGED_DAMAGE";
 			case enchant_vals::mod::RANGED_ARMOR_PENETRATION: return "RANGED_ARMOR_PENETRATION";
             case enchant_vals::mod::DODGE_CHANCE: return "DODGE_CHANCE";
+            case enchant_vals::mod::FREE_DODGES: return "FREE_DODGES";
             case enchant_vals::mod::BONUS_BLOCK: return "BONUS_BLOCK";
             case enchant_vals::mod::BONUS_DODGE: return "BONUS_DODGE";
             case enchant_vals::mod::ATTACK_NOISE: return "ATTACK_NOISE";
@@ -1393,6 +1394,9 @@ void enchant_cache::activate_passive( Character &guy ) const
 
     guy.mod_num_blocks_bonus( modify_value( enchant_vals::mod::BONUS_BLOCK,
                                             guy.get_num_blocks_base() ) - guy.get_num_blocks_base() );
+
+    guy.mod_free_dodges( modify_value( enchant_vals::mod::FREE_DODGES,
+                                       guy.get_num_free_dodges() ) - guy.get_num_free_dodges() );
 
     if( emitter ) {
         get_map().emit_field( guy.pos_bub(), *emitter );

--- a/src/magic_enchantment.h
+++ b/src/magic_enchantment.h
@@ -73,6 +73,7 @@ enum class mod : int {
     DODGE_CHANCE,
     BONUS_DODGE,
     BONUS_BLOCK,
+    FREE_DODGES,
     MELEE_DAMAGE,
     MELEE_RANGE_MODIFIER,
     MELEE_TO_HIT,

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -1127,6 +1127,7 @@ void Character::load( const JsonObject &data )
     data.read( "slow_rad", slow_rad );
     data.read( "scent", scent );
     data.read( "male", male );
+    data.read( "free_dodges_left", free_dodges_left );
     data.read( "cash", cash );
     data.read( "recoil", recoil );
     data.read( "book_chapters", book_chapters );
@@ -1493,6 +1494,8 @@ void Character::store( JsonOut &json ) const
     // gender
     json.member( "male", male );
 
+    // Some misc values that are character-specific
+    json.member( "free_dodges_left", free_dodges_left );
     json.member( "cash", cash );
     json.member( "recoil", recoil );
     json.member( "book_chapters", book_chapters );
@@ -3875,7 +3878,6 @@ void Creature::store( JsonOut &jsout ) const
 
     jsout.member( "blocks_left", num_blocks );
     jsout.member( "dodges_left", num_dodges );
-    jsout.member( "num_free_dodges", num_free_dodges );
     jsout.member( "num_blocks_bonus", num_blocks_bonus );
     jsout.member( "num_dodges_bonus", num_dodges_bonus );
 
@@ -3960,6 +3962,7 @@ void Creature::load( const JsonObject &jsin )
 
     jsin.read( "damage_over_time_map", damage_over_time_map );
 
+    // FIXME? dodges_left and blocks_left (members of Character, not Creature!) are not stored or read
     jsin.read( "blocks_left", num_blocks );
     jsin.read( "dodges_left", num_dodges );
     jsin.read( "num_blocks_bonus", num_blocks_bonus );


### PR DESCRIPTION
#### Summary
Mods "Add an enchantment that modifies the 'free dodges' stat introduced for Martial Art styles"

#### Purpose of change
@Standing-Storm Mentioned wanting to use the "free dodges" concept for Mind Over Matter's clairsentients.

#### Describe the solution
Expose the value to enchantments.

Added a debug mutation so I could easily toggle it on/off.

Fixed an oopsie with how I was previously saving the number of free dodges a character had. We were saving the value (the *wrong* value at that) but never reading it. Now we save *and* read the correct value.

Because I was mislead by the placement of the existing `dodges_left` saved value, and it *appears to be wrong*, I added a FIXME comment there.

#### Describe alternatives you've considered


#### Testing
<img width="666" height="951" alt="image" src="https://github.com/user-attachments/assets/2437c78c-9fdb-492a-bf93-03fccade8640" />


#### Additional context

