### PR TITLE
Remove the per-enemy-type training level caps on melee and dodge skills

### DIFF
--- a/data/mods/TEST_DATA/monsters.json
+++ b/data/mods/TEST_DATA/monsters.json
@@ -50,6 +50,24 @@
     "special_attacks": [ { "id": "TEST_COOLDOWN", "cooldown": 7 } ]
   },
   {
+    "id": "mon_zombie_test_training_cap0",
+    "type": "MONSTER",
+    "copy-from": "mon_zombie",
+    "//COMMENT": "This has a manually defined melee_skill so that changes to the base zombie monster don't require contributors to change tests like Melee_skill_training_caps",
+    "melee_skill": 4,
+    "melee_training_cap": 0,
+    "categories": [ "CLASSIC" ]
+  },
+  {
+    "id": "mon_zombie_test_training_cap6",
+    "type": "MONSTER",
+    "copy-from": "mon_zombie",
+    "//COMMENT": "This has a manually defined melee_skill so that changes to the base zombie monster don't require contributors to change tests like Melee_skill_training_caps",
+    "melee_skill": 4,
+    "melee_training_cap": 6,
+    "categories": [ "CLASSIC" ]
+  },
+  {
     "type": "MONSTER",
     "id": "mon_test_shearable",
     "copy-from": "mon_test_non_shearable",

--- a/doc/JSON/MONSTERS.md
+++ b/doc/JSON/MONSTERS.md
@@ -123,7 +123,7 @@ Property                 | Description
 `melee_dice`             | (integer) Number of dice rolled on monster melee attack to determine bash damage
 `melee_dice_sides`       | (integer) Number of sides on each die rolled by `melee_dice`
 `grab_strength`          | (integer) Intensity of grab effect, from `1` to `n`. A default zombie has a grab strength of `20`
-`melee_training_cap`     | (integer) The maximum melee skill levels learnable by fighting this monster. If not defined defaults to `melee_skill + 2`.
+`melee_training_cap`     | (integer) The maximum melee skill levels learnable by fighting this monster. If not defined defaults to max skill level (currently 10).
 `armor`                  | (object) Monster's protection from different types of damage
 `weakpoints`             | (array of objects) Weakpoints in the monster's protection
 `weakpoint_sets`         | (array of strings) Weakpoint sets to apply to the monster. Defined in [`monster_weakpoints`](/data/json/monster_weakpoints)

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1822,7 +1822,7 @@ void Character::on_dodge( Creature *source, float difficulty, float training_lev
 
     if( source && source->times_combatted_player <= 100 ) {
         source->times_combatted_player++;
-        practice( skill_dodge, difficulty * 2, difficulty );
+        practice( skill_dodge, difficulty * 2 );
     }
     martial_arts_data->ma_ondodge_effects( *this );
 

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -1052,8 +1052,7 @@ void mtype::load( const JsonObject &jo, const std::string_view src )
         }
     }
 
-    optional( jo, was_loaded, "melee_training_cap", melee_training_cap, std::min( melee_skill + 2,
-              MAX_SKILL ) );
+    optional( jo, was_loaded, "melee_training_cap", melee_training_cap, MAX_SKILL );
     optional( jo, was_loaded, "chat_topics", chat_topics );
     // Disable upgrading when JSON contains `"upgrades": false`, but fallback to the
     // normal behavior (including error checking) if "upgrades" is not boolean or not `false`.


### PR DESCRIPTION
#### Summary
Balance "Remove the per-enemy-type training level caps on melee and dodge skills"

#### Purpose of change
Over the years, we've introduced a few anti-cheese methods, some more effective than others.

One of these was `melee_training_cap`, a level limit on how high you could train melee vs that creature. For example, breathers have a melee_training_cap of 2 because they spawn in huge numbers from collapsed towers, but are essentially harmless. Turrets have (or at least had? don't seem to have it now) a training cap so you can't just stand there harmlessly punching a turret that's out of ammo until you're a god, etc.

In #81921 I introduced what is hopefully a longer-term solution, which limits the amount of training attempts on a per-monster basis. You still can't punch a turret until you become a god.

This has lessened the need for such caps, so let's go ahead and loosen them.

#### Describe the solution
The default `melee_training_cap` is no longer the creature's melee skill + 2. Instead it is MAX_SKILL. This means that fighting enough of any generic enemy can get you to 10, unless that generic enemy type *specifically* has a `melee_training_cap`. You will eventually get to melee 10 killing a billion default zombies, even if each one is not impressive on its own.

Similarly, uncap dodge training for the same reason. Dodging a basic zombie might not be very impressive, but if you dodge 100,000 times you *will* be learning something - sometimes they will catch you unexpectedly, sometimes you will trip and have to recover, etc.

#### Describe alternatives you've considered
This PR simply removes the caps without any sort of modifier on exp gain.

Possibly, this may be too fast (since exp gain in general is disgustingly fast). Here's another idea I've been mulling for those scenarios:

"What I would look at doing for that (entirely unrelated to focus) is a logarithmic reduction in learning based on the difference between (your dodge) and (target's melee skill), so that even a child swinging at you can train you infintesimally towards level 10

Alternatively, *exponential growth* while below the target's melee skill (learn fast or die fast) and simply uncapping the upper end. With how our skill exp curves work, this might just plain be better."

#### Testing


#### Additional context
I have been thinking about this change for a while, but it was mostly spurred by a conversation on the development discord with @anoobindisguise. 

This is a periphery part of tackling weirdness regarding focus.
<img width="1651" height="822" alt="image" src="https://github.com/user-attachments/assets/49e59b24-6eab-4a65-971c-145b03a72795" />
