### PR TITLE
overthrow the reign of RELOAD_ONE, aka Reload everything one by one as part of activity

### DIFF
--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -1604,9 +1604,12 @@ class reload_activity_actor : public activity_actor
         }
 
         void start( player_activity &/*act*/, Character &/*who*/ ) override;
-        void do_turn( player_activity &/*act*/, Character &/*who*/ ) override {}
+        void do_turn( player_activity &/*act*/, Character &/*who*/ ) override;
         void finish( player_activity &act, Character &who ) override;
-        void canceled( player_activity &act, Character &/*who*/ ) override;
+        void canceled( player_activity &act, Character &who ) override;
+
+        void reload_msg( Character &who, bool finished = false );
+        void reload( player_activity &act, Character &who, int load_qty = 1 );
 
         std::unique_ptr<activity_actor> clone() const override {
             return std::make_unique<reload_activity_actor>( *this );
@@ -1619,6 +1622,10 @@ class reload_activity_actor : public activity_actor
         explicit reload_activity_actor() = default;
         int moves_total = 0;
         int quantity = 0;
+        int seconds_per_round = 0;
+        int already_loaded = 0;
+        // cache ammo because reloading deletes the location
+        itype_id ammo_id; // NOLINT(cata-serialize)
         item_location target_loc;
         item_location ammo_loc;
 

--- a/src/character_ammo.cpp
+++ b/src/character_ammo.cpp
@@ -165,7 +165,7 @@ int Character::item_reload_cost( const item &it, const item &ammo, int qty ) con
 
     int cost = 0;
     if( it.is_gun() ) {
-        cost = it.get_reload_time();
+        cost = it.get_reload_time() * qty;
     } else if( it.type->magazine ) {
         cost = it.type->magazine->reload_time * qty;
     } else {

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -3080,6 +3080,7 @@ class select_ammo_inventory_preset : public inventory_selector_preset
 
             append_cell( [&you, &target]( const item_location & loc ) {
                 item::reload_option opt( &you, target, loc );
+                // propagate entry.chosen_count here somehow?
                 return std::to_string( opt.moves() );
             }, _( "MOVES" ) );
 

--- a/src/item.h
+++ b/src/item.h
@@ -601,6 +601,7 @@ class item : public visitable
                 const Character *who = nullptr;
                 item_location target;
                 item_location ammo;
+                bool is_reload_one = false;
 
                 int qty() const {
                     return qty_;

--- a/src/item_gun_tool_ammo.cpp
+++ b/src/item_gun_tool_ammo.cpp
@@ -2243,10 +2243,6 @@ void item::reload_option::qty( int val )
     int remaining_capacity = target->is_watertight_container() ?
                              target->get_remaining_capacity_for_liquid( ammo_obj, true ) :
                              target->remaining_ammo_capacity();
-    if( target->has_flag( flag_RELOAD_ONE ) &&
-        !( ammo->has_flag( flag_SPEEDLOADER ) || ammo->has_flag( flag_SPEEDLOADER_CLIP ) ) ) {
-        remaining_capacity = 1;
-    }
     if( ammo_obj.type->ammo ) {
         if( ammo_obj.ammo_type() == ammo_plutonium ) {
             remaining_capacity = remaining_capacity / PLUTONIUM_CHARGES +

--- a/src/item_info.cpp
+++ b/src/item_info.cpp
@@ -1200,9 +1200,7 @@ void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminf
     std::map<gun_mode_id, gun_mode> fire_modes = mod->gun_all_modes();
 
     if( parts->test( iteminfo_parts::GUN_RELOAD_TIME ) ) {
-        info.emplace_back( "GUN", _( "Reload time: " ),
-                           has_flag( flag_RELOAD_ONE ) ? _( "<num> moves per round" ) :
-                           _( "<num> moves" ),
+        info.emplace_back( "GUN", _( "Reload time: " ), _( "<num> moves" ),
                            iteminfo::lower_is_better,  mod->get_reload_time() );
     }
 

--- a/src/player_activity.h
+++ b/src/player_activity.h
@@ -41,9 +41,9 @@ class player_activity
         bool ignoreQuery = false; // NOLINT(cata-serialize)
 
     public:
-        /** Total number of moves required to complete the activity */
+        /** Total number of moves (1/100th of a second) required to complete the activity */
         int moves_total = 0;
-        /** The number of moves remaining in this activity before it is complete. */
+        /** The number of moves (1/100th of a second) remaining in this activity before it is complete. */
         int moves_left = calendar::INDEFINITELY_LONG;
         /** Controls whether this activity can be cancelled at all */
         bool interruptable = true;

--- a/tests/reload_option_test.cpp
+++ b/tests/reload_option_test.cpp
@@ -42,7 +42,7 @@ TEST_CASE( "revolver_reload_option", "[reload],[reload_option],[gun]" )
     REQUIRE( gun->ammo_remaining( ) == 0 );
 
     const item::reload_option gun_option( &dummy, gun, ammo );
-    REQUIRE( gun_option.qty() == 1 );
+    REQUIRE( gun_option.qty() == 7 );
 
     item_location speedloader = dummy.i_add( item( itype_38_speedloader, calendar::turn_zero, 0 ) );
     REQUIRE( speedloader->ammo_remaining( ) == 0 );


### PR DESCRIPTION
#### Summary
Features "overthrow the reign of RELOAD_ONE, aka Reload everything one by one as part of activity"
#### Purpose of change
In #80740 i tried to solve reloading of single loading guns via keybinds, but in the process (or, actually after the process) i realized we can simply offload reloading one by one to activity, and fill the thing to whatever amount user needs, same as we do for magazines
#### Describe the solution
Do exactly this, if player picks empty Henry Golden Boy, great .22 gun that holds whopping 16 round, and has more than two rounds, the game would just load all the rounds into the gun, one by one, so even if player will be interrupted, some rounds will be loaded into the gun already. Speedloader is still useful since it allows the gun to be loaded faster

The code for it was written in half-delirium, so i would appreciate someone making a sanity pass on it
#### Describe alternatives you've considered
Asking the player play piano in order to reload every RELOAD_ONE gun
#### Testing
<img width="920" height="175" alt="image" src="https://github.com/user-attachments/assets/179f5b63-07f3-4df2-87fb-68ab4bc17db9" />

<img width="464" height="61" alt="image" src="https://github.com/user-attachments/assets/755ac4f3-86ad-4879-965b-26544165453e" />

<img width="752" height="169" alt="image" src="https://github.com/user-attachments/assets/ba05d2e6-97e2-4113-93b8-817634bee810" />

#### Additional context
We need to revisit how fast player load stuff, especially guns, loading 16 .22 rounds in 13 seconds is crazy