### PR TITLE
Consume menu activity obsoletion

### DIFF
--- a/data/json/obsoletion_and_migration_0.J/player_activities.json
+++ b/data/json/obsoletion_and_migration_0.J/player_activities.json
@@ -1,0 +1,40 @@
+[
+  {
+    "id": "ACT_EAT_MENU",
+    "type": "activity_type",
+    "activity_level": "NO_EXERCISE",
+    "verb": "eating",
+    "rooted": true,
+    "based_on": "time",
+    "ignored_distractions": [ "hunger", "thirst" ],
+    "can_resume": false
+  },
+  {
+    "id": "ACT_CONSUME_FOOD_MENU",
+    "type": "activity_type",
+    "activity_level": "NO_EXERCISE",
+    "verb": "consuming",
+    "rooted": true,
+    "based_on": "time",
+    "ignored_distractions": [ "hunger", "thirst" ],
+    "can_resume": false
+  },
+  {
+    "id": "ACT_CONSUME_DRINK_MENU",
+    "type": "activity_type",
+    "activity_level": "NO_EXERCISE",
+    "verb": "drinking",
+    "based_on": "time",
+    "ignored_distractions": [ "hunger", "thirst" ],
+    "can_resume": false
+  },
+  {
+    "id": "ACT_CONSUME_MEDS_MENU",
+    "type": "activity_type",
+    "activity_level": "NO_EXERCISE",
+    "verb": "using drugs",
+    "based_on": "time",
+    "ignored_distractions": [ "hunger", "thirst" ],
+    "can_resume": false
+  }
+]

--- a/data/json/player_activities.json
+++ b/data/json/player_activities.json
@@ -944,26 +944,6 @@
     "can_resume": false
   },
   {
-    "id": "ACT_EAT_MENU",
-    "type": "activity_type",
-    "activity_level": "NO_EXERCISE",
-    "verb": "eating",
-    "rooted": true,
-    "based_on": "neither",
-    "ignored_distractions": [ "hunger", "thirst" ],
-    "can_resume": false
-  },
-  {
-    "id": "ACT_CONSUME_FOOD_MENU",
-    "type": "activity_type",
-    "activity_level": "NO_EXERCISE",
-    "verb": "consuming",
-    "rooted": true,
-    "based_on": "neither",
-    "ignored_distractions": [ "hunger", "thirst" ],
-    "can_resume": false
-  },
-  {
     "id": "ACT_SPELLCASTING",
     "type": "activity_type",
     "activity_level": "LIGHT_EXERCISE",
@@ -980,24 +960,6 @@
     "auto_needs": true,
     "rooted": true,
     "based_on": "time",
-    "can_resume": false
-  },
-  {
-    "id": "ACT_CONSUME_DRINK_MENU",
-    "type": "activity_type",
-    "activity_level": "NO_EXERCISE",
-    "verb": "drinking",
-    "based_on": "neither",
-    "ignored_distractions": [ "hunger", "thirst" ],
-    "can_resume": false
-  },
-  {
-    "id": "ACT_CONSUME_MEDS_MENU",
-    "type": "activity_type",
-    "activity_level": "NO_EXERCISE",
-    "verb": "using drugs",
-    "based_on": "neither",
-    "ignored_distractions": [ "hunger", "thirst" ],
     "can_resume": false
   },
   {

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -53,6 +53,7 @@
 #include "flexbuffer_json.h"
 #include "game.h"
 #include "game_constants.h"
+#include "game_inventory.h"
 #include "gates.h"
 #include "gun_mode.h"
 #include "handle_liquid.h"
@@ -133,7 +134,6 @@ static const activity_id ACT_CHOP_TREE( "ACT_CHOP_TREE" );
 static const activity_id ACT_CHURN( "ACT_CHURN" );
 static const activity_id ACT_CLEAR_RUBBLE( "ACT_CLEAR_RUBBLE" );
 static const activity_id ACT_CONSUME( "ACT_CONSUME" );
-static const activity_id ACT_CONSUME_MEDS_MENU( "ACT_CONSUME_MEDS_MENU" );
 static const activity_id ACT_CRACKING( "ACT_CRACKING" );
 static const activity_id ACT_CRAFT( "ACT_CRAFT" );
 static const activity_id ACT_DISABLE( "ACT_DISABLE" );
@@ -141,7 +141,6 @@ static const activity_id ACT_DISASSEMBLE( "ACT_DISASSEMBLE" );
 static const activity_id ACT_DISMEMBER( "ACT_DISMEMBER" );
 static const activity_id ACT_DISSECT( "ACT_DISSECT" );
 static const activity_id ACT_DROP( "ACT_DROP" );
-static const activity_id ACT_EAT_MENU( "ACT_EAT_MENU" );
 static const activity_id ACT_EBOOKSAVE( "ACT_EBOOKSAVE" );
 static const activity_id ACT_E_FILE( "ACT_E_FILE" );
 static const activity_id ACT_FIELD_DRESS( "ACT_FIELD_DRESS" );
@@ -4113,26 +4112,21 @@ void consume_activity_actor::start( player_activity &act, Character &guy )
 {
     int moves = 0;
     Character &player_character = get_player_character();
+    //TODO: why use both `player_character` and `guy`?
+    auto player_will_eat = [this, &moves, &player_character, &guy]( const item & it ) {
+        ret_val<edible_rating> ret = player_character.will_eat( it, true );
+        if( !ret.success() ) {
+            canceled = true;
+            uistate.consume_uistate.clear();
+        } else {
+            moves = to_moves<int>( guy.get_consume_time( it ) );
+        }
+    };
+
     if( consume_location ) {
-        ret_val<edible_rating> ret = player_character.will_eat( *consume_location, true );
-        if( !ret.success() ) {
-            canceled = true;
-            consume_menu_selections = std::vector<int>();
-            consume_menu_selected_items.clear();
-            consume_menu_filter.clear();
-        } else {
-            moves = to_moves<int>( guy.get_consume_time( *consume_location ) );
-        }
+        player_will_eat( *consume_location );
     } else if( !consume_item.is_null() ) {
-        ret_val<edible_rating> ret = player_character.will_eat( consume_item, true );
-        if( !ret.success() ) {
-            canceled = true;
-            consume_menu_selections = std::vector<int>();
-            consume_menu_selected_items.clear();
-            consume_menu_filter.clear();
-        } else {
-            moves = to_moves<int>( guy.get_consume_time( consume_item ) );
-        }
+        player_will_eat( consume_item );
     } else {
         debugmsg( "Item/location to be consumed should not be null." );
         canceled = true;
@@ -4149,13 +4143,7 @@ void consume_activity_actor::finish( player_activity &act, Character & )
     // too late; we've already consumed).
     act.interruptable = false;
 
-    // Consuming an item may cause various effects, including cancelling our activity.
-    // Back up these values since this activity actor might be destroyed.
-    std::vector<int> temp_selections = consume_menu_selections;
-    const std::vector<item_location> temp_selected_items = consume_menu_selected_items;
-    const std::string temp_filter = consume_menu_filter;
     item_location consume_loc = consume_location;
-    activity_id new_act = type;
 
     avatar &player_character = get_avatar();
     if( !canceled ) {
@@ -4171,31 +4159,22 @@ void consume_activity_actor::finish( player_activity &act, Character & )
         }
     }
 
+    /*
+    At this point, this consume_activity_actor may have been cancelled
+    and a new activity (e.g. firstaid_activity_actor) assigned.
+    */
     if( act.id() == ACT_CONSUME ) {
+        // only set to null if there isn't a new activity
         act.set_to_null();
     }
 
     if( act.id() == ACT_FIRSTAID && consume_loc ) {
-        act.targets.clear();
-        act.targets.push_back( consume_loc );
+        uistate.consume_uistate.consume_menu_selected_items = { consume_loc };
     }
 
-    if( !temp_selections.empty() || !temp_selected_items.empty() || !temp_filter.empty() ) {
-        if( act.is_null() ) {
-            player_character.assign_activity( new_act );
-            player_character.activity.values = temp_selections;
-            player_character.activity.targets = temp_selected_items;
-            player_character.activity.str_values = { temp_filter, "true" };
-        } else {
-            // Warning: this can add a redundant menu activity to the backlog.
-            // It will prevent deleting the smart pointer of the selected item_location
-            // if the backlog is not sanitized.
-            player_activity eat_menu( new_act );
-            eat_menu.values = temp_selections;
-            eat_menu.targets = temp_selected_items;
-            eat_menu.str_values = { temp_filter, "true" };
-            player_character.backlog.push_back( eat_menu );
-        }
+    if( !avatar_action::eat_here( player_character ) && reprompt_consume_menu ) {
+        avatar_action::eat_or_use( player_character,
+                                   game_menus::inv::consume( uistate.consume_uistate.consume_menu_comestype ) );
     }
 }
 
@@ -4205,11 +4184,8 @@ void consume_activity_actor::serialize( JsonOut &jsout ) const
 
     jsout.member( "consume_location", consume_location );
     jsout.member( "consume_item", consume_item );
-    jsout.member( "consume_menu_selections", consume_menu_selections );
-    jsout.member( "consume_menu_selected_items", consume_menu_selected_items );
-    jsout.member( "consume_menu_filter", consume_menu_filter );
     jsout.member( "canceled", canceled );
-    jsout.member( "type", type );
+    jsout.member( "reprompt_consume_menu", reprompt_consume_menu );
 
     jsout.end_object();
 }
@@ -4223,11 +4199,19 @@ std::unique_ptr<activity_actor> consume_activity_actor::deserialize( JsonValue &
 
     data.read( "consume_location", actor.consume_location );
     data.read( "consume_item", actor.consume_item );
-    data.read( "consume_menu_selections", actor.consume_menu_selections );
-    data.read( "consume_menu_selected_items", actor.consume_menu_selected_items );
-    data.read( "consume_menu_filter", actor.consume_menu_filter );
     data.read( "canceled", actor.canceled );
-    data.read( "type", actor.type );
+    if( data.has_member( "reprompt_consume_menu" ) ) {
+        data.read( "reprompt_consume_menu", actor.reprompt_consume_menu );
+    }
+    //Remove obsolete reads after 0.J
+    std::vector<int> obsolete_consume_menu_selections;
+    std::vector < item_location > obsolete_cconsume_menu_selected_items;
+    std::string obsolete_cconsume_menu_filter;
+    activity_id obsolete_type;
+    data.read( "consume_menu_selections", obsolete_consume_menu_selections );
+    data.read( "consume_menu_selected_items", obsolete_cconsume_menu_selected_items );
+    data.read( "consume_menu_filter", obsolete_cconsume_menu_filter );
+    data.read( "type", obsolete_type );
 
     return actor.clone();
 }
@@ -8082,21 +8066,9 @@ void firstaid_activity_actor::finish( player_activity &act, Character &who )
     act.set_to_null();
     act.values.clear();
 
-    // Return to first eat or consume meds menu activity in the backlog.
-    for( player_activity &backlog_act : who.backlog ) {
-        if( backlog_act.id() == ACT_EAT_MENU ||
-            backlog_act.id() == ACT_CONSUME_MEDS_MENU ) {
-            backlog_act.auto_resume = true;
-            break;
-        }
-    }
-    // Clear the backlog of any activities that will not auto resume.
-    for( auto iter = who.backlog.begin(); iter != who.backlog.end(); ) {
-        if( !iter->auto_resume ) {
-            iter = who.backlog.erase( iter );
-        } else {
-            ++iter;
-        }
+    if( who.is_avatar() ) {
+        avatar_action::eat_or_use( *who.as_avatar(),
+                                   game_menus::inv::consume( uistate.consume_uistate.consume_menu_comestype ) );
     }
 }
 

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -4173,8 +4173,10 @@ void consume_activity_actor::finish( player_activity &act, Character & )
     }
 
     if( !avatar_action::eat_here( player_character ) && reprompt_consume_menu ) {
-        avatar_action::eat_or_use( player_character,
-                                   game_menus::inv::consume( uistate.consume_uistate.consume_menu_comestype ) );
+        uistate.open_menu = []() {
+            avatar_action::eat_or_use( get_avatar(),
+                                       game_menus::inv::consume( uistate.consume_uistate.consume_menu_comestype ) );
+        };
     }
 }
 
@@ -8067,8 +8069,10 @@ void firstaid_activity_actor::finish( player_activity &act, Character &who )
     act.values.clear();
 
     if( who.is_avatar() ) {
-        avatar_action::eat_or_use( *who.as_avatar(),
-                                   game_menus::inv::consume( uistate.consume_uistate.consume_menu_comestype ) );
+        uistate.open_menu = []() {
+            avatar_action::eat_or_use( get_avatar(),
+                                       game_menus::inv::consume( uistate.consume_uistate.consume_menu_comestype ) );
+        };
     }
 }
 

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -1183,11 +1183,10 @@ class consume_activity_actor : public activity_actor
     private:
         item_location consume_location;
         item consume_item;
-        std::vector<int> consume_menu_selections;
-        std::vector<item_location> consume_menu_selected_items;
-        std::string consume_menu_filter;
         bool canceled = false;
-        activity_id type;
+        // whether to show the consume menu after this activity finishes
+        bool reprompt_consume_menu = false;
+
         /**
          * @pre @p other is a consume_activity_actor
          */
@@ -1197,21 +1196,12 @@ class consume_activity_actor : public activity_actor
                    canceled == c_actor.canceled && &consume_item == &c_actor.consume_item;
         }
     public:
-        consume_activity_actor( const item_location &consume_location,
-                                std::vector<int> consume_menu_selections,
-                                const std::vector<item_location> &consume_menu_selected_items,
-                                const std::string &consume_menu_filter, activity_id type ) :
-            consume_location( consume_location ),
-            consume_menu_selections( std::move( consume_menu_selections ) ),
-            consume_menu_selected_items( consume_menu_selected_items ),
-            consume_menu_filter( consume_menu_filter ),
-            type( type ) {}
+        explicit consume_activity_actor( const item_location &consume_location,
+                                         bool reprompt_consume_menu = false ) :
+            consume_location( consume_location ), reprompt_consume_menu( reprompt_consume_menu ) {}
 
-        explicit consume_activity_actor( const item_location &consume_location ) :
-            consume_location( consume_location ) {}
-
-        explicit consume_activity_actor( const item &consume_item ) :
-            consume_item( consume_item ) {}
+        explicit consume_activity_actor( const item &consume_item, bool reprompt_consume_menu = false ) :
+            consume_item( consume_item ), reprompt_consume_menu( reprompt_consume_menu ) {}
 
         const activity_id &get_type() const override {
             static const activity_id ACT_CONSUME( "ACT_CONSUME" );

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -17,7 +17,6 @@
 
 #include "activity_actor.h"
 #include "avatar.h"
-#include "avatar_action.h"
 #include "bodypart.h"
 #include "calendar.h"
 #include "cata_utility.h"
@@ -91,11 +90,7 @@
 
 static const activity_id ACT_ARMOR_LAYERS( "ACT_ARMOR_LAYERS" );
 static const activity_id ACT_ATM( "ACT_ATM" );
-static const activity_id ACT_CONSUME_DRINK_MENU( "ACT_CONSUME_DRINK_MENU" );
-static const activity_id ACT_CONSUME_FOOD_MENU( "ACT_CONSUME_FOOD_MENU" );
-static const activity_id ACT_CONSUME_MEDS_MENU( "ACT_CONSUME_MEDS_MENU" );
 static const activity_id ACT_DISMEMBER( "ACT_DISMEMBER" );
-static const activity_id ACT_EAT_MENU( "ACT_EAT_MENU" );
 static const activity_id ACT_FERTILIZE_PLOT( "ACT_FERTILIZE_PLOT" );
 static const activity_id ACT_FETCH_REQUIRED( "ACT_FETCH_REQUIRED" );
 static const activity_id ACT_FILL_LIQUID( "ACT_FILL_LIQUID" );
@@ -195,13 +190,9 @@ activity_handlers::do_turn_functions = {
     { ACT_MULTIPLE_STUDY, multiple_study_do_turn },
     { ACT_FETCH_REQUIRED, fetch_do_turn },
     { ACT_TIDY_UP, tidy_up_do_turn },
-    { ACT_EAT_MENU, eat_menu_do_turn },
     { ACT_VEHICLE_DECONSTRUCTION, vehicle_deconstruction_do_turn },
     { ACT_VEHICLE_REPAIR, vehicle_repair_do_turn },
     { ACT_MULTIPLE_CHOP_TREES, chop_trees_do_turn },
-    { ACT_CONSUME_FOOD_MENU, consume_food_menu_do_turn },
-    { ACT_CONSUME_DRINK_MENU, consume_drink_menu_do_turn },
-    { ACT_CONSUME_MEDS_MENU, consume_meds_menu_do_turn },
     { ACT_ARMOR_LAYERS, armor_layers_do_turn },
     { ACT_ATM, atm_do_turn },
     { ACT_REPAIR_ITEM, repair_item_do_turn },
@@ -226,10 +217,6 @@ activity_handlers::finish_functions = {
     { ACT_TOOLMOD_ADD, toolmod_add_finish },
     { ACT_SOCIALIZE, socialize_finish },
     { ACT_ATM, atm_finish },
-    { ACT_EAT_MENU, eat_menu_finish },
-    { ACT_CONSUME_FOOD_MENU, eat_menu_finish },
-    { ACT_CONSUME_DRINK_MENU, eat_menu_finish },
-    { ACT_CONSUME_MEDS_MENU, eat_menu_finish },
     { ACT_ROBOT_CONTROL, robot_control_finish },
     { ACT_PULL_CREATURE, pull_creature_finish },
     { ACT_SPELLCASTING, spellcasting_finish },
@@ -1324,40 +1311,6 @@ void activity_handlers::toolmod_add_finish( player_activity *act, Character *you
     act->targets[1].remove_item();
 }
 
-// This activity opens the menu (it's not meant to queue consumption of items)
-void activity_handlers::eat_menu_do_turn( player_activity *, Character *you )
-{
-    if( !you->is_avatar() ) {
-        debugmsg( "Character %s somehow opened the eat menu!  Cancelling their activity to prevent infinite loop",
-                  you->name );
-        you->cancel_activity();
-        return;
-    }
-
-    avatar &player_character = get_avatar();
-    avatar_action::eat_or_use( player_character, game_menus::inv::consume() );
-}
-
-void activity_handlers::consume_food_menu_do_turn( player_activity *, Character * )
-{
-    avatar &player_character = get_avatar();
-    item_location loc = game_menus::inv::consume_food();
-    avatar_action::eat( player_character, loc );
-}
-
-void activity_handlers::consume_drink_menu_do_turn( player_activity *, Character * )
-{
-    avatar &player_character = get_avatar();
-    item_location loc = game_menus::inv::consume_drink();
-    avatar_action::eat( player_character, loc );
-}
-
-void activity_handlers::consume_meds_menu_do_turn( player_activity *, Character * )
-{
-    avatar &player_character = get_avatar();
-    avatar_action::eat_or_use( player_character, game_menus::inv::consume_meds() );
-}
-
 void activity_handlers::travel_do_turn( player_activity *act, Character *you )
 {
     if( !you->omt_path.empty() ) {
@@ -1564,11 +1517,6 @@ void activity_handlers::atm_finish( player_activity *act, Character * )
     if( !act->index ) {
         act->set_to_null();
     }
-}
-
-void activity_handlers::eat_menu_finish( player_activity *, Character * )
-{
-    // Only exists to keep the eat activity alive between turns
 }
 
 template<typename fn>

--- a/src/activity_handlers.h
+++ b/src/activity_handlers.h
@@ -198,10 +198,6 @@ void armor_layers_do_turn( player_activity *act, Character *you );
 void atm_do_turn( player_activity *act, Character *you );
 void dismember_do_turn( player_activity *act, Character *you );
 void chop_trees_do_turn( player_activity *act, Character *you );
-void consume_drink_menu_do_turn( player_activity *act, Character *you );
-void consume_food_menu_do_turn( player_activity *act, Character *you );
-void consume_meds_menu_do_turn( player_activity *act, Character *you );
-void eat_menu_do_turn( player_activity *act, Character *you );
 void fertilize_plot_do_turn( player_activity *act, Character *you );
 void fetch_do_turn( player_activity *act, Character *you );
 void fill_liquid_do_turn( player_activity *act, Character *you );
@@ -234,7 +230,6 @@ do_turn_functions;
 
 /** activity_finish functions: */
 void atm_finish( player_activity *act, Character *you );
-void eat_menu_finish( player_activity *act, Character *you );
 void gunmod_add_finish( player_activity *act, Character *you );
 void heat_item_finish( player_activity *act, Character *you );
 void mend_item_finish( player_activity *act, Character *you );

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -49,7 +49,6 @@
 #include "options.h"
 #include "output.h"
 #include "pimpl.h"
-#include "player_activity.h"
 #include "popup.h"
 #include "point.h"
 #include "projectile.h"
@@ -973,20 +972,6 @@ bool avatar_action::eat_here( avatar &you )
 
 void avatar_action::eat( avatar &you, item_location &loc )
 {
-    std::string filter;
-    if( !you.activity.str_values.empty() ) {
-        filter = you.activity.str_values.back();
-    }
-    avatar_action::eat( you, loc, you.activity.values, you.activity.targets, filter,
-                        you.activity.id() );
-}
-
-void avatar_action::eat( avatar &you, item_location &loc,
-                         const std::vector<int> &consume_menu_selections,
-                         const std::vector<item_location> &consume_menu_selected_items,
-                         const std::string &consume_menu_filter,
-                         activity_id type )
-{
     map &here = get_map();
 
     if( !loc ) {
@@ -995,8 +980,7 @@ void avatar_action::eat( avatar &you, item_location &loc,
         return;
     }
     loc.overflow( here );
-    you.assign_activity( consume_activity_actor( loc, consume_menu_selections,
-                         consume_menu_selected_items, consume_menu_filter, type ) );
+    you.assign_activity( consume_activity_actor( loc, true ) );
     you.last_item = item( *loc ).typeId();
 }
 

--- a/src/avatar_action.h
+++ b/src/avatar_action.h
@@ -4,10 +4,8 @@
 
 #include <optional>
 #include <string>
-#include <vector>
 
 #include "coordinates.h"
-#include "type_id.h"
 
 class Character;
 class avatar;
@@ -21,10 +19,7 @@ namespace avatar_action
 
 /** Eat food or fuel  'E' (or 'a') */
 void eat( avatar &you, item_location &loc );
-void eat( avatar &you, item_location &loc,
-          const std::vector<int> &consume_menu_selections,
-          const std::vector<item_location> &consume_menu_selected_items,
-          const std::string &consume_menu_filter, activity_id type );
+
 // special rules for eating: grazing etc
 // returns false if no rules are needed
 bool eat_here( avatar &you );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -111,10 +111,6 @@
 #include "weather.h"
 
 static const activity_id ACT_AUTODRIVE( "ACT_AUTODRIVE" );
-static const activity_id ACT_CONSUME_DRINK_MENU( "ACT_CONSUME_DRINK_MENU" );
-static const activity_id ACT_CONSUME_FOOD_MENU( "ACT_CONSUME_FOOD_MENU" );
-static const activity_id ACT_CONSUME_MEDS_MENU( "ACT_CONSUME_MEDS_MENU" );
-static const activity_id ACT_EAT_MENU( "ACT_EAT_MENU" );
 static const activity_id ACT_FISH( "ACT_FISH" );
 static const activity_id ACT_GAME( "ACT_GAME" );
 static const activity_id ACT_HAND_CRANK( "ACT_HAND_CRANK" );
@@ -5324,10 +5320,6 @@ bool Character::can_use_floor_warmth() const
            has_activity( ACT_TRY_SLEEP ) ||
            has_activity( ACT_OPERATION ) ||
            has_activity( ACT_TREE_COMMUNION ) ||
-           has_activity( ACT_EAT_MENU ) ||
-           has_activity( ACT_CONSUME_FOOD_MENU ) ||
-           has_activity( ACT_CONSUME_DRINK_MENU ) ||
-           has_activity( ACT_CONSUME_MEDS_MENU ) ||
            has_activity( ACT_STUDY_SPELL );
 }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2270,7 +2270,10 @@ int game::inventory_item_menu( item_location locThisItem,
                     if( !locThisItem.get_item()->is_container() ) {
                         avatar_action::eat( u, locThisItem );
                     } else {
-                        avatar_action::eat_or_use( u, game_menus::inv::consume( std::string(), locThisItem ) );
+                        uistate.open_menu = [locThisItem = locThisItem]() {
+                            avatar_action::eat_or_use( get_avatar(),
+                                                       game_menus::inv::consume( std::string(), locThisItem ) );
+                        };
                     }
                     break;
                 case 'W': {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2270,7 +2270,7 @@ int game::inventory_item_menu( item_location locThisItem,
                     if( !locThisItem.get_item()->is_container() ) {
                         avatar_action::eat( u, locThisItem );
                     } else {
-                        avatar_action::eat_or_use( u, game_menus::inv::consume( locThisItem ) );
+                        avatar_action::eat_or_use( u, game_menus::inv::consume( std::string(), locThisItem ) );
                     }
                     break;
                 case 'W': {

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -5,6 +5,7 @@
 #include <bitset>
 #include <cmath>
 #include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <iterator>
 #include <list>
@@ -176,7 +177,7 @@ static item_location inv_internal( Character &u, const inventory_selector_preset
         }
         // Set position after filter to keep cursor at the right position
         const std::vector<item_location> &locs = cm_uistate.consume_menu_selected_items;
-        const std::optional<std::pair<size_t, size_t>> &selections = cm_uistate.consume_menu_selections;
+        const std::vector<uint64_t> &selections = cm_uistate.consume_menu_selections;
         bool position_set = false;
         if( !locs.empty() ) {
             bool const hidden = cm_uistate.collated;
@@ -185,8 +186,8 @@ static item_location inv_internal( Character &u, const inventory_selector_preset
                 position_set = inv_s.highlight_one_of( locs );
             }
         }
-        if( !position_set && !!selections ) {
-            inv_s.highlight_position( *selections );
+        if( !position_set && selections.size() == 2 ) {
+            inv_s.highlight_position( { selections[0], selections[1] } );
         }
     }
 
@@ -208,7 +209,7 @@ static item_location inv_internal( Character &u, const inventory_selector_preset
         u.activity.values.clear();
         const std::pair<size_t, size_t> &init_pair = inv_s.get_highlighted_position();
         consume_menu_uistate new_state{
-            std::make_pair( init_pair.first, init_pair.second ),
+            { init_pair.first, init_pair.second },
             collated ? std::vector<item_location> { location, inv_s.get_collation_next() }
 :
             inv_s.get_highlighted().locations,

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <bitset>
 #include <cmath>
+#include <cstddef>
 #include <functional>
 #include <iterator>
 #include <list>
@@ -28,6 +29,7 @@
 #include "display.h"
 #include "enums.h"
 #include "flag.h"
+#include "flexbuffer_json.h"
 #include "game.h"
 #include "game_constants.h"
 #include "input.h"
@@ -41,6 +43,7 @@
 #include "itype.h"
 #include "iuse.h"
 #include "iuse_actor.h"
+#include "json.h"
 #include "map.h"
 #include "mapdata.h"
 #include "messages.h"
@@ -65,15 +68,11 @@
 #include "translations.h"
 #include "type_id.h"
 #include "ui_manager.h"
+#include "uistate.h"
 #include "units.h"
 #include "units_utility.h"
 #include "value_ptr.h"
 #include "vitamin.h"
-
-static const activity_id ACT_CONSUME_DRINK_MENU( "ACT_CONSUME_DRINK_MENU" );
-static const activity_id ACT_CONSUME_FOOD_MENU( "ACT_CONSUME_FOOD_MENU" );
-static const activity_id ACT_CONSUME_MEDS_MENU( "ACT_CONSUME_MEDS_MENU" );
-static const activity_id ACT_EAT_MENU( "ACT_EAT_MENU" );
 
 static const bionic_id bio_painkiller( "bio_painkiller" );
 
@@ -144,7 +143,9 @@ static item_location inv_internal( Character &u, const inventory_selector_preset
                                    const std::string &none_message,
                                    const std::string &hint = std::string(),
                                    item_location container = item_location(),
-                                   bool add_ebooks = false )
+                                   bool add_ebooks = false,
+                                   bool using_consume_menu = false
+                                 )
 {
     inventory_pick_selector inv_s( u, preset );
 
@@ -152,11 +153,7 @@ static item_location inv_internal( Character &u, const inventory_selector_preset
     inv_s.set_hint( hint );
     inv_s.set_display_stats( false );
 
-    const std::vector<activity_id> consuming {
-        ACT_EAT_MENU,
-        ACT_CONSUME_FOOD_MENU,
-        ACT_CONSUME_DRINK_MENU,
-        ACT_CONSUME_MEDS_MENU };
+    const consume_menu_uistate &cm_uistate = uistate.consume_uistate;
 
     u.inv->restack( u );
 
@@ -171,21 +168,25 @@ static item_location inv_internal( Character &u, const inventory_selector_preset
         inv_s.add_nearby_items( radius, add_ebooks );
     }
 
-    if( u.has_activity( consuming ) ) {
-        if( !u.activity.str_values.empty() ) {
-            inv_s.set_filter( u.activity.str_values[0] );
+    //input from global consume menu UI state
+    if( using_consume_menu ) {
+        const std::string consume_menu_filter = cm_uistate.consume_menu_filter;
+        if( !consume_menu_filter.empty() ) {
+            inv_s.set_filter( consume_menu_filter );
         }
         // Set position after filter to keep cursor at the right position
+        const std::vector<item_location> &locs = cm_uistate.consume_menu_selected_items;
+        const std::optional<std::pair<size_t, size_t>> &selections = cm_uistate.consume_menu_selections;
         bool position_set = false;
-        if( !u.activity.targets.empty() ) {
-            bool const hidden = u.activity.values.size() >= 3 && static_cast<bool>( u.activity.values[2] );
-            position_set = inv_s.highlight_one_of( u.activity.targets, hidden );
+        if( !locs.empty() ) {
+            bool const hidden = cm_uistate.collated;
+            position_set = inv_s.highlight_one_of( locs, hidden );
             if( !position_set && hidden ) {
-                position_set = inv_s.highlight_one_of( u.activity.targets );
+                position_set = inv_s.highlight_one_of( locs );
             }
         }
-        if( !position_set && u.activity.values.size() >= 2 ) {
-            inv_s.highlight_position( std::make_pair( u.activity.values[0], u.activity.values[1] ) );
+        if( !position_set && !!selections ) {
+            inv_s.highlight_position( *selections );
         }
     }
 
@@ -199,19 +200,21 @@ static item_location inv_internal( Character &u, const inventory_selector_preset
 
     item_location location = inv_s.execute();
 
-    if( u.has_activity( consuming ) ) {
+    //output to global consume menu UI state
+    if( using_consume_menu ) {
+
         inventory_entry const &e = inv_s.get_highlighted();
         bool const collated = e.is_collation_entry();
         u.activity.values.clear();
-        const auto init_pair = inv_s.get_highlighted_position();
-        u.activity.values.push_back( init_pair.first );
-        u.activity.values.push_back( init_pair.second );
-        u.activity.values.push_back( collated );
-        u.activity.str_values.clear();
-        u.activity.str_values.emplace_back( inv_s.get_filter() );
-        u.activity.targets = collated ? std::vector<item_location> { location, inv_s.get_collation_next() }
-                             :
-                             inv_s.get_highlighted().locations;
+        const std::pair<size_t, size_t> &init_pair = inv_s.get_highlighted_position();
+        consume_menu_uistate new_state{
+            std::make_pair( init_pair.first, init_pair.second ),
+            collated ? std::vector<item_location> { location, inv_s.get_collation_next() }
+:
+            inv_s.get_highlighted().locations,
+            inv_s.get_filter(), collated, cm_uistate.consume_menu_comestype
+        };
+        uistate.consume_uistate = new_state;
     }
 
     return location;
@@ -1026,86 +1029,58 @@ static std::string get_consume_needs_hint( Character &you )
     return hint;
 }
 
-item_location game_menus::inv::consume( const item_location &loc )
-{
-    avatar &you = get_avatar();
-    static item_location container_location;
-    if( !you.has_activity( ACT_EAT_MENU ) ) {
-        you.assign_activity( ACT_EAT_MENU );
-        container_location = loc;
-    }
-    std::string none_message = you.activity.str_values.size() == 2 ?
-                               _( "You have nothing else to consume." ) : _( "You have nothing to consume." );
-    return inv_internal( you, comestible_inventory_preset( you ),
-                         _( "Consume item" ), 1,
-                         none_message,
-                         get_consume_needs_hint( you ),
-                         container_location );
-}
-
 class comestible_filtered_inventory_preset : public comestible_inventory_preset
 {
     public:
-        comestible_filtered_inventory_preset( const Character &you, bool( *predicate )( const item &it ) ) :
+        explicit comestible_filtered_inventory_preset( const Character &you,
+                const std::function<bool( const item &it )> &predicate ) :
             comestible_inventory_preset( you ), predicate( predicate ) {}
 
         bool is_shown( const item_location &loc ) const override {
             return comestible_inventory_preset::is_shown( loc ) &&
                    predicate( *loc );
         }
-
+        void set_predicate( const std::function<bool( const item &it )> &new_predicate ) {
+            predicate = new_predicate;
+        }
     private:
-        bool( *predicate )( const item &it );
+        std::function<bool( const item &it )> predicate;
 };
 
-item_location game_menus::inv::consume_food()
-{
-    avatar &you = get_avatar();
-    if( !you.has_activity( ACT_CONSUME_FOOD_MENU ) ) {
-        you.assign_activity( ACT_CONSUME_FOOD_MENU );
-    }
-    std::string none_message = you.activity.str_values.size() == 2 ?
-                               _( "You have nothing else to eat." ) : _( "You have nothing to eat." );
-    return inv_internal( you, comestible_filtered_inventory_preset( you, []( const item & it ) {
-        return ( it.is_comestible() && it.get_comestible()->comesttype == "FOOD" ) ||
-               it.has_flag( flag_USE_EAT_VERB );
-    } ),
-    _( "Consume food" ), 1,
-    none_message,
-    get_consume_needs_hint( you ) );
-}
 
-item_location game_menus::inv::consume_drink()
+item_location game_menus::inv::consume( const std::string &comestible_type_filter,
+                                        const item_location &loc )
 {
     avatar &you = get_avatar();
-    if( !you.has_activity( ACT_CONSUME_DRINK_MENU ) ) {
-        you.assign_activity( ACT_CONSUME_DRINK_MENU );
-    }
-    std::string none_message = you.activity.str_values.size() == 2 ?
-                               _( "You have nothing else to drink." ) : _( "You have nothing to drink." );
-    return inv_internal( you, comestible_filtered_inventory_preset( you, []( const item & it ) {
-        return it.is_comestible() && it.get_comestible()->comesttype == "DRINK" &&
-               !it.has_flag( flag_USE_EAT_VERB );
-    } ),
-    _( "Consume drink" ), 1,
-    none_message,
-    get_consume_needs_hint( you ) );
-}
+    comestible_filtered_inventory_preset preset( you, []( const item & ) {
+        return true;
+    } );
 
-item_location game_menus::inv::consume_meds()
-{
-    avatar &you = get_avatar();
-    if( !you.has_activity( ACT_CONSUME_MEDS_MENU ) ) {
-        you.assign_activity( ACT_CONSUME_MEDS_MENU );
+    uistate.consume_uistate.consume_menu_comestype = comestible_type_filter;
+    const std::string comestible_type = uistate.consume_uistate.consume_menu_comestype;
+    if( comestible_type == "FOOD" ) {
+        preset.set_predicate( []( const item & it ) {
+            return ( it.is_comestible() && it.get_comestible()->comesttype == "FOOD" ) ||
+                   it.has_flag( flag_USE_EAT_VERB );
+        } );
+    } else if( comestible_type == "DRINK" ) {
+        preset.set_predicate( []( const item & it ) {
+            return it.is_comestible() && it.get_comestible()->comesttype == "DRINK" &&
+                   !it.has_flag( flag_USE_EAT_VERB );
+        } );
+    } else if( comestible_type == "MED" ) {
+        preset.set_predicate( []( const item & it ) {
+            return it.is_medication() || it.is_medical_tool();
+        } );
     }
+
     std::string none_message = you.activity.str_values.size() == 2 ?
-                               _( "You have no more medication to consume." ) : _( "You have no medication to consume." );
-    return inv_internal( you, comestible_filtered_inventory_preset( you, []( const item & it ) {
-        return it.is_medication() || it.is_medical_tool();
-    } ),
-    _( "Consume medication" ), 1,
-    none_message,
-    get_consume_needs_hint( you ) );
+                               _( "You have nothing else to consume." ) : _( "You have nothing to consume." );
+    return inv_internal( you, preset,
+                         _( "Consume item" ), 1,
+                         none_message,
+                         get_consume_needs_hint( you ),
+                         loc, false, true );
 }
 
 class activatable_inventory_preset : public pickup_inventory_preset
@@ -3234,4 +3209,24 @@ item::reload_option game_menus::inv::select_ammo( Character &you, const item_loc
     opt.qty( selected.second );
 
     return opt;
+}
+
+void consume_menu_uistate::serialize( JsonOut &json ) const
+{
+    json.start_object();
+    json.member( "consume_menu_selections", consume_menu_selections );
+    json.member( "consume_menu_selected_items", consume_menu_selected_items );
+    json.member( "consume_menu_filter", consume_menu_filter );
+    json.member( "collated", collated );
+    json.member( "consume_menu_comestype", consume_menu_comestype );
+    json.end_object();
+}
+
+void consume_menu_uistate::deserialize( const JsonObject &jo )
+{
+    jo.read( "consume_menu_selections", consume_menu_selections );
+    jo.read( "consume_menu_selected_items", consume_menu_selected_items );
+    jo.read( "consume_menu_filter", consume_menu_filter );
+    jo.read( "collated", collated );
+    jo.read( "consume_menu_comestype", consume_menu_comestype );
 }

--- a/src/game_inventory.h
+++ b/src/game_inventory.h
@@ -132,13 +132,9 @@ drop_locations smoke_food( Character &you, units::volume total_capacity,
 * Consume an item via a custom menu.
 * If item_location is provided then consume only from the contents of that container.
 */
-item_location consume( const item_location &loc = item_location() );
-/** Consuming a food item via a custom menu. */
-item_location consume_food();
-/** Consuming a drink item via a custom menu. */
-item_location consume_drink();
-/** Consuming a medication item via a custom menu. */
-item_location consume_meds();
+item_location consume( const std::string &comestible_type_filter = std::string(),
+                       const item_location &loc = item_location() );
+
 /** Choosing a container for liquid. */
 item_location container_for( Character &you, const item &liquid, int radius = 0,
                              const item *avoid = nullptr );

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2014,21 +2014,22 @@ void game::open_consume_item_menu()
     avatar &player_character = get_avatar();
     switch( as_m.ret ) {
         case 0: {
-            item_location loc = game_menus::inv::consume_food();
+            item_location loc = game_menus::inv::consume( "FOOD" );
             avatar_action::eat( player_character, loc );
             break;
         }
         case 1: {
-            item_location loc = game_menus::inv::consume_drink();
+            item_location loc = game_menus::inv::consume( "DRINK" );
             avatar_action::eat( player_character, loc );
             break;
         }
         case 2:
-            avatar_action::eat_or_use( player_character, game_menus::inv::consume_meds() );
+            avatar_action::eat_or_use( player_character, game_menus::inv::consume( "MED" ) );
             break;
         default:
-            break;
+            return;
     }
+
 }
 
 static void handle_debug_mode()

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2011,25 +2011,14 @@ void game::open_consume_item_menu()
     as_m.entries.emplace_back( 2, true, 'm', _( "Medication" ) );
     as_m.query();
 
-    avatar &player_character = get_avatar();
-    switch( as_m.ret ) {
-        case 0: {
-            item_location loc = game_menus::inv::consume( "FOOD" );
-            avatar_action::eat( player_character, loc );
-            break;
-        }
-        case 1: {
-            item_location loc = game_menus::inv::consume( "DRINK" );
-            avatar_action::eat( player_character, loc );
-            break;
-        }
-        case 2:
-            avatar_action::eat_or_use( player_character, game_menus::inv::consume( "MED" ) );
-            break;
-        default:
-            return;
+    const int query_returned_index = as_m.ret;
+    if( query_returned_index >= 0 && query_returned_index < 3 ) {
+        const std::array<std::string, 3> comestype_strings = { "FOOD", "DRINK", "MED" };
+        const std::string &selected_comestype = comestype_strings[query_returned_index];
+        uistate.open_menu = [selected_comestype = selected_comestype]() {
+            avatar_action::eat_or_use( get_avatar(), game_menus::inv::consume( selected_comestype ) );
+        };
     }
-
 }
 
 static void handle_debug_mode()

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -421,6 +421,8 @@ void uistatedata::serialize( JsonOut &json ) const
 
     json.member( "overmap_sidebar_uistate" );
     overmap_sidebar_state.serialize( json );
+    json.member( "consume_menu_uistate" );
+    consume_uistate.serialize( json );
 
     json.member( "input_history" );
     json.start_object();
@@ -469,6 +471,7 @@ void uistatedata::deserialize( const JsonObject &jo )
     jo.read( "overmap_show_hordes", overmap_show_hordes );
     jo.read( "overmap_show_revealed_omts", overmap_show_revealed_omts );
     jo.read( "overmap_show_forest_trails", overmap_show_forest_trails );
+    jo.read( "consume_menu_uistate", consume_uistate );
     jo.read( "hidden_recipes", hidden_recipes );
     jo.read( "favorite_recipes", favorite_recipes );
     jo.read( "expanded_recipes", expanded_recipes );

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -43,10 +43,6 @@ static const activity_id ACT_CHOP_LOGS( "ACT_CHOP_LOGS" );
 static const activity_id ACT_CHOP_PLANKS( "ACT_CHOP_PLANKS" );
 static const activity_id ACT_CHOP_TREE( "ACT_CHOP_TREE" );
 static const activity_id ACT_CLEAR_RUBBLE( "ACT_CLEAR_RUBBLE" );
-static const activity_id ACT_CONSUME_DRINK_MENU( "ACT_CONSUME_DRINK_MENU" );
-static const activity_id ACT_CONSUME_FOOD_MENU( "ACT_CONSUME_FOOD_MENU" );
-static const activity_id ACT_CONSUME_MEDS_MENU( "ACT_CONSUME_MEDS_MENU" );
-static const activity_id ACT_EAT_MENU( "ACT_EAT_MENU" );
 static const activity_id ACT_HACKSAW( "ACT_HACKSAW" );
 static const activity_id ACT_HEATING( "ACT_HEATING" );
 static const activity_id ACT_INVOKE_ITEM( "ACT_INVOKE_ITEM" );
@@ -148,10 +144,6 @@ std::optional<std::string> player_activity::get_progress_message( const avatar &
     if( type == ACT_AIM ||
         type == ACT_ARMOR_LAYERS ||
         type == ACT_ATM ||
-        type == ACT_CONSUME_DRINK_MENU ||
-        type == ACT_CONSUME_FOOD_MENU ||
-        type == ACT_CONSUME_MEDS_MENU ||
-        type == ACT_EAT_MENU ||
         type == ACT_INVOKE_ITEM
       ) {
         return std::nullopt;

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -408,7 +408,11 @@ void player_activity::deserialize( const JsonObject &data )
     std::set<std::string> obs_activities {
         "ACT_PICKUP_MENU", // Remove after 0.I
         "ACT_VIEW_RECIPE", // Remove after 0.I
-        "ACT_ADV_INVENTORY" // Remove after 0.I
+        "ACT_ADV_INVENTORY", // Remove after 0.I
+        "ACT_EAT_MENU", // Remove after 0.J
+        "ACT_CONSUME_FOOD_MENU", // Remove after 0.J
+        "ACT_CONSUME_DRINK_MENU", // Remove after 0.J
+        "ACT_CONSUME_MEDS_MENU" // Remove after 0.J
     };
     if( !data.read( "type", tmptype ) ) {
         // Then it's a legacy save.

--- a/src/uistate.h
+++ b/src/uistate.h
@@ -115,7 +115,7 @@ struct overmap_sidebar_uistate {
 struct consume_menu_uistate {
     // values[0] = inventory selector selected column index,
     // values[1] = inventory selector selected index in column
-    std::optional<std::pair<size_t, size_t>> consume_menu_selections;
+    std::vector<uint64_t> consume_menu_selections;
     // targets[0...x] if collated, a pair of {0, 1}, otherwise all item_locations highlighted
     std::vector<item_location> consume_menu_selected_items;
     // str_values[0] = filter (the one you type in, not the new comestype filter)
@@ -126,12 +126,12 @@ struct consume_menu_uistate {
     std::string consume_menu_comestype;
 
     bool empty() const {
-        return !consume_menu_selections && consume_menu_selected_items.empty() &&
+        return consume_menu_selections.empty() && consume_menu_selected_items.empty() &&
                consume_menu_filter.empty();
     }
     void clear() {
         collated = false;
-        consume_menu_selections.reset();
+        consume_menu_selections.clear();
         consume_menu_selected_items.clear();
         consume_menu_filter.clear();
         //comestype does not clear

--- a/src/uistate.h
+++ b/src/uistate.h
@@ -111,6 +111,35 @@ struct overmap_sidebar_uistate {
     void deserialize( const JsonObject &jo );
 };
 
+// the consume menu reopens when done successfully consuming
+struct consume_menu_uistate {
+    // values[0] = inventory selector selected column index,
+    // values[1] = inventory selector selected index in column
+    std::optional<std::pair<size_t, size_t>> consume_menu_selections;
+    // targets[0...x] if collated, a pair of {0, 1}, otherwise all item_locations highlighted
+    std::vector<item_location> consume_menu_selected_items;
+    // str_values[0] = filter (the one you type in, not the new comestype filter)
+    std::string consume_menu_filter;
+    // values[2] = inventory selector collated bool
+    bool collated = false;
+    // new value to unify consume menus; when set, filter items by comestype
+    std::string consume_menu_comestype;
+
+    bool empty() const {
+        return !consume_menu_selections && consume_menu_selected_items.empty() &&
+               consume_menu_filter.empty();
+    }
+    void clear() {
+        collated = false;
+        consume_menu_selections.reset();
+        consume_menu_selected_items.clear();
+        consume_menu_filter.clear();
+        //comestype does not clear
+    }
+    void serialize( JsonOut &json ) const;
+    void deserialize( const JsonObject &jo );
+};
+
 /*
   centralized depot for trivial ui data such as sorting, string_input_popup history, etc.
   To use this, see the ****notes**** below
@@ -159,6 +188,8 @@ class uistatedata
         bool overmap_fast_scroll = false;
 
         overmap_sidebar_uistate overmap_sidebar_state;
+
+        consume_menu_uistate consume_uistate;
 
         // Distraction manager stuff
         bool distraction_noise = true;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Infrastructure "consume menu activity obsoletion"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Obsolete legacy activities.

ACT_EAT_MENU is for re-prompting the consume ('E') menu after a comestible/medical tool is consumed, for convenience's sake. As a feature, this is good. As an _activity_ this doesn't make any sense in the abstract; the _PC_ is not opening a menu, the _player_ is through the UI.

Somehow more egregiously, ACT_CONSUME_DRINK_MENU, ACT_CONSUME_FOOD_MENU, and ACT_CONSUME_MEDS_MENU are copy-pastes of ACT_EAT_MENU each for their respective filtered consume menu (the menu that prompts to only consume food/drink/med).

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

1. Obsolete all prior mentioned activity handlers.
2. Move consume menu handling to a `uistatedata` sub-object `consume_menu_uistate`, preserving the original behavior of ACT_EAT_MENU.
3. Move the filtered consume menu into the main call for the consume menu, preserving the behavior of ACT_CONSUME_x_MENU.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Just updating these handlers seemed silly.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

- Consumed protein ration, water, bandage, painkillers successfully, with consume menu reprompting correctly for each.
- Consumed all items in inventory to confirm no reprompt occurred.
- Consumed bandage in 0.H save, autosaved, then loaded with these changes. There are no menu-related errors, ~but because `firstaid_activity_actor` uses legacy activity variables (_sigh_) the consumed bandage disappears on load. This is minor and will be fixed later.~ This is an existing unrelated issue that will be reported
- Consumed bandage, autosaved/loaded, no errors.
- None of these changes should affect NPCs because the affected activities are avatar-only.
- Verified that NPCs still do self-first aid without error
- Verified that bandage, hemostatic powder, painkillers all apply their effects correctly when used

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Report + ping for undesirable behavior, please

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
