### PR TITLE
Increase shoe spawn rate in wardrobes

### DIFF
--- a/data/json/itemgroups/Clothing_Gear/clothing.json
+++ b/data/json/itemgroups/Clothing_Gear/clothing.json
@@ -4366,62 +4366,61 @@
     "subtype": "distribution",
     "items": [
       {
-        "distribution": [
-          { "item": "boots", "prob": 80 },
-          { "item": "boots_hiking", "prob": 50 },
-          { "item": "boots_steel", "prob": 50 },
-          { "item": "sneakers_steel", "prob": 35 },
-          { "item": "boots_combat", "prob": 45 },
-          { "item": "boots_fur", "prob": 10 },
-          { "item": "boots_western", "prob": 40 },
-          { "item": "boots_winter", "prob": 30 },
-          { "item": "knee_high_boots", "prob": 15 },
-          { "item": "motorbike_boots", "prob": 35 },
-          { "item": "thigh_high_boots", "prob": 5 },
-          { "item": "boots_denim", "prob": 5 }
-        ],
-        "prob": 60
+        "distribution": [ { "item": "sneakers", "prob": 3 }, { "item": "boots", "prob": 2 }, { "item": "dress_shoes", "prob": 1 } ],
+        "prob": 90
       },
       {
         "distribution": [
-          { "item": "bastsandals", "prob": 20 },
-          { "item": "straw_sandals", "prob": 20 },
-          { "item": "flip_flops", "prob": 40 },
-          { "item": "flip_flops_exp", "prob": 5 },
-          { "item": "leathersandals", "prob": 35 },
-          { "item": "espadrilles", "prob": 20 }
+          { "item": "slippers", "prob": 8 },
+          { "item": "flip_flops", "prob": 8 },
+          { "item": "flip_flops_exp", "prob": 3 },
+          { "item": "straw_sandals", "prob": 3 },
+          { "item": "bastsandals", "prob": 3 },
+          { "item": "leathersandals", "prob": 3 },
+          { "item": "espadrilles", "prob": 3 },
+          { "item": "mocassins", "prob": 3 },
+          { "item": "clogs", "prob": 1 },
+          { "item": "geta", "prob": 1 }
         ],
-        "prob": 60
+        "prob": 50
+      },
+      {
+        "distribution": [ { "item": "boots_steel", "prob": 4 }, { "item": "sneakers_steel", "prob": 3 }, { "item": "boots_rubber", "prob": 1 } ],
+        "prob": 30
       },
       {
         "distribution": [
-          { "item": "cleats", "prob": 20 },
-          { "item": "golf_shoes", "prob": 20 },
-          { "item": "dance_shoes", "prob": 30 },
-          { "item": "roller_blades", "prob": 35 },
-          { "item": "rollerskates", "prob": 35 },
-          { "item": "roller_shoes_off", "prob": 45 }
+          { "item": "boots_hiking", "prob": 5 },
+          { "item": "motorbike_boots", "prob": 3 },
+          { "item": "boots_combat", "prob": 2 }
+        ],
+        "prob": 30
+      },
+      {
+        "distribution": [
+          { "item": "lowtops", "prob": 3 },
+          { "item": "golf_shoes", "prob": 3 },
+          { "item": "dance_shoes", "prob": 3 },
+          { "item": "cleats", "prob": 2 },
+          { "item": "rollerskates", "prob": 4 },
+          { "item": "roller_shoes_off", "prob": 4 },
+          { "item": "roller_blades", "prob": 2 }
         ],
         "prob": 20
       },
       {
-        "distribution": [
-          { "item": "dress_shoes", "prob": 50 },
-          { "item": "lowtops", "prob": 30 },
-          { "item": "mocassins", "prob": 10 },
-          { "item": "sneakers", "prob": 35 },
-          { "item": "shoes_denim", "prob": 5 }
-        ],
-        "prob": 70
+        "distribution": [ { "item": "boots_fur", "prob": 1 }, { "item": "boots_faux_fur", "prob": 1 }, { "item": "boots_winter", "prob": 2 } ],
+        "prob": 20
       },
       {
         "distribution": [
-          { "item": "boots_rubber", "prob": 50 },
-          { "item": "clogs", "prob": 20 },
-          { "item": "geta", "prob": 10 },
-          { "item": "slippers", "prob": 75 }
+          { "item": "knee_high_boots", "prob": 5 },
+          { "item": "thigh_high_boots", "prob": 1 },
+          { "item": "boots_western", "prob": 3 },
+          { "item": "shoes_denim", "prob": 2 },
+          { "item": "boots_denim", "prob": 2 }
         ],
-        "prob": 70
+        "prob": 10
       }
     ]
   },

--- a/data/json/itemgroups/SUS/domestic.json
+++ b/data/json/itemgroups/SUS/domestic.json
@@ -1061,7 +1061,7 @@
     "//": "clothing found in a man's wardrobe",
     "subtype": "collection",
     "entries": [
-      { "group": "shoes_unisex", "prob": 50, "count": [ 1, 2 ] },
+      { "group": "shoes_unisex", "count": [ 0, 3 ] },
       { "item": "sleeping_bag_roll", "prob": 5 },
       { "group": "coats_unisex", "prob": 50, "count": [ 0, 3 ] },
       { "group": "suits_unisex", "prob": 50, "count": [ 0, 2 ] },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Balance "Increase shoe spawn rate in wardrobes"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Basically no shoes spawn in houses. If a zombie chews up your starting sneakers, finding a replacement in a house is next to impossible. I don't think shoes should be such rare loot, so it is clearly not working as intended.

1. Judging by the itemgroups, shoes are supposed to spawn in wardrobes, but the chance is too low.
2. The itemgroup `shoes_unisex` gives some weird results.
<img width="551" height="647" alt="shoe-before2" src="https://github.com/user-attachments/assets/cc15a469-ce31-46ff-ae85-b78be38efd89" />

<img width="443" height="654" alt="shoe-before1" src="https://github.com/user-attachments/assets/42de685c-cd60-48a2-895c-9893afe3f87e" />

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

1. Increased the spawn rates. Wardrobes (but not dressers) now spawn 0-3 pairs of spare shoes.
2. Slightly reworked `shoes_unisex`. Shoes in the itemgroup are now divided into categories; here is their approximate distribution:
<img width="437" height="329" alt="shoe-total" src="https://github.com/user-attachments/assets/bc297f85-3b1d-41ca-ae97-b5c0b5cf3540" />

(Everyday - boots and sneakers, Home - slippers and sandals, Work - steel-toed boots, Trekking - hiking boots, Leisure - golf shoes, rollerskates, Rare - denim boots, jackboots)

<img width="456" height="657" alt="shoe-after1" src="https://github.com/user-attachments/assets/33a268db-db3c-4c7b-a957-5c8fc7524544" />

3. I also added faux fur boots to the itemgroup, which were missing for some reason.

#### Describe alternatives you've considered
Suggestions for the numbers?

#### Testing
Shoes can now be found in wardrobes. The spawn rate seems reasonable.
<img width="362" height="592" alt="shoe-after3" src="https://github.com/user-attachments/assets/ddec0a7e-f40d-4f18-9a3e-f83f43d375e8" />
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
`SUS_dresser_mens_single_outfit` also gives strange results, for example, an outfit with 3 pairs of glasses. I'll try to fix this later.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
