### PR TITLE
[0.I Branch Backport] Bugfix: In EOC u_query_omt, distance_limit are not visualized on overmap UI when using tiles

### DIFF
--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -54,7 +54,6 @@
 #include "item_pocket.h"
 #include "itype.h"
 #include "kill_tracker.h"
-#include "line.h"
 #include "list.h"
 #include "localized_comparator.h"
 #include "map.h"
@@ -301,14 +300,6 @@ static tripoint_abs_omt om_target_tile(
     const std::unordered_set<oter_type_str_id> &possible_om_types = {}, bool must_see = true,
     const tripoint_abs_omt &source = tripoint_abs_omt::invalid, bool bounce = false,
     const std::optional<std::string> &message = std::nullopt );
-static void om_range_mark( const tripoint_abs_omt &origin, int range, bool add_notes = true,
-                           const std::string &message = "Y;X: MAX RANGE" );
-static void om_line_mark(
-    const tripoint_abs_omt &origin, const tripoint_abs_omt &dest, bool add_notes = true,
-    const std::string &message = "R;X: PATH" );
-static void om_path_mark(
-    const std::vector<tripoint_abs_omt> &note_pts, bool add_notes = true,
-    const std::string &message = "R;X: PATH" );
 /**
  * Select waypoints and plot a path for a companion to travel
  * @param start start point
@@ -5050,8 +5041,8 @@ tripoint_abs_omt om_target_tile( const tripoint_abs_omt &omt_pos, int min_range,
     const std::unordered_set<oter_type_str_id> bounce_locations = { oter_type_faction_hide_site_0 };
 
     tripoint_abs_omt where;
-    om_range_mark( omt_pos, range );
-    om_range_mark( omt_pos, min_range, true, "Y;X: MIN RANGE" );
+    ui::omap::range_mark( omt_pos, range );
+    ui::omap::range_mark( omt_pos, min_range, true, "Y;X: MIN RANGE" );
     const std::string &real_message = string_format(
                                           message ? *message : _( "Select a location from %d to %d tiles away." ), min_range, range );
     if( source.is_invalid() ) {
@@ -5059,8 +5050,8 @@ tripoint_abs_omt om_target_tile( const tripoint_abs_omt &omt_pos, int min_range,
     } else {
         where = ui::omap::choose_point( real_message, source );
     }
-    om_range_mark( omt_pos, range, false );
-    om_range_mark( omt_pos, min_range, false, "Y;X: MIN RANGE" );
+    ui::omap::range_mark( omt_pos, range, false );
+    ui::omap::range_mark( omt_pos, min_range, false, "Y;X: MIN RANGE" );
 
     if( where.is_invalid() ) {
         return where;
@@ -5085,10 +5076,10 @@ tripoint_abs_omt om_target_tile( const tripoint_abs_omt &omt_pos, int min_range,
         for( const oter_type_str_id &pos_om : bounce_locations ) {
             if( bounce && pos_om == omt_ref && range > 5 ) {
                 if( query_yn( _( "Do you want to bounce off this location to extend range?" ) ) ) {
-                    om_line_mark( omt_pos, omt_tgt );
+                    ui::omap::line_mark( omt_pos, omt_tgt );
                     tripoint_abs_omt dest =
                         om_target_tile( omt_tgt, 2, range * .75, possible_om_types, true, omt_tgt, true );
-                    om_line_mark( omt_pos, omt_tgt, false );
+                    ui::omap::line_mark( omt_pos, omt_tgt, false );
                     return dest;
                 }
             }
@@ -5101,84 +5092,6 @@ tripoint_abs_omt om_target_tile( const tripoint_abs_omt &omt_pos, int min_range,
 
     return om_target_tile( omt_pos, min_range, range, possible_om_types, must_see, omt_pos );
 }
-
-void om_range_mark( const tripoint_abs_omt &origin, int range, bool add_notes,
-                    const std::string &message )
-{
-    std::vector<tripoint_abs_omt> note_pts;
-
-    if( trigdist ) {
-        for( const tripoint_abs_omt &pos : points_on_radius_circ( origin, range ) ) {
-            note_pts.emplace_back( pos );
-        }
-    } else {
-        note_pts.reserve( range * 4 - 4 );
-        //North Limit
-        for( int x = origin.x() - range; x < origin.x() + range + 1; x++ ) {
-            note_pts.emplace_back( x, origin.y() - range, origin.z() );
-        }
-        //South
-        for( int x = origin.x() - range; x < origin.x() + range + 1; x++ ) {
-            note_pts.emplace_back( x, origin.y() + range, origin.z() );
-        }
-        //West
-        for( int y = origin.y() - range; y < origin.y() + range + 1; y++ ) {
-            note_pts.emplace_back( origin.x() - range, y, origin.z() );
-        }
-        //East
-        for( int y = origin.y() - range; y < origin.y() + range + 1; y++ ) {
-            note_pts.emplace_back( origin.x() + range, y, origin.z() );
-        }
-    }
-
-    for( tripoint_abs_omt &pt : note_pts ) {
-        if( add_notes ) {
-            if( !overmap_buffer.has_note( pt ) ) {
-                overmap_buffer.add_note( pt, message );
-            }
-        } else {
-            if( overmap_buffer.has_note( pt ) && overmap_buffer.note( pt ) == message ) {
-                overmap_buffer.delete_note( pt );
-            }
-        }
-    }
-}
-
-void om_line_mark( const tripoint_abs_omt &origin, const tripoint_abs_omt &dest, bool add_notes,
-                   const std::string &message )
-{
-    std::vector<tripoint_abs_omt> note_pts = line_to( origin, dest );
-
-    for( const tripoint_abs_omt &pt : note_pts ) {
-        if( add_notes ) {
-            if( !overmap_buffer.has_note( pt ) ) {
-                overmap_buffer.add_note( pt, message );
-            }
-        } else {
-            if( overmap_buffer.has_note( pt ) && overmap_buffer.note( pt ) == message ) {
-                overmap_buffer.delete_note( pt );
-            }
-        }
-    }
-}
-
-static void om_path_mark(
-    const std::vector<tripoint_abs_omt> &note_pts, bool add_notes,
-    const std::string &message )
-{
-    for( const tripoint_abs_omt &pt : note_pts ) {
-        if( add_notes ) {
-            if( !overmap_buffer.has_note( pt ) ) {
-                overmap_buffer.add_note( pt, message );
-            }
-        } else {
-            if( overmap_buffer.has_note( pt ) && overmap_buffer.note( pt ) == message ) {
-                overmap_buffer.delete_note( pt );
-            }
-        }
-    }
-}
-
 
 bool om_set_hide_site( npc &comp, const tripoint_abs_omt &omt_tgt,
                        const drop_locations &itms,
@@ -5278,7 +5191,7 @@ pf::simple_path<tripoint_abs_omt> om_companion_path( const tripoint_abs_omt &sta
             if( scout_segments.empty() ) {
                 return {};
             }
-            om_path_mark( scout_segments.back().points, false );
+            ui::omap::path_mark( scout_segments.back().points, false );
             range += scout_segments.back().cost / 24;
             scout_segments.pop_back();
             if( scout_segments.empty() ) {
@@ -5297,10 +5210,10 @@ pf::simple_path<tripoint_abs_omt> om_companion_path( const tripoint_abs_omt &sta
             debugmsg( "Got empty travel path during mission planning." );
             continue;
         }
-        om_path_mark( note_pts.points );
+        ui::omap::path_mark( note_pts.points );
         if( note_pts.cost / 24 > range ) {
             ui::omap::choose_point( _( "This path is too far, continue to undo and try again." ), spt );
-            om_path_mark( note_pts.points, false );
+            ui::omap::path_mark( note_pts.points, false );
             continue;
         }
         scout_segments.emplace_back( note_pts );
@@ -5315,7 +5228,7 @@ pf::simple_path<tripoint_abs_omt> om_companion_path( const tripoint_abs_omt &sta
         }
     }
     for( const pf::simple_path<tripoint_abs_omt> &scout_segment : scout_segments ) {
-        om_path_mark( scout_segment.points, false );
+        ui::omap::path_mark( scout_segment.points, false );
     }
     return std::accumulate( scout_segments.begin(), scout_segments.end(),
                             pf::simple_path<tripoint_abs_omt>(), []( pf::simple_path<tripoint_abs_omt> a,

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -4660,9 +4660,17 @@ talk_effect_fun_t::func f_query_omt( const JsonObject &jo, std::string_view memb
                 tripoint_abs_ms abs_ms = read_var_value( *target_var, d ).tripoint();
                 target_pos = project_to<coords::omt>( abs_ms );
             }
-
-            tripoint_abs_omt pick = ui::omap::choose_point( message.evaluate( d ), target_pos, false,
-                                    distance_limit.evaluate( d ) );
+            int distance = distance_limit.evaluate( d );
+            bool is_distance_set = distance != INT_MAX;
+            if( is_distance_set ) {
+                ui::omap::range_mark( target_pos, distance );
+            }
+            tripoint_abs_omt pick =
+                ui::omap::choose_point( message.evaluate( d ), target_pos, false,
+                                        distance );
+            if( is_distance_set ) {
+                ui::omap::range_mark( target_pos, distance, false );
+            }
             if( pick != tripoint_abs_omt::invalid ) {
                 tripoint_abs_ms abs_pos_ms = project_to<coords::ms>( pick );
                 // aim at the center of OMT

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -2656,6 +2656,85 @@ std::optional<city> ui::omap::select_city( uilist &cities_menu,
     return ret_val;
 }
 
+void ui::omap::range_mark( const tripoint_abs_omt &origin, int range, bool add_notes,
+                           const std::string &message )
+{
+    std::vector<tripoint_abs_omt> note_pts;
+
+    if( trigdist ) {
+        note_pts.reserve( range * 7 ); // actual multiplier varies from 5.33 to 8, mostly 6 to 7
+        for( const tripoint_abs_omt &pos : points_on_radius_circ( origin, range ) ) {
+            note_pts.emplace_back( pos );
+        }
+    } else {
+        note_pts.reserve( range * 8 );
+        //North Limit
+        for( int x = origin.x() - range; x < origin.x() + range + 1; x++ ) {
+            note_pts.emplace_back( x, origin.y() - range, origin.z() );
+        }
+        //South
+        for( int x = origin.x() - range; x < origin.x() + range + 1; x++ ) {
+            note_pts.emplace_back( x, origin.y() + range, origin.z() );
+        }
+        //West
+        for( int y = origin.y() - range; y < origin.y() + range + 1; y++ ) {
+            note_pts.emplace_back( origin.x() - range, y, origin.z() );
+        }
+        //East
+        for( int y = origin.y() - range; y < origin.y() + range + 1; y++ ) {
+            note_pts.emplace_back( origin.x() + range, y, origin.z() );
+        }
+    }
+
+    for( tripoint_abs_omt &pt : note_pts ) {
+        if( add_notes ) {
+            if( !overmap_buffer.has_note( pt ) ) {
+                overmap_buffer.add_note( pt, message );
+            }
+        } else {
+            if( overmap_buffer.has_note( pt ) && overmap_buffer.note( pt ) == message ) {
+                overmap_buffer.delete_note( pt );
+            }
+        }
+    }
+}
+
+void ui::omap::line_mark( const tripoint_abs_omt &origin, const tripoint_abs_omt &dest,
+                          bool add_notes,
+                          const std::string &message )
+{
+    std::vector<tripoint_abs_omt> note_pts = line_to( origin, dest );
+
+    for( const tripoint_abs_omt &pt : note_pts ) {
+        if( add_notes ) {
+            if( !overmap_buffer.has_note( pt ) ) {
+                overmap_buffer.add_note( pt, message );
+            }
+        } else {
+            if( overmap_buffer.has_note( pt ) && overmap_buffer.note( pt ) == message ) {
+                overmap_buffer.delete_note( pt );
+            }
+        }
+    }
+}
+
+void ui::omap::path_mark(
+    const std::vector<tripoint_abs_omt> &note_pts, bool add_notes,
+    const std::string &message )
+{
+    for( const tripoint_abs_omt &pt : note_pts ) {
+        if( add_notes ) {
+            if( !overmap_buffer.has_note( pt ) ) {
+                overmap_buffer.add_note( pt, message );
+            }
+        } else {
+            if( overmap_buffer.has_note( pt ) && overmap_buffer.note( pt ) == message ) {
+                overmap_buffer.delete_note( pt );
+            }
+        }
+    }
+}
+
 void ui::omap::force_quit()
 {
     overmap_ui::generated_omts.clear();

--- a/src/overmap_ui.h
+++ b/src/overmap_ui.h
@@ -106,6 +106,17 @@ void setup_cities_menu( uilist &cities_menu, std::vector<city> &cities_container
 std::optional<city> select_city( uilist &cities_menu, std::vector<city> &cities_container,
                                  bool random = false );
 
+void range_mark( const tripoint_abs_omt &origin, int range, bool add_notes = true,
+                 const std::string &message = "Y;X: MAX RANGE" );
+
+void line_mark(
+    const tripoint_abs_omt &origin, const tripoint_abs_omt &dest, bool add_notes = true,
+    const std::string &message = "R;X: PATH" );
+
+void path_mark(
+    const std::vector<tripoint_abs_omt> &note_pts, bool add_notes = true,
+    const std::string &message = "R;X: PATH" );
+
 void force_quit();
 } // namespace omap
 


### PR DESCRIPTION
#### Summary
Bugfixes "distance_limit of EOC 'u_query_omt' not visualized on overmap UI when using tiles"

#### Purpose of change

#84259 Manual backport this PR causing there are conflicts.

#### Describe the solution

I noticed that when using the u_query_omt EOC and specifying the distance_limit parameter, the range was not visualized in the overmap UI. I later found out that this EOC currently does not support visualizing the range when using Tiles, so I added this capability.

While fixing the issue, I refactored the code by moving the three functions—om_range_mark, om_line_mark, and om_path_mark—originally in faction_camp to overmap_ui. This makes the responsibility division more logical and allows other modules to use these functions as well.

#### Describe alternatives you've considered

No other alternative solutions have been identified so far.

#### Testing

After adding the visualization code, you can now see the range indicator when using Tiles.

#### Additional context

None