### PR TITLE
Fix tools not charging from cars outside reality bubble

### DIFF
--- a/src/item_gun_tool_ammo.cpp
+++ b/src/item_gun_tool_ammo.cpp
@@ -2922,31 +2922,66 @@ int item::charge_linked_batteries( vehicle &linked_veh, int turns_elapsed )
 
     if( turns_elapsed < 1 || ( short_time_passed &&
                                !calendar::once_every( time_duration::from_turns( link().charge_interval ) ) ) ) {
+        // To early to get any charge
         return link().charge_rate;
     }
 
-    // If a long time passed, multiply the total by the efficiency rather than cancelling a charge.
-    int transfer_total = short_time_passed ? 1 :
-                         ( turns_elapsed * 1.0f / link().charge_interval ) * link().charge_interval;
-
     if( power_in ) {
-        const int battery_deficit = linked_veh.discharge_battery( here, transfer_total, true );
-        // Around 85% efficient by default; a few of the discharges don't actually recharge
-        if( battery_deficit == 0 && ( !short_time_passed || rng_float( 0.0, 1.0 ) <= link().efficiency ) ) {
-            ammo_set( itype_battery, ammo_remaining( ) + transfer_total );
+        int available_charges = linked_veh.battery_power_level( ).first;
+        int wanted_charges = ammo_capacity( itype_battery->ammo->type ) - ammo_remaining( );
+
+        // Nothing to charge or nothing to charge with
+        if( wanted_charges == 0 || available_charges == 0 ) {
+            return link().charge_rate;
         }
-    } else {
-        // Around 85% efficient by default; a few of the discharges don't actually charge
-        if( !short_time_passed || rng_float( 0.0, 1.0 ) <= link().efficiency ) {
-            const int battery_surplus = linked_veh.charge_battery( here, transfer_total, true );
-            if( battery_surplus == 0 ) {
-                ammo_set( itype_battery, ammo_remaining( ) - transfer_total );
+
+        if( short_time_passed ) {
+            // Single charge - subtract one from source, roll against efficiency to add one to destination
+            linked_veh.discharge_battery( here, 1, true );
+            if( rng_float( 0.0, 1.0 ) <= link().efficiency ) {
+                ammo_set( itype_battery, ammo_remaining( ) + 1 );
             }
         } else {
-            const std::pair<int, int> linked_levels = linked_veh.connected_battery_power_level( here );
-            if( linked_levels.first < linked_levels.second ) {
-                ammo_set( itype_battery, ammo_remaining( ) - transfer_total );
+            // Multiple charges - get minimum from available charges, possible transfer in given time and
+            // amount of charges destination needs to charge itself to full with given efficiency.
+            // Subtract that value from the source and after reduction by efficiency add it to the destination.
+            int possible_transfer = turns_elapsed * 1.0f / link().charge_interval;
+            int required_charges = wanted_charges / link().efficiency;
+            int spent_charges = std::min( { possible_transfer, available_charges, required_charges } );
+            // Avoid rounding error on full charge
+            int received_charges = spent_charges == required_charges ? wanted_charges : spent_charges * link().efficiency;
+
+            linked_veh.discharge_battery( here, spent_charges, true );
+            ammo_set( itype_battery, ammo_remaining( ) + received_charges );
+        }
+    } else {
+        const auto [bat_remaining, bat_capacity] = linked_veh.battery_power_level( );
+        int available_charges = ammo_remaining( );
+        int wanted_charges = bat_capacity - bat_remaining;
+
+        // Nothing to charge or nothing to charge with
+        if( wanted_charges == 0 || available_charges == 0 ) {
+            return link().charge_rate;
+        }
+
+        if( short_time_passed ) {
+            // Single charge - subtract one from source, roll against efficiency to add one to destination
+            ammo_set( itype_battery, ammo_remaining( ) - 1 );
+            if( rng_float( 0.0, 1.0 ) <= link().efficiency ) {
+                linked_veh.charge_battery( here, 1, true );
             }
+        } else {
+            // Multiple charges - get minimum from available charges, possible transfer in given time and
+            // amount of charges destination needs to charge itself to full with given efficiency.
+            // Subtract that value from the source and after reduction by efficiency add it to the destination.
+            int possible_transfer = turns_elapsed * 1.0f / link().charge_interval;
+            int required_charges = wanted_charges / link().efficiency;
+            int spent_charges = std::min( { possible_transfer, available_charges, required_charges } );
+            // Avoid rounding error on full charge
+            int received_charges = spent_charges == required_charges ? wanted_charges : spent_charges * link().efficiency;
+
+            ammo_set( itype_battery, ammo_remaining( ) - spent_charges );
+            linked_veh.charge_battery( here, received_charges, true );
         }
     }
     return link().charge_rate;

--- a/src/item_gun_tool_ammo.cpp
+++ b/src/item_gun_tool_ammo.cpp
@@ -2949,7 +2949,9 @@ int item::charge_linked_batteries( vehicle &linked_veh, int turns_elapsed )
             int required_charges = wanted_charges / link().efficiency;
             int spent_charges = std::min( { possible_transfer, available_charges, required_charges } );
             // Avoid rounding error on full charge
-            int received_charges = spent_charges == required_charges ? wanted_charges : spent_charges * link().efficiency;
+            int received_charges = spent_charges == required_charges
+                                   ? wanted_charges
+                                   : spent_charges * link().efficiency;
 
             linked_veh.discharge_battery( here, spent_charges, true );
             ammo_set( itype_battery, ammo_remaining( ) + received_charges );
@@ -2978,7 +2980,9 @@ int item::charge_linked_batteries( vehicle &linked_veh, int turns_elapsed )
             int required_charges = wanted_charges / link().efficiency;
             int spent_charges = std::min( { possible_transfer, available_charges, required_charges } );
             // Avoid rounding error on full charge
-            int received_charges = spent_charges == required_charges ? wanted_charges : spent_charges * link().efficiency;
+            int received_charges = spent_charges == required_charges
+                                   ? wanted_charges
+                                   : spent_charges * link().efficiency;
 
             ammo_set( itype_battery, ammo_remaining( ) - spent_charges );
             linked_veh.charge_battery( here, received_charges, true );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Fix tools not charging properly from cars outside reality bubble"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #84121
Fixes #84238
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Correctly calculate and apply transferred amount of power.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
N/A
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
car at 3000
mp3 player at 2/50 (5W charge_rate)
theoretical : 2944 :: 50/50 in ~3,1392hrs (3:08:21)

- present -> 2945 :: 50/50 in ~3.1hrs
- away -> 2943 :: 50/50 in ~3hrs ; no change after +1hr away ; no change after +1hr present
- away -> 2973 :: 24/50 in 1.5hrs

car at 25
mp3 player at 2/50 (5W charge_rate)
theoretical : 0 :: 23/50 in ~1,385hrs (1:23:06)

- present -> 0 :: 26/50 in 1.5hrs ; no change after +1hr present
- present -> 0 :: 25/50 in 1.5hrs ; no change after +1hr present
- present -> 0 :: 21/50 in 1.5hrs ; no change after +1hr present
- away -> 16 :: 9/50 in 0.5hrs ; 0 :: 21/50 in +1hr away ; no change after +1hr away
- away -> 0 :: 23/50 in 3hrs ; no change after +3hr away


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
N/A
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
