### PR TITLE
Oil up those pantries, and stock them up

### DIFF
--- a/data/json/itemgroups/Food/food.json
+++ b/data/json/itemgroups/Food/food.json
@@ -382,7 +382,7 @@
       { "item": "syrup_simple", "charges": [ 1, -1 ], "prob": 1 },
       { "item": "syrup_corn", "charges": [ 1, -1 ], "prob": 5 },
       { "item": "molasses", "charges": [ 1, -1 ], "prob": 15 },
-      { "group": "vegetable_oil_bottle", "prob": 40 },
+      { "group": "vegetable_oil_bottle", "prob": 60 },
       { "item": "honey_bottled", "charges": [ 1, -1 ], "prob": 15 },
       { "prob": 5, "item": "honey_glassed", "count": [ 1, -1 ] },
       { "item": "jar_glass_sealed", "prob": 20 },

--- a/data/json/itemgroups/SUS/domestic.json
+++ b/data/json/itemgroups/SUS/domestic.json
@@ -519,7 +519,7 @@
     "//3": "Frequency of pet food appearing based on percentage of Massachusetts homes with a pet.",
     "subtype": "collection",
     "entries": [
-      { "group": "pantry_liquids", "prob": 50, "count": [ 1, 2 ] },
+      { "group": "pantry_liquids", "prob": 60, "count": [ 1, 2 ] },
       { "group": "pasta_ingredients", "prob": 70, "count": [ 1, 3 ] },
       { "group": "cannedfood", "prob": 100, "count": [ 1, 6 ] },
       { "group": "big_canned_food", "prob": 20, "count": [ 1, 2 ] },

--- a/data/json/mapgen_palettes/house_general_palette.json
+++ b/data/json/mapgen_palettes/house_general_palette.json
@@ -344,7 +344,7 @@
       "3": [ { "item": "SUS_utensils", "chance": 50 }, { "item": "SUS_knife_drawer", "chance": 50 } ],
       "4": { "item": "SUS_junk_drawer", "chance": 100 },
       "5": { "item": "SUS_kitchen_sink", "chance": 100 },
-      "6": [ { "item": "SUS_pantry", "chance": 25 }, { "item": "cannedfood", "chance": 20, "repeat": [ 1, 2 ] } ],
+      "6": [ { "item": "SUS_pantry", "chance": 80 }, { "item": "cannedfood", "chance": 20, "repeat": [ 1, 2 ] } ],
       "7": [
         { "item": "SUS_breakfast_cupboard", "chance": 30 },
         { "item": "SUS_coffee_cupboard", "chance": 50 },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Vegetable oil is a rarity in the homes of CDDA despite being a basic necessity if you want to do any cooking, with butter as an relatively expensive alternative.

The reason is that cooking oil specifically has the spawn of a few higher level group as requirements, some of those being pretty low, namely the `SUS_pantry` group with a measly 25% chance to spawn. All those spawn chances compound to ~3% chance of vegetable oil spawning in any one house.

While my main goal was to make vegetable oil more common in homes I also aim to restock CDDA pantries a bit since the spawn chance seems absurdly low.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
`SUS_pantry` spawn chances: 25% -> 80%
`pantry_liquids`: 50 -> 60%
`vegetable_oil_bottle`: 40 ->60% (actual probability probably closer to ~35% due to that group having more than 100% prob)
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Maybe the reason pantries having such low chances to spawn stocked is supposed to represent something like maybe people leaving with their food supplies or something.

I set it to 80% to preserve that possibility of a pantry furniture being empty.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Homes have vegetable oil.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Fixes #84334.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
