### PR TITLE
[XE] Update the blood gift research EOC to include the new powers.

### DIFF
--- a/data/mods/Xedra_Evolved/recipes/vampire.json
+++ b/data/mods/Xedra_Evolved/recipes/vampire.json
@@ -140,7 +140,8 @@
           "VAMPIRE_EARTH_SLUMBER",
           "VAMPIRE_CARDIO_BONUS",
           "VAMPIRE_MOTION_ALARM",
-          "VAMPIRE_BONUS_HP"
+          "VAMPIRE_BONUS_HP",
+          "VAMPIRE_RENDING_TEETH"
         ],
         "type": "mutation",
         "true_eocs": [ "EOC_XE_VAMPIRE_BLOOD_RESEARCH_SUCCESS" ],
@@ -163,7 +164,8 @@
           "VAMPIRE_NO_ILLNESS",
           "VAMPIRE_BAT_FORM",
           "VAMPIRE_WOLF_FORM",
-          "VAMPIRE_MIST_FORM"
+          "VAMPIRE_MIST_FORM",
+          "VAMPIRE_SUMMON_SHADOWS"
         ],
         "type": "mutation",
         "true_eocs": [ "EOC_XE_VAMPIRE_BLOOD_RESEARCH_SUCCESS" ],


### PR DESCRIPTION
#### Summary
Mods "[XE] Update the blood gift research EOC to include the new powers."

#### Purpose of change

The two new blood arts haven't been added to the research EOC, only to the vampvirus and Anathema gain EOCs.
This updates the research so it can give the two powers too.

#### Describe the solution

Update the blood gift research EOC to include the new powers.

#### Describe alternatives you've considered

None

#### Testing

The powers are part of the EOC

#### Additional context