### PR TITLE
[Bombastic Perks] Add the Safety Squint perk (plus a couple fixes)

### DIFF
--- a/data/mods/BombasticPerks/perkdata/absit_invidia.json
+++ b/data/mods/BombasticPerks/perkdata/absit_invidia.json
@@ -49,6 +49,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_PERK_ABSIT_INVIDIA_SALT",
+    "condition": { "u_has_trait": "perk_absit_invidia" },
     "effect": [
       { "u_lose_effect": "taint" },
       {

--- a/data/mods/BombasticPerks/perkdata/absit_invidia.json
+++ b/data/mods/BombasticPerks/perkdata/absit_invidia.json
@@ -56,6 +56,7 @@
         "u_message": "You toss the salt over your shoulder and mutter under your breath the words that you remember from your childhood.",
         "type": "mixed"
       }
-    ]
+    ],
+    "false_effect": [ { "u_message": "You toss the salt over your shoulder.  Hey, any luck you can get, right?", "type": "mixed" } ]
   }
 ]

--- a/data/mods/BombasticPerks/perkdata/rage_against_the_unnatural.json
+++ b/data/mods/BombasticPerks/perkdata/rage_against_the_unnatural.json
@@ -4,7 +4,7 @@
     "id": "EOC_perk_rage_against_the_unnatural_nether_list",
     "condition": {
       "math": [
-        "u_monsters_nearby('mon_albino_penguin', 'mon_amigara_horror', 'mon_blank', 'mon_blood_sacrifice', 'mon_breather', 'mon_breather_hub', 'mon_shrapnel_swarm', 'mon_structural_spur', 'mon_void_spider', 'mon_void_spider_maw', 'mon_void_spider_limb', 'mon_void_spider_spiderling', 'mon_void_spider_spiderling_skewered', 'mon_darkman', 'mon_dog_thing', 'mon_flaming_eye', 'mon_flying_polyp', 'mon_star_vampire', 'mon_star_vampire_coiling', 'mon_unseen_hunter', 'mon_gozu', 'mon_gracke', 'mon_headless_dog_thing', 'mon_tindalos', 'mon_hound_tindalos', 'mon_hound_tindalos_afterimage', 'mon_human_snail', 'mon_hunting_horror', 'mon_kreck', 'mon_shadow', 'mon_shadow_snake', 'mon_shoggoth', 'mon_thing', 'mon_twisted_body', 'mon_yugg', 'mon_vortex', 'mon_shifting_mass', 'mon_impossible_shape', 'mon_absence', 'mon_giant_appendage', 'mon_flatlander', 'mon_memory', 'mon_swarm_structure', 'mon_twisting_blade', 'mon_archunk_weak', 'mon_archunk_medium', 'mon_archunk_strong', 'mon_pale_reflection', 'mon_twisted_reflection', 'mon_dark_reflection', 'mon_better_half', 'mon_XEDRA_officer', 'mon_XEDRA_soldier', 'mon_tainted_shadow', 'mon_hallucinator', 'mon_guilt', 'mon_sloth', 'mon_hanging_roper', 'mon_carrion_grub', 'mon_nether_spearfisher', 'mon_nether_leech', 'mon_nether_fish', 'mon_nether_unviable_butterfly', 'mon_nether_unviable_root', 'mon_nether_unviable_stomper', 'mon_nether_unviable_bug', 'mon_nether_unviable_chunk', 'radius': 1, 'attitude': 'both')",
+        "u_mon_species_nearby('NETHER'', 'radius': 1, 'attitude': 'both')",
         ">",
         "0"
       ]

--- a/data/mods/BombasticPerks/perkdata/rage_against_the_unnatural.json
+++ b/data/mods/BombasticPerks/perkdata/rage_against_the_unnatural.json
@@ -2,13 +2,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_perk_rage_against_the_unnatural_nether_list",
-    "condition": {
-      "math": [
-        "u_mon_species_nearby('NETHER'', 'radius': 1, 'attitude': 'both')",
-        ">",
-        "0"
-      ]
-    },
+    "condition": { "math": [ "u_mon_species_nearby('NETHER', 'radius': 1, 'attitude': 'both')", ">", "0" ] },
     "effect": [  ]
   },
   {

--- a/data/mods/BombasticPerks/perkdata/safety_squint.json
+++ b/data/mods/BombasticPerks/perkdata/safety_squint.json
@@ -1,0 +1,52 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_safety_squint_on",
+    "effect": [ { "u_spawn_item": "perk_safety_squint_integrated_goggles", "suppress_message": true, "force_equip": true } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_safety_squint_off",
+    "effect": [ { "u_remove_item_with_item": "perk_safety_squint_integrated_goggles" } ]
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_perk_safety_squint_reduced_vision",
+    "//": "Hidden effect",
+    "name": [ "" ],
+    "desc": [ "" ],
+    "flags": [ "MYOPIA_SUPERNATURAL" ]
+  },
+  {
+  "id": "perk_safety_squint_integrated_goggles",
+  "copy-from": "goggles_welding",  "type": "ITEM",
+  "subtypes": [
+    "ARMOR", "ARTIFACT"
+  ],
+  "category": "armor",
+  "name": {
+    "str_sp": "the safety squint"
+  },
+  "description": "You've got your eyes shut against the glare, but not all the way.",
+  "weight": "0 g",
+  "volume": "0 ml",
+  "material": [
+    "flesh"
+  ],
+  "symbol": "[",
+  "color": "dark_gray",
+  "warmth": 0,
+  "material_thickness": 0,
+  "environmental_protection": 0,
+  "extend": { "flags": [
+    "ZERO_WEIGHT",
+    "TRADER_AVOID",
+    "PERSONAL",
+    "INTEGRATED",
+    "SEMITANGIBLE",
+    "UNBREAKABLE",
+    "OVERSIZE"
+  ] },
+  "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "ench_effects": [ { "effect": "effect_perk_safety_squint_reduced_vision", "intensity": 1 } ] } ]
+  }
+]

--- a/data/mods/BombasticPerks/perkdata/safety_squint.json
+++ b/data/mods/BombasticPerks/perkdata/safety_squint.json
@@ -7,7 +7,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_safety_squint_off",
-    "effect": [ { "u_remove_item_with_item": "perk_safety_squint_integrated_goggles" } ]
+    "effect": [ { "u_remove_item_with": "perk_safety_squint_integrated_goggles" } ]
   },
   {
     "type": "effect_type",
@@ -15,38 +15,32 @@
     "//": "Hidden effect",
     "name": [ "" ],
     "desc": [ "" ],
-    "flags": [ "MYOPIA_SUPERNATURAL" ]
+    "flags": [ "MYOPIC_SUPERNATURAL" ]
   },
   {
-  "id": "perk_safety_squint_integrated_goggles",
-  "copy-from": "goggles_welding",  "type": "ITEM",
-  "subtypes": [
-    "ARMOR", "ARTIFACT"
-  ],
-  "category": "armor",
-  "name": {
-    "str_sp": "the safety squint"
-  },
-  "description": "You've got your eyes shut against the glare, but not all the way.",
-  "weight": "0 g",
-  "volume": "0 ml",
-  "material": [
-    "flesh"
-  ],
-  "symbol": "[",
-  "color": "dark_gray",
-  "warmth": 0,
-  "material_thickness": 0,
-  "environmental_protection": 0,
-  "extend": { "flags": [
-    "ZERO_WEIGHT",
-    "TRADER_AVOID",
-    "PERSONAL",
-    "INTEGRATED",
-    "SEMITANGIBLE",
-    "UNBREAKABLE",
-    "OVERSIZE"
-  ] },
-  "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "ench_effects": [ { "effect": "effect_perk_safety_squint_reduced_vision", "intensity": 1 } ] } ]
+    "id": "perk_safety_squint_integrated_goggles",
+    "copy-from": "goggles_welding",
+    "looks_like": "integrated_ierde_eyes",
+    "type": "ITEM",
+    "subtypes": [ "ARMOR", "ARTIFACT" ],
+    "category": "armor",
+    "name": { "str_sp": "the safety squint" },
+    "description": "You've got your eyes shut against the glare, but not all the way.",
+    "weight": "0 g",
+    "volume": "0 ml",
+    "material": [ "flesh" ],
+    "symbol": "[",
+    "color": "dark_gray",
+    "warmth": 0,
+    "material_thickness": 0,
+    "environmental_protection": 0,
+    "extend": { "flags": [ "ZERO_WEIGHT", "TRADER_AVOID", "PERSONAL", "INTEGRATED", "SEMITANGIBLE", "UNBREAKABLE", "OVERSIZE" ] },
+    "passive_effects": [
+      {
+        "has": "WORN",
+        "condition": "ALWAYS",
+        "ench_effects": [ { "effect": "effect_perk_safety_squint_reduced_vision", "intensity": 1 } ]
+      }
+    ]
   }
 ]

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -983,6 +983,25 @@
         "topic": "TALK_PERK_MENU_SELECT"
       },
       {
+        "condition": { "not": { "u_has_trait": "perk_safety_squint" } },
+        "text": "Gain [<trait_name:perk_safety_squint>]",
+        "effect": [
+          { "set_string_var": "<trait_name:perk_safety_squint>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:perk_safety_squint>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "perk_safety_squint", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "FIX THIS PART",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { FIX THIS PART }
+        ],
+        "topic": "TALK_PERK_MENU_SELECT"
+      },
+      {
         "condition": { "not": { "u_has_trait": "perk_troubleseeker" } },
         "text": "Gain [<trait_name:perk_troubleseeker>]",
         "effect": [

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -983,25 +983,6 @@
         "topic": "TALK_PERK_MENU_SELECT"
       },
       {
-        "condition": { "not": { "u_has_trait": "perk_safety_squint" } },
-        "text": "Gain [<trait_name:perk_safety_squint>]",
-        "effect": [
-          { "set_string_var": "<trait_name:perk_safety_squint>", "target_var": { "context_val": "trait_name" } },
-          {
-            "set_string_var": "<trait_description:perk_safety_squint>",
-            "target_var": { "context_val": "trait_description" }
-          },
-          { "set_string_var": "perk_safety_squint", "target_var": { "context_val": "trait_id" } },
-          {
-            "set_string_var": "FIX THIS PART",
-            "target_var": { "context_val": "trait_requirement_description" },
-            "i18n": true
-          },
-          { "set_condition": "perk_condition", "condition": { FIX THIS PART }
-        ],
-        "topic": "TALK_PERK_MENU_SELECT"
-      },
-      {
         "condition": { "not": { "u_has_trait": "perk_troubleseeker" } },
         "text": "Gain [<trait_name:perk_troubleseeker>]",
         "effect": [
@@ -1313,6 +1294,33 @@
           {
             "set_condition": "perk_condition",
             "condition": { "and": [ { "math": [ "u_skill('dodge') >= 8" ] }, { "u_has_trait": "perk_lucky_dodge" } ] }
+          }
+        ],
+        "topic": "TALK_PERK_MENU_SELECT"
+      },
+      {
+        "condition": { "not": { "u_has_trait": "perk_safety_squint" } },
+        "text": "Gain [<trait_name:perk_safety_squint>]",
+        "effect": [
+          { "set_string_var": "<trait_name:perk_safety_squint>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:perk_safety_squint>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "perk_safety_squint", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Requires Intelligence 11 or the Principles of Welding proficiency",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          {
+            "set_condition": "perk_condition",
+            "condition": {
+              "or": [
+                { "u_has_proficiency": "prof_welding_basic" },
+                { "math": [ "u_val('intelligence_base') + u_val('intelligence_bonus') >= 11" ] }
+              ]
+            }
           }
         ],
         "topic": "TALK_PERK_MENU_SELECT"

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -465,6 +465,20 @@
   },
   {
     "type": "mutation",
+    "id": "perk_safety_squint",
+    "name": { "str": "The Safety Squint" },
+    "points": 0,
+    "purifiable": false,
+    "valid": false,
+    "description": "They told it to you as a joke, but you always knew it was real and now you've figured out how to do it.  With the proper squinting technique, you can safely weld without any external protection, though you won't be able to see much of your surroundings.  Activate to toggle.",
+    "active": true,
+    "activated_is_setup": true,
+    "activation_msg": "You squint your eyes just right.",
+    "activated_eocs": [ "EOC_safety_squint_on" ],
+    "deactivated_eocs": [ "EOC_safety_squint_off" ]
+  },
+  {
+    "type": "mutation",
     "id": "perk_bedtime_reader",
     "name": { "str": "Bedtime Stories" },
     "points": 0,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Bombastic Perks] Add the Safety Squint perk (plus a couple fixes)"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

They thought they were messing with you when they told you about it, but it's real! It's real and you can do it! 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the Safety Squint perk. When activated, you're treated as wearing a pair of welding goggles, but your vision range is very limited. You can activate and deactivate it at will. It requires either Intelligence 11 or the Basic Welding proficiency

Also switch the detection in Rage Against the Unnatural to looking for the NETHER species instead of individually ennumerated monsters, and make sure that you need to have Absit Invidia to use salt to get rid of the `taint` effect.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

~~Still in Hawai'i, I'll test this later~~

Got the perk, it works. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
