### PR TITLE
give hatchbacks a hatchback

### DIFF
--- a/data/json/vehicleparts/doors.json
+++ b/data/json/vehicleparts/doors.json
@@ -209,7 +209,7 @@
       },
       "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "5 m", "using": [ [ "repair_welding_lc_steel", 3 ] ] }
     },
-    "size": "200000 ml",
+    "size": "125000 ml",
     "extend": { "flags": [ "LOCKABLE_CARGO", "MULTISQUARE", "COVERED" ] },
     "type": "vehicle_part"
   },

--- a/data/json/vehicleparts/doors.json
+++ b/data/json/vehicleparts/doors.json
@@ -190,6 +190,30 @@
     "type": "vehicle_part"
   },
   {
+    "id": "hatchback_trunk",
+    "copy-from": "hatch",
+    "description": "A fold up door covering trunk space.  A window lets you see through it when closed.",
+    "durability": 420,
+    "name": { "str": "hatchback trunk" },
+    "//": "30 cm of weld per quadrant of damage, 4x that to install",
+    "requirements": {
+      "install": {
+        "skills": [ [ "mechanics", 2 ] ],
+        "time": "70 m",
+        "using": [ [ "welding_standard", 120 ], [ "vehicle_bolt_install", 1 ] ]
+      },
+      "removal": {
+        "skills": [ [ "mechanics", 2 ] ],
+        "time": "40 m",
+        "using": [ [ "vehicle_weld_removal", 1 ], [ "vehicle_wrench_2", 1 ] ]
+      },
+      "repair": { "skills": [ [ "mechanics", 3 ] ], "time": "5 m", "using": [ [ "repair_welding_lc_steel", 3 ] ] }
+    },
+    "size": "200000 ml",
+    "extend": { "flags": [ "LOCKABLE_CARGO", "MULTISQUARE", "COVERED" ] },
+    "type": "vehicle_part"
+  },
+  {
     "type": "vehicle_part",
     "id": "door_wood",
     "copy-from": "door",

--- a/data/json/vehicles/cars.json
+++ b/data/json/vehicles/cars.json
@@ -897,8 +897,8 @@
       { "x": -1, "y": 2, "parts": [ "frame#vertical_right", "door#se" ] },
       { "x": -2, "y": -1, "parts": [ "frame#sw", "wheel_mount_medium", "wheel" ] },
       { "x": -2, "y": -1, "parts": [ "halfboard#hatch_wheel_left" ] },
-      { "x": -2, "y": 0, "parts": [ "frame#horizontal_rear", "hatch", "muffler" ] },
-      { "x": -2, "y": 1, "parts": [ "frame#horizontal_rear", "hatch" ] },
+      { "x": -2, "y": 0, "parts": [ "frame#horizontal_rear", "hatchback_trunk", "muffler" ] },
+      { "x": -2, "y": 1, "parts": [ "frame#horizontal_rear", "hatchback_trunk" ] },
       { "x": -2, "y": 2, "parts": [ "frame#se", "wheel_mount_medium", "wheel" ] },
       { "x": -2, "y": 2, "parts": [ "halfboard#hatch_wheel_right" ] }
     ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "give hatchbacks a hatchback"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

The hatchback cars used a "hatch," with a measly 37.5L storage.  The hatch seems to represent just a door with a bit of storage behind it. But, in the US, "hatchback" typically refers to cars with a back door that opens upward from a hinge near the roof-line.  Examples include the Toyota Corolla, VW Golf, and others. These have much more trunk space, as discussed below.

<img width="310" height="163" alt="image" src="https://github.com/user-attachments/assets/256f434c-f6a5-4788-87a2-0f55c873f5f1" />


<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<img width="1661" height="233" alt="hatchback-volume" src="https://github.com/user-attachments/assets/875cd170-2ea2-4395-92a2-727a30f28d84" />

Many hatchbacks have 400-500L of trunk space floor to ceiling. Since we allow passing through even a full cargo space, this must be reduced to at least half for those without package trays.  For this with package trays, the full space can be used, and a survivor can scramble over the top.

The average reasonable cargo volume for our purposes, based on several popular hatchbacks, is ~284 L.  Since we use two tiles to represent this, that's ~142 L for each tile.

I've made a new vehicle part identical to the hatch called the "hatchback trunk."  I chose 125L of cargo storage, just because a little less than half full seems reasonable for being able to pass through.  I've applied it to hatchbacks.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Spawned the cars. They spawn correctly with the correct volume.  Hatchback door opens and closes.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I didn't touch the city/mico/mini cars in this PR, which also use hatches. I need to collect specs on trunk space first. Hopefully will be a future PR.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
