### PR TITLE
Don't spawn horde of blacklisted monsters

### DIFF
--- a/src/horde_map.cpp
+++ b/src/horde_map.cpp
@@ -122,11 +122,14 @@ static bool is_alert( const mtype &type )
 std::unordered_map<tripoint_abs_ms, horde_entity>::iterator horde_map::spawn_entity(
     const tripoint_abs_ms &p, mtype_id id )
 {
+    std::unordered_map<tripoint_abs_ms, horde_entity>::iterator result;
+    if( id.is_null() || !id.is_valid() ) {
+        return result; // Bail out, blacklisted monster or something's wrong.
+    }
     std::unordered_map <tripoint_om_sm, std::unordered_map<tripoint_abs_ms, horde_entity>> &target_map =
                 id->has_flag( mon_flag_DORMANT ) ? dormant_monster_map :
                 is_alert( *id ) ? idle_monster_map :
                 immobile_monster_map;
-    std::unordered_map<tripoint_abs_ms, horde_entity>::iterator result;
     point_abs_om omp;
     tripoint_om_sm sm;
     std::tie( omp, sm ) = project_remain<coords::om>( project_to<coords::sm>( p ) );

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -1718,6 +1718,9 @@ void overmap::spawn_mongroup( const tripoint_om_sm &p, const mongroup_id &type, 
                     // Ran out of space on the submap!
                     return;
                 }
+                if( result.id.is_null() || !result.id.is_valid() ) {
+                    continue; // Blacklisted monster, don't try to spawn this
+                }
                 hordes.spawn_entity( project_combine( pos(), *open_space ), result.id );
             }
         }

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -1718,9 +1718,6 @@ void overmap::spawn_mongroup( const tripoint_om_sm &p, const mongroup_id &type, 
                     // Ran out of space on the submap!
                     return;
                 }
-                if( result.id.is_null() || !result.id.is_valid() ) {
-                    continue; // Blacklisted monster, don't try to spawn this
-                }
                 hordes.spawn_entity( project_combine( pos(), *open_space ), result.id );
             }
         }

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -674,10 +674,18 @@ void overmap::unserialize( const JsonObject &jsobj )
                     result = hordes.spawn_entity( monster_location, new_monster );
                 }
 
-                result->second.destination.deserialize( monster_map_json.next_value() );
-                result->second.tracking_intensity = monster_map_json.next_int();
-                result->second.last_processed.deserialize( monster_map_json.next_value() );
-                result->second.moves = monster_map_json.next_int();
+                if( result != std::unordered_map<tripoint_abs_ms, horde_entity>::iterator() ) {
+                    result->second.destination.deserialize( monster_map_json.next_value() );
+                    result->second.tracking_intensity = monster_map_json.next_int();
+                    result->second.last_processed.deserialize( monster_map_json.next_value() );
+                    result->second.moves = monster_map_json.next_int();
+                } else {
+                    // We deserialized something nasty, skip the rest of the stored values
+                    monster_map_json.next_value();
+                    monster_map_json.next_int();
+                    monster_map_json.next_value();
+                    monster_map_json.next_int();
+                }
             }
         } else if( name == "map_data" ) {
             JsonArray map_data_json = om_member;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Fixes #84374

#### Describe the solution
Don't spawn horde of blacklisted monsters.

#### Describe alternatives you've considered
The check could instead happen within horde_map::spawn_entity()? No strong preference

#### Testing
<img width="1818" height="662" alt="image" src="https://github.com/user-attachments/assets/924a1ad6-ea60-437e-9569-c4476ed446ed" />


#### Additional context
