### PR TITLE
Better assignment of credit/blame for thrown molotovs

### DIFF
--- a/data/json/items/tool/explosives.json
+++ b/data/json/items/tool/explosives.json
@@ -731,6 +731,7 @@
     "material": [ "glass", "cotton" ],
     "symbol": "*",
     "color": "light_gray",
+    "//COMMENT": "The moves action cost should always be at least 100 (one full second) so that the molotov can properly know who's throwing it. See iuse::molotov_lit() for more details.",
     "use_action": {
       "need_wielding": true,
       "target": "molotov_lit",

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -253,8 +253,6 @@ static const efftype_id effect_weak_antibiotic_visible( "weak_antibiotic_visible
 static const efftype_id effect_webbed( "webbed" );
 static const efftype_id effect_weed_high( "weed_high" );
 
-static const faction_id faction_your_followers( "your_followers" );
-
 static const furn_str_id furn_f_translocator_buoy( "f_translocator_buoy" );
 
 static const harvest_drop_type_id harvest_drop_blood( "blood" );
@@ -3621,11 +3619,30 @@ std::optional<int> iuse::grenade_inc_act( Character *p, item *, const tripoint_b
 std::optional<int> iuse::molotov_lit( Character *p, item *it, const tripoint_bub_ms &pos )
 {
 
+    // This string is stored on the molotov as an item var, to record who's responsible for the resulting fires.
+    // Once the molotov has been thrown/dropped, we no longer have a Character pointer at p. So this serves as a record.
+    const std::string credit_or_blame = "molotov_thrower";
+
     if( !p ) {
         // It was thrown or dropped, so burst into flames
-        // This bool is a bit nasty, once it's left the character's inventory we're really not sure who threw or dropped it!
-        // But items assign ownership on pickup by a character, so if the owner is your_followers then it stands to reason it must be the player.
-        const bool thrown_by_player_or_follower = it->get_owner() == faction_your_followers;
+        Character *thrower = nullptr;
+        if( it->has_var( credit_or_blame ) ) {
+            character_id guy_id = character_id( it->get_var( credit_or_blame, 0.0 ) );
+            // Check player
+            if( guy_id == get_player_character().getID() ) {
+                thrower = &get_player_character();
+            }
+            // Check active NPCs (loaded in bubble)
+            for( npc *guy : g->get_npcs_if( [guy_id]( const npc & guy ) {
+            return guy.getID() == guy_id;
+            } ) ) {
+                thrower = guy;
+            }
+            // Check inactive NPCs outside the bubble?!
+            if( !thrower ) {
+                thrower = g->find_npc( guy_id );
+            }
+        }
         map &here = get_map();
         // Because fields decay with a half-life, we need to know how long it takes for the field to decay and set the age to slightly before that.
         // the duration is also used for the effect's timer. It's hilariously lethal regardless.
@@ -3634,14 +3651,15 @@ std::optional<int> iuse::molotov_lit( Character *p, item *it, const tripoint_bub
         for( const tripoint_bub_ms &pt : here.points_in_radius( pos, 1, 0 ) ) {
             Creature *critter = get_creature_tracker().creature_at( pt, true );
             if( critter && one_in( 2 ) ) {
-                if( thrown_by_player_or_follower ) {
-                    critter->add_effect( effect_source( &get_player_character() ), effect_onfire, target_duration );
+                if( thrower ) {
+                    critter->add_effect( effect_source( thrower ), effect_onfire, target_duration,
+                                         critter->random_body_part( true ) );
                 } else {
-                    critter->add_effect( effect_onfire, target_duration );
+                    critter->add_effect( effect_onfire, target_duration, critter->random_body_part( true ) );
                 }
             } else if( !here.get_field( pt, fd_fire ) && one_in( 2 ) ) {
-                if( thrown_by_player_or_follower ) {
-                    here.add_field( pt, fd_fire, 1, base_age, true, effect_source( &get_player_character() ) );
+                if( thrower ) {
+                    here.add_field( pt, fd_fire, 1, base_age, true, effect_source( thrower ) );
                 } else {
                     here.add_field( pt, fd_fire, 1, base_age );
                 }
@@ -3652,6 +3670,12 @@ std::optional<int> iuse::molotov_lit( Character *p, item *it, const tripoint_bub
             player.fulfill_pyromania_sees( here, pos, _( "Fire…  Good…" ), false );
         }
         return 1;
+    }
+
+    // We're holding the molotov while it's burning. So we're now responsible for what this molotov does.
+    // Note: Requires the game to 'tick' once, meaning that the time to light it should always be longer than 1 second!
+    if( p ) {
+        it->set_var( credit_or_blame, p->getID().get_value() );
     }
 
     // 2% chance per turn of going out harmlessly.

--- a/src/player_hardcoded_effects.cpp
+++ b/src/player_hardcoded_effects.cpp
@@ -20,6 +20,7 @@
 #include "creature_tracker.h"
 #include "damage.h"
 #include "effect.h"
+#include "effect_source.h"
 #include "enums.h"
 #include "event.h"
 #include "event_bus.h"
@@ -154,7 +155,13 @@ static const vitamin_id vitamin_redcells( "redcells" );
 static void eff_fun_onfire( Character &u, effect &it )
 {
     const int intense = it.get_intensity();
-    u.deal_damage( nullptr, it.get_bp(), damage_instance( damage_heat, rng( intense, intense * 2 ) ) );
+    u.deal_damage( it.get_source().resolve_creature(), it.get_bp(), damage_instance( damage_heat,
+                   rng( intense, intense * 2 ) ) );
+    if( u.is_limb_broken( it.get_bp() ) ) {
+        // Set effect to be cleaned up during effect processing instead of endlessly burning broken limb.
+        // TODO: Transfer damage towards core instead? (e.g. broken feet --> try legs, if broken --> try torso etc)
+        it.set_duration( 0_turns );
+    }
 }
 static void eff_fun_spores( Character &u, effect &it )
 {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
In #84246 I added a very crude way to track the source of thrown molotovs, reasoning that if the owner of the item was the player faction, the player must be responsible.

This meant that if a player follower threw a molotov, the player would be credited for the resulting fire deaths. That's not quite right, but I couldn't think of a better way at the time.

#### Describe the solution
Well, I thought of a better way.

Instead, a lighted molotov actively records who's holding it. When the molotov activates and spreads its firey insides, it checks for that record and assigns credit/blame accordingly. This works for any `Character`, since it stores a character_id.


While I was testing this I ran into some other problems... those also got fixes lumped in.

First, the `onfire` effect did not credit/blame its source. So a molotov that landed directly, or a fire started by a molotov that later applied `onfire` to a creature still counted as being harmed by "nothing". ("area damage" from fires was properly credited/blamed)

Second, we were assigning `onfire` to bp_null as a default argument, which is all sorts of wrong. Fixed that by applying it to a random body part.

Lastly, forced the `onfire` effect to disappear on a Character once the affected limb is fully depleted. Instead of having a broken limb burning endlessly, to no effect.

#### Describe alternatives you've considered


#### Testing
Throw some molotovs at people, got full credit for the kills regardless of whether the fires or the burning spray of gasoline got them.

No longer had a possible crash from damaging bp_null on a character.

#### Additional context

Known issues:
-If the time for a molotov to light+throw is less than one full second for any reason (character is too fast, character has extra stored moves, base time for molotov lighting is simply too low, etc) then the credit/blame will not be applied.

-Although the `onfire` effect is properly tracking its source, and the player properly gets sad from the resulting murder of a NPC, the NPC still does not get upset about being "attacked" in this way. Ugh!

At least it's not related to my changes. This is an existing issue with applying damage.
