### PR TITLE
Remove legacy use/can_use iuse_actor functions

### DIFF
--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -2194,7 +2194,7 @@ item Character::find_firestarter_with_charges( const int quantity ) const
             const use_function *usef = it.type->get_use( "firestarter" );
             if( usef != nullptr && usef->get_actor_ptr() != nullptr ) {
                 const firestarter_actor *actor = dynamic_cast<const firestarter_actor *>( usef->get_actor_ptr() );
-                if( actor->can_use( *this->as_character(), it, tripoint_bub_ms::zero ).success() ) {
+                if( actor->can_use( *this->as_character(), it, &get_map(), tripoint_bub_ms::zero ).success() ) {
                     ret = it;
                     return true;
                 }

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -3120,7 +3120,7 @@ static void add_firestarter( item *it, std::multimap<int, item *> &firestarters,
     const use_function *usef = it->type->get_use( "firestarter" );
     if( usef != nullptr && usef->get_actor_ptr() != nullptr ) {
         const firestarter_actor *actor = dynamic_cast<const firestarter_actor *>( usef->get_actor_ptr() );
-        if( actor->can_use( you, *it, examp ).success() ) {
+        if( actor->can_use( you, *it, &get_map(), examp ).success() ) {
             firestarters.insert( std::pair<int, item *>( actor->moves_cost_fast, it ) );
         }
     }
@@ -3170,9 +3170,9 @@ static void pick_firestarter_and_fire( Character &you, const tripoint_bub_ms &ex
             const use_function *usef = it->type->get_use( "firestarter" );
             const firestarter_actor *actor = dynamic_cast<const firestarter_actor *>( usef->get_actor_ptr() );
             you.add_msg_if_player( _( "You attempt to start a fire with your %s…" ), it->tname() );
-            const ret_val<void> can_use = actor->can_use( you, *it, examp );
+            const ret_val<void> can_use = actor->can_use( you, *it, &get_map(), examp );
             if( can_use.success() ) {
-                const int charges = actor->use( &you, *it, examp ).value_or( 0 );
+                const int charges = actor->use( &you, *it, &get_map(), examp ).value_or( 0 );
                 you.use_charges( it->typeId(), charges );
                 return;
             } else {
@@ -3768,9 +3768,9 @@ void iexamine::fireplace( Character &you, const tripoint_bub_ms &examp )
                 const use_function *usef = it->type->get_use( "firestarter" );
                 const firestarter_actor *actor = dynamic_cast<const firestarter_actor *>( usef->get_actor_ptr() );
                 you.add_msg_if_player( _( "You attempt to start a fire with your %s…" ), it->tname() );
-                const ret_val<void> can_use = actor->can_use( you, *it, examp );
+                const ret_val<void> can_use = actor->can_use( you, *it, &get_map(), examp );
                 if( can_use.success() ) {
-                    const int charges = actor->use( &you, *it, examp ).value_or( 0 );
+                    const int charges = actor->use( &you, *it, &get_map(), examp ).value_or( 0 );
                     you.use_charges( it->typeId(), charges );
                     return;
                 } else {

--- a/src/item_action.cpp
+++ b/src/item_action.cpp
@@ -158,7 +158,7 @@ item_action_map item_action_generator::map_actions_to_items( Character &you,
 
             const use_function *func = actual_item->get_use( use );
             if( !( func && func->get_actor_ptr() &&
-                   func->get_actor_ptr()->can_use( you, *actual_item, you.pos_bub() ).success() ) ) {
+                   func->get_actor_ptr()->can_use( you, *actual_item, &get_map(), you.pos_bub() ).success() ) ) {
                 continue;
             }
 
@@ -391,17 +391,6 @@ std::string use_function::get_type() const
     } else {
         return errstring;
     }
-}
-
-std::optional<int> iuse_actor::use( Character *p, item &it, const tripoint_bub_ms &pos ) const
-{
-    return use( p, it, &get_map(), pos );
-}
-
-ret_val<void> iuse_actor::can_use( const Character &p, const item &it,
-                                   const tripoint_bub_ms &pos ) const
-{
-    return can_use( p, it, &get_map(), pos );
 }
 
 ret_val<void> iuse_actor::can_use( const Character &, const item &, map *,

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -1763,9 +1763,6 @@ class iuse_function_wrapper : public iuse_actor
             : iuse_actor( type ), cpp_function( f ) { }
 
         ~iuse_function_wrapper() override = default;
-        std::optional<int> use( Character *p, item &it, const tripoint_bub_ms &pos ) const override {
-            return cpp_function( p, &it, pos );
-        }
         std::optional<int> use( Character *p, item &it, map */*here*/,
                                 const tripoint_bub_ms &pos ) const override {
             // TODO: Change cpp_function to be map aware.

--- a/src/iuse.h
+++ b/src/iuse.h
@@ -284,11 +284,7 @@ class iuse_actor
 
         virtual ~iuse_actor() = default;
         virtual void load( const JsonObject &jo, const std::string &src ) = 0;
-        // TODO: Replace usage of map unaware overload with map aware.
-        virtual std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const;
         virtual std::optional<int> use( Character *, item &, map *here, const tripoint_bub_ms & ) const = 0;
-        // TODO: Replace usage of map unaware overload with map aware.
-        virtual ret_val<void> can_use( const Character &, const item &, const tripoint_bub_ms & ) const;
         virtual ret_val<void> can_use( const Character &, const item &, map *here,
                                        const tripoint_bub_ms & ) const;
         virtual void info( const item &, std::vector<iteminfo> & ) const {}

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -645,14 +645,6 @@ void sound_iuse::load( const JsonObject &obj, const std::string & )
 }
 
 std::optional<int> sound_iuse::use( Character *, item &,
-                                    const tripoint_bub_ms &pos ) const
-{
-    sounds::sound( pos, sound_volume, sounds::sound_t::alarm, sound_message.translated(), true,
-                   sound_id, sound_variant );
-    return 0;
-}
-
-std::optional<int> sound_iuse::use( Character *, item &,
                                     map *here, const tripoint_bub_ms &pos ) const
 {
     map &bubble_map = reality_bubble();
@@ -1642,35 +1634,6 @@ void salvage_actor::load( const JsonObject &obj, const std::string & )
 std::unique_ptr<iuse_actor> salvage_actor::clone() const
 {
     return std::make_unique<salvage_actor>( *this );
-}
-
-std::optional<int> salvage_actor::use( Character *p, item &cutter, const tripoint_bub_ms & ) const
-{
-    if( !p ) {
-        debugmsg( "%s called action salvage that requires character but no character is present",
-                  cutter.typeId().str() );
-        return std::nullopt;
-    }
-
-    item_location item_loc = game_menus::inv::salvage( *p, this );
-    if( !item_loc ) {
-        add_msg( _( "Never mind." ) );
-        return std::nullopt;
-    }
-
-    const item &to_cut = *item_loc;
-    if( !to_cut.is_owned_by( *p, true ) ) {
-        if( !query_yn( _( "Cutting the %s may anger the people who own it, continue?" ),
-                       to_cut.tname() ) ) {
-            return false;
-        } else {
-            if( to_cut.get_owner() ) {
-                g->on_witness_theft( to_cut );
-            }
-        }
-    }
-
-    return salvage_actor::try_to_cut_up( *p, cutter, item_loc );
 }
 
 std::optional<int> salvage_actor::use( Character *p, item &cutter, map *,

--- a/src/iuse_actor.h
+++ b/src/iuse_actor.h
@@ -182,7 +182,6 @@ class sound_iuse : public iuse_actor
 
         ~sound_iuse() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint_bub_ms &pos ) const override;
         std::optional<int> use( Character *, item &, map *, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
         std::string get_name() const override;
@@ -552,7 +551,6 @@ class salvage_actor : public iuse_actor
 
         ~salvage_actor() override = default;
         void load( const JsonObject &obj, const std::string & ) override;
-        std::optional<int> use( Character *, item &, const tripoint_bub_ms & ) const override;
         std::optional<int> use( Character *, item &, map *here, const tripoint_bub_ms & ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
     private:

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2447,8 +2447,8 @@ void outfit::activate_combat_items( npc &guy )
             if( transform->transform.target->has_flag( flag_USE_UPS ) && guy.available_ups() == 0_kJ ) {
                 continue;
             }
-            if( transform->can_use( guy, candidate, tripoint_bub_ms::zero ).success() ) {
-                transform->use( &guy, candidate, tripoint_bub_ms::zero );
+            if( transform->can_use( guy, candidate, &get_map(), tripoint_bub_ms::zero ).success() ) {
+                transform->use( &guy, candidate, &get_map(), tripoint_bub_ms::zero );
                 guy.add_msg_if_npc( _( "<npcname> activates their %s." ), candidate.display_name() );
             }
         }
@@ -2467,8 +2467,8 @@ void outfit::deactivate_combat_items( npc &guy )
             candidate.active ) {
             const iuse_transform *transform = dynamic_cast<const iuse_transform *>
                                               ( candidate.type->get_use( "transform" )->get_actor_ptr() );
-            if( transform->can_use( guy, candidate, tripoint_bub_ms::zero ).success() ) {
-                transform->use( &guy, candidate, tripoint_bub_ms::zero );
+            if( transform->can_use( guy, candidate, &get_map(), tripoint_bub_ms::zero ).success() ) {
+                transform->use( &guy, candidate, &get_map(), tripoint_bub_ms::zero );
                 guy.add_msg_if_npc( _( "<npcname> deactivates their %s." ), candidate.display_name() );
             }
         }

--- a/tests/battery_mod_test.cpp
+++ b/tests/battery_mod_test.cpp
@@ -14,6 +14,7 @@
 #include "itype.h"
 #include "iuse.h"
 #include "iuse_actor.h"
+#include "map.h"
 #include "player_helpers.h"
 #include "pocket_type.h"
 #include "ret_val.h"
@@ -179,7 +180,7 @@ TEST_CASE( "battery_tool_mod_test", "[battery][mod]" )
 
                     Character *dummy = &get_avatar();
                     clear_avatar();
-                    actor->use( dummy, flashlight, dummy->pos_bub() );
+                    actor->use( dummy, flashlight, &get_map(), dummy->pos_bub() );
 
                     // Regression tests for #42764 / #42854
                     THEN( "mod remains installed" ) {

--- a/tests/iuse_actor_test.cpp
+++ b/tests/iuse_actor_test.cpp
@@ -144,7 +144,7 @@ TEST_CASE( "tool_transform_when_activated", "[iuse][tool][transform]" )
             const use_function *use = flashlight.type->get_use( "transform" );
             REQUIRE( use != nullptr );
             const iuse_transform *actor = dynamic_cast<const iuse_transform *>( use->get_actor_ptr() );
-            actor->use( dummy, flashlight, dummy->pos_bub() );
+            actor->use( dummy, flashlight, &get_map(), dummy->pos_bub() );
 
             THEN( "it becomes active" ) {
                 CHECK( flashlight.active );

--- a/tests/player_activities_test.cpp
+++ b/tests/player_activities_test.cpp
@@ -419,7 +419,7 @@ TEST_CASE( "shearing", "[activity][shearing][animals]" )
             const use_function *use = elec_shears.type->get_use( "transform" );
             REQUIRE( use != nullptr );
             const iuse_transform *actor = dynamic_cast<const iuse_transform *>( use->get_actor_ptr() );
-            actor->use( &dummy, elec_shears, dummy.pos_bub() );
+            actor->use( &dummy, elec_shears, &get_map(), dummy.pos_bub() );
 
             dummy.i_add( elec_shears );
             REQUIRE( dummy.max_quality( qual_SHEAR ) == 3 );
@@ -467,7 +467,7 @@ TEST_CASE( "shearing", "[activity][shearing][animals]" )
             const use_function *use = elec_shears.type->get_use( "transform" );
             REQUIRE( use != nullptr );
             const iuse_transform *actor = dynamic_cast<const iuse_transform *>( use->get_actor_ptr() );
-            actor->use( &dummy, elec_shears, dummy.pos_bub() );
+            actor->use( &dummy, elec_shears, &get_map(), dummy.pos_bub() );
 
             dummy.i_add( elec_shears );
             REQUIRE( dummy.max_quality( qual_SHEAR ) == 3 );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Remove legacy code. It was marked as TODO and was easy enough.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

See title. Removed identical copy of `salvage_actor::use`, along with multiple now-redundant forwarding functions.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Loaded game, started a fire (one of the affected iexamine actions), no errors. 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Noticed this while converting ACT_START_FIRE to an `activity_actor`.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
