### PR TITLE
Fix oxytorch and reload activity actor crashes

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -6100,6 +6100,7 @@ void reload_activity_actor::reload( player_activity &act, Character &who, int lo
             who.wield( target_loc );
             add_msg( m_neutral, _( "The %s no longer fits in your inventory so you wield it instead." ),
                      reloadable_name );
+            target_loc = who.used_weapon();
             break;
         case 2:
         default:
@@ -6109,7 +6110,7 @@ void reload_activity_actor::reload( player_activity &act, Character &who, int lo
                                                   _( "The %s no longer fits in your inventory so you drop it instead." ),
                                                   reloadable_name );
             }
-            here.add_item_or_charges( loc.pos_bub( here ), reloadable );
+            target_loc = here.add_item_or_charges_ret_loc( loc.pos_bub( here ), reloadable );
             loc.remove_item();
             break;
     }

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -6072,9 +6072,11 @@ void reload_activity_actor::reload( player_activity &act, Character &who, int lo
     }
 
     // Attempt to put item in another pocket before prompting
-    if( who.try_add( reloadable, nullptr, nullptr, false ) != item_location::nowhere ) {
+    item_location new_loc = who.try_add( reloadable, nullptr, nullptr, false );
+    if( new_loc != item_location::nowhere ) {
         // try_add copied the old item, so remove it now.
         loc.remove_item();
+        target_loc = new_loc;
         return;
     }
 

--- a/src/activity_actor.h
+++ b/src/activity_actor.h
@@ -31,6 +31,16 @@ class activity_actor
             return false;
         }
 
+        /**
+         * Updates stored values used for activity with values from another
+         * activity of the same type.
+         * Nothing is updated by default. Each activity_actor type should handle
+         * its own values if required.
+         * @pre @p other is the same type of actor as `this`
+         */
+        virtual void set_resume_values_internal( const activity_actor &,
+                const Character & ) { }
+
     public:
         virtual ~activity_actor() = default;
 
@@ -77,6 +87,18 @@ class activity_actor
             }
 
             return false;
+        }
+
+        /**
+         * Called in player_activity::set_resume_values when this activity is resumed
+         * with another one.
+         * Checks that @p other has the same type as `this` so that
+         * `set_resume_values_internal` can safely `static_cast` @p other.
+         */
+        void set_resume_values( const activity_actor &other, const Character &who ) {
+            if( other.get_type() == get_type() ) {
+                set_resume_values_internal( other, who );
+            }
         }
 
         /**

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -1900,6 +1900,12 @@ class oxytorch_activity_actor : public activity_actor
         tripoint_bub_ms target;
         item_location tool;
 
+        void set_resume_values_internal( const activity_actor &other,
+                                         const Character &/*who*/ ) override {
+            const oxytorch_activity_actor &actor = static_cast<const oxytorch_activity_actor &>
+                                                   ( other );
+            tool = actor.tool;
+        }
         bool can_resume_with_internal( const activity_actor &other,
                                        const Character &/*who*/ ) const override {
             const oxytorch_activity_actor &actor = static_cast<const oxytorch_activity_actor &>

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -5160,6 +5160,7 @@ void Character::assign_activity( const player_activity &act )
         add_msg_if_player( _( "You resume your task." ) );
         activity = backlog.front();
         backlog.pop_front();
+        activity.set_resume_values( act, *this );
     } else {
         if( activity ) {
             backlog.push_front( activity );

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -464,7 +464,7 @@ void player_activity::set_resume_values( const player_activity &other, const Cha
     }
 
     if( actor && other.actor ) {
-        return actor->set_resume_values( *other.actor, who );
+        actor->set_resume_values( *other.actor, who );
     }
 }
 

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -457,6 +457,17 @@ bool player_activity::can_resume_with( const player_activity &other, const Chara
            position == other.position && name == other.name && targets == other.targets;
 }
 
+void player_activity::set_resume_values( const player_activity &other, const Character &who )
+{
+    if( !can_resume_with( other, who ) ) {
+        return;
+    }
+
+    if( actor && other.actor ) {
+        return actor->set_resume_values( *other.actor, who );
+    }
+}
+
 bool player_activity::is_interruptible() const
 {
     return ( type.is_null() || type->interruptable() ) && interruptable;

--- a/src/player_activity.h
+++ b/src/player_activity.h
@@ -169,6 +169,12 @@ class player_activity
          */
         bool can_resume_with( const player_activity &other, const Character &who ) const;
 
+        /**
+         * Passes new activity_actor to the old one so it can update its parameter when
+         * activity is resumed with another one.
+         */
+        void set_resume_values( const player_activity &other, const Character &who ) ;
+
         bool is_interruptible() const;
         bool is_interruptible_with_kb() const;
         bool is_distraction_ignored( distraction_type ) const;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Fix oxytorch and reload activity actor crashes"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #84371
Fixes #76679
Provides infrastructure for updating stored activity_actor values on activity resume.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- For reload activity :
Update target item location in `reload_activity_actor::reload` when it changed due to item no longer fitting into pocket.

- For oxytorch activity :
On resuming activity in `Character::assign_activity` instead of completely discarding new activity pass it down to old activity_actor so it can update it's stored values if they have changed.

This is also resolves the issue with inability to continue activity with another tool when you have multiple tools on person.

Each activity actor which requires some values to be updated on activity resume should implement it's own `set_resume_values_internal` method. Default method updates nothing.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- For reload activity : N/A
- For oxytorch activity : remove special activity actor and move the whole thing to construction activity instead.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Test cases from linked issues no longer crash. Acetylene torch consumes amount of charges appropriate for job resumption and does not start the task anew.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
N/A
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
