### PR TITLE
[DinoMod] bird bodies teach about dino weak points

### DIFF
--- a/data/mods/DinoMod/monsters/bird.json
+++ b/data/mods/DinoMod/monsters/bird.json
@@ -6,6 +6,24 @@
     "extend": { "families": [ "prof_wp_dino" ] }
   },
   {
+    "abstract": "mon_bird_flightless_base",
+    "copy-from": "mon_bird_flightless_base",
+    "type": "MONSTER",
+    "extend": { "families": [ "prof_wp_dino" ] }
+  },
+  {
+    "abstract": "mon_bird_flying_base",
+    "copy-from": "mon_bird_flying_base",
+    "type": "MONSTER",
+    "extend": { "families": [ "prof_wp_dino" ] }
+  },
+  {
+    "abstract": "mon_bird_water_base",
+    "copy-from": "mon_bird_water_base",
+    "type": "MONSTER",
+    "extend": { "families": [ "prof_wp_dino" ] }
+  },
+  {
     "abstract": "mon_generic_chick",
     "type": "MONSTER",
     "copy-from": "mon_generic_chick",

--- a/data/mods/DinoMod/monsters/bird.json
+++ b/data/mods/DinoMod/monsters/bird.json
@@ -88,5 +88,65 @@
     "type": "MONSTER",
     "copy-from": "mon_duck_domestic",
     "extend": { "families": [ "prof_wp_dino" ] }
+  },
+  {
+    "id": "mon_duck_domestic_chick",
+    "type": "MONSTER",
+    "copy-from": "mon_duck_domestic_chick",
+    "extend": { "families": [ "prof_wp_dino" ] }
+  },
+  {
+    "id": "mon_goose_canadian",
+    "type": "MONSTER",
+    "copy-from": "mon_goose_canadian",
+    "extend": { "families": [ "prof_wp_dino" ] }
+  },
+  {
+    "id": "mon_turkey",
+    "type": "MONSTER",
+    "copy-from": "mon_turkey",
+    "extend": { "families": [ "prof_wp_dino" ] }
+  },
+  {
+    "id": "mon_turkey_chick",
+    "type": "MONSTER",
+    "copy-from": "mon_turkey_chick",
+    "extend": { "families": [ "prof_wp_dino" ] }
+  },
+  {
+    "id": "mon_turkey_domestic",
+    "type": "MONSTER",
+    "copy-from": "mon_turkey_domestic",
+    "extend": { "families": [ "prof_wp_dino" ] }
+  },
+  {
+    "id": "mon_turkey_domestic_chick",
+    "type": "MONSTER",
+    "copy-from": "mon_turkey_domestic_chick",
+    "extend": { "families": [ "prof_wp_dino" ] }
+  },
+  {
+    "id": "mon_pheasant",
+    "type": "MONSTER",
+    "copy-from": "mon_pheasant",
+    "extend": { "families": [ "prof_wp_dino" ] }
+  },
+  {
+    "id": "mon_chicken_chick",
+    "type": "MONSTER",
+    "copy-from": "mon_turkey_chick",
+    "extend": { "families": [ "prof_wp_dino" ] }
+  },
+  {
+    "id": "mon_grouse_chick",
+    "type": "MONSTER",
+    "copy-from": "mon_turkey_chick",
+    "extend": { "families": [ "prof_wp_dino" ] }
+  },
+  {
+    "id": "mon_crow_chick",
+    "type": "MONSTER",
+    "copy-from": "mon_crow_chick",
+    "extend": { "families": [ "prof_wp_dino" ] }
   }
 ]

--- a/data/mods/DinoMod/monsters/bird.json
+++ b/data/mods/DinoMod/monsters/bird.json
@@ -1,0 +1,14 @@
+[
+  {
+    "abstract": "mon_bird_flying_base",
+    "copy-from": "mon_bird_flying_base",
+    "type": "MONSTER",
+    "extend": { "families": [ "prof_wp_dino" ] }
+  },
+  {
+    "abstract": "mon_generic_chick",
+    "type": "MONSTER",
+    "copy-from": "mon_generic_chick",
+    "extend": { "families": [ "prof_wp_dino" ] }
+  }
+]

--- a/data/mods/DinoMod/monsters/bird.json
+++ b/data/mods/DinoMod/monsters/bird.json
@@ -1,32 +1,92 @@
 [
   {
-    "abstract": "mon_bird_flying_base",
-    "copy-from": "mon_bird_flying_base",
+    "id": "mon_chicken",
+    "copy-from": "mon_chicken",
     "type": "MONSTER",
     "extend": { "families": [ "prof_wp_dino" ] }
   },
   {
-    "abstract": "mon_bird_flightless_base",
-    "copy-from": "mon_bird_flightless_base",
+    "id": "mon_grouse",
+    "copy-from": "mon_grouse",
     "type": "MONSTER",
     "extend": { "families": [ "prof_wp_dino" ] }
   },
   {
-    "abstract": "mon_bird_flying_base",
-    "copy-from": "mon_bird_flying_base",
+    "id": "mon_crow",
+    "copy-from": "mon_crow",
     "type": "MONSTER",
     "extend": { "families": [ "prof_wp_dino" ] }
   },
   {
-    "abstract": "mon_bird_water_base",
-    "copy-from": "mon_bird_water_base",
+    "id": "mon_raven",
+    "copy-from": "mon_raven",
     "type": "MONSTER",
     "extend": { "families": [ "prof_wp_dino" ] }
   },
   {
-    "abstract": "mon_generic_chick",
+    "id": "mon_bluejay",
     "type": "MONSTER",
-    "copy-from": "mon_generic_chick",
+    "copy-from": "mon_bluejay",
+    "extend": { "families": [ "prof_wp_dino" ] }
+  },
+  {
+    "id": "mon_cardinal",
+    "type": "MONSTER",
+    "copy-from": "mon_cardinal",
+    "extend": { "families": [ "prof_wp_dino" ] }
+  },
+  {
+    "id": "mon_robin",
+    "type": "MONSTER",
+    "copy-from": "mon_robin",
+    "extend": { "families": [ "prof_wp_dino" ] }
+  },
+  {
+    "id": "mon_sparrow",
+    "type": "MONSTER",
+    "copy-from": "mon_sparrow",
+    "extend": { "families": [ "prof_wp_dino" ] }
+  },
+  {
+    "id": "mon_chickadee",
+    "type": "MONSTER",
+    "copy-from": "mon_chickadee",
+    "extend": { "families": [ "prof_wp_dino" ] }
+  },
+  {
+    "id": "mon_chickadee_chick",
+    "type": "MONSTER",
+    "copy-from": "mon_chickadee",
+    "extend": { "families": [ "prof_wp_dino" ] }
+  },
+  {
+    "id": "mon_waxwing",
+    "type": "MONSTER",
+    "copy-from": "mon_waxwing",
+    "extend": { "families": [ "prof_wp_dino" ] }
+  },
+  {
+    "id": "mon_waxwing_chick",
+    "type": "MONSTER",
+    "copy-from": "mon_waxwing_chick",
+    "extend": { "families": [ "prof_wp_dino" ] }
+  },
+  {
+    "id": "mon_duck",
+    "type": "MONSTER",
+    "copy-from": "mon_duck",
+    "extend": { "families": [ "prof_wp_dino" ] }
+  },
+  {
+    "id": "mon_duck_chick",
+    "type": "MONSTER",
+    "copy-from": "mon_duck_chick",
+    "extend": { "families": [ "prof_wp_dino" ] }
+  },
+  {
+    "id": "mon_duck_domestic",
+    "type": "MONSTER",
+    "copy-from": "mon_duck_domestic",
     "extend": { "families": [ "prof_wp_dino" ] }
   }
 ]

--- a/data/mods/DinoMod/proficiencies/weakpoints.json
+++ b/data/mods/DinoMod/proficiencies/weakpoints.json
@@ -5,10 +5,10 @@
     "category": "prof_weakpoint",
     "name": { "str": "Dinosaur Biology" },
     "description": "You are familiar with general dinosaur anatomy, and can exploit potential weaknesses.",
-    "required_proficiencies": [ "prof_intro_biology" ],
+    "required_proficiencies": [ "prof_gross_anatomy" ],
     "can_learn": true,
-    "time_to_learn": "6 h",
-    "default_weakpoint_bonus": 4,
-    "default_weakpoint_penalty": -2
+    "time_to_learn": "30 min",
+    "default_weakpoint_bonus": 1,
+    "default_weakpoint_penalty": 0
   }
 ]

--- a/data/mods/DinoMod/proficiencies/weakpoints.json
+++ b/data/mods/DinoMod/proficiencies/weakpoints.json
@@ -7,7 +7,7 @@
     "description": "You are familiar with general dinosaur anatomy, and can exploit potential weaknesses.",
     "required_proficiencies": [ "prof_gross_anatomy" ],
     "can_learn": true,
-    "time_to_learn": "30 min",
+    "time_to_learn": "30 m",
     "default_weakpoint_bonus": 1,
     "default_weakpoint_penalty": 0
   }


### PR DESCRIPTION
#### Summary
Mods "[DinoMod] bird bodies teach about dino weak points"


#### Purpose of change

Realism, birds are dinosaurs so studying them should teach something useful about dinosaurs.

#### Describe the solution

Adds many new bird id entries in the mod and then adds "prof_wp_dino" to each when DinoMod is active.
Rebalances prof_wp_dino to match bird proficiency stats and requirements.
<img width="1051" height="562" alt="Screenshot 2025-12-31 at 8 54 51 PM" src="https://github.com/user-attachments/assets/bbb14566-4482-40fa-b664-b4d26c98de69" />


#### Describe alternatives you've considered

Do this using the abstract entries but that doesn't appear to work yet

#### Testing

Game loads no errors
Proficiencies appear and work as expected

#### Additional context

Shout out to John Ostrom for settling the debate on this one https://en.wikipedia.org/wiki/John_Ostrom