### PR TITLE
Fix invalid spell in twisted_geometry

### DIFF
--- a/data/json/artifact/relic_procgen_data.json
+++ b/data/json/artifact/relic_procgen_data.json
@@ -855,7 +855,7 @@
     "active_procgen_values": [
       { "weight": 100, "spell_id": "AO_FORCE_PULL", "base_power": 200 },
       { "weight": 100, "spell_id": "AO_TELEPORTITIS", "base_power": -500 },
-      { "weight": 100, "spell_id": "AO_TELEPORT", "base_power": 500 },
+      { "weight": 100, "spell_id": "AEA_TELEPORT", "base_power": 500 },
       { "weight": 100, "spell_id": "AO_SLOW", "base_power": -150 },
       { "weight": 100, "spell_id": "AO_TIME_STOP", "base_power": 1000 },
       { "weight": 100, "spell_id": "AO_DARKNESS_EFFECT", "base_power": -50 },

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1027,7 +1027,8 @@ void DynamicDataLoader::check_consistency()
             { _( "Factions" ), &faction_template::check_consistency },
             { _( "Damage types" ), &damage_type::check },
             { _( "Wounds" ), &wound_type::check_consistency },
-            { _( "Faction missions" ), &faction_mission::check_consistency }
+            { _( "Faction missions" ), &faction_mission::check_consistency },
+            { _( "Relic Procedural Generations" ), &relic_procgen_data::check_consistency }
         }
     };
 

--- a/src/relic.cpp
+++ b/src/relic.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <initializer_list>
 #include <string>
 
 #include "calendar.h"

--- a/src/relic.cpp
+++ b/src/relic.cpp
@@ -110,6 +110,11 @@ void relic_procgen_data::finalize_all()
     relic_procgen_data_factory.finalize();
 }
 
+void relic_procgen_data::check_consistency()
+{
+    relic_procgen_data_factory.check();
+}
+
 relic::~relic() = default;
 
 // me when
@@ -241,6 +246,24 @@ void relic_procgen_data::load( const JsonObject &jo, std::string_view )
         charge.load( jo_inner );
 
         charge_values.add( charge, weight );
+    }
+}
+
+void relic_procgen_data::check() const
+{
+    const std::vector<spell_type> &spells = spell_type::get_all();
+    for( const weighted_int_list<enchantment_active> &l : {
+             passive_hit_you, passive_hit_me, active_procgen_values
+         } ) {
+        for( const std::pair<enchantment_active, int> &e : l ) {
+            auto it = std::find_if( spells.begin(), spells.end(), [&]( const auto & st ) {
+                return st.id == e.first.activated_spell;
+            } );
+            if( it == spells.end() ) {
+                debugmsg( "Invalid spell id %s in active_procgen_values for preset %s",
+                          e.first.activated_spell.str(), id.str() );
+            }
+        }
     }
 }
 

--- a/src/relic.h
+++ b/src/relic.h
@@ -132,9 +132,11 @@ class relic_procgen_data
         static const std::vector<relic_procgen_data> &get_all();
         static void load_relic_procgen_data( const JsonObject &jo, const std::string &src );
         static void finalize_all();
+        static void check_consistency();
         static void reset();
         void load( const JsonObject &jo, std::string_view = {} );
         void deserialize( const JsonObject &jobj );
+        void check() const;
 };
 
 enum class relic_has : int {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Fix invalid spell in twisted_geometry"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #84047
Adds basic relic_procgen_data validator with check for this case.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Replace active spell AO_TELEPORT which does not exist anymore with similar AEA_TELEPORT in twisted_geometry preset. This does not affect existing artifacts, but prevent new broken ones from spawning.
Add basic validator with check for missing spells. This does not stop loading process, but provides a warning debug message on load.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
N/A
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Before: no warnings, 95/1000 test artifacts had AO_TELEPORT.
After: warning at load about missing spell, 0/1000 test artifacts had AO_TELEPORT. Replacement spell functions correctly.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
N/A
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
