### PR TITLE
Fix map cache not revealing map

### DIFF
--- a/data/json/effects_on_condition/computer_eocs.json
+++ b/data/json/effects_on_condition/computer_eocs.json
@@ -1,35 +1,6 @@
 [
   {
     "type": "effect_on_condition",
-    "id": "EOC_SMARTPHONE_EOCS",
-    "//": "should be removed if any of #74335, #71814, #50277 and #28975 would be resolved",
-    "effect": [
-      {
-        "run_eoc_selector": [ "EOC_READ_LOCAL_FILES_pseudo", "EOC_CHECK_MAP_CACHE_pseudo" ],
-        "allow_cancel": true,
-        "names": [ "Dig into local files and logs", "Check map application" ],
-        "title": "Pick the action",
-        "descriptions": [
-          "You can take a look at the local files stored on this phone.",
-          "You can check is there any map cache on this smartphone."
-        ]
-      }
-    ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_READ_LOCAL_FILES_pseudo",
-    "//": "for selector cannot pick EoCs that are failing",
-    "effect": [ { "run_eocs": "EOC_READ_LOCAL_FILES" } ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_CHECK_MAP_CACHE_pseudo",
-    "//": "for selector cannot pick EoCs that are failing",
-    "effect": [ { "run_eocs": "EOC_CHECK_MAP_CACHE" } ]
-  },
-  {
-    "type": "effect_on_condition",
     "id": "EOC_READ_LOCAL_FILES",
     "condition": { "compare_string": [ { "npc_val": "snippet_file" }, "has", "lack" ] },
     "false_effect": [ { "npc_add_var": "snippet_file", "possible_values": [ "has", "lack" ] }, { "run_eocs": "EOC_READ_LOCAL_FILES" } ],

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -157,6 +157,7 @@ static const flag_id json_flag_DISABLE_FLIGHT( "DISABLE_FLIGHT" );
 static const flag_id json_flag_FILTHY( "FILTHY" );
 static const flag_id json_flag_GRAB( "GRAB" );
 static const flag_id json_flag_GRAB_FILTER( "GRAB_FILTER" );
+static const flag_id json_flag_PRESERVE_SPAWN_LOC( "PRESERVE_SPAWN_LOC" );
 
 static const itype_id itype_beartrap( "beartrap" );
 static const itype_id itype_milk( "milk" );
@@ -3310,6 +3311,25 @@ void monster::drop_items_on_death( map *here, item *corpse )
             }
         }
     }
+
+    // Check if item has PRESERVE_SPAWN_LOC and set it if necessary
+    // This probably needs to be encapsulated in some generic function
+    for( item &it : new_items ) {
+        if( it.has_flag( json_flag_PRESERVE_SPAWN_LOC ) &&
+            !it.has_var( "spawn_location" ) ) {
+            it.set_var( "spawn_location", pos_abs().to_string_writable() );
+        }
+
+        // since efiles are not in standard pocket, check it separately
+        if( it.has_pocket_type( pocket_type::E_FILE_STORAGE ) ) {
+            for( item *it_software : it.all_items_top( pocket_type::E_FILE_STORAGE ) ) {
+                if( it_software->has_flag( json_flag_PRESERVE_SPAWN_LOC ) &&
+                    !it_software->has_var( "spawn_location" ) ) {
+                    it_software->set_var( "spawn_location", pos_abs().to_string_writable() );
+                }
+            }
+        }
+    };
 }
 
 void monster::spawn_dissectables_on_death( item *corpse ) const


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Technically solves #79536
#### Describe the solution
Add handling for PRESERVE_SPAWN_LOC when monster dies
Also remove EOCs that are not used anymore
#### Describe alternatives you've considered
Actually making all the item spawn be rooted in some master function, but i could not find all the places it can happen
Also said function would need to be chained, for generic itemgroup spawn do not have access to coordinates in any way
#### Testing
Killed zombies, picked smartphone, tried to use map cache, map was revealed
#### Additional context
Secondary issue is that because software is not a standard pocket (CONTAINER, MAGAZINE, MAGAZINE_WELL), it has to have it's own treatment for applying flag