### PR TITLE
New Hub 01 quest tying together Mobile Weather Stations & the giant monster corpse

### DIFF
--- a/data/json/effects_on_condition/item_eocs.json
+++ b/data/json/effects_on_condition/item_eocs.json
@@ -32,7 +32,9 @@
         { "u_near_om_location": "highlands", "range": 10 },
         { "u_near_om_location": "exodii_base_x0y0z0", "range": 10 },
         { "u_near_om_location": "microlab_portal_security1", "range": 10 },
-        { "u_near_om_location": "labyrinth_entrance", "range": 10 }
+        { "u_near_om_location": "labyrinth_entrance", "range": 10 },
+        { "u_near_om_location": "corpse_surface", "range": 10 },
+        { "u_near_om_location": "corpse_brain", "range": 10 }
       ]
     },
     "effect": {

--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -269,6 +269,19 @@
   },
   {
     "type": "ITEM",
+    "id": "mws_monster_corpse_weather_data",
+    "category": "books",
+    "symbol": ",",
+    "color": "white",
+    "name": { "str": "alien \"atmospheric\" datasheet" },
+    "description": "A piece of paper covered in complex \"weather\" recordings from the inside of a giant, dead creature.",
+    "price": "0 cent",
+    "volume": "4 ml",
+    "weight": "1 g",
+    "material": [ "paper" ]
+  },
+  {
+    "type": "ITEM",
     "id": "HEW_weather_data",
     "name": { "str": "HEW datasheet" },
     "category": "books",

--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -441,7 +441,7 @@
     "id": "HEW_printout_data_monster_corpse",
     "name": { "str": "HEW printout LKG1" },
     "category": "books",
-    "description": "A short paper report labeled with the mysterious title \"LKG1.\"  While most of the document is coded in a series of overlapping numbers and dots that you cannot understand, the paper also reads: \"ANOMALOUS CONDITIONS DETECTED.  ACTIVE SPACETIME DISTURBANCES.  ABNORMAL ORGANICS.\"",
+    "description": "A short paper report labeled with the mysterious title \"LKG1.\"  While most of the document is coded in a series of overlapping numbers and dots that you cannot understand, the paper also reads: \"ANOMALOUS CONDITIONS DETECTED.  ALIEN VOLATILE ORGANICS.\"",
     "color": "white",
     "symbol": ",",
     "material": [ "paper" ],

--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -425,6 +425,19 @@
   },
   {
     "type": "ITEM",
+    "id": "HEW_printout_data_monster_corpse",
+    "name": { "str": "HEW printout LKG1" },
+    "category": "books",
+    "description": "A short paper report labeled with the mysterious title \"LKG1.\"  While most of the document is coded in a series of overlapping numbers and dots that you cannot understand, the paper also reads: \"ANOMALOUS CONDITIONS DETECTED.  ACTIVE SPACETIME DISTURBANCES.  ABNORMAL ORGANICS.\"",
+    "color": "white",
+    "symbol": ",",
+    "material": [ "paper" ],
+    "volume": "4 ml",
+    "weight": "1 g",
+    "flags": [ "TRADER_AVOID" ]
+  },
+  {
+    "type": "ITEM",
     "id": "fp_loyalty_card",
     "category": "other",
     "symbol": "-",

--- a/data/json/mapgen/robofaq_locs/robofac_mission_chunks.json
+++ b/data/json/mapgen/robofaq_locs/robofac_mission_chunks.json
@@ -95,5 +95,104 @@
         "u": { "monster": "mon_leech_stalk" }
       }
     }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "robofac_monster_corpse_field_team_roof",
+    "object": {
+      "faction_owner": [ { "id": "robofac_auxiliaries", "x": [ 0, 23 ], "y": [ 0, 23 ] } ],
+      "mapgensize": [ 24, 24 ],
+      "rows": [
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "           R            ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        ".....                   ",
+        ".....                   ",
+        ".....                   ",
+        ".....                   ",
+        ".....                   "
+      ],
+      "terrain": { ".": "t_canvas_roof" },
+      "monster": { "R": { "monster": "mon_robofac_camspy" } },
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "robofac_monster_corpse_field_team",
+    "object": {
+      "faction_owner": [ { "id": "robofac_auxiliaries", "x": [ 0, 23 ], "y": [ 0, 23 ] } ],
+      "mapgensize": [ 24, 24 ],
+      "rows": [
+        "                        ",
+        "                        ",
+        "                        ",
+        "   R                 R  ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        " %%%                    ",
+        " % %                    ",
+        " %%%                    ",
+        "WWWWW                   ",
+        "W..rW                   ",
+        "D.clW               R   ",
+        "W..tW                   ",
+        "WWWWW                   "
+      ],
+      "terrain": {
+        ".": "t_dirt",
+        "c": "t_dirt",
+        "r": "t_dirt",
+        "l": "t_dirt",
+        "t": "t_dirt",
+        "D": "t_dirt",
+        "W": "t_dirt",
+        "T": "t_dirt",
+        "%": "t_dirt"
+      },
+      "furniture": {
+        "W": "f_canvas_wall",
+        "D": "f_canvas_door_o",
+        "c": "f_camp_chair",
+        "r": "f_tourist_table",
+        "l": "f_tourist_table",
+        "t": "f_tourist_table",
+        "%": "f_sandbag_half"
+      },
+      "item": { "r": { "item": "radio" }, "l": { "item": "laptop" }, "t": { "item": "emf_detector" } },
+      "monster": { "R": { "monster": "mon_robofac_camspy" } },
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "place_npcs": [
+        { "class": "robofac_merc_monster_corpse_1", "x": 2, "y": 21 },
+        { "class": "robofac_merc_monster_corpse_2", "x": 2, "y": 17 }
+      ],
+      "place_nested": [ { "chunks": [ "robofac_monster_corpse_field_team_roof" ], "x": 0, "y": 0, "z": 1 } ]
+    }
   }
 ]

--- a/data/json/npcs/robofac/NPC_Steven_Gould.json
+++ b/data/json/npcs/robofac/NPC_Steven_Gould.json
@@ -102,7 +102,7 @@
     "id": "TALK_ROBOFAC_MERC_MONSTER_CORPSE_1_EQUIPMENT_ACCEPTED",
     "type": "talk_topic",
     "dynamic_line": "You didn't get that from me, yeah?",
-    "responses": [ { "text": "Thanks." }, "topic": "TALK_DONE"  ]
+    "responses": [ { "text": "Thanks.", "topic": "TALK_DONE" } ]
   },
   {
     "type": "npc",

--- a/data/json/npcs/robofac/NPC_Steven_Gould.json
+++ b/data/json/npcs/robofac/NPC_Steven_Gould.json
@@ -55,10 +55,7 @@
     "type": "talk_topic",
     "dynamic_line": "Ah, the other contractor.  We've got things covered up here… but I guess you're going down into the \"thing.\"  If you've got coins, I've got a bit of spare equipment that might be useful.",
     "responses": [
-      {
-        "text": "Any idea what's going on down there?",
-        "topic": "TALK_ROBOFAC_MERC_MONSTER_CORPSE_1_RECON"
-      },
+      { "text": "Any idea what's going on down there?", "topic": "TALK_ROBOFAC_MERC_MONSTER_CORPSE_1_RECON" },
       {
         "text": "What kind of equipment you looking to trade?",
         "topic": "TALK_ROBOFAC_MERC_MONSTER_CORPSE_1_EQUIPMENT",

--- a/data/json/npcs/robofac/NPC_Steven_Gould.json
+++ b/data/json/npcs/robofac/NPC_Steven_Gould.json
@@ -48,10 +48,7 @@
     "type": "item_group",
     "id": "NC_ROBOFAC_MERC_MONSTER_CORPSE_1_carry",
     "subtype": "collection",
-    "items": [
-      { "item": "RobofacCoin", "count": [ 15, 18 ] },
-      { "group": "charged_smart_phone" }
-    ]
+    "items": [ { "item": "RobofacCoin", "count": [ 15, 18 ] }, { "group": "charged_smart_phone" } ]
   },
   {
     "id": [ "TALK_ROBOFAC_MERC_MONSTER_CORPSE_1" ],

--- a/data/json/npcs/robofac/NPC_Steven_Gould.json
+++ b/data/json/npcs/robofac/NPC_Steven_Gould.json
@@ -68,9 +68,7 @@
     "id": "TALK_ROBOFAC_MERC_MONSTER_CORPSE_1_RECON",
     "type": "talk_topic",
     "dynamic_line": "Well… guess I don't have to tell you about the giant hunk of meat outside.  We've finished our subsurface scans, and if I didn't know any better, I'd say this thing is a giant piece of calamari.  Nasty shit.  I'd be shocked if it weren't for all the other strange shit going on out there these days.",
-    "responses": [
-      { "text": "Thanks.", "topic": "TALK_DONE" }
-    ]
+    "responses": [ { "text": "Thanks.", "topic": "TALK_DONE" } ]
   },
   {
     "id": "TALK_ROBOFAC_MERC_MONSTER_CORPSE_1_EQUIPMENT",

--- a/data/json/npcs/robofac/NPC_Steven_Gould.json
+++ b/data/json/npcs/robofac/NPC_Steven_Gould.json
@@ -68,9 +68,7 @@
     "id": "TALK_ROBOFAC_MERC_MONSTER_CORPSE_1_RECON",
     "type": "talk_topic",
     "dynamic_line": "Well... guess I don't have to tell you about the giant hunk of meat outside.  We've finished our subsurface scans, and if I didn't know any better, I'd say this thing is a giant piece of calamari.  Nasty shit.  I'd be shocked if it weren't for all the other strange shit going on out there these days.",
-    "responses": [
-      { "text": "Thanks.", "topic": "TALK_DONE" }
-    ]
+    "responses": [ { "text": "Thanks.", "topic": "TALK_DONE" } ]
   },
   {
     "id": "TALK_ROBOFAC_MERC_MONSTER_CORPSE_1_EQUIPMENT",

--- a/data/json/npcs/robofac/NPC_Steven_Gould.json
+++ b/data/json/npcs/robofac/NPC_Steven_Gould.json
@@ -1,0 +1,124 @@
+[
+  {
+    "type": "npc",
+    "id": "robofac_merc_monster_corpse_1",
+    "name_unique": "Steven Gould",
+    "//": "Appears at the field station during the quest Invasive \"Meteorology:\" contact the field team.",
+    "name_suffix": "Hub Mercenary",
+    "class": "NC_ROBOFAC_MERC_MONSTER_CORPSE_1",
+    "attitude": 0,
+    "mission": 7,
+    "chat": "TALK_ROBOFAC_MERC_MONSTER_CORPSE_1",
+    "faction": "robofac_auxiliaries"
+  },
+  {
+    "type": "npc_class",
+    "id": "NC_ROBOFAC_MERC_MONSTER_CORPSE_1",
+    "name": { "str": "Hub Mercenary" },
+    "job_description": "Fighting for the all-mighty dollar.",
+    "common": false,
+    "traits": [
+      { "trait": "hair_medium", "variant": "black" },
+      { "trait": "natural_hair_color_black" },
+      { "trait": "eye_color", "variant": "brown" },
+      { "trait": "SKIN_PINK" }
+    ],
+    "bonus_str": 1,
+    "bonus_dex": 1,
+    "bonus_per": 1,
+    "bonus_int": 4,
+    "worn_override": "NC_ROBOFAC_MERC_MONSTER_CORPSE_1_worn",
+    "carry_override": "NC_ROBOFAC_MERC_MONSTER_CORPSE_1_carry"
+  },
+  {
+    "type": "item_group",
+    "id": "NC_ROBOFAC_MERC_MONSTER_CORPSE_1_worn",
+    "subtype": "collection",
+    "items": [
+      { "item": "under_armor" },
+      { "item": "under_armor_shorts" },
+      { "item": "socks" },
+      { "item": "robofac_enviro_suit" },
+      { "group": "clothing_watch" },
+      { "item": "knife_combat", "container-item": "bootsheath" },
+      { "group": "robofac_helmet_merc" }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_ROBOFAC_MERC_MONSTER_CORPSE_1_carry",
+    "subtype": "collection",
+    "items": [
+      { "item": "RobofacCoin", "count": [ 15, 18 ] },
+      { "group": "charged_smart_phone" }
+    ]
+  },
+  {
+    "id": [ "TALK_ROBOFAC_MERC_MONSTER_CORPSE_1" ],
+    "type": "talk_topic",
+    "dynamic_line": "Ah, the other contractor.  We've got things covered up here… but I guess you're going down into the \"thing.\"  If you've got coins, I've got a bit of spare equipment that might be useful.",
+    "responses": [
+      {
+        "text": "Any idea what's going on down there?",
+        "topic": "TALK_ROBOFAC_MERC_MONSTER_CORPSE_1_RECON"
+      },
+      {
+        "text": "What kind of equipment you looking to trade?",
+        "topic": "TALK_ROBOFAC_MERC_MONSTER_CORPSE_1_EQUIPMENT",
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "bought_gear_monster_corpse_merc" } ] } }
+      },
+      { "text": "I'll see you around.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_MONSTER_CORPSE_1_RECON",
+    "type": "talk_topic",
+    "dynamic_line": "Well... guess I don't have to tell you about the giant hunk of meat outside.  We've finished our subsurface scans, and if I didn't know any better, I'd say this thing is a giant piece of calamari.  Nasty shit.  I'd be shocked if it weren't for all the other strange shit going on out there these days.",
+    "responses": [
+      { "text": "Thanks.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_MONSTER_CORPSE_1_EQUIPMENT",
+    "type": "talk_topic",
+    "dynamic_line": "I've got an extra recon helmet and a powered air purifying respirator system.  The light amplification on the helmet still works.  The PAPR is a scavenged military mask with an old commercial blower.  Package deal.  Don't ask where I got 'em.  Ten coins.",
+    "responses": [
+      { "text": "No, thanks.", "topic": "TALK_DONE" },
+      {
+        "text": "[10 HGC] You have a deal.",
+        "topic": "TALK_ROBOFAC_MERC_MONSTER_CORPSE_1_EQUIPMENT_ACCEPTED",
+        "condition": { "u_has_items": { "item": "RobofacCoin", "count": 10 } },
+        "effect": [
+          { "u_consume_item": "RobofacCoin", "count": 10, "popup": true },
+          { "u_spawn_item": "military_papr_mask" },
+          { "u_spawn_item": "basic_papr_belt_off" },
+          { "u_spawn_item": "robofac_head_rig" },
+          { "u_add_var": "bought_gear_monster_corpse_merc", "value": "yes" }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_MONSTER_CORPSE_1_EQUIPMENT_ACCEPTED",
+    "type": "talk_topic",
+    "dynamic_line": "You didn't get that from me, yeah?",
+    "responses": [ { "text": "Thanks." }, "topic": "TALK_DONE"  ]
+  },
+  {
+    "type": "npc",
+    "id": "robofac_merc_monster_corpse_2",
+    "//": "just a grunt",
+    "name_unique": "armed mercenary",
+    "class": "NC_ANCILLA_GRUNT",
+    "attitude": 0,
+    "mission": 7,
+    "chat": "TALK_ROBOFAC_MERC_MONSTER_CORPSE_2",
+    "faction": "robofac_auxiliaries"
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_MONSTER_CORPSE_2",
+    "type": "talk_topic",
+    "dynamic_line": "I'm just paid to stand guard and watch the drones.  Talk to the boss in the pavilion if you need something.",
+    "responses": [ { "text": "Thanks.", "topic": "TALK_DONE" } ]
+  }
+]

--- a/data/json/npcs/robofac/NPC_Steven_Gould.json
+++ b/data/json/npcs/robofac/NPC_Steven_Gould.json
@@ -73,7 +73,7 @@
   {
     "id": "TALK_ROBOFAC_MERC_MONSTER_CORPSE_1_RECON",
     "type": "talk_topic",
-    "dynamic_line": "Well... guess I don't have to tell you about the giant hunk of meat outside.  We've finished our subsurface scans, and if I didn't know any better, I'd say this thing is a giant piece of calamari.  Nasty shit.  I'd be shocked if it weren't for all the other strange shit going on out there these days.",
+    "dynamic_line": "Well… guess I don't have to tell you about the giant hunk of meat outside.  We've finished our subsurface scans, and if I didn't know any better, I'd say this thing is a giant piece of calamari.  Nasty shit.  I'd be shocked if it weren't for all the other strange shit going on out there these days.",
     "responses": [
       { "text": "Thanks.", "topic": "TALK_DONE" }
     ]

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
@@ -338,18 +338,20 @@
         "text": "I have some HEW recordings.",
         "condition": {
           "and": [
-            { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_mws_4" } ] },
+            { "compare_string": [ "yes", { "u_val": "dialogue_intercom_accepted_robofac_intercom_mws_4" } ] },
             {
               "or": [
                 { "u_has_items": { "item": "HEW_printout_data_portal_storm", "count": 1 } },
                 { "u_has_items": { "item": "HEW_printout_data_vitrified", "count": 1 } },
                 { "u_has_items": { "item": "HEW_printout_data_exodii", "count": 1 } },
+                { "u_has_items": { "item": "HEW_printout_data_strange_temple", "count": 1 } },
                 { "u_has_items": { "item": "HEW_printout_data_lixa", "count": 1 } },
                 { "u_has_items": { "item": "HEW_printout_data_highlands", "count": 1 } },
                 { "u_has_items": { "item": "HEW_printout_data_labyrinth", "count": 1 } },
                 { "u_has_items": { "item": "HEW_printout_data_physics_lab", "count": 1 } },
                 { "u_has_items": { "item": "HEW_printout_data_amigara", "count": 1 } },
-                { "u_has_items": { "item": "HEW_printout_data_radiosphere", "count": 1 } }
+                { "u_has_items": { "item": "HEW_printout_data_radiosphere", "count": 1 } },
+                { "u_has_items": { "item": "HEW_printout_data_monster_corpse", "count": 1 } }
               ]
             }
           ]

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
@@ -1694,11 +1694,7 @@
           "t": "f_tourist_table",
           "%": "f_sandbag_half"
         },
-        "item": {
-          "r": { "item": "radio" },
-          "l": { "item": "laptop" },
-          "t": { "item": "emf_detector" }
-        },
+        "item": { "r": { "item": "radio" }, "l": { "item": "laptop" }, "t": { "item": "emf_detector" } },
         "monster": { "R": { "monster": "mon_robofac_camspy" } },
         "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
         "place_npcs": [

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
@@ -1646,12 +1646,7 @@
     "difficulty": 5,
     "value": 0,
     "start": {
-      "assign_mission_target": {
-        "om_terrain": "corpse_surface",
-        "om_special": "nether_monster_corpse",
-        "reveal_radius": 2,
-        "random": false
-      },
+      "assign_mission_target": { "om_terrain": "corpse_surface", "om_special": "nether_monster_corpse", "reveal_radius": 2, "random": false },
       "update_mapgen": {
         "rows": [
           "                        ",

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
@@ -1204,10 +1204,10 @@
       "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE_OFFER_ADVICE_SCAN_LOCATION"
     ],
     "type": "talk_topic",
-    "dynamic_line": "The recording you brought us suggests that there is some underground source of alien organic volatiles.  We've cross-referenced with our existing geographic data, and we think we've identified several underground structures that are the source of these organics.  We'd like you and a field team to go to the source and measure atmospheric conditions using one of the mobile weather stations.",
+    "dynamic_line": "The recording you brought us suggests that there is some underground source of alien organic volatiles.  We've cross-referenced with our existing geographic data, and we think we've identified several underground structures that may match the signatures you've brought us.  We'd like you and a field team to go to one of these and measure underground atmospheric conditions - with your HEW station, of course.",
     "responses": [
       {
-        "text": "Alright, so go underground, set up the station, make a recording.  I'm in.",
+        "text": "Alright, so go underground to specific coordinates, set up the HEW station, and make a recording.  I'm in.",
         "effect": [
           { "assign_mission": "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE_FIELD_TEAM" },
           { "assign_mission": "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE" }
@@ -1220,7 +1220,7 @@
       },
       { "text": "Field team?", "topic": "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE_OFFER_ADVICE_FIELD_TEAM" },
       {
-        "text": "Do I need to scan at these exact coordinates?",
+        "text": "Do I need to scan at these EXACT coordinates?",
         "topic": "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE_OFFER_ADVICE_SCAN_LOCATION"
       },
       { "text": "What else do you have available?", "topic": "TALK_ROBOFAC_INTERCOM_CONTRACTS" }
@@ -1239,7 +1239,7 @@
   {
     "id": "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE_OFFER_ADVICE_SCAN_LOCATION",
     "type": "talk_topic",
-    "dynamic_line": "Yes, ideally.  However, like other recordings, you don't need to be present for the full hour the recording runs - you can set up the station, leave, and come back later for the report."
+    "dynamic_line": "Yes, absolutely.  We think recordings from these exact coordinates will give us the most useful data on these volatile organics.  However, like other recordings, you don't need to be present for the full hour the recording runs - you can set up the station, leave, and come back later for the report."
   },
   {
     "id": "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE_ACCEPTED",
@@ -1607,7 +1607,7 @@
     "id": "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE",
     "type": "mission_definition",
     "name": { "str": "Invasive \"Meteorology\"" },
-    "description": "Go to the underground coordinates, set up a mobile weather station, and make a recording.  You may wish to rendezvous with the advanced field team, if you can find them.",
+    "description": "Go to the <color_yellow>exact underground coordinates</color>, set up a HEW station, and make a recording.  Return the <color_yellow>alient \"atmospheric\" datasheet</color> to Hub 01.  You may wish to rendezvous with the advanced field team, if you can find them.",
     "goal": "MGOAL_NULL",
     "difficulty": 5,
     "value": 0,
@@ -1647,61 +1647,7 @@
     "value": 0,
     "start": {
       "assign_mission_target": { "om_terrain": "corpse_surface", "om_special": "nether_monster_corpse", "reveal_radius": 2, "random": false },
-      "update_mapgen": {
-        "rows": [
-          "                        ",
-          "                        ",
-          "                        ",
-          "   R                 R  ",
-          "                        ",
-          "                        ",
-          "                        ",
-          "                        ",
-          "                        ",
-          "                        ",
-          "                        ",
-          "                        ",
-          "                        ",
-          "                        ",
-          "                        ",
-          "                        ",
-          " %%%                    ",
-          " % %                    ",
-          " %%%                    ",
-          "WWWWW                   ",
-          "W..rW                   ",
-          "D.clW               R   ",
-          "W..tW                   ",
-          "WWWWW                   "
-        ],
-        "terrain": {
-          ".": "t_dirt",
-          "c": "t_dirt",
-          "r": "t_dirt",
-          "l": "t_dirt",
-          "t": "t_dirt",
-          "D": "t_dirt",
-          "W": "t_dirt",
-          "T": "t_dirt",
-          "%": "t_dirt"
-        },
-        "furniture": {
-          "W": "f_canvas_wall",
-          "D": "f_canvas_door_o",
-          "c": "f_camp_chair",
-          "r": "f_tourist_table",
-          "l": "f_tourist_table",
-          "t": "f_tourist_table",
-          "%": "f_sandbag_half"
-        },
-        "item": { "r": { "item": "radio" }, "l": { "item": "laptop" }, "t": { "item": "emf_detector" } },
-        "monster": { "R": { "monster": "mon_robofac_camspy" } },
-        "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
-        "place_npcs": [
-          { "class": "robofac_merc_monster_corpse_1", "x": 2, "y": 21 },
-          { "class": "robofac_merc_monster_corpse_2", "x": 2, "y": 17 }
-        ]
-      }
+      "update_mapgen": { "place_nested": [ { "chunks": [ "robofac_monster_corpse_field_team" ], "x": 0, "y": 0 } ] }
     },
     "origins": [ "ORIGIN_SECONDARY" ],
     "has_generic_rewards": false,

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
@@ -1612,12 +1612,7 @@
     "difficulty": 5,
     "value": 0,
     "start": {
-      "assign_mission_target": {
-        "om_terrain": "corpse_bowels_mid",
-        "om_special": "nether_monster_corpse",
-        "reveal_radius": 1,
-        "random": false
-      }
+      "assign_mission_target": { "om_terrain": "corpse_bowels_mid", "om_special": "nether_monster_corpse", "reveal_radius": 1, "random": false }
     },
     "end": {
       "effect": [

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
@@ -95,7 +95,12 @@
       },
       {
         "text": "I'm back.  I don't know what the hell that thing was, but it wasn't a cave.  [Hand over the alien \"atmospheric data.\"]",
-        "condition": { "and": [ { "u_has_mission": "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE" }, { "u_has_item": "mws_monster_corpse_weather_data" } ] },
+        "condition": {
+          "and": [
+            { "u_has_mission": "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE" },
+            { "u_has_item": "mws_monster_corpse_weather_data" }
+          ]
+        },
         "effect": [
           { "u_consume_item": "mws_monster_corpse_weather_data", "count": 1, "popup": true },
           { "finish_mission": "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE", "success": true }

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
@@ -1607,7 +1607,7 @@
     "id": "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE",
     "type": "mission_definition",
     "name": { "str": "Invasive \"Meteorology\"" },
-    "description": "Go to the <color_yellow>exact underground coordinates</color>, set up a HEW station, and make a recording.  Return the <color_yellow>alient \"atmospheric\" datasheet</color> to Hub 01.  You may wish to rendezvous with the advanced field team, if you can find them.",
+    "description": "Go to the <color_yellow>exact underground coordinates</color>, set up a HEW station, and make a recording.  Return the <color_yellow>alien \"atmospheric\" datasheet</color> to Hub 01.  You may wish to rendezvous with the advanced field team, if you can find them.",
     "goal": "MGOAL_NULL",
     "difficulty": 5,
     "value": 0,

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
@@ -12,7 +12,8 @@
       "MISSION_ROBOFAC_INTERCOM_MWS_1_ACCEPTED",
       "MISSION_ROBOFAC_INTERCOM_MWS_2_ACCEPTED",
       "MISSION_ROBOFAC_INTERCOM_MWS_3_ACCEPTED",
-      "MISSION_ROBOFAC_INTERCOM_MWS_4_ACCEPTED"
+      "MISSION_ROBOFAC_INTERCOM_MWS_4_ACCEPTED",
+      "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE_ACCEPTED"
     ],
     "type": "talk_topic",
     "dynamic_line": "What would you like to discuss?",
@@ -91,6 +92,15 @@
           { "finish_mission": "MISSION_ROBOFAC_INTERCOM_MWS_3", "success": true }
         ],
         "topic": "MISSION_ROBOFAC_INTERCOM_MWS_3_COMPLETE"
+      },
+      {
+        "text": "I'm back.  I don't know what the hell that thing was, but it wasn't a cave.  [Hand over the alien \"atmospheric data.\"]",
+        "condition": { "and": [ { "u_has_mission": "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE" }, { "u_has_item": "mws_monster_corpse_weather_data" } ] },
+        "effect": [
+          { "u_consume_item": "mws_monster_corpse_weather_data", "count": 1, "popup": true },
+          { "finish_mission": "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE", "success": true }
+        ],
+        "topic": "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE_COMPLETE"
       },
       {
         "text": "[Contract: Return to sender]",
@@ -193,6 +203,19 @@
           ]
         },
         "topic": "MISSION_ROBOFAC_INTERCOM_MWS_4_OFFER"
+      },
+      {
+        "text": "[Contract: Invasive \"Meteorolgoy\"]",
+        "condition": {
+          "and": [
+            { "not": { "u_has_mission": "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE" } },
+            {
+              "not": { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_mws_monster_corpse" } ] }
+            },
+            { "math": [ "HEW_monster_corpse_data_sold > 0" ] }
+          ]
+        },
+        "topic": "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE_OFFER"
       },
       {
         "text": "[Contract: Data Retrieval]",
@@ -1169,6 +1192,65 @@
     "responses": [ { "text": "Thank you.", "topic": "TALK_ROBOFAC_INTERCOM_SERVICES" } ]
   },
   {
+    "id": [
+      "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE_OFFER",
+      "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE_OFFER_ADVICE_DANGERS",
+      "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE_OFFER_ADVICE_FIELD_TEAM",
+      "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE_OFFER_ADVICE_SCAN_LOCATION"
+    ],
+    "type": "talk_topic",
+    "dynamic_line": "The recording you brought us suggests that there is some underground source of organic volatiles.  We've cross-referenced with our existing geographic data, and indeed, we think there is some sort of large... structure.  We'd like you and a field team to go to the source and measure atmospheric conditions using one of the mobile weather stations.",
+    "responses": [
+      {
+        "text": "Alright, so go underground, set up the station, make a recording.  I'm in.",
+        "effect": [
+          { "assign_mission": "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE" }
+        ],
+        "topic": "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE_ACCEPTED"
+      },
+      {
+        "text": "Any idea what I can expect?",
+        "topic": "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE_OFFER_ADVICE_DANGERS"
+      },
+      {
+        "text": "Field team?",
+        "topic": "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE_OFFER_ADVICE_FIELD_TEAM"
+      },
+      {
+        "text": "Do I need to scan at these exact coordinates?",
+        "topic": "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE_OFFER_ADVICE_SCAN_LOCATION"
+      },
+      { "text": "What else do you have available?", "topic": "TALK_ROBOFAC_INTERCOM_CONTRACTS" }
+    ]
+  },
+  {
+    "id": "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE_OFFER_ADVICE_DANGERS",
+    "type": "talk_topic",
+    "dynamic_line": "There appear to be lifeforms, alien and otherwise.  We don't know anything about them.  The field team should beat you there, so you may wish to speak to them.  It is likely very dark, so we are prepared to sell you a field-issue recon helmet in advance.  Ask after we talk if you're interested."
+  },
+  {
+    "id": "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE_OFFER_ADVICE_FIELD_TEAM",
+    "type": "talk_topic",
+    "dynamic_line": "Yes, we've already contracted several others to perform surface recon.  It may be worth speaking with them to see if you can assist."
+  },
+  {
+    "id": "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE_OFFER_ADVICE_SCAN_LOCATION",
+    "type": "talk_topic",
+    "dynamic_line": "Yes, this area is the source of the abnormal HEW recordings.  However, like other recordings, you don't need to be present for the full hour the recording runs - you can set up the station, leave, and come back later for the report."
+  },
+  {
+    "id": "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE_ACCEPTED",
+    "type": "talk_topic",
+    "dynamic_line": "Excellent.  You'll meet the advanced team on the surface near your coordinates.  We expect the underground system to be quite dark, so we are prepared to sell you our field-issue recon helmet.  You may ask if interested.",
+    "speaker_effect": { "effect": [ { "u_add_var": "dialogue_intercom_u_hub_prototypes", "value": "yes" } ] }
+  },
+  {
+    "id": "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE_COMPLETE",
+    "type": "talk_topic",
+    "dynamic_line": "The intercom's tray slides open and you deposit the report.  There is a brief silence, and then it opens with your payment.  \"You have our thanks and your payment.  It will take us some time for Research to digest this and the other field data, but perhaps we will have more contracts for you later.",
+    "responses": [ { "text": "Thank you.", "topic": "TALK_ROBOFAC_INTERCOM_SERVICES" } ]
+  },
+  {
     "id": "MISSION_ROBOFAC_INTERCOM_LIXA_SM_1",
     "type": "mission_definition",
     "name": { "str": "Data Retrieval" },
@@ -1501,6 +1583,35 @@
     "end": {
       "effect": [
         { "u_add_var": "dialogue_intercom_completed_robofac_intercom_mws_4", "value": "yes" },
+        { "math": [ "u_hub01_completed_missions++" ] }
+      ]
+    },
+    "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
+    "dialogue": {
+      "describe": "…",
+      "offer": "…",
+      "accepted": "…",
+      "rejected": "…",
+      "advice": "…",
+      "inquire": "…",
+      "success": "…",
+      "success_lie": "…",
+      "failure": "…"
+    }
+  },
+  {
+    "id": "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE",
+    "type": "mission_definition",
+    "name": { "str": "Invasive \"Meteorolgoy\"" },
+    "description": "Go to the underground coordinates, set up a mobile weather station, and make a recording.  You may wish to rendezvous with the advanced field team, if you can find them.",
+    "goal": "MGOAL_NULL",
+    "difficulty": 5,
+    "value": 0,
+    "end": {
+      "effect": [
+        { "u_spawn_item": "RobofacCoin", "count": 8 },
+        { "u_add_var": "dialogue_intercom_completed_robofac_intercom_mws_monster_corpse", "value": "yes" },
         { "math": [ "u_hub01_completed_missions++" ] }
       ]
     },

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
@@ -1582,9 +1582,7 @@
     "goal": "MGOAL_NULL",
     "difficulty": 5,
     "value": 0,
-    "start": {
-      "effect": { "u_add_var": "dialogue_intercom_accepted_robofac_intercom_mws_4", "value": "yes" }
-    },
+    "start": { "effect": { "u_add_var": "dialogue_intercom_accepted_robofac_intercom_mws_4", "value": "yes" } },
     "end": {
       "effect": [
         { "u_add_var": "dialogue_intercom_completed_robofac_intercom_mws_4", "value": "yes" },

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
@@ -205,7 +205,7 @@
         "topic": "MISSION_ROBOFAC_INTERCOM_MWS_4_OFFER"
       },
       {
-        "text": "[Contract: Invasive \"Meteorolgoy\"]",
+        "text": "[Contract: Invasive \"Meteorology\"]",
         "condition": {
           "and": [
             { "not": { "u_has_mission": "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE" } },
@@ -1188,7 +1188,7 @@
   {
     "id": "MISSION_ROBOFAC_INTERCOM_MWS_4_COMPLETE",
     "type": "talk_topic",
-    "dynamic_line": "The intercom's tray slides open and you deposit the report.  There is a brief silence, and then it opens with your payment.  \"You have our thanks and your payment.  If you're interested in an open contract, please let us know.",
+    "dynamic_line": "The intercom's tray slides open and you deposit the report.  There is a brief silence, and then it opens with your payment.",
     "responses": [ { "text": "Thank you.", "topic": "TALK_ROBOFAC_INTERCOM_SERVICES" } ]
   },
   {
@@ -1199,11 +1199,12 @@
       "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE_OFFER_ADVICE_SCAN_LOCATION"
     ],
     "type": "talk_topic",
-    "dynamic_line": "The recording you brought us suggests that there is some underground source of organic volatiles.  We've cross-referenced with our existing geographic data, and indeed, we think there is some sort of large... structure.  We'd like you and a field team to go to the source and measure atmospheric conditions using one of the mobile weather stations.",
+    "dynamic_line": "The recording you brought us suggests that there is some underground source of alien organic volatiles.  We've cross-referenced with our existing geographic data, and we think we've identified several underground structures that are the source of these organics.  We'd like you and a field team to go to the source and measure atmospheric conditions using one of the mobile weather stations.",
     "responses": [
       {
         "text": "Alright, so go underground, set up the station, make a recording.  I'm in.",
         "effect": [
+          { "assign_mission": "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE_FIELD_TEAM" },
           { "assign_mission": "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE" }
         ],
         "topic": "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE_ACCEPTED"
@@ -1226,28 +1227,27 @@
   {
     "id": "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE_OFFER_ADVICE_DANGERS",
     "type": "talk_topic",
-    "dynamic_line": "There appear to be lifeforms, alien and otherwise.  We don't know anything about them.  The field team should beat you there, so you may wish to speak to them.  It is likely very dark, so we are prepared to sell you a field-issue recon helmet in advance.  Ask after we talk if you're interested."
+    "dynamic_line": "There appear to be lifeforms, alien and otherwise.  We don't know anything about them."
   },
   {
     "id": "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE_OFFER_ADVICE_FIELD_TEAM",
     "type": "talk_topic",
-    "dynamic_line": "Yes, we've already contracted several others to perform surface recon.  It may be worth speaking with them to see if you can assist."
+    "dynamic_line": "Yes, we've already contracted several others to perform surface reconnaissance.  It may be worth speaking with them to share information."
   },
   {
     "id": "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE_OFFER_ADVICE_SCAN_LOCATION",
     "type": "talk_topic",
-    "dynamic_line": "Yes, this area is the source of the abnormal HEW recordings.  However, like other recordings, you don't need to be present for the full hour the recording runs - you can set up the station, leave, and come back later for the report."
+    "dynamic_line": "Yes, ideally.  However, like other recordings, you don't need to be present for the full hour the recording runs - you can set up the station, leave, and come back later for the report."
   },
   {
     "id": "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE_ACCEPTED",
     "type": "talk_topic",
-    "dynamic_line": "Excellent.  You'll meet the advanced team on the surface near your coordinates.  We expect the underground system to be quite dark, so we are prepared to sell you our field-issue recon helmet.  You may ask if interested.",
-    "speaker_effect": { "effect": [ { "u_add_var": "dialogue_intercom_u_hub_prototypes", "value": "yes" } ] }
+    "dynamic_line": "Excellent.  You'll meet the advanced team on the surface near your coordinates."
   },
   {
     "id": "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE_COMPLETE",
     "type": "talk_topic",
-    "dynamic_line": "The intercom's tray slides open and you deposit the report.  There is a brief silence, and then it opens with your payment.  \"You have our thanks and your payment.  It will take us some time for Research to digest this and the other field data, but perhaps we will have more contracts for you later.",
+    "dynamic_line": "The intercom's tray slides open and you deposit the report.  There is a brief silence, and then it opens with your payment.  \"You have our thanks and your payment.  It will take us some time for Research to digest this and the other field data, but perhaps we will have more related contracts for you later.",
     "responses": [ { "text": "Thank you.", "topic": "TALK_ROBOFAC_INTERCOM_SERVICES" } ]
   },
   {
@@ -1580,6 +1580,9 @@
     "goal": "MGOAL_NULL",
     "difficulty": 5,
     "value": 0,
+    "start": {
+      "effect": { "u_add_var": "dialogue_intercom_accepted_robofac_intercom_mws_4", "value": "yes" }
+    },
     "end": {
       "effect": [
         { "u_add_var": "dialogue_intercom_completed_robofac_intercom_mws_4", "value": "yes" },
@@ -1603,17 +1606,116 @@
   {
     "id": "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE",
     "type": "mission_definition",
-    "name": { "str": "Invasive \"Meteorolgoy\"" },
+    "name": { "str": "Invasive \"Meteorology\"" },
     "description": "Go to the underground coordinates, set up a mobile weather station, and make a recording.  You may wish to rendezvous with the advanced field team, if you can find them.",
     "goal": "MGOAL_NULL",
     "difficulty": 5,
     "value": 0,
+    "start": {
+      "assign_mission_target": {
+        "om_terrain": "corpse_bowels_mid",
+        "om_special": "nether_monster_corpse",
+        "reveal_radius": 1,
+        "random": false
+      }
+    },
     "end": {
       "effect": [
         { "u_spawn_item": "RobofacCoin", "count": 8 },
         { "u_add_var": "dialogue_intercom_completed_robofac_intercom_mws_monster_corpse", "value": "yes" },
         { "math": [ "u_hub01_completed_missions++" ] }
       ]
+    },
+    "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
+    "dialogue": {
+      "describe": "…",
+      "offer": "…",
+      "accepted": "…",
+      "rejected": "…",
+      "advice": "…",
+      "inquire": "…",
+      "success": "…",
+      "success_lie": "…",
+      "failure": "…"
+    }
+  },
+  {
+    "id": "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE_FIELD_TEAM",
+    "type": "mission_definition",
+    "name": { "str": "Invasive \"Meteorology:\" contact the field team" },
+    "//": "Place the field team here instead of at the entrance, just incase the rare Yrax spawns.  It'd be odd for them to be in the same place.",
+    "description": "A team of Hub 01 contractors is at work near the organic mass.  I can check in with them if I want to, but it isn't essential to my mission.",
+    "goal": "MGOAL_GO_TO_TYPE",
+    "destination": "corpse_surface",
+    "difficulty": 5,
+    "value": 0,
+    "start": {
+      "assign_mission_target": {
+        "om_terrain": "corpse_surface",
+        "om_special": "nether_monster_corpse",
+        "reveal_radius": 2,
+        "random": false
+      },
+      "update_mapgen": {
+        "rows": [
+          "                        ",
+          "                        ",
+          "                        ",
+          "   R                 R  ",
+          "                        ",
+          "                        ",
+          "                        ",
+          "                        ",
+          "                        ",
+          "                        ",
+          "                        ",
+          "                        ",
+          "                        ",
+          "                        ",
+          "                        ",
+          "                        ",
+          " %%%                    ",
+          " % %                    ",
+          " %%%                    ",
+          "WWWWW                   ",
+          "W..rW                   ",
+          "D.clW               R   ",
+          "W..tW                   ",
+          "WWWWW                   "
+        ],
+        "terrain": {
+          ".": "t_dirt",
+          "c": "t_dirt",
+          "r": "t_dirt",
+          "l": "t_dirt",
+          "t": "t_dirt",
+          "D": "t_dirt",
+          "W": "t_dirt",
+          "T": "t_dirt",
+          "%": "t_dirt"
+        },
+        "furniture": {
+          "W": "f_canvas_wall",
+          "D": "f_canvas_door_o",
+          "c": "f_camp_chair",
+          "r": "f_tourist_table",
+          "l": "f_tourist_table",
+          "t": "f_tourist_table",
+          "%": "f_sandbag_half"
+        },
+        "item": {
+          "r": { "item": "radio" },
+          "l": { "item": "laptop" },
+          "t": { "item": "emf_detector" }
+        },
+        "monster": { "R": { "monster": "mon_robofac_camspy" } },
+        "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+        "place_npcs": [
+          { "class": "robofac_merc_monster_corpse_1", "x": 2, "y": 21 },
+          { "class": "robofac_merc_monster_corpse_2", "x": 2, "y": 17 }
+        ]
+      }
     },
     "origins": [ "ORIGIN_SECONDARY" ],
     "has_generic_rewards": false,

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
@@ -1218,10 +1218,7 @@
         "text": "Any idea what I can expect?",
         "topic": "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE_OFFER_ADVICE_DANGERS"
       },
-      {
-        "text": "Field team?",
-        "topic": "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE_OFFER_ADVICE_FIELD_TEAM"
-      },
+      { "text": "Field team?", "topic": "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE_OFFER_ADVICE_FIELD_TEAM" },
       {
         "text": "Do I need to scan at these exact coordinates?",
         "topic": "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE_OFFER_ADVICE_SCAN_LOCATION"

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_prototypes.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_prototypes.json
@@ -207,7 +207,7 @@
         "condition": {
           "and": [
             { "u_has_items": { "item": "xedra_mobile_weather_station", "count": 1 } },
-            { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_mws_4" } ] },
+            { "compare_string": [ "yes", { "u_val": "dialogue_intercom_accepted_robofac_intercom_mws_4" } ] },
             { "math": [ "!has_var(u_dialogue_hub_rnd_u_project_ongoing)" ] },
             { "math": [ "!has_var(u_dialogue_hub_rnd_u_completed_mws)" ] }
           ]

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_trades.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_trades.json
@@ -634,7 +634,7 @@
   {
     "id": "TALK_ROBOFAC_INTERCOM_SELL_HEW_DATA_STRANGE_TEMPLE",
     "type": "talk_topic",
-    "dynamic_line": "You deposit the sheet in the tray.  After a long silence, the tray opens again, this time with a pile of twenty coins.  \"This is a very curious recording because it's for the most part normal.  However, the instruments detected one extremely dense resonance point.  Whatever this structure is, it houses something of extra-dimensional origins.\"",
+    "dynamic_line": "You deposit the sheet in the tray.  After a long silence, the tray opens again, this time with a pile of twenty coins.  \"This is a very curious recording.  For the most part it's normal.  However, the instruments detected one extremely dense resonance point.  Whatever this structure is, it houses something of extra-dimensional origins.\"",
     "speaker_effect": {
       "effect": [
         { "npc_add_var": "dialogue_intercom_accepted_HEW_recording", "value": "yes" },

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_trades.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_trades.json
@@ -425,7 +425,8 @@
       "TALK_ROBOFAC_INTERCOM_SELL_HEW_DATA_LABYRINTH",
       "TALK_ROBOFAC_INTERCOM_SELL_HEW_DATA_PHYSICS_LAB",
       "TALK_ROBOFAC_INTERCOM_SELL_HEW_DATA_AMIGARA",
-      "TALK_ROBOFAC_INTERCOM_SELL_HEW_DATA_RADIOSPHERE"
+      "TALK_ROBOFAC_INTERCOM_SELL_HEW_DATA_RADIOSPHERE",
+      "TALK_ROBOFAC_INTERCOM_SELL_HEW_DATA_MONSTER_CORPSE"
     ],
     "type": "talk_topic",
     "dynamic_line": "Excellent; please deposit the printouts in the intercom's tray.",
@@ -551,7 +552,7 @@
         },
         "effect": [
           { "u_consume_item": "HEW_printout_data_amigara", "count": 1, "popup": true },
-          { "math": [ "HEW_amigara_lab_data_sold++" ] },
+          { "math": [ "HEW_amigara_data_sold++" ] },
           { "u_spawn_item": "RobofacCoin", "count": 20 }
         ],
         "topic": "TALK_ROBOFAC_INTERCOM_SELL_HEW_DATA_AMIGARA"
@@ -566,10 +567,25 @@
         },
         "effect": [
           { "u_consume_item": "HEW_printout_data_radiosphere", "count": 1, "popup": true },
-          { "math": [ "HEW_radiosphere_lab_data_sold++" ] },
+          { "math": [ "HEW_radiosphere_data_sold++" ] },
           { "u_spawn_item": "RobofacCoin", "count": 20 }
         ],
         "topic": "TALK_ROBOFAC_INTERCOM_SELL_HEW_DATA_RADIOSPHERE"
+      },
+      {
+        "text": "[Deposit datasheet LKG1.]",
+        "condition": {
+          "and": [
+            { "u_has_items": { "item": "HEW_printout_data_monster_corpse", "count": 1 } },
+            { "math": [ "HEW_monster_corpse_data_sold < 1" ] }
+          ]
+        },
+        "effect": [
+          { "u_consume_item": "HEW_printout_data_monster_corpse", "count": 1, "popup": true },
+          { "math": [ "HEW_monster_corpse_data_sold++" ] },
+          { "u_spawn_item": "RobofacCoin", "count": 20 }
+        ],
+        "topic": "TALK_ROBOFAC_INTERCOM_SELL_HEW_DATA_MONSTER_CORPSE"
       },
       { "text": "That would be all.", "topic": "TALK_ROBOFAC_INTERCOM_SERVICES" }
     ]
@@ -685,6 +701,17 @@
     "id": "TALK_ROBOFAC_INTERCOM_SELL_HEW_DATA_RADIOSPHERE",
     "type": "talk_topic",
     "dynamic_line": "You deposit the sheet in the tray.  After a long silence, the tray opens again, this time with a pile of twenty coins.  \"Incredible - these are clearly non-Earth conditions!  What is strange is that there are a substantial number of man-made radio waves, but they all appear to be the same very high frequency radio waveform.  We will study these further.\"",
+    "speaker_effect": {
+      "effect": [
+        { "npc_add_var": "dialogue_intercom_accepted_HEW_recording", "value": "yes" },
+        { "finish_mission": "MISSION_ROBOFAC_INTERCOM_MWS_4", "success": true }
+      ]
+    }
+  },
+  {
+    "id": "TALK_ROBOFAC_INTERCOM_SELL_HEW_DATA_MONSTER_CORPSE",
+    "type": "talk_topic",
+    "dynamic_line": "You deposit the sheet in the tray.  After a long silence, the tray opens again, this time with a pile of twenty coins.  \"Curiously, this report indicates that there are alien volatile organic compounds in the area you recorded in, and hints that they have an underground origin.  We may be interested in contracting you for further investigation.  Ask of you are interested.\"",
     "speaker_effect": {
       "effect": [
         { "npc_add_var": "dialogue_intercom_accepted_HEW_recording", "value": "yes" },

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5795,7 +5795,7 @@ static void process_vehicle_items( vehicle &cur_veh, int part )
                 if( trig_dist( veh_position, closest_radiosphere ) <= 10 ) {
                     cur_veh.add_item( here, vp, item( itype_HEW_printout_data_radiosphere, calendar::turn_zero ) );
                 }
-                if( trig_dist( veh_position, closest_monster_corpse ) <= 1 ) {
+                if( trig_dist( veh_position, closest_monster_corpse ) < 1 ) {
                     cur_veh.add_item( here, vp, item( itype_mws_monster_corpse_weather_data, calendar::turn_zero ) );
                 } else if( trig_dist( veh_position, closest_monster_corpse ) <= 10 ) {
                     cur_veh.add_item( here, vp, item( itype_HEW_printout_data_monster_corpse, calendar::turn_zero ) );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -166,6 +166,7 @@ static const itype_id itype_HEW_printout_data_exodii( "HEW_printout_data_exodii"
 static const itype_id itype_HEW_printout_data_highlands( "HEW_printout_data_highlands" );
 static const itype_id itype_HEW_printout_data_labyrinth( "HEW_printout_data_labyrinth" );
 static const itype_id itype_HEW_printout_data_lixa( "HEW_printout_data_lixa" );
+static const itype_id itype_HEW_printout_data_monster_corpse( "HEW_printout_data_monster_corpse" );
 static const itype_id itype_HEW_printout_data_physics_lab( "HEW_printout_data_physics_lab" );
 static const itype_id itype_HEW_printout_data_portal_storm( "HEW_printout_data_portal_storm" );
 static const itype_id itype_HEW_printout_data_radiosphere( "HEW_printout_data_radiosphere" );
@@ -5764,6 +5765,8 @@ static void process_vehicle_items( vehicle &cur_veh, int part )
                         "mine_amigara_finale_central", 10, false );
                 const tripoint_abs_omt closest_radiosphere = overmap_buffer.find_closest( veh_position,
                         "radiosphere_radio_tower_top", 10, false );
+                const tripoint_abs_omt closest_monster_corpse = overmap_buffer.find_closest( veh_position,
+                        "corpse_brain", 10, false );
                 if( trig_dist( veh_position, closest_vitrified_farm ) <= 10 ) {
                     cur_veh.add_item( here, vp, item( itype_HEW_printout_data_vitrified, calendar::turn_zero ) );
                 }
@@ -5790,6 +5793,9 @@ static void process_vehicle_items( vehicle &cur_veh, int part )
                 }
                 if( trig_dist( veh_position, closest_radiosphere ) <= 10 ) {
                     cur_veh.add_item( here, vp, item( itype_HEW_printout_data_radiosphere, calendar::turn_zero ) );
+                }
+                if( trig_dist( veh_position, closest_monster_corpse ) <= 10 ) {
+                    cur_veh.add_item( here, vp, item( itype_HEW_printout_data_monster_corpse, calendar::turn_zero ) );
                 }
             }
         }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5767,7 +5767,7 @@ static void process_vehicle_items( vehicle &cur_veh, int part )
                 const tripoint_abs_omt closest_radiosphere = overmap_buffer.find_closest( veh_position,
                         "radiosphere_radio_tower_top", 10, false );
                 const tripoint_abs_omt closest_monster_corpse = overmap_buffer.find_closest( veh_position,
-                        "corpse_brain", 10, false );
+                        "corpse_bowels_mid", 10, false );
                 if( trig_dist( veh_position, closest_vitrified_farm ) <= 10 ) {
                     cur_veh.add_item( here, vp, item( itype_HEW_printout_data_vitrified, calendar::turn_zero ) );
                 }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5797,8 +5797,7 @@ static void process_vehicle_items( vehicle &cur_veh, int part )
                 }
                 if( trig_dist( veh_position, closest_monster_corpse ) <= 1 ) {
                     cur_veh.add_item( here, vp, item( itype_mws_monster_corpse_weather_data, calendar::turn_zero ) );
-                }
-                else if( trig_dist( veh_position, closest_monster_corpse ) <= 10 ) {
+                } else if( trig_dist( veh_position, closest_monster_corpse ) <= 10 ) {
                     cur_veh.add_item( here, vp, item( itype_HEW_printout_data_monster_corpse, calendar::turn_zero ) );
                 }
             }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -174,6 +174,7 @@ static const itype_id itype_HEW_printout_data_strange_temple( "HEW_printout_data
 static const itype_id itype_HEW_printout_data_vitrified( "HEW_printout_data_vitrified" );
 static const itype_id itype_battery( "battery" );
 static const itype_id itype_maple_sap( "maple_sap" );
+static const itype_id itype_mws_monster_corpse_weather_data( "mws_monster_corpse_weather_data" );
 static const itype_id itype_mws_portal_storm_weather_data( "mws_portal_storm_weather_data" );
 static const itype_id itype_mws_weather_data( "mws_weather_data" );
 static const itype_id itype_mws_weather_data_incomplete( "mws_weather_data_incomplete" );
@@ -5794,7 +5795,10 @@ static void process_vehicle_items( vehicle &cur_veh, int part )
                 if( trig_dist( veh_position, closest_radiosphere ) <= 10 ) {
                     cur_veh.add_item( here, vp, item( itype_HEW_printout_data_radiosphere, calendar::turn_zero ) );
                 }
-                if( trig_dist( veh_position, closest_monster_corpse ) <= 10 ) {
+                if( trig_dist( veh_position, closest_monster_corpse ) <= 1 ) {
+                    cur_veh.add_item( here, vp, item( itype_mws_monster_corpse_weather_data, calendar::turn_zero ) );
+                }
+                else if( trig_dist( veh_position, closest_monster_corpse ) <= 10 ) {
                     cur_veh.add_item( here, vp, item( itype_HEW_printout_data_monster_corpse, calendar::turn_zero ) );
                 }
             }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "New Hub 01 quest - Invasive 'Meteorology'"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I really love the giant monster corpse, and I also like that there isn't anything "useful" inside, so to speak.  But this also means that, outside of exploration, there isn't much motivation to visit.  It also seems clear to me that at least the Hub would be interested in this thing and its alien biology.  Following the implementation of mobile weather stations in #84226 and #84309 I thought there was an opportunity for a new Hub 01 quest pointing to the corpse.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

After starting the 5th weather mission for Hub 01 ("True Weatherperson"), the survivor is able to sell the Hub printouts from their Hazardous Environment Weather station.  They've previously been able to scan a short list of nether and extra-dimensional places and get some flavor text.  This PR adds the ability to scan near the giant monster corpse, which will reveal alien volatile organic compounds.  Upon selling this HEW report to the Hub, they'll offer a new mission to take a station deep into the bowels of the creature and scan its internal atmosphere.

Upon accepting, a forward team of a 2 hub mercs will set up shop near the monster corpse (to do surface and subsurface scans).  Visiting them is optional.  They'll give the survivor a little blurb about how it looks like a squid, and offer to sell them a PAPR and a hub helmet.

_The forward team setup near one part of the monster corpse_
<img width="666" height="570" alt="image" src="https://github.com/user-attachments/assets/8da509dc-d38f-495d-b32c-d8439b786314" />

The survivor needs to enter the bowel overmap tiles, set up a mobile weather station, and perform a 1 hour recording. They then return the recording to the Hub for a coin reward.

_The datasheet_
<img width="635" height="342" alt="image" src="https://github.com/user-attachments/assets/b159e175-3bc6-4277-9166-c742f3c2beeb" />

This could hypothetically be the start of a new science quest chain that moves away from weather/portal storms and into alien biology/biochemistry.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Not doing this.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Ran through the quest line from start to finish. Debug started the quest several times to make sure the forward team special was properly placed.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

In parallel, I also fixed a bug that prevented survivors from selling HEW reports.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
