### PR TITLE
Do not render non-zombies on map when showing horde

### DIFF
--- a/src/horde_map.cpp
+++ b/src/horde_map.cpp
@@ -68,7 +68,7 @@ horde_entity *horde_map::entity_at( const tripoint_om_ms &p )
 
 // TODO: if callers want to filter for dormant vs idle vs active, etc we can do it cheaply.
 std::vector < std::unordered_map<tripoint_abs_ms, horde_entity> *> horde_map::entity_group_at(
-    const tripoint_om_omt &p )
+    const tripoint_om_omt &p, int filter )
 {
     // TODO: It might be worthwhile to have a single top level map of per-submap containers,
     // and each entry of that map holds each variant container.
@@ -79,33 +79,44 @@ std::vector < std::unordered_map<tripoint_abs_ms, horde_entity> *> horde_map::en
         for( int x = 0; x <= 1; ++x ) {
             tripoint_om_sm target_submap = project_to<coords::sm>( p ) + point{ x, y };
             std::vector<std::unordered_map<tripoint_abs_ms, horde_entity> *> submap_of_hordes =
-                entity_group_at( target_submap );
+                entity_group_at( target_submap, filter );
             horde_chunk.insert( horde_chunk.end(), submap_of_hordes.begin(), submap_of_hordes.end() );
         }
     }
     return horde_chunk;
 }
 
-// TODO: if callers want to filter for dormant vs idle vs active, etc we can do it cheaply.
 std::vector<std::unordered_map<tripoint_abs_ms, horde_entity> *> horde_map::entity_group_at(
-    const tripoint_om_sm &p )
+    const tripoint_om_sm &p, int filter )
 {
     std::vector<std::unordered_map<tripoint_abs_ms, horde_entity>*> horde_chunk;
-    auto active_monster_map_iter = active_monster_map.find( p );
-    if( active_monster_map_iter != active_monster_map.end() ) {
-        horde_chunk.push_back( &active_monster_map_iter->second );
+
+    if( filter & horde_map_flavors::active ) {
+        auto active_monster_map_iter = active_monster_map.find( p );
+        if( active_monster_map_iter != active_monster_map.end() ) {
+            horde_chunk.push_back( &active_monster_map_iter->second );
+        }
     }
-    auto idle_monster_map_iter = idle_monster_map.find( p );
-    if( idle_monster_map_iter != idle_monster_map.end() ) {
-        horde_chunk.push_back( &idle_monster_map_iter->second );
+
+    if( filter & horde_map_flavors::idle ) {
+        auto idle_monster_map_iter = idle_monster_map.find( p );
+        if( idle_monster_map_iter != idle_monster_map.end() ) {
+            horde_chunk.push_back( &idle_monster_map_iter->second );
+        }
     }
-    auto dormant_monster_map_iter = dormant_monster_map.find( p );
-    if( dormant_monster_map_iter != dormant_monster_map.end() ) {
-        horde_chunk.push_back( &dormant_monster_map_iter->second );
+
+    if( filter & horde_map_flavors::dormant ) {
+        auto dormant_monster_map_iter = dormant_monster_map.find( p );
+        if( dormant_monster_map_iter != dormant_monster_map.end() ) {
+            horde_chunk.push_back( &dormant_monster_map_iter->second );
+        }
     }
-    auto immobile_monster_map_iter = immobile_monster_map.find( p );
-    if( immobile_monster_map_iter != immobile_monster_map.end() ) {
-        horde_chunk.push_back( &immobile_monster_map_iter->second );
+
+    if( filter & horde_map_flavors::immobile ) {
+        auto immobile_monster_map_iter = immobile_monster_map.find( p );
+        if( immobile_monster_map_iter != immobile_monster_map.end() ) {
+            horde_chunk.push_back( &immobile_monster_map_iter->second );
+        }
     }
     return horde_chunk;
 }

--- a/src/horde_map.h
+++ b/src/horde_map.h
@@ -57,10 +57,12 @@ class horde_map
             return location;
         }
         horde_entity *entity_at( const tripoint_om_ms &p );
-        std::vector < std::unordered_map<tripoint_abs_ms, horde_entity>*> entity_group_at(
-            const tripoint_om_omt &p );
-        std::vector<std::unordered_map<tripoint_abs_ms, horde_entity> *>entity_group_at(
-            const tripoint_om_sm &p );
+        std::vector<std::unordered_map<tripoint_abs_ms, horde_entity>*> entity_group_at(
+            const tripoint_om_omt &p, int filter = horde_map_flavors::active | horde_map_flavors::idle |
+                    horde_map_flavors::dormant | horde_map_flavors::immobile );
+        std::vector<std::unordered_map<tripoint_abs_ms, horde_entity>*> entity_group_at(
+            const tripoint_om_sm &p, int filter = horde_map_flavors::active | horde_map_flavors::idle |
+                    horde_map_flavors::dormant | horde_map_flavors::immobile );
         std::unordered_map<tripoint_abs_ms, horde_entity>::iterator
         spawn_entity( const tripoint_abs_ms &p, mtype_id id );
         std::unordered_map<tripoint_abs_ms, horde_entity>::iterator spawn_entity( const tripoint_abs_ms &p,

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -1729,12 +1729,11 @@ horde_entity *overmap::entity_at( const tripoint_om_ms &p )
     return hordes.entity_at( p );
 }
 
-
 // This should really be const but I don't want to mess with it right now.
 std::vector<std::unordered_map<tripoint_abs_ms, horde_entity>*> overmap::hordes_at(
-    const tripoint_om_omt &p )
+    const tripoint_om_omt &p, int filter )
 {
-    return hordes.entity_group_at( p );
+    return hordes.entity_group_at( p, filter );
 }
 
 /**

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -536,7 +536,8 @@ class overmap
         void spawn_mongroup( const tripoint_om_sm &p, const mongroup_id &type, int count );
         horde_entity *entity_at( const tripoint_om_ms &p );
         std::vector<std::unordered_map<tripoint_abs_ms, horde_entity>*> hordes_at(
-            const tripoint_om_omt &p );
+            const tripoint_om_omt &p, int filter );
+
         /**
          * Getter for overmap scents.
          * @returns a reference to a scent_trace from the requested location.

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -512,11 +512,11 @@ bool overmapbuffer::has_horde( const tripoint_abs_omt &p )
     return false;
 }
 
-int overmapbuffer::get_horde_size( const tripoint_abs_omt &p )
+int overmapbuffer::get_horde_size( const tripoint_abs_omt &p, int filter )
 {
     int horde_size = 0;
     std::vector<std::unordered_map<tripoint_abs_ms, horde_entity>*> hordes = overmap_buffer.hordes_at(
-                p );
+                p, filter );
     for( std::unordered_map<tripoint_abs_ms, horde_entity> *horde_group : hordes ) {
         horde_size += horde_group->size();
     }
@@ -2135,15 +2135,14 @@ horde_entity *overmapbuffer::entity_at( const tripoint_abs_ms &p )
 }
 
 std::vector<std::unordered_map<tripoint_abs_ms, horde_entity>*> overmapbuffer::hordes_at(
-    const tripoint_abs_omt &p )
+    const tripoint_abs_omt &p, int filter )
 {
     point_abs_om omp;
     tripoint_om_omt omt;
     std::tie( omp, omt ) = project_remain<coords::om>( p );
     overmap &om = get( omp );
-    return om.hordes_at( omt );
+    return om.hordes_at( omt, filter );
 }
-
 
 horde_entity &overmapbuffer::spawn_monster( const tripoint_abs_ms &p, mtype_id id )
 {

--- a/src/overmapbuffer.h
+++ b/src/overmapbuffer.h
@@ -19,6 +19,7 @@
 #include "cata_path.h"
 #include "coordinates.h"
 #include "enums.h"
+#include "horde_map.h"
 #include "map_scale_constants.h"
 #include "memory_fast.h"
 #include "overmap.h"
@@ -244,7 +245,8 @@ class overmapbuffer
         bool has_camp( const tripoint_abs_omt &p );
         bool has_vehicle( const tripoint_abs_omt &p );
         bool has_horde( const tripoint_abs_omt &p );
-        int get_horde_size( const tripoint_abs_omt &p );
+        int get_horde_size( const tripoint_abs_omt &p, int filter = horde_map_flavors::active |
+                            horde_map_flavors::idle | horde_map_flavors::dormant | horde_map_flavors::immobile );
         std::vector<om_vehicle> get_vehicle( const tripoint_abs_omt &p );
         std::string get_vehicle_ter_sym( const tripoint_abs_omt &omt );
         std::string get_vehicle_tile_id( const tripoint_abs_omt &omt );
@@ -554,7 +556,8 @@ class overmapbuffer
         void spawn_mongroup( const tripoint_abs_sm &p, const mongroup_id &type, int count );
         horde_entity *entity_at( const tripoint_abs_ms &p );
         std::vector<std::unordered_map<tripoint_abs_ms, horde_entity>*> hordes_at(
-            const tripoint_abs_omt &p );
+            const tripoint_abs_omt &p, int filter = horde_map_flavors::active | horde_map_flavors::idle |
+                    horde_map_flavors::dormant | horde_map_flavors::immobile );
         /**
          * Find radio station with given frequency, search an unspecified area around
          * the current player location.

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -890,7 +890,7 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
                     }
                 }
                 if( showhordes && los ) {
-                    const int horde_size = overmap_buffer.get_horde_size( omp );
+                    const int horde_size = overmap_buffer.get_horde_size( omp, horde_map_flavors::active );
                     if( horde_size >= HORDE_VISIBILITY_SIZE ) {
                         // Scale down the range of horde population, which can be 1-576 to a range of 1-10
                         // These thresholds are generated with pow( sprite_size, 2.4 ).


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fix #84050
#### Describe the solution
Pass `filter` int/bitwise enum to function that counts horde size, so we check only monsters in `active` horde bucket
Also clean up a check that places marker
#### Testing
~~It worked, i promise, but then at some point it stopped, and no monster is inserted into hordes anymore???~~ it's because i checked ASCII map, but then checked to tileset map, but apparently tileset map uses different code to check for it

Before:
<img width="2115" height="1366" alt="image" src="https://github.com/user-attachments/assets/6f7e9365-a6cd-49d4-9785-3716aca0eb0a" />

After:
<img width="497" height="427" alt="image" src="https://github.com/user-attachments/assets/c7a02726-ec7b-40e1-b2ea-29d1cd9e9179" />

<img width="744" height="538" alt="image" src="https://github.com/user-attachments/assets/51cb3a14-bfaa-40d9-a62f-4bfba19809fe" />
