### PR TITLE
Exodii (nomad) bionic-powered air purifying respirator

### DIFF
--- a/data/json/items/armor/bespoke_armor/custom_headgear.json
+++ b/data/json/items/armor/bespoke_armor/custom_headgear.json
@@ -545,5 +545,66 @@
     "name": { "str": "scavenger cowl" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
     "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
+  },
+  {
+    "id": "helmet_nomad_papr",
+    "type": "ITEM",
+    "subtypes": [ "TOOL", "ARMOR" ],
+    "name": { "str": "advanced nomad cowl" },
+    "description": "A denim cowl with additional leather padding stitched onto the head with integrated protection from a sun brim, a plastic face-shield sealed with rubber gaskets, a filter cartridge intake, and several rubber-tube connections for a powered air purifying respirator system, all designed for long travels.  The design includes some clever shaping that allows it to offer a lot of coverage without interfering too much with vision and breathing.",
+    "weight": "600 g",
+    "volume": "2500 ml",
+    "price_postapoc": "4 USD 50 cent",
+    "material": [ "denim", "leather", "plastic" ],
+    "symbol": "[",
+    "looks_like": "balclava",
+    "color": "white",
+    "armor": [
+      {
+        "material": [
+          { "type": "denim", "covered_by_mat": 100, "thickness": 2.0 },
+          { "type": "leather", "covered_by_mat": 100, "thickness": 1.5 }
+        ],
+        "covers": [ "head" ],
+        "specifically_covers": [ "head_crown", "head_nape", "head_ear_l", "head_ear_r", "head_forehead" ],
+        "coverage": 100,
+        "encumbrance": 20
+      },
+      {
+        "material": [ { "type": "denim", "covered_by_mat": 100, "thickness": 2.0 } ],
+        "covers": [ "head" ],
+        "specifically_covers": [ "head_throat" ],
+        "coverage": 100,
+        "encumbrance": 0
+      },
+      {
+        "material": [ { "type": "plastic", "covered_by_mat": 100, "thickness": 2.0 } ],
+        "covers": [ "eyes" ],
+        "coverage": 100,
+        "encumbrance": 5
+      },
+      {
+        "material": [ { "type": "plastic", "covered_by_mat": 100, "thickness": 2.0 } ],
+        "covers": [ "mouth" ],
+        "coverage": 100,
+        "encumbrance": 3
+      }
+    ],
+    "warmth": 10,
+    "material_thickness": 3,
+    "environmental_protection": 4,
+    "environmental_protection_with_filter": 16,
+    "pocket_data": [
+      {
+        "pocket_type": "MAGAZINE_WELL",
+        "rigid": true,
+        "flag_restriction": [ "GASFILTER_SM" ],
+        "default_magazine": "gasfilter_sm"
+      }
+    ],
+    "use_action": [ "GASMASK_ACTIVATE" ],
+    "tick_action": [ "GASMASK" ],
+    "flags": [ "VARSIZE", "SUN_GLASSES", "RAINPROOF", "PADDED", "SLEEP_IGNORE", "PAPR_MASK" ],
+    "tool_ammo": "gasfilter_s"
   }
 ]

--- a/data/json/items/armor/bespoke_armor/utility.json
+++ b/data/json/items/armor/bespoke_armor/utility.json
@@ -268,6 +268,7 @@
     ],
     "tool_ammo": [ "battery" ],
     "use_action": [
+      { "type": "holster", "holster_prompt": "Store item", "holster_msg": "You put your %1$s in your %2$s" },
       {
         "type": "holster",
         "holster_prompt": "Store item",

--- a/data/json/items/armor/bespoke_armor/utility.json
+++ b/data/json/items/armor/bespoke_armor/utility.json
@@ -270,16 +270,11 @@
     "use_action": [
       { "type": "holster", "holster_prompt": "Store item", "holster_msg": "You put your %1$s in your %2$s" },
       {
-        "type": "holster",
-        "holster_prompt": "Store item",
-        "holster_msg": "You put your %1$s in your %2$s"
-      },
-      {
-      "menu_text": "Turn off",
-      "type": "transform",
-      "msg": "You turn the PAPR blower on the %s off.",
-      "target": "nomad_papr_blower_273diyua_off",
-      "ammo_scale": 0
+        "menu_text": "Turn off",
+        "type": "transform",
+        "msg": "You turn the PAPR blower on the %s off.",
+        "target": "nomad_papr_blower_273diyua_off",
+        "ammo_scale": 0
       }
     ],
     "power_draw": "4000 mW",

--- a/data/json/items/armor/bespoke_armor/utility.json
+++ b/data/json/items/armor/bespoke_armor/utility.json
@@ -199,5 +199,103 @@
     "name": { "str": "survivor harness", "str_pl": "survivor harnesses" },
     "proportional": { "weight": 0.75, "volume": 0.75, "price": 0.5 },
     "extend": { "flags": [ "UNDERSIZE", "PREFIX_XS" ] }
+  },
+  {
+    "id": "nomad_papr_blower_273diyua_off",
+    "//": "The exodii PAPR, with space for a baselard and handcanon shells",
+    "type": "ITEM",
+    "subtypes": [ "ARMOR", "TOOL" ],
+    "name": { "str": "nomad utility belt" },
+    "description": "A sturdy leather belt and powered air purifying respirator blower designed for exploring the apocalyptic wasteland.  On one side hangs an archaic dagger sheath.  The other side is lined with 10 cartridge loops fit for 27.3x110 Diyua shells.  Mounted to the back is a spartan PAPR blower, shielded in plastic, with connections for a bionic interface.  Paired with a PAPR mask this will protect from all manner of post-apocalyptic environmental threats.  Activate it to turn it on.",
+    "weight": "1549 g",
+    "volume": "2250 ml",
+    "price": "150 USD",
+    "price_postapoc": "25 USD",
+    "material": [ "leather" ],
+    "symbol": "[",
+    "looks_like": "holster",
+    "color": "brown",
+    "material_thickness": 2,
+    "pocket_data": [
+      {
+        "holster": true,
+        "max_contains_volume": "1 L",
+        "max_contains_weight": "2 kg",
+        "max_item_length": "70 cm",
+        "moves": 20,
+        "flag_restriction": [ "SHEATH_KNIFE" ]
+      },
+      {
+        "ammo_restriction": { "273x110": 10 },
+        "moves": 25,
+        "volume_encumber_modifier": 0.3
+      }
+    ],
+    "tool_ammo": [ "battery" ],
+    "use_action": [
+      {
+        "type": "holster",
+        "holster_prompt": "Store item",
+        "holster_msg": "You put your %1$s in your %2$s"
+      },
+      {
+        "type": "transform",
+        "msg": "You activate the PAPR blower on your %s.",
+        "target": "nomad_papr_blower_273diyua_on"
+      }
+    ],
+    "flags": [ "WATER_FRIENDLY", "STURDY", "BELTED", "OVERSIZE", "USES_BIONIC_POWER" ],
+    "armor": [ { "encumbrance": [ 2, 6 ], "coverage": 100, "covers": [ "torso" ], "specifically_covers": [ "torso_waist" ] } ]
+  },
+  {
+    "id": "nomad_papr_blower_273diyua_on",
+    "//": "The exodii PAPR, with space for a baselard and handcanon shells",
+    "type": "ITEM",
+    "subtypes": [ "ARMOR", "TOOL" ],
+    "name": { "str": "nomad utility belt (on)", "str_pl": "nomad utility belts (on)" },
+    "description": "A sturdy leather belt and powered air purifying respirator blower designed for exploring the apocalyptic wasteland.  On one side hangs an archaic dagger sheath.  The other side is lined with 10 cartridge loops fit for 27.3x110 Diyua shells.  Mounted to the back is a spartan PAPR blower, shielded in plastic, with connections for a bionic interface.  Paired with a PAPR mask this will protect from all manner of post-apocalyptic environmental threats.  Activate it to turn it on.",
+    "weight": "1549 g",
+    "volume": "2250 ml",
+    "price": "150 USD",
+    "price_postapoc": "25 USD",
+    "material": [ "leather", "plastic" ],
+    "symbol": "[",
+    "looks_like": "holster",
+    "color": "brown",
+    "material_thickness": 2,
+    "pocket_data": [
+      {
+        "holster": true,
+        "max_contains_volume": "1 L",
+        "max_contains_weight": "2 kg",
+        "max_item_length": "70 cm",
+        "moves": 20,
+        "flag_restriction": [ "SHEATH_KNIFE" ]
+      },
+      {
+        "ammo_restriction": { "273x110": 10 },
+        "moves": 25,
+        "volume_encumber_modifier": 0.3
+      }
+    ],
+    "tool_ammo": [ "battery" ],
+    "use_action": [
+      {
+        "type": "holster",
+        "holster_prompt": "Store item",
+        "holster_msg": "You put your %1$s in your %2$s"
+      },
+      {
+      "menu_text": "Turn off",
+      "type": "transform",
+      "msg": "You turn the PAPR blower on the %s off.",
+      "target": "nomad_papr_blower_273diyua_off",
+      "ammo_scale": 0
+      }
+    ],
+    "power_draw": "4000 mW",
+    "revert_to": "nomad_papr_blower_273diyua_off",
+    "flags": [ "WATER_FRIENDLY", "STURDY", "BELTED", "OVERSIZE", "USES_BIONIC_POWER", "PAPR_BLOWER", "TRADER_AVOID", "SPAWN_ACTIVE" ],
+    "armor": [ { "encumbrance": [ 2, 6 ], "coverage": 100, "covers": [ "torso" ], "specifically_covers": [ "torso_waist" ] } ]
   }
 ]

--- a/data/json/items/armor/bespoke_armor/utility.json
+++ b/data/json/items/armor/bespoke_armor/utility.json
@@ -229,11 +229,7 @@
     ],
     "tool_ammo": [ "battery" ],
     "use_action": [
-      {
-        "type": "holster",
-        "holster_prompt": "Store item",
-        "holster_msg": "You put your %1$s in your %2$s"
-      },
+      { "type": "holster", "holster_prompt": "Store item", "holster_msg": "You put your %1$s in your %2$s" },
       {
         "type": "transform",
         "msg": "You activate the PAPR blower on your %s.",

--- a/data/json/items/armor/bespoke_armor/utility.json
+++ b/data/json/items/armor/bespoke_armor/utility.json
@@ -225,11 +225,7 @@
         "moves": 20,
         "flag_restriction": [ "SHEATH_KNIFE" ]
       },
-      {
-        "ammo_restriction": { "273x110": 10 },
-        "moves": 25,
-        "volume_encumber_modifier": 0.3
-      }
+      { "ammo_restriction": { "273x110": 10 }, "moves": 25, "volume_encumber_modifier": 0.3 }
     ],
     "tool_ammo": [ "battery" ],
     "use_action": [

--- a/data/json/items/armor/bespoke_armor/utility.json
+++ b/data/json/items/armor/bespoke_armor/utility.json
@@ -264,11 +264,7 @@
         "moves": 20,
         "flag_restriction": [ "SHEATH_KNIFE" ]
       },
-      {
-        "ammo_restriction": { "273x110": 10 },
-        "moves": 25,
-        "volume_encumber_modifier": 0.3
-      }
+      { "ammo_restriction": { "273x110": 10 }, "moves": 25, "volume_encumber_modifier": 0.3 }
     ],
     "tool_ammo": [ "battery" ],
     "use_action": [

--- a/data/json/recipes/armor/bespoke_armor/nomad.json
+++ b/data/json/recipes/armor/bespoke_armor/nomad.json
@@ -258,5 +258,34 @@
     ],
     "byproducts": [ [ "scrap_leather", 11 ] ],
     "flags": [ "SECRET" ]
+  },
+  {
+    "result": "helmet_nomad_papr",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_HEAD",
+    "skill_used": "tailor",
+    "skills_required": [ "electronics", 3 ],
+    "difficulty": 5,
+    "time": "5 h",
+    "book_learn": [ [ "bp_nomad_cowl", 4 ] ],
+    "using": [ [ "filament_canvas", 80 ], [ "fastener_small", 4 ], [ "soldering_standard", 10 ] ],
+    "qualities": [ { "id": "LEATHER_AWL", "level": 1 }, { "id": "SEW", "level": 2 }, { "id": "FABRIC_CUT", "level": 1 } ],
+    "components": [
+      [ [ "hat_ball", 1 ], [ "hat_boonie", 1 ], [ "hat_golf", 1 ] ],
+      [ [ "hose", 4 ] ],
+      [ [ "helmet_motor", 1 ], [ "basic_papr_helmet", 1 ], [ "divemask_full_modular", 1 ], [ "face_shield_plastic", 2 ], [ "flight_helmet", 1 ] ],
+      [ [ "leather", 8 ], [ "tanned_hide", 2 ], [ "sheet_leather", 2 ], [ "sheet_leather_patchwork", 2 ] ],
+      [ [ "chunk_rubber", 16 ] ],
+      [ [ "sheet_denim", 10 ], [ "sheet_denim_patchwork", 10 ] ]
+    ],
+    "proficiencies": [
+      { "proficiency": "prof_leatherworking_basic" },
+      { "proficiency": "prof_leatherworking" },
+      { "proficiency": "prof_closures_waterproofing" },
+      { "proficiency": "prof_closures" }
+    ],
+    "flags": [ "SECRET" ]
   }
 ]

--- a/data/json/recipes/armor/bespoke_armor/nomad.json
+++ b/data/json/recipes/armor/bespoke_armor/nomad.json
@@ -275,7 +275,13 @@
     "components": [
       [ [ "hat_ball", 1 ], [ "hat_boonie", 1 ], [ "hat_golf", 1 ] ],
       [ [ "hose", 4 ] ],
-      [ [ "helmet_motor", 1 ], [ "basic_papr_helmet", 1 ], [ "divemask_full_modular", 1 ], [ "face_shield_plastic", 2 ], [ "flight_helmet", 1 ] ],
+      [
+        [ "helmet_motor", 1 ],
+        [ "basic_papr_helmet", 1 ],
+        [ "divemask_full_modular", 1 ],
+        [ "face_shield_plastic", 2 ],
+        [ "flight_helmet", 1 ]
+      ],
       [ [ "leather", 8 ], [ "tanned_hide", 2 ], [ "sheet_leather", 2 ], [ "sheet_leather_patchwork", 2 ] ],
       [ [ "chunk_rubber", 16 ] ],
       [ [ "sheet_denim", 10 ], [ "sheet_denim_patchwork", 10 ] ]

--- a/data/json/recipes/armor/bespoke_armor/nomad.json
+++ b/data/json/recipes/armor/bespoke_armor/nomad.json
@@ -229,5 +229,34 @@
     "components": [ [ [ "chunk_rubber", 2 ] ], [ [ "thread_kevlar", 20 ] ], [ [ "glue_weak", 500 ] ] ],
     "flags": [ "SECRET" ],
     "byproducts": [ [ "scrap_cotton", 5 ], [ "scrap_lycra", 4 ] ]
+  },
+  {
+    "result": "nomad_papr_blower_273diyua_off",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_STORAGE",
+    "activity_level": "LIGHT_EXERCISE",
+    "skill_used": "tailor",
+    "difficulty": 6,
+    "skills_required": [ "electronics", 3 ],
+    "time": "5 h",
+    "book_learn": [ [ "bp_nomad_jumpsuit", 4 ] ],
+    "using": [ [ "filament_canvas", 150 ], [ "soldering_standard", 10 ] ],
+    "proficiencies": [
+      { "proficiency": "prof_leatherworking_basic" },
+      { "proficiency": "prof_leatherworking" },
+      { "proficiency": "prof_closures_waterproofing" }
+    ],
+    "qualities": [ { "id": "LEATHER_AWL", "level": 1 }, { "id": "SEW", "level": 2 }, { "id": "FABRIC_CUT", "level": 1 } ],
+    "components": [
+      [ [ "leather", 4 ], [ "tanned_hide", 1 ], [ "sheet_leather", 1 ], [ "sheet_leather_patchwork", 1 ] ],
+      [ [ "sheath", 1 ] ],
+      [ [ "exodii_wire_kit", 1 ] ],
+      [ [ "basic_papr_belt_off", 1 ], [ "military_papr_blower_off", 1 ], [ "molle_papr_blower_off", 1 ] ],
+      [ [ "plastic_sheet", 2 ] ],
+      [ [ "tool_belt", 1 ] ]
+    ],
+    "byproducts": [ [ "scrap_leather", 11 ] ],
+    "flags": [ "SECRET" ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "New exodii powered respirator gear and recipes"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Following #84355 and #84366 which introduced and expanded powered air purifying respirators, I was wondering if any factions would make their own.  Most factions would probably utilize existing models.  The Exodii, however? I think they need some love.  They'd definitely fabricate some cool stuff that runs on the bionic interface, which isn't currently an option in other PAPR gear.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Two new items:

_nomad utility belt_: a sick leather belt with a PAPR blower powered by the bionic interface, a sheath sized big enough for a baselard, and cartridge loops for the massive 26.3x110 Diyua shells. Perfect for the inter-dimensional nomad on the go.  The recipe is included alongside the nomad harness in the existing blueprint item.

_advanced nomad cowl_: a variation of the existing cowl with a PAPR system.  It's basically identical except it has lower mouth encumbrance and lower heat, but like all PAPR requires an active blower to filter air (like the one on the utility belt, but any will do). The recipe is included alongside the cowl in the existing blueprint item.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

not making these.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

spawned, crafted, tested functionality and cross functionality with CBM power.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
_cowl_
<img width="1020" height="837" alt="cowl-blueprint" src="https://github.com/user-attachments/assets/8a50397a-041f-4de3-932d-12fa5a13e4c1" />

_belt_
<img width="1026" height="761" alt="belt-blueprint" src="https://github.com/user-attachments/assets/72f4750c-8404-4975-b4b5-8d3313e3ef89" />

<s>The belt currently holds ten 26.3x110 shells.  I think this might be slightly absurd, but it seemed a very Exodii thing to do, so I'd be very grateful for a sanity check there.</s> Actually, I did some quick math.

_Average waist size in the US:_ ~100.5 cm (https://www.cdc.gov/nchs/fastats/body-measurements.htm)
_Width of an example baselard:_ ~2.9 cm at widest (http://myarmoury.com/review_tod_bwbaselard.html#:~:text=Several%20surviving%20pieces%20can%20be%20found%20in,much%20underrepresented%20on%20the%20reproduction%20market%20today.)
_Common PAPR blower unit width:_ ~29cm (https://multimedia.3m.com/mws/media/774951O/3m-versaflo-tr-300-papr-assemblies-technical-specifications.pdf)

This leaves ~68.6 cm for shell loops (i.e, if packed tight, the belt could actually hold 25 shells at diameter 27.3mm/ea).  I think 10 is a good number, to account for spacing between items for weight balance, buckle, the fact survivors are probably skinnier on average, etc.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
