### PR TITLE
Add tests for overmap flag string consistency and location flags

### DIFF
--- a/src/overmap_location.cpp
+++ b/src/overmap_location.cpp
@@ -96,6 +96,11 @@ void overmap_locations::reset()
     locations.reset();
 }
 
+const std::vector<overmap_location> &overmap_locations::get_all()
+{
+    return locations.get_all();
+}
+
 void overmap_locations::finalize()
 {
     locations.finalize();

--- a/src/overmap_location.h
+++ b/src/overmap_location.h
@@ -24,6 +24,9 @@ struct overmap_location {
         // Test if oter meets the terrain restrictions.
         bool test( const int_id<oter_t> &oter ) const;
         const TerrColType &get_all_terrains() const;
+        const std::vector<std::string> &get_flags() const {
+            return flags;
+        }
         oter_type_id get_random_terrain() const;
 
         // Used by generic_factory
@@ -43,6 +46,7 @@ void load( const JsonObject &jo, const std::string &src );
 void check_consistency();
 void reset();
 void finalize();
+const std::vector<overmap_location> &get_all();
 
 } // namespace overmap_locations
 

--- a/tests/item_pocket_test.cpp
+++ b/tests/item_pocket_test.cpp
@@ -50,8 +50,8 @@
 #include "value_ptr.h"
 #include "weather.h"
 
-static const ammotype ammo_test_9mm( "test_9mm" );
 static const ammotype ammo_45( "45" );
+static const ammotype ammo_test_9mm( "test_9mm" );
 
 static const item_group_id Item_spawn_data_wallet_duct_tape_full( "wallet_duct_tape_full" );
 static const item_group_id Item_spawn_data_wallet_full( "wallet_full" );

--- a/tests/item_pocket_test.cpp
+++ b/tests/item_pocket_test.cpp
@@ -51,7 +51,7 @@
 #include "weather.h"
 
 static const ammotype ammo_test_9mm( "test_9mm" );
-static const ammotype ammo_test_45( "45" );
+static const ammotype ammo_45( "45" );
 
 static const item_group_id Item_spawn_data_wallet_duct_tape_full( "wallet_duct_tape_full" );
 static const item_group_id Item_spawn_data_wallet_full( "wallet_full" );
@@ -420,7 +420,7 @@ TEST_CASE( "max_container_volume", "[pocket][max_contains_volume]" )
         pocket_data data_ammo_box( pocket_type::CONTAINER );
 
         data_ammo_box.ammo_restriction.emplace( ammo_test_9mm, 200 );
-        data_ammo_box.ammo_restriction.emplace( ammo_test_45, 90 );
+        data_ammo_box.ammo_restriction.emplace( ammo_45, 90 );
         data_ammo_box.raw_volume_capacity = 1_ml;
 
         THEN( "volume_capacity uses the largest restricted ammo volume" ) {
@@ -432,7 +432,7 @@ TEST_CASE( "max_container_volume", "[pocket][max_contains_volume]" )
         pocket_data data_ammo_box( pocket_type::CONTAINER );
 
         data_ammo_box.ammo_restriction.emplace( ammo_test_9mm, 200 );
-        data_ammo_box.ammo_restriction.emplace( ammo_test_45, 150 );
+        data_ammo_box.ammo_restriction.emplace( ammo_45, 150 );
         data_ammo_box.raw_volume_capacity = 1_ml;
 
         THEN( "volume_capacity follows the most space-intensive ammo" ) {
@@ -536,7 +536,7 @@ TEST_CASE( "magazine_with_ammo_restriction", "[pocket][magazine][ammo_restrictio
         const int full_clip_qty_9mm = 10;
         const int full_clip_qty_45 = 6;
         data_mag.ammo_restriction.emplace( ammo_test_9mm, full_clip_qty_9mm );
-        data_mag.ammo_restriction.emplace( ammo_test_45, full_clip_qty_45 );
+        data_mag.ammo_restriction.emplace( ammo_45, full_clip_qty_45 );
         item_pocket pocket_mag( &data_mag );
 
         WHEN( "it does not already contain any ammo" ) {

--- a/tests/item_pocket_test.cpp
+++ b/tests/item_pocket_test.cpp
@@ -3081,3 +3081,4 @@ TEST_CASE( "unload_from_spillable_container", "[item][pocket]" )
         }
     }
 }
+

--- a/tests/item_pocket_test.cpp
+++ b/tests/item_pocket_test.cpp
@@ -3081,4 +3081,3 @@ TEST_CASE( "unload_from_spillable_container", "[item][pocket]" )
         }
     }
 }
-

--- a/tests/item_pocket_test.cpp
+++ b/tests/item_pocket_test.cpp
@@ -51,6 +51,7 @@
 #include "weather.h"
 
 static const ammotype ammo_test_9mm( "test_9mm" );
+static const ammotype ammo_test_45( "45" );
 
 static const item_group_id Item_spawn_data_wallet_duct_tape_full( "wallet_duct_tape_full" );
 static const item_group_id Item_spawn_data_wallet_full( "wallet_full" );
@@ -388,8 +389,6 @@ TEST_CASE( "max_item_volume", "[pocket][max_item_volume]" )
 //
 TEST_CASE( "max_container_volume", "[pocket][max_contains_volume]" )
 {
-    // TODO: Add tests for having multiple ammo types in the ammo_restriction
-
     WHEN( "pocket has no ammo_restriction" ) {
         pocket_data data_box( pocket_type::CONTAINER );
         // Just a normal 1-liter box
@@ -414,6 +413,30 @@ TEST_CASE( "max_container_volume", "[pocket][max_contains_volume]" )
 
         THEN( "volume_capacity is based on the pocket's ammo type" ) {
             CHECK( data_ammo_box.volume_capacity() == 1_liter );
+        }
+    }
+
+    WHEN( "pocket has multiple ammo_restrictions" ) {
+        pocket_data data_ammo_box( pocket_type::CONTAINER );
+
+        data_ammo_box.ammo_restriction.emplace( ammo_test_9mm, 200 );
+        data_ammo_box.ammo_restriction.emplace( ammo_test_45, 90 );
+        data_ammo_box.raw_volume_capacity = 1_ml;
+
+        THEN( "volume_capacity uses the largest restricted ammo volume" ) {
+            CHECK( data_ammo_box.volume_capacity() == 1_liter );
+        }
+    }
+
+    WHEN( "pocket has multiple ammo_restrictions with a larger alternate ammo type" ) {
+        pocket_data data_ammo_box( pocket_type::CONTAINER );
+
+        data_ammo_box.ammo_restriction.emplace( ammo_test_9mm, 200 );
+        data_ammo_box.ammo_restriction.emplace( ammo_test_45, 150 );
+        data_ammo_box.raw_volume_capacity = 1_ml;
+
+        THEN( "volume_capacity follows the most space-intensive ammo" ) {
+            CHECK( data_ammo_box.volume_capacity() == 1250_ml );
         }
     }
 }
@@ -441,8 +464,6 @@ TEST_CASE( "magazine_with_ammo_restriction", "[pocket][magazine][ammo_restrictio
     data_mag.min_item_volume = 0_liter;
     data_mag.max_item_length = 0_meter;
     data_mag.max_contains_weight = 0_gram;
-
-    // TODO: Add tests for multiple ammo types in the same clip
 
     GIVEN( "magazine has 9mm ammo_restriction" ) {
         // Magazine ammo_restriction may be a single { ammotype, count } or a list of ammotypes and
@@ -510,6 +531,73 @@ TEST_CASE( "magazine_with_ammo_restriction", "[pocket][magazine][ammo_restrictio
             }
         }
     }
+
+    GIVEN( "magazine has multiple ammo_restrictions" ) {
+        const int full_clip_qty_9mm = 10;
+        const int full_clip_qty_45 = 6;
+        data_mag.ammo_restriction.emplace( ammo_test_9mm, full_clip_qty_9mm );
+        data_mag.ammo_restriction.emplace( ammo_test_45, full_clip_qty_45 );
+        item_pocket pocket_mag( &data_mag );
+
+        WHEN( "it does not already contain any ammo" ) {
+            REQUIRE( pocket_mag.empty() );
+
+            THEN( "it can contain a full clip of any allowed ammo type" ) {
+                const item ammo_9mm( itype_test_9mm_ammo, calendar::turn_zero, full_clip_qty_9mm );
+                const item ammo_45( itype_test_45_ammo, calendar::turn_zero, full_clip_qty_45 );
+                expect_can_contain( pocket_mag, ammo_9mm );
+                expect_can_contain( pocket_mag, ammo_45 );
+            }
+
+            THEN( "it cannot exceed any allowed ammo restriction" ) {
+                item ammo_9mm_over( itype_test_9mm_ammo, calendar::turn_zero, full_clip_qty_9mm + 1 );
+                item ammo_45_over( itype_test_45_ammo, calendar::turn_zero, full_clip_qty_45 + 1 );
+                expect_cannot_contain( pocket_mag, ammo_9mm_over,
+                                       "tried to put too many charges of ammo in item",
+                                       item_pocket::contain_code::ERR_NO_SPACE );
+                expect_cannot_contain( pocket_mag, ammo_45_over,
+                                       "tried to put too many charges of ammo in item",
+                                       item_pocket::contain_code::ERR_NO_SPACE );
+            }
+        }
+
+        WHEN( "it is partly full of 9mm ammo" ) {
+            const int half_clip_qty_9mm = full_clip_qty_9mm / 2;
+            item ammo_9mm_half_clip( itype_test_9mm_ammo, calendar::turn_zero, half_clip_qty_9mm );
+            expect_can_insert( pocket_mag, ammo_9mm_half_clip );
+
+            THEN( "it can contain more of the same ammo" ) {
+                item ammo_9mm_refill( itype_test_9mm_ammo, calendar::turn_zero,
+                                      full_clip_qty_9mm - half_clip_qty_9mm );
+                expect_can_contain( pocket_mag, ammo_9mm_refill );
+            }
+
+            THEN( "it cannot contain ammo of another allowed type" ) {
+                item ammo_45( itype_test_45_ammo, calendar::turn_zero, 1 );
+                expect_cannot_contain( pocket_mag, ammo_45, "can't mix different ammo",
+                                       item_pocket::contain_code::ERR_NO_SPACE );
+            }
+        }
+
+        WHEN( "it is partly full of .45 ammo" ) {
+            const int half_clip_qty_45 = full_clip_qty_45 / 2;
+            item ammo_45_half_clip( itype_test_45_ammo, calendar::turn_zero, half_clip_qty_45 );
+            expect_can_insert( pocket_mag, ammo_45_half_clip );
+
+            THEN( "it can contain more of the same ammo" ) {
+                item ammo_45_refill( itype_test_45_ammo, calendar::turn_zero,
+                                     full_clip_qty_45 - half_clip_qty_45 );
+                expect_can_contain( pocket_mag, ammo_45_refill );
+            }
+
+            THEN( "it cannot contain ammo of another allowed type" ) {
+                item ammo_9mm( itype_test_9mm_ammo, calendar::turn_zero, 1 );
+                expect_cannot_contain( pocket_mag, ammo_9mm, "can't mix different ammo",
+                                       item_pocket::contain_code::ERR_NO_SPACE );
+            }
+        }
+    }
+
 }
 
 // Flag restriction

--- a/tests/overmap_test.cpp
+++ b/tests/overmap_test.cpp
@@ -20,6 +20,7 @@
 #include "common_types.h"
 #include "coordinates.h"
 #include "debug.h"
+#include "enum_conversions.h"
 #include "enums.h"
 #include "game.h"
 #include "global_vars.h"
@@ -35,6 +36,7 @@
 #include "options.h"
 #include "output.h"
 #include "overmap.h"
+#include "overmap_location.h"
 #include "overmap_types.h"
 #include "overmapbuffer.h"
 #include "point.h"
@@ -54,6 +56,84 @@ static const oter_str_id oter_cabin_west( "cabin_west" );
 
 static const overmap_special_id overmap_special_Cabin( "Cabin" );
 static const overmap_special_id overmap_special_Lab( "Lab" );
+
+static std::vector<oter_flags> all_oter_flags()
+{
+    const int max_flag = static_cast<int>( oter_flags::num_oter_flags );
+    std::vector<oter_flags> flags;
+    flags.reserve( max_flag );
+    for( int i = 0; i < max_flag; ++i ) {
+        flags.emplace_back( static_cast<oter_flags>( i ) );
+    }
+    return flags;
+}
+
+static std::vector<std::string> location_flag_strings()
+{
+    std::unordered_set<std::string> unique_flags;
+    for( const overmap_location &loc : overmap_locations::get_all() ) {
+        for( const std::string &flag : loc.get_flags() ) {
+            unique_flags.insert( flag );
+        }
+    }
+    std::vector<std::string> result( unique_flags.begin(), unique_flags.end() );
+    std::sort( result.begin(), result.end() );
+    return result;
+}
+
+static bool any_terrain_with_flag( const oter_flags flag )
+{
+    for( const oter_t &ter : overmap_terrains::get_all() ) {
+        if( ter.has_flag( flag ) ) {
+            return true;
+        }
+    }
+    return false;
+}
+
+TEST_CASE( "oter_flags_string_round_trip", "[overmap][flags]" )
+{
+    const auto &flag_map = io::get_enum_lookup_map<oter_flags>();
+    const std::vector<oter_flags> flags = all_oter_flags();
+
+    CHECK( flag_map.size() == flags.size() );
+
+    std::unordered_set<std::string> seen_strings;
+    for( const oter_flags flag : flags ) {
+        const std::string flag_string = io::enum_to_string( flag );
+        CAPTURE( flag_string );
+        CHECK_FALSE( flag_string.empty() );
+        CHECK( flag_map.count( flag_string ) == 1 );
+        CHECK( io::string_to_enum<oter_flags>( flag_string ) == flag );
+        CHECK( seen_strings.emplace( flag_string ).second );
+    }
+}
+
+TEST_CASE( "overmap_location_flags_are_valid", "[overmap][flags]" )
+{
+    const std::vector<std::string> flags = location_flag_strings();
+
+    for( const std::string &flag : flags ) {
+        CAPTURE( flag );
+        CHECK( io::enum_is_valid<oter_flags>( flag ) );
+        CHECK( io::string_to_enum_optional<oter_flags>( flag ).has_value() );
+    }
+}
+
+TEST_CASE( "overmap_location_flags_match_terrain_flags", "[overmap][flags]" )
+{
+    const std::vector<std::string> flags = location_flag_strings();
+    const auto &flag_map = io::get_enum_lookup_map<oter_flags>();
+
+    for( const std::string &flag : flags ) {
+        const auto iter = flag_map.find( flag );
+        if( iter == flag_map.end() ) {
+            continue;
+        }
+        CAPTURE( flag );
+        CHECK( any_terrain_with_flag( iter->second ) );
+    }
+}
 
 TEST_CASE( "set_and_get_overmap_scents", "[overmap]" )
 {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Add coverage to ensure overmap flag strings round-trip correctly and that overmap location flag references remain valid and map to at least one terrain.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Introduce small helper accessors on overmap locations and add three overmap tests: enum string round‑trip for oter_flags, validation of flags used by overmap locations, and a check that each referenced flag exists on some terrain.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Relying on existing JSON loading errors and manual review without tests.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
