### PR TITLE
Adjusted USP .45 pistol dispersion

### DIFF
--- a/data/json/items/gun/45.json
+++ b/data/json/items/gun/45.json
@@ -323,6 +323,7 @@
     "barrel_length": "108 mm",
     "ammo": [ "45" ],
     "material": [ "plastic", "steel" ],
+    "dispersion": 480,
     "price": "700 USD",
     "price_postapoc": "25 USD",
     "valid_mod_locations": [ [ "barrel", 1 ], [ "mechanism", 2 ], [ "rail", 1 ], [ "sights mount", 1 ], [ "stock mount", 1 ] ],


### PR DESCRIPTION
#### Summary

Bugfixes "Adjusted USP .45 pistol dispersion"

#### Purpose of change

Fixes #84268

#### Describe the solution

USP .45 was inheriting handgun base dispersion; add an explicit dispersion value (480) to align it with comparable .45 pistols.