### PR TITLE
Fix Matchbook Reload Behaviour

### DIFF
--- a/data/json/items/ammo.json
+++ b/data/json/items/ammo.json
@@ -113,9 +113,10 @@
     "volume": "4 ml",
     "weight": "1 mg",
     "color": "red",
-    "flags": [ "TRADER_AVOID" ],
+    "flags": [ "TRADER_AVOID", "FIRESTARTER" ],
     "material": [ "wood" ],
-    "ammo_type": "match"
+    "ammo_type": "match",
+    "use_action": { "type": "firestarter", "moves": 3000, "moves_slow": 8000 }
   },
   {
     "type": "ITEM",

--- a/data/json/items/tool/fire.json
+++ b/data/json/items/tool/fire.json
@@ -182,7 +182,7 @@
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "holster": true, "ammo_restriction": { "match": 20 } } ],
     "//COMMENT": "Open flame or effectively so. ~5 seconds to transfer flame assuming optimal conditions, a minute at worst.",
     "use_action": { "type": "firestarter", "moves": 500, "moves_slow": 6000 },
-    "flags": [ "FIRESTARTER", "NO_RELOAD", "WATER_BREAK" ]
+    "flags": [ "FIRESTARTER", "WATER_BREAK" ]
   },
   {
     "id": "survival_match",


### PR DESCRIPTION
#### Summary
Bugfixes "Fixes #82763" 

#### Purpose of change
Matchbooks became unusable after all matches were spent due to the `NO_RELOAD` flag preventing reinsertion.

#### Describe the solution
Removed the `NO_RELOAD` flag from the matchbook item, allowing matches to be reinserted as intended. Existing ammo restrictions continue to limit matchbooks to holding matches only.

#### Describe alternatives considered
Considered making individual matches directly activatable, but left behavior unchanged pending maintainer guidance.

#### Testing
Not tested (JSON-only change).
