### PR TITLE
Fix float values provided in json silently converting into ints

### DIFF
--- a/data/json/artifact/relic_procgen_data.json
+++ b/data/json/artifact/relic_procgen_data.json
@@ -885,14 +885,7 @@
       }
     ],
     "passive_mult_procgen_values": [
-      {
-        "weight": 100,
-        "min_value": -1,
-        "max_value": 2,
-        "type": "CARRY_WEIGHT",
-        "increment": 0.3,
-        "power_per_increment": 50
-      },
+      { "weight": 100, "min_value": -1, "max_value": 2, "type": "CARRY_WEIGHT", "increment": 0.3, "power_per_increment": 50 },
       {
         "weight": 100,
         "min_value": -0.6,

--- a/data/json/artifact/relic_procgen_data.json
+++ b/data/json/artifact/relic_procgen_data.json
@@ -877,6 +877,16 @@
       },
       {
         "weight": 100,
+        "min_value": -35,
+        "max_value": 35,
+        "type": "SPEED",
+        "increment": 5,
+        "power_per_increment": 150
+      }
+    ],
+    "passive_mult_procgen_values": [
+      {
+        "weight": 100,
         "min_value": -1,
         "max_value": 2,
         "type": "CARRY_WEIGHT",
@@ -898,14 +908,6 @@
         "type": "ATTACK_SPEED",
         "increment": 0.2,
         "power_per_increment": -100
-      },
-      {
-        "weight": 100,
-        "min_value": -35,
-        "max_value": 35,
-        "type": "SPEED",
-        "increment": 5,
-        "power_per_increment": 150
       }
     ],
     "type_weights": [

--- a/data/json/effects_on_condition/bionic_active_eocs.json
+++ b/data/json/effects_on_condition/bionic_active_eocs.json
@@ -122,7 +122,7 @@
       },
       { "math": [ "u_val('pkill') = 0" ] },
       { "math": [ "u_val('stim') = 0" ] },
-      { "turn_cost": "1 s" }
+      { "turn_cost": { "math": [ "1" ] } }
     ]
   }
 ]

--- a/data/json/effects_on_condition/bionic_active_eocs.json
+++ b/data/json/effects_on_condition/bionic_active_eocs.json
@@ -122,7 +122,7 @@
       },
       { "math": [ "u_val('pkill') = 0" ] },
       { "math": [ "u_val('stim') = 0" ] },
-      { "turn_cost": 1 }
+      { "turn_cost": "1 s" }
     ]
   }
 ]

--- a/data/json/field_type.json
+++ b/data/json/field_type.json
@@ -1518,7 +1518,7 @@
     "id": "fd_fog",
     "type": "field_type",
     "intensity_levels": [
-      { "name": "mist", "sym": "~", "dangerous": false, "transparent": false, "translucency": 5, "concentration": 0.5 },
+      { "name": "mist", "sym": "~", "dangerous": false, "transparent": false, "translucency": 5, "concentration": 1 },
       { "name": "fog", "translucency": 3 },
       { "name": "dense fog", "translucency": 1 }
     ],
@@ -1589,7 +1589,7 @@
         "color": "light_green",
         "transparent": false,
         "translucency": 8,
-        "concentration": 1.5,
+        "concentration": 1,
         "effects": [
           {
             "effect_id": "hallucinogenic_acid_light",

--- a/data/json/items/comestibles/carnivore.json
+++ b/data/json/items/comestibles/carnivore.json
@@ -27,7 +27,7 @@
     "spoils_in": "12 hours",
     "flags": [ "RAW" ],
     "smoking_result": "froglegs_smoked",
-    "vitamins": [ [ "calcium", 18 ], [ "iron", 1.5 ], [ "meat_allergen", 1 ] ],
+    "vitamins": [ [ "calcium", 18 ], [ "iron", 1 ], [ "meat_allergen", 1 ] ],
     "calories": 73
   },
   {

--- a/data/json/items/comestibles/other.json
+++ b/data/json/items/comestibles/other.json
@@ -1410,11 +1410,11 @@
     "quench": 1,
     "fun": -10,
     "//0": "DW 0.2g protein 0.04 fat 0.04 carb... 0.2*4+0.04*4+0.04*9 = 1.326kcal",
-    "calories": 1.3,
+    "calories": 1,
     "parasites": 20,
     "flags": [ "FREEZERBURN", "RAW", "NO_AUTO_CONSUME", "BIRD", "NUTRIENT_OVERRIDE" ],
     "//1": "1 earthworm has such a small amount of vitamins, i'm not sure it's possible to model them.",
-    "vitamins": [ [ "calcium", 0.3 ], [ "iron", 0.8 ], [ "meat_allergen", 1 ] ]
+    "vitamins": [ [ "calcium", 1 ], [ "iron", 1 ], [ "meat_allergen", 1 ] ]
   },
   {
     "type": "ITEM",
@@ -1427,7 +1427,7 @@
     "volume": "20 ml",
     "quench": 10,
     "fun": -20,
-    "calories": 13.2,
+    "calories": 13,
     "parasites": 10,
     "vitamins": [ [ "calcium", 3 ], [ "iron", 8 ] ]
   },

--- a/data/json/items/tool/landscaping.json
+++ b/data/json/items/tool/landscaping.json
@@ -428,7 +428,7 @@
           "effect": {
             "run_eocs": "EOC_toolweapon_activate",
             "variables": {
-              "turn_cost": "1 s",
+              "turn_cost": { "math": [ "0.8" ] },
               "transform_target": "trimmer_on",
               "success_message": { "i18n": true, "str": "With a roar, the hedge trimmer leaps to life!" },
               "volume": 15,

--- a/data/json/items/tool/landscaping.json
+++ b/data/json/items/tool/landscaping.json
@@ -428,7 +428,7 @@
           "effect": {
             "run_eocs": "EOC_toolweapon_activate",
             "variables": {
-              "turn_cost": 0.8,
+              "turn_cost": "1 s",
               "transform_target": "trimmer_on",
               "success_message": { "i18n": true, "str": "With a roar, the hedge trimmer leaps to life!" },
               "volume": 15,

--- a/data/json/items/tool/masonry.json
+++ b/data/json/items/tool/masonry.json
@@ -27,7 +27,7 @@
           "effect": {
             "run_eocs": "EOC_toolweapon_activate",
             "variables": {
-              "turn_cost": 0.8,
+              "turn_cost": "1 s",
               "transform_target": "masonrysaw_on",
               "success_message": { "i18n": true, "str": "With a roar, the <npc_name> screams to life!" },
               "volume": 20,

--- a/data/json/items/tool/masonry.json
+++ b/data/json/items/tool/masonry.json
@@ -27,7 +27,7 @@
           "effect": {
             "run_eocs": "EOC_toolweapon_activate",
             "variables": {
-              "turn_cost": "1 s",
+              "turn_cost": { "math": [ "0.8" ] },
               "transform_target": "masonrysaw_on",
               "success_message": { "i18n": true, "str": "With a roar, the <npc_name> screams to life!" },
               "volume": 20,

--- a/data/json/items/tool/woodworking.json
+++ b/data/json/items/tool/woodworking.json
@@ -65,7 +65,7 @@
           "id": "EOC_toolweapon_activate__chainsaw",
           "condition": { "and": [ { "math": [ "rng(0, 10) - n_damage_level() > 5" ] }, { "not": "u_is_underwater" }, "has_ammo" ] },
           "effect": [
-            { "turn_cost": "1 s" },
+            { "turn_cost": { "math": [ "0.8" ] } },
             { "u_make_sound": "With a roar, the chainsaw screams to life!", "type": "combat", "volume": 20 },
             { "u_message": "With a roar, the chainsaw screams to life!" },
             { "transform_item": "chainsaw_on", "active": true },
@@ -364,7 +364,7 @@
           "effect": {
             "run_eocs": "EOC_toolweapon_activate",
             "variables": {
-              "turn_cost": "1 s",
+              "turn_cost": { "math": [ "0.6" ] },
               "transform_target": "elec_chainsaw_on",
               "success_message": { "i18n": true, "str": "With a roar, the electric chainsaw screams to life!" },
               "volume": 20,
@@ -435,7 +435,7 @@
             "effect": {
               "run_eocs": "EOC_toolweapon_activate",
               "variables": {
-                "turn_cost": "1 s",
+                "turn_cost": { "math": [ "0.6" ] },
                 "transform_target": "elec_chainsaw_cord_on",
                 "success_message": { "i18n": true, "str": "With a roar, the corded electric chainsaw screams to life!" },
                 "volume": 20,

--- a/data/json/items/tool/woodworking.json
+++ b/data/json/items/tool/woodworking.json
@@ -65,7 +65,7 @@
           "id": "EOC_toolweapon_activate__chainsaw",
           "condition": { "and": [ { "math": [ "rng(0, 10) - n_damage_level() > 5" ] }, { "not": "u_is_underwater" }, "has_ammo" ] },
           "effect": [
-            { "turn_cost": 0.8 },
+            { "turn_cost": "1 s" },
             { "u_make_sound": "With a roar, the chainsaw screams to life!", "type": "combat", "volume": 20 },
             { "u_message": "With a roar, the chainsaw screams to life!" },
             { "transform_item": "chainsaw_on", "active": true },
@@ -364,7 +364,7 @@
           "effect": {
             "run_eocs": "EOC_toolweapon_activate",
             "variables": {
-              "turn_cost": 0.6,
+              "turn_cost": "1 s",
               "transform_target": "elec_chainsaw_on",
               "success_message": { "i18n": true, "str": "With a roar, the electric chainsaw screams to life!" },
               "volume": 20,
@@ -435,7 +435,7 @@
             "effect": {
               "run_eocs": "EOC_toolweapon_activate",
               "variables": {
-                "turn_cost": 0.6,
+                "turn_cost": "1 s",
                 "transform_target": "elec_chainsaw_cord_on",
                 "success_message": { "i18n": true, "str": "With a roar, the corded electric chainsaw screams to life!" },
                 "volume": 20,

--- a/data/json/obsoletion_and_migration_0.I/prosthetics.json
+++ b/data/json/obsoletion_and_migration_0.I/prosthetics.json
@@ -417,7 +417,7 @@
     "flags": [ "LIMB_LOWER", "HEAL_OVERRIDE" ],
     "sub_parts": [ "leg_hip_r", "leg_upper_r", "leg_knee_r", "leg_lower_r", "leg_draped_r" ],
     "encumbrance_per_weight": [
-      { "weight": "1 mg", "encumbrance": 1.5 },
+      { "weight": "1 mg", "encumbrance": 1 },
       { "weight": "300 g", "encumbrance": 6 },
       { "weight": "800 g", "encumbrance": 12 },
       { "weight": "1300 g", "encumbrance": 30 },
@@ -480,7 +480,7 @@
     "flags": [ "LIMB_LOWER", "HEAL_OVERRIDE" ],
     "sub_parts": [ "leg_hip_l", "leg_upper_l", "leg_knee_l", "leg_lower_l", "leg_draped_l" ],
     "encumbrance_per_weight": [
-      { "weight": "1 mg", "encumbrance": 1.5 },
+      { "weight": "1 mg", "encumbrance": 1 },
       { "weight": "300 g", "encumbrance": 6 },
       { "weight": "800 g", "encumbrance": 12 },
       { "weight": "1300 g", "encumbrance": 30 },

--- a/data/json/recipes/practice/fabrication.json
+++ b/data/json/recipes/practice/fabrication.json
@@ -374,7 +374,7 @@
       { "proficiency": "prof_machining_basic", "time_multiplier": 1.5, "skill_penalty": 1.25 }
     ],
     "time": "1 h 30m",
-    "byproducts": [ [ "scrap", 7.5 ] ],
+    "byproducts": [ [ "scrap", 7 ] ],
     "tools": [ [ [ "fake_lathe", 50 ] ] ],
     "components": [
       [
@@ -403,7 +403,7 @@
       { "proficiency": "prof_machining_basic", "time_multiplier": 1.5, "skill_penalty": 1.25 }
     ],
     "time": "1 h 30m",
-    "byproducts": [ [ "scrap", 7.5 ] ],
+    "byproducts": [ [ "scrap", 7 ] ],
     "tools": [ [ [ "fake_mill_vertical", 50 ] ] ],
     "components": [
       [

--- a/data/json/region_settings/region_settings/regional_map_settings.json
+++ b/data/json/region_settings/region_settings/regional_map_settings.json
@@ -52,7 +52,7 @@
   {
     "type": "region_settings_river",
     "id": "default",
-    "river_scale": 1.0,
+    "river_scale": 1,
     "river_frequency": 1.5,
     "river_branch_chance": 64.0,
     "river_branch_remerge_chance": 2.0,

--- a/data/mods/Limb_WIP/mutations/mutation_limbs.json
+++ b/data/mods/Limb_WIP/mutations/mutation_limbs.json
@@ -796,7 +796,7 @@
     "flags": [ "LIMB_LOWER", "HEAL_OVERRIDE" ],
     "sub_parts": [ "leg_hip_r", "leg_upper_r", "leg_knee_r", "leg_lower_r", "leg_draped_r" ],
     "encumbrance_per_weight": [
-      { "weight": "1 mg", "encumbrance": 1.5 },
+      { "weight": "1 mg", "encumbrance": 1 },
       { "weight": "300 g", "encumbrance": 6 },
       { "weight": "800 g", "encumbrance": 12 },
       { "weight": "1300 g", "encumbrance": 30 },
@@ -859,7 +859,7 @@
     "flags": [ "LIMB_LOWER", "HEAL_OVERRIDE" ],
     "sub_parts": [ "leg_hip_l", "leg_upper_l", "leg_knee_l", "leg_lower_l", "leg_draped_l" ],
     "encumbrance_per_weight": [
-      { "weight": "1 mg", "encumbrance": 1.5 },
+      { "weight": "1 mg", "encumbrance": 1 },
       { "weight": "300 g", "encumbrance": 6 },
       { "weight": "800 g", "encumbrance": 12 },
       { "weight": "1300 g", "encumbrance": 30 },

--- a/data/mods/Magiclysm/effect_on_conditions/transformations.json
+++ b/data/mods/Magiclysm/effect_on_conditions/transformations.json
@@ -77,7 +77,7 @@
                     "id": "EOC_DRUID_SHIFTER_BEAR_FORM_activated_3",
                     "condition": { "math": [ "u_val('mana') >= 50" ] },
                     "effect": [
-                      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+                      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "2.5" ] } },
                       { "math": [ "u_transformed_mana = u_val('mana') - 50" ] },
                       { "math": [ "u_preshift_size = u_val('size')" ] },
                       {
@@ -122,7 +122,7 @@
                     "id": "EOC_DRUID_SHIFTER_BEAR_FORM_deactivated",
                     "condition": { "u_has_trait": "DRUID_SHIFTER_BEAR_FORM_TRAITS" },
                     "effect": [
-                      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+                      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "2.5" ] } },
                       {
                         "u_message": "Your body shifts and contracts and you return to your humanoid form.",
                         "type": "neutral"
@@ -191,7 +191,7 @@
                     "id": "EOC_DRUID_SHIFTER_COUGAR_FORM_activated_3",
                     "condition": { "math": [ "u_val('mana') >= 50" ] },
                     "effect": [
-                      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+                      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "2.5" ] } },
                       { "math": [ "u_transformed_mana = u_val('mana') - 50" ] },
                       { "math": [ "u_preshift_size = u_val('size')" ] },
                       {
@@ -228,7 +228,7 @@
                     "id": "EOC_DRUID_SHIFTER_COUGAR_FORM_deactivated",
                     "condition": { "u_has_trait": "DRUID_SHIFTER_COUGAR_FORM_TRAITS" },
                     "effect": [
-                      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+                      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "2.5" ] } },
                       {
                         "u_message": "Your body shifts and your fur disappears as you return to your humanoid form.",
                         "type": "neutral"
@@ -292,7 +292,7 @@
                     "id": "EOC_DRUID_SHIFTER_DEER_FORM_activated_3",
                     "condition": { "math": [ "u_val('mana') >= 50" ] },
                     "effect": [
-                      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+                      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "2.5" ] } },
                       { "math": [ "u_transformed_mana = u_val('mana') - 50" ] },
                       { "math": [ "u_preshift_size = u_val('size')" ] },
                       {
@@ -337,7 +337,7 @@
                     "id": "EOC_DRUID_SHIFTER_DEER_FORM_deactivated",
                     "condition": { "u_has_trait": "DRUID_SHIFTER_DEER_FORM_TRAITS" },
                     "effect": [
-                      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+                      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "2.5" ] } },
                       {
                         "u_message": "Your body shifts and your fingers separate as you return to your humanoid form.",
                         "type": "neutral"
@@ -406,7 +406,7 @@
                     "id": "EOC_DRUID_SHIFTER_RAVEN_FORM_activated_3",
                     "condition": { "math": [ "u_val('mana') >= 50" ] },
                     "effect": [
-                      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+                      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "2.5" ] } },
                       { "math": [ "u_val('mana') -= 50" ] },
                       { "math": [ "u_transformed_mana = u_val('mana') - 50" ] },
                       { "math": [ "u_preshift_size = u_val('size')" ] },
@@ -455,7 +455,7 @@
                     "id": "EOC_DRUID_SHIFTER_RAVEN_FORM_deactivated",
                     "condition": { "u_has_trait": "DRUID_SHIFTER_RAVEN_FORM_TRAITS" },
                     "effect": [
-                      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+                      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "2.5" ] } },
                       {
                         "u_message": "Your body shifts and changes and you return to your humanoid form.",
                         "type": "neutral"

--- a/data/mods/Perk_melee/EOC/duelist_eocs.json
+++ b/data/mods/Perk_melee/EOC/duelist_eocs.json
@@ -15,7 +15,7 @@
       ]
     },
     "effect": [
-      { "turn_cost": 0.05 },
+      { "turn_cost": "0 s" },
       {
         "u_run_inv_eocs": "all",
         "search_data": [ { "wielded_only": true } ],

--- a/data/mods/Perk_melee/EOC/duelist_eocs.json
+++ b/data/mods/Perk_melee/EOC/duelist_eocs.json
@@ -15,7 +15,7 @@
       ]
     },
     "effect": [
-      { "turn_cost": "0 s" },
+      { "turn_cost": { "math": [ "0.05" ] } },
       {
         "u_run_inv_eocs": "all",
         "search_data": [ { "wielded_only": true } ],

--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -5545,7 +5545,7 @@
             "effect": {
               "run_eocs": "EOC_toolweapon_activate",
               "variables": {
-                "turn_cost": "1 s",
+                "turn_cost": { "math": [ "0.8" ] },
                 "transform_target": "carver_on",
                 "success_message": { "i18n": true, "str": "The electric carver's serrated blades start buzzing!" },
                 "volume": 20,

--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -5545,7 +5545,7 @@
             "effect": {
               "run_eocs": "EOC_toolweapon_activate",
               "variables": {
-                "turn_cost": 0.8,
+                "turn_cost": "1 s",
                 "transform_target": "carver_on",
                 "success_message": { "i18n": true, "str": "The electric carver's serrated blades start buzzing!" },
                 "volume": 20,

--- a/data/mods/TropiCataclysm/region_settings/tropical_regional_map_settings.json
+++ b/data/mods/TropiCataclysm/region_settings/tropical_regional_map_settings.json
@@ -3,7 +3,7 @@
     "type": "region_settings_river",
     "id": "default",
     "copy-from": "default",
-    "river_scale": 1.65
+    "river_scale": 1
   },
   {
     "type": "region_settings_ocean",

--- a/data/mods/Xedra_Evolved/eocs/shapeshifter_eocs.json
+++ b/data/mods/Xedra_Evolved/eocs/shapeshifter_eocs.json
@@ -124,7 +124,7 @@
                     "id": "EOC_WEREWOLF_WOLF_FORM_activated_3",
                     "condition": { "math": [ "u_val('mana') >= 20" ] },
                     "effect": [
-                      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 1.5 },
+                      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "1.5" ] } },
                       { "math": [ "u_val('mana') -= 20" ] },
                       { "run_eocs": "EOC_SHAPESHIFTING_ARMOR_CHECK_SUBSUME_INTO_FORM" },
                       { "u_add_trait": "VAMPIRE_WOLF_FORM_TRAITS" },
@@ -149,7 +149,7 @@
                     "id": "EOC_WEREWOLF_WOLF_FORM_deactivated",
                     "condition": { "u_has_trait": "VAMPIRE_WOLF_FORM_TRAITS" },
                     "effect": [
-                      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 1.5 },
+                      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "1.5" ] } },
                       {
                         "u_message": "Your body shifts and contracts and you return to your humanoid form.",
                         "type": "neutral"
@@ -198,7 +198,7 @@
                     "id": "EOC_WEREWOLF_HYBRID_FORM_activated_3",
                     "condition": { "math": [ "u_val('mana') >= 20" ] },
                     "effect": [
-                      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 1.5 },
+                      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "1.5" ] } },
                       { "math": [ "u_val('mana') -= 20" ] },
                       { "math": [ "u_calories('dont_affect_weariness': true) *= 3" ] },
                       { "math": [ "u_werewolf_healing_tick_counter = 0" ] },
@@ -225,7 +225,7 @@
                     "id": "EOC_WEREWOLF_HYBRID_FORM_deactivated",
                     "condition": { "u_has_trait": "WEREWOLF_HYBRID_FORM_TRAITS" },
                     "effect": [
-                      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 1.5 },
+                      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "1.5" ] } },
                       {
                         "u_message": "Your body shifts and contracts and you return to your humanoid form.",
                         "type": "neutral"

--- a/data/mods/Xedra_Evolved/items/hedge_magic_items.json
+++ b/data/mods/Xedra_Evolved/items/hedge_magic_items.json
@@ -422,7 +422,10 @@
       "effect_on_conditions": [
         {
           "id": "EOC_HEDGE_FOOR_OR_DRINK_MAGIC_SQUARE",
-          "effect": [ { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "2.5" ] } }, { "run_eocs": "EOC_HEDGE_FOOD_OR_DRINK_SELECTOR" } ]
+          "effect": [
+            { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "2.5" ] } },
+            { "run_eocs": "EOC_HEDGE_FOOD_OR_DRINK_SELECTOR" }
+          ]
         }
       ]
     }

--- a/data/mods/Xedra_Evolved/items/hedge_magic_items.json
+++ b/data/mods/Xedra_Evolved/items/hedge_magic_items.json
@@ -316,7 +316,7 @@
         {
           "id": "EOC_HEDGE_WALK_ON_WATER_MAGIC_SQUARE",
           "effect": [
-            { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+            { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "2.5" ] } },
             { "u_add_effect": "effect_hedge_walk_on_water_magic_square", "duration": 1800, "intensity": 30 }
           ]
         }
@@ -339,7 +339,7 @@
         {
           "id": "EOC_HEDGE_BREATHE_WATER_MAGIC_SQUARE",
           "effect": [
-            { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+            { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "2.5" ] } },
             { "u_add_effect": "effect_hedge_breathe_water_magic_square", "duration": 7200, "intensity": 120 }
           ]
         }
@@ -365,7 +365,7 @@
         {
           "id": "EOC_HEDGE_BASH_TERRAIN_MAGIC_SQUARE",
           "effect": [
-            { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+            { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "2.5" ] } },
             { "u_cast_spell": { "id": "hedge_bash_terrain_magic_square_real" }, "targeted": true }
           ]
         }
@@ -388,7 +388,7 @@
         {
           "id": "EOC_HEDGE_ARMED_MEN_MAGIC_SQUARE",
           "effect": [
-            { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+            { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "2.5" ] } },
             {
               "u_spawn_monster": "GROUP_HEDGE_TO_CAUSE_ARMED_MEN",
               "real_count": { "math": [ "2 + rand(3)" ] },
@@ -422,7 +422,7 @@
       "effect_on_conditions": [
         {
           "id": "EOC_HEDGE_FOOR_OR_DRINK_MAGIC_SQUARE",
-          "effect": [ { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 }, { "run_eocs": "EOC_HEDGE_FOOD_OR_DRINK_SELECTOR" } ]
+          "effect": [ { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "2.5" ] } }, { "run_eocs": "EOC_HEDGE_FOOD_OR_DRINK_SELECTOR" } ]
         }
       ]
     }
@@ -446,7 +446,7 @@
         {
           "id": "EOC_HEDGE_INVISIBILITY_MAGIC_SQUARE",
           "effect": [
-            { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+            { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "2.5" ] } },
             { "u_add_effect": "effect_invisibility_magic_square", "duration": 4620, "intensity": 77 }
           ]
         }

--- a/data/mods/Xedra_Evolved/mod_interactions/bombastic_perks/perks/perk_data/grack_pack.json
+++ b/data/mods/Xedra_Evolved/mod_interactions/bombastic_perks/perks/perk_data/grack_pack.json
@@ -3,7 +3,7 @@
     "type": "effect_on_condition",
     "id": "EOC_XE_PERK_GRACK_PACK",
     "effect": [
-      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 1.5 },
+      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "1.5" ] } },
       { "u_cast_spell": { "id": "perk_GRACKEN_FRIENDSHIP_spell" }, "targeted": true }
     ]
   },

--- a/data/mods/Xedra_Evolved/mutations/playable_changeling_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/playable_changeling_eocs.json
@@ -1221,7 +1221,7 @@
             "id": "EOC_POOKA_SHAPESHIFT_FULL_BAT_activated_2",
             "condition": { "math": [ "u_val('mana') >= 2" ] },
             "effect": [
-              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "2.5" ] } },
               { "run_eocs": "EOC_SHAPESHIFTING_ARMOR_CHECK_SUBSUME_INTO_FORM" },
               { "u_add_trait": "VAMPIRE_BAT_FORM_TRAITS" },
               { "u_add_trait": "ECHOLOCATION" },
@@ -1246,7 +1246,7 @@
             "id": "EOC_POOKA_SHAPESHIFT_FULL_BAT_deactivated",
             "condition": { "u_has_trait": "VAMPIRE_BAT_FORM_TRAITS" },
             "effect": [
-              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "2.5" ] } },
               { "u_lose_trait": "ECHOLOCATION" },
               { "math": [ "u_calories() *= 4" ] },
               { "u_lose_trait": "VAMPIRE_BAT_FORM_TRAITS" },
@@ -1284,7 +1284,7 @@
             "id": "EOC_POOKA_SHAPESHIFT_FULL_RAVEN_activated_2",
             "condition": { "math": [ "u_val('mana') >= 2" ] },
             "effect": [
-              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "2.5" ] } },
               { "run_eocs": "EOC_SHAPESHIFTING_ARMOR_CHECK_SUBSUME_INTO_FORM" },
               { "u_add_trait": "TURN_INTO_RAVEN_TRAITS" },
               { "math": [ "u_calories() /= 4" ] },
@@ -1308,7 +1308,7 @@
             "id": "EOC_POOKA_SHAPESHIFT_FULL_RAVEN_deactivated",
             "condition": { "u_has_trait": "TURN_INTO_RAVEN_TRAITS" },
             "effect": [
-              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "2.5" ] } },
               { "math": [ "u_calories() *= 4" ] },
               { "u_lose_trait": "TURN_INTO_RAVEN_TRAITS" },
               {
@@ -1345,7 +1345,7 @@
             "id": "EOC_POOKA_SHAPESHIFT_FULL_BEAR_activated_2",
             "condition": { "math": [ "u_val('mana') >= 2" ] },
             "effect": [
-              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "2.5" ] } },
               { "run_eocs": "EOC_SHAPESHIFTING_ARMOR_CHECK_SUBSUME_INTO_FORM" },
               { "u_add_trait": "TURN_INTO_BEAR_TRAITS" },
               { "math": [ "u_calories() *= 3" ] },
@@ -1369,7 +1369,7 @@
             "id": "EOC_POOKA_SHAPESHIFT_FULL_BEAR_deactivated",
             "condition": { "u_has_trait": "TURN_INTO_BEAR_TRAITS" },
             "effect": [
-              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "2.5" ] } },
               { "math": [ "u_calories() /= 3" ] },
               { "u_lose_trait": "TURN_INTO_BEAR_TRAITS" },
               {
@@ -1406,7 +1406,7 @@
             "id": "EOC_POOKA_SHAPESHIFT_FULL_DEER_activated_2",
             "condition": { "math": [ "u_val('mana') >= 2" ] },
             "effect": [
-              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "2.5" ] } },
               { "run_eocs": "EOC_SHAPESHIFTING_ARMOR_CHECK_SUBSUME_INTO_FORM" },
               { "u_add_trait": "TURN_INTO_DEER_TRAITS" },
               {
@@ -1429,7 +1429,7 @@
             "id": "EOC_POOKA_SHAPESHIFT_FULL_DEER_deactivated",
             "condition": { "u_has_trait": "TURN_INTO_DEER_TRAITS" },
             "effect": [
-              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "2.5" ] } },
               { "u_lose_trait": "TURN_INTO_DEER_TRAITS" },
               {
                 "u_message": "Your body shifts and contracts and you return to your humanoid form.",
@@ -1465,7 +1465,7 @@
             "id": "EOC_POOKA_SHAPESHIFT_FULL_WOLF_activated_2",
             "condition": { "math": [ "u_val('mana') >= 2" ] },
             "effect": [
-              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "2.5" ] } },
               { "run_eocs": "EOC_SHAPESHIFTING_ARMOR_CHECK_SUBSUME_INTO_FORM" },
               { "u_add_trait": "VAMPIRE_WOLF_FORM_TRAITS" },
               {
@@ -1488,7 +1488,7 @@
             "id": "EOC_POOKA_SHAPESHIFT_FULL_WOLF_deactivated",
             "condition": { "u_has_trait": "VAMPIRE_WOLF_FORM_TRAITS" },
             "effect": [
-              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "2.5" ] } },
               { "u_lose_trait": "VAMPIRE_WOLF_FORM_TRAITS" },
               { "u_message": "Your fur disappears and you walk once again on two legs.", "type": "neutral" },
               { "run_eocs": "EOC_SHAPESHIFTING_ARMOR_CHECK_RETURN_ARMOR_TO_NORMAL" }
@@ -1521,7 +1521,7 @@
             "id": "EOC_POOKA_SHAPESHIFT_FULL_COUGAR_activated_2",
             "condition": { "math": [ "u_val('mana') >= 2" ] },
             "effect": [
-              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "2.5" ] } },
               { "run_eocs": "EOC_SHAPESHIFTING_ARMOR_CHECK_SUBSUME_INTO_FORM" },
               { "u_add_trait": "TURN_INTO_COUGAR_TRAITS" },
               { "u_add_trait": "FELINE_LEAP" },
@@ -1546,7 +1546,7 @@
             "id": "EOC_POOKA_SHAPESHIFT_FULL_COUGAR_deactivated",
             "condition": { "u_has_trait": "TURN_INTO_COUGAR_TRAITS" },
             "effect": [
-              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "2.5" ] } },
               { "u_lose_trait": "TURN_INTO_COUGAR_TRAITS" },
               { "u_lose_trait": "FELINE_LEAP" },
               { "u_lose_trait": "WHISKERS" },

--- a/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
@@ -766,7 +766,7 @@
             "id": "EOC_EYEGLEAM_activated_2",
             "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -500" ] },
             "effect": [
-              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 0.25 },
+              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "0.25" ] } },
               { "math": [ "u_vitamin('human_blood_vitamin') -= 100" ] },
               { "u_add_effect": "eyegleam", "duration": "PERMANENT" },
               { "u_message": "Your eyes gleam red momentarily as they drink in all available light.", "type": "good" },
@@ -886,7 +886,7 @@
             "id": "EOC_VAMPIRIC_STRENGTH_activated_2",
             "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -500" ] },
             "effect": [
-              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 0.25 },
+              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "0.25" ] } },
               { "math": [ "u_vitamin('human_blood_vitamin') -= 150" ] },
               { "u_add_effect": "effect_vampiric_strength", "duration": "PERMANENT" },
               {
@@ -981,7 +981,7 @@
             "id": "EOC_VAMPIRIC_RESILIENCE_activated_2",
             "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -500" ] },
             "effect": [
-              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 0.25 },
+              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "0.25" ] } },
               { "math": [ "u_vitamin('human_blood_vitamin') -= 150" ] },
               { "u_add_effect": "effect_vampiric_resilience", "duration": "PERMANENT" },
               {
@@ -1117,7 +1117,7 @@
             "id": "EOC_COAGULANTWEAVE_activated_2",
             "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -500" ] },
             "effect": [
-              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 0.75 },
+              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "0.75" ] } },
               { "math": [ "u_vitamin('human_blood_vitamin') -= 500" ] },
               { "u_add_effect": "blood_weave", "duration": "PERMANENT" },
               { "u_lose_effect": "bleed", "target_part": "ALL" },
@@ -1278,7 +1278,7 @@
             "id": "EOC_VAMPIRIC_DODGE_activated_2",
             "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -500" ] },
             "effect": [
-              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 0.75 },
+              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "0.75" ] } },
               { "math": [ "u_vitamin('human_blood_vitamin') -= 250" ] },
               { "u_add_effect": "effect_vampiric_dodge", "duration": "PERMANENT" },
               {
@@ -1373,7 +1373,7 @@
             "id": "EOC_VAMPIRIC_STEALTH_BONUS_activated_2",
             "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -500" ] },
             "effect": [
-              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 0.75 },
+              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "0.75" ] } },
               { "math": [ "u_vitamin('human_blood_vitamin') -= 100" ] },
               { "u_add_effect": "effect_vampiric_stealth_bonus", "duration": "PERMANENT" },
               {
@@ -1526,7 +1526,7 @@
             "id": "EOC_VAMPIRE_BEAST_CLAWS_activated_2",
             "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -500" ] },
             "effect": [
-              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 0.75 },
+              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "0.75" ] } },
               { "math": [ "u_vitamin('human_blood_vitamin') -= 125" ] },
               { "u_add_trait": "VAMPIRE_BEAST_CLAWS_active" },
               {
@@ -1795,7 +1795,7 @@
             "id": "EOC_VAMPIRE_RENDING_TEETH_activated_2",
             "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= -500" ] },
             "effect": [
-              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 0.75 },
+              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "0.75" ] } },
               { "math": [ "u_vitamin('human_blood_vitamin') -= 200" ] },
               { "u_add_trait": "VAMPIRE_RENDING_TEETH_active" },
               {
@@ -1959,7 +1959,7 @@
               { "run_eocs": "EOC_VAMPIRE_CANCEL_WOLF_FORM" },
               { "run_eocs": "EOC_VAMPIRE_CANCEL_MIST_FORM" },
               { "run_eocs": "EOC_VAMPIRE_CANCEL_SHADOW_FORM" },
-              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 1.5 },
+              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "1.5" ] } },
               {
                 "if": { "u_has_trait": "VAMPIRE_FORM_UPGRADE" },
                 "then": { "math": [ "u_vitamin('human_blood_vitamin') -= 300" ] },
@@ -2030,7 +2030,7 @@
               { "run_eocs": "EOC_VAMPIRE_CANCEL_BAT_FORM" },
               { "run_eocs": "EOC_VAMPIRE_CANCEL_MIST_FORM" },
               { "run_eocs": "EOC_VAMPIRE_CANCEL_SHADOW_FORM" },
-              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 1.5 },
+              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "1.5" ] } },
               { "run_eocs": "EOC_SHAPESHIFTING_ARMOR_CHECK_SUBSUME_INTO_FORM" },
               {
                 "if": { "u_has_trait": "VAMPIRE_FORM_UPGRADE" },
@@ -2087,7 +2087,7 @@
               { "run_eocs": "EOC_VAMPIRE_CANCEL_BAT_FORM" },
               { "run_eocs": "EOC_VAMPIRE_CANCEL_WOLF_FORM" },
               { "run_eocs": "EOC_VAMPIRE_CANCEL_SHADOW_FORM" },
-              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 1.5 },
+              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "1.5" ] } },
               {
                 "if": { "u_has_trait": "VAMPIRE_FORM_UPGRADE" },
                 "then": { "math": [ "u_vitamin('human_blood_vitamin') -= 300" ] },
@@ -2274,7 +2274,7 @@
               { "run_eocs": "EOC_VAMPIRE_CANCEL_BAT_FORM" },
               { "run_eocs": "EOC_VAMPIRE_CANCEL_WOLF_FORM" },
               { "run_eocs": "EOC_VAMPIRE_CANCEL_MIST_FORM" },
-              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 1.5 },
+              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "1.5" ] } },
               {
                 "if": { "u_has_trait": "VAMPIRE_FORM_UPGRADE" },
                 "then": { "math": [ "u_vitamin('human_blood_vitamin') -= 400" ] },
@@ -2456,7 +2456,7 @@
             "id": "EOC_BLIND_THE_SUN_activated_2",
             "condition": { "math": [ "u_vitamin('human_blood_vitamin') >= 0" ] },
             "effect": [
-              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 1.25 },
+              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "1.25" ] } },
               { "math": [ "u_vitamin('human_blood_vitamin') -= 1000" ] },
               { "u_add_effect": "vampire_blind_the_sun", "duration": "PERMANENT" },
               {
@@ -2865,7 +2865,7 @@
     "id": "EOC_VAMPIRE_INVISIBLE_IN_DARK",
     "condition": { "not": { "and": [ "is_day", "u_is_outside", { "not": { "is_weather": "blotted_sun" } } ] } },
     "effect": [
-      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 0.25 },
+      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "0.25" ] } },
       { "math": [ "u_vitamin('human_blood_vitamin') -= 300" ] },
       {
         "u_add_effect": "effect_vampire_invisible_in_dark",

--- a/data/mods/Xedra_Evolved/mutations/werewolf_trait_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/werewolf_trait_eocs.json
@@ -165,7 +165,7 @@
                     "id": "EOC_WEREWOLF_TRANSFORM_INTO_PRIMAL_activated_3",
                     "condition": { "math": [ "u_val('mana') >= 50" ] },
                     "effect": [
-                      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 2.5 },
+                      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "2.5" ] } },
                       { "math": [ "u_val('mana') -= 50" ] },
                       { "math": [ "u_calories('dont_affect_weariness': true) *= 3" ] },
                       { "math": [ "u_werewolf_healing_tick_counter = 0" ] },
@@ -191,7 +191,7 @@
                     "id": "EOC_WEREWOLF_TRANSFORM_INTO_PRIMAL_FORM_deactivated",
                     "condition": { "u_has_trait": "WEREWOLF_PRIMAL_FORM_TRAITS" },
                     "effect": [
-                      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 1.5 },
+                      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "1.5" ] } },
                       {
                         "u_message": "Your body shifts and contracts and you return to your humanoid form.",
                         "type": "neutral"

--- a/data/mods/Xedra_Evolved/mutations/xe_lilin_trait_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/xe_lilin_trait_eocs.json
@@ -196,7 +196,7 @@
             "id": "EOC_LILIN_TURN_INTO_OWL_activated_2",
             "condition": { "math": [ "u_vitamin('lilin_ruach_vitamin') >= 360 * lilin_has_ruach_efficiency()" ] },
             "effect": [
-              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 1.5 },
+              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "1.5" ] } },
               { "math": [ "u_vitamin('lilin_ruach_vitamin') -= 360 * lilin_has_ruach_efficiency()" ] },
               { "run_eocs": "EOC_SHAPESHIFTING_ARMOR_CHECK_SUBSUME_INTO_FORM" },
               { "u_add_trait": "TURN_INTO_OWL_TRAITS" },
@@ -390,7 +390,7 @@
             "id": "EOC_LILIN_TRANSFORM_INTO_WAR_OWL_FORM_activated_2",
             "condition": { "math": [ "u_vitamin('lilin_ruach_vitamin') >= 480 * lilin_has_ruach_efficiency()" ] },
             "effect": [
-              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": 1.5 },
+              { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "math": [ "1.5" ] } },
               { "math": [ "u_vitamin('lilin_ruach_vitamin') -= 480 * lilin_has_ruach_efficiency()" ] },
               { "u_add_trait": "LILIN_WAR_OWL_FORM_TRAITS" },
               { "u_add_trait": "LILIN_WAR_OWL_FORM_LEAPER" },

--- a/data/mods/aftershock_exoplanet/items/armor/energy_shield.json
+++ b/data/mods/aftershock_exoplanet/items/armor/energy_shield.json
@@ -81,7 +81,7 @@
               "shield_max_hp": 600,
               "shield_regen": 2,
               "shield_regen_rate": 1,
-              "turn_cost": "1 s",
+              "turn_cost": { "math": [ "1" ] },
               "success_message": "a",
               "failure_message": "b"
             }

--- a/data/mods/aftershock_exoplanet/items/armor/energy_shield.json
+++ b/data/mods/aftershock_exoplanet/items/armor/energy_shield.json
@@ -81,7 +81,7 @@
               "shield_max_hp": 600,
               "shield_regen": 2,
               "shield_regen_rate": 1,
-              "turn_cost": 1,
+              "turn_cost": "1 s",
               "success_message": "a",
               "failure_message": "b"
             }

--- a/data/mods/desert_region/region_settings/region_settings/desert_regional_map_settings.json
+++ b/data/mods/desert_region/region_settings/region_settings/desert_regional_map_settings.json
@@ -3,7 +3,7 @@
     "type": "region_settings_river",
     "id": "default",
     "copy-from": "default",
-    "river_scale": 1.0,
+    "river_scale": 1,
     "river_frequency": 4.5,
     "river_branch_chance": 128.0,
     "river_branch_remerge_chance": 4.0,

--- a/data/mods/rural_biome/region_settings/region_settings/rural_regional_map_settings.json
+++ b/data/mods/rural_biome/region_settings/region_settings/rural_regional_map_settings.json
@@ -3,7 +3,7 @@
     "type": "region_settings_river",
     "id": "default_ruralbiome",
     "copy-from": "default",
-    "river_scale": 1.0,
+    "river_scale": 1,
     "river_frequency": 1.5,
     "river_branch_chance": 64.0,
     "river_branch_remerge_chance": 2.0,

--- a/doc/JSON/ARTIFACTS.md
+++ b/doc/JSON/ARTIFACTS.md
@@ -104,8 +104,8 @@ The various ways this artifact can charge and use charges.
 As the names suggest, these are *passive* benefits/penalties to having the artifact (i.e. always present without activating the artifact's abilities).  **Add** values add or subtract from existing scores, and **mult** values multiply them.  A multiply value of -1 is -100% and a multiply of 2.5 is +250%. These are entered as a list of possible 'abilities' the artifact could get. It does not by default get all these abilities, rather when it spawns it selects from the list provided.
 
 - **weight:** the weight of this value in the list, to be chosen randomly
-- **min_value:** the minimum possible value for this value type. for add must be an integer, for mult it can be a float
-- **max_value:** the maximum possible value for this value type. for add must be an integer, for mult it can be a float
+- **min_value:** the minimum possible value for this value type
+- **max_value:** the maximum possible value for this value type
 - **type:** the type of enchantment value. see MAGIC.md for detailed documentation on enchantment values
 - **increment:** the increment that is used for the power multiplier
 - **power_per_increment:** the power value per increment

--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -5445,7 +5445,7 @@ Subtract this many turns from the alpha talker's moves.
 
 | Syntax | Optionality | Value  | Info |
 | --- | --- | --- | --- |
-| "turn_cost" | **mandatory** | number, duration, [variable object](#variable-object) or value between two | how long the action takes (can be specified in number of turns (as decimal), or as a duration) |
+| "turn_cost" | **mandatory** | number, duration, [variable object](#variable-object) or value between two | how long the action takes as a duration |
 
 ##### Examples
 
@@ -5453,14 +5453,6 @@ Subtract this many turns from the alpha talker's moves.
 {
   "effect": [
     { "turn_cost": "1 sec" }
-  ]
-}
-```
-
-```jsonc
-{
-  "effect": [
-    { "turn_cost": 0.6 }
   ]
 }
 ```

--- a/src/flexbuffer_json-inl.h
+++ b/src/flexbuffer_json-inl.h
@@ -118,7 +118,7 @@ inline JsonValue::operator std::string() const
 
 inline JsonValue::operator int() const
 {
-    if( json_.IsNumeric() ) {
+    if( json_.IsIntOrUint() ) {
         return static_cast<int>( json_.AsInt64() );
     }
     throw_error( "Expected an int, got " + flexbuffer_type_to_string( json_.GetType() ) );
@@ -126,7 +126,7 @@ inline JsonValue::operator int() const
 
 inline JsonValue::operator int64_t() const
 {
-    if( json_.IsNumeric() ) {
+    if( json_.IsIntOrUint() ) {
         return static_cast<int64_t>( json_.AsInt64() );
     }
     throw_error( "Expected an int64_t, got " + flexbuffer_type_to_string( json_.GetType() ) );
@@ -134,7 +134,7 @@ inline JsonValue::operator int64_t() const
 
 inline JsonValue::operator uint64_t() const
 {
-    if( json_.IsNumeric() ) {
+    if( json_.IsIntOrUint() ) {
         // These are always stored as signed ints.
         int64_t signed_value = json_.AsInt64();
         if( signed_value >= 0 ) {
@@ -147,7 +147,7 @@ inline JsonValue::operator uint64_t() const
 
 inline JsonValue::operator unsigned() const
 {
-    if( json_.IsNumeric() ) {
+    if( json_.IsIntOrUint() ) {
         // These are always stored as signed ints.
         int64_t signed_value = json_.AsInt64();
         if( signed_value >= 0 ) {
@@ -214,7 +214,7 @@ inline bool JsonValue::test_number() const
 }
 inline bool JsonValue::test_int() const
 {
-    return json_.IsNumeric();
+    return json_.IsIntOrUint();
 }
 inline bool JsonValue::test_float() const
 {

--- a/src/flexbuffer_json.cpp
+++ b/src/flexbuffer_json.cpp
@@ -148,7 +148,7 @@ bool JsonValue::read( bool &b, bool throw_on_error ) const
 bool JsonValue::read( char &c, bool throw_on_error ) const
 {
     if( !test_int() ) {
-        return error_or_false( throw_on_error, "Syntax error.  Expected number" );
+        return error_or_false( throw_on_error, "Syntax error.  Expected integer" );
     }
     c = get_int();
     return true;
@@ -156,7 +156,7 @@ bool JsonValue::read( char &c, bool throw_on_error ) const
 bool JsonValue::read( signed char &c, bool throw_on_error ) const
 {
     if( !test_int() ) {
-        return error_or_false( throw_on_error, "Syntax error.  Expected number" );
+        return error_or_false( throw_on_error, "Syntax error.  Expected integer" );
     }
     // TODO: test for overflow
     c = get_int();
@@ -165,7 +165,7 @@ bool JsonValue::read( signed char &c, bool throw_on_error ) const
 bool JsonValue::read( unsigned char &c, bool throw_on_error ) const
 {
     if( !test_int() ) {
-        return error_or_false( throw_on_error, "Syntax error.  Expected number" );
+        return error_or_false( throw_on_error, "Syntax error.  Expected integer" );
     }
     // TODO: test for overflow
     c = get_int();
@@ -174,7 +174,7 @@ bool JsonValue::read( unsigned char &c, bool throw_on_error ) const
 bool JsonValue::read( short unsigned int &s, bool throw_on_error ) const
 {
     if( !test_int() ) {
-        return error_or_false( throw_on_error, "Syntax error.  Expected number" );
+        return error_or_false( throw_on_error, "Syntax error.  Expected integer" );
     }
     // TODO: test for overflow
     s = get_int();
@@ -183,7 +183,7 @@ bool JsonValue::read( short unsigned int &s, bool throw_on_error ) const
 bool JsonValue::read( short int &s, bool throw_on_error ) const
 {
     if( !test_int() ) {
-        return error_or_false( throw_on_error, "Syntax error.  Expected number" );
+        return error_or_false( throw_on_error, "Syntax error.  Expected integer" );
     }
     // TODO: test for overflow
     s = get_int();
@@ -192,7 +192,7 @@ bool JsonValue::read( short int &s, bool throw_on_error ) const
 bool JsonValue::read( int &i, bool throw_on_error ) const
 {
     if( !test_int() ) {
-        return error_or_false( throw_on_error, "Syntax error.  Expected number" );
+        return error_or_false( throw_on_error, "Syntax error.  Expected integer" );
     }
     i = get_int();
     return true;
@@ -200,7 +200,7 @@ bool JsonValue::read( int &i, bool throw_on_error ) const
 bool JsonValue::read( int64_t &i, bool throw_on_error ) const
 {
     if( !test_int() ) {
-        return error_or_false( throw_on_error, "Syntax error.  Expected number" );
+        return error_or_false( throw_on_error, "Syntax error.  Expected integer" );
     }
     i = get_int64();
     return true;
@@ -208,7 +208,7 @@ bool JsonValue::read( int64_t &i, bool throw_on_error ) const
 bool JsonValue::read( uint64_t &i, bool throw_on_error ) const
 {
     if( !test_int() ) {
-        return error_or_false( throw_on_error, "Syntax error.  Expected number" );
+        return error_or_false( throw_on_error, "Syntax error.  Expected integer" );
     }
     i = get_uint64();
     return true;
@@ -216,7 +216,7 @@ bool JsonValue::read( uint64_t &i, bool throw_on_error ) const
 bool JsonValue::read( unsigned int &u, bool throw_on_error ) const
 {
     if( !test_int() ) {
-        return error_or_false( throw_on_error, "Syntax error.  Expected number" );
+        return error_or_false( throw_on_error, "Syntax error.  Expected integer" );
     }
     u = get_uint();
     return true;

--- a/src/flexbuffer_json.cpp
+++ b/src/flexbuffer_json.cpp
@@ -147,7 +147,7 @@ bool JsonValue::read( bool &b, bool throw_on_error ) const
 }
 bool JsonValue::read( char &c, bool throw_on_error ) const
 {
-    if( !test_number() ) {
+    if( !test_int() ) {
         return error_or_false( throw_on_error, "Syntax error.  Expected number" );
     }
     c = get_int();
@@ -155,7 +155,7 @@ bool JsonValue::read( char &c, bool throw_on_error ) const
 }
 bool JsonValue::read( signed char &c, bool throw_on_error ) const
 {
-    if( !test_number() ) {
+    if( !test_int() ) {
         return error_or_false( throw_on_error, "Syntax error.  Expected number" );
     }
     // TODO: test for overflow
@@ -164,7 +164,7 @@ bool JsonValue::read( signed char &c, bool throw_on_error ) const
 }
 bool JsonValue::read( unsigned char &c, bool throw_on_error ) const
 {
-    if( !test_number() ) {
+    if( !test_int() ) {
         return error_or_false( throw_on_error, "Syntax error.  Expected number" );
     }
     // TODO: test for overflow
@@ -173,7 +173,7 @@ bool JsonValue::read( unsigned char &c, bool throw_on_error ) const
 }
 bool JsonValue::read( short unsigned int &s, bool throw_on_error ) const
 {
-    if( !test_number() ) {
+    if( !test_int() ) {
         return error_or_false( throw_on_error, "Syntax error.  Expected number" );
     }
     // TODO: test for overflow
@@ -182,7 +182,7 @@ bool JsonValue::read( short unsigned int &s, bool throw_on_error ) const
 }
 bool JsonValue::read( short int &s, bool throw_on_error ) const
 {
-    if( !test_number() ) {
+    if( !test_int() ) {
         return error_or_false( throw_on_error, "Syntax error.  Expected number" );
     }
     // TODO: test for overflow
@@ -191,7 +191,7 @@ bool JsonValue::read( short int &s, bool throw_on_error ) const
 }
 bool JsonValue::read( int &i, bool throw_on_error ) const
 {
-    if( !test_number() ) {
+    if( !test_int() ) {
         return error_or_false( throw_on_error, "Syntax error.  Expected number" );
     }
     i = get_int();
@@ -199,7 +199,7 @@ bool JsonValue::read( int &i, bool throw_on_error ) const
 }
 bool JsonValue::read( int64_t &i, bool throw_on_error ) const
 {
-    if( !test_number() ) {
+    if( !test_int() ) {
         return error_or_false( throw_on_error, "Syntax error.  Expected number" );
     }
     i = get_int64();
@@ -207,7 +207,7 @@ bool JsonValue::read( int64_t &i, bool throw_on_error ) const
 }
 bool JsonValue::read( uint64_t &i, bool throw_on_error ) const
 {
-    if( !test_number() ) {
+    if( !test_int() ) {
         return error_or_false( throw_on_error, "Syntax error.  Expected number" );
     }
     i = get_uint64();
@@ -215,7 +215,7 @@ bool JsonValue::read( uint64_t &i, bool throw_on_error ) const
 }
 bool JsonValue::read( unsigned int &u, bool throw_on_error ) const
 {
-    if( !test_number() ) {
+    if( !test_int() ) {
         return error_or_false( throw_on_error, "Syntax error.  Expected number" );
     }
     u = get_uint();

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -1054,7 +1054,7 @@ void enchant_cache::set_has( enchantment::has value )
     active_conditions.first = value;
 }
 
-void enchant_cache::add_value_add( enchant_vals::mod value, int add_value )
+void enchant_cache::add_value_add( enchant_vals::mod value, float add_value )
 {
     values_add[value] = add_value;
 }

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -632,7 +632,7 @@ void enchant_cache::load( const JsonObject &jo, std::string_view,
             try {
                 const enchant_vals::mod value = io::string_to_enum<enchant_vals::mod>
                                                 ( value_obj.get_string( "value" ) );
-                const int add = value_obj.get_int( "add", 0 );
+                const double add = value_obj.get_float( "add", 0 );
                 if( add != 0 ) {
                     values_add.emplace( value, add );
                 }

--- a/src/magic_enchantment.h
+++ b/src/magic_enchantment.h
@@ -375,7 +375,7 @@ class enchant_cache : public enchantment
                                     const std::map<TKey, double> &mult_map ) const;
 
         void serialize( JsonOut &jsout ) const;
-        void add_value_add( enchant_vals::mod value, int add_value );
+        void add_value_add( enchant_vals::mod value, float add_value );
 
         void set_has( enchantment::has value );
         void add_value_mult( enchant_vals::mod value, float mult_value );

--- a/src/relic.cpp
+++ b/src/relic.cpp
@@ -198,7 +198,7 @@ void relic_procgen_data::load( const JsonObject &jo, std::string_view )
     for( const JsonObject jo_inner : jo.get_array( "passive_add_procgen_values" ) ) {
         int weight = 0;
         mandatory( jo_inner, was_loaded, "weight", weight );
-        relic_procgen_data::enchantment_value_passive<int> val;
+        relic_procgen_data::enchantment_value_passive<float> val;
         val.load( jo_inner );
 
         passive_add_procgen_values.add( val, weight );
@@ -673,9 +673,9 @@ int relic_procgen_data::power_level( const enchant_cache &ench ) const
 {
     int power = 0;
 
-    for( const std::pair<relic_procgen_data::enchantment_value_passive<int>, int>
+    for( const std::pair<relic_procgen_data::enchantment_value_passive<float>, int>
          &add_val_passive : passive_add_procgen_values ) {
-        int val = ench.get_value_add( add_val_passive.first.type );
+        float val = ench.get_value_add( add_val_passive.first.type );
         if( val != 0 ) {
             power += static_cast<float>( add_val_passive.first.power_per_increment ) /
                      static_cast<float>( add_val_passive.first.increment ) * val;
@@ -748,10 +748,10 @@ relic relic_procgen_data::generate( const relic_procgen_data::generation_rules &
                 break;
             }
             case relic_procgen_data::type::passive_enchantment_add: {
-                const relic_procgen_data::enchantment_value_passive<int> *add = passive_add_procgen_values.pick();
+                const relic_procgen_data::enchantment_value_passive<float> *add = passive_add_procgen_values.pick();
                 if( add != nullptr ) {
                     enchant_cache ench;
-                    int value = rng( add->min_value, add->max_value );
+                    float value = rng_float( add->min_value, add->max_value );
                     if( value == 0 ) {
                         break;
                     }

--- a/src/relic.h
+++ b/src/relic.h
@@ -108,7 +108,7 @@ class relic_procgen_data
     private:
 
         weighted_int_list<relic_charge_template> charge_values;
-        weighted_int_list<enchantment_value_passive<int>> passive_add_procgen_values;
+        weighted_int_list<enchantment_value_passive<float>> passive_add_procgen_values;
         weighted_int_list<enchantment_value_passive<float>> passive_mult_procgen_values;
         weighted_int_list<enchantment_active> passive_hit_you;
         weighted_int_list<enchantment_active> passive_hit_me;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Fix float values provided in json silently converting into ints"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Due to incorrect checks in `JsonValue` for integer values it was possible to specify in json a number with fractions for a value represented by int in C++. `AsInt64` was used on them and fractions were silently gone.

That was allowing things like #80804 to happen without error. It was most likely also causing invalid or undesired behavior in every other such case. Specifically I've tested MindOverMatter's `clairsentient_crystal_procgen` preset. It defines for example
```
      {
        "weight": 50,
        "min_value": 0.1,
        "max_value": 1,
        "type": "AVOID_FRIENDRY_FIRE",
        "increment": 0.1,
        "power_per_increment": 75,
        "ench_has": "HELD"
      },
```
`min_value` and `increment` were rounded to zero resulting in `AVOID_FRIENDRY_FIRE` never appear on any artifact (0/10000).

Fixes #80804
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Make `JsonValue` use for integer values `IsIntOrUint` instead of `IsNumeric`.
- Allow `relic_procgen_data` accept floats values for `passive_add_procgen_values`
Reasoning: There is already a lot of magic enchantments which expect a float value - like multiplier or a 0.0 .. 1.0 chance. That contradicts int only restriction on add values, but it's already there. Options are - ether lift the restriction, or rework all of those values for something suitable for int add mechanic. Much more work and less flexibility. It will also likely to break a lot of not-in-repo mods. So unless there is some specific reason to add values be restricted to ints first option is preferable. Would really appreciate some input from people knowledgeable on the matter with this one.
- Fix all the incorrect values in json. Use `math` workaround where it is possible and round values down where it is not.
Note: not sure if workaround works. But worst case scenario should be - things were broken and remain broken.
- Remove from `turn_cost` info in EOC documentation a statement about ability to use fractions of a turn. That does not work since EOC durations use `time_duration` which stores time `int turns_`, not in moves.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Keep int add values and rework enchants instead.
- Do nothing, pretend everything is good. No really, that may be a good option.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Run cata_tests. Runs ok.
Make a world with each in-repo mod and start a game. Game starts.
Spawn some `clairsentient_crystal_procgen` based arts in MindOverMatter and check if they have `AVOID_FRIENDRY_FIRE` now. They do: 818/10000.
Save/load save with arts to see if they will retain their properties. Look same.
Load old 215hr hoarder save. Loads.

No matter how much I test I don't think I will be able to cover everything.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Expect thing to break!
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
