### PR TITLE
Validate spell classes, targeted monster ids and species

### DIFF
--- a/data/mods/TEST_DATA/magic.json
+++ b/data/mods/TEST_DATA/magic.json
@@ -226,7 +226,7 @@
     "sound_ambient": true,
     "sound_id": "test_sound",
     "sound_variant": "not_default",
-    "targeted_monster_ids": [ "mon_test" ],
+    "targeted_monster_ids": [ "mon_test_base" ],
     "extra_effects": [ { "id": "test_fake_spell" } ],
     "affected_body_parts": [ "head" ],
     "flags": [ "CONCENTRATE" ],

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -514,7 +514,7 @@ void spell_type::check_consistency()
                       sp_t.id.c_str() );
         }
 
-        if( sp_t.spell_class.is_valid() ) {
+        if( !sp_t.spell_class.is_valid() ) {
             debugmsg( R"(ERROR: %s has invalid spell class "%s"!)", sp_t.id.c_str(), sp_t.spell_class.c_str() );
         }
 

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -514,8 +514,7 @@ void spell_type::check_consistency()
                       sp_t.id.c_str() );
         }
 
-        // TODO: this may need to use trait_id::NULL_ID()?
-        if( !sp_t.spell_class.is_valid() && sp_t.spell_class.c_str() != "NONE" ) {
+        if( !sp_t.spell_class.is_valid() && sp_t.spell_class.str() != "NONE" ) {
             debugmsg( R"(ERROR: %s has invalid spell class "%s"!)", sp_t.id.c_str(), sp_t.spell_class.c_str() );
         }
 

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -514,6 +514,28 @@ void spell_type::check_consistency()
                       sp_t.id.c_str() );
         }
 
+        if( sp_t.spell_class.is_valid() ) {
+            debugmsg( R"(ERROR: %s has invalid spell class "%s"!)", sp_t.id.c_str(), sp_t.spell_class.c_str() );
+        }
+
+        if( !sp_t.targeted_monster_ids.empty() ) {
+            for( const auto &targeted_monster : sp_t.targeted_monster_ids ) {
+                if( !targeted_monster.is_valid() ) {
+                    debugmsg( R"(ERROR: %s target monster with invalid id "%s"!)", sp_t.id.c_str(),
+                              targeted_monster.str() );
+                }
+            }
+        }
+
+        if( !sp_t.targeted_species_ids.empty() ) {
+            for( const auto &targeted_species : sp_t.targeted_species_ids ) {
+                if( !targeted_species.is_valid() ) {
+                    debugmsg( R"(ERROR: %s target species with invalid id "%s"!)", sp_t.id.c_str(),
+                              targeted_species.str() );
+                }
+            }
+        }
+
         if( sp_t.exp_for_level_formula_id.has_value() &&
             sp_t.exp_for_level_formula_id.value()->num_params != 1 ) {
             debugmsg( "ERROR: %s exp_for_level_formula_id has params that != 1!", sp_t.id.c_str() );

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -514,7 +514,8 @@ void spell_type::check_consistency()
                       sp_t.id.c_str() );
         }
 
-        if( !sp_t.spell_class.is_valid() ) {
+        // TODO: this may need to use trait_id::NULL_ID()?
+        if( !sp_t.spell_class.is_valid() && sp_t.spell_class.c_str() != "NONE" ) {
             debugmsg( R"(ERROR: %s has invalid spell class "%s"!)", sp_t.id.c_str(), sp_t.spell_class.c_str() );
         }
 

--- a/tests/json_test.cpp
+++ b/tests/json_test.cpp
@@ -39,7 +39,7 @@ static const flag_id json_flag_DIRTY( "DIRTY" );
 static const itype_id itype_test_rag( "test_rag" );
 
 static const mtype_id foo( "foo" );
-static const mtype_id mon_test( "mon_test" );
+static const mtype_id mon_test_base( "mon_test_base" );
 
 static const requirement_id requirement_data_test_components( "test_components" );
 
@@ -90,7 +90,7 @@ TEST_CASE( "spell_type_handles_all_members", "[json]" )
         fake_additional_effect.id = spell_test_fake_spell;
         const std::vector<fake_spell> test_fake_spell_vec{ fake_additional_effect };
         const std::map<std::string, int> test_learn_spell{ { fake_additional_effect.id.c_str(), 1 } };
-        const std::set<mtype_id> test_fake_mon{ mon_test };
+        const std::set<mtype_id> test_fake_mon{ mon_test_base };
 
         CHECK( test_spell.id == spell_test_spell_json );
         CHECK( test_spell.name == to_translation( "test spell" ) );


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Prevent #84375 and #84382
#### Describe the solution
Apply snippets proposed by me
#### Testing
purposefully made a typo in vanilla spell, the game recognized incorrect id