### PR TITLE
Fix consume menu crash on save

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -4196,7 +4196,7 @@ void consume_activity_actor::serialize( JsonOut &jsout ) const
 
     jsout.member( "consume_location", consume_location );
     jsout.member( "consume_item", consume_item );
-    jsout.member( "was_canceled", was_canceled );
+    jsout.member( "canceled", was_canceled );
     jsout.member( "reprompt_consume_menu", reprompt_consume_menu );
 
     jsout.end_object();
@@ -4211,7 +4211,7 @@ std::unique_ptr<activity_actor> consume_activity_actor::deserialize( JsonValue &
 
     data.read( "consume_location", actor.consume_location );
     data.read( "consume_item", actor.consume_item );
-    data.read( "was_canceled", actor.was_canceled );
+    data.read( "canceled", actor.was_canceled );
     if( data.has_member( "reprompt_consume_menu" ) ) {
         data.read( "reprompt_consume_menu", actor.reprompt_consume_menu );
     }

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -4111,18 +4111,18 @@ std::unique_ptr<activity_actor> open_gate_activity_actor::deserialize( JsonValue
     return actor.clone();
 }
 
-void consume_activity_actor::start( player_activity &act, Character &who )
+void consume_activity_actor::start( player_activity &act, Character &guy )
 {
     int moves = 0;
     Character &player_character = get_player_character();
-    //TODO: why use both `player_character` and `who`?
-    auto player_will_eat = [this, &moves, &player_character, &who]( const item & it ) {
+    //TODO: why use both `player_character` and `guy`?
+    auto player_will_eat = [this, &moves, &player_character, &guy]( const item & it ) {
         ret_val<edible_rating> ret = player_character.will_eat( it, true );
         if( !ret.success() ) {
             was_canceled = true;
             uistate.consume_uistate.clear();
         } else {
-            moves = to_moves<int>( who.get_consume_time( it ) );
+            moves = to_moves<int>( guy.get_consume_time( it ) );
         }
     };
 

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -8131,6 +8131,13 @@ void firstaid_activity_actor::finish( player_activity &act, Character &who )
     }
 }
 
+void firstaid_activity_actor::canceled( player_activity &, Character &who )
+{
+    if( who.is_avatar() ) {
+        uistate.consume_uistate.clear();
+    }
+}
+
 void firstaid_activity_actor::serialize( JsonOut &jsout ) const
 {
     jsout.start_object();

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -4177,13 +4177,8 @@ void consume_activity_actor::finish( player_activity &act, Character & )
 
     if( !avatar_action::eat_here( player_character ) && reprompt_consume_menu ) {
         uistate.open_menu = []() {
-            item_location consume_loc_next = game_menus::inv::consume(
-                                                 uistate.consume_uistate.consume_menu_comestype );
-            if( consume_loc_next != item_location::nowhere ) {
-                avatar_action::eat_or_use( get_avatar(), consume_loc_next );
-            } else {
-                uistate.consume_uistate.clear();
-            }
+            avatar_action::eat_or_use( get_avatar(),
+                                       game_menus::inv::consume( uistate.consume_uistate.consume_menu_comestype ) );
         };
     }
 }

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -2779,6 +2779,7 @@ class firstaid_activity_actor : public activity_actor
         void start( player_activity &act, Character &who ) override;
         void do_turn( player_activity &, Character & ) override {};
         void finish( player_activity &act, Character &who ) override;
+        void canceled( player_activity &, Character &who ) override;
 
         std::unique_ptr<activity_actor> clone() const override {
             return std::make_unique<firstaid_activity_actor>( *this );

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -1208,7 +1208,7 @@ class consume_activity_actor : public activity_actor
             return ACT_CONSUME;
         }
 
-        void start( player_activity &act, Character &who ) override;
+        void start( player_activity &act, Character &guy ) override;
         void do_turn( player_activity &, Character & ) override {}
         void finish( player_activity &act, Character & ) override;
         void canceled( player_activity &, Character &who ) override;

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -1183,7 +1183,7 @@ class consume_activity_actor : public activity_actor
     private:
         item_location consume_location;
         item consume_item;
-        bool canceled = false;
+        bool was_canceled = false;
         // whether to show the consume menu after this activity finishes
         bool reprompt_consume_menu = false;
 
@@ -1193,7 +1193,7 @@ class consume_activity_actor : public activity_actor
         bool can_resume_with_internal( const activity_actor &other, const Character & ) const override {
             const consume_activity_actor &c_actor = static_cast<const consume_activity_actor &>( other );
             return consume_location == c_actor.consume_location &&
-                   canceled == c_actor.canceled && &consume_item == &c_actor.consume_item;
+                   was_canceled == c_actor.was_canceled && &consume_item == &c_actor.consume_item;
         }
     public:
         explicit consume_activity_actor( const item_location &consume_location,
@@ -1208,9 +1208,10 @@ class consume_activity_actor : public activity_actor
             return ACT_CONSUME;
         }
 
-        void start( player_activity &act, Character &guy ) override;
+        void start( player_activity &act, Character &who ) override;
         void do_turn( player_activity &, Character & ) override {}
         void finish( player_activity &act, Character & ) override;
+        void canceled( player_activity &, Character &who ) override;
 
         std::unique_ptr<activity_actor> clone() const override {
             return std::make_unique<consume_activity_actor>( *this );

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1077,11 +1077,16 @@ item_location game_menus::inv::consume( const std::string &comestible_type_filte
 
     std::string none_message = you.activity.str_values.size() == 2 ?
                                _( "You have nothing else to consume." ) : _( "You have nothing to consume." );
-    return inv_internal( you, preset,
-                         _( "Consume item" ), 1,
-                         none_message,
-                         get_consume_needs_hint( you ),
-                         loc, false, true );
+
+    item_location returned_location = inv_internal( you, preset,
+                                      _( "Consume item" ), 1,
+                                      none_message,
+                                      get_consume_needs_hint( you ),
+                                      loc, false, true );
+    if( returned_location == item_location::nowhere ) {
+        uistate.consume_uistate.clear();
+    }
+    return returned_location;
 }
 
 class activatable_inventory_preset : public pickup_inventory_preset

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -3217,7 +3217,6 @@ void consume_menu_uistate::serialize( JsonOut &json ) const
 {
     json.start_object();
     json.member( "consume_menu_selections", consume_menu_selections );
-    json.member( "consume_menu_selected_items", consume_menu_selected_items );
     json.member( "consume_menu_filter", consume_menu_filter );
     json.member( "collated", collated );
     json.member( "consume_menu_comestype", consume_menu_comestype );
@@ -3227,7 +3226,6 @@ void consume_menu_uistate::serialize( JsonOut &json ) const
 void consume_menu_uistate::deserialize( const JsonObject &jo )
 {
     jo.read( "consume_menu_selections", consume_menu_selections );
-    jo.read( "consume_menu_selected_items", consume_menu_selected_items );
     jo.read( "consume_menu_filter", consume_menu_filter );
     jo.read( "collated", collated );
     jo.read( "consume_menu_comestype", consume_menu_comestype );

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -201,8 +201,8 @@ static item_location inv_internal( Character &u, const inventory_selector_preset
 
     item_location location = inv_s.execute();
 
-    //output to global consume menu UI state
-    if( using_consume_menu ) {
+    // If something was chosen output to global consume menu UI state
+    if( using_consume_menu && location != item_location::nowhere ) {
 
         inventory_entry const &e = inv_s.get_highlighted();
         bool const collated = e.is_collation_entry();

--- a/src/uistate.h
+++ b/src/uistate.h
@@ -117,7 +117,7 @@ struct consume_menu_uistate {
     // values[1] = inventory selector selected index in column
     std::vector<size_t> consume_menu_selections;
     // targets[0...x] if collated, a pair of {0, 1}, otherwise all item_locations highlighted
-    std::vector<item_location> consume_menu_selected_items;
+    std::vector<item_location> consume_menu_selected_items; // NOLINT(cata-serialize)
     // str_values[0] = filter (the one you type in, not the new comestype filter)
     std::string consume_menu_filter;
     // values[2] = inventory selector collated bool

--- a/src/uistate.h
+++ b/src/uistate.h
@@ -115,7 +115,7 @@ struct overmap_sidebar_uistate {
 struct consume_menu_uistate {
     // values[0] = inventory selector selected column index,
     // values[1] = inventory selector selected index in column
-    std::vector<size_t> consume_menu_selections;
+    std::vector<uint64_t> consume_menu_selections;
     // targets[0...x] if collated, a pair of {0, 1}, otherwise all item_locations highlighted
     std::vector<item_location> consume_menu_selected_items; // NOLINT(cata-serialize)
     // str_values[0] = filter (the one you type in, not the new comestype filter)

--- a/src/uistate.h
+++ b/src/uistate.h
@@ -115,7 +115,7 @@ struct overmap_sidebar_uistate {
 struct consume_menu_uistate {
     // values[0] = inventory selector selected column index,
     // values[1] = inventory selector selected index in column
-    std::vector<uint64_t> consume_menu_selections;
+    std::vector<size_t> consume_menu_selections;
     // targets[0...x] if collated, a pair of {0, 1}, otherwise all item_locations highlighted
     std::vector<item_location> consume_menu_selected_items;
     // str_values[0] = filter (the one you type in, not the new comestype filter)


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Fix consume menu crash on save"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #84423
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Reset consume menu state when player leaves it for good or is interrupted while keeping it's state preserved for chained activations.
- Don't save or load `consume_uistate.consume_menu_selected_items` since it may contain invalid `item_loaction`s.
- ~~Change `consume_menu_uistate.consume_menu_selections` to `size_t` since its what `highlight_position` wants.~~

This prevents attempts to save invalid `item_loaction`s which was causing crashes on save and errors on load. Also brings consume window behavior in line with other inventory windows
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
N/A
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Consume items one after another without leaving consume window. Cursor stays at the item. Filter is set.
Run out of items, move to other food pile or exit window and open it again manually. UI state is reset.
Cant really test the crashes since they are intermittent and not easily reproducible.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Known issues:
- Not saving `consume_uistate.consume_menu_selected_items` will result in consume menu reset in case when player was caught by autosave mid-consuming and then will load such a save.
- Saves made between #84348 and these changes on first load will give debug message `Unread data.  Invalid or misplaced field name "consume_menu_selected_items" in JSON data`. It does not seem to cause actual issues with save loading and can should be safe to ignore. (Is there some mechanism to obsolete such data without warning?)

Other things to consider:
- Invalid `item_location`s now only can happen when one of the stored items will rot away or change location somehow during player consuming something else.  While invalid locations are no longer written to disk they still used in attempt to restore consume menu cursor position. Not sure if it is safe.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
