### PR TITLE
Bind unload onto ground, rename keys for clarity

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -2640,7 +2640,7 @@
   },
   {
     "type": "keybinding",
-    "name": "Unload item",
+    "name": "Unload container into inventory (keep items)",
     "category": "DEFAULTMODE",
     "id": "unload",
     "bindings": [ { "input_method": "keyboard_char", "key": "U" }, { "input_method": "keyboard_code", "key": "u", "mod": [ "shift" ] } ]
@@ -2701,9 +2701,10 @@
   },
   {
     "type": "keybinding",
-    "name": "Unload container",
+    "name": "Unload container onto ground (drop items)",
     "category": "DEFAULTMODE",
-    "id": "unload_container"
+    "id": "unload_container",
+    "bindings": [ { "input_method": "keyboard_any", "key": "BACKSPACE" } ]
   },
   {
     "type": "keybinding",


### PR DESCRIPTION
#### Summary
Interface "Bind unload onto ground key, rename keys for clarity"

#### Purpose of change
How do you dump your backpack's contents onto the ground? Well uh, first you have to bind a key, and you have to figure out which key...
<img width="614" height="58" alt="image" src="https://github.com/user-attachments/assets/34a2288b-8342-42ce-b997-96d45685e06a" />

#### Describe the solution
Just tell people what the damn key does!
<img width="546" height="55" alt="image" src="https://github.com/user-attachments/assets/627b7ed4-ffc2-4031-8e5f-8f99aaa6aca6" />

Also give it a default binding

#### Describe alternatives you've considered
I would like both of these to be on the `u` key, but `u`(lowercase) is used for movement.

#### Testing
Pressed the unload keys, they worked

#### Additional context
