### PR TITLE
Fix use-after-free during saving (#76742)

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -255,7 +255,12 @@ vehicle::vehicle( const vproto_id &proto_id )
     }
 }
 
-vehicle::~vehicle() = default;
+vehicle::~vehicle()
+{
+    if( destructor_callback ) {
+        destructor_callback( *this );
+    }
+}
 
 turret_cpu::~turret_cpu() = default;
 

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -2514,6 +2514,18 @@ class vehicle
         // Returns debug data to overlay on the screen, a vector of {map tile position
         // relative to vehicle pos, color and text}.
         std::vector<std::tuple<point_rel_ms, int, std::string>> get_debug_overlay_data() const;
+
+    private:
+        // Set by set_destructor_callback below. This is null when not set.
+        std::function<void( const vehicle & )> destructor_callback; // NOLINT(cata-serialize)
+
+    public:
+        // Sets a callback that will be called when this is destroyed. Currently only being used
+        // by item_location::impl::item_on_vehicle to check for validity of its vehicle reference.
+        template<typename Callback>
+        void set_destructor_callback( Callback &&cb ) {
+            destructor_callback = std::forward<Callback>( cb );
+        }
 };
 
 // For reference what each function is supposed to do, see their implementation in


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Fix #76742"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

Fixed a use-after-free bug in the saving logic. The UI state serialization holds references to vehicles owned by the map, but the map was being cleared before the UI serialization. This adds safety checks so that when a vehicle is destroyed, the serialization of the UI state uses the last known parameters of the target vehicle.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

Reiterating the problem:

```C++
// bool game::save() in game_io.cpp
if( !save_player_data() ||
    !save_achievements() ||
    !save_factions_missions_npcs() ||
    !save_external_options_record() ||
    !save_dimension_data() ||

    // Destroys vehicles
    !save_maps() ||

    !get_auto_pickup().save_character() ||
    !get_auto_notes_settings().save( true ) ||
    !get_safemode().save_character() ||
    !zone_manager::get_manager().save_zones() ||

    // Still has references to vehicles
    !write_to_file( PATH_INFO::world_base_save_path() / "uistate.json", [&](
std::ostream & fout ) {
JsonOut jsout( fout );
    uistate.serialize( jsout );
}, _( "uistate data" ) ) ) {
    debugmsg( "game not saved" );
    return false;
} else {
    //...
}
```

I added a callback to `vehicle` which it can call when it's destroyed so that `item_location::impl::item_on_vehicle` won't access free'd references.
```C++
vehicle::~vehicle() {
    if (destructor_callback) {
        destructor_callback(*this);
    }
}
```

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Above is the least obstrusive way I can think of. The other is to change `submap` to use `std::vector<std::shared_ptr<vehicle>> vehicles;` instead then propagate that to a `shared_ptr<vehicle>` in `vehicle_cursor` instead of `vehicle &`.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

1) Build CDDA with `SANITIZE=address`.

2) Reproduce #76742 as per @mqrause's [comment](https://github.com/CleverRaven/Cataclysm-DDA/issues/76742#issuecomment-2393667440).

3) Observe the crash.

4) Rebuild with fixes and reproduce, no more crashes.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

##### Build

CDDA was built using macOS with:

```sh
make NATIVE=osx DEBUG_SYMBOLS=1 TILES=1 SOUND=1 RUNTESTS=0 ASTYLE=0 LINTJSON=0 OSX_MIN=26.0 CLANG=1 PCH=1 SANITIZE=address
```

The `SANITIZE=address` is important. This is a use-after-free bug, it may silently do weird, UB things without -fsanitize.

##### Repro details

I used the following save file for testing:

[76742-trimmed.tar.gz](https://github.com/user-attachments/files/24420526/76742-trimmed.tar.gz)

1) Open AIM (/ key)
2) Place plastic bottle with fruit juice in the sedan
3) Open plastic bottle (c key)
4) Exit AIM (esc key)
5) Walk away
6) Save and Quit

Also tested quicksaving on the same file

6) Quicksave
7) Walk some more
8) Quicksave again

#### Addendum

This is the ASan report of the use-after-free:

[asan-report.txt](https://github.com/user-attachments/files/24420529/asan-report.txt)

The deserialization of the UI state seems borked too but I think it's outside the scope of this PR. And there's probably an open issue for that that I don't know about.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
