### PR TITLE
Reduce the amount of clothing in dressers

### DIFF
--- a/data/json/itemgroups/Clothing_Gear/clothing.json
+++ b/data/json/itemgroups/Clothing_Gear/clothing.json
@@ -3533,7 +3533,6 @@
     "type": "item_group",
     "id": "laundry",
     "items": [
-      [ "basket_laundry", 30 ],
       [ "jeans", 90 ],
       [ "jeans_ripped", 10 ],
       [ "jeans_skinny", 20 ],

--- a/data/json/itemgroups/SUS/domestic.json
+++ b/data/json/itemgroups/SUS/domestic.json
@@ -1048,11 +1048,13 @@
     "subtype": "collection",
     "entries": [
       { "group": "shoes_unisex", "count": [ 0, 3 ] },
+      { "group": "coats_unisex", "count": [ 1, 6 ] },
+      { "group": "suits_mens", "prob": 25, "count": [ 1, 2 ] },
+      { "group": "suits_unisex", "prob": 25, "count": [ 1, 2 ] },
+      { "group": "bags_unisex", "prob": 65, "count": [ 1, 2 ] },
+      { "group": "SUS_dresser_mens", "prob": 25 },
+      { "group": "SUS_dresser_mens_single_outfit", "count": [ 0, 4 ] },
       { "item": "sleeping_bag_roll", "prob": 5 },
-      { "group": "coats_unisex", "prob": 50, "count": [ 0, 3 ] },
-      { "group": "suits_unisex", "prob": 50, "count": [ 0, 2 ] },
-      { "group": "suits_mens", "prob": 25, "count": [ 0, 2 ] },
-      { "group": "SUS_dresser_mens", "prob": 100 },
       { "item": "crutches", "prob": 1 }
     ]
   },
@@ -1062,13 +1064,15 @@
     "//": "clothing found in a woman's wardrobe",
     "subtype": "collection",
     "entries": [
-      { "group": "shoes_unisex", "prob": 50, "count": [ 1, 2 ] },
-      { "group": "shoes_womens", "prob": 60, "count": [ 1, 2 ] },
+      { "group": "shoes_unisex", "count": [ 0, 2 ] },
+      { "group": "shoes_womens", "count": [ 1, 2 ] },
+      { "group": "coats_unisex", "count": [ 1, 6 ] },
+      { "group": "suits_womens", "count": [ 2, 6 ] },
+      { "group": "suits_unisex", "prob": 25, "count": [ 1, 2 ] },
+      { "group": "bags_unisex", "prob": 65, "count": [ 1, 2 ] },
+      { "group": "SUS_dresser_womens", "prob": 25 },
+      { "group": "SUS_dresser_womens_single_outfit", "count": [ 0, 4 ] },
       { "item": "sleeping_bag_roll", "prob": 5 },
-      { "group": "coats_unisex", "prob": 50, "count": [ 0, 3 ] },
-      { "group": "suits_unisex", "prob": 50, "count": [ 0, 2 ] },
-      { "group": "suits_womens", "prob": 25, "count": [ 0, 2 ] },
-      { "group": "SUS_dresser_womens", "prob": 100 },
       { "item": "crutches", "prob": 1 }
     ]
   },
@@ -1076,22 +1080,44 @@
     "id": "SUS_dresser_mens",
     "type": "item_group",
     "//": "clothing found in a man's dresser",
-    "subtype": "collection",
+    "subtype": "distribution",
     "entries": [
-      { "group": "accesories_personal_unisex", "prob": 10 },
-      { "group": "accesories_personal_mens", "prob": 10 },
-      { "group": "masks_unisex", "prob": 3 },
-      { "group": "socks_unisex", "count": [ 7, 14 ], "prob": 100 },
-      { "group": "scarfs_unisex", "prob": 30 },
-      { "group": "shirts_unisex", "count": [ 7, 14 ], "prob": 100 },
-      { "group": "underwear_mens", "count": [ 5, 7 ], "prob": 100 },
-      { "group": "underwear_unisex", "count": [ 3, 7 ], "prob": 100 },
-      { "group": "pants_unisex", "count": [ 4, 7 ], "prob": 50 },
-      { "group": "pants_male", "count": [ 4, 7 ], "prob": 5 },
-      { "group": "gloves_unisex", "prob": 30 },
-      { "group": "hats_unisex", "prob": 10 },
-      { "group": "bags_unisex", "prob": 50 },
-      { "group": "SUS_dresser_mens_single_outfit", "count": [ 1, 2 ], "prob": 80 }
+      {
+        "collection": [
+          { "group": "socks_unisex", "count": [ 4, 12 ] },
+          { "group": "underwear_mens", "count": [ 4, 10 ] },
+          { "group": "underwear_unisex", "count": [ 1, 3 ] },
+          { "group": "shirts_unisex", "count": [ 4, 10 ] },
+          { "group": "pants_male", "count": [ 2, 8 ] },
+          { "group": "pants_unisex", "count": [ 0, 2 ] },
+          { "group": "hats_unisex", "count": [ 1, 3 ] },
+          { "group": "scarfs_unisex", "count": [ 0, 2 ] },
+          { "group": "gloves_unisex", "count": [ 0, 2 ] },
+          { "group": "bags_unisex_small", "count": [ 0, 2 ] },
+          { "group": "accesories_personal_unisex", "prob": 30 },
+          { "group": "accesories_personal_mens", "prob": 10 },
+          { "group": "masks_unisex", "prob": 5 }
+        ],
+        "prob": 2
+      },
+      {
+        "collection": [
+          { "group": "socks_unisex", "count": [ 2, 4 ] },
+          { "group": "underwear_mens", "count": [ 2, 4 ] },
+          { "group": "underwear_unisex", "count": [ 0, 1 ] },
+          { "group": "shirts_unisex", "count": [ 1, 5 ] },
+          { "group": "pants_male", "count": [ 0, 3 ] },
+          { "group": "pants_unisex", "count": [ 0, 1 ] },
+          { "group": "hats_unisex", "prob": 30 },
+          { "group": "scarfs_unisex", "prob": 15 },
+          { "group": "gloves_unisex", "prob": 15 },
+          { "group": "bags_unisex_small", "prob": 30 },
+          { "group": "accesories_personal_unisex", "prob": 30 },
+          { "group": "accesories_personal_mens", "prob": 10 },
+          { "group": "masks_unisex", "prob": 5 }
+        ],
+        "prob": 1
+      }
     ]
   },
   {
@@ -1141,24 +1167,45 @@
     "id": "SUS_dresser_womens",
     "type": "item_group",
     "//": "clothing found in a woman's dresser",
-    "subtype": "collection",
+    "subtype": "distribution",
     "entries": [
-      { "group": "accesories_personal_unisex", "prob": 30 },
-      { "group": "accesories_personal_womens", "prob": 5 },
-      { "group": "masks_unisex", "prob": 3 },
-      { "group": "socks_unisex", "count": [ 7, 14 ], "prob": 100 },
-      { "group": "scarfs_unisex", "prob": 30 },
-      { "group": "shirts_unisex", "count": [ 7, 14 ], "prob": 100 },
-      { "group": "shirts_womens", "count": [ 1, 4 ], "prob": 50 },
-      { "group": "underwear_womens", "count": [ 4, 7 ], "prob": 100 },
-      { "group": "underwear_unisex", "count": [ 4, 7 ], "prob": 100 },
-      { "group": "pants_unisex", "count": [ 4, 7 ], "prob": 100 },
-      { "group": "pants_female", "count": [ 4, 7 ], "prob": 100 },
-      { "group": "gloves_womens", "prob": 5 },
-      { "group": "gloves_unisex", "prob": 30 },
-      { "group": "hats_unisex", "prob": 10 },
-      { "group": "bags_unisex", "prob": 50 },
-      { "group": "SUS_dresser_womens_single_outfit", "count": [ 1, 2 ], "prob": 80 }
+      {
+        "collection": [
+          { "group": "socks_unisex", "count": [ 4, 12 ] },
+          { "group": "underwear_womens", "count": [ 4, 10 ] },
+          { "group": "underwear_unisex", "count": [ 1, 3 ] },
+          { "group": "shirts_unisex", "count": [ 4, 10 ] },
+          { "group": "pants_female", "count": [ 2, 8 ] },
+          { "group": "pants_unisex", "count": [ 0, 2 ] },
+          { "group": "hats_unisex", "count": [ 1, 3 ] },
+          { "group": "scarfs_unisex", "count": [ 0, 2 ] },
+          { "group": "gloves_unisex", "count": [ 0, 2 ] },
+          { "group": "gloves_womens", "prob": 5 },
+          { "group": "bags_unisex_small", "count": [ 0, 2 ] },
+          { "group": "accesories_personal_unisex", "prob": 30 },
+          { "group": "accesories_personal_womens", "prob": 80 },
+          { "group": "masks_unisex", "prob": 5 }
+        ],
+        "prob": 2
+      },
+      {
+        "collection": [
+          { "group": "socks_unisex", "count": [ 2, 4 ] },
+          { "group": "underwear_womens", "count": [ 2, 4 ] },
+          { "group": "underwear_unisex", "count": [ 0, 1 ] },
+          { "group": "shirts_unisex", "count": [ 1, 5 ] },
+          { "group": "pants_female", "count": [ 0, 3 ] },
+          { "group": "pants_unisex", "count": [ 0, 1 ] },
+          { "group": "hats_unisex", "prob": 30 },
+          { "group": "scarfs_unisex", "prob": 15 },
+          { "group": "gloves_unisex", "prob": 15 },
+          { "group": "bags_unisex_small", "prob": 30 },
+          { "group": "accesories_personal_unisex", "prob": 30 },
+          { "group": "accesories_personal_womens", "prob": 30 },
+          { "group": "masks_unisex", "prob": 5 }
+        ],
+        "prob": 1
+      }
     ]
   },
   {

--- a/data/json/itemgroups/SUS/domestic.json
+++ b/data/json/itemgroups/SUS/domestic.json
@@ -767,6 +767,16 @@
     ]
   },
   {
+    "id": "SUS_laundry_basket",
+    "type": "item_group",
+    "//": "SUS item groups are collections that contain a reasonable realistic distribution of items that might spawn in a given storage furniture.",
+    "//2": "This group is for a laundry basket.",
+    "subtype": "collection",
+    "container-item": "basket_laundry",
+    "on_overflow": "discard",
+    "entries": [ { "group": "laundry", "count": [ 5, 15 ] } ]
+  },
+  {
     "id": "SUS_bathroom_sink",
     "type": "item_group",
     "//": "SUS item groups are collections that contain a reasonable realistic distribution of items that might spawn in a given storage furniture.",

--- a/data/json/mapgen_palettes/house_general_abandoned.json
+++ b/data/json/mapgen_palettes/house_general_abandoned.json
@@ -176,7 +176,7 @@
       "8": [ { "item": "SUS_bathroom_medicine", "chance": 1 }, { "item": "harddrugs_residential", "chance": 5 } ],
       "@": { "item": "bed", "chance": 5 },
       "Z": { "item": "laundry", "chance": 10 },
-      "W": { "item": "laundry", "chance": 10 }
+      "W": { "item": "SUS_laundry_basket", "chance": 10 }
     },
     "nested": {
       "|": { "chunks": [ [ "bile_field", 1 ], [ "shelter_graffiti", 2 ], [ "general_graffiti", 10 ], [ "null", 75 ] ] },

--- a/data/json/mapgen_palettes/house_general_palette.json
+++ b/data/json/mapgen_palettes/house_general_palette.json
@@ -338,7 +338,9 @@
         { "item": "camping", "chance": 5, "repeat": [ 1, 2 ] }
       ],
       "V": { "item": "home_display_case", "chance": 50 },
+      "W": { "item": "SUS_laundry_basket", "chance": 60 },
       "Y": { "item": "SUS_trash_trashcan", "chance": 30 },
+      "Z": { "item": "laundry", "chance": 50, "repeat": [ 2, 10 ] },
       "1": [ { "item": "SUS_dishes", "chance": 100 }, { "item": "SUS_silverware", "chance": 100 } ],
       "2": { "item": "SUS_cookware", "chance": 100 },
       "3": [ { "item": "SUS_utensils", "chance": 50 }, { "item": "SUS_knife_drawer", "chance": 50 } ],
@@ -359,8 +361,6 @@
       "9": { "item": "shower", "chance": 30, "repeat": [ 1, 2 ] },
       "@": { "item": "bed", "chance": 50 },
       "¤": { "item": "nightstand", "chance": 30 },
-      "Z": { "item": "laundry", "chance": 100 },
-      "W": { "item": "laundry", "chance": 50 },
       "z": [
         { "item": "allsporting", "chance": 40, "repeat": [ 1, 2 ] },
         { "item": "chem_home", "chance": 50, "repeat": [ 1, 2 ] },
@@ -846,7 +846,6 @@
         { "item": "SUS_hair_drawer", "chance": 30 },
         { "item": "shower", "chance": 50, "repeat": [ 2, 3 ] }
       ],
-      "W": { "item": "laundry", "chance": 75, "repeat": [ 2, 3 ] },
       "Y": { "item": "SUS_trash_trashcan", "chance": 80 },
       "1": [
         { "item": "SUS_dishes", "chance": 100 },
@@ -964,7 +963,7 @@
         { "item": "SUS_hair_drawer", "chance": 30 },
         { "item": "shower", "chance": 50, "repeat": [ 2, 3 ] }
       ],
-      "W": { "item": "laundry", "chance": 75, "repeat": [ 2, 3 ] },
+      "W": { "item": "SUS_laundry_basket", "chance": 90 },
       "Y": { "item": "SUS_trash_trashcan", "chance": 90 },
       "1": [
         { "item": "SUS_dishes", "chance": 100 },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
There have been reports that wardrobes and dressers contain too much clothing. I examined the relevant itemgroups, and that's likely the case. The minimum amount of clothing is set quite high and with a 100% probability. It feels as if the owners, before the end of the world, stuffed all the dressers in the house with clothes and never touched them again. Even if the current values correspond to some real statistical data, they are a bit out of place in this context.

And currently, wardrobes and dressers contain almost identical itemgroups.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
1. Slightly reduce the overall amount of clothing. The itemgroup now has 2 variants: full and almost empty (2:1 odds).
2. Move `SUS_*_single_outfit` from dressers to wardrobes. Wardrobes no longer always contains items from dressers.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Any other values? I didn't change the itemgroup assortment itself, only their spawn chance, so there might still be strange results. I'll revisit wardrobes in my next PR. The idea is that wardrobes will primarily store outerwear and outfit sets. If you have any suggestions, feel free to write them.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
"Empty" variants:
<img width="299" height="167" alt="clothes-dresser-empty" src="https://github.com/user-attachments/assets/461b7339-3d7d-4727-af23-1776615f05d3" />
<img width="416" height="189" alt="clothes-ward-empty" src="https://github.com/user-attachments/assets/c61dd82f-52f5-4b05-bfde-e5c1be56eae8" />

"Full" variant:
<img width="322" height="367" alt="clothes-dresser-full" src="https://github.com/user-attachments/assets/6a6a2434-97eb-4b99-ab4d-0429e3f0da28" />
<img width="343" height="493" alt="clothes-ward-full" src="https://github.com/user-attachments/assets/ad20f547-93d6-4782-8a63-d575cf869c9d" />

Itemgroup test:
<img width="472" height="646" alt="clothes-test-dresser" src="https://github.com/user-attachments/assets/fac9f9d6-278e-4fcc-8cb3-d557cde97872" />
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
