### PR TITLE
add "flailers" into radiosphere dimension

### DIFF
--- a/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
@@ -692,7 +692,7 @@
           },
           {
             "u_location_variable": { "context_val": "nearest_floor" },
-            "terrain": "t_ladder_down",
+            "terrain": "t_grate",
             "target_max_radius": 60,
             "min_radius": 0,
             "max_radius": 0

--- a/data/json/items/corpses/nether.json
+++ b/data/json/items/corpses/nether.json
@@ -55,7 +55,7 @@
     "material": [ "cotton" ],
     "price_postapoc": "0 USD",
     "volume": "150 ml",
-    "weight": "120 g",
+    "weight": "60 g",
     "flags": [ "TRADER_AVOID" ]
   }
 ]

--- a/data/json/items/corpses/nether.json
+++ b/data/json/items/corpses/nether.json
@@ -48,7 +48,7 @@
     "type": "ITEM",
     "id": "broken_flailer_radiosphere",
     "name": { "str": "torn flailer" },
-    "description": "torn up cloth flacsimile of a bird, you could tear it up even further for materials.",
+    "description": "torn up cloth facsimile of a bird, you could tear it up even further for materials.",
     "symbol": "v",
     "color": "light_gray",
     "category": "corpses",

--- a/data/json/items/corpses/nether.json
+++ b/data/json/items/corpses/nether.json
@@ -43,5 +43,19 @@
     "volume": "600 L",
     "weight": "900 kg",
     "flags": [ "TRADER_AVOID" ]
+  },
+  {
+    "type": "ITEM",
+    "id": "broken_flailer_radiosphere",
+    "name": { "str": "torn flailer" },
+    "description": "torn up cloth flacsimile of a bird, you could tear it up even further for materials.",
+    "symbol": "v",
+    "color": "light_gray",
+    "category": "corpses",
+    "material": [ "cotton" ],
+    "price_postapoc": "0 USD",
+    "volume": "150 ml",
+    "weight": "120 g",
+    "flags": [ "TRADER_AVOID" ]
   }
 ]

--- a/data/json/mapgen/radiosphere.json
+++ b/data/json/mapgen/radiosphere.json
@@ -19,9 +19,9 @@
         "          g gg g        ",
         "gggggggggggggggggggggggg",
         "          g,,,,g        ",
-        "ggggggggggg,RR,ggggggggg",
-        "ggggggggggg,RU,ggggggggg",
-        "          gv,,,g        ",
+        "ggggggggggg,UU,ggggggggg",
+        "ggggggggggg,UU,ggggggggg",
+        "          g,,,,g        ",
         "gggggggggggggggggggggggg",
         "          g gg g        ",
         "          g gg g        ",
@@ -41,42 +41,39 @@
       ],
       "palettes": [ "roof_palette" ],
       "terrain": {
-        "R": "t_radio_tower",
-        "U": [ [ "t_radio_tower", 90 ], [ "t_radiosphere_radio_tower_liminal_light", 10 ] ],
+        "U": [ [ "t_radio_tower", 90 ], [ "t_radiosphere_radio_tower_liminal_light", 4 ] ],
         "a": "t_railing",
         ",": "t_metal_floor_no_roof",
         "g": "t_grate"
       },
+      "furniture": { "U": [ [ "f_null", 40 ], [ "f_cellphone_booster", 20 ], [ "f_small_satellite_dish", 20 ] ] },
       "place_nested": [
-        { "chunks": [ [ "null", 90 ], [ "radio_tower_leech", 9 ], [ "mx_radiosphere_radio_tower", 1 ] ], "x": 9, "y": 2 },
-        {
-          "chunks": [ [ "null", 90 ], [ "radio_tower_2x2_holdout", 10 ], [ "radio_tower_2x2_sniper", 5 ] ],
-          "x": 10,
-          "y": 5
-        }
+        { "chunks": [ [ "null", 180 ], [ "radio_tower_flailer", 15 ], [ "mx_radiosphere_radio_tower", 5 ] ], "x": 9, "y": 2 },
+        { "chunks": [ [ "null", 90 ], [ "radio_tower_2x2_holdout", 10 ] ], "x": 10, "y": 5 }
       ]
     }
   },
   {
     "type": "mapgen",
-    "nested_mapgen_id": "radio_tower_leech",
+    "nested_mapgen_id": "radio_tower_flailer",
     "object": {
       "mapgensize": [ 8, 8 ],
       "rows": [
         " x xx x ",
         "xxxxxxxx",
-        " xxxxxx ",
-        "xxxBBxxx",
-        "xxxBBxxx",
-        " xxxxxx ",
+        " xBBBBx ",
+        "xxB  Bxx",
+        "xxB  Bxx",
+        " xBBBBx ",
         "xxxxxxxx",
         " x xx x "
       ],
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "monster": {
-        "x": [ { "monster": "mon_leech_stalk", "chance": 20 }, { "monster": "mon_leech_pod_cluster", "chance": 10 } ],
-        "B": [ { "monster": "mon_leech_blossom", "chance": 80 } ]
-      }
+        "x": [ { "monster": "mon_flailer_radiosphere", "chance": 2 } ],
+        "B": [ { "monster": "mon_flailer_radiosphere", "chance": 10 } ]
+      },
+      "item": { "B": [ { "item": "blanket", "chance": 50 } ] }
     }
   },
   {

--- a/data/json/mapgen/radiosphere.json
+++ b/data/json/mapgen/radiosphere.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "overmap_terrain",
-    "id": [ "radiosphere_radio_tower_top" ],
+    "id": [ "radiosphere_radio_tower_top", "radiosphere_radio_tower_top_leech" ],
     "vision_levels": "isolated_tower",
     "name": "radio tower",
     "sym": ".",
@@ -45,10 +45,38 @@
         "U": [ [ "t_radio_tower", 90 ], [ "t_radiosphere_radio_tower_liminal_light", 10 ] ],
         "a": "t_railing",
         ",": "t_metal_floor_no_roof",
-        "g": "t_grate",
-        "*": "t_glass_roof"
+        "g": "t_grate"
       },
-      "place_nested": [ { "chunks": [ [ "null", 99 ], [ "mx_radiosphere_radio_tower", 1 ] ], "x": 9, "y": 2 } ]
+      "place_nested": [
+        { "chunks": [ [ "null", 90 ], [ "radio_tower_leech", 9 ], [ "mx_radiosphere_radio_tower", 1 ] ], "x": 9, "y": 2 },
+        {
+          "chunks": [ [ "null", 90 ], [ "radio_tower_2x2_holdout", 10 ], [ "radio_tower_2x2_sniper", 5 ] ],
+          "x": 10,
+          "y": 5
+        }
+      ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "radio_tower_leech",
+    "object": {
+      "mapgensize": [ 8, 8 ],
+      "rows": [
+        " x xx x ",
+        "xxxxxxxx",
+        " xxxxxx ",
+        "xxxBBxxx",
+        "xxxBBxxx",
+        " xxxxxx ",
+        "xxxxxxxx",
+        " x xx x "
+      ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "monster": {
+        "x": [ { "monster": "mon_leech_stalk", "chance": 20 }, { "monster": "mon_leech_pod_cluster", "chance": 10 } ],
+        "B": [ { "monster": "mon_leech_blossom", "chance": 80 } ]
+      }
     }
   },
   {
@@ -95,6 +123,8 @@
     "description": "The sheer fact you can stand on this dumbfounds you, but anything left behind on this plane will vanish.",
     "symbol": "~",
     "color": "cyan",
+    "trap": "tr_lava",
+    "light_emitted": 50,
     "move_cost": 4,
     "flags": [ "TRANSPARENT", "NO_SCENT", "DESTROY_ITEM" ]
   },

--- a/data/json/mapgen/radiosphere.json
+++ b/data/json/mapgen/radiosphere.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "overmap_terrain",
-    "id": [ "radiosphere_radio_tower_top", "radiosphere_radio_tower_top_leech" ],
+    "id": [ "radiosphere_radio_tower_top" ],
     "vision_levels": "isolated_tower",
     "name": "radio tower",
     "sym": ".",

--- a/data/json/monsters/radiosphere.json
+++ b/data/json/monsters/radiosphere.json
@@ -3,7 +3,7 @@
     "id": "mon_flailer_radiosphere",
     "type": "MONSTER",
     "name": { "str_sp": "flailer" },
-    "description": "A cloth facsimile of a bird, flailing around in the air. It seems deliberate with it's movement.",
+    "description": "A cloth facsimile of a bird, flailing around in the air.  It seems deliberate with it's movement.",
     "bodytype": "bird",
     "default_faction": "bird_small_flying",
     "categories": [ "WILDLIFE" ],

--- a/data/json/monsters/radiosphere.json
+++ b/data/json/monsters/radiosphere.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": "mon_flailer_radiosphere",
+    "type": "MONSTER",
+    "name": { "str_sp": "flailer" },
+    "description": "A cloth facsimilie of a bird, flailing around in the air. It seems deliberate with it's movement.",
+    "bodytype": "bird",
+    "default_faction": "bird_small_flying",
+    "categories": [ "WILDLIFE" ],
+    "species": [ "BIRD" ],
+    "volume": "600 ml",
+    "weight": "450 g",
+    "//": "~0.75g/ml density for most wild birds",
+    "hp": 1,
+    "speed": 200,
+    "material": [ "cotton" ],
+    "symbol": "v",
+    "color": "white",
+    "aggression": -99,
+    "morale": 5,
+    "dodge": 4,
+    "baby_flags": [ "SPRING", "SUMMER" ],
+    "fear_triggers": [ "SOUND", "PLAYER_CLOSE", "FRIEND_ATTACKED", "FRIEND_DIED", "FIRE", "HURT" ],
+    "flags": [
+      "HEARS",
+      "ANIMAL",
+      "PATH_AVOID_DANGER",
+      "FLIES",
+      "SWARMS",
+      "CANPLAY",
+      "CAN_BE_CULLED",
+      "PET_WONT_FOLLOW",
+      "SMALL_HIDER"
+    ],
+    "copy-from": "mon_bird_flying_base"
+  }
+]

--- a/data/json/monsters/radiosphere.json
+++ b/data/json/monsters/radiosphere.json
@@ -3,7 +3,7 @@
     "id": "mon_flailer_radiosphere",
     "type": "MONSTER",
     "name": { "str_sp": "flailer" },
-    "description": "A cloth facsimile of a bird, flailing around in the air.  It seems deliberate with it's movement.",
+    "description": "A cloth facsimile of a bird, flailing around in the air.  It seems deliberate with its movement.",
     "bodytype": "bird",
     "default_faction": "bird_small_flying",
     "categories": [ "WILDLIFE" ],

--- a/data/json/monsters/radiosphere.json
+++ b/data/json/monsters/radiosphere.json
@@ -3,7 +3,7 @@
     "id": "mon_flailer_radiosphere",
     "type": "MONSTER",
     "name": { "str_sp": "flailer" },
-    "description": "A cloth facsimilie of a bird, flailing around in the air. It seems deliberate with it's movement.",
+    "description": "A cloth facsimile of a bird, flailing around in the air. It seems deliberate with it's movement.",
     "bodytype": "bird",
     "default_faction": "bird_small_flying",
     "categories": [ "WILDLIFE" ],

--- a/data/json/monsters/radiosphere.json
+++ b/data/json/monsters/radiosphere.json
@@ -8,9 +8,8 @@
     "default_faction": "bird_small_flying",
     "categories": [ "WILDLIFE" ],
     "species": [ "BIRD" ],
-    "volume": "600 ml",
-    "weight": "450 g",
-    "//": "~0.75g/ml density for most wild birds",
+    "volume": "150 ml",
+    "weight": "120 g",
     "hp": 1,
     "speed": 200,
     "material": [ "cotton" ],
@@ -20,6 +19,7 @@
     "morale": 5,
     "dodge": 4,
     "baby_flags": [ "SPRING", "SUMMER" ],
+    "death_function": { "corpse_type": "BROKEN" },
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE", "FRIEND_ATTACKED", "FRIEND_DIED", "FIRE", "HURT" ],
     "flags": [
       "HEARS",
@@ -32,6 +32,7 @@
       "PET_WONT_FOLLOW",
       "SMALL_HIDER"
     ],
+    "biosignature": {  },
     "copy-from": "mon_bird_flying_base"
   }
 ]

--- a/data/json/uncraft/corpses/nether.json
+++ b/data/json/uncraft/corpses/nether.json
@@ -11,8 +11,8 @@
     "result": "broken_flailer_radiosphere",
     "type": "uncraft",
     "activity_level": "LIGHT_EXERCISE",
-    "time": "1 m",
+    "time": "2 m",
     "qualities": [ { "id": "CUT", "level": 2 } ],
-    "components": [ [ [ "cotton_patchwork", 30 ] ] ]
+    "components": [ [ [ "cotton_patchwork", 18 ] ] ]
   }
 ]

--- a/data/json/uncraft/corpses/nether.json
+++ b/data/json/uncraft/corpses/nether.json
@@ -6,5 +6,13 @@
     "time": "90 m",
     "qualities": [ { "id": "CUT", "level": 2 } ],
     "components": [ [ [ "mutflesh", 1500 ] ] ]
+  },
+  {
+    "result": "broken_flailer_radiosphere",
+    "type": "uncraft",
+    "activity_level": "LIGHT_EXERCISE",
+    "time": "1 m",
+    "qualities": [ { "id": "CUT", "level": 2 } ],
+    "components": [ [ [ "cotton_patchwork", 36 ] ] ]
   }
 ]

--- a/data/json/uncraft/corpses/nether.json
+++ b/data/json/uncraft/corpses/nether.json
@@ -13,6 +13,6 @@
     "activity_level": "LIGHT_EXERCISE",
     "time": "1 m",
     "qualities": [ { "id": "CUT", "level": 2 } ],
-    "components": [ [ [ "cotton_patchwork", 36 ] ] ]
+    "components": [ [ [ "cotton_patchwork", 30 ] ] ]
   }
 ]

--- a/tools/spell_checker/dictionary.txt
+++ b/tools/spell_checker/dictionary.txt
@@ -1928,6 +1928,7 @@ Fabrique
 Fabritechnics
 Facebook
 facemasks
+facsimile
 facto
 faders
 fae
@@ -2052,6 +2053,8 @@ flatbread
 FlatCoin
 FlatCoins
 flatjaw
+flailer
+flailers
 flatlander
 flatlanders
 Flavio


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Features "Flailer birds in radiosphere dimension"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
make the dimension less empty.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add "flailers", cloth facsimiles of birds that flail around in the air. They're meant to be more of a "weird creature you can spot" rather than an active threat.
They spawn in nests that can sometimes appear on radiosphere's radio towers.
You can disassemble them for cloth, though i'm open toward more esoteric butchery results.

This PR also changes some minor stuff regarding the radiosphere radio towers themselves, adding a bit more detail to them (like satellite dishes) while also removing the ladder, that was bugging me.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Power leeches. I didn't go with them, cause they felt too invasive for what I was going for with this dimension.
Maybe something that didn't require nether magic to stay alive, but i didn't feel like doing that.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
walked around the dimension, the Flailer den nested mapgen correctly spawns, the flailers.. exist. I killed one and tore it apart into cotton scraps.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
if there's a better word than "flailer" then i'll consider it. these are meant to resemble cloth sheets against a strong wind, just tumbling in the air aimlessly.

I also plan at some point to allow longer stays in the dimension, if you got an anchoring device active while inside.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
