### PR TITLE
Hotwire car if it's still hotwireable

### DIFF
--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -2053,7 +2053,7 @@ void vehicle::build_interact_menu( veh_menu &menu, map *here, const tripoint_bub
         .on_submit( [this] { display_effects(); } );
     }
 
-    if( is_locked && controls_here ) {
+    if( ( is_locked || has_security_working( *here ) ) && controls_here ) {
         if( player_inside ) {
             menu.add( _( "Hotwire" ) )
             .enable( get_player_character().crafting_inventory().has_quality( qual_SCREW ) )


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Played the game, found a car, decided to hotwire it, failed
In spark of brilliance decided to take off the car battery so it will not scream when i fail
Later found that it also renders the car unusable (duh), installed it back
Found the game now think the car is not locked, and do not show the hotwiring option
#### Describe the solution
Add hotwiring menu even if `is_locked` = false
#### Describe alternatives you've considered
Is it actually so hard to remove immobilizer that you need both electronic 4 and mechanic 4? Also fixing immobilizer fault requires both skills at 5, so there is a disagreement here also
#### Testing
Car that i had still has option, albeit it is shown when you interact with control panel, and i spend like 30 minutes searching for similar setup car (immobilizer + security system not destroyed + dashboard is intact) and failed to