### PR TITLE
[Sky Island] Remove mission cleanup

### DIFF
--- a/data/mods/Sky_Island/EOCs.json
+++ b/data/mods/Sky_Island/EOCs.json
@@ -196,7 +196,6 @@
         ]
       },
       { "clear_dimension": "dimension_sky_island_mission" },
-      { "alter_timed_events": "return_portal_close" },
       { "math": [ "timeawayfromhome = 0 - bonuspulses" ] }
     ]
   },

--- a/data/mods/Sky_Island/missions_and_mapgen.json
+++ b/data/mods/Sky_Island/missions_and_mapgen.json
@@ -103,15 +103,7 @@
     "type": "effect_on_condition",
     "id": "EOC_create_extract",
     "//": "Actually creates the extract by first choosing a location, then assigning a mission there.  It will also clean up that spot later so the exit room doesn't remain for future expeditions.",
-    "effect": [
-      { "run_eocs": [ "EOC_Random_Loc_Extract" ] },
-      {
-        "revert_location": { "global_val": "OM_missionspot" },
-        "time_in_future": "infinite",
-        "key": "return_portal_close"
-      },
-      { "assign_mission": "MISSION_REACH_EXTRACT" }
-    ]
+    "effect": [ { "run_eocs": [ "EOC_Random_Loc_Extract" ] }, { "assign_mission": "MISSION_REACH_EXTRACT" } ]
   },
   {
     "type": "effect_on_condition",
@@ -137,11 +129,6 @@
     "//": "Actually creates a bonus mission by first choosing a location, then assigning a mission there.  It will also clean up that spot later so any map changes don't remain for future expeditions.",
     "effect": [
       { "run_eocs": [ "EOC_Random_Loc_Mission" ] },
-      {
-        "revert_location": { "global_val": "OM_missionspot" },
-        "time_in_future": "infinite",
-        "key": "return_portal_close"
-      },
       {
         "weighted_list_eocs": [
           [ "EOC_bonusmission_1", 45 ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Sky Island] Remove mission cleanup"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Found a last-minute bug in Sky Island after playing a while--if you die, the game crashes. This is a big problem! Fortunately, it turns out that it's because of end-of-raid cleanup--removal of mission sites, exits, etc--and the nice thing about dimensions is that the whole dimension is being deleted so we don't have to care about that anymore.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Remove the functions for `alter_timed_events` and `revert_location`. That's all the problem of the people in that dimension to deal with now.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Game no longer crashes on death.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
