### PR TITLE
Stop serializing bad vehicle item_locations

### DIFF
--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -492,6 +492,18 @@ class item_location::impl::item_on_vehicle : public item_location::impl
         item_on_vehicle( const vehicle_cursor &cur, int idx ) : impl( idx ), cur( cur ) {}
 
         void serialize( JsonOut &js ) const override {
+            const std::vector<wrapped_vehicle> &vehicles = get_map().get_vehicles();
+            const auto same_veh = [this]( const wrapped_vehicle & wv ) {
+                return wv.v == &cur.veh;
+            };
+            if( std::find_if( vehicles.begin(), vehicles.end(), same_veh ) == vehicles.end() ) {
+                debugmsg( "Could not find vehicle for item_location on vehicle" );
+                // This is intended as a temporary patch, but if you're reading this you know how it goes sometimes.
+                // Serialize exactly like an item_location::nowhere just in case this sticks around long enough for that to change...
+                item_location dummy = item_location::nowhere;
+                dummy.serialize( js );
+                return;
+            }
             js.start_object();
             js.member( "type", "vehicle" );
             js.member( "position", pos_abs() );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Intended to supersede #84442

* Intended to supersede #84452

#### Describe the solution
Don't save bad vehicle locations, but still throw an error

The written item_location is instead a dummy item_location::nowhere.

#### Describe alternatives you've considered


#### Testing
The original symptoms of this error had inconsistent reproductions; as such I wasn't sure of the exact behavior when deserializing. It may differ on a case to case basis.

I have not tried with the new eating menu

#### Additional context
[Originally put forward by Ehughsbaird](https://discord.com/channels/598523535169945603/1392273718562127984/1403754251020271648), I just made a minor edit in case this sticks around forever.

<img width="1802" height="588" alt="image" src="https://github.com/user-attachments/assets/d8ab42c5-5965-4d20-bf31-e3ff2ee4f9ae" />

