### PR TITLE
[Magiclysm] Fewer joke scrolls

### DIFF
--- a/data/mods/Magiclysm/itemgroups/itemgroups.json
+++ b/data/mods/Magiclysm/itemgroups/itemgroups.json
@@ -230,28 +230,28 @@
   {
     "id": "SUS_trash_floor_light",
     "type": "item_group",
-    "copy-from": "SUS_trash_floor_lightr",
-    "extend": {
-      "items": [
-        { "group": "magiclysm_joke_scrolls", "prob": 1 }
-      ]
-    }
+    "copy-from": "SUS_trash_floor_light",
+    "subtype": "collection",
+    "extend": { "items": [ { "group": "magiclysm_joke_scrolls", "prob": 1 } ] }
   },
   {
     "id": "SUS_trash_floor_heavy",
     "type": "item_group",
     "copy-from": "SUS_trash_floor_heavy",
-    "extend": {
-      "items": [
-        { "group": "magiclysm_joke_scrolls", "prob": 1 }
-      ]
-    }
+    "subtype": "collection",
+    "extend": { "items": [ { "group": "magiclysm_joke_scrolls", "prob": 1 } ] }
   },
   {
     "id": "magiclysm_joke_scrolls",
     "type": "item_group",
     "subtype": "distribution",
-    "entries": [ { "item": "null", "prob": 16 }, { "item": "summon_scroll_smudged", "prob": 2 }, { "item": "spell_scroll_tornskin", "prob": 2 }, { "item": "spell_scroll_stormshaper_cloak_of_frog", "prob": 2 }, { "item": "spell_scroll_animist_magic_fissile", "prob": 2 }] }
+    "entries": [
+      { "item": "null", "prob": 16 },
+      { "item": "summon_scroll_smudged", "prob": 2 },
+      { "item": "spell_scroll_tornskin", "prob": 2 },
+      { "item": "spell_scroll_stormshaper_cloak_of_frog", "prob": 2 },
+      { "item": "spell_scroll_animist_magic_fissile", "prob": 2 }
+    ]
   },
   {
     "id": "mon_zombie_soldier_death_drops",

--- a/data/mods/Magiclysm/itemgroups/itemgroups.json
+++ b/data/mods/Magiclysm/itemgroups/itemgroups.json
@@ -233,12 +233,15 @@
     "copy-from": "SUS_trash_floor",
     "extend": {
       "items": [
-        [ "summon_scroll_smudged", 5 ],
-        [ "spell_scroll_tornskin", 5 ],
-        [ "spell_scroll_stormshaper_cloak_of_frog", 5 ],
-        [ "spell_scroll_animist_magic_fissile", 5 ]
+        { "group": "magiclysm_joke_scrolls", "prob": 1 }
       ]
     }
+  },
+  {
+    "id": "magiclysm_joke_scrolls",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries": [ { "item": "null", "prob": 80 }, { "item": "summon_scroll_smudged", "prob": 2 }, { "item": "spell_scroll_tornskin", "prob": 2 }, { "item": "spell_scroll_stormshaper_cloak_of_frog", "prob": 2 }, { "item": "spell_scroll_animist_magic_fissile", "prob": 2 }] }
   },
   {
     "id": "mon_zombie_soldier_death_drops",

--- a/data/mods/Magiclysm/itemgroups/itemgroups.json
+++ b/data/mods/Magiclysm/itemgroups/itemgroups.json
@@ -228,9 +228,19 @@
     "extend": { "items": [ [ "mana_potion_lesser", 15 ] ] }
   },
   {
-    "id": "SUS_trash_floor",
+    "id": "SUS_trash_floor_light",
     "type": "item_group",
-    "copy-from": "SUS_trash_floor",
+    "copy-from": "SUS_trash_floor_lightr",
+    "extend": {
+      "items": [
+        { "group": "magiclysm_joke_scrolls", "prob": 1 }
+      ]
+    }
+  },
+  {
+    "id": "SUS_trash_floor_heavy",
+    "type": "item_group",
+    "copy-from": "SUS_trash_floor_heavy",
     "extend": {
       "items": [
         { "group": "magiclysm_joke_scrolls", "prob": 1 }

--- a/data/mods/Magiclysm/itemgroups/itemgroups.json
+++ b/data/mods/Magiclysm/itemgroups/itemgroups.json
@@ -251,7 +251,7 @@
     "id": "magiclysm_joke_scrolls",
     "type": "item_group",
     "subtype": "distribution",
-    "entries": [ { "item": "null", "prob": 80 }, { "item": "summon_scroll_smudged", "prob": 2 }, { "item": "spell_scroll_tornskin", "prob": 2 }, { "item": "spell_scroll_stormshaper_cloak_of_frog", "prob": 2 }, { "item": "spell_scroll_animist_magic_fissile", "prob": 2 }] }
+    "entries": [ { "item": "null", "prob": 16 }, { "item": "summon_scroll_smudged", "prob": 2 }, { "item": "spell_scroll_tornskin", "prob": 2 }, { "item": "spell_scroll_stormshaper_cloak_of_frog", "prob": 2 }, { "item": "spell_scroll_animist_magic_fissile", "prob": 2 }] }
   },
   {
     "id": "mon_zombie_soldier_death_drops",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Magiclysm] Fewer joke scrolls"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

The way itemgroups were done, there was a 20% chance to spawn a joke scroll when `SUS_trash_floor` was called, and many places have a chance to call it for every square of floor. It was too much. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Reduce the odds. Move the actual scrolls to a `magiclysm_joke_scrolls` itemgroup and call it in `SUS_trash_floor_light` and `SUS_trash_floor_heavy`. Add `null` to the itemgroup so it often doesn't spawn. The odds now are more like 0.25% chance per square that `SUS_trash_floor` is called on.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

All you people looting tons of joke scrolls to sell to the Forge, I see you
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
