### PR TITLE
Default zoom settings

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -712,6 +712,9 @@ void game::setup()
     globvars.clear_global_values();
     unique_npcs.clear();
     get_weather().weather_override = WEATHER_NULL;
+
+    set_zoom(get_option<int>("DEFAULT_ZOOM_LEVEL"));
+    set_overmap_zoom(get_option<int>("DEFAULT_OVERMAP_ZOOM_LEVEL"));
     // back to menu for save loading, new game etc
 }
 
@@ -6410,7 +6413,7 @@ void game::zoom_in_overmap()
 void game::reset_zoom()
 {
 #if defined(TILES)
-    tileset_zoom = DEFAULT_TILESET_ZOOM;
+    tileset_zoom = get_option<int>("DEFAULT_ZOOM_LEVEL");
     rescale_tileset( tileset_zoom );
 #endif // TILES
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -713,8 +713,8 @@ void game::setup()
     unique_npcs.clear();
     get_weather().weather_override = WEATHER_NULL;
 
-    set_zoom(get_option<int>("DEFAULT_ZOOM_LEVEL"));
-    set_overmap_zoom(get_option<int>("DEFAULT_OVERMAP_ZOOM_LEVEL"));
+    set_zoom( get_option<int>( "DEFAULT_ZOOM_LEVEL" ) );
+    set_overmap_zoom( get_option<int>( "DEFAULT_OVERMAP_ZOOM_LEVEL" ) );
     // back to menu for save loading, new game etc
 }
 
@@ -6413,7 +6413,7 @@ void game::zoom_in_overmap()
 void game::reset_zoom()
 {
 #if defined(TILES)
-    tileset_zoom = get_option<int>("DEFAULT_ZOOM_LEVEL");
+    tileset_zoom = get_option<int>( "DEFAULT_ZOOM_LEVEL" );
     rescale_tileset( tileset_zoom );
 #endif // TILES
 }
@@ -6430,12 +6430,12 @@ void game::set_zoom( const int level )
 #endif // TILES
 }
 
-void game::set_overmap_zoom(const int level)
+void game::set_overmap_zoom( const int level )
 {
 #if defined(TILES)
-    if (overmap_tileset_zoom != level) {
+    if( overmap_tileset_zoom != level ) {
         overmap_tileset_zoom = level;
-        overmap_tilecontext->set_draw_scale(overmap_tileset_zoom);
+        overmap_tilecontext->set_draw_scale( overmap_tileset_zoom );
     }
 #endif // TILES
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6427,6 +6427,16 @@ void game::set_zoom( const int level )
 #endif // TILES
 }
 
+void game::set_overmap_zoom(const int level)
+{
+#if defined(TILES)
+    if (overmap_tileset_zoom != level) {
+        overmap_tileset_zoom = level;
+        overmap_tilecontext->set_draw_scale(overmap_tileset_zoom);
+    }
+#endif // TILES
+}
+
 int game::get_zoom() const
 {
 #if defined(TILES)

--- a/src/game.h
+++ b/src/game.h
@@ -782,6 +782,7 @@ class game
         void reenter_fullscreen();
         void zoom_in_overmap();
         void zoom_out_overmap();
+        void set_overmap_zoom( int level );
         void zoom_in();
         void zoom_out();
         void reset_zoom();

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2175,9 +2175,8 @@ void options_manager::add_options_interface()
            );
 
         add( "DEFAULT_ZOOM_LEVEL", page_id, to_translation( "Default zoom level" ),
-             to_translation( "Larger values mean larger zoom out." ),
-        {
-            { 64, to_translation("0.25x") },
+        to_translation( "Larger values mean larger zoom out." ), {
+            { 64, to_translation( "0.25x" ) },
             { 32, to_translation( "0.5x" ) },
             { 16, to_translation( "1x" ) },
             { 8, to_translation( "2x" ) },
@@ -2186,10 +2185,9 @@ void options_manager::add_options_interface()
         16, 16 );
 
         add( "DEFAULT_OVERMAP_ZOOM_LEVEL", page_id, to_translation( "Default overmap zoom level" ),
-             to_translation( "Larger values mean larger zoom out." ),
-        {
-            { 64, to_translation("0.25x")},
-            { 32, to_translation("0.5x")},
+        to_translation( "Larger values mean larger zoom out." ), {
+            { 64, to_translation( "0.25x" )},
+            { 32, to_translation( "0.5x" )},
             { 16, to_translation( "1x" ) },
             { 8, to_translation( "2x" ) },
             { 4, to_translation( "4x" ) }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2174,6 +2174,28 @@ void options_manager::add_options_interface()
              1, 50, 1
            );
 
+        add( "DEFAULT_ZOOM_LEVEL", page_id, to_translation( "Default zoom level" ),
+             to_translation( "Larger values mean larger zoom out." ),
+        {
+            { 64, to_translation("0.25x") },
+            { 32, to_translation( "0.5x" ) },
+            { 16, to_translation( "1x" ) },
+            { 8, to_translation( "2x" ) },
+            { 4, to_translation( "4x" ) }
+        },
+        16, 16 );
+
+        add( "DEFAULT_OVERMAP_ZOOM_LEVEL", page_id, to_translation( "Default overmap zoom level" ),
+             to_translation( "Larger values mean larger zoom out." ),
+        {
+            { 64, to_translation("0.25x")},
+            { 32, to_translation("0.5x")},
+            { 16, to_translation( "1x" ) },
+            { 8, to_translation( "2x" ) },
+            { 4, to_translation( "4x" ) }
+        },
+        16, 16 );
+
         add( "FAST_SCROLL_OFFSET", page_id, to_translation( "Overmap fast scroll offset" ),
              to_translation( "With Fast Scroll option enabled, shift view on the overmap and while looking around by this many squares per keypress." ),
              1, 50, 5

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -2065,14 +2065,6 @@ static tripoint_abs_omt display()
     tripoint_abs_omt &select = data.select;
     input_context &ictxt = data.ictxt;
 
-    const int previous_zoom = g->get_zoom();
-    g->set_zoom( overmap_zoom_level );
-    on_out_of_scope reset_zoom( [&]() {
-        overmap_zoom_level = g->get_zoom();
-        g->set_zoom( previous_zoom );
-        g->mark_main_ui_adaptor_resize();
-    } );
-
     background_pane bg_pane;
 
     data.ui = std::make_shared<ui_adaptor>();


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Interface "Options for default zoom levels"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Currently the game will default to "16" as the zoom level when loading. This change adds 2 settings, zoom level and overmap zoom level. These 2 settings allow the user to specify the zoom level that the game should load into.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Added 2 options under Interface > QOL, one for the tileset zoom level, and one for the overmap zoom level.
Each option has 5 possible values (and their corresponding zoom level):
* 0.25x (64)
* 0.5x (32)
* 1x (16, default)
* 2x (8)
* 4x (4)

On game setup (game::setup()), retrieve the option values and set their corresponding zoom level.
Switching between game and overmap will preserve the current zoom level.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Not implementing this change
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Start game, go to options, change the default zoom levels
Load into a world
Observe zoom level is as set in the settings
Open map
Observe zoom level is as set in the settings
Changed zoom level in both states
Open and close map
Observe that the zoom level previously changed is preserved
Observe that the screen position does not change when switching back from overmap to game view after changing zoom level (#50209)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Code from #50209 in overmap_ui.cpp was causing an issue where the overmap_zoom_level variable would reset to the default value when opening the map (undesired), but not reflect this change in the interface. Removing the snippet didn't cause the issue mentioned in the PR to occur, but additional testing may be required.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
