### PR TITLE
Fix horde map iterator comparison UB

### DIFF
--- a/src/horde_map.h
+++ b/src/horde_map.h
@@ -3,6 +3,7 @@
 #define CATA_SRC_HORDE_MAP_H
 
 #include <iterator>
+#include <optional>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -63,10 +64,11 @@ class horde_map
         std::vector<std::unordered_map<tripoint_abs_ms, horde_entity>*> entity_group_at(
             const tripoint_om_sm &p, int filter = horde_map_flavors::active | horde_map_flavors::idle |
                     horde_map_flavors::dormant | horde_map_flavors::immobile );
-        std::unordered_map<tripoint_abs_ms, horde_entity>::iterator
+        std::optional<std::unordered_map<tripoint_abs_ms, horde_entity>::iterator>
         spawn_entity( const tripoint_abs_ms &p, mtype_id id );
-        std::unordered_map<tripoint_abs_ms, horde_entity>::iterator spawn_entity( const tripoint_abs_ms &p,
-                const monster &mon );
+        std::optional<std::unordered_map<tripoint_abs_ms, horde_entity>::iterator> spawn_entity(
+            const tripoint_abs_ms &p,
+            const monster &mon );
         void signal_entities( const tripoint_abs_ms &origin, int volume );
         void insert( node_type &&node );
         void clear();

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -1663,7 +1663,7 @@ void mongroup::wander( const overmap &om )
 
 horde_entity &overmap::spawn_monster( const tripoint_abs_ms &p, mtype_id id )
 {
-    return hordes.spawn_entity( p, id )->second;
+    return ( *hordes.spawn_entity( p, id ) )->second;
 }
 
 // Seeks through the submap looking for open areas.

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -659,7 +659,7 @@ void overmap::unserialize( const JsonObject &jsobj )
             JsonArray monster_map_json = om_member;
             while( monster_map_json.has_more() ) {
                 tripoint_abs_ms monster_location;
-                std::unordered_map<tripoint_abs_ms, horde_entity>::iterator result;
+                std::optional<std::unordered_map<tripoint_abs_ms, horde_entity>::iterator> result;
                 monster_location.deserialize( monster_map_json.next_value() );
                 point_abs_om omp;
                 tripoint_om_sm monster_submap;
@@ -674,11 +674,11 @@ void overmap::unserialize( const JsonObject &jsobj )
                     result = hordes.spawn_entity( monster_location, new_monster );
                 }
 
-                if( result != std::unordered_map<tripoint_abs_ms, horde_entity>::iterator() ) {
-                    result->second.destination.deserialize( monster_map_json.next_value() );
-                    result->second.tracking_intensity = monster_map_json.next_int();
-                    result->second.last_processed.deserialize( monster_map_json.next_value() );
-                    result->second.moves = monster_map_json.next_int();
+                if( result.has_value() ) {
+                    ( *result )->second.destination.deserialize( monster_map_json.next_value() );
+                    ( *result )->second.tracking_intensity = monster_map_json.next_int();
+                    ( *result )->second.last_processed.deserialize( monster_map_json.next_value() );
+                    ( *result )->second.moves = monster_map_json.next_int();
                 } else {
                     // We deserialized something nasty, skip the rest of the stored values
                     monster_map_json.next_value();


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix UB from #84385. MSVC debug stl correct asserts on this: https://stackoverflow.com/a/62266595. It's allowed to compare a default constructed iterator against another default constructed iterator, but not against any other iterator. But the correct pattern for these functions would be to use an optional<iterator> return type instead of a sentinel/dummy iterator value.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Use an optional<> to resolve the question of 'did this function actually return a valid iterator'.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
