### PR TITLE
Persist zoom level

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6433,6 +6433,8 @@ void game::set_overmap_zoom( const int level )
         uistate.overmap_tileset_zoom = level;
         overmap_tilecontext->set_draw_scale( uistate.overmap_tileset_zoom );
     }
+#else
+    static_cast<void>(level);
 #endif // TILES
 }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6367,6 +6367,7 @@ void game::zoom_out()
     } else {
         tileset_zoom = 64;
     }
+    uistate.zoom_level = tileset_zoom;
     rescale_tileset( tileset_zoom );
 #endif
 }
@@ -6379,6 +6380,7 @@ void game::zoom_out_overmap()
     } else {
         overmap_tileset_zoom = 64;
     }
+    uistate.zoom_level_overmap = overmap_tileset_zoom;
     overmap_tilecontext->set_draw_scale( overmap_tileset_zoom );
 #endif
 }
@@ -6391,6 +6393,7 @@ void game::zoom_in()
     } else {
         tileset_zoom = tileset_zoom * 2;
     }
+    uistate.zoom_level = tileset_zoom;
     rescale_tileset( tileset_zoom );
 #endif
 }
@@ -6403,6 +6406,7 @@ void game::zoom_in_overmap()
     } else {
         overmap_tileset_zoom *= 2;
     }
+    uistate.zoom_level_overmap = overmap_tileset_zoom;
     overmap_tilecontext->set_draw_scale( overmap_tileset_zoom );
 #endif
 }
@@ -6411,6 +6415,7 @@ void game::reset_zoom()
 {
 #if defined(TILES)
     tileset_zoom = DEFAULT_TILESET_ZOOM;
+    uistate.zoom_level = tileset_zoom;
     rescale_tileset( tileset_zoom );
 #endif // TILES
 }
@@ -6420,6 +6425,7 @@ void game::set_zoom( const int level )
 #if defined(TILES)
     if( tileset_zoom != level ) {
         tileset_zoom = level;
+        uistate.zoom_level = tileset_zoom;
         rescale_tileset( tileset_zoom );
     }
 #else
@@ -6432,6 +6438,7 @@ void game::set_overmap_zoom(const int level)
 #if defined(TILES)
     if (overmap_tileset_zoom != level) {
         overmap_tileset_zoom = level;
+        uistate.zoom_level_overmap = overmap_tileset_zoom;
         overmap_tilecontext->set_draw_scale(overmap_tileset_zoom);
     }
 #endif // TILES

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -456,7 +456,6 @@ game::game() :
     next_npc_id( 1 ),
     next_mission_id( 1 ),
     remoteveh_cache_time( calendar::before_time_starts ),
-    tileset_zoom( DEFAULT_TILESET_ZOOM ),
     last_mouse_edge_scroll( std::chrono::steady_clock::now() )
 {
     current_map.set( &m );
@@ -2502,7 +2501,7 @@ std::pair<tripoint_rel_omt, tripoint_rel_omt> game::mouse_edge_scrolling( input_
 tripoint_rel_ms game::mouse_edge_scrolling_terrain( input_context &ctxt )
 {
     std::pair<tripoint_rel_ms, tripoint_rel_ms> ret = mouse_edge_scrolling( ctxt,
-            std::max( DEFAULT_TILESET_ZOOM / tileset_zoom, 1 ),
+            std::max( DEFAULT_TILESET_ZOOM / uistate.tileset_zoom, 1 ),
             last_mouse_edge_scroll_vector_terrain, g->is_tileset_isometric() );
     last_mouse_edge_scroll_vector_terrain = ret.second;
     last_mouse_edge_scroll_vector_overmap = tripoint_rel_omt::zero;
@@ -6025,7 +6024,7 @@ look_around_result game::look_around(
     is_looking = true;
     const tripoint_rel_ms prev_offset = u.view_offset;
 #if defined(TILES)
-    const int prev_tileset_zoom = tileset_zoom;
+    const int prev_tileset_zoom = uistate.tileset_zoom;
     while( is_moving_zone && square_dist( start_point, end_point ) > 256 / get_zoom() &&
            get_zoom() != 4 ) {
         zoom_out();
@@ -6362,71 +6361,65 @@ static constexpr int MAXIMUM_ZOOM_LEVEL = 4;
 void game::zoom_out()
 {
 #if defined(TILES)
-    if( tileset_zoom > MAXIMUM_ZOOM_LEVEL ) {
-        tileset_zoom = tileset_zoom / 2;
+    if( uistate.tileset_zoom > MAXIMUM_ZOOM_LEVEL ) {
+        uistate.tileset_zoom = uistate.tileset_zoom / 2;
     } else {
-        tileset_zoom = 64;
+        uistate.tileset_zoom = 64;
     }
-    uistate.zoom_level = tileset_zoom;
-    rescale_tileset( tileset_zoom );
+    rescale_tileset( uistate.tileset_zoom );
 #endif
 }
 
 void game::zoom_out_overmap()
 {
 #if defined(TILES)
-    if( overmap_tileset_zoom > MAXIMUM_ZOOM_LEVEL ) {
-        overmap_tileset_zoom /= 2;
+    if( uistate.overmap_tileset_zoom > MAXIMUM_ZOOM_LEVEL ) {
+        uistate.overmap_tileset_zoom /= 2;
     } else {
-        overmap_tileset_zoom = 64;
+        uistate.overmap_tileset_zoom = 64;
     }
-    uistate.zoom_level_overmap = overmap_tileset_zoom;
-    overmap_tilecontext->set_draw_scale( overmap_tileset_zoom );
+    overmap_tilecontext->set_draw_scale( uistate.overmap_tileset_zoom );
 #endif
 }
 
 void game::zoom_in()
 {
 #if defined(TILES)
-    if( tileset_zoom == 64 ) {
-        tileset_zoom = MAXIMUM_ZOOM_LEVEL;
+    if( uistate.tileset_zoom == 64 ) {
+        uistate.tileset_zoom = MAXIMUM_ZOOM_LEVEL;
     } else {
-        tileset_zoom = tileset_zoom * 2;
+        uistate.tileset_zoom = uistate.tileset_zoom * 2;
     }
-    uistate.zoom_level = tileset_zoom;
-    rescale_tileset( tileset_zoom );
+    rescale_tileset( uistate.tileset_zoom );
 #endif
 }
 
 void game::zoom_in_overmap()
 {
 #if defined(TILES)
-    if( overmap_tileset_zoom == 64 ) {
-        overmap_tileset_zoom = MAXIMUM_ZOOM_LEVEL;
+    if( uistate.overmap_tileset_zoom == 64 ) {
+        uistate.overmap_tileset_zoom = MAXIMUM_ZOOM_LEVEL;
     } else {
-        overmap_tileset_zoom *= 2;
+        uistate.overmap_tileset_zoom *= 2;
     }
-    uistate.zoom_level_overmap = overmap_tileset_zoom;
-    overmap_tilecontext->set_draw_scale( overmap_tileset_zoom );
+    overmap_tilecontext->set_draw_scale( uistate.overmap_tileset_zoom );
 #endif
 }
 
 void game::reset_zoom()
 {
 #if defined(TILES)
-    tileset_zoom = DEFAULT_TILESET_ZOOM;
-    uistate.zoom_level = tileset_zoom;
-    rescale_tileset( tileset_zoom );
+    uistate.tileset_zoom = DEFAULT_TILESET_ZOOM;
+    rescale_tileset( uistate.tileset_zoom );
 #endif // TILES
 }
 
 void game::set_zoom( const int level )
 {
 #if defined(TILES)
-    if( tileset_zoom != level ) {
-        tileset_zoom = level;
-        uistate.zoom_level = tileset_zoom;
-        rescale_tileset( tileset_zoom );
+    if( uistate.tileset_zoom != level ) {
+        uistate.tileset_zoom = level;
+        rescale_tileset( uistate.tileset_zoom );
     }
 #else
     static_cast<void>( level );
@@ -6436,10 +6429,9 @@ void game::set_zoom( const int level )
 void game::set_overmap_zoom(const int level)
 {
 #if defined(TILES)
-    if (overmap_tileset_zoom != level) {
-        overmap_tileset_zoom = level;
-        uistate.zoom_level_overmap = overmap_tileset_zoom;
-        overmap_tilecontext->set_draw_scale(overmap_tileset_zoom);
+    if ( uistate.overmap_tileset_zoom != level) {
+        uistate.overmap_tileset_zoom = level;
+        overmap_tilecontext->set_draw_scale( uistate.overmap_tileset_zoom );
     }
 #endif // TILES
 }
@@ -6447,7 +6439,7 @@ void game::set_overmap_zoom(const int level)
 int game::get_zoom() const
 {
 #if defined(TILES)
-    return tileset_zoom;
+    return uistate.tileset_zoom;
 #else
     return DEFAULT_TILESET_ZOOM;
 #endif

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6434,7 +6434,7 @@ void game::set_overmap_zoom( const int level )
         overmap_tilecontext->set_draw_scale( uistate.overmap_tileset_zoom );
     }
 #else
-    static_cast<void>(level);
+    static_cast<void>( level );
 #endif // TILES
 }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6426,10 +6426,10 @@ void game::set_zoom( const int level )
 #endif // TILES
 }
 
-void game::set_overmap_zoom(const int level)
+void game::set_overmap_zoom( const int level )
 {
 #if defined(TILES)
-    if ( uistate.overmap_tileset_zoom != level) {
+    if( uistate.overmap_tileset_zoom != level ) {
         uistate.overmap_tileset_zoom = level;
         overmap_tilecontext->set_draw_scale( uistate.overmap_tileset_zoom );
     }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6427,6 +6427,16 @@ void game::set_zoom( const int level )
 #endif // TILES
 }
 
+void game::set_overmap_zoom(const int level)
+{
+#if defined(TILES)
+    if (overmap_tileset_zoom != level) {
+        overmap_tileset_zoom = level;
+        overmap_tilecontext->set_draw_scale(overmap_tileset_zoom);
+    }
+#endif // TILES
+}
+
 int game::get_zoom() const
 {
 #if defined(TILES)

--- a/src/game.h
+++ b/src/game.h
@@ -36,8 +36,6 @@
 #include "units_fwd.h"
 #include "weather.h"
 
-constexpr int DEFAULT_TILESET_ZOOM = 16;
-
 // The reference to the one and only game instance.
 class game;
 
@@ -1288,10 +1286,6 @@ class game
 
         // Times the user has input an action
         int user_action_counter = 0; // NOLINT(cata-serialize)
-
-        /** How far the tileset should be zoomed out, 16 is default. 32 is zoomed in by x2, 8 is zoomed out by x0.5 */
-        int tileset_zoom = 0; // NOLINT(cata-serialize)
-        int overmap_tileset_zoom = DEFAULT_TILESET_ZOOM; // NOLINT(cata-serialize)
 
         /** Seed for all the random numbers that should have consistent randomness (weather). */
         unsigned int seed = 0; // NOLINT(cata-serialize)

--- a/src/game.h
+++ b/src/game.h
@@ -783,6 +783,7 @@ class game
         void reenter_fullscreen();
         void zoom_in_overmap();
         void zoom_out_overmap();
+        void set_overmap_zoom( int level );
         void zoom_in();
         void zoom_out();
         void reset_zoom();

--- a/src/game_io.cpp
+++ b/src/game_io.cpp
@@ -476,8 +476,8 @@ bool game::load( const save_t &name )
                     // recalculate light level for correctly resuming crafting and disassembly
                     here.build_map_cache( here.get_abs_sub().z() );
 
-                    set_zoom( uistate.zoom_level );
-                    set_overmap_zoom( uistate.zoom_level_overmap );
+                    set_zoom( uistate.tileset_zoom );
+                    set_overmap_zoom( uistate.overmap_tileset_zoom );
                 }
             },
         }

--- a/src/game_io.cpp
+++ b/src/game_io.cpp
@@ -475,6 +475,9 @@ bool game::load( const save_t &name )
                     effect_on_conditions::load_existing_character( u );
                     // recalculate light level for correctly resuming crafting and disassembly
                     here.build_map_cache( here.get_abs_sub().z() );
+
+                    set_zoom( uistate.zoom_level );
+                    set_overmap_zoom( uistate.zoom_level_overmap );
                 }
             },
         }

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -402,6 +402,8 @@ void uistatedata::serialize( JsonOut &json ) const
     json.member( "overmap_debug_mongroup", overmap_debug_mongroup );
     json.member( "overmap_fast_travel", overmap_fast_travel );
     json.member( "overmap_fast_scroll", overmap_fast_scroll );
+    json.member( "zoom_level", zoom_level );
+    json.member( "zoom_level_overmap", zoom_level_overmap );
     json.member( "distraction_noise", distraction_noise );
     json.member( "distraction_pain", distraction_pain );
     json.member( "distraction_attack", distraction_attack );
@@ -483,6 +485,8 @@ void uistatedata::deserialize( const JsonObject &jo )
     jo.read( "overmap_debug_mongroup", overmap_debug_mongroup );
     jo.read( "overmap_fast_travel", overmap_fast_travel );
     jo.read( "overmap_fast_scroll", overmap_fast_scroll );
+    jo.read( "zoom_level", zoom_level );
+    jo.read( "zoom_level_overmap", zoom_level_overmap );
     jo.read( "overmap_sidebar_uistate", overmap_sidebar_state );
     jo.read( "distraction_noise", distraction_noise );
     jo.read( "distraction_pain", distraction_pain );

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -402,8 +402,8 @@ void uistatedata::serialize( JsonOut &json ) const
     json.member( "overmap_debug_mongroup", overmap_debug_mongroup );
     json.member( "overmap_fast_travel", overmap_fast_travel );
     json.member( "overmap_fast_scroll", overmap_fast_scroll );
-    json.member( "zoom_level", zoom_level );
-    json.member( "zoom_level_overmap", zoom_level_overmap );
+    json.member( "tileset_zoom", tileset_zoom );
+    json.member( "overmap_tileset_zoom", overmap_tileset_zoom );
     json.member( "distraction_noise", distraction_noise );
     json.member( "distraction_pain", distraction_pain );
     json.member( "distraction_attack", distraction_attack );
@@ -485,8 +485,8 @@ void uistatedata::deserialize( const JsonObject &jo )
     jo.read( "overmap_debug_mongroup", overmap_debug_mongroup );
     jo.read( "overmap_fast_travel", overmap_fast_travel );
     jo.read( "overmap_fast_scroll", overmap_fast_scroll );
-    jo.read( "zoom_level", zoom_level );
-    jo.read( "zoom_level_overmap", zoom_level_overmap );
+    jo.read( "tileset_zoom", tileset_zoom );
+    jo.read( "overmap_tileset_zoom", overmap_tileset_zoom );
     jo.read( "overmap_sidebar_uistate", overmap_sidebar_state );
     jo.read( "distraction_noise", distraction_noise );
     jo.read( "distraction_pain", distraction_pain );

--- a/src/uistate.h
+++ b/src/uistate.h
@@ -14,6 +14,7 @@
 #include "json.h"
 #include "omdata.h"
 #include "type_id.h"
+#include "game.h"
 
 class item;
 
@@ -186,6 +187,9 @@ class uistatedata
         bool overmap_debug_mongroup = false;
         bool overmap_fast_travel = false;
         bool overmap_fast_scroll = false;
+
+        int zoom_level = DEFAULT_TILESET_ZOOM;
+        int zoom_level_overmap = DEFAULT_TILESET_ZOOM;
 
         overmap_sidebar_uistate overmap_sidebar_state;
 

--- a/src/uistate.h
+++ b/src/uistate.h
@@ -14,7 +14,8 @@
 #include "json.h"
 #include "omdata.h"
 #include "type_id.h"
-#include "game.h"
+
+constexpr int DEFAULT_TILESET_ZOOM = 16;
 
 class item;
 
@@ -188,8 +189,8 @@ class uistatedata
         bool overmap_fast_travel = false;
         bool overmap_fast_scroll = false;
 
-        int zoom_level = DEFAULT_TILESET_ZOOM;
-        int zoom_level_overmap = DEFAULT_TILESET_ZOOM;
+        int tileset_zoom = DEFAULT_TILESET_ZOOM;
+        int overmap_tileset_zoom = DEFAULT_TILESET_ZOOM;
 
         overmap_sidebar_uistate overmap_sidebar_state;
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Interface "Persist zoom levels"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Currently the game will default to "16" as the zoom level when creating a game and loading a save. With this change, the game will keep track of the zoom levels and restore to their previous value when loading a save.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Moved tileset_zoom and overmap_tileset_zoom to uistate
Keep these 2 fields in sync with the zoom levels
When loading a save, after restoring the uistate, set the zoom level to the saved values
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Adding an option to set the default zoom level #84473
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Start game
Create a world & character
Observe the zoom level
Change the zoom level
Save the game
Exit
Start and load the game
Observe the zoom level, it will be the same as it was when the game was saved
Repeat for the overmap zoom

<!-- 
#### Additional context

Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
