### PR TITLE
Improve ammo_effects stuff

### DIFF
--- a/data/json/ammo_effects.json
+++ b/data/json/ammo_effects.json
@@ -2,18 +2,18 @@
   {
     "id": "AE_NULL",
     "type": "ammo_effect",
-    "aoe": {
-      "field_type": "fd_null",
-      "intensity_min": 0,
-      "intensity_max": 0,
-      "radius": 0,
-      "radius_z": 0,
-      "chance": 100,
-      "size": 0,
-      "check_passable": false,
-      "check_sees": false,
-      "check_sees_radius": 0
-    },
+    "aoe": [
+      {
+        "field_type": "fd_null",
+        "intensity_min": 0,
+        "intensity_max": 0,
+        "radius": 0,
+        "radius_z": 0,
+        "chance": 100,
+        "size": 0,
+        "check_passable": false
+      }
+    ],
     "explosion": {
       "power": 0,
       "distance_factor": 0.8,
@@ -191,91 +191,101 @@
     "//": "Prevent HARDTOSHOOT monster flag from having any effect; automatically applied to ammo with `SHOT` flag or which have liquid phase. Hardcoded"
   },
   {
+    "id": "ACT_ON_RANGED_HIT",
+    "type": "ammo_effect",
+    "//": "Is applied on projectiles made out of items with ACT_ON_RANGED_HIT flag. Hardcoded"
+  },
+  {
+    "id": "HURT_WHEN_WIELDED",
+    "type": "ammo_effect",
+    "//": "Is applied on projectiles made out of items with HURT_WHEN_WIELDED flag. Hardcoded"
+  },
+  {
     "id": "FLAME",
     "type": "ammo_effect",
     "//": "Very small explosion that lights fires",
-    "aoe": { "field_type": "fd_fire", "intensity_min": 1, "intensity_max": 1, "size": 3 }
+    "aoe": [ { "field_type": "fd_fire", "intensity_min": 1, "intensity_max": 1, "size": 3 } ]
   },
   {
     "id": "NAPALM",
     "type": "ammo_effect",
     "//": "Explosion that spreads fire",
-    "aoe": { "field_type": "fd_fire", "intensity_min": 1, "intensity_max": 1, "size": 3 },
+    "aoe": [ { "field_type": "fd_fire", "intensity_min": 1, "intensity_max": 1, "size": 3 } ],
     "explosion": { "power": 60, "distance_factor": 0.7, "fire": true }
   },
   {
     "id": "PYROPHORIC",
     "type": "ammo_effect",
     "//": "Large explosion that spreads fire of high intensity",
-    "aoe": { "field_type": "fd_fire", "intensity_min": 2, "intensity_max": 2, "radius": 3 },
+    "aoe": [ { "field_type": "fd_fire", "intensity_min": 2, "intensity_max": 2, "radius": 3 } ],
     "explosion": { "power": 360, "distance_factor": 0.8, "fire": true }
   },
   {
     "id": "ACIDBOMB",
     "type": "ammo_effect",
     "//": "Leaves a pool of acid on detonation",
-    "aoe": { "field_type": "fd_acid", "intensity_min": 3, "intensity_max": 3 }
+    "aoe": [ { "field_type": "fd_acid", "intensity_min": 3, "intensity_max": 3 } ]
   },
   {
     "id": "TOXICGAS",
     "type": "ammo_effect",
     "//": "Creates a cloud of toxic gas on hit",
-    "aoe": { "field_type": "fd_toxic_gas", "intensity_min": 3, "intensity_max": 3 }
+    "aoe": [ { "field_type": "fd_toxic_gas", "intensity_min": 3, "intensity_max": 3 } ]
   },
   {
     "id": "GAS_FUNGICIDAL",
     "type": "ammo_effect",
     "//": "Creates a cloud of fungicidal gas on hit",
-    "aoe": { "field_type": "fd_fungicidal_gas", "intensity_min": 3, "intensity_max": 3 }
+    "aoe": [ { "field_type": "fd_fungicidal_gas", "intensity_min": 3, "intensity_max": 3 } ]
   },
   {
     "id": "GAS_INSECTICIDAL",
     "type": "ammo_effect",
     "//": "Creates a cloud of insecticidal gas on hit",
-    "aoe": { "field_type": "fd_insecticidal_gas", "intensity_min": 3, "intensity_max": 3 }
+    "aoe": [ { "field_type": "fd_insecticidal_gas", "intensity_min": 3, "intensity_max": 3 } ]
   },
   {
     "id": "SMOKE",
     "type": "ammo_effect",
     "//": "Generates a cloud of smoke at the target",
-    "aoe": { "field_type": "fd_smoke", "intensity_min": 3, "intensity_max": 3 }
+    "aoe": [ { "field_type": "fd_smoke", "intensity_min": 3, "intensity_max": 3 } ]
   },
   {
     "id": "SMOKE_BIG",
     "type": "ammo_effect",
     "//": "Generates a large cloud of smoke at the target",
-    "aoe": { "field_type": "fd_smoke", "intensity_min": 3, "intensity_max": 3, "radius": 6 }
+    "aoe": [ { "field_type": "fd_smoke", "intensity_min": 3, "intensity_max": 3, "radius": 6 } ]
   },
   {
     "id": "FLARE",
     "type": "ammo_effect",
     "//": "Lights the target tile on fire",
-    "aoe": { "field_type": "fd_fire", "intensity_min": 1, "intensity_max": 1 }
+    "aoe": [ { "field_type": "fd_fire", "intensity_min": 1, "intensity_max": 1 } ]
   },
   {
     "id": "LIGHTNING",
     "type": "ammo_effect",
     "//": "Creates a trail of lightning",
-    "aoe": { "field_type": "fd_electricity", "intensity_min": 6, "intensity_max": 10, "chance": 25 }
+    "aoe": [ { "field_type": "fd_electricity", "intensity_min": 6, "intensity_max": 10, "chance": 25 } ]
   },
   {
     "id": "PLASMA",
     "type": "ammo_effect",
     "//": "Creates a trail of superheated plasma",
-    "aoe": { "field_type": "fd_plasma", "intensity_min": 2, "intensity_max": 3, "chance": 50 },
-    "trail": { "field_type": "fd_plasma", "intensity_min": 1, "intensity_max": 2, "chance": 50 }
+    "aoe": [ { "field_type": "fd_plasma", "intensity_min": 2, "intensity_max": 3, "chance": 50 } ],
+    "trail": [ { "field_type": "fd_plasma", "intensity_min": 1, "intensity_max": 2, "chance": 50 } ]
   },
   {
     "id": "PLASMA_BUBBLE",
     "type": "ammo_effect",
     "//": "Creates a cloud of superheated plasma",
-    "aoe": { "field_type": "fd_plasma", "intensity_min": 1, "intensity_max": 3, "radius": 1, "chance": 10 }
+    "aoe": [ { "field_type": "fd_plasma", "intensity_min": 1, "intensity_max": 3, "radius": 1, "chance": 10 } ]
   },
   {
     "id": "PLASMA_FAN",
     "type": "ammo_effect",
     "always_cast_spell": true,
-    "spell_data": { "id": "spell_plasma_fan" }
+    "spell_data": [ { "id": "spell_plasma_fan" } ]
   },
   {
     "id": "EXPLOSIVE",
@@ -344,13 +354,13 @@
     "id": "CORROSIVE",
     "type": "ammo_effect",
     "always_cast_spell": true,
-    "spell_data": { "id": "spell_corrosive_spray" }
+    "spell_data": [ { "id": "spell_corrosive_spray" } ]
   },
   {
     "id": "GLUE_FOAM",
     "type": "ammo_effect",
     "always_cast_spell": true,
-    "spell_data": { "id": "spell_adhesive_spray" }
+    "spell_data": [ { "id": "spell_adhesive_spray" } ]
   },
   {
     "id": "EXPLOSIVE_HESHOT",
@@ -418,43 +428,43 @@
     "id": "TRAIL",
     "type": "ammo_effect",
     "//": "Creates a trail of smoke",
-    "trail": { "field_type": "fd_smoke", "intensity_min": 1, "intensity_max": 2, "chance": 75 }
+    "trail": [ { "field_type": "fd_smoke", "intensity_min": 1, "intensity_max": 2, "chance": 75 } ]
   },
   {
     "id": "STREAM_TINY",
     "type": "ammo_effect",
     "//": "Sometimes leaves a trail of small fire fields. All of these STREAM_XXXXXX effects have hardcoded interactions in projectile_attack (ballistics.cpp)",
-    "trail": { "field_type": "fd_fire", "intensity_min": 1, "intensity_max": 1, "chance": 10 }
+    "trail": [ { "field_type": "fd_fire", "intensity_min": 1, "intensity_max": 1, "chance": 10 } ]
   },
   {
     "id": "STREAM",
     "type": "ammo_effect",
     "//": "Leaves a trail of fire fields",
-    "trail": { "field_type": "fd_fire", "intensity_min": 1, "intensity_max": 2, "chance": 66 }
+    "trail": [ { "field_type": "fd_fire", "intensity_min": 1, "intensity_max": 2, "chance": 66 } ]
   },
   {
     "id": "STREAM_BIG",
     "type": "ammo_effect",
     "//": "Leaves a trail of intense fire fields",
-    "trail": { "field_type": "fd_fire", "intensity_min": 2, "intensity_max": 2, "chance": 75 }
+    "trail": [ { "field_type": "fd_fire", "intensity_min": 2, "intensity_max": 2, "chance": 75 } ]
   },
   {
     "id": "PYROTECHNIC_DISPLAY",
     "type": "ammo_effect",
     "//": "Looks like huge fires, but doesn't actually burn stuff.",
-    "trail": { "field_type": "fd_fire_FAKE", "intensity_min": 1, "intensity_max": 3, "chance": 85 }
+    "trail": [ { "field_type": "fd_fire_FAKE", "intensity_min": 1, "intensity_max": 3, "chance": 85 } ]
   },
   {
     "id": "STREAM_GAS_FUNGICIDAL",
     "type": "ammo_effect",
     "//": "Leaves a trail of fungicidal gas",
-    "trail": { "field_type": "fd_fungicidal_gas", "intensity_min": 1, "intensity_max": 2, "chance": 66 }
+    "trail": [ { "field_type": "fd_fungicidal_gas", "intensity_min": 1, "intensity_max": 2, "chance": 66 } ]
   },
   {
     "id": "LASER",
     "type": "ammo_effect",
     "//": "Creates a trail of laser",
-    "trail": { "field_type": "fd_laser", "intensity_min": 2, "intensity_max": 2 }
+    "trail": [ { "field_type": "fd_laser", "intensity_min": 2, "intensity_max": 2 } ]
   },
   {
     "id": "GENE_STING_BARB",

--- a/data/json/monster_special_attacks/monster_ammo.json
+++ b/data/json/monster_special_attacks/monster_ammo.json
@@ -43,25 +43,25 @@
     "id": "BILE_BOMB",
     "type": "ammo_effect",
     "//": "Leaves a pool of bile on detonation",
-    "aoe": { "field_type": "fd_bile", "intensity_min": 3, "intensity_max": 3 }
+    "aoe": [ { "field_type": "fd_bile", "intensity_min": 3, "intensity_max": 3 } ]
   },
   {
     "id": "BILE_JET",
     "type": "ammo_effect",
     "//": "Creates a trail of bile",
-    "trail": { "field_type": "fd_bile", "intensity_min": 1, "intensity_max": 2, "chance": 75 }
+    "trail": [ { "field_type": "fd_bile", "intensity_min": 1, "intensity_max": 2, "chance": 75 } ]
   },
   {
     "id": "BILE_JET_ADV",
     "type": "ammo_effect",
     "//": "Creates a trail of advanced bile",
-    "trail": { "field_type": "fd_bile_adv", "intensity_min": 1, "intensity_max": 2, "chance": 75 }
+    "trail": [ { "field_type": "fd_bile_adv", "intensity_min": 1, "intensity_max": 2, "chance": 75 } ]
   },
   {
     "id": "BILE_BOMB_ADV",
     "type": "ammo_effect",
     "//": "Leaves a pool of advanced bile on detonation",
-    "aoe": { "field_type": "fd_bile_adv", "intensity_min": 3, "intensity_max": 3 }
+    "aoe": [ { "field_type": "fd_bile_adv", "intensity_min": 3, "intensity_max": 3 } ]
   },
   {
     "id": "BILE_GLOW",

--- a/data/mods/CrazyCataclysm/crazy_ammo_effects.json
+++ b/data/mods/CrazyCataclysm/crazy_ammo_effects.json
@@ -8,18 +8,18 @@
     "id": "CLEAN_DUST",
     "type": "ammo_effect",
     "always_cast_spell": true,
-    "spell_data": { "id": "spell_clean_dust" }
+    "spell_data": [ { "id": "spell_clean_dust" } ]
   },
   {
     "id": "CLEAN_SPLINTERS",
     "type": "ammo_effect",
     "always_cast_spell": true,
-    "spell_data": { "id": "spell_clean_splinters" }
+    "spell_data": [ { "id": "spell_clean_splinters" } ]
   },
   {
     "id": "CLEAN_BLOOD",
     "type": "ammo_effect",
     "always_cast_spell": true,
-    "spell_data": { "id": "spell_clean_blood" }
+    "spell_data": [ { "id": "spell_clean_blood" } ]
   }
 ]

--- a/data/mods/MindOverMatter/ammo_effects.json
+++ b/data/mods/MindOverMatter/ammo_effects.json
@@ -3,8 +3,8 @@
     "id": "LIGHTNING_TRAIL",
     "type": "ammo_effect",
     "//": "Creates a trail of lightning plasma",
-    "aoe": { "field_type": "fd_electricity", "intensity_min": 6, "intensity_max": 10, "chance": 25 },
-    "trail": { "field_type": "fd_electricity", "intensity_min": 1, "intensity_max": 2, "chance": 65 }
+    "aoe": [ { "field_type": "fd_electricity", "intensity_min": 6, "intensity_max": 10, "chance": 25 } ],
+    "trail": [ { "field_type": "fd_electricity", "intensity_min": 1, "intensity_max": 2, "chance": 65 } ]
   },
   {
     "id": "NEURAL_STUNGUN",

--- a/data/mods/Xedra_Evolved/ammo_effects.json
+++ b/data/mods/Xedra_Evolved/ammo_effects.json
@@ -7,13 +7,13 @@
   {
     "id": "GRENADE_FIRE_EXPL",
     "type": "ammo_effect",
-    "aoe": { "field_type": "fd_fire", "intensity_min": 1, "intensity_max": 1, "size": 5 },
+    "aoe": [ { "field_type": "fd_fire", "intensity_min": 1, "intensity_max": 1, "size": 5 } ],
     "explosion": { "power": 250, "distance_factor": 0.7, "fire": true }
   },
   {
     "id": "GRENADE_ELEC_EXPL",
     "type": "ammo_effect",
     "do_emp_blast": true,
-    "aoe": { "field_type": "fd_electricity", "intensity_min": 10, "intensity_max": 10, "chance": 100, "size": 50 }
+    "aoe": [ { "field_type": "fd_electricity", "intensity_min": 10, "intensity_max": 10, "chance": 100, "size": 50 } ]
   }
 ]

--- a/data/mods/aftershock_exoplanet/items/ammo_effects.json
+++ b/data/mods/aftershock_exoplanet/items/ammo_effects.json
@@ -13,7 +13,7 @@
   {
     "id": "PUMP_LASER",
     "type": "ammo_effect",
-    "aoe": { "field_type": "fd_fire", "intensity_min": 1, "intensity_max": 1, "radius": 3, "size": 4, "chance": 50 },
+    "aoe": [ { "field_type": "fd_fire", "intensity_min": 1, "intensity_max": 1, "radius": 3, "size": 4, "chance": 50 } ],
     "explosion": { "power": 5000, "max_noise": 35, "distance_factor": 0.5 }
   },
   {
@@ -24,50 +24,50 @@
   {
     "id": "ELECTRO_ANOMALY",
     "type": "ammo_effect",
-    "aoe": { "field_type": "fd_elect_anomaly", "intensity_min": 2, "intensity_max": 3, "radius": 0 }
+    "aoe": [ { "field_type": "fd_elect_anomaly", "intensity_min": 2, "intensity_max": 3, "radius": 0 } ]
   },
   {
     "id": "SMALL_ELECTRIC_BURST",
     "type": "ammo_effect",
-    "aoe": { "field_type": "fd_electricity", "intensity_min": 1, "intensity_max": 2, "chance": 10, "radius": 1 }
+    "aoe": [ { "field_type": "fd_electricity", "intensity_min": 1, "intensity_max": 2, "chance": 10, "radius": 1 } ]
   },
   {
     "id": "TACTICAL_LASER_EXPLOSION",
     "type": "ammo_effect",
-    "trigger_chance": 5,
+    "trigger_chance": 20,
     "explosion": { "power": 500, "max_noise": 35, "distance_factor": 0.2 }
   },
   {
     "id": "DAZZLE_BEAM",
     "type": "ammo_effect",
-    "trail": { "field_type": "fd_dazzling", "intensity_min": 1, "intensity_max": 1 }
+    "trail": [ { "field_type": "fd_dazzling", "intensity_min": 1, "intensity_max": 1 } ]
   },
   {
     "id": "SEISMIC_MAPPING",
     "type": "ammo_effect",
-    "aoe": { "field_type": "fd_clairvoyant", "intensity_min": 10, "intensity_max": 10 }
+    "aoe": [ { "field_type": "fd_clairvoyant", "intensity_min": 10, "intensity_max": 10 } ]
   },
   {
     "id": "TOXIC_FOAM",
     "type": "ammo_effect",
-    "aoe": { "field_type": "fd_toxic_foam", "intensity_min": 1, "intensity_max": 4, "chance": 70, "radius": 1 }
+    "aoe": [ { "field_type": "fd_toxic_foam", "intensity_min": 1, "intensity_max": 4, "chance": 70, "radius": 1 } ]
   },
   {
     "id": "ELECTRIC_CHAIN",
     "type": "ammo_effect",
     "always_cast_spell": true,
-    "spell_data": { "id": "spell_electric_chain" }
+    "spell_data": [ { "id": "spell_electric_chain" } ]
   },
   {
     "id": "FUSION_FAN",
     "type": "ammo_effect",
     "always_cast_spell": true,
-    "spell_data": { "id": "spell_fusion_fan" }
+    "spell_data": [ { "id": "spell_fusion_fan" } ]
   },
   {
     "id": "VAHAGN",
     "type": "ammo_effect",
     "always_cast_spell": true,
-    "spell_data": { "id": "spell_vahagn" }
+    "spell_data": [ { "id": "spell_vahagn" } ]
   }
 ]

--- a/doc/JSON/ITEM.md
+++ b/doc/JSON/ITEM.md
@@ -252,24 +252,27 @@ ammo_effects define what effect the projectile, that you shoot, would have. List
 {
   "id": "AE_NULL",           // id of an effect
   "type": "ammo_effect",     // define it is an ammo effect
-  "aoe": {                   // this field would be spawned at the tile projectile hit
-    "field_type": "fd_fog",  // field, that would be spawned around the center of projectile; default "fd_null"
-    "intensity_min": 1,      // min intensity of the field; default 0
-    "intensity_max": 3,      // max intensity of the field; default 0
-    "radius": 5,             // radius of a field to spawn; default 1
-    "radius_z": 1,           // radius across z-level; default 0
-    "chance": 100,           // probability to spawn 1 unit of field, from 0 to 100; default 100
-    "size": 0,               // seems to be the threshold, where autoturret stops shooting the weapon to prevent friendly fire;; default 0
-    "check_passable": false, // if false, projectile is able to penetrate impassable terrains, if penetration is defined (like walls and windows); if true, projectile can't penetrate even the sheet of glass; default false
-    "check_sees": false,     // if false, field can be spawned behind the opaque wall (for example, behind the concrete wall); if true, it can't; default false
-    "check_sees_radius": 0   // if "check_sees" is true, and this value is smaller than "radius", this value is used as radius instead. The purpose nor reasoning is unknown, probably some legacy of mininuke, so just don't use it; default 0
-  },
-  "trail": {                 // this field would be spawned across whole projectile path
+  "trigger_chance": 20,      // chance to run this specific ammo effect; default 100
+  "aoe": [ 
+    {                          // this field would be spawned at the tile projectile hit
+      "field_type": "fd_fog",  // field, that would be spawned around the center of projectile; default "fd_null"
+      "intensity_min": 1,      // min intensity of the field; default 0
+      "intensity_max": 3,      // max intensity of the field; default 0
+      "radius": 5,             // radius of a field to spawn; default 1
+      "radius_z": 1,           // radius across z-level; default 0
+      "chance": 100,           // probability to spawn 1 unit of field, from 0 to 100; default 100
+      "size": 0,               // seems to be the threshold, where autoturret stops shooting the weapon to prevent friendly fire;; default 0
+      "check_passable": false, // if false, projectile is able to penetrate impassable terrains, if penetration is defined (like walls and windows); if true, projectile can't penetrate even the sheet of glass; default   false
+    }
+  ],
+  "trail": [ 
+    {                        // this field would be spawned across whole projectile path
     "field_type": "fd_fog",  // field, that would be spawned; defautl "fd_null"
     "intensity_min": 1,      // min intensity of the field; default 0
     "intensity_max": 3,      // max intensity of the field; default 0
     "chance": 100            // probability to spawn 1 unit of field, from 0 to 100; default 100
-  },
+    }
+  ],
   "explosion": {             // explosion, that will happen at the tile that projectile hit
     "power": 0,              // mandatory; power of the explosion, in grams of tnt; pipebomb is about 300, grenade (without shrapnel) is 240
     "distance_factor": 0.8,  // how fast the explosion decay, closer to 1 mean lesser "power" loss per tile, 0.8 means 20% of power loss per tile; default 0.75, value should be bigger than 0, but lesser than 1
@@ -281,7 +284,7 @@ ammo_effects define what effect the projectile, that you shoot, would have. List
       "drop": "null"         // Which item to drop at landing point
     }
   },
-  "on_hit_effects": [        // This effects will be applied if body part is hit
+  "on_hit_effects": [        // These effects will be applied if body part is hit
     {
       "effect": "bile_stink",// id of an effect, mandatory
       "duration": "5 m",     // duration, mandatory
@@ -289,12 +292,24 @@ ammo_effects define what effect the projectile, that you shoot, would have. List
       "need_touch_skin": true// if true, and projectile is liquid, the target need to be soaked through for effect to be applied
     }
   ],
-  "do_flashbang": false,     // Creates a one tile radius EMP explosion at the hit location; default false
-  "do_emp_blast": false,     // Creates a hardcoded flashbang explosion; default false
+    "aoe_effects": [          // These effects will be applied on all monsters in area
+    {
+      "effect": "bile_stink", // id of an effect, mandatory
+      "duration": "5 m",      // duration, mandatory
+      "intensity_min": 1,     // min intensity of the field; default 1
+      "intensity_max": 3,     // max intensity of the field; default intensity_min
+      "radius": 5,            // radius of a field to spawn; default 1
+      "chance": 100,          // probability to apply the field on each separate creature in area, from 1 to 100; default 100
+    } 
+  ],
+  "do_flashbang": false,     // Creates a hardcoded flashbang explosion; default false
+  "do_emp_blast": false,     // Creates a one tile radius EMP explosion at the hit location; default false
   "foamcrete_build": false,  // Creates foamcrete fields and walls on the hit location, used in aftershock; default false
   "eoc": [ "EOC_CAUSE_PAIN", "EOC_CAUSE_VOMIT" ], // Runs EoC when hit the target. See EFFECT_ON_CONDITION.md#typical-alpha-and-beta-talkers-by-cases for more information
-  "spell_data": { "id": "bear_trap" }, // Spell, that would be casted when projectile hits an enemy
-  "spell_data": { "id": "release_the_deltas", "hit_self": true, "min_level": 10 }, // another example
+  "spell_data": [ 
+    { "id": "bear_trap" },   // Spell, that would be casted when projectile hits an enemy
+    { "id": "release_the_deltas", "hit_self": true, "min_level": 10 } // another example
+  ],
   "always_cast_spell ": false // if spell_data is used, and this is true, spell would be casted even if projectile did not deal any damage. Default false.
 }
 ```

--- a/src/ammo_effect.cpp
+++ b/src/ammo_effect.cpp
@@ -1,7 +1,6 @@
 #include "ammo_effect.h"
 
 #include "debug.h"
-#include "flexbuffer_json.h"
 #include "generic_factory.h"
 
 generic_factory<ammo_effect> &get_all_ammo_effects()
@@ -58,39 +57,54 @@ int_id<ammo_effect>::int_id( const ammo_effect_str_id &id ) : _id( id.id() )
 {
 }
 
+void aoe_effect::deserialize( const JsonObject &jo )
+{
+    mandatory( jo, was_loaded, "effect", effect );
+    mandatory( jo, was_loaded, "duration", duration );
+    optional( jo, was_loaded, "intensity_min", intensity_min, numeric_bound_reader<int> {0}, 1 );
+    optional( jo, was_loaded, "intensity_max", intensity_max, numeric_bound_reader<int> { intensity_min },
+              intensity_min );
+    optional( jo, was_loaded, "chance", chance, numeric_bound_reader<int> {0, 100}, 100 );
+    optional( jo, was_loaded, "radius", radius, numeric_bound_reader<int> {0}, 1 );
+}
+
 void on_hit_effect::deserialize( const JsonObject &jo )
 {
-    optional( jo, false, "need_touch_skin", need_touch_skin, false );
-    mandatory( jo, false, "duration", duration );
-    mandatory( jo, false, "effect", effect );
-    mandatory( jo, false, "intensity", intensity );
+    optional( jo, was_loaded, "need_touch_skin", need_touch_skin, false );
+    mandatory( jo, was_loaded, "duration", duration );
+    mandatory( jo, was_loaded, "effect", effect );
+    mandatory( jo, was_loaded, "intensity", intensity );
+}
+
+void aoe_field_effect::deserialize( const JsonObject &jo )
+{
+    mandatory( jo, was_loaded, "field_type", field_type );
+    optional( jo, was_loaded, "intensity_min", intensity_min, numeric_bound_reader<int> {0}, 0 );
+    optional( jo, was_loaded, "intensity_max", intensity_max, numeric_bound_reader<int> { intensity_min },
+              intensity_min );
+    optional( jo, was_loaded, "radius", radius, numeric_bound_reader<int> {0}, 1 );
+    optional( jo, was_loaded, "radius_z", radius_z, numeric_bound_reader<int> {0},  0 );
+    optional( jo, was_loaded, "chance", chance, numeric_bound_reader<int> {0, 100}, 100 );
+    optional( jo, was_loaded, "size", size, numeric_bound_reader<int> {0}, 0 );
+    optional( jo, was_loaded, "check_passable", check_passable, false );
+}
+
+void trail_field_effect::deserialize( const JsonObject &jo )
+{
+    mandatory( jo, was_loaded, "field_type", field_type );
+    optional( jo, was_loaded, "intensity_min", intensity_min, numeric_bound_reader<int> {0}, 0 );
+    optional( jo, was_loaded, "intensity_max", intensity_max, numeric_bound_reader<int> { intensity_min },
+              intensity_min );
+    optional( jo, was_loaded, "chance", chance, numeric_bound_reader<int> {0, 100}, 100 );
 }
 
 void ammo_effect::load( const JsonObject &jo, std::string_view )
 {
-    optional( jo, was_loaded, "trigger_chance", trigger_chance, 1 );
-
-    if( jo.has_member( "aoe" ) ) {
-        JsonObject joa = jo.get_object( "aoe" );
-        optional( joa, was_loaded, "field_type", aoe_field_type_name, "fd_null" );
-        optional( joa, was_loaded, "intensity_min", aoe_intensity_min, 0 );
-        optional( joa, was_loaded, "intensity_max", aoe_intensity_max, 0 );
-        optional( joa, was_loaded, "radius", aoe_radius, 1 );
-        optional( joa, was_loaded, "radius_z", aoe_radius_z, 0 );
-        optional( joa, was_loaded, "chance", aoe_chance, 100 );
-        optional( joa, was_loaded, "size", aoe_size, 0 );
-        optional( joa, was_loaded, "check_passable", aoe_check_passable, false );
-        optional( joa, was_loaded, "check_sees", aoe_check_sees, false );
-        optional( joa, was_loaded, "check_sees_radius", aoe_check_sees_radius, 0 );
-    }
-    if( jo.has_member( "trail" ) ) {
-        JsonObject joa = jo.get_object( "trail" );
-        optional( joa, was_loaded, "field_type", trail_field_type_name, "fd_null" );
-        optional( joa, was_loaded, "intensity_min", trail_intensity_min, 0 );
-        optional( joa, was_loaded, "intensity_max", trail_intensity_max, 0 );
-        optional( joa, was_loaded, "chance", trail_chance, 100 );
-    }
+    optional( jo, was_loaded, "trigger_chance", trigger_chance, 100 );
+    optional( jo, was_loaded, "aoe", aoe_field_types );
+    optional( jo, was_loaded, "trail", trail_field_types );
     optional( jo, was_loaded, "on_hit_effects", on_hit_effects );
+    optional( jo, was_loaded, "aoe_effects", aoe_effects );
     optional( jo, was_loaded, "explosion", aoe_explosion_data );
     optional( jo, was_loaded, "do_flashbang", do_flashbang, false );
     optional( jo, was_loaded, "do_emp_blast", do_emp_blast, false );
@@ -98,54 +112,27 @@ void ammo_effect::load( const JsonObject &jo, std::string_view )
     optional( jo, was_loaded, "eoc", eoc );
     optional( jo, was_loaded, "spell_data", spell_data );
     optional( jo, was_loaded, "always_cast_spell", always_cast_spell, false );
-
-
-}
-
-void ammo_effect::finalize()
-{
-    for( const ammo_effect &ae : ammo_effects::get_all() ) {
-        const_cast<ammo_effect &>( ae ).aoe_field_type = field_type_id( ae.aoe_field_type_name );
-        const_cast<ammo_effect &>( ae ).trail_field_type = field_type_id( ae.trail_field_type_name );
-    }
-
 }
 
 void ammo_effect::check() const
 {
-    if( !aoe_field_type.is_valid() ) {
-        debugmsg( "No such field type %s", aoe_field_type_name );
+    for( const aoe_field_effect &aoe : aoe_field_types ) {
+        if( !aoe.field_type.is_valid() ) {
+            debugmsg( "Ammo effect %s aoe section uses invalid field type %s", id.str(), aoe.field_type.str() );
+        }
     }
-    if( aoe_check_sees_radius < 0 ) {
-        debugmsg( "Value of aoe_check_sees_radius cannot be negative" );
+
+    for( const trail_field_effect &trail : trail_field_types ) {
+        if( !trail.field_type.is_valid() ) {
+            debugmsg( "Ammo effect %s trail section uses invalid field type %s", id.str(),
+                      trail.field_type.str() );
+        }
     }
-    if( aoe_size < 0 ) {
-        debugmsg( "Value of aoe_size cannot be negative" );
-    }
-    if( aoe_chance > 100 || aoe_chance <= 0 ) {
-        debugmsg( "Field chance of %s out of range (%d of min 1 max 100)", id.c_str(), aoe_chance );
-    }
-    if( aoe_radius_z < 0 || aoe_radius < 0 ) {
-        debugmsg( "Radius values cannot be negative" );
-    }
-    if( aoe_intensity_min < 0 ) {
-        debugmsg( "Field intensity cannot be negative" );
-    }
-    if( aoe_intensity_max < aoe_intensity_min ) {
-        debugmsg( "Maximum intensity must be greater than or equal to minimum intensity" );
-    }
-    if( !trail_field_type.is_valid() ) {
-        debugmsg( "No such field type %s", trail_field_type_name );
-    }
-    if( trail_chance > 100 || trail_chance <= 0 ) {
-        debugmsg( "Field chance divisor cannot be negative" );
-        debugmsg( "Field chance of %s out of range (%d of min 1 max 100)", id.c_str(), trail_chance );
-    }
-    if( trail_intensity_min < 0 ) {
-        debugmsg( "Field intensity cannot be negative" );
-    }
-    if( trail_intensity_max < trail_intensity_min ) {
-        debugmsg( "Maximum intensity must be greater than or equal to minimum intensity" );
+
+    for( const fake_spell &spell : spell_data ) {
+        if( !spell.is_valid() ) {
+            debugmsg( "Ammo effect %s spell section uses invalid spell id %s", id.str(), spell.id.str() );
+        }
     }
 }
 

--- a/src/ammo_effect.h
+++ b/src/ammo_effect.h
@@ -10,7 +10,6 @@
 
 #include "calendar.h"
 #include "explosion.h"
-#include "field_type.h"
 #include "magic.h"
 #include "type_id.h"
 
@@ -21,51 +20,81 @@ template <typename T> class generic_factory;
 generic_factory<ammo_effect> &get_all_ammo_effects();
 
 struct on_hit_effect {
-    bool need_touch_skin;
     efftype_id effect;
     time_duration duration;
     int intensity;
+    bool need_touch_skin;
 
     void deserialize( const JsonObject &jo );
+    bool was_loaded = false;
+};
+
+struct aoe_effect {
+    efftype_id effect;
+    time_duration duration;
+    int intensity_min;
+    int intensity_max;
+    int chance;
+    int radius;
+
+    void deserialize( const JsonObject &jo );
+    bool was_loaded = false;
+};
+
+struct aoe_field_effect {
+    field_type_str_id field_type = field_type_str_id::NULL_ID();
+    int intensity_min = 0;
+    int intensity_max = 0;
+    int radius = 1;
+    int radius_z = 0;
+    int chance = 100;
+    int size = 0;
+    bool check_passable = false;
+
+    void deserialize( const JsonObject &jo );
+    bool was_loaded = false;
+};
+
+struct trail_field_effect {
+    field_type_str_id field_type = field_type_str_id::NULL_ID();
+    int intensity_min = 0;
+    int intensity_max = 0;
+    int chance = 100;
+
+    void deserialize( const JsonObject &jo );
+    bool was_loaded = false;
 };
 
 struct ammo_effect {
     public:
         void load( const JsonObject &jo, std::string_view src );
-        void finalize();
         void check() const;
-        fake_spell spell_data;
 
-        field_type_id aoe_field_type = fd_null.id_or( INVALID_FIELD_TYPE_ID );
-        /** used during JSON loading only */
-        int trigger_chance = 1;
-
-        std::string aoe_field_type_name = "fd_null";
-        int aoe_intensity_min = 0;
-        int aoe_intensity_max = 0;
-        int aoe_radius = 1;
-        int aoe_radius_z = 0;
-        int aoe_chance = 100;
-        int aoe_size = 0;
-        explosion_data aoe_explosion_data;
-        bool aoe_check_passable = false;
-
-        bool aoe_check_sees = false;
-        int aoe_check_sees_radius = 0;
+        // x in 100
+        int trigger_chance = 100;
+        // apply_ammo_effects()
         bool do_flashbang = false;
+        // apply_ammo_effects()
         bool do_emp_blast = false;
+        // apply_ammo_effects()
         bool foamcrete_build = false;
-        std::vector<effect_on_condition_id> eoc;
+        // if true, spell is castes no matter if creature was hit or not
         bool always_cast_spell = false;
 
-        field_type_id trail_field_type = fd_null.id_or( INVALID_FIELD_TYPE_ID );
-        /** used during JSON loading only */
-        std::string trail_field_type_name = "fd_null";
-        int trail_intensity_min = 0;
-        int trail_intensity_max = 0;
-        int trail_chance = 100;
-
+        // apply_ammo_effects()
+        explosion_data aoe_explosion_data;
+        // apply_ammo_effects()
+        std::vector<aoe_field_effect> aoe_field_types;
+        // map::shoot()
+        std::vector<trail_field_effect> trail_field_types;
+        // apply_effects_nodamage()
         std::vector<on_hit_effect> on_hit_effects;
+        // apply_effects_nodamage()
+        std::vector<aoe_effect> aoe_effects;
+        // apply_ammo_effects()
+        std::vector<fake_spell> spell_data;
+        // apply_ammo_effects()
+        std::vector<effect_on_condition_id> eoc;
 
         // Used by generic_factory
         ammo_effect_str_id id;

--- a/src/game_ui_tile_info.cpp
+++ b/src/game_ui_tile_info.cpp
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "avatar.h"
+#include "calendar.h"
 #include "catacharset.h"
 #include "color.h"
 #include "construction.h"
@@ -482,6 +483,19 @@ void game::print_debug_info( const tripoint_bub_ms &lp, const catacurses::window
                    lp.to_string_writable() );
         mvwprintz( w_look, point( column, ++line ), c_white, "tripoint_abs_ms: %s",
                    here.get_abs( lp ).to_string_writable() );
+
+        for( const std::pair<const field_type_id, field_entry> &fd : here.field_at( lp ) ) {
+            mvwprintz( w_look, point( column, ++line ), c_white, "field: " );
+            mvwprintz( w_look, point( column + utf8_width( "field: " ), line ), c_yellow, "%s",
+                       fd.first.id().c_str() );
+            mvwprintz( w_look, point( column, ++line ), c_white, "age: %s (%s seconds)",
+                       to_string( fd.second.get_field_age() ), to_seconds<int>( fd.second.get_field_age() ) );
+            mvwprintz( w_look, point( column, ++line ), c_white, "intensity: %s",
+                       fd.second.get_field_intensity() );
+            mvwprintz( w_look, point( column, ++line ), c_white, "causer: %s",
+                       fd.second.get_causer() == nullptr ? "none" : fd.second.get_causer()->disp_name() );
+            mvwprintz( w_look, point( column, ++line ), c_white, "\n" );
+        }
     }
 }
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4654,6 +4654,7 @@ void map::crush( const tripoint_bub_ms &p )
         vp->vehicle().damage( *this, vp->part_index(), rng( 100, 1000 ), damage_bash, false );
     }
 }
+
 double map::shoot( const tripoint_bub_ms &p, projectile &proj, const bool hit_items )
 {
     if( !inbounds( p ) ) {
@@ -4758,10 +4759,11 @@ double map::shoot( const tripoint_bub_ms &p, projectile &proj, const bool hit_it
     }
     dam = std::max( 0.0f, dam );
 
-    for( const ammo_effect &ae : ammo_effects::get_all() ) {
-        if( ammo_effects.count( ae.id ) > 0 ) {
-            if( x_in_y( ae.trail_chance, 100 ) ) {
-                add_field( p, ae.trail_field_type, rng( ae.trail_intensity_min, ae.trail_intensity_max ) );
+    // apply trail from ammo effect
+    for( const ammo_effect_str_id &ae_str : proj.proj_effects ) {
+        for( const trail_field_effect &trail : ae_str.obj().trail_field_types ) {
+            if( !trail.field_type.is_null() && x_in_y( trail.chance, 100 ) ) {
+                add_field( p, trail.field_type, rng( trail.intensity_min, trail.intensity_max ) );
             }
         }
     }
@@ -10771,6 +10773,21 @@ std::list<Creature *> map::get_creatures_in_radius( const tripoint_bub_ms &cente
     creature_tracker &creatures = get_creature_tracker();
     std::list<Creature *> creature_list;
     for( const tripoint_bub_ms &loc : points_in_radius( center, radius, radiusz ) ) {
+        Creature *tmp_critter = creatures.creature_at( loc );
+        if( tmp_critter != nullptr ) {
+            creature_list.push_back( tmp_critter );
+        }
+
+    }
+    return creature_list;
+}
+
+std::list<Creature *> map::get_creatures_in_radius_circ( const tripoint_bub_ms &center,
+        size_t radius, size_t radiusz ) const
+{
+    creature_tracker &creatures = get_creature_tracker();
+    std::list<Creature *> creature_list;
+    for( const tripoint_bub_ms &loc : points_in_radius_circ( center, radius, radiusz ) ) {
         Creature *tmp_critter = creatures.creature_at( loc );
         if( tmp_critter != nullptr ) {
             creature_list.push_back( tmp_critter );

--- a/src/map.h
+++ b/src/map.h
@@ -2246,6 +2246,9 @@ class map
         std::list<Creature *> get_creatures_in_radius( const tripoint_bub_ms &center, size_t radius,
                 size_t radiusz = 0 ) const;
 
+        std::list<Creature *> get_creatures_in_radius_circ( const tripoint_bub_ms &center, size_t radius,
+                size_t radiusz = 0 ) const;
+
         level_cache &access_cache( int zlev );
         const level_cache &access_cache( int zlev ) const;
         bool dont_draw_lower_floor( const tripoint_bub_ms &p ) const;
@@ -2401,6 +2404,7 @@ class tinymap : private map
         tripoint_range<tripoint_omt_ms> points_on_zlevel( int z ) const;
         tripoint_range<tripoint_omt_ms> points_in_rectangle(
             const tripoint_omt_ms &from, const tripoint_omt_ms &to ) const;
+        // rectangular prism
         tripoint_range<tripoint_omt_ms> points_in_radius(
             const tripoint_omt_ms &center, size_t radius, size_t radiusz = 0 ) const;
         map_stack i_at( const tripoint_omt_ms &p ) {

--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -2,11 +2,13 @@
 
 #include <algorithm>
 #include <limits>
+#include <list>
 #include <memory>
 #include <string>
 #include <vector>
 
 #include "ammo_effect.h"
+#include "calendar.h"
 #include "character.h"
 #include "condition.h"
 #include "creature.h"
@@ -15,11 +17,13 @@
 #include "dialogue.h"
 #include "dialogue_helpers.h"
 #include "effect_on_condition.h"
+#include "effect_source.h"
 #include "enums.h"
 #include "explosion.h"
 #include "field.h"
 #include "field_type.h"
 #include "item.h"
+#include "line.h"
 #include "magic.h"
 #include "map.h"
 #include "map_iterator.h"
@@ -153,23 +157,24 @@ void apply_ammo_effects( Creature *source, const tripoint_bub_ms &p,
     Character &player_character = get_player_character();
 
     for( const ammo_effect &ae : ammo_effects::get_all() ) {
-        if( !one_in( ae.trigger_chance ) ) {
+        if( x_in_y( ae.trigger_chance, 100 ) ) {
             continue;
         }
         if( effects.count( ae.id ) > 0 ) {
-            for( const tripoint_bub_ms &pt : here.points_in_radius( p, ae.aoe_radius,
-                    ae.aoe_radius_z ) ) {
-                if( x_in_y( ae.aoe_chance, 100 ) ) {
-                    const bool check_sees = !ae.aoe_check_sees || here.sees( p, pt, ae.aoe_check_sees_radius );
-                    const bool check_passable = !ae.aoe_check_passable || here.passable( pt );
-                    if( check_sees && check_passable ) {
-                        here.add_field( pt, ae.aoe_field_type, rng( ae.aoe_intensity_min, ae.aoe_intensity_max ) );
+            for( const aoe_field_effect &aoe : ae.aoe_field_types ) {
+                for( const tripoint_bub_ms &pt : points_in_radius_circ( p, aoe.radius, aoe.radius_z ) ) {
+                    if( x_in_y( aoe.chance, 100 ) ) {
+                        const bool check_passable = !aoe.check_passable || here.passable( pt );
+                        if( check_passable ) {
+                            here.add_field( pt, aoe.field_type, rng( aoe.intensity_min, aoe.intensity_max ), 0_turns,
+                                            true, effect_source( source ) );
 
-                        if( player_character.has_unfulfilled_pyromania() ) {
-                            for( const auto &fd : here.field_at( pt ) ) {
-                                if( fd.first->has_fire ) {
-                                    if( player_character.fulfill_pyromania_sees( here, pt, "" ) ) {
-                                        break;
+                            if( player_character.has_unfulfilled_pyromania() ) {
+                                for( const auto &fd : here.field_at( pt ) ) {
+                                    if( fd.first->has_fire ) {
+                                        if( player_character.fulfill_pyromania_sees( here, pt, "" ) ) {
+                                            break;
+                                        }
                                     }
                                 }
                             }
@@ -177,6 +182,15 @@ void apply_ammo_effects( Creature *source, const tripoint_bub_ms &p,
                     }
                 }
             }
+
+            // apply aoe_effects (but not on_hit_effects, this one is in apply_effects_nodamage())
+            for( const aoe_effect &eff : ae.aoe_effects ) {
+                for( Creature *cr : here.get_creatures_in_radius_circ( p, eff.radius ) ) {
+                    cr->add_effect( effect_source( source ), eff.effect, eff.duration, false, rng( eff.intensity_min,
+                                    eff.intensity_max ) );
+                }
+            }
+
             if( ae.aoe_explosion_data.power > 0 ) {
                 explosion_handler::explosion( source, p, ae.aoe_explosion_data );
             }
@@ -194,18 +208,16 @@ void apply_ammo_effects( Creature *source, const tripoint_bub_ms &p,
             for( const effect_on_condition_id &eoc : ae.eoc ) {
                 Creature *critter = get_creature_tracker().creature_at( p );
                 dialogue d( get_talker_for( *source ), critter == nullptr ? nullptr : get_talker_for( critter ) );
-                // `p` is tripoint relative to the upper left corner of currently loaded overmap
-                // not very useful for player's purposes methinks, but much appreciated
-                // write_var_value( var_type::context, "proj_target_tripoint", &d, p.abs().to_string());
                 write_var_value( var_type::context, "proj_damage", &d, dealt_damage );
                 eoc->activate( d );
             }
+
             //cast ammo effect spells
-            const spell ammo_spell = ae.spell_data.get_spell();
-            if( ammo_spell.is_valid() ) {
+            for( const fake_spell &f_spell : ae.spell_data ) {
+                const spell ammo_spell = f_spell.get_spell();
                 if( ae.always_cast_spell || dealt_damage > 0 ) {
-                    ammo_spell.cast_all_effects( *const_cast<Creature *>( source ), p );
-                    ammo_spell.make_sound( p, *const_cast<Creature *>( source ) );
+                    ammo_spell.cast_all_effects( *source, p );
+                    ammo_spell.make_sound( p, *source );
                 }
             }
         }
@@ -217,7 +229,9 @@ int max_aoe_size( const std::set<ammo_effect_str_id> &tags )
     int aoe_size = 0;
     for( const ammo_effect &aed : ammo_effects::get_all() ) {
         if( tags.count( aed.id ) > 0 ) {
-            aoe_size = std::max( aoe_size,  aed.aoe_size ) ;
+            for( const aoe_field_effect &ammo_aoe_effect : aed.aoe_field_types ) {
+                aoe_size = std::max( aoe_size, ammo_aoe_effect.size ) ;
+            }
         }
     }
     return aoe_size;


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
As part of my another PR (will be pushed in the future) i had to revisit the code for ammo effects, and boy if it's old, so i had to update it, and throw a few additions
#### Describe the solution
Notable stuff:
- Moved aoe fields, trail fields and spells to array notation, so now you can define multiple fields/trails/spells to be fired in one effect
- Removed `check_sees` and `check_sees_radius` fields, i blamed them back to the ancient #4253, and still failed to understand why nukes needed their field radius spawn decreased if player sees it. "i see, therefore nuke_gas spread less"
- Added aoe_effects to apply effects on all creatures in radius
- Removed many of ammo_effect::check() since they are now checked on loading, using our new cool bound_readers
- Moved some stuff in header for padding purposes

- Switched to use points_in_radius_circ instead of points_in_radius, so that effects will spawn fields in circles, not in rectangles

| Before  | After  |
|---|---|
| <img width="513" height="510" alt="image" src="https://github.com/user-attachments/assets/59ddc5c6-d062-4a90-9dcf-fa6f1309b744" />  | <img width="496" height="479" alt="image" src="https://github.com/user-attachments/assets/6b1e2c0b-9484-4f2a-aadc-42bb78cc4ee4" /> |

- Separately to it, added a debug view for fields, so i could test stuff more easily

<img width="469" height="204" alt="image" src="https://github.com/user-attachments/assets/42f4f98a-27c8-4711-9afe-fb47ecf0af32" />

#### Testing
Tested quite extensively as part of that future PR, everything seems to work
#### Additional context
Liquid attacks probably need to be updated to work with monsters, or at least to be applied to all NPCs, from code it looks it checks the avatar no matter what