### PR TITLE
Chacne to find army clips in on_hand_223

### DIFF
--- a/data/json/itemgroups/Weapons_Mods_Ammo/nested_ammo.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/nested_ammo.json
@@ -345,10 +345,20 @@
     "//": "a collection of ammo that would be found with a loaded gun.",
     "subtype": "collection",
     "entries": [
-      { "group": "boxed_223_20_used", "prob": 100 },
-      { "group": "223_loose", "prob": 100, "count": [ 1, 4 ] },
-      { "group": "boxed_223_20", "prob": 50 },
-      { "group": "boxed_223_50", "prob": 25 }
+      {
+        "distribution": [
+          {
+            "collection": [
+              { "group": "223_loose", "prob": 100, "count": [ 1, 4 ] },
+              { "group": "boxed_223_20_used", "prob": 100 },
+              { "group": "boxed_223_20", "prob": 50 },
+              { "group": "boxed_223_50", "prob": 25 }
+            ],
+            "prob": 100
+          },
+          { "collection": [ { "group": "clip223_10rd_556", "prob": 100, "count": [ 1, 5 ] } ], "prob": 20 }
+        ]
+      }
     ]
   },
   {


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Lil feature i realised i can make
#### Describe the solution
20% chance that instead of finding loose ammo in boxes, you will loot a few 556 clips from dead body
#### Describe alternatives you've considered
Also add them as gun shop loot, but maybe later
#### Testing
Just manually spawning on_hand_223
<img width="790" height="790" alt="image" src="https://github.com/user-attachments/assets/5237e367-5915-4280-83e9-5ad85d57e00d" />

#### Additional context
I forgot how confusing the itemgroup syntax is