### PR TITLE
fix magazine variant shown in iteminfo

### DIFF
--- a/src/item.h
+++ b/src/item.h
@@ -520,6 +520,7 @@ class item : public visitable
                             bool debug ) const;
         void ammo_info( std::vector<iteminfo> &info, const iteminfo_query *parts, int batch,
                         bool debug ) const;
+        std::string print_compatible_mags_or_flags() const;
         void gun_info( const item *mod, std::vector<iteminfo> &info, const iteminfo_query *parts, int batch,
                        bool debug ) const;
         void gunmod_info( std::vector<iteminfo> &info, const iteminfo_query *parts, int batch,

--- a/src/itype.cpp
+++ b/src/itype.cpp
@@ -469,6 +469,19 @@ const itype_id &itype::tool_slot_first_ammo() const
     return itype_id::NULL_ID();
 }
 
+std::set<std::string> itype::all_variant_names() const
+{
+    std::set<std::string> ret;
+
+    for( const itype_variant_data &var : variants ) {
+        if( var.weight > 0 ) {
+            ret.insert( var.alt_name.translated() );
+        }
+    }
+
+    return ret;
+}
+
 int islot_ammo::dispersion_considering_length( units::length barrel_length ) const
 {
 

--- a/src/itype.h
+++ b/src/itype.h
@@ -1479,6 +1479,9 @@ struct itype {
         // Type of the variant - so people can turn off certain types of variants
         itype_variant_kind variant_kind = itype_variant_kind::last;
 
+        // return translated names of all variants this itype can have, if it's weight is > 0
+        std::set<std::string> all_variant_names() const;
+
         phase_id phase = phase_id::SOLID; // e.g. solid, liquid, gas
 
         /** If positive starts countdown to countdown_action at item creation */


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
While playing, found the game do not respect gun brand option, and always showed the generic description for magazines 
#### Describe the solution
Refactor function to check SHOW_GUN_VARIANTS, and print accordingly
Also make it a single function instead of slapping a comment "Keep this identical with tool magazines in ..."
#### Testing
With option:
<img width="648" height="73" alt="image" src="https://github.com/user-attachments/assets/109a8033-7289-4a62-9c1b-398bf5077066" />

Without option
<img width="653" height="77" alt="image" src="https://github.com/user-attachments/assets/143231de-7b19-42e9-9da3-b4ddb8ca1a29" />