### PR TITLE
Put back drugs and medical tools in E menu

### DIFF
--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -798,7 +798,7 @@ class comestible_inventory_preset : public inventory_selector_preset
         }
 
         bool is_shown( const item_location &loc ) const override {
-            return  loc->is_comestible() && you.can_consume_as_is( *loc );
+            return ( loc->is_comestible() && you.can_consume_as_is( *loc ) ) || loc->is_medical_tool();
         }
 
         std::string get_denial( const item_location &loc ) const override {

--- a/src/medical_ui.cpp
+++ b/src/medical_ui.cpp
@@ -25,10 +25,8 @@
 #include "flag.h"
 #include "game.h"
 #include "game_constants.h"
-#include "game_inventory.h"
 #include "input_context.h"
 #include "input_enums.h"
-#include "item_location.h"
 #include "output.h"
 #include "point.h"
 #include "string_formatter.h"
@@ -1023,9 +1021,8 @@ void Character::disp_medical()
         } else if( action == "APPLY" ) {
             avatar *a = this->as_avatar();
             if( a ) {
-                item_location loc = game_menus::inv::consume( "MED" );
-                avatar_action::eat( *a, loc );
-                break; // Close Medical Menu so that consume menu can work properly
+                avatar_action::use_item( *a );
+                break;
             } else {
                 popup( _( "Applying not implemented for NPCs." ) );
             }

--- a/src/medical_ui.cpp
+++ b/src/medical_ui.cpp
@@ -1022,7 +1022,6 @@ void Character::disp_medical()
             avatar *a = this->as_avatar();
             if( a ) {
                 avatar_action::use_item( *a );
-                break;
             } else {
                 popup( _( "Applying not implemented for NPCs." ) );
             }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
Follow up to #76920
Fixes #84502
Fixes #84520 by simply reverting any change to the medical menu
#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Allow medical tools in E menu and revert changes to medical menu

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
Get alcohol wipes 
Debug damage self
`a`ctivate > wipes are there and work
`E`at > same
Go through medical menu > it works also
Do the same with bandages > it works

Spawn ibuprofen > show up in `E`at but not in `a`ctivate and works
same thing for mutagen primer and injectable iron

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
