### PR TITLE
Split math_exception_impl constructor in two

### DIFF
--- a/src/math_parser_type.h
+++ b/src/math_parser_type.h
@@ -31,15 +31,18 @@ class math_exception_impl : public exception
     public:
         static constexpr int severity = severity_;
 
-        template < typename... Args,
-                   typename = std::enable_if_t <
-                       ( sizeof...( Args ) > 0 ) &&
-                   !( ( std::is_same_v<std::decay_t<Args>, math_exception_impl> || ... ) )
-                   >
+        constexpr explicit math_exception_impl()
+            : exception( string_format( "%s", _severity_str<severity_>() ) ) {}
+
+        template <typename Arg, typename... Args,
+                  typename = std::enable_if_t<
+                      !std::is_same_v<std::decay_t<Arg>, math_exception_impl>
+                  >
         >
-        constexpr explicit math_exception_impl( Args && ...args )
+        constexpr explicit math_exception_impl( Arg &&arg, Args &&... args )
             : exception( string_format( "%s: %s", _severity_str<severity_>(),
-                                        string_format( std::forward<Args>( args )... ) ) ) {}
+                                        string_format( std::forward<Arg>( arg ),
+                                                       std::forward<Args>( args )... ) ) ) {}
 };
 
 // syntax error in parsed expression

--- a/src/math_parser_type.h
+++ b/src/math_parser_type.h
@@ -34,15 +34,15 @@ class math_exception_impl : public exception
         constexpr explicit math_exception_impl()
             : exception( string_format( "%s", _severity_str<severity_>() ) ) {}
 
-        template <typename Arg, typename... Args,
-                  typename = std::enable_if_t<
-                      !std::is_same_v<std::decay_t<Arg>, math_exception_impl>
-                  >
-        >
-        constexpr explicit math_exception_impl( Arg &&arg, Args &&... args )
+        template < typename Arg, typename... Args,
+                   typename = std::enable_if_t <
+                       !std::is_same_v<std::decay_t<Arg>, math_exception_impl>
+                       >
+                   >
+        constexpr explicit math_exception_impl( Arg && arg, Args && ... args )
             : exception( string_format( "%s: %s", _severity_str<severity_>(),
                                         string_format( std::forward<Arg>( arg ),
-                                                       std::forward<Args>( args )... ) ) ) {}
+                                                std::forward<Args>( args )... ) ) ) {}
 };
 
 // syntax error in parsed expression


### PR DESCRIPTION
As suggested by @akrieger

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Alternative solution to the clang20 error fixed by #84404
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
See the patch
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Built locally under CMake with windows-tiles-sounds-x64-clang-cl profile under VS Insiders 18 and its clang 20
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
