### PR TITLE
Fix the projectile effects

### DIFF
--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -156,8 +156,9 @@ void apply_ammo_effects( Creature *source, const tripoint_bub_ms &p,
     map &here = get_map();
     Character &player_character = get_player_character();
 
-    for( const ammo_effect &ae : ammo_effects::get_all() ) {
-        if( x_in_y( ae.trigger_chance, 100 ) ) {
+    for( const ammo_effect_str_id &ae_str : effects ) {
+        ammo_effect ae = ae_str.obj();
+        if( !x_in_y( ae.trigger_chance, 100 ) ) {
             continue;
         }
         if( effects.count( ae.id ) > 0 ) {


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
In #84499, as the last minute change, i switched the logic of trigger_chance from previous `one_in_x()` to `x_in_y(trigger_chance, 100)`. In the process i messed up and forgot to inverse the result, so right now all ammo effects have 0% chance to happen
#### Describe the solution
Add the inversion
While here, stop iterating over all ammo effects ever, and iterate only over what was passed to projectile
#### Testing
Shoot gun with ammo effect, ammo effect works as expected