### PR TITLE
Move ACT_SPELLCASTING handler to activity_actor

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -43,6 +43,8 @@
 #include "creature.h"
 #include "creature_tracker.h"
 #include "debug.h"
+#include "dialogue.h"
+#include "effect_on_condition.h"
 #include "enum_conversions.h"
 #include "enums.h"
 #include "event.h"
@@ -102,6 +104,7 @@
 #include "skill.h"
 #include "sounds.h"
 #include "string_formatter.h"
+#include "talker.h"
 #include "translation.h"
 #include "translations.h"
 #include "type_id.h"
@@ -193,6 +196,7 @@ static const activity_id ACT_ROBOT_CONTROL( "ACT_ROBOT_CONTROL" );
 static const activity_id ACT_SHAVE( "ACT_SHAVE" );
 static const activity_id ACT_SHEARING( "ACT_SHEARING" );
 static const activity_id ACT_SKIN( "ACT_SKIN" );
+static const activity_id ACT_SPELLCASTING( "ACT_SPELLCASTING" );
 static const activity_id ACT_START_ENGINES( "ACT_START_ENGINES" );
 static const activity_id ACT_STASH( "ACT_STASH" );
 static const activity_id ACT_STUDY_SPELL( "ACT_STUDY_SPELL" );
@@ -284,6 +288,7 @@ static const itype_id itype_water_clean( "water_clean" );
 static const json_character_flag json_flag_PAIN_IMMUNE( "PAIN_IMMUNE" );
 static const json_character_flag json_flag_READ_IN_DARKNESS( "READ_IN_DARKNESS" );
 static const json_character_flag json_flag_SAFECRACK_NO_TOOL( "SAFECRACK_NO_TOOL" );
+static const json_character_flag json_flag_SILENT_SPELL( "SILENT_SPELL" );
 
 static const mongroup_id GROUP_FISH( "GROUP_FISH" );
 
@@ -2607,6 +2612,168 @@ std::unique_ptr<activity_actor> study_spell_activity_actor::deserialize( JsonVal
     data.read( "until_level_gained", actor.until_level_gained );
     data.read( "xp_gained", actor.xp_gained );
     data.read( "cancelled", actor.cancelled );
+
+    return actor.clone();
+}
+
+void spellcasting_activity_actor::start( player_activity &act, Character &who )
+{
+    act.moves_total = to_moves<int>( initial_moves );
+    act.moves_left = act.moves_total;
+
+    if( who.magic->casting_ignore ) {
+        const std::vector<distraction_type> ignored_distractions = {
+            distraction_type::noise,
+            distraction_type::pain,
+            distraction_type::attacked,
+            distraction_type::hostile_spotted_near,
+            distraction_type::hostile_spotted_far,
+            distraction_type::talked_to,
+            distraction_type::asthma,
+            distraction_type::motion_alarm,
+            distraction_type::weather_change,
+            distraction_type::mutation
+        };
+        for( const distraction_type ignored : ignored_distractions ) {
+            act.ignore_distraction( ignored );
+        }
+    }
+}
+
+void spellcasting_activity_actor::finish( player_activity &act, Character &who )
+{
+    act.set_to_null();
+    const int mana_override = mana_cost_override;
+    const spell_id sp = spell_selected;
+    bool is_fake_spell = !!fake_spell_level;
+
+    // bionic spells are built from the ground up
+    spell temp_spell( sp );
+    spell &spell_being_cast = !is_fake_spell ? who.magic->get_spell( sp ) : temp_spell;
+
+    // we need to set the bionic spell's level
+    if( is_fake_spell ) {
+        spell_being_cast.set_level( who, *fake_spell_level );
+    }
+
+    // choose target for spell before continuing
+    const std::optional<tripoint_bub_ms> target = !spell_target ? spell_being_cast.select_target(
+                &who ) : get_map().get_bub( *spell_target );
+    if( target ) {
+        // npcs check for target viability
+        if( !who.is_npc() || spell_being_cast.is_valid_target( who, *target ) ) {
+            // no turning back now. it's all said and done.
+            bool success = always_succeeds ||
+                           rng_float( 0.0f, 1.0f ) >= spell_being_cast.spell_fail( who );
+            int exp_gained = spell_being_cast.casting_exp( who );
+            if( !success ) {
+                who.add_msg_if_player( game_message_params{ m_bad, gmf_bypass_cooldown },
+                                       _( "You lose your concentration!" ) );
+                if( !spell_being_cast.is_max_level( who ) && !is_fake_spell ) {
+                    // still get some experience for trying
+                    exp_gained *= spell_being_cast.get_failure_exp_percent( who );
+                    spell_being_cast.gain_exp( who, exp_gained );
+                }
+                if( !mana_override ) {
+                    spell_being_cast.consume_spell_cost( who, false );
+                }
+                dialogue character_talker( get_talker_for( who ), nullptr );
+                std::vector<effect_on_condition_id> failure_eocs = spell_being_cast.get_failure_eoc_ids();
+                for( effect_on_condition_id failure_eoc : failure_eocs ) {
+                    failure_eoc->activate( character_talker );
+                }
+                get_event_bus().send<event_type::spellcasting_finish>( who.getID(), false, sp,
+                        spell_being_cast.spell_class(), spell_being_cast.get_difficulty( who ),
+                        spell_being_cast.energy_cost( who ), spell_being_cast.casting_time( who ),
+                        spell_being_cast.damage( who ) );
+                return;
+            }
+
+            if( spell_being_cast.has_flag( spell_flag::VERBAL ) && !who.has_flag( json_flag_SILENT_SPELL ) ) {
+                sounds::sound( who.pos_bub(), who.get_shout_volume() / 2, sounds::sound_t::speech,
+                               _( "cast a spell" ),
+                               false );
+            }
+
+            who.add_msg_if_player( spell_being_cast.message(), spell_being_cast.name() );
+
+            // this is here now so that the spell first consume its components then casts its effects, necessary to cast
+            // spells with the components in hand.
+            spell_being_cast.use_components( who );
+
+            if( !mana_override ) {
+                spell_being_cast.consume_spell_cost( who, true );
+            }
+
+            if( spell_item_casting ) {
+                item *it = spell_item_casting.get_item();
+                if( it != nullptr && it->has_flag( flag_SINGLE_USE ) ) {
+                    who.i_rem( it );
+                    spell_item_casting = item_location::nowhere;
+                } else if( it && !it->has_flag( flag_USE_PLAYER_ENERGY ) ) {
+                    who.consume_charges( *it, it->type->charges_to_use() );
+                }
+            }
+
+            spell_being_cast.cast_all_effects( who, *target );
+
+            if( !is_fake_spell ) {
+                if( !spell_being_cast.is_max_level( who ) ) {
+                    // reap the reward
+                    int old_level = spell_being_cast.get_level();
+                    if( old_level == 0 ) {
+                        spell_being_cast.gain_level( who );
+                        who.add_msg_if_player( m_good,
+                                               _( "Something about how this spell works just clicked!  You gained a level!" ) );
+                    } else {
+                        spell_being_cast.gain_exp( who, exp_gained );
+                    }
+                    if( spell_being_cast.get_level() != old_level ) {
+                        // Level 0-1 message is printed above - notify player when leveling up further
+                        if( old_level > 0 ) {
+                            who.add_msg_if_player( m_good, _( "You gained a level in %s!" ), spell_being_cast.name() );
+                        }
+                    }
+                }
+            }
+            get_event_bus().send<event_type::spellcasting_finish>( who.getID(), true, sp,
+                    spell_being_cast.spell_class(), spell_being_cast.get_difficulty( who ),
+                    spell_being_cast.energy_cost( who ), spell_being_cast.casting_time( who ),
+                    spell_being_cast.damage( who ) );
+        }
+    }
+}
+
+std::string spellcasting_activity_actor::get_progress_message( const player_activity & ) const
+{
+    return spell_selected->name.translated();
+}
+
+void spellcasting_activity_actor::serialize( JsonOut &jsout ) const
+{
+    jsout.start_object();
+    jsout.member( "initial_moves", initial_moves );
+    jsout.member( "spell_selected", spell_selected );
+    jsout.member( "fake_spell_level", fake_spell_level );
+    jsout.member( "always_succeeds", always_succeeds );
+    jsout.member( "mana_cost_override", mana_cost_override );
+    jsout.member( "spell_target", spell_target );
+    jsout.member( "spell_item_casting", spell_item_casting );
+    jsout.end_object();
+}
+
+std::unique_ptr<activity_actor> spellcasting_activity_actor::deserialize( JsonValue &jsin )
+{
+    spellcasting_activity_actor actor;
+    JsonObject data = jsin.get_object();
+
+    data.read( "initial_moves", actor.initial_moves );
+    data.read( "spell_selected", actor.spell_selected );
+    data.read( "fake_spell_level", actor.fake_spell_level );
+    data.read( "always_succeeds", actor.always_succeeds );
+    data.read( "mana_cost_override", actor.mana_cost_override );
+    data.read( "spell_target", actor.spell_target );
+    data.read( "spell_item_casting", actor.spell_item_casting );
 
     return actor.clone();
 }
@@ -11271,6 +11438,7 @@ deserialize_functions = {
     { ACT_SHAVE, &shave_activity_actor::deserialize },
     { ACT_SHEARING, &shearing_activity_actor::deserialize },
     { ACT_SKIN, &butchery_activity_actor::deserialize },
+    { ACT_SPELLCASTING, &spellcasting_activity_actor::deserialize },
     { ACT_START_ENGINES, &start_engines_activity_actor::deserialize },
     { ACT_STASH, &stash_activity_actor::deserialize },
     { ACT_STUDY_SPELL, &study_spell_activity_actor::deserialize },

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -633,6 +633,52 @@ class study_spell_activity_actor : public activity_actor
         bool cancelled = false;
 };
 
+class spellcasting_activity_actor : public activity_actor
+{
+    public:
+        explicit spellcasting_activity_actor( time_duration initial_moves, spell_id spell_selected,
+                                              std::optional<tripoint_abs_ms> spell_target = std::nullopt,
+                                              std::optional<int> fake_spell_level = std::nullopt,
+                                              bool always_succeeds = false, bool mana_cost_override = false,
+                                              const item_location &spell_item_casting = item_location::nowhere ) :
+            initial_moves( initial_moves ), spell_selected( spell_selected ), spell_target( spell_target ),
+            fake_spell_level( fake_spell_level ), always_succeeds( always_succeeds ),
+            mana_cost_override( mana_cost_override ), spell_item_casting( spell_item_casting )
+        {};
+
+        const activity_id &get_type() const override {
+            static const activity_id ACT_SPELLCASTING( "ACT_SPELLCASTING" );
+            return ACT_SPELLCASTING;
+        }
+
+        void start( player_activity &act, Character & ) override;
+        void do_turn( player_activity &, Character & ) override {};
+        void finish( player_activity &act, Character &who ) override;
+
+        std::string get_progress_message( const player_activity & ) const override;
+
+        std::unique_ptr<activity_actor> clone() const override {
+            return std::make_unique<spellcasting_activity_actor>( *this );
+        }
+
+        void serialize( JsonOut &jsout ) const override;
+        static std::unique_ptr<activity_actor> deserialize( JsonValue &jsin );
+
+    private:
+        spellcasting_activity_actor() = default;
+        time_duration initial_moves;
+        spell_id spell_selected;
+        // if not provided, spell prompts to select target
+        std::optional<tripoint_abs_ms> spell_target;
+        // if provided, constructs a standalone `spell_selected` with this given level
+        // for items/bionics
+        std::optional<int> fake_spell_level;
+        bool always_succeeds; // if true, the spell never fails
+        bool mana_cost_override; // if true, spell does not consume mana
+        // for handling cleanup of item passed from cast_spell_actor::use()
+        item_location spell_item_casting;
+};
+
 class move_items_activity_actor : public activity_actor
 {
     private:

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -29,8 +29,6 @@
 #include "creature_tracker.h"
 #include "cuboid_rectangle.h"
 #include "debug.h"
-#include "dialogue.h"
-#include "effect_on_condition.h"
 #include "enums.h"
 #include "event.h"
 #include "event_bus.h"
@@ -72,9 +70,7 @@
 #include "ret_val.h"
 #include "rng.h"
 #include "skill.h"
-#include "sounds.h"
 #include "string_formatter.h"
-#include "talker.h"
 #include "text_snippets.h"
 #include "translation.h"
 #include "translations.h"
@@ -110,7 +106,6 @@ static const activity_id ACT_MULTIPLE_STUDY( "ACT_MULTIPLE_STUDY" );
 static const activity_id ACT_PULL_CREATURE( "ACT_PULL_CREATURE" );
 static const activity_id ACT_REPAIR_ITEM( "ACT_REPAIR_ITEM" );
 static const activity_id ACT_SOCIALIZE( "ACT_SOCIALIZE" );
-static const activity_id ACT_SPELLCASTING( "ACT_SPELLCASTING" );
 static const activity_id ACT_START_FIRE( "ACT_START_FIRE" );
 static const activity_id ACT_TIDY_UP( "ACT_TIDY_UP" );
 static const activity_id ACT_TOOLMOD_ADD( "ACT_TOOLMOD_ADD" );
@@ -148,7 +143,6 @@ static const itype_id itype_pseudo_magazine_mod( "pseudo_magazine_mod" );
 
 static const json_character_flag json_flag_ASOCIAL1( "ASOCIAL1" );
 static const json_character_flag json_flag_ASOCIAL2( "ASOCIAL2" );
-static const json_character_flag json_flag_SILENT_SPELL( "SILENT_SPELL" );
 static const json_character_flag json_flag_SOCIAL1( "SOCIAL1" );
 static const json_character_flag json_flag_SOCIAL2( "SOCIAL2" );
 
@@ -203,8 +197,7 @@ activity_handlers::finish_functions = {
     { ACT_TOOLMOD_ADD, toolmod_add_finish },
     { ACT_SOCIALIZE, socialize_finish },
     { ACT_ATM, atm_finish },
-    { ACT_PULL_CREATURE, pull_creature_finish },
-    { ACT_SPELLCASTING, spellcasting_finish }
+    { ACT_PULL_CREATURE, pull_creature_finish }
 };
 
 static void assign_multi_activity( Character &you, const player_activity &act )
@@ -1587,107 +1580,4 @@ void activity_handlers::tree_communion_do_turn( player_activity *act, Character 
     }
     you->add_msg_if_player( m_info, _( "The trees have shown you what they will." ) );
     act->set_to_null();
-}
-
-void activity_handlers::spellcasting_finish( player_activity *act, Character *you )
-{
-    act->set_to_null();
-    const int level_override = act->get_value( 0 );
-    spell_id sp( act->name );
-
-    // if level is -1 then we know it's a player spell, otherwise we build it from the ground up
-    spell temp_spell( sp );
-    spell &spell_being_cast = ( level_override == -1 ) ? you->magic->get_spell( sp ) : temp_spell;
-
-    // if level != 1 then we need to set the spell's level
-    if( level_override != -1 ) {
-        spell_being_cast.set_level( *you, level_override );
-    }
-
-    // choose target for spell before continuing
-    const std::optional<tripoint_bub_ms> target = act->coords.empty() ? spell_being_cast.select_target(
-                you ) : get_map().get_bub( act->coords.front() );
-    if( target ) {
-        // npcs check for target viability
-        if( !you->is_npc() || spell_being_cast.is_valid_target( *you, *target ) ) {
-            // no turning back now. it's all said and done.
-            bool success = act->get_value( 1 ) == 1 ||
-                           rng_float( 0.0f, 1.0f ) >= spell_being_cast.spell_fail( *you );
-            int exp_gained = spell_being_cast.casting_exp( *you );
-            if( !success ) {
-                you->add_msg_if_player( game_message_params{ m_bad, gmf_bypass_cooldown },
-                                        _( "You lose your concentration!" ) );
-                if( !spell_being_cast.is_max_level( *you ) && level_override == -1 ) {
-                    // still get some experience for trying
-                    exp_gained *= spell_being_cast.get_failure_exp_percent( *you );
-                    spell_being_cast.gain_exp( *you, exp_gained );
-                }
-                if( act->get_value( 2 ) != 0 ) {
-                    spell_being_cast.consume_spell_cost( *you, false );
-                }
-                dialogue d( get_talker_for( you ), nullptr );
-                std::vector<effect_on_condition_id> failure_eocs = spell_being_cast.get_failure_eoc_ids();
-                for( effect_on_condition_id failure_eoc : failure_eocs ) {
-                    failure_eoc->activate( d );
-                }
-                get_event_bus().send<event_type::spellcasting_finish>( you->getID(), false, sp,
-                        spell_being_cast.spell_class(), spell_being_cast.get_difficulty( *you ),
-                        spell_being_cast.energy_cost( *you ), spell_being_cast.casting_time( *you ),
-                        spell_being_cast.damage( *you ) );
-                return;
-            }
-
-            if( spell_being_cast.has_flag( spell_flag::VERBAL ) && !you->has_flag( json_flag_SILENT_SPELL ) ) {
-                sounds::sound( you->pos_bub(), you->get_shout_volume() / 2, sounds::sound_t::speech,
-                               _( "cast a spell" ),
-                               false );
-            }
-
-            you->add_msg_if_player( spell_being_cast.message(), spell_being_cast.name() );
-
-            // this is here now so that the spell first consume its components then casts its effects, necessary to cast
-            // spells with the components in hand.
-            spell_being_cast.use_components( *you );
-
-            if( act->get_value( 2 ) != 0 ) {
-                spell_being_cast.consume_spell_cost( *you, true );
-            }
-
-            if( !act->targets.empty() ) {
-                item *it = act->targets.front().get_item();
-                if( it != nullptr && it->has_flag( flag_SINGLE_USE ) ) {
-                    you->i_rem( it );
-                    act->targets.erase( act->targets.end() - 1 );
-                } else if( it && !it->has_flag( flag_USE_PLAYER_ENERGY ) ) {
-                    you->consume_charges( *it, it->type->charges_to_use() );
-                }
-            }
-
-            spell_being_cast.cast_all_effects( *you, *target );
-
-            if( level_override == -1 ) {
-                if( !spell_being_cast.is_max_level( *you ) ) {
-                    // reap the reward
-                    int old_level = spell_being_cast.get_level();
-                    if( old_level == 0 ) {
-                        spell_being_cast.gain_level( *you );
-                        you->add_msg_if_player( m_good,
-                                                _( "Something about how this spell works just clicked!  You gained a level!" ) );
-                    } else {
-                        spell_being_cast.gain_exp( *you, exp_gained );
-                    }
-                    if( spell_being_cast.get_level() != old_level ) {
-                        // Level 0-1 message is printed above - notify player when leveling up further
-                        if( old_level > 0 ) {
-                            you->add_msg_if_player( m_good, _( "You gained a level in %s!" ), spell_being_cast.name() );
-                        }
-                    }
-                }
-            }
-            get_event_bus().send<event_type::spellcasting_finish>( you->getID(), true, sp,
-                    spell_being_cast.spell_class(), spell_being_cast.get_difficulty( *you ),
-                    spell_being_cast.energy_cost( *you ), spell_being_cast.casting_time( *you ),
-                    spell_being_cast.damage( *you ) );
-        }
-    }
 }

--- a/src/activity_handlers.h
+++ b/src/activity_handlers.h
@@ -232,7 +232,6 @@ void mend_item_finish( player_activity *act, Character *you );
 void pull_creature_finish( player_activity *act, Character *you );
 void repair_item_finish( player_activity *act, Character *you );
 void socialize_finish( player_activity *act, Character *you );
-void spellcasting_finish( player_activity *act, Character *you );
 void start_fire_finish( player_activity *act, Character *you );
 void teach_finish( player_activity *act, Character *you );
 void toolmod_add_finish( player_activity *act, Character *you );

--- a/src/character.h
+++ b/src/character.h
@@ -2625,6 +2625,10 @@ class Character : public Creature, public visitable
         // gets all the spells known by this character that have this spell class
         // spells returned are a copy, do not try to edit them from here, instead use known_magic::get_spell
         std::vector<spell> spells_known_of_class( const trait_id &spell_class ) const;
+        /**
+        * @param fake_spell - "true" indicates a spell cast by a bionic
+        * @param target - if not provided, defers to spell::select_target()
+        */
         bool cast_spell( spell &sp, bool fake_spell, const std::optional<tripoint_bub_ms> &target );
 
         /** Called when a player triggers a trap, returns true if they don't set it off */

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -102,7 +102,6 @@
 
 static const activity_id ACT_FIRSTAID( "ACT_FIRSTAID" );
 static const activity_id ACT_REPAIR_ITEM( "ACT_REPAIR_ITEM" );
-static const activity_id ACT_SPELLCASTING( "ACT_SPELLCASTING" );
 static const activity_id ACT_START_FIRE( "ACT_START_FIRE" );
 
 static const damage_type_id damage_acid( "acid" );
@@ -2720,26 +2719,10 @@ std::optional<int> cast_spell_actor::use( Character *p, item &it, map * /*here*/
         return 0;
     }
 
-    player_activity cast_spell( ACT_SPELLCASTING, casting.casting_time( *p ) );
-    // [0] this is used as a spell level override for items casting spells
-    cast_spell.values.emplace_back( spell_level );
-    if( no_fail ) {
-        // [1] if this value is 1, the spell never fails
-        cast_spell.values.emplace_back( 1 );
-    } else {
-        // [1]
-        cast_spell.values.emplace_back( 0 );
-    }
-    cast_spell.name = casting.id().c_str();
-    if( it.has_flag( flag_USE_PLAYER_ENERGY ) ) {
-        // [2] this value overrides the mana cost if set to 0
-        cast_spell.values.emplace_back( 1 );
-    } else {
-        // [2]
-        cast_spell.values.emplace_back( 0 );
-    }
-    p->assign_activity( cast_spell );
-    p->activity.targets.emplace_back( *p, &it );
+    p->assign_activity( spellcasting_activity_actor(
+                            time_duration::from_moves<int>( casting.casting_time( *p ) ),
+                            casting.id(), std::nullopt, spell_level,
+                            no_fail, it.has_flag( flag_USE_PLAYER_ENERGY ), item_location( *p, &it ) ) );
     // Actual handling of charges_to_use is in activity_handlers::spellcasting_finish
     return 0;
 }

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -1380,7 +1380,7 @@ void npc::move()
         set_attitude( NPCATT_NULL );
     }
     regen_ai_cache();
-    // NPCs under operation should just stay still
+    // NPCs under operation or casting spells should just stay still
     if( activity.id() == ACT_OPERATION || activity.id() == ACT_SPELLCASTING ) {
         execute_action( npc_player_activity );
         return;

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -20,7 +20,6 @@
 #include "game.h"
 #include "item.h"
 #include "itype.h"
-#include "magic.h"
 #include "messages.h"
 #include "rng.h"
 #include "skill.h"
@@ -51,7 +50,6 @@ static const activity_id ACT_MIGRATION_CANCEL( "ACT_MIGRATION_CANCEL" );
 static const activity_id ACT_NULL( "ACT_NULL" );
 static const activity_id ACT_PICKAXE( "ACT_PICKAXE" );
 static const activity_id ACT_READ( "ACT_READ" );
-static const activity_id ACT_SPELLCASTING( "ACT_SPELLCASTING" );
 static const activity_id ACT_TRAVELLING( "ACT_TRAVELLING" );
 static const activity_id ACT_VEHICLE( "ACT_VEHICLE" );
 static const activity_id ACT_WORKOUT_ACTIVE( "ACT_WORKOUT_ACTIVE" );
@@ -179,11 +177,6 @@ std::optional<std::string> player_activity::get_progress_message( const avatar &
             const int percentage = ( ( moves_total - moves_left ) * 100 ) / moves_total;
 
             extra_info = string_format( "%d%%", percentage );
-        }
-
-        if( type == ACT_SPELLCASTING ) {
-            const std::string spell_name = spell_id( name )->name.translated();
-            extra_info = string_format( "%s …", spell_name );
         }
     }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Infrastructure "move ACT_SPELLCASTING handler to activity_actor"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Update legacy activities.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

See title. I primarily used Magiclysm to test this, which I'm not familiar with at all, so "correct" in the testing section is "looks correct". A couple of the parameters for the legacy spellcasting handler were tough to parse, so if something concerning spells seems broken, please ping me.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

- Cast spells "Seismic Stomp" and "Ethereal Hands" successfully, noted mana spent also correct.
- Used "the Louverture" to test item spells both from inventory and on ground, worked correctly, no mana spent.
- Used "Super Stun Gun" bionic to test bionic spells, worked correctly, noted bionic energy spent and no mana spent.
- Cast "Utility Molding", autosaved and loaded, spell still cast correctly.
- Cast "Utility Molding" in a 0.H save, loaded in this branch, legacy activity cancelled correctly.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
