### PR TITLE
[MoM] No drunken psi mastery

### DIFF
--- a/data/mods/MindOverMatter/effectoncondition/conditions_for_eocs.json
+++ b/data/mods/MindOverMatter/effectoncondition/conditions_for_eocs.json
@@ -343,5 +343,27 @@
       ]
     },
     "effect": [  ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CONDITION_MOM_BANNED_EFFECTS_TO_PRACTICE_CONCENTRATION",
+    "condition": {
+      "or": [
+        { "math": [ "u_vitamin('BAC') > 2500" ] },
+        { "u_has_effect": "winded" },
+        { "u_has_effect": "weed_high" },
+        { "u_has_effect": "high" },
+        { "u_has_effect": "datura" },
+        { "u_has_effect": "hallu" },
+        { "u_has_effect": "nausea" },
+        { "u_has_effect": "onfire", "bodypart": "head" },
+        { "u_has_effect": "onfire", "bodypart": "torso" },
+        { "u_has_effect": "onfire", "bodypart": "arm_r" },
+        { "u_has_effect": "onfire", "bodypart": "arm_l" },
+        { "u_has_effect": "onfire", "bodypart": "leg_r" },
+        { "u_has_effect": "onfire", "bodypart": "leg_l" }
+      ]
+    },
+    "effect": [  ]
   }
 ]

--- a/data/mods/MindOverMatter/effectoncondition/conditions_for_eocs.json
+++ b/data/mods/MindOverMatter/effectoncondition/conditions_for_eocs.json
@@ -349,13 +349,14 @@
     "id": "EOC_CONDITION_MOM_BANNED_EFFECTS_TO_PRACTICE_CONCENTRATION",
     "condition": {
       "or": [
-        { "math": [ "u_vitamin('BAC') > 2500" ] },
+        { "math": [ "u_vitamin('BAC') > 1000" ] },
         { "u_has_effect": "winded" },
         { "u_has_effect": "weed_high" },
         { "u_has_effect": "high" },
         { "u_has_effect": "datura" },
         { "u_has_effect": "hallu" },
         { "u_has_effect": "nausea" },
+        { "u_has_effect": "meth" },
         { "u_has_effect": "onfire", "bodypart": "head" },
         { "u_has_effect": "onfire", "bodypart": "torso" },
         { "u_has_effect": "onfire", "bodypart": "arm_r" },

--- a/data/mods/MindOverMatter/effectoncondition/eoc_on_power_use_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_on_power_use_events.json
@@ -704,6 +704,7 @@
     "condition": {
       "and": [
         { "not": { "u_has_proficiency": "prof_concentration_basic" } },
+        { "not": { "test_eoc": "EOC_CONDITION_MOM_BANNED_EFFECTS_TO_PRACTICE_CONCENTRATION" } },
         { "math": [ "u_vitamin('vitamin_maintained_powers') > 0" ] }
       ]
     },
@@ -716,6 +717,7 @@
           "condition": {
             "and": [
               { "not": { "u_has_proficiency": "prof_concentration_intermediate" } },
+              { "not": { "test_eoc": "EOC_CONDITION_MOM_BANNED_EFFECTS_TO_PRACTICE_CONCENTRATION" } },
               { "math": [ "u_vitamin('vitamin_maintained_powers') > 0" ] }
             ]
           },
@@ -727,6 +729,7 @@
                 "condition": {
                   "and": [
                     { "not": { "u_has_proficiency": "prof_concentration_master" } },
+                    { "not": { "test_eoc": "EOC_CONDITION_MOM_BANNED_EFFECTS_TO_PRACTICE_CONCENTRATION" } },
                     { "math": [ "u_vitamin('vitamin_maintained_powers') > 0" ] }
                   ]
                 },

--- a/data/mods/MindOverMatter/effects/effects_psionic.json
+++ b/data/mods/MindOverMatter/effects/effects_psionic.json
@@ -1321,7 +1321,7 @@
       "hallucination_attacks",
       "deaf",
       "weed_high",
-      "High",
+      "high",
       "drunk",
       "no_sight",
       "glare",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "[MoM] No drunken psi mastery"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Heard a story about someone training concentration proficiency by getting blind drunk, picking up something heavy, and then, since you check concentration every time a whole list of effects are applied including `downed`, the repeated fall-down-vomit-stand-up cycle triggered those checks repeatedly, rocketing their proficiency to mastery.

Now, I admit this _is_ very funny, but there's a reason that you generally practice new skills without a ton of distractions. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add a list of effects that prevent you from gaining concentration proficiency XP. These are mostly pretty obvious--you can't be drunk or high (drugs to enhance psychic powers are a well-worn media trope but that drunk is not usually "weed"), you can't be totally out of breath, you can't be hallucinating, you can't be nauseated, and you can't be on fire. You train during normal circumstances so you can keep your concentration during those adverse ones. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Gave myself permanent datura, waited three days while concentrating, concentration proficiency did not go up.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
