### PR TITLE
Ignore weight effects for characters that don't need food (NPCs)

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3155,6 +3155,9 @@ void Character::calc_bmi_encumb( std::map<bodypart_id, encumbrance_data> &vals )
     for( const std::pair<const bodypart_str_id, bodypart> &elem : get_body() ) {
         int penalty = std::floor( elem.second.get_bmi_encumbrance_scalar() * std::max( 0.0f,
                                   get_bmi_fat() - static_cast<float>( elem.second.get_bmi_encumbrance_threshold() ) ) );
+        if( !needs_food() ) {
+            penalty = 0;
+        }
         vals[elem.first.id()].encumbrance += penalty;
     }
 }

--- a/src/character_health.cpp
+++ b/src/character_health.cpp
@@ -836,6 +836,9 @@ int Character::get_stored_kcal() const
 
 int Character::kcal_speed_penalty() const
 {
+    if( !needs_food() ) {
+        return 0;
+    }
     static const std::vector<std::pair<float, float>> starv_thresholds = { {
             std::make_pair( 0.0f, -90.0f ),
             std::make_pair( character_weight_category::emaciated, -50.f ),

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -669,6 +669,9 @@ void npc::randomize( const npc_class_id &type, const npc_template_id &tem_id )
     double weight_percent = std::clamp<double>( chi_squared_roll( time_influence ) / 5.0,
                             0.2, 5.0 );
     set_stored_kcal( weight_percent * get_healthy_kcal() );
+    if( !needs_food() ) {
+        set_stored_kcal( get_healthy_kcal() );
+    }
     starting_weapon( myclass );
     starting_clothes( *this, myclass, male );
     starting_inv( *this, myclass );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
🤷 

#### Describe the solution
Ignore weight effects for characters that don't need food

Always set NPCs that don't need food to healthy weight on start, instead of using the time scaling

Also ignore obesity/overweight encumbrance on characters that don't need_food()

#### Describe alternatives you've considered


#### Testing
No testing performed, very simple changes

#### Additional context
