### PR TITLE
Remove false warning about automatically generated item groups

### DIFF
--- a/data/json/itemgroups/Agriculture_Forage_Excavation/agriculture.json
+++ b/data/json/itemgroups/Agriculture_Forage_Excavation/agriculture.json
@@ -208,7 +208,6 @@
     "type": "item_group",
     "id": "juice_pulp_wooden_barrel_7_77",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "wooden_barrel",
     "entries": [ { "item": "juice_pulp", "count": [ 7, 77 ] } ]
   }

--- a/data/json/itemgroups/Clothing_Gear/clothing.json
+++ b/data/json/itemgroups/Clothing_Gear/clothing.json
@@ -4703,7 +4703,6 @@
     "type": "item_group",
     "id": "antifungal_bottle_plastic_pill_prescription_0_10",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_prescription",
     "entries": [ { "item": "antifungal", "container-item": "null", "count": [ 0, 10 ] } ]
   },
@@ -4711,7 +4710,6 @@
     "type": "item_group",
     "id": "antiparasitic_bottle_plastic_pill_prescription_0_10",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_prescription",
     "entries": [ { "item": "antiparasitic", "container-item": "null", "count": [ 0, 10 ] } ]
   },
@@ -4719,7 +4717,6 @@
     "type": "item_group",
     "id": "diazepam_bottle_plastic_pill_prescription_0_10",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_prescription",
     "entries": [ { "item": "diazepam", "container-item": "null", "count": [ 0, 10 ] } ]
   }

--- a/data/json/itemgroups/Clothing_Gear/gear_civilian.json
+++ b/data/json/itemgroups/Clothing_Gear/gear_civilian.json
@@ -386,7 +386,6 @@
     "type": "item_group",
     "id": "licorice_bag_plastic_1_4",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "licorice", "container-item": "null", "count": [ 1, 4 ] } ]
   }

--- a/data/json/itemgroups/Drugs_Tobacco_Alcohol/drugs.json
+++ b/data/json/itemgroups/Drugs_Tobacco_Alcohol/drugs.json
@@ -430,7 +430,6 @@
     "type": "item_group",
     "id": "tramadol_bottle_plastic_pill_prescription_1_10",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_prescription",
     "entries": [ { "item": "tramadol", "container-item": "null", "count": [ 1, 10 ] } ]
   },
@@ -566,7 +565,6 @@
     "type": "item_group",
     "id": "weed_jar_3l_glass_sealed_10_420",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "jar_3l_glass_sealed",
     "entries": [ { "item": "weed", "count": [ 10, 420 ] } ]
   },
@@ -574,7 +572,6 @@
     "type": "item_group",
     "id": "hi_q_shatter_jar_glass_sealed_5_140",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "jar_glass_sealed",
     "entries": [ { "item": "hi_q_shatter", "count": [ 5, 140 ] } ]
   },
@@ -582,7 +579,6 @@
     "type": "item_group",
     "id": "hi_q_wax_jar_glass_sealed_5_140",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "jar_glass_sealed",
     "entries": [ { "item": "hi_q_wax", "count": [ 5, 140 ] } ]
   },
@@ -590,7 +586,6 @@
     "type": "item_group",
     "id": "calcium_tablet_bottle_plastic_pill_supplement_1_20",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_supplement",
     "entries": [ { "item": "calcium_tablet", "container-item": "null", "count": [ 1, 20 ] } ]
   },
@@ -620,7 +615,6 @@
     "type": "item_group",
     "id": "caffeine_bottle_plastic_pill_supplement_1_10",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_supplement",
     "entries": [ { "item": "caffeine", "container-item": "null", "count": [ 1, 10 ] } ]
   },
@@ -635,7 +629,6 @@
     "type": "item_group",
     "id": "homeopathic_pills_bottle_plastic_pill_supplement_1_20",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_supplement",
     "entries": [ { "item": "homeopathic_pills", "container-item": "null", "count": [ 1, 20 ] } ]
   },
@@ -643,7 +636,6 @@
     "type": "item_group",
     "id": "thorazine_bottle_plastic_pill_prescription_1_10",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_prescription",
     "entries": [ { "item": "thorazine", "container-item": "null", "count": [ 1, 10 ] } ]
   },
@@ -651,7 +643,6 @@
     "type": "item_group",
     "id": "prozac_bottle_plastic_pill_prescription_1_15",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_prescription",
     "entries": [ { "item": "prozac", "container-item": "null", "count": [ 1, 15 ] } ]
   },
@@ -659,7 +650,6 @@
     "type": "item_group",
     "id": "strong_antibiotic_bottle_plastic_pill_prescription_1_5",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_prescription",
     "entries": [ { "item": "strong_antibiotic", "container-item": "null", "count": [ 1, 5 ] } ]
   },
@@ -813,7 +803,6 @@
     "type": "item_group",
     "id": "codeine_bottle_plastic_pill_painkiller_10",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_painkiller",
     "entries": [ { "item": "codeine", "container-item": "null", "count": 10 } ]
   },
@@ -821,7 +810,6 @@
     "type": "item_group",
     "id": "oxycodone_bottle_plastic_pill_prescription_10",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_prescription",
     "entries": [ { "item": "oxycodone", "container-item": "null", "count": 10 } ]
   },
@@ -829,7 +817,6 @@
     "type": "item_group",
     "id": "meth_bag_zipper_6",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_zipper",
     "entries": [ { "item": "meth", "container-item": "null", "count": 6 } ]
   },

--- a/data/json/itemgroups/Drugs_Tobacco_Alcohol/tobacco.json
+++ b/data/json/itemgroups/Drugs_Tobacco_Alcohol/tobacco.json
@@ -105,7 +105,6 @@
     "type": "item_group",
     "id": "chaw_wrapper_1_20",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "wrapper",
     "entries": [ { "item": "chaw", "container-item": "null", "count": [ 1, 20 ] } ]
   },
@@ -113,7 +112,6 @@
     "type": "item_group",
     "id": "cig_box_cigarette_20",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "box_cigarette",
     "entries": [ { "group": "cigarettes_new" } ]
   },

--- a/data/json/itemgroups/Food/food.json
+++ b/data/json/itemgroups/Food/food.json
@@ -1255,7 +1255,6 @@
     "type": "item_group",
     "id": "confit_meat_jar_3l_glass_sealed_12",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "jar_3l_glass_sealed",
     "entries": [ { "item": "confit_meat", "container-item": "null", "count": 12 } ]
   },
@@ -1284,7 +1283,6 @@
     "type": "item_group",
     "id": "chem_agar_bottle_plastic_small_50",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_small",
     "entries": [ { "item": "chem_agar", "container-item": "null", "count": 50 } ]
   },
@@ -1293,7 +1291,6 @@
     "id": "brown_bread_can_medium_14",
     "subtype": "collection",
     "on_overflow": "discard",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "can_medium",
     "entries": [ { "item": "brown_bread", "container-item": "null", "count": 14 } ]
   },
@@ -1301,7 +1298,6 @@
     "type": "item_group",
     "id": "pelmeni_can_medium_2",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "can_medium",
     "entries": [ { "item": "pelmeni", "container-item": "null", "count": 2 } ]
   },
@@ -1309,7 +1305,6 @@
     "type": "item_group",
     "id": "canned_liver_can_food_4",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "can_food",
     "entries": [ { "item": "canned_liver", "container-item": "null", "count": 4 } ]
   },
@@ -1317,7 +1312,6 @@
     "type": "item_group",
     "id": "can_beans_can_food_big_12",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "can_food_big",
     "entries": [ { "item": "can_beans", "container-item": "null", "count": 12 } ]
   },
@@ -1325,7 +1319,6 @@
     "type": "item_group",
     "id": "can_tomato_can_food_big_24",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "can_food_big",
     "entries": [ { "item": "can_tomato", "container-item": "null", "count": 24 } ]
   },
@@ -1333,7 +1326,6 @@
     "type": "item_group",
     "id": "can_pineapple_can_food_big_12",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "can_food_big",
     "entries": [ { "item": "can_pineapple", "container-item": "null", "count": 12 } ]
   },
@@ -1341,7 +1333,6 @@
     "type": "item_group",
     "id": "can_corn_can_food_big_6",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "can_food_big",
     "entries": [ { "item": "can_corn", "container-item": "null", "count": 6 } ]
   },
@@ -1406,7 +1397,6 @@
     "type": "item_group",
     "id": "pecorino_cheese_wrapper_4",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "wrapper",
     "entries": [ { "item": "pecorino_cheese", "container-item": "null", "count": 4 } ]
   },
@@ -1414,7 +1404,6 @@
     "type": "item_group",
     "id": "pine_nuts_bag_plastic_4",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "pine_nuts", "container-item": "null", "count": 4 } ]
   },
@@ -1422,7 +1411,6 @@
     "type": "item_group",
     "id": "candy_bag_plastic_3",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "candy", "container-item": "null", "count": 3 } ]
   },
@@ -1430,7 +1418,6 @@
     "type": "item_group",
     "id": "candy2_bag_plastic_3",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "candy2", "container-item": "null", "count": 3 } ]
   },
@@ -1438,7 +1425,6 @@
     "type": "item_group",
     "id": "candy3_bag_plastic_3",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "candy3", "container-item": "null", "count": 3 } ]
   },
@@ -1446,7 +1432,6 @@
     "type": "item_group",
     "id": "candy4_bag_plastic_3",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "candy4", "container-item": "null", "count": 3 } ]
   },
@@ -1454,7 +1439,6 @@
     "type": "item_group",
     "id": "cow_candy_bag_plastic_3",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "cow_candy", "container-item": "null", "count": 3 } ]
   },
@@ -1462,7 +1446,6 @@
     "type": "item_group",
     "id": "maltballs_box_snack_4",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "box_snack",
     "entries": [ { "item": "maltballs", "container-item": "null", "count": 4 } ]
   },
@@ -1470,7 +1453,6 @@
     "type": "item_group",
     "id": "mintpatties_bag_plastic_3",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "mintpatties", "container-item": "null", "count": 3 } ]
   },
@@ -1478,7 +1460,6 @@
     "type": "item_group",
     "id": "candycigarette_box_cigarette_3",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "box_cigarette",
     "entries": [ { "item": "candycigarette", "container-item": "null", "count": 3 } ]
   },
@@ -1486,7 +1467,6 @@
     "type": "item_group",
     "id": "maple_candy_bag_plastic_2",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "maple_candy", "container-item": "null", "count": 2 } ]
   },
@@ -1494,7 +1474,6 @@
     "type": "item_group",
     "id": "candy_bracelet_bag_plastic_3",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "candy_bracelet", "container-item": "null", "count": 3 } ]
   },
@@ -1502,7 +1481,6 @@
     "type": "item_group",
     "id": "candy_coated_peanuts_box_snack_2",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "box_snack",
     "entries": [ { "item": "candy_coated_peanuts", "container-item": "null", "count": 2 } ]
   },
@@ -1510,7 +1488,6 @@
     "type": "item_group",
     "id": "pretzels_bag_plastic_3",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "pretzels", "container-item": "null", "count": 3 } ]
   },
@@ -1518,7 +1495,6 @@
     "type": "item_group",
     "id": "porkstick_bag_plastic_4",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "porkstick", "container-item": "null", "count": 4 } ]
   },
@@ -1526,7 +1502,6 @@
     "type": "item_group",
     "id": "chocpretzels_bag_plastic_3",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "chocpretzels", "container-item": "null", "count": 3 } ]
   },
@@ -1534,7 +1509,6 @@
     "type": "item_group",
     "id": "popcorn_bag_plastic_4",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "popcorn", "container-item": "null", "count": 4 } ]
   },
@@ -1542,7 +1516,6 @@
     "type": "item_group",
     "id": "popcorn2_bag_plastic_4",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "popcorn2", "container-item": "null", "count": 4 } ]
   },
@@ -1550,7 +1523,6 @@
     "type": "item_group",
     "id": "popcorn3_bag_plastic_4",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "popcorn3", "container-item": "null", "count": 4 } ]
   },
@@ -1558,7 +1530,6 @@
     "type": "item_group",
     "id": "cracklins_bag_plastic_4",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "cracklins", "container-item": "null", "count": 4 } ]
   },
@@ -1566,7 +1537,6 @@
     "type": "item_group",
     "id": "granola_bag_plastic_4",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "granola", "container-item": "null", "count": 4 } ]
   },
@@ -1574,7 +1544,6 @@
     "type": "item_group",
     "id": "sandwich_deluxe_wrapper_2",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "wrapper",
     "entries": [ { "item": "sandwich_deluxe", "container-item": "null", "count": 2 } ]
   },
@@ -1582,7 +1551,6 @@
     "type": "item_group",
     "id": "sandwich_reuben_wrapper_2",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "wrapper",
     "entries": [ { "item": "sandwich_reuben", "container-item": "null", "count": 2 } ]
   },
@@ -1590,7 +1558,6 @@
     "type": "item_group",
     "id": "foodplace_food_box_small_4",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "box_small",
     "entries": [ { "item": "foodplace_food", "container-item": "null", "count": 4 } ]
   },
@@ -1598,7 +1565,6 @@
     "type": "item_group",
     "id": "pie_veggy_box_small_8",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "box_small",
     "entries": [ { "item": "pie_veggy", "container-item": "null", "count": 8 } ]
   },
@@ -1606,7 +1572,6 @@
     "type": "item_group",
     "id": "pie_maple_box_small_8",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "box_small",
     "entries": [ { "item": "pie_maple", "container-item": "null", "count": 8 } ]
   },
@@ -1614,7 +1579,6 @@
     "type": "item_group",
     "id": "stuffed_clams_box_small_5",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "box_small",
     "entries": [ { "item": "stuffed_clams", "container-item": "null", "count": 5 } ]
   },
@@ -1622,7 +1586,6 @@
     "type": "item_group",
     "id": "currywurst_wrapper_2",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "wrapper",
     "entries": [ { "item": "currywurst", "container-item": "null", "count": 2 } ]
   },
@@ -1630,7 +1593,6 @@
     "type": "item_group",
     "id": "cheese_bag_plastic_4_8",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "cheese", "container-item": "null", "count": [ 4, 8 ] } ]
   },
@@ -1638,7 +1600,6 @@
     "type": "item_group",
     "id": "tea_bag_box_tea_1_10",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "box_tea",
     "entries": [ { "item": "tea_bag", "container-item": "null", "count": [ 1, 10 ] } ]
   },
@@ -1646,7 +1607,6 @@
     "type": "item_group",
     "id": "tea_fruit_bag_box_tea_1_10",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "box_tea",
     "entries": [ { "item": "tea_fruit_bag", "container-item": "null", "count": [ 1, 10 ] } ]
   },
@@ -1654,7 +1614,6 @@
     "type": "item_group",
     "id": "tea_green_bag_box_tea_1_10",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "box_tea",
     "entries": [ { "item": "tea_green_bag", "container-item": "null", "count": [ 1, 10 ] } ]
   },
@@ -1662,7 +1621,6 @@
     "type": "item_group",
     "id": "tea_bag_chamomile_box_tea_1_10",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "box_tea",
     "entries": [ { "item": "tea_bag_chamomile", "container-item": "null", "count": [ 1, 10 ] } ]
   },
@@ -1670,7 +1628,6 @@
     "type": "item_group",
     "id": "herbal_tea_bag_box_tea_1_10",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "box_tea",
     "entries": [ { "item": "herbal_tea_bag", "container-item": "null", "count": [ 1, 10 ] } ]
   },
@@ -1678,7 +1635,6 @@
     "type": "item_group",
     "id": "tea_bag_dandelion_box_tea_1_10",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "box_tea",
     "entries": [ { "item": "tea_bag_dandelion", "container-item": "null", "count": [ 1, 10 ] } ]
   },
@@ -1686,7 +1642,6 @@
     "type": "item_group",
     "id": "soup_instant_chicken_noodle_powder_bag_paper_powder_1",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_paper_powder",
     "entries": [ { "item": "soup_instant_chicken_noodle_powder", "container-item": "null", "count": [ 1, 1 ] } ]
   },
@@ -1694,7 +1649,6 @@
     "type": "item_group",
     "id": "soup_instant_vegetable_powder_bag_paper_powder_1",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_paper_powder",
     "entries": [ { "item": "soup_instant_vegetable_powder", "container-item": "null", "count": [ 1, 1 ] } ]
   },

--- a/data/json/itemgroups/Labs/labs_mutagen.json
+++ b/data/json/itemgroups/Labs/labs_mutagen.json
@@ -137,7 +137,6 @@
     "type": "item_group",
     "id": "protein_powder_bottle_plastic_small_9",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_small",
     "entries": [ { "item": "protein_powder", "container-item": "null", "count": 9 } ]
   },
@@ -145,7 +144,6 @@
     "type": "item_group",
     "id": "heroin_bag_zipper_4",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_zipper",
     "entries": [ { "item": "heroin", "container-item": "null", "count": 4 } ]
   },
@@ -153,7 +151,6 @@
     "type": "item_group",
     "id": "tramadol_bottle_plastic_pill_prescription_10",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_prescription",
     "entries": [ { "item": "tramadol", "container-item": "null", "count": 10 } ]
   },
@@ -161,7 +158,6 @@
     "type": "item_group",
     "id": "thorazine_bottle_plastic_pill_prescription_10",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_prescription",
     "entries": [ { "item": "thorazine", "container-item": "null", "count": 10 } ]
   },
@@ -169,7 +165,6 @@
     "type": "item_group",
     "id": "pills_sleep_bottle_plastic_pill_prescription_10",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_prescription",
     "entries": [ { "item": "pills_sleep", "container-item": "null", "count": 10 } ]
   },
@@ -177,7 +172,6 @@
     "type": "item_group",
     "id": "vitamins_bottle_plastic_pill_supplement_20",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_supplement",
     "entries": [ { "item": "vitamins", "container-item": "null", "count": 20 } ]
   }

--- a/data/json/itemgroups/Locations_MapExtras/Arsonist_stock.json
+++ b/data/json/itemgroups/Locations_MapExtras/Arsonist_stock.json
@@ -20,7 +20,6 @@
     "type": "item_group",
     "id": "fertilizer_commercial_bag_canvas_60",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_canvas",
     "entries": [ { "item": "fertilizer_commercial", "container-item": "null", "count": 60 } ]
   }

--- a/data/json/itemgroups/Locations_MapExtras/locations.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations.json
@@ -2899,7 +2899,6 @@
     "type": "item_group",
     "id": "tobacco_bag_plastic_20",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "tobacco", "container-item": "null", "count": 20 } ]
   },
@@ -2907,7 +2906,6 @@
     "type": "item_group",
     "id": "lsd_bag_zipper_1_5",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_zipper",
     "entries": [ { "item": "lsd", "count": [ 1, 5 ] } ]
   },
@@ -2915,7 +2913,6 @@
     "type": "item_group",
     "id": "cig_box_cigarette_0_10",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "box_cigarette",
     "entries": [ { "item": "cig", "container-item": "null", "count": [ 0, 10 ] } ]
   },
@@ -2923,7 +2920,6 @@
     "type": "item_group",
     "id": "quikclot_bag_plastic_6",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "quikclot", "container-item": "null", "count": 6 } ]
   },
@@ -2931,7 +2927,6 @@
     "type": "item_group",
     "id": "antibiotics_bottle_plastic_pill_prescription_15",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_prescription",
     "entries": [ { "item": "antibiotics", "container-item": "null", "count": 15 } ]
   },
@@ -2947,7 +2942,6 @@
     "type": "item_group",
     "id": "melatonin_tablet_bottle_plastic_pill_supplement_10",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_supplement",
     "entries": [ { "item": "melatonin_tablet", "container-item": "null", "count": 10 } ]
   }

--- a/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
@@ -2122,7 +2122,6 @@
     "type": "item_group",
     "id": "egg_bird_unfert_carton_egg_10",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "carton_egg",
     "entries": [ { "item": "egg_bird_unfert", "count": 10 } ]
   },
@@ -2130,7 +2129,6 @@
     "type": "item_group",
     "id": "antifungal_bottle_plastic_pill_prescription_1_10",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_prescription",
     "entries": [ { "item": "antifungal", "container-item": "null", "count": [ 1, 10 ] } ]
   },
@@ -2138,7 +2136,6 @@
     "type": "item_group",
     "id": "cattlefodder_bag_canvas_50",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_canvas",
     "entries": [ { "item": "cattlefodder", "count": 50 } ]
   },
@@ -2146,7 +2143,6 @@
     "type": "item_group",
     "id": "birdfood_bag_canvas_60",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_canvas",
     "entries": [ { "item": "birdfood", "count": 60 } ]
   },

--- a/data/json/itemgroups/Locations_MapExtras/mall_item_groups.json
+++ b/data/json/itemgroups/Locations_MapExtras/mall_item_groups.json
@@ -266,7 +266,6 @@
     "type": "item_group",
     "id": "chaw_wrapper_20",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "wrapper",
     "entries": [ { "item": "chaw", "container-item": "null", "count": 20 } ]
   }

--- a/data/json/itemgroups/Locations_MapExtras/mansion.json
+++ b/data/json/itemgroups/Locations_MapExtras/mansion.json
@@ -1685,7 +1685,6 @@
     "type": "item_group",
     "id": "vitamins_bottle_plastic_pill_supplement_1_10",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_supplement",
     "entries": [ { "item": "vitamins", "container-item": "null", "count": [ 1, 10 ] } ]
   }

--- a/data/json/itemgroups/Monsters_Animals_Lairs/monster_drops_lairs.json
+++ b/data/json/itemgroups/Monsters_Animals_Lairs/monster_drops_lairs.json
@@ -295,7 +295,6 @@
     "type": "item_group",
     "id": "caffeine_bottle_plastic_pill_supplement_10",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_supplement",
     "entries": [ { "item": "caffeine", "container-item": "null", "count": 10 } ]
   }

--- a/data/json/itemgroups/SUS/domestic.json
+++ b/data/json/itemgroups/SUS/domestic.json
@@ -1221,7 +1221,6 @@
     "type": "item_group",
     "id": "adderall_bottle_plastic_pill_prescription_1",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_prescription",
     "entries": [ { "item": "adderall", "container-item": "null" } ]
   },
@@ -1229,7 +1228,6 @@
     "type": "item_group",
     "id": "weak_antibiotic_bottle_plastic_pill_prescription_1",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_prescription",
     "entries": [ { "item": "weak_antibiotic", "container-item": "null" } ]
   },
@@ -1285,7 +1283,6 @@
     "type": "item_group",
     "id": "garlic_powder_bag_plastic",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "garlic_powder", "container-item": "null", "count": [ 10, 100 ] } ]
   },
@@ -1293,7 +1290,6 @@
     "type": "item_group",
     "id": "garlic_powder_bag_paper",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_paper_powder",
     "entries": [ { "item": "garlic_powder", "container-item": "null", "count": [ 25, 500 ] } ]
   },
@@ -1301,7 +1297,6 @@
     "type": "item_group",
     "id": "tums_bottle_plastic_small_1_20",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_small",
     "entries": [ { "item": "tums", "container-item": "null", "count": [ 1, 20 ] } ]
   }

--- a/data/json/itemgroups/SUS/fridges.json
+++ b/data/json/itemgroups/SUS/fridges.json
@@ -1067,7 +1067,6 @@
     "type": "item_group",
     "id": "salsa_jar_glass_sealed_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "jar_glass_sealed",
     "entries": [ { "item": "salsa", "container-item": "null", "count": [ 1, -1 ] } ]
   },
@@ -1075,7 +1074,6 @@
     "type": "item_group",
     "id": "butter_wrapper_32",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "wrapper",
     "entries": [ { "item": "butter", "container-item": "null", "count": 32 } ]
   },
@@ -1083,7 +1081,6 @@
     "type": "item_group",
     "id": "sauerkraut_jar_glass_sealed_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "jar_glass_sealed",
     "entries": [ { "item": "sauerkraut", "container-item": "null", "count": [ 1, -1 ] } ]
   },
@@ -1091,7 +1088,6 @@
     "type": "item_group",
     "id": "pickle_jar_glass_sealed_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "jar_glass_sealed",
     "entries": [ { "item": "pickle", "count": [ 1, -1 ] } ]
   },
@@ -1099,7 +1095,6 @@
     "type": "item_group",
     "id": "meat_pickled_jar_glass_sealed_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "jar_glass_sealed",
     "entries": [ { "item": "meat_pickled", "container-item": "null", "count": [ 1, -1 ] } ]
   },
@@ -1107,7 +1102,6 @@
     "type": "item_group",
     "id": "fish_pickled_jar_glass_sealed_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "jar_glass_sealed",
     "entries": [ { "item": "fish_pickled", "container-item": "null", "count": [ 1, -1 ] } ]
   },
@@ -1115,7 +1109,6 @@
     "type": "item_group",
     "id": "veggy_pickled_jar_glass_sealed_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "jar_glass_sealed",
     "entries": [ { "item": "veggy_pickled", "container-item": "null", "count": [ 1, -1 ] } ]
   },
@@ -1123,7 +1116,6 @@
     "type": "item_group",
     "id": "egg_bird_unfert_carton_egg_1_2",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "carton_egg",
     "entries": [ { "item": "egg_bird_unfert", "count": [ 1, 2 ] } ]
   },
@@ -1131,7 +1123,6 @@
     "type": "item_group",
     "id": "blt_wrapper_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "wrapper",
     "entries": [ { "item": "blt", "container-item": "null", "count": [ 1, -1 ] } ]
   },
@@ -1139,7 +1130,6 @@
     "type": "item_group",
     "id": "fries_box_small_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "box_small",
     "entries": [ { "item": "fries", "container-item": "null", "count": [ 1, -1 ] } ]
   },
@@ -1147,7 +1137,6 @@
     "type": "item_group",
     "id": "cheese_fries_box_small_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "box_small",
     "entries": [ { "item": "cheese_fries", "container-item": "null", "count": [ 1, -1 ] } ]
   },
@@ -1155,7 +1144,6 @@
     "type": "item_group",
     "id": "onion_rings_box_small_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "box_small",
     "entries": [ { "item": "onion_rings", "container-item": "null", "count": [ 1, -1 ] } ]
   },
@@ -1163,7 +1151,6 @@
     "type": "item_group",
     "id": "pizza_meat_box_small_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "box_small",
     "entries": [ { "item": "pizza_meat", "container-item": "null", "count": [ 1, -1 ] } ]
   },
@@ -1171,7 +1158,6 @@
     "type": "item_group",
     "id": "pizza_veggy_box_small_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "box_small",
     "entries": [ { "item": "pizza_veggy", "container-item": "null", "count": [ 1, -1 ] } ]
   },
@@ -1179,7 +1165,6 @@
     "type": "item_group",
     "id": "pizza_cheese_box_small_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "box_small",
     "entries": [ { "item": "pizza_cheese", "container-item": "null", "count": [ 1, -1 ] } ]
   },
@@ -1187,7 +1172,6 @@
     "type": "item_group",
     "id": "pizza_supreme_box_small_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "box_small",
     "entries": [ { "item": "pizza_supreme", "container-item": "null", "count": [ 1, -1 ] } ]
   },
@@ -1195,7 +1179,6 @@
     "type": "item_group",
     "id": "nachosv_bag_plastic_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic",
     "entries": [ { "item": "nachosv", "container-item": "null", "count": [ 1, -1 ] } ]
   },
@@ -1203,7 +1186,6 @@
     "type": "item_group",
     "id": "nachosmc_bag_plastic_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic",
     "entries": [ { "item": "nachosmc", "container-item": "null", "count": [ 1, -1 ] } ]
   },
@@ -1211,7 +1193,6 @@
     "type": "item_group",
     "id": "nachosc_bag_plastic_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic",
     "entries": [ { "item": "nachosc", "container-item": "null", "count": [ 1, -1 ] } ]
   },
@@ -1219,7 +1200,6 @@
     "type": "item_group",
     "id": "cheeseburger_wrapper_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "wrapper",
     "entries": [ { "item": "cheeseburger", "container-item": "null", "count": [ 1, -1 ] } ]
   },
@@ -1227,7 +1207,6 @@
     "type": "item_group",
     "id": "hamburger_wrapper_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "wrapper",
     "entries": [ { "item": "hamburger", "container-item": "null", "count": [ 1, -1 ] } ]
   },
@@ -1235,7 +1214,6 @@
     "type": "item_group",
     "id": "fish_fried_box_small_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "box_small",
     "entries": [ { "item": "fish_fried", "container-item": "null", "count": [ 1, -1 ] } ]
   },
@@ -1243,7 +1221,6 @@
     "type": "item_group",
     "id": "fish_sandwich_wrapper_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "wrapper",
     "entries": [ { "item": "fish_sandwich", "container-item": "null", "count": [ 1, -1 ] } ]
   },
@@ -1251,7 +1228,6 @@
     "type": "item_group",
     "id": "lobster_roll_wrapper_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "wrapper",
     "entries": [ { "item": "lobster_roll", "container-item": "null", "count": [ 1, -1 ] } ]
   },
@@ -1259,7 +1235,6 @@
     "type": "item_group",
     "id": "sloppyjoe_wrapper_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "wrapper",
     "entries": [ { "item": "sloppyjoe", "container-item": "null", "count": [ 1, -1 ] } ]
   },
@@ -1267,7 +1242,6 @@
     "type": "item_group",
     "id": "sandwich_t_wrapper_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "wrapper",
     "entries": [ { "item": "sandwich_t", "container-item": "null", "count": [ 1, -1 ] } ]
   },
@@ -1275,7 +1249,6 @@
     "type": "item_group",
     "id": "junk_burrito_bag_plastic_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic",
     "entries": [ { "item": "junk_burrito", "container-item": "null", "count": [ 1, -1 ] } ]
   },
@@ -1283,7 +1256,6 @@
     "type": "item_group",
     "id": "chili_can_medium_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "can_medium",
     "entries": [ { "item": "chili", "container-item": "null", "count": [ 1, -1 ] } ]
   },
@@ -1291,7 +1263,6 @@
     "type": "item_group",
     "id": "veggy_salad_bowl_plastic_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bowl_plastic",
     "entries": [ { "item": "veggy_salad", "container-item": "null", "count": [ 1, -1 ] } ]
   },
@@ -1299,7 +1270,6 @@
     "type": "item_group",
     "id": "sandwich_veggy_wrapper_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "wrapper",
     "entries": [ { "item": "sandwich_veggy", "container-item": "null", "count": [ 1, -1 ] } ]
   },
@@ -1307,7 +1277,6 @@
     "type": "item_group",
     "id": "sandwich_jam_butter_wrapper_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "wrapper",
     "entries": [ { "item": "sandwich_jam_butter", "container-item": "null", "count": [ 1, -1 ] } ]
   },
@@ -1315,7 +1284,6 @@
     "type": "item_group",
     "id": "sandwich_jam_wrapper_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "wrapper",
     "entries": [ { "item": "sandwich_jam", "container-item": "null", "count": [ 1, -1 ] } ]
   },
@@ -1323,7 +1291,6 @@
     "type": "item_group",
     "id": "sandwich_cheese_wrapper_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "wrapper",
     "entries": [ { "item": "sandwich_cheese", "container-item": "null", "count": [ 1, -1 ] } ]
   },
@@ -1331,7 +1298,6 @@
     "type": "item_group",
     "id": "sandwich_deluxe_wrapper_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "wrapper",
     "entries": [ { "item": "sandwich_deluxe", "container-item": "null", "count": [ 1, -1 ] } ]
   },
@@ -1339,7 +1305,6 @@
     "type": "item_group",
     "id": "sandwich_reuben_wrapper_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "wrapper",
     "entries": [ { "item": "sandwich_reuben", "container-item": "null", "count": [ 1, -1 ] } ]
   },
@@ -1347,7 +1312,6 @@
     "type": "item_group",
     "id": "sandwich_pb_wrapper_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "wrapper",
     "entries": [ { "item": "sandwich_pb", "container-item": "null", "count": [ 1, -1 ] } ]
   },
@@ -1355,7 +1319,6 @@
     "type": "item_group",
     "id": "sandwich_pbj_wrapper_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "wrapper",
     "entries": [ { "item": "sandwich_pbj", "container-item": "null", "count": [ 1, -1 ] } ]
   }

--- a/data/json/itemgroups/SUS/mre_packages.json
+++ b/data/json/itemgroups/SUS/mre_packages.json
@@ -206,7 +206,6 @@
     "type": "item_group",
     "id": "candy2_wrapper_1",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "wrapper",
     "entries": [ { "item": "candy2", "container-item": "null" } ]
   },
@@ -214,7 +213,6 @@
     "type": "item_group",
     "id": "cookies_wrapper_1",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "wrapper",
     "entries": [ { "item": "cookies", "container-item": "null" } ]
   },
@@ -222,7 +220,6 @@
     "type": "item_group",
     "id": "pur_tablets_beverage_bag_6",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_zipper",
     "entries": [ { "item": "pur_tablets", "count": 6 } ]
   },
@@ -230,7 +227,6 @@
     "type": "item_group",
     "id": "sugar_beverage_bag_2",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_zipper",
     "entries": [ { "item": "sugar", "container-item": "null", "count": 10 } ]
   },
@@ -238,7 +234,6 @@
     "type": "item_group",
     "id": "crackers_mre_bag_small_2",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "mre_bag_small",
     "entries": [ { "item": "crackers", "container-item": "null", "count": 2 } ]
   },
@@ -246,7 +241,6 @@
     "type": "item_group",
     "id": "pur_tablets_beverage_bag_0_6",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_zipper",
     "entries": [ { "item": "pur_tablets", "count": [ 0, 6 ] } ]
   },
@@ -254,7 +248,6 @@
     "type": "item_group",
     "id": "sugar_beverage_bag_0_2",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_zipper",
     "entries": [ { "item": "sugar", "container-item": "null", "count": [ 0, 10 ] } ]
   },
@@ -262,7 +255,6 @@
     "type": "item_group",
     "id": "crackers_mre_bag_small_0_2",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "mre_bag_small",
     "entries": [ { "item": "crackers", "container-item": "null", "count": [ 0, 2 ] } ]
   }

--- a/data/json/itemgroups/activities_hobbies.json
+++ b/data/json/itemgroups/activities_hobbies.json
@@ -722,7 +722,6 @@
     "type": "item_group",
     "id": "bottle_otc_painkiller_1_20",
     "subtype": "distribution",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_painkiller",
     "entries": [
       { "item": "aspirin", "container-item": "null", "count": [ 1, 20 ] },
@@ -734,7 +733,6 @@
     "type": "item_group",
     "id": "protein_powder_bottle_plastic_small_1_9",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_small",
     "entries": [ { "item": "protein_powder", "container-item": "null", "count": [ 1, 9 ] } ]
   },
@@ -742,7 +740,6 @@
     "type": "item_group",
     "id": "quikclot_bag_plastic_1_6",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "quikclot", "container-item": "null", "count": [ 1, 6 ] } ]
   },
@@ -750,7 +747,6 @@
     "type": "item_group",
     "id": "bfipowder_bottle_plastic_small_1_4",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_small",
     "entries": [ { "item": "bfipowder", "container-item": "null", "count": [ 1, 4 ] } ]
   },
@@ -758,7 +754,6 @@
     "type": "item_group",
     "id": "pur_tablets_bottle_plastic_small_1_50",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_small",
     "entries": [ { "item": "pur_tablets", "count": [ 1, 50 ] } ]
   }

--- a/data/json/itemgroups/art_antiques_crafts.json
+++ b/data/json/itemgroups/art_antiques_crafts.json
@@ -319,7 +319,6 @@
     "type": "item_group",
     "id": "cheese_hard_wrapper_8",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "wrapper",
     "entries": [ { "item": "cheese_hard", "container-item": "null", "count": 8 } ]
   }

--- a/data/json/itemgroups/collections_domestic.json
+++ b/data/json/itemgroups/collections_domestic.json
@@ -1299,7 +1299,6 @@
     "type": "item_group",
     "id": "iodine_bottle_plastic_pill_supplement_1_10",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_supplement",
     "entries": [ { "item": "iodine", "container-item": "null", "count": [ 1, 10 ] } ]
   },
@@ -1307,7 +1306,6 @@
     "type": "item_group",
     "id": "prussian_blue_bottle_plastic_pill_supplement_1_10",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_supplement",
     "entries": [ { "item": "prussian_blue", "container-item": "null", "count": [ 1, 10 ] } ]
   },
@@ -1369,7 +1367,6 @@
     "type": "item_group",
     "id": "yeast_bag_plastic_full",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "yeast", "container-item": "null", "count": 50 } ]
   },
@@ -1377,7 +1374,6 @@
     "type": "item_group",
     "id": "yeast_bag_paper_full",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_paper_powder",
     "entries": [ { "item": "yeast", "container-item": "null", "count": 180 } ]
   },
@@ -1425,7 +1421,6 @@
     "type": "item_group",
     "id": "yeast_bag_plastic",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "yeast", "container-item": "null", "count": [ 5, 50 ] } ]
   },
@@ -1433,7 +1428,6 @@
     "type": "item_group",
     "id": "yeast_bag_paper",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_paper_powder",
     "entries": [ { "item": "yeast", "container-item": "null", "count": [ 20, 180 ] } ]
   },
@@ -1441,7 +1435,6 @@
     "type": "item_group",
     "id": "yeast_bag_paper_bulk",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_paper_powder_bulk",
     "entries": [ { "item": "yeast", "container-item": "null", "count": [ 20, 1000 ] } ]
   },
@@ -1449,7 +1442,6 @@
     "type": "item_group",
     "id": "yogurt_starter_culture_bag_plastic_4",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "yogurt_starter_culture", "container-item": "null", "count": 4 } ]
   },
@@ -1457,7 +1449,6 @@
     "type": "item_group",
     "id": "vitamins_bottle_plastic_pill_supplement_1_20",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_supplement",
     "entries": [ { "item": "vitamins", "container-item": "null", "count": [ 1, 20 ] } ]
   },
@@ -1465,7 +1456,6 @@
     "type": "item_group",
     "id": "cig_box_cigarette_1_20",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "box_cigarette",
     "entries": [ { "group": "cigarettes_opened" } ]
   },
@@ -1473,7 +1463,6 @@
     "type": "item_group",
     "id": "melatonin_tablet_bottle_plastic_pill_supplement_1_30",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_supplement",
     "entries": [ { "item": "melatonin_tablet", "container-item": "null", "count": [ 1, 30 ] } ]
   },
@@ -1488,7 +1477,6 @@
     "type": "item_group",
     "id": "coke_bag_zipper_1_8",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_zipper",
     "entries": [ { "item": "coke", "container-item": "null", "count": [ 1, 8 ] } ]
   },
@@ -1496,7 +1484,6 @@
     "type": "item_group",
     "id": "meth_bag_zipper_1_6",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_zipper",
     "entries": [ { "item": "meth", "container-item": "null", "count": [ 1, 6 ] } ]
   },
@@ -1504,7 +1491,6 @@
     "type": "item_group",
     "id": "licorice_bag_plastic_4",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "licorice", "container-item": "null", "count": 4 } ]
   },
@@ -1539,7 +1525,6 @@
     "type": "item_group",
     "id": "bacon_bag_plastic_2",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "bacon", "container-item": "null", "count": 2 } ]
   },
@@ -1649,7 +1634,6 @@
     "type": "item_group",
     "id": "powder_eggs_bottle_plastic_small_16",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_small",
     "entries": [ { "item": "powder_eggs", "container-item": "null", "count": 16 } ]
   },
@@ -1657,7 +1641,6 @@
     "type": "item_group",
     "id": "fchicken_box_small_4",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "box_small",
     "entries": [ { "item": "fchicken", "container-item": "null", "count": 4 } ]
   },
@@ -1665,7 +1648,6 @@
     "type": "item_group",
     "id": "bologna_bag_plastic_10",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bowl_plastic",
     "entries": [ { "item": "bologna", "container-item": "null", "count": 10 } ]
   },
@@ -1673,7 +1655,6 @@
     "type": "item_group",
     "id": "toastem_box_small_8",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "box_small",
     "entries": [ { "item": "toastem", "container-item": "null", "count": 8 } ]
   },
@@ -1681,7 +1662,6 @@
     "type": "item_group",
     "id": "toasterpastryfrozen_box_snack_2",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "box_snack",
     "entries": [ { "item": "toasterpastryfrozen", "container-item": "null", "count": 2 } ]
   },
@@ -1689,7 +1669,6 @@
     "type": "item_group",
     "id": "brownie_box_small_4",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "box_small",
     "entries": [ { "item": "brownie", "container-item": "null", "count": 4 } ]
   },
@@ -1697,7 +1676,6 @@
     "type": "item_group",
     "id": "lemonade_powder_bottle_plastic_small_10",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_small",
     "entries": [ { "item": "lemonade_powder", "container-item": "null", "count": 10 } ]
   },
@@ -1705,7 +1683,6 @@
     "type": "item_group",
     "id": "pizza_veggy_box_small_4",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "box_small",
     "entries": [ { "item": "pizza_veggy", "container-item": "null", "count": 4 } ]
   },
@@ -1713,7 +1690,6 @@
     "type": "item_group",
     "id": "pizza_meat_box_small_4",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "box_small",
     "entries": [ { "item": "pizza_meat", "container-item": "null", "count": 4 } ]
   },
@@ -1721,7 +1697,6 @@
     "type": "item_group",
     "id": "pizza_cheese_box_small_4",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "box_small",
     "entries": [ { "item": "pizza_cheese", "container-item": "null", "count": 4 } ]
   },
@@ -1729,7 +1704,6 @@
     "type": "item_group",
     "id": "hotdogs_frozen_bag_plastic_10",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bowl_plastic",
     "entries": [ { "item": "hotdogs_frozen", "container-item": "null", "count": 10 } ]
   },
@@ -1737,7 +1711,6 @@
     "type": "item_group",
     "id": "corndogs_frozen_bag_plastic_2",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bowl_plastic",
     "entries": [ { "item": "corndogs_frozen", "container-item": "null", "count": 2 } ]
   },
@@ -1787,7 +1760,6 @@
     "type": "item_group",
     "id": "can_herring_jar_glass_sealed_2",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "jar_glass_sealed",
     "entries": [ { "item": "can_herring", "container-item": "null", "count": 2 } ]
   },
@@ -1848,7 +1820,6 @@
     "type": "item_group",
     "id": "curry_powder_bag_paper_full",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_paper_powder",
     "entries": [ { "item": "curry_powder", "container-item": "null", "count": 500 } ]
   },
@@ -1884,7 +1855,6 @@
     "type": "item_group",
     "id": "curry_powder_bag_plastic",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "curry_powder", "container-item": "null", "count": [ 10, 100 ] } ]
   },
@@ -1892,7 +1862,6 @@
     "type": "item_group",
     "id": "curry_powder_bag_paper",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_paper_powder",
     "entries": [ { "item": "curry_powder", "container-item": "null", "count": [ 25, 500 ] } ]
   },
@@ -1941,7 +1910,6 @@
     "type": "item_group",
     "id": "chilly-p_bag_plastic",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "chilly-p", "container-item": "null", "count": [ 10, 100 ] } ]
   },
@@ -1949,7 +1917,6 @@
     "type": "item_group",
     "id": "chilly-p_bag_paper",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_paper_powder",
     "entries": [ { "item": "chilly-p", "container-item": "null", "count": [ 25, 500 ] } ]
   },
@@ -2042,7 +2009,6 @@
     "type": "item_group",
     "id": "oyster_crackers_plastic_bag_vac_8",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "plastic_bag_vac",
     "entries": [ { "item": "oyster_crackers", "container-item": "null", "count": 8 } ]
   },
@@ -2050,7 +2016,6 @@
     "type": "item_group",
     "id": "biscuit_box_small_10",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "box_small",
     "entries": [ { "item": "biscuit", "container-item": "null", "count": 10 } ]
   },
@@ -2058,7 +2023,6 @@
     "type": "item_group",
     "id": "cheese_bag_plastic",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "cheese", "container-item": "null", "count": [ 2, 16 ] } ]
   },
@@ -2072,7 +2036,6 @@
     "type": "item_group",
     "id": "veggy_pickled_jar_glass_sealed_2",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "jar_glass_sealed",
     "entries": [ { "item": "veggy_pickled", "container-item": "null", "count": 2 } ]
   },
@@ -2080,7 +2043,6 @@
     "type": "item_group",
     "id": "sauerkraut_jar_glass_sealed_2",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "jar_glass_sealed",
     "entries": [ { "item": "sauerkraut", "container-item": "null", "count": 2 } ]
   },
@@ -2088,7 +2050,6 @@
     "type": "item_group",
     "id": "meat_pickled_jar_glass_sealed_2",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "jar_glass_sealed",
     "entries": [ { "item": "meat_pickled", "container-item": "null", "count": 2 } ]
   },
@@ -2096,7 +2057,6 @@
     "type": "item_group",
     "id": "fish_pickled_jar_glass_sealed_2",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "jar_glass_sealed",
     "entries": [ { "item": "fish_pickled", "container-item": "null", "count": 2 } ]
   },
@@ -2104,7 +2064,6 @@
     "type": "item_group",
     "id": "meat_canned_jar_3l_glass_sealed_12",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "jar_3l_glass_sealed",
     "entries": [ { "item": "meat_canned", "container-item": "null", "count": 12 } ]
   },
@@ -2112,7 +2071,6 @@
     "type": "item_group",
     "id": "veggy_canned_jar_3l_glass_sealed_12",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "jar_3l_glass_sealed",
     "entries": [ { "item": "veggy_canned", "container-item": "null", "count": 12 } ]
   },
@@ -2126,7 +2084,6 @@
     "type": "item_group",
     "id": "can_tomato_jar_3l_glass_sealed_24",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "jar_3l_glass_sealed",
     "entries": [ { "item": "can_tomato", "container-item": "null", "count": 24 } ]
   },
@@ -2134,7 +2091,6 @@
     "type": "item_group",
     "id": "fish_pickled_jar_3l_glass_sealed_12",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "jar_3l_glass_sealed",
     "entries": [ { "item": "fish_pickled", "container-item": "null", "count": 12 } ]
   },
@@ -2142,7 +2098,6 @@
     "type": "item_group",
     "id": "meat_pickled_jar_3l_glass_sealed_12",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "jar_3l_glass_sealed",
     "entries": [ { "item": "meat_pickled", "container-item": "null", "count": 12 } ]
   },
@@ -2150,7 +2105,6 @@
     "type": "item_group",
     "id": "veggy_pickled_jar_3l_glass_sealed_12",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "jar_3l_glass_sealed",
     "entries": [ { "item": "veggy_pickled", "container-item": "null", "count": 12 } ]
   },
@@ -2158,7 +2112,6 @@
     "type": "item_group",
     "id": "butter_wrapper_1_32",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "wrapper",
     "entries": [ { "item": "butter", "container-item": "null", "count": [ 1, 32 ] } ]
   },
@@ -2184,7 +2137,6 @@
     "type": "item_group",
     "id": "sandwich_t_wrapper_2",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "wrapper",
     "entries": [ { "item": "sandwich_t", "container-item": "null", "count": 2 } ]
   },
@@ -2192,7 +2144,6 @@
     "type": "item_group",
     "id": "irradiated_lettuce_bag_plastic_5",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic",
     "entries": [ { "item": "lettuce", "container-item": "null", "count": 5, "custom-flags": [ "IRRADIATED" ] } ]
   },
@@ -2200,7 +2151,6 @@
     "type": "item_group",
     "id": "irradiated_cabbage_bag_plastic_8",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic",
     "entries": [ { "item": "cabbage", "container-item": "null", "count": 8, "custom-flags": [ "IRRADIATED" ] } ]
   },
@@ -2208,7 +2158,6 @@
     "type": "item_group",
     "id": "irradiated_carrot_bag_plastic_6",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic",
     "entries": [ { "item": "carrot", "container-item": "null", "count": 6, "custom-flags": [ "IRRADIATED" ] } ]
   },
@@ -2216,7 +2165,6 @@
     "type": "item_group",
     "id": "frozen_dinner_box_small_2",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "box_small",
     "entries": [ { "item": "frozen_dinner", "container-item": "null", "count": 2 } ]
   },
@@ -2230,7 +2178,6 @@
     "type": "item_group",
     "id": "blt_wrapper_2",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "wrapper",
     "entries": [ { "item": "blt", "container-item": "null", "count": 2 } ]
   },
@@ -2238,7 +2185,6 @@
     "type": "item_group",
     "id": "irradiated_cranberries_bag_plastic_3",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic",
     "entries": [ { "item": "cranberries", "container-item": "null", "count": 3, "custom-flags": [ "IRRADIATED" ] } ]
   },
@@ -2246,7 +2192,6 @@
     "type": "item_group",
     "id": "pickle_jar_glass_sealed_2",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "jar_glass_sealed",
     "entries": [ { "item": "pickle", "count": 2 } ]
   },
@@ -2254,7 +2199,6 @@
     "type": "item_group",
     "id": "heroin_bag_zipper_1_4",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_zipper",
     "entries": [ { "item": "heroin", "container-item": "null", "count": [ 1, 4 ] } ]
   },
@@ -2262,7 +2206,6 @@
     "type": "item_group",
     "id": "fried_seeds_bag_plastic_4",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "fried_seeds", "container-item": "null", "count": 4 } ]
   },
@@ -2270,7 +2213,6 @@
     "type": "item_group",
     "id": "fungicide_bag_plastic_400",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "fungicide", "container-item": "null", "count": 400 } ]
   },

--- a/data/json/itemgroups/corpses.json
+++ b/data/json/itemgroups/corpses.json
@@ -505,7 +505,6 @@
     "type": "item_group",
     "id": "adderall_bottle_plastic_pill_prescription_10",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_prescription",
     "entries": [ { "item": "adderall", "container-item": "null", "count": 10 } ]
   }

--- a/data/json/itemgroups/food_service.json
+++ b/data/json/itemgroups/food_service.json
@@ -1568,7 +1568,6 @@
     "type": "item_group",
     "id": "cookies_box_snack_4",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "box_snack",
     "entries": [ { "item": "cookies", "container-item": "null", "count": 4 } ]
   },
@@ -1592,7 +1591,6 @@
     "type": "item_group",
     "id": "bee_balm_jar_3l_glass_sealed_1_12",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "jar_3l_glass_sealed",
     "entries": [ { "item": "bee_balm", "count": [ 1, 12 ] } ]
   },
@@ -1600,7 +1598,6 @@
     "type": "item_group",
     "id": "raw_burdock_jar_3l_glass_sealed_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "jar_3l_glass_sealed",
     "entries": [ { "item": "raw_burdock", "count": [ 1, -1 ] } ]
   },
@@ -1608,7 +1605,6 @@
     "type": "item_group",
     "id": "tea_raw_jar_glass_sealed_10_40",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "jar_glass_sealed",
     "entries": [ { "item": "tea_raw", "container-item": "null", "count": [ 10, 40 ] } ]
   },
@@ -1616,7 +1612,6 @@
     "type": "item_group",
     "id": "tea_green_raw_jar_glass_sealed_10_40",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "jar_glass_sealed",
     "entries": [ { "item": "tea_green_raw", "container-item": "null", "count": [ 10, 40 ] } ]
   },
@@ -1624,7 +1619,6 @@
     "type": "item_group",
     "id": "wild_herbs_jar_glass_sealed_20_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "jar_glass_sealed",
     "entries": [ { "item": "wild_herbs", "count": [ 20, -1 ] } ]
   },
@@ -1632,7 +1626,6 @@
     "type": "item_group",
     "id": "raw_dandelion_jar_glass_sealed_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "jar_glass_sealed",
     "entries": [ { "item": "raw_dandelion", "count": [ 1, -1 ] } ]
   },
@@ -1640,7 +1633,6 @@
     "type": "item_group",
     "id": "milk_powder_jar_glass_sealed_1_8",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "jar_glass_sealed",
     "entries": [ { "item": "milk_powder", "container-item": "null", "count": [ 1, 8 ] } ]
   },
@@ -1648,7 +1640,6 @@
     "type": "item_group",
     "id": "cinnamon_jar_glass_sealed_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "jar_glass_sealed",
     "entries": [ { "item": "cinnamon", "container-item": "null", "count": [ 1, -1 ] } ]
   },
@@ -1656,7 +1647,6 @@
     "type": "item_group",
     "id": "sugar_jar_glass_sealed_10_140",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "jar_glass_sealed",
     "on_overflow": "spill",
     "entries": [ { "item": "sugar", "container-item": "null", "count": [ 10, 140 ] } ]
@@ -1719,7 +1709,6 @@
     "type": "item_group",
     "id": "sugar_bag_paper_full",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_paper_powder",
     "entries": [ { "item": "sugar", "container-item": "null", "count": 400 } ]
   },
@@ -1768,7 +1757,6 @@
     "type": "item_group",
     "id": "sugar_bag_plastic",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "sugar", "container-item": "null", "count": [ 10, 80 ] } ]
   },
@@ -1776,7 +1764,6 @@
     "type": "item_group",
     "id": "sugar_bag_paper",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_paper_powder",
     "entries": [ { "item": "sugar", "container-item": "null", "count": [ 25, 400 ] } ]
   },
@@ -1784,7 +1771,6 @@
     "type": "item_group",
     "id": "sugar_bag_paper_bulk",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_paper_powder_bulk",
     "entries": [ { "item": "sugar", "container-item": "null", "count": [ 30, 1600 ] } ]
   },
@@ -1807,7 +1793,6 @@
     "type": "item_group",
     "id": "fried_mozzarella_sticks_bag_plastic_4",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "fried_mozzarella_sticks", "container-item": "null", "count": 4 } ]
   },
@@ -1815,7 +1800,6 @@
     "type": "item_group",
     "id": "hotdogs_cooked_wrapper_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "wrapper",
     "entries": [ { "item": "hotdogs_cooked", "container-item": "null", "count": [ 1, -1 ] } ]
   },
@@ -1823,7 +1807,6 @@
     "type": "item_group",
     "id": "hotdogs_newyork_wrapper_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "wrapper",
     "entries": [ { "item": "hotdogs_newyork", "container-item": "null", "count": [ 1, -1 ] } ]
   },
@@ -1831,7 +1814,6 @@
     "type": "item_group",
     "id": "crab_cakes_box_small_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "box_small",
     "entries": [ { "item": "crab_cakes", "container-item": "null", "count": [ 1, -1 ] } ]
   },
@@ -1839,7 +1821,6 @@
     "type": "item_group",
     "id": "stuffed_clams_box_small_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "box_small",
     "entries": [ { "item": "stuffed_clams", "container-item": "null", "count": [ 1, -1 ] } ]
   },
@@ -1864,7 +1845,6 @@
     "type": "item_group",
     "id": "flour_bag_plastic_full",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "flour", "container-item": "null", "count": 20 } ]
   },
@@ -1872,7 +1852,6 @@
     "type": "item_group",
     "id": "flour_bag_paper_full",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_paper_powder",
     "entries": [ { "item": "flour", "container-item": "null", "count": 100 } ]
   },
@@ -1905,7 +1884,6 @@
     "type": "item_group",
     "id": "flour_bag_paper",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_paper_powder",
     "entries": [ { "item": "flour", "container-item": "null", "count": [ 10, 100 ] } ]
   },
@@ -1913,7 +1891,6 @@
     "type": "item_group",
     "id": "flour_bag_paper_bulk",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_paper_powder_bulk",
     "entries": [ { "item": "flour", "container-item": "null", "count": [ 10, 400 ] } ]
   },
@@ -1921,7 +1898,6 @@
     "type": "item_group",
     "id": "flour_bag_plastic",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "flour", "container-item": "null", "count": [ 2, 20 ] } ]
   },
@@ -1936,7 +1912,6 @@
     "type": "item_group",
     "id": "bread_flour_bag_paper_powder_20",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_paper_powder",
     "entries": [ { "item": "bread_flour", "container-item": "null", "count": 20 } ]
   },
@@ -1958,7 +1933,6 @@
     "type": "item_group",
     "id": "choco_coffee_beans_bag_plastic_5",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "choco_coffee_beans", "container-item": "null", "count": 5 } ]
   },
@@ -1966,7 +1940,6 @@
     "type": "item_group",
     "id": "coffee_raw_bag_plastic_20",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "coffee_raw", "container-item": "null", "count": 20 } ]
   },
@@ -1974,7 +1947,6 @@
     "type": "item_group",
     "id": "toast_bag_plastic_2",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "toast", "container-item": "null", "count": 2 } ]
   },
@@ -2035,7 +2007,6 @@
     "type": "item_group",
     "id": "salt_bag_paper_full",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_paper_powder",
     "entries": [ { "item": "salt", "container-item": "null", "count": 500 } ]
   },
@@ -2084,7 +2055,6 @@
     "type": "item_group",
     "id": "salt_bag_plastic",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "salt", "container-item": "null", "count": [ 10, 100 ] } ]
   },
@@ -2092,7 +2062,6 @@
     "type": "item_group",
     "id": "salt_bag_paper",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_paper_powder",
     "entries": [ { "item": "salt", "container-item": "null", "count": [ 25, 500 ] } ]
   },
@@ -2100,7 +2069,6 @@
     "type": "item_group",
     "id": "salt_bag_paper_bulk",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_paper_powder_bulk",
     "entries": [ { "item": "salt", "container-item": "null", "count": [ 25, 2000 ] } ]
   },
@@ -2115,7 +2083,6 @@
     "type": "item_group",
     "id": "artificial_sweetener_box_small_71",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "box_small",
     "entries": [ { "item": "artificial_sweetener", "container-item": "null", "count": 71 } ]
   },
@@ -2177,7 +2144,6 @@
     "type": "item_group",
     "id": "seasoning_salt_bag_plastic_full",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "seasoning_salt", "container-item": "null", "count": 100 } ]
   },
@@ -2232,7 +2198,6 @@
     "type": "item_group",
     "id": "seasoning_salt_bag_plastic",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "seasoning_salt", "container-item": "null", "count": [ 10, 100 ] } ]
   },
@@ -2354,7 +2319,6 @@
     "type": "item_group",
     "id": "seasoning_italian_bag_plastic",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "seasoning_italian", "container-item": "null", "count": [ 10, 100 ] } ]
   },
@@ -2383,7 +2347,6 @@
     "type": "item_group",
     "id": "oyster_crackers_plastic_bag_vac_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "plastic_bag_vac",
     "entries": [ { "item": "oyster_crackers", "container-item": "null", "count": [ 1, -1 ] } ]
   },
@@ -2403,7 +2366,6 @@
     "type": "item_group",
     "id": "brioche_box_small_6",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "box_small",
     "entries": [ { "item": "brioche", "container-item": "null", "count": 6 } ]
   },
@@ -2418,7 +2380,6 @@
     "type": "item_group",
     "id": "koji_bag_plastic_25",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "koji", "container-item": "null", "count": 25 } ]
   },
@@ -2440,7 +2401,6 @@
     "type": "item_group",
     "id": "chem_citric_acid_bottle_glass_50",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_glass",
     "entries": [ { "item": "chem_citric_acid", "container-item": "null", "count": 50 } ]
   },
@@ -2448,7 +2408,6 @@
     "type": "item_group",
     "id": "sprinkles_bottle_plastic_small_62",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_small",
     "entries": [ { "item": "sprinkles", "container-item": "null", "count": 62 } ]
   },
@@ -2665,7 +2624,6 @@
     "type": "item_group",
     "id": "cinnamon_bag_plastic",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "cinnamon", "container-item": "null", "count": [ 10, 100 ] } ]
   },
@@ -2673,7 +2631,6 @@
     "type": "item_group",
     "id": "cinnamon_bag_paper",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_paper_powder",
     "entries": [ { "item": "cinnamon", "container-item": "null", "count": [ 25, 500 ] } ]
   },
@@ -2681,7 +2638,6 @@
     "type": "item_group",
     "id": "egg_bird_unfert_carton_egg_6_12",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "carton_egg",
     "entries": [ { "item": "egg_bird_unfert", "count": [ 6, 12 ] } ]
   },
@@ -2689,7 +2645,6 @@
     "type": "item_group",
     "id": "butter_wrapper_8",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "wrapper",
     "entries": [ { "item": "butter", "container-item": "null", "count": 8 } ]
   },
@@ -2697,7 +2652,6 @@
     "type": "item_group",
     "id": "butter_wrapper_8_64",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "wrapper",
     "entries": [ { "item": "butter", "container-item": "null", "count": [ 8, 64 ] } ]
   },
@@ -2705,7 +2659,6 @@
     "type": "item_group",
     "id": "cabbage_bag_plastic_8",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic",
     "entries": [ { "item": "cabbage", "count": 8 } ]
   },
@@ -2713,7 +2666,6 @@
     "type": "item_group",
     "id": "carrot_bowl_plastic_2",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bowl_plastic",
     "entries": [ { "item": "carrot", "count": 2 } ]
   },
@@ -2721,7 +2673,6 @@
     "type": "item_group",
     "id": "chilidogs_wrapper_2",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "wrapper",
     "entries": [ { "item": "chilidogs", "container-item": "null", "count": 2 } ]
   },
@@ -2729,7 +2680,6 @@
     "type": "item_group",
     "id": "corndogs_cooked_wrapper_2",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "wrapper",
     "entries": [ { "item": "corndogs_cooked", "container-item": "null", "count": 2 } ]
   },
@@ -2737,7 +2687,6 @@
     "type": "item_group",
     "id": "pie_box_small_8",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "box_small",
     "entries": [ { "item": "pie", "container-item": "null", "count": 8 } ]
   },
@@ -2745,7 +2694,6 @@
     "type": "item_group",
     "id": "pie_meat_box_small_8",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "box_small",
     "entries": [ { "item": "pie_meat", "container-item": "null", "count": 8 } ]
   },
@@ -2753,7 +2701,6 @@
     "type": "item_group",
     "id": "PBJ_Toast_bag_plastic_2",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "PBJ_Toast", "container-item": "null", "count": 2 } ]
   },
@@ -2761,7 +2708,6 @@
     "type": "item_group",
     "id": "offal_pickled_jar_glass_sealed_2",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "jar_glass_sealed",
     "entries": [ { "item": "offal_pickled", "container-item": "null", "count": 2 } ]
   },

--- a/data/json/itemgroups/military.json
+++ b/data/json/itemgroups/military.json
@@ -876,7 +876,6 @@
     "type": "item_group",
     "id": "chocolate_wrapper_1_3",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "wrapper",
     "entries": [ { "item": "chocolate", "container-item": "null", "count": [ 1, 3 ] } ]
   },
@@ -884,7 +883,6 @@
     "type": "item_group",
     "id": "neccowafers_bag_plastic_3",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "neccowafers", "container-item": "null", "count": 3 } ]
   },
@@ -892,7 +890,6 @@
     "type": "item_group",
     "id": "iodine_bottle_plastic_pill_supplement_10",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_supplement",
     "entries": [ { "item": "iodine", "container-item": "null", "count": 10 } ]
   },
@@ -900,7 +897,6 @@
     "type": "item_group",
     "id": "prussian_blue_bottle_plastic_pill_supplement_10",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_supplement",
     "entries": [ { "item": "prussian_blue", "container-item": "null", "count": 10 } ]
   },
@@ -908,7 +904,6 @@
     "type": "item_group",
     "id": "antiparasitic_bottle_plastic_pill_prescription_5",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_prescription",
     "entries": [ { "item": "antiparasitic", "container-item": "null", "count": 5 } ]
   },
@@ -916,7 +911,6 @@
     "type": "item_group",
     "id": "codeine_bottle_plastic_pill_painkiller_1_10",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_painkiller",
     "entries": [ { "item": "codeine", "container-item": "null", "count": [ 1, 10 ] } ]
   },
@@ -924,7 +918,6 @@
     "type": "item_group",
     "id": "antibiotics_bottle_plastic_pill_prescription_1_15",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_prescription",
     "entries": [ { "item": "antibiotics", "container-item": "null", "count": [ 1, 15 ] } ]
   },
@@ -932,7 +925,6 @@
     "type": "item_group",
     "id": "weak_antibiotic_bottle_plastic_pill_prescription_1_5",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_prescription",
     "entries": [ { "item": "weak_antibiotic", "container-item": "null", "count": [ 1, 5 ] } ]
   },
@@ -940,7 +932,6 @@
     "type": "item_group",
     "id": "chocolate_wrapper_3",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "wrapper",
     "entries": [ { "item": "chocolate", "container-item": "null", "count": 3 } ]
   }

--- a/data/json/itemgroups/oa_shared_item_groups.json
+++ b/data/json/itemgroups/oa_shared_item_groups.json
@@ -8,7 +8,6 @@
     "type": "item_group",
     "id": "cig_box_cigarette_1_5",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "box_cigarette",
     "entries": [ { "item": "cig", "container-item": "null", "count": [ 1, 5 ] } ]
   }

--- a/data/json/itemgroups/science_and_tech.json
+++ b/data/json/itemgroups/science_and_tech.json
@@ -599,7 +599,6 @@
     "type": "item_group",
     "id": "adderall_bottle_plastic_pill_prescription_1_10",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_prescription",
     "entries": [ { "item": "adderall", "container-item": "null", "count": [ 1, 10 ] } ]
   },
@@ -614,7 +613,6 @@
     "type": "item_group",
     "id": "antiparasitic_bottle_plastic_pill_prescription_1_10",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_prescription",
     "entries": [ { "item": "antiparasitic", "container-item": "null", "count": [ 1, 10 ] } ]
   },
@@ -622,7 +620,6 @@
     "type": "item_group",
     "id": "diazepam_bottle_plastic_pill_prescription_1_10",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_prescription",
     "entries": [ { "item": "diazepam", "container-item": "null", "count": [ 1, 10 ] } ]
   },
@@ -630,7 +627,6 @@
     "type": "item_group",
     "id": "chem_sulphur_bottle_plastic_small_100_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_small",
     "entries": [ { "item": "chem_sulphur", "container-item": "null", "charges": [ 100, 1500 ] } ]
   },
@@ -638,7 +634,6 @@
     "type": "item_group",
     "id": "chem_citric_acid_bottle_glass_100_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_glass",
     "entries": [ { "item": "chem_citric_acid", "container-item": "null", "count": [ 100, -1 ] } ]
   },

--- a/data/json/itemgroups/stashes.json
+++ b/data/json/itemgroups/stashes.json
@@ -659,7 +659,6 @@
     "type": "item_group",
     "id": "pills_sleep_bottle_plastic_pill_prescription_1_10",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_prescription",
     "entries": [ { "item": "pills_sleep", "container-item": "null", "count": [ 1, 10 ] } ]
   },
@@ -667,7 +666,6 @@
     "type": "item_group",
     "id": "oxycodone_bottle_plastic_pill_prescription_1_10",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_prescription",
     "entries": [ { "item": "oxycodone", "container-item": "null", "count": [ 1, 10 ] } ]
   },
@@ -675,7 +673,6 @@
     "type": "item_group",
     "id": "xanax_bottle_plastic_pill_prescription_1_10",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_prescription",
     "entries": [ { "item": "xanax", "container-item": "null", "count": [ 1, 10 ] } ]
   },
@@ -683,7 +680,6 @@
     "type": "item_group",
     "id": "tobacco_bag_plastic_1_20",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "tobacco", "container-item": "null", "count": [ 1, 20 ] } ]
   },
@@ -691,7 +687,6 @@
     "type": "item_group",
     "id": "crack_bag_zipper_1_4",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_zipper",
     "entries": [ { "item": "crack", "container-item": "null", "count": [ 1, 4 ] } ]
   },
@@ -699,7 +694,6 @@
     "type": "item_group",
     "id": "antifungal_bottle_plastic_pill_prescription_1_5",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_prescription",
     "entries": [ { "item": "antifungal", "container-item": "null", "count": [ 1, 5 ] } ]
   },
@@ -707,7 +701,6 @@
     "type": "item_group",
     "id": "homeopathic_pills_bottle_plastic_pill_supplement_20",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_supplement",
     "entries": [ { "item": "homeopathic_pills", "container-item": "null", "count": 20 } ]
   },
@@ -715,7 +708,6 @@
     "type": "item_group",
     "id": "cookies_box_snack_1_4",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "box_snack",
     "entries": [ { "item": "cookies", "container-item": "null", "count": [ 1, 4 ] } ]
   }

--- a/data/json/itemgroups/supplies.json
+++ b/data/json/itemgroups/supplies.json
@@ -970,7 +970,6 @@
     "type": "item_group",
     "id": "chem_peptone_broth_bottle_plastic_small_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_small",
     "entries": [ { "item": "chem_peptone_broth", "container-item": "null", "count": [ 1, -1 ] } ]
   },
@@ -978,7 +977,6 @@
     "type": "item_group",
     "id": "chem_agar_bottle_plastic_small_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_small",
     "entries": [ { "item": "chem_agar", "container-item": "null", "count": [ 1, -1 ] } ]
   },
@@ -986,7 +984,6 @@
     "type": "item_group",
     "id": "chem_acrylamide_bottle_glass_1_inf",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_glass",
     "entries": [ { "item": "chem_acrylamide", "container-item": "null", "count": [ 1, -1 ] } ]
   },

--- a/data/json/itemgroups/tools.json
+++ b/data/json/itemgroups/tools.json
@@ -1004,7 +1004,6 @@
     "type": "item_group",
     "id": "pur_tablets_bottle_plastic_small_50",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_small",
     "entries": [ { "item": "pur_tablets", "count": 50 } ]
   },
@@ -1012,7 +1011,6 @@
     "type": "item_group",
     "id": "pur_tablets_bottle_plastic_small_0_50",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_small",
     "entries": [ { "item": "pur_tablets", "count": [ 0, 50 ] } ]
   },
@@ -1020,7 +1018,6 @@
     "type": "item_group",
     "id": "bottle_otc_painkiller_10",
     "subtype": "distribution",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_painkiller",
     "entries": [
       { "item": "aspirin", "container-item": "null", "count": 10 },
@@ -1032,7 +1029,6 @@
     "type": "item_group",
     "id": "bottle_otc_painkiller_0_10",
     "subtype": "distribution",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_painkiller",
     "entries": [
       { "item": "aspirin", "container-item": "null", "count": [ 0, 10 ] },
@@ -1044,7 +1040,6 @@
     "type": "item_group",
     "id": "quikclot_bag_plastic_5",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "quikclot", "container-item": "null", "count": 5 } ]
   },
@@ -1052,7 +1047,6 @@
     "type": "item_group",
     "id": "pur_tablets_bottle_plastic_small_0_9",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_small",
     "entries": [ { "item": "pur_tablets", "count": [ 0, 9 ] } ]
   },
@@ -1060,7 +1054,6 @@
     "type": "item_group",
     "id": "quikclot_bag_plastic_0_5",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "quikclot", "container-item": "null", "count": [ 0, 5 ] } ]
   },
@@ -1068,7 +1061,6 @@
     "type": "item_group",
     "id": "pur_tablets_bottle_plastic_small_75_100",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_small",
     "entries": [ { "item": "pur_tablets", "count": [ 75, 100 ] } ]
   },

--- a/data/json/mapgen/animalshelter.json
+++ b/data/json/mapgen/animalshelter.json
@@ -422,7 +422,6 @@
     "type": "item_group",
     "id": "calcium_tablet_bottle_plastic_pill_supplement_20",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_supplement",
     "entries": [ { "item": "calcium_tablet", "container-item": "null", "count": 20 } ]
   },
@@ -430,7 +429,6 @@
     "type": "item_group",
     "id": "dogfood_dry_bag_plastic_18",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic",
     "entries": [ { "item": "dogfood_dry", "container-item": "null", "count": 18 } ]
   },
@@ -438,7 +436,6 @@
     "type": "item_group",
     "id": "catfood_dry_bag_plastic_18",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic",
     "entries": [ { "item": "catfood_dry", "container-item": "null", "count": 18 } ]
   },
@@ -446,7 +443,6 @@
     "type": "item_group",
     "id": "antifungal_bottle_plastic_pill_prescription_5",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_prescription",
     "entries": [ { "item": "antifungal", "container-item": "null", "count": 5 } ]
   }

--- a/data/json/mapgen/hazardous_waste_sarcophagus.json
+++ b/data/json/mapgen/hazardous_waste_sarcophagus.json
@@ -411,7 +411,6 @@
     "type": "item_group",
     "id": "meat_tainted_55gal_drum_3_20",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "55gal_drum",
     "entries": [ { "item": "meat_tainted", "count": [ 3, 20 ] } ]
   }

--- a/data/json/mapgen/house/house_suicide.json
+++ b/data/json/mapgen/house/house_suicide.json
@@ -155,7 +155,6 @@
     "type": "item_group",
     "id": "oxycodone_bottle_plastic_pill_prescription_1",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_prescription",
     "entries": [ { "item": "oxycodone", "container-item": "null" } ]
   }

--- a/data/json/mapgen/map_extras/toxic_waste.json
+++ b/data/json/mapgen/map_extras/toxic_waste.json
@@ -197,7 +197,6 @@
     "type": "item_group",
     "id": "meat_mutant_tainted_55gal_drum_3_15",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "55gal_drum",
     "entries": [ { "item": "meat_mutant_tainted", "count": [ 3, 15 ] } ]
   },
@@ -205,7 +204,6 @@
     "type": "item_group",
     "id": "veggy_tainted_55gal_drum_3_50",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "55gal_drum",
     "entries": [ { "item": "veggy_tainted", "count": [ 3, 50 ] } ]
   }

--- a/data/json/mapgen/sewage_treatment.json
+++ b/data/json/mapgen/sewage_treatment.json
@@ -641,7 +641,6 @@
     "type": "item_group",
     "id": "slime_scrap_flask_glass_1",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "flask_glass",
     "entries": [ { "item": "slime_scrap" } ]
   }

--- a/data/json/mapgen_palettes/stadium_palette.json
+++ b/data/json/mapgen_palettes/stadium_palette.json
@@ -272,7 +272,6 @@
     "type": "item_group",
     "id": "bread_bag_plastic_2",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic_small",
     "entries": [ { "item": "bread", "container-item": "null", "count": 2 } ]
   }

--- a/data/json/npcs/NC_CITY_COP.json
+++ b/data/json/npcs/NC_CITY_COP.json
@@ -198,7 +198,6 @@
     "type": "item_group",
     "id": "xanax_bottle_plastic_pill_prescription_10",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_prescription",
     "entries": [ { "item": "xanax", "container-item": "null", "count": 10 } ]
   },
@@ -206,7 +205,6 @@
     "type": "item_group",
     "id": "prozac_bottle_plastic_pill_prescription_15",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_prescription",
     "entries": [ { "item": "prozac", "container-item": "null", "count": 15 } ]
   },
@@ -214,7 +212,6 @@
     "type": "item_group",
     "id": "diazepam_bottle_plastic_pill_prescription_10",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_pill_prescription",
     "entries": [ { "item": "diazepam", "container-item": "null", "count": 10 } ]
   },
@@ -222,7 +219,6 @@
     "type": "item_group",
     "id": "coke_bag_zipper_8",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_zipper",
     "entries": [ { "item": "coke", "container-item": "null", "count": 8 } ]
   },
@@ -230,7 +226,6 @@
     "type": "item_group",
     "id": "crack_bag_zipper_4",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_zipper",
     "entries": [ { "item": "crack", "container-item": "null", "count": 4 } ]
   }

--- a/data/json/npcs/godco/classes.json
+++ b/data/json/npcs/godco/classes.json
@@ -1346,7 +1346,6 @@
     "type": "item_group",
     "id": "poppy_pain_jar_glass_sealed_2",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "jar_glass_sealed",
     "entries": [ { "item": "poppy_pain", "count": 2 } ]
   },
@@ -1354,7 +1353,6 @@
     "type": "item_group",
     "id": "poppy_sleep_jar_glass_sealed_2",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "jar_glass_sealed",
     "entries": [ { "item": "poppy_sleep", "count": 2 } ]
   }

--- a/data/json/npcs/items_generic.json
+++ b/data/json/npcs/items_generic.json
@@ -1139,7 +1139,6 @@
     "type": "item_group",
     "id": "pur_tablets_bottle_plastic_small_50",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_small",
     "entries": [ { "item": "pur_tablets", "count": 50 } ]
   }

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/BAR_ENCOUNTER_MERCENARIES/BEM_drugs.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/BAR_ENCOUNTER_MERCENARIES/BEM_drugs.json
@@ -66,7 +66,6 @@
     "type": "item_group",
     "id": "pure_meth_bag_zipper_1_6",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_zipper",
     "entries": [ { "item": "pure_meth", "container-item": "null", "count": [ 1, 6 ] } ]
   }

--- a/data/mods/Xedra_Evolved/itemgroups/itemgroups.json
+++ b/data/mods/Xedra_Evolved/itemgroups/itemgroups.json
@@ -558,7 +558,6 @@
     "type": "item_group",
     "id": "wyld_candy_wrapper_wyld_20",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "wrapper_wyld",
     "entries": [ { "item": "wyld_candy", "container-item": "null", "count": 20 } ]
   },

--- a/data/mods/aftershock_exoplanet/itemgroups/food_groups.json
+++ b/data/mods/aftershock_exoplanet/itemgroups/food_groups.json
@@ -126,7 +126,6 @@
     "type": "item_group",
     "id": "afs_kibble_afs_foil_bag_2",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "afs_foil_bag",
     "entries": [ { "item": "afs_kibble", "count": 2 } ]
   },
@@ -134,7 +133,6 @@
     "type": "item_group",
     "id": "afs_kelp_afs_foil_bag_9",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "afs_foil_bag",
     "entries": [ { "item": "kelp_sugar", "count": 9 } ]
   },
@@ -142,7 +140,6 @@
     "type": "item_group",
     "id": "afs_ruined_food_can_food_2",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "can_food",
     "entries": [ { "item": "afs_ruined_food", "count": 2 } ]
   },
@@ -150,7 +147,6 @@
     "type": "item_group",
     "id": "afs_ruined_food_afs_foil_bag_5",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "afs_foil_bag",
     "entries": [ { "item": "afs_ruined_food", "count": 5 } ]
   },
@@ -158,7 +154,6 @@
     "type": "item_group",
     "id": "afs_mealgrubs_afs_foil_bag_5",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "afs_foil_bag",
     "entries": [ { "item": "afs_mealgrubs", "container-item": "null", "count": 5 } ]
   }

--- a/data/mods/aftershock_exoplanet/itemgroups/spaceship_groups.json
+++ b/data/mods/aftershock_exoplanet/itemgroups/spaceship_groups.json
@@ -28,7 +28,6 @@
     "type": "item_group",
     "id": "afs_escapepod_ration_bag_plastic_4",
     "subtype": "collection",
-    "//": "This group was created automatically and may contain errors.",
     "container-item": "bag_plastic",
     "entries": [ { "item": "afs_escapepod_ration", "container-item": "null", "count": 4 } ]
   }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
When removing charges from the last batch of item types, a lot of item groups had to be automatically created or converted to accommodate those changes.

Those changes were automated, but extensively reviewed both by myself and several other reviewers.

Well it's been over a year, and there have been **zero** found systemic errors. So clearly, if there was some problem in the script we'd have seen it by now.

Instead these warnings linger and scare the less-informed contributors by suggesting there's errors, when there are none.

#### Describe the solution
Delete.

#### Describe alternatives you've considered
We probably should never have added these comments in the first place.

#### Testing
If it loads it can ship. The only changes were a single regex pass.

#### Additional context
