### PR TITLE
Check validity of NPC enums during loading

### DIFF
--- a/data/json/npcs/Kindred/NPC_Brigitte_LaCroix.json
+++ b/data/json/npcs/Kindred/NPC_Brigitte_LaCroix.json
@@ -90,7 +90,7 @@
     "gender": "female",
     "name_suffix": "Bone Seer",
     "class": "NC_BONE_SEER",
-    "attitude": 7,
+    "attitude": 0,
     "mission": 3,
     "chat": "TALK_BONE_SEER",
     "faction": "no_faction",

--- a/data/json/npcs/militia/GM_Militia_Guard.json
+++ b/data/json/npcs/militia/GM_Militia_Guard.json
@@ -4,7 +4,7 @@
     "id": "MILITIA_GUARD1",
     "//": "A member of the Gray Moose Lodge, trying to safe in their isolated location",
     "class": "MILITIA_GUARD1",
-    "attitude": 7,
+    "attitude": 0,
     "name_suffix": "Militia Guard",
     "mission": 8,
     "chat": "TALK_MILITIA_Guard1",

--- a/data/mods/DinoMod/NPC/NC_BO_BARONYX.json
+++ b/data/mods/DinoMod/NPC/NC_BO_BARONYX.json
@@ -27,7 +27,7 @@
     "gender": "male",
     "name_suffix": "CEO",
     "class": "NC_SWAMPER",
-    "attitude": 7,
+    "attitude": 0,
     "mission": 3,
     "chat": "TALK_SWAMPER",
     "faction": "swamper",

--- a/data/mods/DinoMod/NPC/NC_Red.json
+++ b/data/mods/DinoMod/NPC/NC_Red.json
@@ -4,7 +4,7 @@
     "id": "old_guard_red",
     "name_unique": "Red",
     "class": "NC_SOLDIER",
-    "attitude": 7,
+    "attitude": 0,
     "mission": 3,
     "chat": "TALK_OLD_GUARD_RED",
     "faction": "old_guard",

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -332,6 +332,26 @@ void npc_template::load( const JsonObject &jsobj, std::string_view src )
     if( jsobj.has_string( "temp_suffix" ) ) {
         jsobj.read( "temp_suffix", tem.temp_suffix );
     }
+    std::set allowed_attitudes = {
+        NPCATT_NULL,
+        NPCATT_TALK,
+        NPCATT_FOLLOW,
+        NPCATT_LEAD,
+        NPCATT_WAIT,
+        NPCATT_MUG,
+        NPCATT_WAIT_FOR_LEAVE,
+        NPCATT_KILL,
+        NPCATT_FLEE,
+        NPCATT_HEAL
+    };
+    const npc_attitude to_set = static_cast<npc_attitude>( jsobj.get_int( "attitude" ) );
+    if( allowed_attitudes.count( to_set ) > 0 ) {
+        guy.set_attitude( to_set );
+    } else {
+        debugmsg( "NPC class %s has invalid attitude enum %d", guy.idz.c_str(),
+                  static_cast<int>( to_set ) );
+        guy.set_attitude( NPCATT_NULL );
+    }
     guy.set_attitude( static_cast<npc_attitude>( jsobj.get_int( "attitude" ) ) );
     guy.mission = static_cast<npc_mission>( jsobj.get_int( "mission" ) );
     guy.chatbin.first_topic = jsobj.get_string( "chat" );
@@ -3162,7 +3182,7 @@ std::string npc_attitude_name( npc_attitude att )
         case NPCATT_LEGACY_4:
         case NPCATT_LEGACY_5:
         case NPCATT_LEGACY_6:
-            return _( "NPC Legacy Attitude" );
+            return _( "ERROR!  Legacy Attitude" );
         default:
             break;
     }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
<img width="416" height="174" alt="image" src="https://github.com/user-attachments/assets/2c3f7516-bd3d-42d4-bd74-bd01654c217d" />


#### Describe the solution
Legacy enum should never show up, obviously

Check during loading for invalid enums, yell if so

Change translation string for legacy attitudes to make it even-more-obvious that this is wrong.

#### Describe alternatives you've considered
Although `NPCATT_FLEE` is a non-legacy attitude, the comment in npc.h suggests it is deprecated.

It sure doesn't look that way, and it's still in NPCs.MD, so I've set it to be "allowed" right now. Simple change if we want to remove it later.

#### Testing
<img width="2560" height="1400" alt="image" src="https://github.com/user-attachments/assets/52fa6323-d514-4d51-88d5-5504a326834f" />



#### Additional context
