### PR TITLE
Obsolete sky islands (has no maintainer)

### DIFF
--- a/data/mods/Sky_Island/modinfo.json
+++ b/data/mods/Sky_Island/modinfo.json
@@ -7,6 +7,7 @@
     "description": "An attempt at an entirely new way to play CDDA, inspired by games like Escape from Tarkov and Dark and Darker.  Begin on a floating island in the sky and warp down to random spots on the earth below to conduct expeditions for items you need.  Permadeath is gone - you will return to the island on death but lose any items you had on you.  Build up your stockpile, carry out missions for unique rewards, customize your home island, unlock upgrades, and be prudent about what you take on any given outing.  Be aware that 'PLAY NOW' will NOT work, you MUST make a custom character.",
     "category": "total_conversion",
     "dependencies": [ "dda" ],
+    "obsolete": true,
     "version": "0.4.0"
   }
 ]


### PR DESCRIPTION
#### Summary
Mods "Obsolete unmaintained sky islands mod"

#### Purpose of change
The Sky Islands mod has no maintainer. Actually, it has never had one.

#### Describe the solution
In line with our policies, obsolete it.

#### Describe alternatives you've considered
Er, we probably should never have merged it without a maintainer in the first place.

#### Testing
Yep, it's obsolete.

<img width="1294" height="1354" alt="image" src="https://github.com/user-attachments/assets/78074daf-fb63-42fe-816d-58b3b7c78a73" />


#### Additional context
