### PR TITLE
Improve mobile weather stations functions (1/2)

### DIFF
--- a/data/json/items/tool/science.json
+++ b/data/json/items/tool/science.json
@@ -676,6 +676,26 @@
     "tool_ammo": [ "battery" ]
   },
   {
+    "id": "mws_advanced_weather_sensor_array",
+    "type": "ITEM",
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "ambient weather sensor array" },
+    "description": "Represents the hardware and software for displaying the weather in a HEW system.  You should not see this item in game.",
+    "weight": "4000 g",
+    "volume": "80000 ml",
+    "longest_side": "55 cm",
+    "price": "400 USD",
+    "price_postapoc": "50 cent",
+    "material": [ "plastic", "aluminum" ],
+    "symbol": "[",
+    "looks_like": "briefcase",
+    "color": "yellow",
+    "charges_per_use": 1,
+    "flags": [ "THERMOMETER", "HYGROMETER", "BAROMETER", "ELECTRONIC" ],
+    "use_action": [ "WEATHER_TOOL" ],
+    "tool_ammo": [ "battery" ]
+  },
+  {
     "id": "mws_HE_sensor_array",
     "type": "ITEM",
     "subtypes": [ "TOOL" ],

--- a/data/json/vehicleparts/utilities.json
+++ b/data/json/vehicleparts/utilities.json
@@ -164,7 +164,7 @@
     "damage_reduction": { "bash": 1 },
     "size": "10 ml",
     "flags": [ "CARGO", "OBSTACLE", "MWS", "ENABLED_DRAINS_EPOWER", "ADVANCED_MWS", "NO_INSTALL_HIDDEN" ],
-    "pseudo_tools": [ { "id": "mws_weather_sensor_array", "hotkey": "a" }, { "id": "mws_HE_sensor_array", "hotkey": "b" } ],
+    "pseudo_tools": [ { "id": "mws_advanced_weather_sensor_array", "hotkey": "a" }, { "id": "mws_HE_sensor_array", "hotkey": "b" } ],
     "variants": [ { "symbols": "T", "symbols_broken": "#" } ]
   },
   {
@@ -190,7 +190,7 @@
     "damage_reduction": { "bash": 1 },
     "size": "10 ml",
     "flags": [ "CARGO", "OBSTACLE", "MWS", "ENABLED_DRAINS_EPOWER", "ADVANCED_MWS", "NO_INSTALL_HIDDEN" ],
-    "pseudo_tools": [ { "id": "mws_weather_sensor_array", "hotkey": "a" }, { "id": "mws_HE_sensor_array", "hotkey": "b" } ],
+    "pseudo_tools": [ { "id": "mws_advanced_weather_sensor_array", "hotkey": "a" }, { "id": "mws_HE_sensor_array", "hotkey": "b" } ],
     "variants": [ { "symbols": "T", "symbols_broken": "#" } ]
   }
 ]

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -7961,7 +7961,6 @@ std::optional<int> iuse::weather_tool( Character *p, item *it, const tripoint_bu
         std::string dirstring = get_dirstring( weather.winddirection );
         p->add_msg_if_player( m_neutral, _( "Wind Direction: From the %s." ), dirstring );
     }
-    
     if( it->typeId() == itype_mws_advanced_weather_sensor_array ) {
         p->add_msg_if_player( m_neutral, _( "Ambient radiation: %d mSv/h." ),
                           here.get_radiation( p->pos_bub() ) );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -7940,7 +7940,9 @@ std::optional<int> iuse::weather_tool( Character *p, item *it, const tripoint_bu
         }
     }
 
-    if( ( it->typeId() == itype_weather_reader ) || ( it->typeId() == itype_mws_weather_sensor_array ) || ( it->typeId() == itype_mws_advanced_weather_sensor_array ) ) {
+    if( ( it->typeId() == itype_weather_reader ) ||
+        ( it->typeId() == itype_mws_weather_sensor_array ) ||
+        ( it->typeId() == itype_mws_advanced_weather_sensor_array ) ) {
         int vehwindspeed = 0;
         if( optional_vpart_position vp = here.veh_at( p->pos_bub() ) ) {
             vehwindspeed = std::abs( vp->vehicle().velocity / 100 ); // For mph

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -287,6 +287,8 @@ static const itype_id itype_mininuke_act( "mininuke_act" );
 static const itype_id itype_molotov( "molotov" );
 static const itype_id itype_multi_cooker( "multi_cooker" );
 static const itype_id itype_multi_cooker_filled( "multi_cooker_filled" );
+static const itype_id itype_mws_advanced_weather_sensor_array( "mws_advanced_weather_sensor_array" );
+static const itype_id itype_mws_weather_sensor_array( "mws_weather_sensor_array" );
 static const itype_id itype_nicotine_liquid( "nicotine_liquid" );
 static const itype_id itype_paper( "paper" );
 static const itype_id itype_pot( "pot" );
@@ -302,6 +304,7 @@ static const itype_id itype_spiral_stone( "spiral_stone" );
 static const itype_id itype_splinter( "splinter" );
 static const itype_id itype_stick( "stick" );
 static const itype_id itype_syringe( "syringe" );
+static const itype_id itype_thermometer( "thermometer" );
 static const itype_id itype_tongs( "tongs" );
 static const itype_id itype_toolset( "toolset" );
 static const itype_id itype_towel( "towel" );
@@ -7884,6 +7887,8 @@ std::optional<int> iuse::weather_tool( Character *p, item *it, const tripoint_bu
 
     /* Possibly used twice. Worth spending the time to precalculate. */
     const units::temperature player_local_temp = weather.get_temperature( p->pos_bub() );
+    
+    const float sun_irrad = sun_irradiance( calendar::turn );
 
     if( !it->activation_success() ) {
         p->add_msg_if_player( m_bad, _( "The %s doesn't seem to work.  Try again." ),
@@ -7892,7 +7897,7 @@ std::optional<int> iuse::weather_tool( Character *p, item *it, const tripoint_bu
     }
 
     if( it->typeId() == itype_weather_reader ) {
-        p->add_msg_if_player( m_neutral, _( "The %s's monitor slowly outputs the data…" ),
+        p->add_msg_if_player( m_neutral, _( "The system desplays a snapshot of atmospheric data:" ),
                               it->tname() );
     }
     if( it->has_flag( flag_THERMOMETER ) ) {
@@ -7903,8 +7908,14 @@ std::optional<int> iuse::weather_tool( Character *p, item *it, const tripoint_bu
         } else {
             temperature_str = print_temperature( player_local_temp );
         }
-        p->add_msg_if_player( m_neutral, _( "The %1$s reads %2$s." ), it->tname(),
-                              temperature_str );
+        if( it->typeId() == itype_thermometer ) {
+            p->add_msg_if_player( m_neutral, _( "The %1$s reads %2$s." ), it->tname(),
+                                  temperature_str );
+        } else {
+            p->add_msg_if_player(
+                m_neutral, _( "Temperature: %s." ), temperature_str );
+        }
+            
     }
     if( it->has_flag( flag_HYGROMETER ) ) {
         if( it->typeId() == itype_hygrometer ) {
@@ -7930,7 +7941,7 @@ std::optional<int> iuse::weather_tool( Character *p, item *it, const tripoint_bu
         }
     }
 
-    if( it->typeId() == itype_weather_reader ) {
+    if( ( it->typeId() == itype_weather_reader ) || ( it->typeId() == itype_mws_weather_sensor_array ) || ( it->typeId() == itype_mws_advanced_weather_sensor_array ) ) {
         int vehwindspeed = 0;
         if( optional_vpart_position vp = here.veh_at( p->pos_bub() ) ) {
             vehwindspeed = std::abs( vp->vehicle().velocity / 100 ); // For mph
@@ -7949,7 +7960,14 @@ std::optional<int> iuse::weather_tool( Character *p, item *it, const tripoint_bu
         std::string dirstring = get_dirstring( weather.winddirection );
         p->add_msg_if_player( m_neutral, _( "Wind Direction: From the %s." ), dirstring );
     }
-
+    
+    if( it->typeId() == itype_mws_advanced_weather_sensor_array ) {
+        p->add_msg_if_player( m_neutral, _( "Ambient radiation: %d mSv/h" ),
+                          here.get_radiation( p->pos_bub() ) );
+        p->add_msg_if_player( m_neutral,
+                              _( "Irradiance: %.1f." ), sun_irrad );
+    }
+    
     return 1; //TODO check
 }
 

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -7963,7 +7963,7 @@ std::optional<int> iuse::weather_tool( Character *p, item *it, const tripoint_bu
     }
     if( it->typeId() == itype_mws_advanced_weather_sensor_array ) {
         p->add_msg_if_player( m_neutral, _( "Ambient radiation: %d mSv/h." ),
-                          here.get_radiation( p->pos_bub() ) );
+                              here.get_radiation( p->pos_bub() ) );
         p->add_msg_if_player( m_neutral,
                               _( "Irradiance: %.1f." ), sun_irrad );
     }

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -7962,7 +7962,7 @@ std::optional<int> iuse::weather_tool( Character *p, item *it, const tripoint_bu
     }
     
     if( it->typeId() == itype_mws_advanced_weather_sensor_array ) {
-        p->add_msg_if_player( m_neutral, _( "Ambient radiation: %d mSv/h" ),
+        p->add_msg_if_player( m_neutral, _( "Ambient radiation: %d mSv/h." ),
                           here.get_radiation( p->pos_bub() ) );
         p->add_msg_if_player( m_neutral,
                               _( "Irradiance: %.1f." ), sun_irrad );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -7897,7 +7897,7 @@ std::optional<int> iuse::weather_tool( Character *p, item *it, const tripoint_bu
     }
 
     if( it->typeId() == itype_weather_reader ) {
-        p->add_msg_if_player( m_neutral, _( "The system desplays a snapshot of atmospheric data:" ),
+        p->add_msg_if_player( m_neutral, _( "The system displays a snapshot of atmospheric data:" ),
                               it->tname() );
     }
     if( it->has_flag( flag_THERMOMETER ) ) {

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -7967,7 +7967,6 @@ std::optional<int> iuse::weather_tool( Character *p, item *it, const tripoint_bu
         p->add_msg_if_player( m_neutral,
                               _( "Irradiance: %.1f." ), sun_irrad );
     }
-    
     return 1; //TODO check
 }
 

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -7887,7 +7887,6 @@ std::optional<int> iuse::weather_tool( Character *p, item *it, const tripoint_bu
 
     /* Possibly used twice. Worth spending the time to precalculate. */
     const units::temperature player_local_temp = weather.get_temperature( p->pos_bub() );
-    
     const float sun_irrad = sun_irradiance( calendar::turn );
 
     if( !it->activation_success() ) {

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -287,7 +287,8 @@ static const itype_id itype_mininuke_act( "mininuke_act" );
 static const itype_id itype_molotov( "molotov" );
 static const itype_id itype_multi_cooker( "multi_cooker" );
 static const itype_id itype_multi_cooker_filled( "multi_cooker_filled" );
-static const itype_id itype_mws_advanced_weather_sensor_array( "mws_advanced_weather_sensor_array" );
+static const itype_id
+itype_mws_advanced_weather_sensor_array( "mws_advanced_weather_sensor_array" );
 static const itype_id itype_mws_weather_sensor_array( "mws_weather_sensor_array" );
 static const itype_id itype_nicotine_liquid( "nicotine_liquid" );
 static const itype_id itype_paper( "paper" );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -7915,7 +7915,6 @@ std::optional<int> iuse::weather_tool( Character *p, item *it, const tripoint_bu
             p->add_msg_if_player(
                 m_neutral, _( "Temperature: %s." ), temperature_str );
         }
-            
     }
     if( it->has_flag( flag_HYGROMETER ) ) {
         if( it->typeId() == itype_hygrometer ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Features "Improve mobile weather station functions (1/2)"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Mobile Weather Stations (MWSs) are now part of a relatively extensive quest-line, but their fundamental usage is lacking (only reported temp, pressure, and humidity).

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

This is part 1 of 2 to improve their function.

Now, the standard MWS reports: temp, humidity, pressure, wind speed, feels like temp, and wind direction.  The advanced MWSs also report radiation and a lux reading.

Part 2/2 will expand the station to interface with complex weather modeling software to give weather forecasts.  These will be associated with a new Hub-adjacent NPC, so waiting for #84410 to merge before proceeding.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

none

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Spawned MWSs and tested function.  Working as intended.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

mobile weather station:
<img width="337" height="132" alt="MWS-1" src="https://github.com/user-attachments/assets/9c484845-eacd-4555-9605-86a599bfff40" />

hazardous environment/HEW-NRE:
<img width="343" height="171" alt="MWS-2" src="https://github.com/user-attachments/assets/dbc7b32a-b402-4d3f-afb9-0de659683df8" />

(I've fixed the missing period at end of radiation reading -- just didn't want to rebuilt for a screenshot)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
