### PR TITLE
Backport https://github.com/CleverRaven/Cataclysm-DDA/pull/84542

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4264,6 +4264,9 @@ void Character::calc_bmi_encumb( std::map<bodypart_id, encumbrance_data> &vals )
     for( const std::pair<const bodypart_str_id, bodypart> &elem : get_body() ) {
         int penalty = std::floor( elem.second.get_bmi_encumbrance_scalar() * std::max( 0.0f,
                                   get_bmi_fat() - static_cast<float>( elem.second.get_bmi_encumbrance_threshold() ) ) );
+        if( !needs_food() ) {
+            penalty = 0;
+        }
         vals[elem.first.id()].encumbrance += penalty;
     }
 }
@@ -4527,6 +4530,9 @@ int Character::get_stored_kcal() const
 
 int Character::kcal_speed_penalty() const
 {
+    if( !needs_food() ) {
+        return 0;
+    }
     static const std::vector<std::pair<float, float>> starv_thresholds = { {
             std::make_pair( 0.0f, -90.0f ),
             std::make_pair( character_weight_category::emaciated, -50.f ),

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -663,6 +663,9 @@ void npc::randomize( const npc_class_id &type, const npc_template_id &tem_id )
     double weight_percent = std::clamp<double>( chi_squared_roll( time_influence ) / 5.0,
                             0.2, 5.0 );
     set_stored_kcal( weight_percent * get_healthy_kcal() );
+    if( !needs_food() ) {
+        set_stored_kcal( get_healthy_kcal() );
+    }
     starting_weapon( myclass );
     starting_clothes( *this, myclass, male );
     starting_inv( *this, myclass );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Bugfixes for stable

#### Describe the solution
Bugfixes for stable

#### Describe alternatives you've considered


#### Testing

#### Additional context
~~I don't know why the bot didn't want to backport this? Looks to have applied cleanly?~~ Oh, we did some fanciness to separate out the character_health.cpp stuff from character.cpp, no wonder the bot couldn't handle it.