### PR TITLE
Make powered air-purifying respirator blowers noisy

### DIFF
--- a/data/json/effects_on_condition/item_eocs.json
+++ b/data/json/effects_on_condition/item_eocs.json
@@ -150,6 +150,28 @@
     "effect": [ { "u_message": "Your <npc_name> goes quiet." }, { "transform_item": { "context_val": "transform_target" } } ]
   },
   {
+    "id": "EOC_papr_blower_running",
+    "type": "effect_on_condition",
+    "effect": {
+      "if": { "one_in_chance": { "context_val": "sound_chance" } },
+      "then": [
+        { "message": { "context_val": "sound_message" }, "sound": true },
+        {
+          "npc_make_sound": { "context_val": "sound_message" },
+          "type": "activity",
+          "volume": { "context_val": "volume" },
+          "ambient": true
+        }
+      ],
+      "else": {
+        "npc_make_sound": { "context_val": "sound_message" },
+        "type": "activity",
+        "volume": { "context_val": "volume" },
+        "ambient": true
+      }
+    }
+  },
+  {
     "type": "effect_on_condition",
     "id": "barber_hair",
     "effect": { "open_dialogue": { "topic": "TALK_CUT_YOUR_HAIR" } }

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -2738,11 +2738,7 @@
           "id": "EOC_papr_blower_running__basic",
           "effect": {
             "run_eocs": "EOC_papr_blower_running",
-            "variables": {
-              "sound_chance": 50,
-              "sound_message": { "i18n": true, "str": "The PAPR blower fan hums." },
-              "volume": 12
-            }
+            "variables": { "sound_chance": 50, "sound_message": { "i18n": true, "str": "The PAPR blower fan hums." }, "volume": 12 }
           }
         }
       ]

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -2938,11 +2938,7 @@
           "id": "EOC_papr_blower_running__molle",
           "effect": {
             "run_eocs": "EOC_papr_blower_running",
-            "variables": {
-              "sound_chance": 50,
-              "sound_message": { "i18n": true, "str": "The PAPR blower fan hums." },
-              "volume": 8
-            }
+            "variables": { "sound_chance": 50, "sound_message": { "i18n": true, "str": "The PAPR blower fan hums." }, "volume": 8 }
           }
         }
       ]

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -2731,7 +2731,22 @@
       "target": "basic_papr_belt_off",
       "ammo_scale": 0
     },
-    "tick_action": [ { "type": "sound", "sound_volume": 12, "sound_id": "misc" } ],
+    "tick_action": {
+      "type": "effect_on_conditions",
+      "effect_on_conditions": [
+        {
+          "id": "EOC_papr_blower_running__basic",
+          "effect": {
+            "run_eocs": "EOC_papr_blower_running",
+            "variables": {
+              "sound_chance": 50,
+              "sound_message": { "i18n": true, "str": "The PAPR blower fan hums." },
+              "volume": 12
+            }
+          }
+        }
+      ]
+    },
     "tool_ammo": [ "battery" ],
     "flags": [ "BELTED", "OVERSIZE", "ELECTRONIC", "TRADER_AVOID", "WATER_BREAK", "SPAWN_ACTIVE", "PAPR_BLOWER" ],
     "armor": [
@@ -2820,7 +2835,22 @@
       "target": "military_papr_blower_off",
       "ammo_scale": 0
     },
-    "tick_action": [ { "type": "sound", "sound_volume": 12, "sound_id": "misc" } ],
+    "tick_action": {
+      "type": "effect_on_conditions",
+      "effect_on_conditions": [
+        {
+          "id": "EOC_papr_blower_running__military",
+          "effect": {
+            "run_eocs": "EOC_papr_blower_running",
+            "variables": {
+              "sound_chance": 50,
+              "sound_message": { "i18n": true, "str": "The PAPR blower fan hums." },
+              "volume": 12
+            }
+          }
+        }
+      ]
+    },
     "tool_ammo": [ "battery" ],
     "flags": [ "BELTED", "OVERSIZE", "ELECTRONIC", "TRADER_AVOID", "SPAWN_ACTIVE", "PAPR_BLOWER" ],
     "armor": [
@@ -2909,7 +2939,22 @@
       "target": "molle_papr_blower_off",
       "ammo_scale": 0
     },
-    "tick_action": [ { "type": "sound", "sound_volume": 8, "sound_id": "misc" } ],
+    "tick_action": {
+      "type": "effect_on_conditions",
+      "effect_on_conditions": [
+        {
+          "id": "EOC_papr_blower_running__molle",
+          "effect": {
+            "run_eocs": "EOC_papr_blower_running",
+            "variables": {
+              "sound_chance": 50,
+              "sound_message": { "i18n": true, "str": "The PAPR blower fan hums." },
+              "volume": 8
+            }
+          }
+        }
+      ]
+    },
     "tool_ammo": [ "battery" ],
     "flags": [ "WATER_FRIENDLY", "BELTED", "OVERSIZE", "ELECTRONIC", "TRADER_AVOID", "SPAWN_ACTIVE", "PAPR_BLOWER" ],
     "armor": [

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -2838,11 +2838,7 @@
           "id": "EOC_papr_blower_running__military",
           "effect": {
             "run_eocs": "EOC_papr_blower_running",
-            "variables": {
-              "sound_chance": 50,
-              "sound_message": { "i18n": true, "str": "The PAPR blower fan hums." },
-              "volume": 12
-            }
+            "variables": { "sound_chance": 50, "sound_message": { "i18n": true, "str": "The PAPR blower fan hums." }, "volume": 12 }
           }
         }
       ]

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -2731,6 +2731,10 @@
       "target": "basic_papr_belt_off",
       "ammo_scale": 0
     },
+    "tick_action": [
+      { "type": "sound", "sound_volume": 12, "sound_chance": 100, "sound_id": "misc" },
+      { "type": "sound", "sound_message": "Your PAPR blower fan hums.", "sound_volume": 0, "sound_chance": 5, "sound_id": "misc" }
+    ],
     "tool_ammo": [ "battery" ],
     "flags": [ "BELTED", "OVERSIZE", "ELECTRONIC", "TRADER_AVOID", "WATER_BREAK", "SPAWN_ACTIVE", "PAPR_BLOWER" ],
     "armor": [
@@ -2819,6 +2823,10 @@
       "target": "military_papr_blower_off",
       "ammo_scale": 0
     },
+    "tick_action": [
+      { "type": "sound", "sound_volume": 12, "sound_chance": 100, "sound_id": "misc" },
+      { "type": "sound", "sound_message": "Your PAPR blower fan hums.", "sound_volume": 0, "sound_chance": 5, "sound_id": "misc" }
+    ],
     "tool_ammo": [ "battery" ],
     "flags": [ "BELTED", "OVERSIZE", "ELECTRONIC", "TRADER_AVOID", "SPAWN_ACTIVE", "PAPR_BLOWER" ],
     "armor": [
@@ -2863,6 +2871,10 @@
       "need_charges": 1,
       "need_charges_msg": "The %s's batteries are dead."
     },
+    "tick_action": [
+      { "type": "sound", "sound_volume": 8, "sound_chance": 100, "sound_id": "misc" },
+      { "type": "sound", "sound_message": "Your PAPR blower fan quietly hums.", "sound_volume": 0, "sound_chance": 5, "sound_id": "misc" }
+    ],
     "tool_ammo": [ "battery" ],
     "flags": [ "WATER_FRIENDLY", "BELTED", "OVERSIZE", "ELECTRONIC" ],
     "armor": [

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -2706,7 +2706,7 @@
     "type": "ITEM",
     "subtypes": [ "TOOL", "ARMOR" ],
     "name": { "str": "PAPR blower (on)", "str_pl": "PAPR blowers (on)" },
-    "description": "A blower unit for a powered air purifying respirator system.  It has been attached to a basic rubber and plastic belt.  If paired with a prepared PAPR mask, this will provide excellent protection against chemical, biological, radiological, and nuclear threats.",
+    "description": "A blower unit for a powered air purifying respirator system.  It has been attached to a basic rubber and plastic belt.  If paired with a prepared PAPR mask, this will provide excellent protection against chemical, biological, radiological, and nuclear threats.  The fan is audibly running.  Activate it to turn it off.",
     "weight": "918 g",
     "volume": "1000 ml",
     "material": [ "rubber", "plastic" ],
@@ -2731,10 +2731,7 @@
       "target": "basic_papr_belt_off",
       "ammo_scale": 0
     },
-    "tick_action": [
-      { "type": "sound", "sound_volume": 12, "sound_chance": 100, "sound_id": "misc" },
-      { "type": "sound", "sound_message": "Your PAPR blower fan hums.", "sound_volume": 0, "sound_chance": 5, "sound_id": "misc" }
-    ],
+    "tick_action": [ { "type": "sound", "sound_volume": 12, "sound_id": "misc" } ],
     "tool_ammo": [ "battery" ],
     "flags": [ "BELTED", "OVERSIZE", "ELECTRONIC", "TRADER_AVOID", "WATER_BREAK", "SPAWN_ACTIVE", "PAPR_BLOWER" ],
     "armor": [
@@ -2753,7 +2750,7 @@
     "type": "ITEM",
     "subtypes": [ "TOOL", "ARMOR" ],
     "name": { "str": "military PAPR blower (off)", "str_pl": "military PAPR blowers (off)" },
-    "description": "A sturdy blower unit for a powered air purifying respirator system.  Its large triangular body is designed to be worn on the back.  When active and paired with a prepared PAPR mask, this will provide excellent protection against chemical, biological, radiological, and nuclear threats.",
+    "description": "A sturdy blower unit for a powered air purifying respirator system.  Its large triangular body is designed to be worn on the back.  When active and paired with a prepared PAPR mask, this will provide excellent protection against chemical, biological, radiological, and nuclear threats.  Activate it to turn it on.",
     "weight": "653 g",
     "volume": "3589 ml",
     "price": "1400 USD",
@@ -2798,7 +2795,7 @@
     "type": "ITEM",
     "subtypes": [ "TOOL", "ARMOR" ],
     "name": { "str": "military PAPR blower (on)", "str_pl": "military PAPR blowers (on)" },
-    "description": "A sturdy blower unit for a powered air purifying respirator system.  Its large triangular body is designed to be worn on the back.  When active and paired with a prepared PAPR mask, this will provide excellent protection against chemical, biological, radiological, and nuclear threats.",
+    "description": "A sturdy blower unit for a powered air purifying respirator system.  Its large triangular body is designed to be worn on the back.  When active and paired with a prepared PAPR mask, this will provide excellent protection against chemical, biological, radiological, and nuclear threats.  The fan is audibly running.  Activate it to turn it off.",
     "weight": "653 g",
     "volume": "3589 ml",
     "material": [ "rubber", "plastic" ],
@@ -2823,10 +2820,7 @@
       "target": "military_papr_blower_off",
       "ammo_scale": 0
     },
-    "tick_action": [
-      { "type": "sound", "sound_volume": 12, "sound_chance": 100, "sound_id": "misc" },
-      { "type": "sound", "sound_message": "Your PAPR blower fan hums.", "sound_volume": 0, "sound_chance": 5, "sound_id": "misc" }
-    ],
+    "tick_action": [ { "type": "sound", "sound_volume": 12, "sound_id": "misc" } ],
     "tool_ammo": [ "battery" ],
     "flags": [ "BELTED", "OVERSIZE", "ELECTRONIC", "TRADER_AVOID", "SPAWN_ACTIVE", "PAPR_BLOWER" ],
     "armor": [
@@ -2845,7 +2839,7 @@
     "type": "ITEM",
     "subtypes": [ "TOOL", "ARMOR" ],
     "name": { "str": "modular PAPR blower (off)", "str_pl": "modular PAPR blowers (off)" },
-    "description": "A blower unit for a powered air purifying respirator system, built from a flexible silicon and butyl rubber blend.  Its components are arranged linearly in a narrow strip close to the body and is outfitted with straps to wear it about the waist.  If paired with the appropriate straps, it can also attached to any compatible MOLLE system.  When active and paired with a prepared PAPR mask, this will provide excellent protection against chemical, biological, radiological, and nuclear threats.",
+    "description": "A blower unit for a powered air purifying respirator system, built from a flexible silicon and butyl rubber blend.  Its components are arranged linearly in a narrow strip close to the body and is outfitted with straps to wear it about the waist.  If paired with the appropriate straps, it can also attached to any compatible MOLLE system.  When active and paired with a prepared PAPR mask, this will provide excellent protection against chemical, biological, radiological, and nuclear threats.  Activate it to turn it on.",
     "weight": "920 g",
     "volume": "3000 ml",
     "price": "1600 USD",
@@ -2871,10 +2865,6 @@
       "need_charges": 1,
       "need_charges_msg": "The %s's batteries are dead."
     },
-    "tick_action": [
-      { "type": "sound", "sound_volume": 8, "sound_chance": 100, "sound_id": "misc" },
-      { "type": "sound", "sound_message": "Your PAPR blower fan quietly hums.", "sound_volume": 0, "sound_chance": 5, "sound_id": "misc" }
-    ],
     "tool_ammo": [ "battery" ],
     "flags": [ "WATER_FRIENDLY", "BELTED", "OVERSIZE", "ELECTRONIC" ],
     "armor": [
@@ -2894,7 +2884,7 @@
     "type": "ITEM",
     "subtypes": [ "TOOL", "ARMOR" ],
     "name": { "str": "modular PAPR blower (on)", "str_pl": "modular PAPR blowers (on)" },
-    "description": "A blower unit for a powered air purifying respirator system, built from a flexible silicon and butyl rubber blend.  Its components are arranged linearly in a narrow strip close to the body and is outfitted with straps to wear it about the waist.  If paired with the appropriate straps, it can also attached to any compatible MOLLE system.  When active and paired with a prepared PAPR mask, this will provide excellent protection against chemical, biological, radiological, and nuclear threats.",
+    "description": "A blower unit for a powered air purifying respirator system, built from a flexible silicon and butyl rubber blend.  Its components are arranged linearly in a narrow strip close to the body and is outfitted with straps to wear it about the waist.  If paired with the appropriate straps, it can also attached to any compatible MOLLE system.  When active and paired with a prepared PAPR mask, this will provide excellent protection against chemical, biological, radiological, and nuclear threats.  The fan is audibly running.  Activate it to turn it off.",
     "weight": "920 g",
     "volume": "3000 ml",
     "material": [ "butyl_rubber", "plastic" ],
@@ -2919,6 +2909,7 @@
       "target": "molle_papr_blower_off",
       "ammo_scale": 0
     },
+    "tick_action": [ { "type": "sound", "sound_volume": 8, "sound_id": "misc" } ],
     "tool_ammo": [ "battery" ],
     "flags": [ "WATER_FRIENDLY", "BELTED", "OVERSIZE", "ELECTRONIC", "TRADER_AVOID", "SPAWN_ACTIVE", "PAPR_BLOWER" ],
     "armor": [


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Features "PAPR blowers make noise"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

PAPR blowers have been in game for a bit now, but were missing a critical downside: they're noisy.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Added on_tick EOCs to make noise.  Active PAPR blowers now constantly make noise.  Basic and military variants make 12.  The modular variant makes 8 (as it is based on a real-world Avon MP-PAPR that operates more quietly).  There is a 1/50 chance every turn of a message, as well.

<details>
<img width="495" height="338" alt="PAPR-sound1" src="https://github.com/user-attachments/assets/acb6bf90-a8a8-4120-adae-e3acd92daf8c" />
</details>

Item descriptions were amended to make it clear they make noise.

<details>
<img width="616" height="83" alt="papr-sound2" src="https://github.com/user-attachments/assets/87d8d5ec-dc22-45d2-ba1f-91c3222b9a83" />
</details>

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Considered several volume options spanning ~8-12.  Settled on high and low end.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Spawned, turned on and off, waited around for messages.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
