### PR TITLE
Replace Weakening with ROT1

### DIFF
--- a/data/mods/MindOverMatter/npcs/dialogue/follower_dialogue.json
+++ b/data/mods/MindOverMatter/npcs/dialogue/follower_dialogue.json
@@ -20,7 +20,7 @@
                 { "npc_has_trait": "SCHIZOPHRENIC" },
                 { "npc_has_trait": "JITTERY" },
                 { "npc_has_trait": "MOODSWINGS" },
-                { "npc_has_trait": "WEAKENING" },
+                { "npc_has_trait": "ROT1" },
                 { "npc_has_trait": "NARCOLEPTIC" },
                 { "npc_has_trait": "SEASONAL_ALLERGIES" },
                 { "npc_has_trait": "SEASONAL_AFFECTIVE" }
@@ -454,10 +454,10 @@
       {
         "text": "Hold still.  *Remove <npc_name>'s weakening sickness*",
         "topic": "TALK_DONE",
-        "condition": { "npc_has_trait": "WEAKENING" },
+        "condition": { "npc_has_trait": "ROT1" },
         "effect": [
-          { "npc_lose_trait": "WEAKENING" },
-          { "u_add_trait": "WEAKENING" },
+          { "npc_lose_trait": "ROT1" },
+          { "u_add_trait": "ROT1" },
           {
             "u_message": "You touch <npc_name> and reach out with your powers, looking for the illness within them.  You soon find it, a shadow over their entire body, and draw it into yourself.",
             "popup": true

--- a/data/mods/MindOverMatter/powers/vitakinesis_eoc.json
+++ b/data/mods/MindOverMatter/powers/vitakinesis_eoc.json
@@ -865,7 +865,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_VITAKIN_BANISH_ILLNESS_WEAKENING",
-    "condition": { "u_has_trait": "WEAKENING" },
+    "condition": { "u_has_trait": "ROT1" },
     "effect": [ { "u_assign_activity": "ACT_VITAKIN_BANISH_ILLNESS_WEAKENING", "duration": "480 minutes" } ],
     "false_effect": [ { "u_message": "You don't have a weakening sickness.  There is no need to attempt to cure it.", "type": "mixed" } ]
   },
@@ -883,7 +883,7 @@
     "condition": { "math": [ "vita_banish_illness_equation() >= 15" ] },
     "effect": [
       { "u_message": "New vigor fills your body.", "type": "good" },
-      { "u_lose_trait": "WEAKENING" },
+      { "u_lose_trait": "ROT1" },
       { "math": [ "u_vitamin('vitamin_psionic_drain') += rng( 45,75 )" ] }
     ],
     "false_effect": [


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Traint Weakening doesn't exist"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
replace with something that should work
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
replaced with existing mutation
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
NONE
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
