### PR TITLE
Reduce micromanagement of metamagic perks

### DIFF
--- a/data/mods/BombasticPerks/perkdata/metamagic/silent.json
+++ b/data/mods/BombasticPerks/perkdata/metamagic/silent.json
@@ -29,7 +29,9 @@
         "math": [ "u_spellcasting_adjustment('cost', 'mod': 'magiclysm', 'flag_blacklist': 'CONSUMES_RUNES' ) = 0.2" ]
       },
       {
-        "math": [ "u_spellcasting_adjustment('cost', 'mod': 'magiclysm', 'flag_blacklist': 'CONSUMES_RUNES', 'flag_whitelist': 'SILENT' ) = -0.2" ]
+        "math": [
+          "u_spellcasting_adjustment('cost', 'mod': 'magiclysm', 'flag_blacklist': 'CONSUMES_RUNES', 'flag_whitelist': 'SILENT' ) = -0.2"
+        ]
       }
     ]
   }

--- a/data/mods/BombasticPerks/perkdata/metamagic/silent.json
+++ b/data/mods/BombasticPerks/perkdata/metamagic/silent.json
@@ -27,6 +27,9 @@
       { "math": [ "u_spellcasting_adjustment('sound', 'mod': 'magiclysm', 'flag_blacklist': 'CONSUMES_RUNES' ) = -1" ] },
       {
         "math": [ "u_spellcasting_adjustment('cost', 'mod': 'magiclysm', 'flag_blacklist': 'CONSUMES_RUNES' ) = 0.2" ]
+      },
+      {
+        "math": [ "u_spellcasting_adjustment('cost', 'mod': 'magiclysm', 'flag_blacklist': 'CONSUMES_RUNES', 'flag_whitelist': 'SILENT' ) = -0.2" ]
       }
     ]
   }

--- a/data/mods/BombasticPerks/perkdata/metamagic/still.json
+++ b/data/mods/BombasticPerks/perkdata/metamagic/still.json
@@ -29,6 +29,9 @@
       },
       {
         "math": [ "u_spellcasting_adjustment('cost', 'mod': 'magiclysm', 'flag_blacklist': 'CONSUMES_RUNES' ) = 0.2" ]
+      },
+      {
+        "math": [ "u_spellcasting_adjustment('cost', 'mod': 'magiclysm', 'flag_blacklist': 'CONSUMES_RUNES', 'flag_whitelist': 'NO_HANDS' ) = -0.2" ]
       }
     ]
   }

--- a/data/mods/BombasticPerks/perkdata/metamagic/still.json
+++ b/data/mods/BombasticPerks/perkdata/metamagic/still.json
@@ -31,7 +31,9 @@
         "math": [ "u_spellcasting_adjustment('cost', 'mod': 'magiclysm', 'flag_blacklist': 'CONSUMES_RUNES' ) = 0.2" ]
       },
       {
-        "math": [ "u_spellcasting_adjustment('cost', 'mod': 'magiclysm', 'flag_blacklist': 'CONSUMES_RUNES', 'flag_whitelist': 'NO_HANDS' ) = -0.2" ]
+        "math": [
+          "u_spellcasting_adjustment('cost', 'mod': 'magiclysm', 'flag_blacklist': 'CONSUMES_RUNES', 'flag_whitelist': 'NO_HANDS' ) = -0.2"
+        ]
       }
     ]
   }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Refunds the increased metamagic cost for the Silent and Still perks if the affected spell would not benefit.

#### Describe the solution

Adds a line to invert the extra cost using the `flag_whitelist` option. This makes the perks equivalent with the Intuitive perk that only affects spells flagged `CONCENTRATION`.

#### Describe alternatives you've considered

#### Testing

Tested the still effect in earlier versions. The flags do not appear to have changed in experimental.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
