### PR TITLE
expose sound_type for `sound` use action

### DIFF
--- a/doc/JSON/ITEM.md
+++ b/doc/JSON/ITEM.md
@@ -1496,6 +1496,7 @@ The contents of `use_action` fields can either be a string indicating a built-in
   "type": "sound",            // Makes sound
   "name": "Turn on",          // Optional name for the action. Default "Activate"
   "sound_message": "Bzzzz.",  // message shown to player if they are able to hear the sound. %s is replaced by item name
+  "sound_type": "alarm",      // type of the sound emitted. Default "alarm". Possible types are "background", "weather", "sensory", "music", "movement", "speech", "electronic_speech", "activity", "destructive_activity", "alarm", "combat", "alert", "order"
   "sound_id": "misc",         // ID of the audio to be played. Default "misc". See SOUNDPACKS.md for more details
   "sound_variant": "default", // Default is "default"
   "sound_volume": 5           // Loudness of the noise

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -642,6 +642,7 @@ void sound_iuse::load( const JsonObject &obj, const std::string & )
     optional( obj, false, "name", name );
     optional( obj, false, "sound_message", sound_message );
     optional( obj, false, "sound_volume", sound_volume, 0 );
+    optional( obj, false, "sound_type", sound_type, enum_flags_reader<sounds::sound_t> { "alarm" } );
     optional( obj, false, "sound_id", sound_id, "misc" );
     optional( obj, false, "sound_variant", sound_variant, "default" );
 }
@@ -652,7 +653,7 @@ std::optional<int> sound_iuse::use( Character *, item &,
     map &bubble_map = reality_bubble();
 
     if( bubble_map.inbounds( here->get_abs( pos ) ) ) {
-        sounds::sound( bubble_map.get_bub( here->get_abs( pos ) ), sound_volume, sounds::sound_t::alarm,
+        sounds::sound( bubble_map.get_bub( here->get_abs( pos ) ), sound_volume, sound_type,
                        sound_message.translated(), true,
                        sound_id, sound_variant );
     }

--- a/src/iuse_actor.h
+++ b/src/iuse_actor.h
@@ -33,6 +33,10 @@ struct furn_t;
 
 enum class link_state : int;
 enum class ot_match_type : int;
+namespace sounds
+{
+enum class sound_t : int;
+} // namespace sounds
 
 /**
  * Transform an item into a specific type.
@@ -181,6 +185,7 @@ class sound_iuse : public iuse_actor
 
         translation sound_message;
 
+        sounds::sound_t sound_type;
         int sound_volume = 0;
         std::string sound_id;
         std::string sound_variant;


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
For #84577, author needs a sound type exposed to sound use_action
#### Describe the solution
Expose
#### Testing
Added dummy tick action to PAPR
```json
    "tick_action": {
      "type": "sound",
      "sound_type": "movement",
      "sound_message": "whooooo…",
      "sound_id": "humming",
      "sound_variant": "machinery",
      "sound_volume": 20
    },
```
Sound is emitted without printing a message
#### Additional context
I don't really know the difference between all the types, so i failed to document the difference between them