### PR TITLE
Improve m27 rifles

### DIFF
--- a/data/json/itemgroups/Weapons_Mods_Ammo/arsenal/223.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/arsenal/223.json
@@ -38,7 +38,12 @@
   {
     "type": "item_group",
     "id": "milspec_arsenal_223",
-    "items": [ { "group": "nested_m4_carbine_no_ammo", "prob": 70 }, { "group": "nested_m27_assault_rifle_no_ammo", "prob": 40 } ]
+    "items": [
+      { "group": "nested_m4_carbine_no_ammo", "prob": 70 },
+      { "group": "nested_h&k416a5_assault_rifle_no_ammo", "prob": 40 },
+      { "group": "nested_m27_assault_rifle_no_ammo", "prob": 15 },
+      { "group": "nested_m38dmr_no_ammo", "prob": 5 }
+    ]
   },
   {
     "id": "nested_m4_carbine_no_ammo",
@@ -50,7 +55,19 @@
     "id": "nested_m27_assault_rifle_no_ammo",
     "type": "item_group",
     "subtype": "collection",
-    "items": [ { "item": "modular_m27_assault_rifle" }, { "group": "stanag_mags", "count": [ 1, 3 ] } ]
+    "items": [ { "group": "m27iar" }, { "group": "stanag_mags", "count": [ 1, 3 ] } ]
+  },
+  {
+    "id": "nested_h&k416a5_assault_rifle_no_ammo",
+    "type": "item_group",
+    "subtype": "collection",
+    "items": [ { "group": "h&k416a5_any" }, { "group": "stanag_mags", "count": [ 1, 3 ] } ]
+  },
+  {
+    "id": "nested_m38dmr_no_ammo",
+    "type": "item_group",
+    "subtype": "collection",
+    "items": [ { "group": "m38dmr" }, { "group": "stanag_mags", "count": [ 1, 3 ] } ]
   },
   {
     "id": "stanag_mags",

--- a/data/json/itemgroups/Weapons_Mods_Ammo/arsenal/police_armory.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/arsenal/police_armory.json
@@ -1197,19 +1197,9 @@
     "//": "1-3 rifles weighted towards 1 rifle",
     "subtype": "collection",
     "entries": [
-      { "item": "modular_m27_assault_rifle", "variant": "modular_h&k416a5", "contents-item": "holo_sight" },
-      {
-        "item": "modular_m27_assault_rifle",
-        "variant": "modular_h&k416a5",
-        "contents-item": "holo_sight",
-        "prob": 50
-      },
-      {
-        "item": "modular_m27_assault_rifle",
-        "variant": "modular_h&k416a5",
-        "contents-item": "holo_sight",
-        "prob": 25
-      }
+      { "group": "h&k416a5_default_or_short", "contents-item": "holo_sight" },
+      { "group": "h&k416a5_default_or_short", "contents-item": "holo_sight", "prob": 50 },
+      { "group": "h&k416a5_default_or_short", "contents-item": "holo_sight", "prob": 25 }
     ]
   },
   {

--- a/data/json/itemgroups/Weapons_Mods_Ammo/conversions/conversion_guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/conversions/conversion_guns.json
@@ -108,6 +108,76 @@
     "entries": [ { "item": "modular_ar15", "contents-item": "retool_ar15_22" } ]
   },
   {
+    "id": "h&k416a5_any",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "modular_m27_assault_rifle", "variant": "modular_h&k416a5", "contents-item": "retool_ar15_223rem" },
+      {
+        "item": "modular_m27_assault_rifle",
+        "variant": "modular_h&k416a5",
+        "contents-item": "retool_ar15_223rem_short"
+      },
+      {
+        "item": "modular_m27_assault_rifle",
+        "variant": "modular_h&k416a5",
+        "contents-item": "retool_ar15_223rem_medium"
+      },
+      {
+        "item": "modular_m27_assault_rifle",
+        "variant": "modular_h&k416a5",
+        "contents-item": "retool_ar15_223rem_extended"
+      }
+    ]
+  },
+  {
+    "id": "h&k416a5_default_or_short",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "modular_m27_assault_rifle", "variant": "modular_h&k416a5", "contents-item": "retool_ar15_223rem" },
+      {
+        "item": "modular_m27_assault_rifle",
+        "variant": "modular_h&k416a5",
+        "contents-item": "retool_ar15_223rem_short"
+      }
+    ]
+  },
+  {
+    "id": "m27iar",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [
+      {
+        "item": "modular_m27_assault_rifle",
+        "variant": "modular_m27iar",
+        "contents-item": [
+          "retool_ar15_223rem",
+          "shoulder_strap",
+          "bipod",
+          "grip",
+          "mipim",
+          "red_dot_sight",
+          "hybrid_sight_4x",
+          "suppressor",
+          "adjustable_stock"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "m38dmr",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [
+      {
+        "item": "modular_m27_assault_rifle",
+        "variant": "modular_m38dmr",
+        "contents-item": [ "retool_ar15_223rem", "shoulder_strap", "bipod", "grip", "mipim", "rifle_scope", "suppressor", "adjustable_stock" ]
+      }
+    ]
+  },
+  {
     "id": "ar_pistol",
     "type": "item_group",
     "subtype": "collection",

--- a/data/json/itemgroups/Weapons_Mods_Ammo/gunmod.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/gunmod.json
@@ -72,6 +72,7 @@
       [ "m320_mod", 10 ],
       [ "masterkey", 30 ],
       [ "m26_mass", 35 ],
+      [ "mipim", 10 ],
       [ "sword_bayonet", 10 ]
     ]
   },
@@ -135,13 +136,6 @@
       [ "laser_sight", 15 ],
       [ "offset_sights", 6 ]
     ]
-  },
-  {
-    "type": "item_group",
-    "id": "m38dmr_mods",
-    "//": "Default mods for the m38dmr variant of the NATO assault rifle",
-    "subtype": "collection",
-    "entries": [ { "item": "suppressor" }, { "item": "rifle_scope" }, { "item": "bipod" } ]
   },
   {
     "type": "item_group",

--- a/data/json/itemgroups/Weapons_Mods_Ammo/guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/guns.json
@@ -538,8 +538,7 @@
         "prob": 8
       },
       {
-        "item": "modular_m27_assault_rifle",
-        "variant": "modular_h&k416a5",
+        "group": "h&k416a5_any",
         "ammo-item": "556_mk318",
         "charges": [ 0, 30 ],
         "contents-item": "shoulder_strap",
@@ -586,8 +585,7 @@
         "prob": 8
       },
       {
-        "item": "modular_m27_assault_rifle",
-        "variant": "modular_h&k416a5",
+        "group": "h&k416a5_any",
         "ammo-item": "556_mk318",
         "charges": 30,
         "contents-item": "shoulder_strap",
@@ -696,8 +694,7 @@
       {
         "collection": [
           {
-            "item": "modular_m27_assault_rifle",
-            "variant": "modular_h&k416a5",
+            "group": "h&k416a5_any",
             "ammo-item": "556_mk318",
             "charges": [ 0, 30 ],
             "contents-item": "shoulder_strap",
@@ -1030,8 +1027,7 @@
       {
         "collection": [
           {
-            "item": "modular_m27_assault_rifle",
-            "variant": "modular_h&k416a5",
+            "group": "h&k416a5_any",
             "ammo-item": "556_mk318",
             "charges": [ 0, 30 ],
             "contents-item": "shoulder_strap",

--- a/data/json/itemgroups/Weapons_Mods_Ammo/nested_guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/nested_guns.json
@@ -1920,7 +1920,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "modular_m27_assault_rifle", "variant": "modular_h&k416a5", "charges": [ 0, 30 ] },
+      { "group": "h&k416a5_any", "charges": [ 0, 30 ] },
       { "item": "stanag30" },
       { "item": "stanag30", "prob": 50 },
       { "group": "on_hand_223" }
@@ -1933,7 +1933,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "modular_m27_assault_rifle", "variant": "modular_m27iar", "charges": [ 0, 30 ] },
+      { "group": "m27iar", "charges": [ 0, 30 ] },
       { "item": "stanag30" },
       { "item": "stanag30", "prob": 50 },
       { "group": "on_hand_223" }

--- a/data/json/itemgroups/military.json
+++ b/data/json/itemgroups/military.json
@@ -5,20 +5,8 @@
     "subtype": "distribution",
     "entries": [
       { "group": "modular_m4a1", "prob": 88, "charges": [ 0, 30 ], "contents-group": "issued_carbine_mods" },
-      {
-        "item": "modular_m27_assault_rifle",
-        "variant": "modular_m27iar",
-        "prob": 10,
-        "charges": [ 0, 30 ],
-        "contents-group": "issued_carbine_mods"
-      },
-      {
-        "item": "modular_m27_assault_rifle",
-        "variant": "modular_m38dmr",
-        "contents-group": "m38dmr_mods",
-        "prob": 1,
-        "charges": [ 0, 30 ]
-      },
+      { "group": "m27iar", "prob": 10, "charges": [ 0, 30 ] },
+      { "group": "m38dmr", "prob": 1, "charges": [ 0, 30 ] },
       { "item": "modular_m16a4", "prob": 2, "charges": [ 0, 30 ], "contents-group": "issued_slings" }
     ]
   },

--- a/data/json/items/gun/223.json
+++ b/data/json/items/gun/223.json
@@ -81,7 +81,6 @@
     "ammo": [ "NULL" ],
     "dispersion": 180,
     "min_cycle_recoil": 1350,
-    "default_mods": [ "retool_ar15_223rem" ],
     "modes": [ [ "DEFAULT", "semi-auto", 1 ], [ "AUTO", "auto", 4 ] ],
     "valid_mod_locations": [ [ "barrel", 1 ], [ "bore", 1 ], [ "mechanism", 2 ], [ "sling", 1 ], [ "stock accessory", 1 ], [ "stock", 1 ] ],
     "flags": [ "NO_TURRET" ]

--- a/data/json/items/gunmod/rail.json
+++ b/data/json/items/gunmod/rail.json
@@ -55,6 +55,63 @@
     "min_skills": [ [ "weapon", 2 ], [ "gun", 1 ] ]
   },
   {
+    "id": "mipim",
+    "type": "ITEM",
+    "subtypes": [ "TOOL", "GUNMOD" ],
+    "name": { "str": "army flashlight-laser module" },
+    "description": "Officially designated as Mini Integrated Pointing Illumination Module (MIPIM), also known as AN/PEQ-16, it is a little squarey box, mounted on a firearm side rail, that combines both laser sight and flashlight.",
+    "weight": "68 g",
+    "volume": "360 ml",
+    "longest_side": "104 mm",
+    "price": "2200 USD",
+    "price_postapoc": "15 USD",
+    "install_time": "10 m",
+    "material": [ "steel", "plastic" ],
+    "symbol": ":",
+    "color": "brown",
+    "location": "rail",
+    "mod_targets": [ "pistol", "shotgun", "smg", "rifle", "crossbow", "launcher" ],
+    "min_skills": [ [ "weapon", 1 ] ],
+    "charges_per_use": 1,
+    "is_visible_when_installed": true,
+    "flags": [ "LASER_SIGHT" ],
+    "use_action": {
+      "type": "transform",
+      "msg": "You turn the army flashlight-laser module flashlight on.",
+      "target": "mipim_on",
+      "need_charges": 1,
+      "need_charges_msg": "The mounted flashlight's batteries are dead."
+    },
+    "pocket_data": [
+      {
+        "pocket_type": "MAGAZINE_WELL",
+        "rigid": true,
+        "flag_restriction": [ "BATTERY_MEDIUM" ],
+        "default_magazine": "medium_battery_cell"
+      }
+    ],
+    "tool_ammo": [ "battery" ]
+  },
+  {
+    "id": "mipim_on",
+    "copy-from": "mipim",
+    "type": "ITEM",
+    "subtypes": [ "TOOL", "GUNMOD" ],
+    "name": { "str": "army flashlight-laser module (on)", "str_pl": "army flashlight-laser modules (on)" },
+    "//": "about 30 m of work off a single battery",
+    "power_draw": "31 W",
+    "revert_to": "mipim",
+    "use_action": {
+      "menu_text": "Turn off",
+      "type": "transform",
+      "msg": "You turn the army flashlight-laser module off.",
+      "target": "mipim",
+      "ammo_scale": 0
+    },
+    "light": 160,
+    "extend": { "flags": [ "CHARGEDIM", "TRADER_AVOID", "SPAWN_ACTIVE" ] }
+  },
+  {
     "id": "offset_grip",
     "type": "ITEM",
     "subtypes": [ "GUNMOD" ],

--- a/data/json/mapgen/military/mil_base/mil_base_z0.json
+++ b/data/json/mapgen/military/mil_base/mil_base_z0.json
@@ -769,15 +769,7 @@
         { "item": "mgl", "x": 10, "y": 11, "chance": 75, "repeat": 3 },
         { "item": "40x46mm_m433", "x": 10, "y": 12, "chance": 75, "repeat": 20 },
         { "group": "modular_m4a1", "x": 12, "y": [ 9, 11 ], "magazine": 100, "chance": 75, "repeat": 30 },
-        {
-          "item": "modular_m27_assault_rifle",
-          "variant": "modular_m27iar",
-          "x": 12,
-          "y": 9,
-          "magazine": 100,
-          "chance": 75,
-          "repeat": 8
-        },
+        { "group": "m27iar", "x": 12, "y": 9, "magazine": 100, "chance": 75, "repeat": 8 },
         { "item": "modular_m16a4", "x": 12, "y": 9, "magazine": 100, "chance": 75, "repeat": 2 },
         { "item": "stanag30", "x": 12, "y": 12, "chance": 75, "repeat": 80 },
         { "item": "stanag50", "x": 12, "y": 12, "chance": 75, "repeat": 20 },

--- a/data/json/npcs/robofac/NPC_robofac_generic_security.json
+++ b/data/json/npcs/robofac/NPC_robofac_generic_security.json
@@ -74,14 +74,7 @@
     "type": "item_group",
     "id": "NC_robofac_security_weapon",
     "subtype": "collection",
-    "entries": [
-      {
-        "item": "modular_m27_assault_rifle",
-        "variant": "modular_m38dmr",
-        "contents-group": "robofac_sec_weapon_mods",
-        "charges": 30
-      }
-    ]
+    "entries": [ { "group": "h&k416a5_default_or_short", "contents-group": "robofac_sec_weapon_mods", "charges": 30 } ]
   },
   {
     "type": "item_group",

--- a/data/json/obsoletion_and_migration_0.I/obsolete_npc_class.json
+++ b/data/json/obsoletion_and_migration_0.I/obsolete_npc_class.json
@@ -638,7 +638,7 @@
       { "group": "modular_m4a1", "prob": 50 },
       [ "m14ebr", 35 ],
       [ "m249", 20 ],
-      [ "modular_m27_assault_rifle", 50 ],
+      { "group": "h&k416a5_any", "prob": 50 },
       [ "M24", 35 ]
     ]
   },

--- a/data/mods/package_bionic_professions/bionic_professions.json
+++ b/data/mods/package_bionic_professions/bionic_professions.json
@@ -611,14 +611,7 @@
           { "group": "charged_two_way_radio" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
           { "item": "sheath", "contents-item": "knife_combat" },
-          {
-            "item": "modular_m27_assault_rifle",
-            "variant": "modular_h&k416a5",
-            "ammo-item": "556",
-            "charges": 30,
-            "contents-item": [ "shoulder_strap", "acog_scope" ],
-            "custom-flags": [ "auto_wield" ]
-          },
+          { "group": "h&k416a5_any", "ammo-item": "556", "charges": 30, "custom-flags": [ "auto_wield" ] },
           { "group": "us_ballistic_vest_pristine" },
           { "item": "legpouch_large", "contents-group": "army_mags_m4" }
         ]


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
I found `modular_m27_assault_rifle` uses `default_mods`, which is not how modular guns should be made
#### Describe the solution
Remove `default_mods`
make multiple itemgroups to handle the resulted guns that lack the upper receiver; such itemgroups also handle the gunmods that should be installed on m27 and m38dmr as per their army specification
replace uses of item/item with gunmod with related group
add mipim that also should be part of m27 and m38dmr as per their specs
#### Describe alternatives you've considered
Make a copy of upper receivers from ar-15 specifically for HK416, since HK416 (and, therefore, all it's derivatives like m27 and m38dmr) are not directly compatible with them
#### Testing
M27 IAR gunmods it spawns naturally with now:

<img width="650" height="577" alt="image" src="https://github.com/user-attachments/assets/c7ccdaaa-d141-48e7-87d5-f3c58a49cd49" />

#### Additional context
Someone broke `is_visible_when_installed` in the meantime, and it is not shown in inventory :/