### PR TITLE
[Sky Island] red exit room glow

### DIFF
--- a/data/mods/Sky_Island/furniture_and_terrain.json
+++ b/data/mods/Sky_Island/furniture_and_terrain.json
@@ -79,6 +79,16 @@
     }
   },
   {
+    "type": "terrain",
+    "id": "t_wall_r_glow",
+    "copy-from": "t_wall_color",
+    "looks_like": "t_wall_r",
+    "name": "red glowing wall",
+    "description": "A red wall emitting otherworldly glow, enough to be noticeable at night.",
+    "color": "red",
+    "light_emitted": 120
+  },
+  {
     "id": "fakeitem_statue",
     "type": "ITEM",
     "subtypes": [ "TOOL" ],

--- a/data/mods/Sky_Island/missions_and_mapgen.json
+++ b/data/mods/Sky_Island/missions_and_mapgen.json
@@ -1061,7 +1061,13 @@
         "           "
       ],
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
-      "terrain": { "D": [ "t_door_c" ], "-": [ "t_wall_r_glow" ], ".": [ "t_carpet_red" ], "X": [ "t_carpet_red" ], "x": [ "t_carpet_red" ] },
+      "terrain": {
+        "D": [ "t_door_c" ],
+        "-": [ "t_wall_r_glow" ],
+        ".": [ "t_carpet_red" ],
+        "X": [ "t_carpet_red" ],
+        "x": [ "t_carpet_red" ]
+      },
       "furniture": { "X": [ "f_returnportal" ], "D": [ "f_null" ], ".": [ "f_null" ], "x": [ "f_null" ] }
     }
   },

--- a/data/mods/Sky_Island/missions_and_mapgen.json
+++ b/data/mods/Sky_Island/missions_and_mapgen.json
@@ -1061,7 +1061,7 @@
         "           "
       ],
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
-      "terrain": { "D": [ "t_door_c" ], "-": [ "t_wall_r" ], ".": [ "t_carpet_red" ], "X": [ "t_carpet_red" ], "x": [ "t_carpet_red" ] },
+      "terrain": { "D": [ "t_door_c" ], "-": [ "t_wall_r_glow" ], ".": [ "t_carpet_red" ], "X": [ "t_carpet_red" ], "x": [ "t_carpet_red" ] },
       "furniture": { "X": [ "f_returnportal" ], "D": [ "f_null" ], ".": [ "f_null" ], "x": [ "f_null" ] }
     }
   },


### PR DESCRIPTION

#### Summary
None

#### Purpose of change
Considering the rather otherworldly stuff with this whole Sky Island thing is, i feel like the Whoever-otherworldly-being-running-this can have the red exit room to be glowing noticeable in the night. 

#### Describe the solution

Adds a variant of the red wall that emits light and use it in the red exit room mapgen.

#### Describe alternatives you've considered

Keep it to myself.

#### Testing
![Screenshot_20260110_234347](https://github.com/user-attachments/assets/dabae04d-ed62-4c0c-b9c6-e98e84ef8ce7)

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
