### PR TITLE
Powered air purifying respirator blows make noise (reprise)

### DIFF
--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -2731,6 +2731,14 @@
       "target": "basic_papr_belt_off",
       "ammo_scale": 0
     },
+    "tick_action": {
+      "type": "sound",
+      "sound_type": "movement",
+      "sound_message": "whooooo…",
+      "sound_id": "humming",
+      "sound_variant": "machinery",
+      "sound_volume": 12
+    },
     "tool_ammo": [ "battery" ],
     "flags": [ "BELTED", "OVERSIZE", "ELECTRONIC", "TRADER_AVOID", "WATER_BREAK", "SPAWN_ACTIVE", "PAPR_BLOWER" ],
     "armor": [
@@ -2819,6 +2827,14 @@
       "target": "military_papr_blower_off",
       "ammo_scale": 0
     },
+    "tick_action": {
+      "type": "sound",
+      "sound_type": "movement",
+      "sound_message": "whooooo…",
+      "sound_id": "humming",
+      "sound_variant": "machinery",
+      "sound_volume": 12
+    },
     "tool_ammo": [ "battery" ],
     "flags": [ "BELTED", "OVERSIZE", "ELECTRONIC", "TRADER_AVOID", "SPAWN_ACTIVE", "PAPR_BLOWER" ],
     "armor": [
@@ -2906,6 +2922,14 @@
       "msg": "You turn the %s off.",
       "target": "molle_papr_blower_off",
       "ammo_scale": 0
+    },
+    "tick_action": {
+      "type": "sound",
+      "sound_type": "movement",
+      "sound_message": "whooooo…",
+      "sound_id": "humming",
+      "sound_variant": "machinery",
+      "sound_volume": 8
     },
     "tool_ammo": [ "battery" ],
     "flags": [ "WATER_FRIENDLY", "BELTED", "OVERSIZE", "ELECTRONIC", "TRADER_AVOID", "SPAWN_ACTIVE", "PAPR_BLOWER" ],

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -2682,7 +2682,7 @@
     "charges_per_use": 1,
     "use_action": {
       "type": "transform",
-      "msg": "You activate your %s.",
+      "msg": "You activate your %s and the fan starts to audibly whoosh.",
       "target": "basic_papr_belt_on",
       "need_charges": 1,
       "need_charges_msg": "The %s's batteries are dead."
@@ -2706,7 +2706,7 @@
     "type": "ITEM",
     "subtypes": [ "TOOL", "ARMOR" ],
     "name": { "str": "PAPR blower (on)", "str_pl": "PAPR blowers (on)" },
-    "description": "A blower unit for a powered air purifying respirator system.  It has been attached to a basic rubber and plastic belt.  If paired with a prepared PAPR mask, this will provide excellent protection against chemical, biological, radiological, and nuclear threats.",
+    "description": "A blower unit for a powered air purifying respirator system.  It has been attached to a basic rubber and plastic belt.  If paired with a prepared PAPR mask, this will provide excellent protection against chemical, biological, radiological, and nuclear threats.  The fan is audibly blowing.",
     "weight": "918 g",
     "volume": "1000 ml",
     "material": [ "rubber", "plastic" ],
@@ -2778,7 +2778,7 @@
     "charges_per_use": 1,
     "use_action": {
       "type": "transform",
-      "msg": "You activate your %s.",
+      "msg": "You activate your %s and the fan starts to audibly whoosh.",
       "target": "military_papr_blower_on",
       "need_charges": 1,
       "need_charges_msg": "The %s's batteries are dead."
@@ -2802,7 +2802,7 @@
     "type": "ITEM",
     "subtypes": [ "TOOL", "ARMOR" ],
     "name": { "str": "military PAPR blower (on)", "str_pl": "military PAPR blowers (on)" },
-    "description": "A sturdy blower unit for a powered air purifying respirator system.  Its large triangular body is designed to be worn on the back.  When active and paired with a prepared PAPR mask, this will provide excellent protection against chemical, biological, radiological, and nuclear threats.",
+    "description": "A sturdy blower unit for a powered air purifying respirator system.  Its large triangular body is designed to be worn on the back.  When active and paired with a prepared PAPR mask, this will provide excellent protection against chemical, biological, radiological, and nuclear threats.  The fan is audibly blowing.",
     "weight": "653 g",
     "volume": "3589 ml",
     "material": [ "rubber", "plastic" ],
@@ -2874,7 +2874,7 @@
     "charges_per_use": 1,
     "use_action": {
       "type": "transform",
-      "msg": "You activate your %s.",
+      "msg": "You activate your %s and the fan starts to audibly whoosh.",
       "target": "molle_papr_blower_on",
       "need_charges": 1,
       "need_charges_msg": "The %s's batteries are dead."
@@ -2898,7 +2898,7 @@
     "type": "ITEM",
     "subtypes": [ "TOOL", "ARMOR" ],
     "name": { "str": "modular PAPR blower (on)", "str_pl": "modular PAPR blowers (on)" },
-    "description": "A blower unit for a powered air purifying respirator system, built from a flexible silicon and butyl rubber blend.  Its components are arranged linearly in a narrow strip close to the body and is outfitted with straps to wear it about the waist.  If paired with the appropriate straps, it can also attached to any compatible MOLLE system.  When active and paired with a prepared PAPR mask, this will provide excellent protection against chemical, biological, radiological, and nuclear threats.",
+    "description": "A blower unit for a powered air purifying respirator system, built from a flexible silicon and butyl rubber blend.  Its components are arranged linearly in a narrow strip close to the body and is outfitted with straps to wear it about the waist.  If paired with the appropriate straps, it can also attached to any compatible MOLLE system.  When active and paired with a prepared PAPR mask, this will provide excellent protection against chemical, biological, radiological, and nuclear threats.  The fan is quietly blowing.",
     "weight": "920 g",
     "volume": "3000 ml",
     "material": [ "butyl_rubber", "plastic" ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Features "PAPRs make noise"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

PAPRs didn't make noise, and they should.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Active PAPR blowers now constantly make noise. Basic and military variants make 12. The modular variant makes 8 (as it is based on a real-world Avon MP-PAPR that operates more quietly).

Thanks to #84607, I was able to add noise as a tick_action to operate under the same rules as vehicles (which are noisy every tick, but don't spam the log).  The item description and activation message now make it clear that PAPRs make noise, but there are no log messages if on the PCs person.  If they are not on the PCs person, they produce log messages using the same rules as vehicles (i.e., approximately one every 100 ticks).

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Different noise values, but these seemed fine and there was no disagreement in discord.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Spawned items, turned on and off. Works as expected.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
