### PR TITLE
Supermarket memory cards are empty and known to be empty

### DIFF
--- a/data/json/itemgroups/SUS/supermarket.json
+++ b/data/json/itemgroups/SUS/supermarket.json
@@ -626,8 +626,8 @@
     "type": "item_group",
     "subtype": "distribution",
     "entries": [
-      { "group": "used_usb_drives", "prob": 60, "contents-group": "SUS_efiles_office", "count": [ 3, 8 ] },
-      { "group": "used_memory_cards", "prob": 60, "contents-group": "SUS_efiles_office", "count": [ 2, 7 ] },
+      { "group": "used_usb_drives", "prob": 60, "variables": [ { "browsed": "true" } ] },
+      { "group": "used_memory_cards", "prob": 60, "variables": [ { "browsed": "true" } ] },
       { "item": "battery_charger", "prob": 80 }
     ]
   },

--- a/doc/JSON/ITEM_SPAWN.md
+++ b/doc/JSON/ITEM_SPAWN.md
@@ -115,7 +115,8 @@ Each entry can have more values (shown above as `...`).  They allow further prop
 "artifact": <object>
 "event": <string>
 "snippets": <string>
-"faults": <object>
+"faults": <array>
+"variables": <global_variables:impl_t> (either string and string, or string and double)
 ```
 
 `contents` is added as contents of the created item.  It is not checked if they can be put into the item.  This allows water, that contains a book, that contains a steel frame, that contains a corpse.
@@ -152,7 +153,13 @@ Current possible values are:
   `chance`: chance to apply any of the faults. Default is 100, always apply
 For example:
 ```json
-  { "group": "nested_ar10", "prob": 89, "faults": { "id": [ "fault_stovepipe" ], "chance": 50 } },
+  { "group": "nested_ar10", "prob": 89, "faults": [ { "id": [ "fault_stovepipe" ], "chance": 50 } ] },
+```
+
+`variables`: Variables can be loaded into item at itemgroup level, if necessary:
+For example:
+```json
+  { "group": "used_usb_drives", "prob": 60, "variables": [ { "browsed": "true" } ] },
 ```
 
 `artifact`: This object determines that the item or group that is spawned by this entry will become an artifact. Here is an example:

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -4660,9 +4660,9 @@ void Item_factory::add_entry( Item_group &ig, const JsonObject &obj,
     }
 
     if( obj.has_array( "faults" ) ) {
-        for( const JsonObject jo : obj.get_object( "faults" ) ) {
+        for( const JsonObject &jo : obj.get_object( "faults" ) ) {
             int chance = jo.get_int( "chance", 100 );
-            for( std::string ids : jo.get_array( "id" ) ) {
+            for( const std::string &ids : jo.get_array( "id" ) ) {
                 modifier.faults.emplace_back( fault_id( ids ), chance );
             }
         }
@@ -4670,7 +4670,7 @@ void Item_factory::add_entry( Item_group &ig, const JsonObject &obj,
     }
 
     if( obj.has_array( "variables" ) ) {
-        for( const JsonObject jo : obj.get_array( "variables" ) ) {
+        for( const JsonObject &jo : obj.get_array( "variables" ) ) {
             for( const JsonMember &jv : jo ) {
                 diag_value dv;
                 mandatory( jo, false, jv.name(), dv );

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -4660,9 +4660,9 @@ void Item_factory::add_entry( Item_group &ig, const JsonObject &obj,
     }
 
     if( obj.has_array( "faults" ) ) {
-        for( const JsonObject &jo : obj.get_array( "faults" ) ) {
+        for( const JsonObject jo : obj.get_array( "faults" ) ) {
             int chance = jo.get_int( "chance", 100 );
-            for( const std::string &ids : jo.get_array( "id" ) ) {
+            for( const JsonValue &ids : jo.get_array( "id" ) ) {
                 modifier.faults.emplace_back( fault_id( ids ), chance );
             }
         }
@@ -4670,7 +4670,7 @@ void Item_factory::add_entry( Item_group &ig, const JsonObject &obj,
     }
 
     if( obj.has_array( "variables" ) ) {
-        for( const JsonObject &jo : obj.get_array( "variables" ) ) {
+        for( const JsonObject jo : obj.get_array( "variables" ) ) {
             for( const JsonMember &jv : jo ) {
                 diag_value dv;
                 mandatory( jo, false, jv.name(), dv );

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -4660,7 +4660,7 @@ void Item_factory::add_entry( Item_group &ig, const JsonObject &obj,
     }
 
     if( obj.has_array( "faults" ) ) {
-        for( const JsonObject &jo : obj.get_object( "faults" ) ) {
+        for( const JsonObject &jo : obj.get_array( "faults" ) ) {
             int chance = jo.get_int( "chance", 100 );
             for( const std::string &ids : jo.get_array( "id" ) ) {
                 modifier.faults.emplace_back( fault_id( ids ), chance );

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -25,6 +25,7 @@
 #include "itype.h"
 #include "iuse.h"
 #include "iuse_actor.h"
+#include "math_parser_diag_value.h"
 #include "options.h"
 #include "pocket_type.h"
 #include "relic.h"
@@ -524,6 +525,12 @@ void Item_modifier::modify( item &new_item, const std::string &context ) const
             if( x_in_y( f.second, 100 ) ) {
                 new_item.set_fault( f.first, false, false );
             }
+        }
+    }
+
+    if( !item_vars.empty() ) {
+        for( const auto &[str, diag_val] : item_vars ) {
+            new_item.set_var( str, diag_val );
         }
     }
 

--- a/src/item_group.h
+++ b/src/item_group.h
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "enums.h"
+#include "global_vars.h"
 #include "item.h"
 #include "relic.h"
 #include "type_id.h"
@@ -282,6 +283,11 @@ class Item_modifier
         * add this faults to item, if possible
         */
         std::vector<std::pair<fault_id, int>> faults;
+
+        /**
+        * add this variables to item
+        */
+        global_variables::impl_t item_vars;
 
         /**
          * Custom sub set of snippets to be randomly chosen from and then applied to the item.


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
USBs and memory cards in shop should be empty, and we know they are empty, so they should be `browsed` also
#### Describe the solution
Add a code to support writing vars to items at itemgroup level
Remove `contents-group` from memory cards and usbs in supermarket, write var "browsed" so they will be considered browsed
While there, fix `faults` itemgroup field to be a proper array, luckily no one used it yet
#### Testing
Before:
<img width="513" height="1440" alt="image" src="https://github.com/user-attachments/assets/5b3f796b-97f7-47b9-a9f0-73916c99fbc2" />

After:
<img width="575" height="408" alt="image" src="https://github.com/user-attachments/assets/eb20afc3-5e11-4f7c-9842-247d1dff3eba" />