### PR TITLE
[MoM] Rework Mycus world foliage

### DIFF
--- a/data/mods/MindOverMatter/dimensions/mycus_world/itemgroups.json
+++ b/data/mods/MindOverMatter/dimensions/mycus_world/itemgroups.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "item_group",
+    "id": "mom_mycus_forest_items",
+    "items": [ [ "rock", 40 ], [ "rock_flaking", 5 ], [ "flint", 2 ], [ "rock_large", 5 ] ]
+  }
+]

--- a/data/mods/MindOverMatter/dimensions/mycus_world/region_settings.json
+++ b/data/mods/MindOverMatter/dimensions/mycus_world/region_settings.json
@@ -43,7 +43,16 @@
     "type": "region_settings_terrain_furniture",
     "id": "mom_mycus_world",
     "copy-from": "default",
-    "ter_furn": [ "mom_mycus_world_t_region_groundcover", "mom_mycus_world_t_region_groundcover_forest" ]
+    "ter_furn": [
+      "mom_mycus_world_t_region_groundcover",
+      "mom_mycus_world_t_region_groundcover_forest",
+      "mom_mycus_world_t_region_tree",
+      "mom_mycus_world_t_region_tree_nut",
+      "mom_mycus_world_t_region_tree_fruit",
+      "mom_mycus_world_t_region_tree_shade",
+      "mom_mycus_world_t_region_tree_evergreen",
+      "mom_mycus_world_t_region_shrub"
+    ]
   },
   {
     "type": "region_terrain_furniture",
@@ -66,6 +75,7 @@
   {
     "type": "region_settings_forest_mapgen",
     "id": "mom_mycus_world",
+    "copy-from": "default",
     "biomes": [ "biome_forest_mom_mycus_world" ]
   },
   {
@@ -80,31 +90,40 @@
   {
     "type": "forest_biome_mapgen",
     "id": "biome_forest_mom_mycus_world",
+    "copy-from": "biome_forest_default",
     "terrains": [ "forest" ],
     "sparseness_adjacency_factor": 3,
     "item_group": "forest",
     "item_group_chance": 0,
     "item_spawn_iterations": 1,
-    "groundcover": [ [ "t_region_groundcover_forest", 1 ] ],
-    "components": [ "trees_forest", "shrubs_and_flowers_forest", "clutter_forest", "water_forest" ]
+    "groundcover": { "t_region_groundcover_forest": 1 },
+    "components": [
+      "trees_forest_mom_mycus",
+      "shrubs_and_flowers_forest_mom_mycus",
+      "clutter_forest_mom_mycus",
+      "water_forest_mom_mycus"
+    ]
   },
   {
     "type": "forest_biome_component",
-    "id": "trees_forest",
+    "id": "trees_forest_mom_mycus",
+    "copy-from": "trees_forest",
     "sequence": 0,
     "chance": 12,
     "types": [ [ "t_tree_fungal", 128 ], [ "t_tree_fungal_young", 32 ] ]
   },
   {
     "type": "forest_biome_component",
-    "id": "shrubs_and_flowers_forest",
+    "id": "shrubs_and_flowers_forest_mom_mycus",
+    "copy-from": "shrubs_and_flowers_forest",
     "sequence": 1,
     "chance": 10,
     "types": [ [ "t_shrub_fungal", 120 ], [ "t_tree_fungal_young", 10 ], [ "t_marloss", 1 ] ]
   },
   {
     "type": "forest_biome_component",
-    "id": "clutter_forest",
+    "id": "clutter_forest_mom_mycus",
+    "copy-from": "clutter_forest",
     "sequence": 2,
     "chance": 80,
     "types": [
@@ -120,9 +139,52 @@
   },
   {
     "type": "forest_biome_component",
-    "id": "water_forest",
+    "id": "water_forest_mom_mycus",
+    "copy-from": "clutter_forest",
     "sequence": 3,
     "chance": 512,
     "types": [ [ "t_puddle", 1 ], [ "t_puddle_mycus", 10 ] ]
+  },
+  {
+    "type": "region_terrain_furniture",
+    "id": "mom_mycus_world_t_region_tree",
+    "ter_id": "t_region_tree",
+    "replace_with_terrain": [ [ "t_tree_fungal", 128 ], [ "t_tree_fungal_young", 32 ] ]
+  },
+  {
+    "type": "region_terrain_furniture",
+    "id": "mom_mycus_world_t_region_tree_nut",
+    "ter_id": "t_region_tree",
+    "replace_with_terrain": [ [ "t_tree_fungal", 128 ], [ "t_tree_fungal_young", 32 ] ]
+  },
+  {
+    "type": "region_terrain_furniture",
+    "id": "mom_mycus_world_t_region_tree_fruit",
+    "ter_id": "t_region_tree",
+    "replace_with_terrain": [ [ "t_tree_fungal", 128 ], [ "t_tree_fungal_young", 32 ] ]
+  },
+  {
+    "type": "region_terrain_furniture",
+    "id": "mom_mycus_world_t_region_tree_shade",
+    "ter_id": "t_region_tree",
+    "replace_with_terrain": [ [ "t_tree_fungal", 128 ], [ "t_tree_fungal_young", 32 ] ]
+  },
+  {
+    "type": "region_terrain_furniture",
+    "id": "mom_mycus_world_t_region_tree_evergreen",
+    "ter_id": "t_region_tree",
+    "replace_with_terrain": [ [ "t_tree_fungal", 128 ], [ "t_tree_fungal_young", 32 ] ]
+  },
+  {
+    "type": "region_terrain_furniture",
+    "id": "mom_mycus_world_t_region_tree_evergreen",
+    "ter_id": "t_region_tree",
+    "replace_with_terrain": [ [ "t_tree_fungal", 128 ], [ "t_tree_fungal_young", 32 ] ]
+  },
+  {
+    "type": "region_terrain_furniture",
+    "id": "mom_mycus_world_t_region_shrub",
+    "ter_id": "t_region_shrub",
+    "replace_with_terrain": [ [ "t_shrub_fungal", 120 ], [ "t_tree_fungal_young", 10 ], [ "t_marloss", 1 ] ]
   }
 ]

--- a/data/mods/MindOverMatter/dimensions/mycus_world/region_settings.json
+++ b/data/mods/MindOverMatter/dimensions/mycus_world/region_settings.json
@@ -12,6 +12,7 @@
     "lakes": null,
     "ocean": null,
     "forests": "mom_mycus_world",
+    "forest_composition": "mom_mycus_world",
     "terrain_furniture": "mom_mycus_world",
     "default_oter": [
       "open_air",
@@ -93,8 +94,8 @@
     "copy-from": "biome_forest_default",
     "terrains": [ "forest" ],
     "sparseness_adjacency_factor": 3,
-    "item_group": "forest",
-    "item_group_chance": 0,
+    "item_group": "mom_mycus_forest_items",
+    "item_group_chance": 1,
     "item_spawn_iterations": 1,
     "groundcover": { "t_region_groundcover_forest": 1 },
     "components": [


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "[MoM] Rework Mycus world foliage"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fixes #84619 
Fixes #84595 

This DOES _NOT_ break the Mycus world's forests. 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Give the Mycus world's forest unique IDs, ~~breaking the dimension and causing pseudoterrain. However, this does fix regular forests, and to be honest I'm not sure it's possible to have separate forest mapgen on a dimensional basis right now--nothing I tried worked and there are no in-repo examples (every example changes the default forest).~~

Found it, it's `forest_composition` that I was missing.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Regular forests are back to normal.
Mycus world forests are fungal.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Now I can rework the standing portal in the crimson meadow so you can go to that world.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
