### PR TITLE
Obsolete ACT_ARMOR_LAYERS, move to uistate::open_menu

### DIFF
--- a/data/json/obsoletion_and_migration_0.J/player_activities.json
+++ b/data/json/obsoletion_and_migration_0.J/player_activities.json
@@ -36,5 +36,13 @@
     "based_on": "time",
     "ignored_distractions": [ "hunger", "thirst" ],
     "can_resume": false
+  },
+  {
+    "id": "ACT_ARMOR_LAYERS",
+    "type": "activity_type",
+    "activity_level": "NO_EXERCISE",
+    "verb": "fiddling with your clothes",
+    "based_on": "time",
+    "can_resume": false
   }
 ]

--- a/data/json/player_activities.json
+++ b/data/json/player_activities.json
@@ -559,14 +559,6 @@
     "auto_needs": true
   },
   {
-    "id": "ACT_ARMOR_LAYERS",
-    "type": "activity_type",
-    "activity_level": "NO_EXERCISE",
-    "verb": "fiddling with your clothes",
-    "based_on": "neither",
-    "can_resume": false
-  },
-  {
     "id": "ACT_START_FIRE",
     "type": "activity_type",
     "activity_level": "NO_EXERCISE",

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -20,7 +20,6 @@
 #include "calendar.h"
 #include "cata_utility.h"
 #include "character.h"
-#include "character_attire.h"
 #include "character_id.h"
 #include "character_martial_arts.h"
 #include "clzones.h"
@@ -82,7 +81,6 @@
 #include "vpart_position.h"
 #include "weather.h"
 
-static const activity_id ACT_ARMOR_LAYERS( "ACT_ARMOR_LAYERS" );
 static const activity_id ACT_ATM( "ACT_ATM" );
 static const activity_id ACT_DISMEMBER( "ACT_DISMEMBER" );
 static const activity_id ACT_FERTILIZE_PLOT( "ACT_FERTILIZE_PLOT" );
@@ -175,7 +173,6 @@ activity_handlers::do_turn_functions = {
     { ACT_VEHICLE_DECONSTRUCTION, vehicle_deconstruction_do_turn },
     { ACT_VEHICLE_REPAIR, vehicle_repair_do_turn },
     { ACT_MULTIPLE_CHOP_TREES, chop_trees_do_turn },
-    { ACT_ARMOR_LAYERS, armor_layers_do_turn },
     { ACT_ATM, atm_do_turn },
     { ACT_REPAIR_ITEM, repair_item_do_turn },
     { ACT_TRAVELLING, travel_do_turn },
@@ -1217,12 +1214,6 @@ void activity_handlers::travel_do_turn( player_activity *act, Character *you )
         ui::omap::force_quit();
     }
     act->set_to_null();
-}
-
-void activity_handlers::armor_layers_do_turn( player_activity *, Character *you )
-{
-    you->cancel_activity();
-    you->worn.sort_armor( *you );
 }
 
 void activity_handlers::atm_do_turn( player_activity *, Character *you )

--- a/src/activity_handlers.h
+++ b/src/activity_handlers.h
@@ -194,7 +194,6 @@ void generic_game_turn_handler( player_activity *act, Character *you, int morale
                                 int morale_max_bonus );
 
 /** activity_do_turn functions: */
-void armor_layers_do_turn( player_activity *act, Character *you );
 void atm_do_turn( player_activity *act, Character *you );
 void dismember_do_turn( player_activity *act, Character *you );
 void chop_trees_do_turn( player_activity *act, Character *you );

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -36,7 +36,6 @@
 #include "weather.h"
 
 static const activity_id ACT_AIM( "ACT_AIM" );
-static const activity_id ACT_ARMOR_LAYERS( "ACT_ARMOR_LAYERS" );
 static const activity_id ACT_ATM( "ACT_ATM" );
 static const activity_id ACT_CHOP_LOGS( "ACT_CHOP_LOGS" );
 static const activity_id ACT_CHOP_PLANKS( "ACT_CHOP_PLANKS" );
@@ -140,7 +139,6 @@ std::optional<std::string> player_activity::get_progress_message( const avatar &
     }
 
     if( type == ACT_AIM ||
-        type == ACT_ARMOR_LAYERS ||
         type == ACT_ATM ||
         type == ACT_INVOKE_ITEM
       ) {

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -412,7 +412,8 @@ void player_activity::deserialize( const JsonObject &data )
         "ACT_EAT_MENU", // Remove after 0.J
         "ACT_CONSUME_FOOD_MENU", // Remove after 0.J
         "ACT_CONSUME_DRINK_MENU", // Remove after 0.J
-        "ACT_CONSUME_MEDS_MENU" // Remove after 0.J
+        "ACT_CONSUME_MEDS_MENU", // Remove after 0.J
+        "ACT_ARMOR_LAYERS" // Remove after 0.J
     };
     if( !data.read( "type", tmptype ) ) {
         // Then it's a legacy save.

--- a/src/savegame_legacy.cpp
+++ b/src/savegame_legacy.cpp
@@ -10,7 +10,6 @@
 #include "type_id.h"
 
 static const activity_id ACT_AIM( "ACT_AIM" );
-static const activity_id ACT_ARMOR_LAYERS( "ACT_ARMOR_LAYERS" );
 static const activity_id ACT_ATM( "ACT_ATM" );
 static const activity_id ACT_BURROW( "ACT_BURROW" );
 static const activity_id ACT_BUTCHER( "ACT_BUTCHER" );
@@ -223,7 +222,7 @@ void player_activity::deserialize_legacy_type( int legacy_type, activity_id &des
         ACT_PICKUP,
         ACT_MOVE_ITEMS,
         activity_id::NULL_ID(), // ACT_ADV_INVENTORY is uistate.open_menu now
-        ACT_ARMOR_LAYERS,
+        activity_id::NULL_ID(), // ACT_ARMOR_LAYERS is uistate.open_menu now
         ACT_START_FIRE,
         ACT_OPEN_GATE,
         ACT_FILL_LIQUID,


### PR DESCRIPTION

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Infrastructure "obsolete ACT_ARMOR_LAYERS, move to uistate::open_menu"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Update legacy activities.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

See title. Same principle as #84348 in that ACT_ARMOR_LAYERS was a hack to reopen the sort armor menu.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

- Opened sort armor menu, equipped and removed clothing items, menu reopened correctly. Also tested moving equipment order, works as intended.
- The legacy activity takes place in one turn and can't be serialized, so testing a 0.H save isn't possible/necessary as far as I can tell.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
