### PR TITLE
[MoM] Add Rainywood Oubliette dimension

### DIFF
--- a/data/mods/MindOverMatter/dimensions/innawood_rainy_mom.json
+++ b/data/mods/MindOverMatter/dimensions/innawood_rainy_mom.json
@@ -1,0 +1,21 @@
+[
+  {
+    "type": "region_settings",
+    "id": "mom_innawood_rainy",
+    "copy-from": "default",
+    "cities": null,
+    "highways": null,
+    "place_roads": false,
+    "weather": "mom_innawood_rainy",
+    "feature_flag_settings": { "blacklist": [ "LAB", "MAN_MADE", "MILITARY", "URBAN", "FARM", "EXODII", "HIGHLANDS" ], "whitelist": [  ] }
+  },
+  {
+    "type": "weather_generator",
+    "id": "mom_innawood_rainy",
+    "copy-from": "default",
+    "base_temperature": 8.5,
+    "base_humidity": 75.0,
+    "base_pressure": 999,
+    "base_wind": 4.4
+  }
+]

--- a/data/mods/MindOverMatter/dimensions/innawood_rainy_mom.json
+++ b/data/mods/MindOverMatter/dimensions/innawood_rainy_mom.json
@@ -14,7 +14,7 @@
     "id": "mom_innawood_rainy",
     "copy-from": "default",
     "base_temperature": 8.5,
-    "base_humidity": 75.0,
+    "base_humidity": 80.0,
     "base_pressure": 999,
     "base_wind": 4.4
   }

--- a/data/mods/MindOverMatter/monsters/monster_eoc_spells.json
+++ b/data/mods/MindOverMatter/monsters/monster_eoc_spells.json
@@ -590,7 +590,7 @@
     "effect": [
       { "math": [ "_dimension_time = 3600 + rand(259200)" ] },
       {
-        "switch": { "math": [ "rand(4)" ] },
+        "switch": { "math": [ "rand(6)" ] },
         "cases": [
           {
             "case": 0,
@@ -610,6 +610,20 @@
             "case": 3,
             "effect": [
               {
+                "u_travel_to_dimension": "mom_innawood_rainy",
+                "npc_travel_radius": 0,
+                "region_type": "mom_innawood_rainy",
+                "npc_travel_filter": "none",
+                "fail_message": "You experience brief vertigo, but nothing dangerous seems to happen.",
+                "success_message": "Your surroundings warp and fold before reforming into a strange landscape."
+              },
+              { "run_eocs": "EOC_PORTAL_OUBLIETTE_RETURN", "time_in_future": { "math": [ "_dimension_time" ] } }
+            ]
+          },
+          {
+            "case": 5,
+            "effect": [
+              {
                 "u_travel_to_dimension": "highlands",
                 "npc_travel_radius": 0,
                 "region_type": "highlands",
@@ -621,7 +635,7 @@
             ]
           },
           {
-            "case": 4,
+            "case": 6,
             "effect": [
               {
                 "u_travel_to_dimension": "mycus_world",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[MoM] Add Rainywood Oubliette dimension"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

#84565 made me think a dimension of near-constant rain would be a nice brief challenge.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the rainywood dimension as a possible Oubliette destination. It's like Innawood, but `base_pressure` is 999 and `base_humidity` is 80, so it rains a _lot_. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Waited in Rainywood three days, it rained literally the entire time.

(About half drizzle, but there were 3 lightning storms)

Also next up....triffid world?
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
