### PR TITLE
If ‘force‘ is set for EOC u_teleport, skip collision test for vehicle

### DIFF
--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -4457,7 +4457,7 @@ You or NPC is teleported to `target_var` coordinates
 | "u_teleport", / "npc_teleport" | **mandatory** | [variable object](#variable-object) | location to teleport; should use `target_var`, created previously |
 | "success_message" | optional | string or [variable object](#variable-object) | message, that would be printed, if teleportation was successful |
 | "fail_message" | optional | string or [variable object](#variable-object) | message, that would be printed, if teleportation was failed, like if coordinates contained creature or impassable obstacle (like wall) |
-| "force" | optional | boolean | default false; if true, teleportation can't fail - any creature, that stand on target coordinates, would be brutally telefragged, and if impassable obstacle occur, the closest point would be picked instead |
+| "force" | optional | boolean | default false; if true, teleportation can't fail - any creature, that stand on target coordinates, would be brutally telefragged, and if impassable obstacle occur, the closest point would be picked instead. For the vehicle, collision test will be skipped. |
 | "force_safe" | optional | boolean | default false; if true, teleportation cannot^(tm) fail.  If there is a creature or obstacle at the target coordinate, the closest passable point within 5 horizontal tiles is picked instead.  If there is no point, the creature remains where they are. |
 
 ##### Valid talkers:

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -7837,7 +7837,7 @@ talk_effect_fun_t::func f_teleport( const JsonObject &jo, std::string_view membe
         }
         vehicle *veh = d.actor( is_npc )->get_vehicle();
         if( veh ) {
-            if( teleport::teleport_vehicle( *veh, target_pos ) ) {
+            if( teleport::teleport_vehicle( *veh, target_pos, force ) ) {
                 add_msg( success_message.evaluate( d ) );
             } else {
                 add_msg( fail_message.evaluate( d ) );

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -390,7 +390,7 @@ bool teleport::teleport_to_point( Creature &critter, tripoint_bub_ms target, boo
     return true;
 }
 
-bool teleport::teleport_vehicle( vehicle &veh, const tripoint_abs_ms &dp )
+bool teleport::teleport_vehicle( vehicle &veh, const tripoint_abs_ms &dp, bool force )
 {
     map &here = get_map();
     map *dest = &here;
@@ -439,7 +439,8 @@ bool teleport::teleport_vehicle( vehicle &veh, const tripoint_abs_ms &dp )
             break;
         }
     }
-    if( !TestForVehicleTeleportCollision( veh, here, dest, dp ) ) {
+    // Once forced teleportation is specified, collision test is skipped.
+    if( !force && !TestForVehicleTeleportCollision( veh, here, dest, dp ) ) {
         return false;
     }
     here.memory_clear_vehicle_points( veh );

--- a/src/teleport.h
+++ b/src/teleport.h
@@ -17,7 +17,7 @@ class teleport
                                        bool add_teleglow = true );
         static bool teleport_to_point( Creature &critter, tripoint_bub_ms target, bool safe,
                                        bool add_teleglow, bool display_message = true, bool force = false, bool force_safe = false );
-        static bool teleport_vehicle( vehicle &veh, const tripoint_abs_ms &dp );
+        static bool teleport_vehicle( vehicle &veh, const tripoint_abs_ms &dp, bool force = false );
         static bool teleport_zone( zone_data &zone, const tripoint_abs_ms &dp );
 
 };


### PR DESCRIPTION
#### Summary
Features "If ‘force‘ is set for EOC u_teleport, skip collision test for vehicle"

#### Purpose of change

When I use the EOC u_teleport teleportation vehicle, it gets intercepted in this method, preventing successful teleportation.
That truck highlighted in the screenshot was flagged as having a collision. After debugging, I found that the MoveCost here is 0.

I’ve pinpointed the collision cause: the vehicle part 'board' collided with the adjacent furniture 'f_432gal_drum_rubber'. This bug is so bizarre—it shouldn’t even be in the same Tile.

<img width="869" height="821" alt="image" src="https://github.com/user-attachments/assets/2462cc50-2315-456e-aa2b-bae120ebddc9" />


#### Describe the solution

Before identifying the root cause of the bug, the current solution I think is to enable the force parameter in u_teleport to bypass collision test. When developers explicitly set 'force' to true, this approach aligns with the semantics of this EOC.

#### Describe alternatives you've considered

Identifying the root cause of the bug, the final solution may still require assistance from core developers for troubleshooting.

#### Testing

I tested a scenario where a vehicle would definitely fail to teleport due to collision detection. When I set the force parameter of u_teleport to true, the teleportation succeeded.

#### Additional context

None
