### PR TITLE
Fix segfaulting input_context lifetime issues.

### DIFF
--- a/src/input_context.h
+++ b/src/input_context.h
@@ -1,16 +1,14 @@
 #pragma once
 
 #include <functional>
+#include <list>
 #include <map>
+#include <memory>
 #include <optional>
 #include <set>
 #include <string>
 #include <string_view>
 #include <vector>
-
-#if defined(__ANDROID__) || defined(TILES)
-#include <list>
-#endif
 
 #include "action.h"
 #include "coords_fwd.h"
@@ -37,19 +35,44 @@ class window;
  * This turns this class into an abstraction method between actual
  * input(keyboard, gamepad etc.) and game.
  */
+class input_context;
+struct input_context_handle {
+    input_context *cxtx;
+};
+
+class input_context_stack_impl
+{
+    public:
+        input_context *back();
+        void pop();
+        void push( std::shared_ptr<input_context_handle> const &context );
+
+    private:
+        std::list<std::weak_ptr<input_context_handle>> stack;
+        input_context *reap();
+
+};
+
 class input_context
 {
         friend class keybindings_ui;
+
+        // We use a shared_ptr to an intermediate handle object to resolve lifecycle issues with the
+        // input_context_stack. Each input_context will own a handle which holds a raw pointer back
+        // to the input_context. We store a weak_ptr to the handle in the input_context_stack. The
+        // destructor for input_context will safely destruct the handle, input_context_stack will
+        // lazily reap dead weak_ptrs on the next access.
+        std::shared_ptr<input_context_handle> handle{ new input_context_handle{this} };
+
     public:
 #if defined(__ANDROID__) || defined(TILES)
         // Whatever's on top is our current input context.
-        static std::list<input_context *> input_context_stack;
+        static input_context_stack_impl input_context_stack;
 #endif
-
         input_context() : registered_any_input( false ), category( "default" ),
             coordinate_input_received( false ), handling_coordinate_input( false ) {
 #if defined(__ANDROID__) || defined(TILES)
-            input_context_stack.push_back( this );
+            input_context_stack.push( handle );
 #endif
 #if defined(__ANDROID__)
             allow_text_entry = false;
@@ -64,7 +87,7 @@ class input_context
               coordinate_input_received( false ), handling_coordinate_input( false ),
               preferred_keyboard_mode( preferred_keyboard_mode ) {
 #if defined(__ANDROID__) || defined(TILES)
-            input_context_stack.push_back( this );
+            input_context_stack.push( handle );
 #endif
 #if defined(__ANDROID__)
             allow_text_entry = false;
@@ -73,9 +96,7 @@ class input_context
         }
 
 #if defined(__ANDROID__) || defined(TILES)
-        virtual ~input_context() {
-            input_context_stack.remove( this );
-        }
+        virtual ~input_context() = default;
 #endif
 
 #if defined(__ANDROID__)

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -2521,10 +2521,6 @@ static void draw_gamepad_radial_menu()
         return;
     }
 
-    if( input_context::input_context_stack.empty() ) {
-        return;
-    }
-
     input_context *ctxt = input_context::input_context_stack.back();
     if( !ctxt ) {
         return;
@@ -2823,23 +2819,21 @@ static void CheckMessages()
     }
 
     // Copy the current input context
-    if( !input_context::input_context_stack.empty() ) {
-        input_context *new_input_context = *--input_context::input_context_stack.end();
-        if( new_input_context && *new_input_context != touch_input_context ) {
+    input_context *new_input_context = input_context::input_context_stack.back();
+    if( new_input_context && *new_input_context != touch_input_context ) {
 
-            // If we were in an allow_text_entry input context, and text input is still active, and we're auto-managing keyboard, hide it.
-            if( touch_input_context.allow_text_entry &&
-                !new_input_context->allow_text_entry &&
-                !is_string_input( *new_input_context ) &&
-                SDL_IsTextInputActive() &&
-                get_option<bool>( "ANDROID_AUTO_KEYBOARD" ) ) {
-                StopTextInput();
-            }
-
-            touch_input_context = *new_input_context;
-            needupdate = true;
-            ui_manager::redraw_invalidated();
+        // If we were in an allow_text_entry input context, and text input is still active, and we're auto-managing keyboard, hide it.
+        if( touch_input_context.allow_text_entry &&
+            !new_input_context->allow_text_entry &&
+            !is_string_input( *new_input_context ) &&
+            SDL_IsTextInputActive() &&
+            get_option<bool>( "ANDROID_AUTO_KEYBOARD" ) ) {
+            StopTextInput();
         }
+
+        touch_input_context = *new_input_context;
+        needupdate = true;
+        ui_manager::redraw_invalidated();
     }
 
     bool is_default_mode = touch_input_context.get_category() == "DEFAULTMODE";


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Possibly addresses #84600. Also hopefully fixes existing failures in the linux asan build. There are spooky lifetime issues with input_context and input_context_stack, which is never great.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Change the stack to a stack of weak_ptrs to a handle which holds the raw pointers to the original input_stack. Then add a shared_ptr to the handle to input_context, which is destroyed when the owning context is destroyed. This indirection means we don't have to refactor the entire input_context api to use a pointer type, and the destructor for input_context doesn't race with the destructor for input_context_stack.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Load and save and quit my game. CI, specifically the asan build, should pass.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
