### PR TITLE
Improve apis npc

### DIFF
--- a/data/json/npcs/classes.json
+++ b/data/json/npcs/classes.json
@@ -399,10 +399,11 @@
     "bonus_dex": { "rng": [ 5, 10 ] },
     "bonus_int": { "rng": [ -4, -8 ] },
     "bonus_per": { "rng": [ 4, 8 ] },
+    "bonus_str": { "rng": [ 2, 4 ] },
     "skills": [
-      { "skill": "dodge", "level": { "dice": [ 2, 2 ] } },
-      { "skill": "melee", "level": { "dice": [ 2, 2 ] } },
-      { "skill": "unarmed", "level": { "dice": [ 2, 2 ] } }
+      { "skill": "dodge", "level": { "dice": [ 5, 5 ] } },
+      { "skill": "melee", "level": { "dice": [ 5, 5 ] } },
+      { "skill": "unarmed", "level": { "dice": [ 5, 5 ] } }
     ],
     "worn_override": "EMPTY_GROUP",
     "carry_override": "EMPTY_GROUP",
@@ -415,12 +416,18 @@
       [ "MANDIBLES", 100 ],
       [ "TAIL_STING", 100 ],
       [ "INSECT_ARMS_OK", 100 ],
-      [ "CHITIN3", 100 ],
+      [ "CHITIN", 100 ],
+      [ "CHITIN2", 100 ],
       [ "POISONOUS2", 100 ],
       [ "PAINRESIST", 100 ],
       [ "ADRENALINE", 100 ],
       [ "FLEET2", 100 ],
-      [ "ANTENNAE", 100 ]
+      [ "ANTENNAE", 100 ],
+      [ "COMPOUND_EYES", 100 ],
+      [ "MUTE_INSECT", 100 ],
+      [ "PROBOSCIS", 100 ],
+      [ "personality_brave", 100 ],
+      [ "personality_aggressive_plus", 100 ]
     ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Balance "Apis npc is more insectoid, more brave, less talkative, and more dangerous"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Apis was a really old and weird npc. It had sclerotin plate, a spider-only mutation, but no epicuticle, which is supposed to be the "underlayer" for a chitinous mutant. They were also not very threatening, and also were in my experience extremely cowardly (I could stand directly adjacent to them and they'd never attack me), and were missing some new mutations for insect, and also were very talkative ("You hear Apis saying "What was that? I thought I heard BZZZZZZZZZZ"). It's supposed to be ambiguous if Apis is a bee that turned into a person or a person that turned into a bee, so them speaking English is a no-no.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
1. Apis gets personality_brave and personality_volatile to hopefully ensure they are more likely to actually attack you when hostile.
2. Apis gets CHITIN and CHITIN2 instead of only CHITIN3.
3. Apis gets PROBOSCIS and COMPOUND_EYES.
4. Apis gets MUTE_INESCT.
5. Apis gets their strength increased by 2-4.
6. Apis gets their skills increased from 2 melee/dodge/unarmed to 5 melee/dodge/unarmed.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Give apis regular mute. I think it's funny that they specifically have the insect version even though from the player's perspective they do the same thing.
- Remove apis, add queen bee.
- Make a flag to make NPCs butcher into mutant humanoid meat, because Apis is still made of perfectly edible and non toxic human.
- Add a route for the player to become an apis themselves by creating a hive-specific variant of royal jelly and giving that toxins, insect mutagen, mutagen catalyst, and a small amount of alpha mutagen (so it's unclear if a regular bee ate the jelly and became humanoid like a mouse of nema situation)
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
