### PR TITLE
[Xedra Evolved] Sidebar updates

### DIFF
--- a/data/mods/Xedra_Evolved/ui/mana_widgets.json
+++ b/data/mods/Xedra_Evolved/ui/mana_widgets.json
@@ -1,0 +1,71 @@
+[
+  {
+    "//": "Maximum mana points, in light blue color.",
+    "id": "xe_max_mana_num",
+    "type": "widget",
+    "label": "Max Mana",
+    "style": "number",
+    "var": "max_mana",
+    "colors": [ "c_pink" ]
+  },
+  {
+    "//": "Base widget for other mana widgets to copy-from.  Sets var and colors.",
+    "id": "xe_mana_base",
+    "type": "widget",
+    "var": "mana",
+    "colors": [ "c_red", "c_light_red", "c_yellow", "c_pink" ]
+  },
+  {
+    "//": "Current number of mana points, with color.",
+    "id": "xe_mana_num",
+    "type": "widget",
+    "copy-from": "xe_mana_base",
+    "label": "Mana",
+    "style": "number"
+  },
+  {
+    "//": "Wide bar-graph of current mana level, using the default 'bucket' fill.",
+    "id": "xe_mana_graph",
+    "type": "widget",
+    "copy-from": "xe_mana_base",
+    "label": "Mana",
+    "style": "graph",
+    "width": 25,
+    "symbols": ".-=#",
+    "fill": "bucket"
+  },
+  {
+    "//": "Like the mana graph, but using a 'pool' fill.",
+    "id": "xe_mana_pool",
+    "type": "widget",
+    "copy-from": "xe_mana_graph",
+    "fill": "pool"
+  },
+  {
+    "//": "Both current and maximum mana numbers, side by side",
+    "id": "xe_current_max_mana_nums_layout",
+    "type": "widget",
+    "label": "Xedra Current/Max Mana",
+    "style": "layout",
+    "arrange": "columns",
+    "widgets": [ "xe_mana_num", "xe_max_mana_num" ]
+  },
+  {
+    "//": "Bar graph of current mana, with 'bucket' fill.",
+    "id": "xe_mana_graph_layout",
+    "type": "widget",
+    "style": "layout",
+    "label": "Xedra Mana Graph",
+    "arrange": "columns",
+    "widgets": [ "xe_mana_graph" ]
+  },
+  {
+    "//": "Bar graph of current mana, with 'pool' fill.",
+    "id": "xe_mana_pool_layout",
+    "type": "widget",
+    "style": "layout",
+    "label": "Xedra Mana Pool",
+    "arrange": "columns",
+    "widgets": [ "xe_mana_pool" ]
+  }
+]

--- a/data/mods/Xedra_Evolved/ui/ruach_counter.json
+++ b/data/mods/Xedra_Evolved/ui/ruach_counter.json
@@ -1,56 +1,5 @@
 [
   {
-    "id": "ruach_counter_meter_block",
-    "type": "widget",
-    "style": "layout",
-    "label": "Ruach Descriptor",
-    "arrange": "minimum_columns",
-    "widgets": [ "ruach_counter_meter" ]
-  },
-  {
-    "id": "ruach_counter_numbers_block",
-    "type": "widget",
-    "style": "layout",
-    "label": "Ruach Numbers",
-    "arrange": "minimum_columns",
-    "widgets": [ "ruach_counter_numbers" ]
-  },
-  {
-    "id": "ruach_counter_graph_block",
-    "type": "widget",
-    "style": "layout",
-    "label": "Ruach Graph",
-    "arrange": "minimum_columns",
-    "widgets": [ "ruach_counter_graph" ]
-  },
-  {
-    "id": "spacebar_ruach_counter_block",
-    "type": "widget",
-    "style": "layout",
-    "label": "Ruach Descriptor",
-    "arrange": "minimum_columns",
-    "width": 58,
-    "widgets": [ "spacebar_separator_2", "ruach_counter_meter" ]
-  },
-  {
-    "id": "spacebar_ruach_numbers_block",
-    "type": "widget",
-    "style": "layout",
-    "label": "Ruach Numbers",
-    "arrange": "minimum_columns",
-    "width": 58,
-    "widgets": [ "spacebar_separator_2", "ruach_counter_spacebar_numbers" ]
-  },
-  {
-    "id": "spacebar_ruach_graph_block",
-    "type": "widget",
-    "style": "layout",
-    "label": "Ruach Graph",
-    "arrange": "minimum_columns",
-    "width": 58,
-    "widgets": [ "spacebar_separator_2", "ruach_counter_spacebar_graph" ]
-  },
-  {
     "id": "ruach_counter_meter",
     "type": "widget",
     "style": "text",
@@ -120,7 +69,7 @@
         }
       }
     ],
-    "padding": 0
+    "padding": 1
   },
   {
     "id": "ruach_counter_numbers",
@@ -136,56 +85,7 @@
         "condition": { "u_has_trait": "LILIN_TRAITS" }
       }
     ],
-    "padding": 0
-  },
-  {
-    "id": "ruach_counter_spacebar_numbers",
-    "type": "widget",
-    "style": "text",
-    "label": "Ruach",
-    "flags": [ "W_DISABLED_WHEN_EMPTY" ],
-    "clauses": [
-      {
-        "id": "ruach_numbers",
-        "text": "<color_green><u_val:ruach_amount_for_graph></color>          Max: <color_green><u_val:ruach_max_amount_for_graph></color>          Days: <color_green><u_val:ruach_days_left></color>",
-        "parse_tags": true,
-        "condition": { "u_has_trait": "LILIN_TRAITS" }
-      }
-    ],
-    "padding": 0
-  },
-  {
-    "id": "ruach_counter_spacebar_graph",
-    "type": "widget",
-    "label": "Ruach",
-    "var": "custom",
-    "custom_var": {
-      "value": { "math": [ "u_vitamin('lilin_ruach_vitamin')" ] },
-      "range": [
-        0,
-        {
-          "math": [
-            "(1680 + (u_has_trait('LILIN_HOLD_MORE_RUACH') * 1680) + (u_has_trait('LILIN_HOLD_MORE_RUACH_2') * 1680) + (u_has_trait('LILIN_HOLD_MORE_RUACH_3') * 1680) ) * 0.333333"
-          ]
-        },
-        {
-          "math": [
-            "(1680 + (u_has_trait('LILIN_HOLD_MORE_RUACH') * 1680) + (u_has_trait('LILIN_HOLD_MORE_RUACH_2') * 1680) + (u_has_trait('LILIN_HOLD_MORE_RUACH_3') * 1680) ) * 0.6666666"
-          ]
-        },
-        {
-          "math": [
-            "1680 + (u_has_trait('LILIN_HOLD_MORE_RUACH') * 1680) + (u_has_trait('LILIN_HOLD_MORE_RUACH_2') * 1680) + (u_has_trait('LILIN_HOLD_MORE_RUACH_3') * 1680)"
-          ]
-        }
-      ]
-    },
-    "style": "graph",
-    "width": 56,
-    "symbols": ".יוא",
-    "fill": "bucket",
-    "colors": [ "c_red", "c_light_red", "c_yellow", "c_light_green", "c_green" ],
-    "padding": 0
+    "padding": 1
   },
   {
     "id": "ruach_counter_graph",
@@ -219,6 +119,6 @@
     "symbols": ".יוא",
     "fill": "bucket",
     "colors": [ "c_red", "c_light_red", "c_yellow", "c_light_green", "c_green" ],
-    "padding": 0
+    "padding": 1
   }
 ]

--- a/data/mods/Xedra_Evolved/ui/sidebar.json
+++ b/data/mods/Xedra_Evolved/ui/sidebar.json
@@ -1,72 +1,45 @@
 [
   {
-    "//": "Maximum mana points, in light blue color.",
-    "id": "xe_max_mana_num",
-    "type": "widget",
-    "label": "Max Mana",
-    "style": "number",
-    "var": "max_mana",
-    "colors": [ "c_pink" ]
+    "id": "blood_ruach_blank_line",
+    "string": "",
+    "style": "text",
+    "type": "widget"
   },
   {
-    "//": "Base widget for other mana widgets to copy-from.  Sets var and colors.",
-    "id": "xe_mana_base",
-    "type": "widget",
-    "var": "mana",
-    "colors": [ "c_red", "c_light_red", "c_yellow", "c_pink" ]
-  },
-  {
-    "//": "Current number of mana points, with color.",
-    "id": "xe_mana_num",
-    "type": "widget",
-    "copy-from": "xe_mana_base",
-    "label": "Mana",
-    "style": "number"
-  },
-  {
-    "//": "Wide bar-graph of current mana level, using the default 'bucket' fill.",
-    "id": "xe_mana_graph",
-    "type": "widget",
-    "copy-from": "xe_mana_base",
-    "label": "Mana",
-    "style": "graph",
-    "width": 25,
-    "symbols": ".-=#",
-    "fill": "bucket"
-  },
-  {
-    "//": "Like the mana graph, but using a 'pool' fill.",
-    "id": "xe_mana_pool",
-    "type": "widget",
-    "copy-from": "xe_mana_graph",
-    "fill": "pool"
-  },
-  {
-    "//": "Both current and maximum mana numbers, side by side",
-    "id": "xe_current_max_mana_nums_layout",
-    "type": "widget",
-    "label": "Xedra Current/Max Mana",
+    "clauses": [
+      { "condition": { "u_has_effect": "vampire_virus" }, "id": "content", "widgets": "vampire_blood_levels" },
+      { "condition": { "u_has_trait": "LILIN_TRAITS" }, "id": "content", "widgets": "ruach_counter_meter" }
+    ],
+    "default_clause": { "widgets": "blood_ruach_blank_line" },
+    "flags": [ "W_DISABLED_WHEN_EMPTY" ],
+    "label": "Blood/Ruach Descriptor",
+    "id": "blood_ruach_descriptor",
     "style": "layout",
-    "arrange": "columns",
-    "widgets": [ "xe_mana_num", "xe_max_mana_num" ]
+    "type": "widget"
   },
   {
-    "//": "Bar graph of current mana, with 'bucket' fill.",
-    "id": "xe_mana_graph_layout",
-    "type": "widget",
+    "clauses": [
+      { "condition": { "u_has_effect": "vampire_virus" }, "id": "content", "widgets": "vampire_blood_levels_numbers" },
+      { "condition": { "u_has_trait": "LILIN_TRAITS" }, "id": "content", "widgets": "ruach_counter_numbers" }
+    ],
+    "default_clause": { "widgets": "blood_ruach_blank_line" },
+    "flags": [ "W_DISABLED_WHEN_EMPTY" ],
+    "label": "Blood/Ruach Numbers",
+    "id": "blood_ruach_numbers",
     "style": "layout",
-    "label": "Xedra Mana Graph",
-    "arrange": "columns",
-    "widgets": [ "xe_mana_graph" ]
+    "type": "widget"
   },
   {
-    "//": "Bar graph of current mana, with 'pool' fill.",
-    "id": "xe_mana_pool_layout",
-    "type": "widget",
+    "clauses": [
+      { "condition": { "u_has_effect": "vampire_virus" }, "id": "content", "widgets": "vampire_blood_levels_graph" },
+      { "condition": { "u_has_trait": "LILIN_TRAITS" }, "id": "content", "widgets": "ruach_counter_graph" }
+    ],
+    "default_clause": { "widgets": "blood_ruach_blank_line" },
+    "flags": [ "W_DISABLED_WHEN_EMPTY" ],
+    "label": "Blood/Ruach Graph",
+    "id": "blood_ruach_graph",
     "style": "layout",
-    "label": "Xedra Mana Pool",
-    "arrange": "columns",
-    "widgets": [ "xe_mana_pool" ]
+    "type": "widget"
   },
   {
     "//": "Extend the custom sidebar with Xedra-specific sections",
@@ -78,12 +51,9 @@
         "xe_current_max_mana_nums_layout",
         "xe_mana_graph_layout",
         "xe_mana_pool_layout",
-        "vampire_blood_levels",
-        "vampire_blood_levels_numbers",
-        "vampire_blood_levels_graph",
-        "ruach_counter_meter_block",
-        "ruach_counter_numbers_block",
-        "ruach_counter_graph_block"
+        "blood_ruach_descriptor",
+        "blood_ruach_numbers",
+        "blood_ruach_graph"
       ]
     }
   },
@@ -97,12 +67,9 @@
         "xe_current_max_mana_nums_layout",
         "xe_mana_graph_layout",
         "xe_mana_pool_layout",
-        "vampire_blood_levels",
-        "vampire_blood_levels_numbers",
-        "vampire_blood_levels_graph",
-        "ruach_counter_meter_block",
-        "ruach_counter_numbers_block",
-        "ruach_counter_graph_block"
+        "blood_ruach_descriptor",
+        "blood_ruach_numbers",
+        "blood_ruach_graph"
       ]
     }
   },
@@ -116,12 +83,9 @@
         "xe_current_max_mana_nums_layout",
         "xe_mana_graph_layout",
         "xe_mana_pool_layout",
-        "vampire_blood_levels",
-        "vampire_blood_levels_numbers",
-        "vampire_blood_levels_graph",
-        "ruach_counter_meter_block",
-        "ruach_counter_numbers_block",
-        "ruach_counter_graph_block"
+        "blood_ruach_descriptor",
+        "blood_ruach_numbers",
+        "blood_ruach_graph"
       ]
     }
   },
@@ -135,12 +99,9 @@
         "xe_current_max_mana_nums_layout",
         "xe_mana_graph_layout",
         "xe_mana_pool_layout",
-        "vampire_blood_levels",
-        "vampire_blood_levels_numbers",
-        "vampire_blood_levels_graph",
-        "ruach_counter_meter_block",
-        "ruach_counter_numbers_block",
-        "ruach_counter_graph_block"
+        "blood_ruach_descriptor",
+        "blood_ruach_numbers",
+        "blood_ruach_graph"
       ]
     }
   },
@@ -154,25 +115,91 @@
         "xe_current_max_mana_nums_layout",
         "xe_mana_graph_layout",
         "xe_mana_pool_layout",
-        "vampire_blood_levels",
-        "vampire_blood_levels_numbers",
-        "vampire_blood_levels_graph",
-        "ruach_counter_meter_block",
-        "ruach_counter_numbers_block",
-        "ruach_counter_graph_block"
+        "blood_ruach_descriptor",
+        "blood_ruach_numbers",
+        "blood_ruach_graph"
       ]
     }
   },
   {
-    "//": "spacebar Wide bar-graph of current mana level, using the default 'bucket' fill.",
-    "id": "xe_spacebar_mana_graph",
+    "//": "spacebar Extend the custom sidebar with Xedra-specific sections",
+    "copy-from": "spacebar",
     "type": "widget",
-    "copy-from": "xe_mana_base",
-    "label": "Mana",
-    "style": "graph",
-    "width": 36,
-    "symbols": ".oO",
-    "fill": "bucket"
+    "id": "spacebar",
+    "extend": {
+      "widgets": [
+        "xe_current_max_mana_nums_layout",
+        "xe_mana_graph_layout",
+        "xe_mana_pool_layout",
+        "blood_ruach_descriptor",
+        "blood_ruach_numbers",
+        "blood_ruach_graph"
+      ]
+    }
+  },
+  {
+    "//": "Extend the custom sidebar with Xedra-specific sections",
+    "copy-from": "my_labels_sidebar",
+    "type": "widget",
+    "id": "my_labels_sidebar",
+    "extend": {
+      "widgets": [
+        "xe_current_max_mana_nums_layout",
+        "xe_mana_graph_layout",
+        "xe_mana_pool_layout",
+        "blood_ruach_descriptor",
+        "blood_ruach_numbers",
+        "blood_ruach_graph"
+      ]
+    }
+  },
+  {
+    "//": "Extend the custom sidebar with Xedra-specific sections",
+    "copy-from": "legacy_classic_sidebar_one_padding",
+    "type": "widget",
+    "id": "legacy_classic_sidebar_one_padding",
+    "extend": {
+      "widgets": [
+        "xe_current_max_mana_nums_layout",
+        "xe_mana_graph_layout",
+        "xe_mana_pool_layout",
+        "blood_ruach_descriptor",
+        "blood_ruach_numbers",
+        "blood_ruach_graph"
+      ]
+    }
+  },
+  {
+    "//": "Extend the custom sidebar with Xedra-specific sections",
+    "copy-from": "my_labels_sidebar_cleaner",
+    "type": "widget",
+    "id": "my_labels_sidebar_cleaner",
+    "extend": {
+      "widgets": [
+        "xe_current_max_mana_nums_layout",
+        "xe_mana_graph_layout",
+        "xe_mana_pool_layout",
+        "blood_ruach_descriptor",
+        "blood_ruach_numbers",
+        "blood_ruach_graph"
+      ]
+    }
+  },
+  {
+    "//": "Extend the custom sidebar with Xedra-specific sections",
+    "copy-from": "custom_sidebar",
+    "type": "widget",
+    "id": "custom_sidebar",
+    "extend": {
+      "widgets": [
+        "xe_current_max_mana_nums_layout",
+        "xe_mana_graph_layout",
+        "xe_mana_pool_layout",
+        "blood_ruach_descriptor",
+        "blood_ruach_numbers",
+        "blood_ruach_graph"
+      ]
+    }
   },
   {
     "id": "vampire_needs_desc_layout_label",
@@ -191,102 +218,6 @@
       "pain_desc_label",
       "body_temp_desc_label"
     ]
-  },
-  {
-    "//": "spacebar Current number of mana points, with color.",
-    "id": "xe_spacebar_mana_num",
-    "type": "widget",
-    "copy-from": "xe_mana_base",
-    "label": "Mana",
-    "width": 28,
-    "style": "number",
-    "colors": [ "c_pink" ]
-  },
-  {
-    "//": "spacebar Maximum mana points, in light blue color.",
-    "id": "xe_spacebar_max_mana_num",
-    "type": "widget",
-    "label": "Max Mana",
-    "style": "number",
-    "var": "max_mana",
-    "width": 28,
-    "colors": [ "c_pink" ]
-  },
-  {
-    "//": "spacebar Both current and maximum mana numbers, side by side",
-    "id": "xe_spacebar_current_max_mana_nums_layout",
-    "type": "widget",
-    "label": "Xedra Current/Max Mana",
-    "style": "layout",
-    "arrange": "minimum_columns",
-    "width": 56,
-    "widgets": [ "xe_spacebar_mana_num", "xe_spacebar_max_mana_num" ]
-  },
-  {
-    "id": "xe_spacebar_mana_bar_block",
-    "type": "widget",
-    "style": "layout",
-    "label": "xe_mana_bar",
-    "arrange": "minimum_columns",
-    "widgets": [ "spacebar_separator_2", "xe_spacebar_mana_graph" ]
-  },
-  {
-    "id": "xe_spacebar_mana_numbers_block",
-    "type": "widget",
-    "style": "layout",
-    "label": "xe_mana_number",
-    "arrange": "minimum_columns",
-    "widgets": [ "spacebar_separator_2", "xe_spacebar_current_max_mana_nums_layout" ]
-  },
-  {
-    "//": "spacebar Extend the custom sidebar with Xedra-specific sections",
-    "copy-from": "spacebar",
-    "type": "widget",
-    "id": "spacebar",
-    "extend": {
-      "widgets": [
-        "xe_spacebar_mana_numbers_block",
-        "xe_spacebar_mana_bar_block",
-        "vampire_blood_levels",
-        "vampire_blood_levels_numbers",
-        "vampire_blood_levels_graph",
-        "spacebar_ruach_counter_block",
-        "spacebar_ruach_numbers_block",
-        "spacebar_ruach_graph_block"
-      ]
-    }
-  },
-  {
-    "//": "Extend the custom sidebar with Xedra-specific sections",
-    "copy-from": "my_labels_sidebar",
-    "type": "widget",
-    "id": "my_labels_sidebar",
-    "extend": {
-      "widgets": [
-        "xe_current_max_mana_nums_layout",
-        "xe_mana_graph_layout",
-        "xe_mana_pool_layout",
-        "vampire_blood_levels",
-        "vampire_blood_levels_numbers",
-        "vampire_blood_levels_graph"
-      ]
-    }
-  },
-  {
-    "//": "Extend the custom sidebar with Xedra-specific sections",
-    "copy-from": "legacy_classic_sidebar_one_padding",
-    "type": "widget",
-    "id": "legacy_classic_sidebar_one_padding",
-    "extend": {
-      "widgets": [
-        "xe_current_max_mana_nums_layout",
-        "xe_mana_graph_layout",
-        "xe_mana_pool_layout",
-        "vampire_blood_levels",
-        "vampire_blood_levels_numbers",
-        "vampire_blood_levels_graph"
-      ]
-    }
   },
   {
     "id": "vampire_sidebar",

--- a/data/mods/Xedra_Evolved/ui/vamp_blood_levels.json
+++ b/data/mods/Xedra_Evolved/ui/vamp_blood_levels.json
@@ -2,7 +2,7 @@
   {
     "id": "vampire_blood_levels",
     "type": "widget",
-    "label": "Blood levels",
+    "label": "Blood",
     "style": "text",
     "flags": [ "W_DISABLED_WHEN_EMPTY" ],
     "clauses": [
@@ -187,7 +187,7 @@
     "id": "vampire_blood_levels_numbers",
     "type": "widget",
     "style": "text",
-    "label": "Blood counter",
+    "label": "Blood",
     "flags": [ "W_DISABLED_WHEN_EMPTY" ],
     "clauses": [
       {
@@ -240,7 +240,7 @@
   {
     "id": "vampire_blood_levels_graph",
     "type": "widget",
-    "label": "Blood graph",
+    "label": "Blood",
     "var": "custom",
     "flags": [ "W_DISABLED_WHEN_EMPTY" ],
     "//": "Distillate the Inner Blood ensures that the UI won't show the negatively high levels.",


### PR DESCRIPTION

#### Summary
Mods "[Xedra Evolved] Sidebar updates"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Update the sidebar widgets for for ruach and blood added by Xedra Evolved to take up less space and properly hide the ruach/blood graph when not applicable. 

#### Describe the solution

Wrapping the graphs inside of another widget using clauses to display that widget or a blank line allows the vitamin graphs for blood and ruach to be hidden when they don't apply.
Liliths and Vampires are also mutually exclusive conditions so we also use the same outer widget to display either the blood, ruach or blank widget for each of the three widgets that are added by XE.
There was also two base game sidebars that were missing the XE widgets so those were extended to add the XE widgets.
The widget itself will not go away even when all widgets are empty and flagged `W_DISABLED_WHEN_EMPTY` so there will be a blank line when the player is neither lilith or a vampire.  
#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Vampire
<img width="696" height="154" alt="image" src="https://github.com/user-attachments/assets/108dd169-2461-438f-8923-da4775366573" />
Lilith
<img width="696" height="154" alt="image" src="https://github.com/user-attachments/assets/1716c5b3-4b4d-43d9-85a8-def17c6cefb8" />
Neither
<img width="696" height="154" alt="image" src="https://github.com/user-attachments/assets/bbd8502e-b8bc-4518-a3b6-9394893f299d" />


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I ripped out the half done spacebar sidebar variants of the widgets, only 1/3 of them were done so I decided that instead of going back and redoing sidebar specific version for each widget, just to keep the same widget for all the sidebars. This leaves less work for future sidebar changes