### PR TITLE
When completing Sky_Island missions with Innawood installed, gives bonus experience for Bombasticperks, Sorcerer, Perk-Melee, and Xedra_Evolved

### DIFF
--- a/data/mods/BombasticPerks/corefiles/core_eocs.json
+++ b/data/mods/BombasticPerks/corefiles/core_eocs.json
@@ -11,7 +11,7 @@
     "effect": [
       { "run_eocs": "EOC_give_perk_point" },
       { "math": [ "u_used_exp += u_exp_to_perk" ] },
-      { "math": [ "u_available_exp = u_val('exp') - u_used_exp" ] },
+      { "math": [ "u_available_exp = u_val('exp') + u_bonus_exp - u_used_exp" ] },
       { "math": [ "u_exp_to_perk += u_exp_per_level" ] },
       { "math": [ "u_current_level += 1" ] },
       { "run_eocs": "EOC_level_up_notification" }
@@ -28,7 +28,7 @@
     "id": "EOC_on_kill_check_exp",
     "eoc_type": "EVENT",
     "required_event": "character_kills_monster",
-    "effect": [ { "math": [ "u_available_exp = u_val('exp') - u_used_exp" ] }, { "run_eocs": "EOC_level_up" } ]
+    "effect": [ { "math": [ "u_available_exp = u_val('exp') + u_bonus_exp - u_used_exp" ] }, { "run_eocs": "EOC_level_up" } ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/Perk_melee/EOC/leveling.json
+++ b/data/mods/Perk_melee/EOC/leveling.json
@@ -12,7 +12,7 @@
       { "u_message": "Your experience with martial arts has increased!" },
       { "run_eocs": "EOC_give_ma_perk_point" },
       { "math": [ "u_ma_used_exp += u_ma_exp_to_perk" ] },
-      { "math": [ "u_ma_available_exp = u_val('exp') - u_ma_used_exp" ] },
+      { "math": [ "u_ma_available_exp = u_val('exp') + u_bonus_exp - u_ma_used_exp" ] },
       { "math": [ "u_ma_exp_to_perk += u_ma_exp_per_level" ] },
       { "math": [ "u_ma_current_level += 1" ] }
     ]
@@ -28,7 +28,10 @@
     "id": "EOC_perk_ma_kill_check_exp",
     "eoc_type": "EVENT",
     "required_event": "character_kills_monster",
-    "effect": [ { "math": [ "u_ma_available_exp = u_val('exp') - u_ma_used_exp" ] }, { "run_eocs": "EOC_perk_ma_level_up" } ]
+    "effect": [
+      { "math": [ "u_ma_available_exp = u_val('exp') + u_bonus_exp - u_ma_used_exp" ] },
+      { "run_eocs": "EOC_perk_ma_level_up" }
+    ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/Sky_Island/EOCs.json
+++ b/data/mods/Sky_Island/EOCs.json
@@ -1173,29 +1173,5 @@
     "type": "effect_on_condition",
     "id": "EOC_WARPED_POND_CREATION_SE",
     "effect": [ { "mapgen_update": "mx_skyisland_pond", "om_terrain": "sky_island_core", "offset_x": 1, "offset_y": 1 } ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_innawood_bonus_exp_warpshards",
-    "//": "Gives bonus exp to help with Sorcerer and Bombasticperks due to there being few monsters in Innawood",
-    "condition": { "mod_is_loaded": "innawood" },
-    "effect": [
-      { "math": [ "u_bonus_exp += 25" ] },
-      { "run_eocs": "EOC_on_kill_check_exp", "condition": { "mod_is_loaded": "bombastic_perks" } },
-      { "run_eocs": "EOC_perk_ma_kill_check_exp", "condition": { "mod_is_loaded": "perk_melee_system" } },
-      { "run_eocs": "EOC_on_kill_check_exp_sorcerer", "condition": { "mod_is_loaded": "sorcerer" } }
-    ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_innawood_bonus_exp_material_tokens",
-    "//": "Gives bonus exp to help with Sorcerer and Bombasticperks due to there being few monsters in Innawood",
-    "condition": { "mod_is_loaded": "innawood" },
-    "effect": [
-      { "math": [ "u_bonus_exp += ( owed_material_tokens * 2 ) / 5" ] },
-      { "run_eocs": "EOC_on_kill_check_exp", "condition": { "mod_is_loaded": "bombastic_perks" } },
-      { "run_eocs": "EOC_perk_ma_kill_check_exp", "condition": { "mod_is_loaded": "perk_melee_system" } },
-      { "run_eocs": "EOC_on_kill_check_exp_sorcerer", "condition": { "mod_is_loaded": "sorcerer" } }
-    ]
   }
 ]

--- a/data/mods/Sky_Island/EOCs.json
+++ b/data/mods/Sky_Island/EOCs.json
@@ -217,7 +217,8 @@
         "u_message": "You've returned home safely using a designated exit point.  You have earned <global_val:owed_material_tokens> material tokens for your success.",
         "popup": true
       },
-      { "u_spawn_item": "warptoken_material", "count": { "global_val": "owed_material_tokens", "default": 50 } }
+      { "u_spawn_item": "warptoken_material", "count": { "global_val": "owed_material_tokens", "default": 50 } },
+      { "run_eocs": "EOC_innawood_bonus_exp_material_tokens" }
     ]
   },
   {
@@ -1172,5 +1173,29 @@
     "type": "effect_on_condition",
     "id": "EOC_WARPED_POND_CREATION_SE",
     "effect": [ { "mapgen_update": "mx_skyisland_pond", "om_terrain": "sky_island_core", "offset_x": 1, "offset_y": 1 } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_innawood_bonus_exp_warpshards",
+    "//": "Gives bonus exp to help with Sorcerer and Bombasticperks due to there being few monsters in Innawood",
+    "condition": { "mod_is_loaded": "innawood" },
+    "effect": [
+      { "math": [ "u_bonus_exp += 25" ] },
+      { "run_eocs": "EOC_on_kill_check_exp", "condition": { "mod_is_loaded": "bombastic_perks" } },
+      { "run_eocs": "EOC_perk_ma_kill_check_exp", "condition": { "mod_is_loaded": "perk_melee_system" } },
+      { "run_eocs": "EOC_on_kill_check_exp_sorcerer", "condition": { "mod_is_loaded": "sorcerer" } }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_innawood_bonus_exp_material_tokens",
+    "//": "Gives bonus exp to help with Sorcerer and Bombasticperks due to there being few monsters in Innawood",
+    "condition": { "mod_is_loaded": "innawood" },
+    "effect": [
+      { "math": [ "u_bonus_exp += ( owed_material_tokens * 2 ) / 5" ] },
+      { "run_eocs": "EOC_on_kill_check_exp", "condition": { "mod_is_loaded": "bombastic_perks" } },
+      { "run_eocs": "EOC_perk_ma_kill_check_exp", "condition": { "mod_is_loaded": "perk_melee_system" } },
+      { "run_eocs": "EOC_on_kill_check_exp_sorcerer", "condition": { "mod_is_loaded": "sorcerer" } }
+    ]
   }
 ]

--- a/data/mods/Sky_Island/missions_and_mapgen.json
+++ b/data/mods/Sky_Island/missions_and_mapgen.json
@@ -465,7 +465,13 @@
       "assign_mission_target": { "var": { "global_val": "OM_missionspot" } },
       "update_mapgen": { "place_nested": [ { "chunks": [ "mx_treasuregoal" ], "x": [ 0, 13 ], "y": [ 0, 13 ] } ] }
     },
-    "end": { "effect": [ { "run_eocs": "EOC_bonuspulse" }, { "math": [ "u_missionswon++" ] } ] }
+    "end": {
+      "effect": [
+        { "run_eocs": "EOC_bonuspulse" },
+        { "math": [ "u_missionswon++" ] },
+        { "run_eocs": "EOC_innawood_bonus_exp_warpshards" }
+      ]
+    }
   },
   {
     "id": "MISSION_BONUS_KILL_LIGHT",

--- a/data/mods/Sorcerer/experience_points.json
+++ b/data/mods/Sorcerer/experience_points.json
@@ -5,7 +5,7 @@
     "condition": { "math": [ "u_available_exp_sorcerer > u_exp_to_sorcerer_level" ] },
     "effect": [
       { "math": [ "u_used_exp_sorcerer += u_exp_to_sorcerer_level" ] },
-      { "math": [ "u_available_exp_sorcerer = u_val('exp') - u_used_exp_sorcerer" ] },
+      { "math": [ "u_available_exp_sorcerer = u_val('exp') + u_bonus_exp - u_used_exp_sorcerer" ] },
       { "math": [ "u_exp_to_sorcerer_level += u_exp_per_sorcerer_level" ] },
       { "run_eocs": "EOC_level_up_sorcerer" }
     ]
@@ -17,7 +17,7 @@
     "required_event": "character_kills_monster",
     "condition": { "u_has_trait": "SORCERER" },
     "effect": [
-      { "math": [ "u_available_exp_sorcerer = u_val('exp') - u_used_exp_sorcerer" ] },
+      { "math": [ "u_available_exp_sorcerer = u_val('exp') + u_bonus_exp - u_used_exp_sorcerer" ] },
       { "run_eocs": "EOC_check_level_up_sorcerer" }
     ]
   },

--- a/data/mods/Xedra_Evolved/enchantments/weapon.json
+++ b/data/mods/Xedra_Evolved/enchantments/weapon.json
@@ -29,7 +29,7 @@
     "id": "EXP_BASH",
     "has": "WIELD",
     "condition": "ALWAYS",
-    "melee_damage_bonus": [ { "type": "bash", "add": { "math": [ "u_val('exp') / 750" ] } } ]
+    "melee_damage_bonus": [ { "type": "bash", "add": { "math": [ "( u_val('exp') + u_bonus_exp ) / 750" ] } } ]
   },
   {
     "type": "enchantment",

--- a/data/mods/innawood/experience_eocs.json
+++ b/data/mods/innawood/experience_eocs.json
@@ -1,0 +1,26 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_innawood_bonus_exp_warpshards",
+    "//": "For Sky Island.  Gives bonus exp to help with Sorcerer and Bombasticperks due to there being few monsters in Innawood",
+    "condition": { "mod_is_loaded": "innawood" },
+    "effect": [
+      { "math": [ "u_bonus_exp += 25" ] },
+      { "run_eocs": "EOC_on_kill_check_exp", "condition": { "mod_is_loaded": "bombastic_perks" } },
+      { "run_eocs": "EOC_perk_ma_kill_check_exp", "condition": { "mod_is_loaded": "perk_melee_system" } },
+      { "run_eocs": "EOC_on_kill_check_exp_sorcerer", "condition": { "mod_is_loaded": "sorcerer" } }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_innawood_bonus_exp_material_tokens",
+    "//": "For Sky Island.  Gives bonus exp to help with Sorcerer and Bombasticperks due to there being few monsters in Innawood",
+    "condition": { "mod_is_loaded": "innawood" },
+    "effect": [
+      { "math": [ "u_bonus_exp += ( owed_material_tokens * 2 ) / 5" ] },
+      { "run_eocs": "EOC_on_kill_check_exp", "condition": { "mod_is_loaded": "bombastic_perks" } },
+      { "run_eocs": "EOC_perk_ma_kill_check_exp", "condition": { "mod_is_loaded": "perk_melee_system" } },
+      { "run_eocs": "EOC_on_kill_check_exp_sorcerer", "condition": { "mod_is_loaded": "sorcerer" } }
+    ]
+  }
+]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "Excursions with Sky Island and Innawood gives bonus experience for Bombastic Perks, Sorcerer, and Martial Mastery"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Several mods read the player's experience points to handle progression.
Innawood has the slight problem that the player ends up killing a lot less enemies, thus earning a lot less experience points.
This PR aims to help alleviate this by giving out bonus experience when performing Sky Island excursions, and when doing the one Sky Island quest that doesn't involve killing things.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Sky Island calls functions that increments `u_bonus_exp`. Then, it goes though Bombasticperks, Sorcerer, and Perk-Melee and checks inf they are loaded. If they are, their `EOC_on_kill_check_exp` are run.
When Bombasticperks, Sorcerer, Perk-Melee, and Xedra_Evolved checks how much experience is available, `u_bonus_exp` is added to the amount.
Completing the mission to find the warp shards gives 25 bonus experience.
Completing an excursion awards experience equal to `material tokens awarded` * 2 / 5
So by default you gain 50 tokens and 20 experience.
For reference, a basic zombie gives 4 experience.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Giving experience points directly. Didn't manage to get that to work. But come to think of it, that might be because I forgot to run `EOC_on_kill_check_exp` when trying that.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I've ran the game and made sure the EOCs worked correctly. I was awarded experience at the end of an excursion as expected. When I gained enough experience to level up, I did also level up as expected.

I have not played long enough to check that the amount of experience granted is balanced.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
This is part of a broader effort to make Innawood and Sky Island more compatible.
Eventually I'd like to award bonus experience from other Innawood things, like gaining skills, surviving for a long time, crafting important items for the first time, gaining achievements, and so on. But that's a task for later.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
