### PR TITLE
Techniqueify `HOOVES`

### DIFF
--- a/data/json/items/armor/integrated.json
+++ b/data/json/items/armor/integrated.json
@@ -1780,7 +1780,7 @@
     "type": "ITEM",
     "subtypes": [ "ARMOR" ],
     "category": "armor",
-    "name": { "str": "hooves" },
+    "name": { "str_sp": "hooves" },
     "description": "You have hooves on the ends of your feet rather than toes.  They allow powerful kicking attacks, but prevent wearing footwear.",
     "weight": "250 g",
     "volume": "500 ml",
@@ -1790,7 +1790,14 @@
     "symbol": "b",
     "color": "brown",
     "warmth": 2,
-    "techniques": [ "HOOVES_KICK", "HOOVES_KICK_NATURAL", "HOOVES_KICK_CRIT" ],
+    "techniques": [
+      "HOOVES_KICK",
+      "HOOVES_KICK_AGAINST_LARGE",
+      "HOOVES_KICK_NATURAL",
+      "HOOVES_KICK_NATURAL_AGAINST_LARGE",
+      "HOOVES_KICK_CRIT",
+      "HOOVES_KICK_CRIT_AGAINST_LARGE"
+    ],
     "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "PERSONAL", "WATER_FRIENDLY", "PROVIDES_TECHNIQUES" ],
     "armor": [
       {

--- a/data/json/items/armor/integrated.json
+++ b/data/json/items/armor/integrated.json
@@ -1774,5 +1774,32 @@
       }
     ],
     "melee_damage": { "stab": 15 }
+  },
+  {
+    "id": "integrated_hooves",
+    "type": "ITEM",
+    "subtypes": [ "ARMOR" ],
+    "category": "armor",
+    "name": { "str": "hooves" },
+    "description": "You have hooves on the ends of your feet rather than toes.  They allow powerful kicking attacks, but prevent wearing footwear.",
+    "weight": "250 g",
+    "volume": "500 ml",
+    "price": "0 cent",
+    "price_postapoc": "0 cent",
+    "material": [ "chitin" ],
+    "symbol": "b",
+    "color": "brown",
+    "warmth": 2,
+    "techniques": [ "HOOVES_KICK", "HOOVES_KICK_CRIT" ],
+    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "PERSONAL", "WATER_FRIENDLY", "PROVIDES_TECHNIQUES" ],
+    "armor": [
+      {
+        "material": [ { "type": "chitin", "covered_by_mat": 100, "thickness": 2.5 } ],
+        "covers": [ "foot_l", "foot_r" ],
+        "specifically_covers": [ "foot_toes_r", "foot_toes_l", "foot_sole_r", "foot_sole_l" ],
+        "coverage": 100,
+        "encumbrance": 1
+      }
+    ]
   }
 ]

--- a/data/json/items/armor/integrated.json
+++ b/data/json/items/armor/integrated.json
@@ -1790,7 +1790,7 @@
     "symbol": "b",
     "color": "brown",
     "warmth": 2,
-    "techniques": [ "HOOVES_KICK", "HOOVES_KICK_CRIT" ],
+    "techniques": [ "HOOVES_KICK", "HOOVES_KICK_NATURAL", "HOOVES_KICK_CRIT" ],
     "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "PERSONAL", "WATER_FRIENDLY", "PROVIDES_TECHNIQUES" ],
     "armor": [
       {

--- a/data/json/mutations/mutation_techs.json
+++ b/data/json/mutations/mutation_techs.json
@@ -228,10 +228,39 @@
     "melee_allowed": true,
     "messages": [ "You kick %s with your hooves", "<npcname> kicks %s with their hooves" ],
     "unarmed_allowed": true,
-    "weighting": 3,
+    "weighting": -4,
     "reach_ok": false,
-    "attack_vectors": [ "vector_foot_toes", "vector_foot_sole" ],
-    "condition": { "and": [ { "not": { "npc_has_flag": "GRAB_FILTER" } }, { "not": { "u_has_effect": "GRAB" } } ] },
+    "attack_vectors": [ "vector_foot_toes", "vector_foot_sole", "vector_foot_heel" ],
+    "condition": {
+      "and": [
+        { "not": { "u_has_effect": "natural_stance" } },
+        { "and": [ { "not": { "npc_has_flag": "GRAB_FILTER" } }, { "not": { "u_has_effect": "GRAB" } } ] }
+      ]
+    },
+    "tech_effects": [ { "id": "downed", "chance": 50, "duration": 2, "on_damage": true, "message": "%s is knocked to the ground!" } ],
+    "flat_bonuses": [
+      { "stat": "damage", "type": "bash", "scaling-stat": "str", "scale": 0.5 },
+      { "stat": "damage", "type": "bash", "scaling-stat": "unarmed", "scale": 1.0 },
+      { "stat": "movecost", "scaling-stat": "melee", "scale": -1.25 },
+      { "stat": "movecost", "scaling-stat": "dex", "scale": -0.5 }
+    ]
+  },
+  {
+    "type": "technique",
+    "id": "HOOVES_KICK_NATURAL",
+    "name": "Hoof Kick",
+    "melee_allowed": true,
+    "messages": [ "You kick %s with your hooves", "<npcname> kicks %s with their hooves" ],
+    "unarmed_allowed": true,
+    "weighting": 0,
+    "reach_ok": false,
+    "attack_vectors": [ "vector_foot_toes", "vector_foot_sole", "vector_foot_heel" ],
+    "condition": {
+      "and": [
+        { "u_has_effect": "natural_stance" },
+        { "and": [ { "not": { "npc_has_flag": "GRAB_FILTER" } }, { "not": { "u_has_effect": "GRAB" } } ] }
+      ]
+    },
     "tech_effects": [ { "id": "downed", "chance": 50, "duration": 2, "on_damage": true, "message": "%s is knocked to the ground!" } ],
     "flat_bonuses": [
       { "stat": "damage", "type": "bash", "scaling-stat": "str", "scale": 0.5 },
@@ -249,7 +278,7 @@
     "unarmed_allowed": true,
     "reach_ok": false,
     "crit_tec": true,
-    "attack_vectors": [ "vector_foot_toes", "vector_foot_sole" ],
+    "attack_vectors": [ "vector_foot_toes", "vector_foot_sole", "vector_foot_heel" ],
     "tech_effects": [ { "id": "downed", "chance": 100, "duration": 2, "on_damage": true, "message": "%s is knocked to the ground!" } ],
     "flat_bonuses": [
       { "stat": "damage", "type": "bash", "scaling-stat": "str", "scale": 0.75 },

--- a/data/json/mutations/mutation_techs.json
+++ b/data/json/mutations/mutation_techs.json
@@ -220,5 +220,43 @@
       { "stat": "movecost", "scaling-stat": "melee", "scale": -1.25 },
       { "stat": "movecost", "scaling-stat": "dex", "scale": -0.5 }
     ]
+  },
+  {
+    "type": "technique",
+    "id": "HOOVES_KICK",
+    "name": "Hoof Kick",
+    "melee_allowed": true,
+    "messages": [ "You kick %s with your hooves", "<npcname> kicks %s with their hooves" ],
+    "unarmed_allowed": true,
+    "weighting": 3,
+    "reach_ok": false,
+    "attack_vectors": [ "vector_foot_toes", "vector_foot_sole" ],
+    "condition": { "and": [ { "not": { "npc_has_flag": "GRAB_FILTER" } }, { "not": { "u_has_effect": "GRAB" } } ] },
+    "tech_effects": [ { "id": "downed", "chance": 50, "duration": 2, "on_damage": true, "message": "%s is knocked to the ground!" } ],
+    "flat_bonuses": [
+      { "stat": "damage", "type": "bash", "scaling-stat": "str", "scale": 0.5 },
+      { "stat": "damage", "type": "bash", "scaling-stat": "unarmed", "scale": 1.0 },
+      { "stat": "movecost", "scaling-stat": "melee", "scale": -1.25 },
+      { "stat": "movecost", "scaling-stat": "dex", "scale": -0.5 }
+    ]
+  },
+  {
+    "type": "technique",
+    "id": "HOOVES_KICK_CRIT",
+    "name": "Critical Hoof Kick",
+    "melee_allowed": true,
+    "messages": [ "You deliver a wicked kick to %s with your hooves", "<npcname> delivers a kick bite to %s with their hooves" ],
+    "unarmed_allowed": true,
+    "reach_ok": false,
+    "crit_tec": true,
+    "attack_vectors": [ "vector_foot_toes", "vector_foot_sole" ],
+    "tech_effects": [ { "id": "downed", "chance": 100, "duration": 2, "on_damage": true, "message": "%s is knocked to the ground!" } ],
+    "flat_bonuses": [
+      { "stat": "damage", "type": "bash", "scaling-stat": "str", "scale": 0.75 },
+      { "stat": "damage", "type": "bash", "scaling-stat": "unarmed", "scale": 4.4 },
+      { "stat": "arpen", "type": "bash", "scaling-stat": "unarmed", "scale": 1 },
+      { "stat": "movecost", "scaling-stat": "melee", "scale": -1.25 },
+      { "stat": "movecost", "scaling-stat": "dex", "scale": -0.5 }
+    ]
   }
 ]

--- a/data/json/mutations/mutation_techs.json
+++ b/data/json/mutations/mutation_techs.json
@@ -233,11 +233,36 @@
     "attack_vectors": [ "vector_foot_toes", "vector_foot_sole", "vector_foot_heel" ],
     "condition": {
       "and": [
+        { "math": [ "u_val('size') >= n_val('size')" ] },
         { "not": { "u_has_effect": "natural_stance" } },
         { "and": [ { "not": { "npc_has_flag": "GRAB_FILTER" } }, { "not": { "u_has_effect": "GRAB" } } ] }
       ]
     },
     "tech_effects": [ { "id": "downed", "chance": 50, "duration": 2, "on_damage": true, "message": "%s is knocked to the ground!" } ],
+    "flat_bonuses": [
+      { "stat": "damage", "type": "bash", "scaling-stat": "str", "scale": 0.5 },
+      { "stat": "damage", "type": "bash", "scaling-stat": "unarmed", "scale": 1.0 },
+      { "stat": "movecost", "scaling-stat": "melee", "scale": -1.25 },
+      { "stat": "movecost", "scaling-stat": "dex", "scale": -0.5 }
+    ]
+  },
+  {
+    "type": "technique",
+    "id": "HOOVES_KICK_AGAINST_LARGE",
+    "name": "Hoof Kick",
+    "melee_allowed": true,
+    "messages": [ "You kick %s with your hooves", "<npcname> kicks %s with their hooves" ],
+    "unarmed_allowed": true,
+    "weighting": -4,
+    "reach_ok": false,
+    "attack_vectors": [ "vector_foot_toes", "vector_foot_sole", "vector_foot_heel" ],
+    "condition": {
+      "and": [
+        { "math": [ "u_val('size') < n_val('size')" ] },
+        { "not": { "u_has_effect": "natural_stance" } },
+        { "and": [ { "not": { "npc_has_flag": "GRAB_FILTER" } }, { "not": { "u_has_effect": "GRAB" } } ] }
+      ]
+    },
     "flat_bonuses": [
       { "stat": "damage", "type": "bash", "scaling-stat": "str", "scale": 0.5 },
       { "stat": "damage", "type": "bash", "scaling-stat": "unarmed", "scale": 1.0 },
@@ -257,6 +282,32 @@
     "attack_vectors": [ "vector_foot_toes", "vector_foot_sole", "vector_foot_heel" ],
     "condition": {
       "and": [
+        { "math": [ "u_val('size') >= n_val('size')" ] },
+        { "u_has_effect": "natural_stance" },
+        { "and": [ { "not": { "npc_has_flag": "GRAB_FILTER" } }, { "not": { "u_has_effect": "GRAB" } } ] }
+      ]
+    },
+    "tech_effects": [ { "id": "downed", "chance": 50, "duration": 2, "on_damage": true, "message": "%s is knocked to the ground!" } ],
+    "flat_bonuses": [
+      { "stat": "damage", "type": "bash", "scaling-stat": "str", "scale": 0.5 },
+      { "stat": "damage", "type": "bash", "scaling-stat": "unarmed", "scale": 1.0 },
+      { "stat": "movecost", "scaling-stat": "melee", "scale": -1.25 },
+      { "stat": "movecost", "scaling-stat": "dex", "scale": -0.5 }
+    ]
+  },
+  {
+    "type": "technique",
+    "id": "HOOVES_KICK_NATURAL_AGAINST_LARGE",
+    "name": "Hoof Kick",
+    "melee_allowed": true,
+    "messages": [ "You kick %s with your hooves", "<npcname> kicks %s with their hooves" ],
+    "unarmed_allowed": true,
+    "weighting": 0,
+    "reach_ok": false,
+    "attack_vectors": [ "vector_foot_toes", "vector_foot_sole", "vector_foot_heel" ],
+    "condition": {
+      "and": [
+        { "math": [ "u_val('size') < n_val('size')" ] },
         { "u_has_effect": "natural_stance" },
         { "and": [ { "not": { "npc_has_flag": "GRAB_FILTER" } }, { "not": { "u_has_effect": "GRAB" } } ] }
       ]
@@ -279,7 +330,27 @@
     "reach_ok": false,
     "crit_tec": true,
     "attack_vectors": [ "vector_foot_toes", "vector_foot_sole", "vector_foot_heel" ],
+    "condition": { "math": [ "u_val('size') >= n_val('size')" ] },
     "tech_effects": [ { "id": "downed", "chance": 100, "duration": 2, "on_damage": true, "message": "%s is knocked to the ground!" } ],
+    "flat_bonuses": [
+      { "stat": "damage", "type": "bash", "scaling-stat": "str", "scale": 0.75 },
+      { "stat": "damage", "type": "bash", "scaling-stat": "unarmed", "scale": 4.4 },
+      { "stat": "arpen", "type": "bash", "scaling-stat": "unarmed", "scale": 1 },
+      { "stat": "movecost", "scaling-stat": "melee", "scale": -1.25 },
+      { "stat": "movecost", "scaling-stat": "dex", "scale": -0.5 }
+    ]
+  },
+  {
+    "type": "technique",
+    "id": "HOOVES_KICK_CRIT_AGAINST_LARGE",
+    "name": "Critical Hoof Kick",
+    "melee_allowed": true,
+    "messages": [ "You deliver a wicked kick to %s with your hooves", "<npcname> delivers a kick bite to %s with their hooves" ],
+    "unarmed_allowed": true,
+    "reach_ok": false,
+    "crit_tec": true,
+    "attack_vectors": [ "vector_foot_toes", "vector_foot_sole", "vector_foot_heel" ],
+    "condition": { "math": [ "u_val('size') < n_val('size')" ] },
     "flat_bonuses": [
       { "stat": "damage", "type": "bash", "scaling-stat": "str", "scale": 0.75 },
       { "stat": "damage", "type": "bash", "scaling-stat": "unarmed", "scale": 4.4 },

--- a/data/json/mutations/mutations_limbs.json
+++ b/data/json/mutations/mutations_limbs.json
@@ -1008,13 +1008,7 @@
     "flags": [ "TOUGH_FEET" ],
     "destroys_gear": true,
     "restricts_gear": [ "foot_sole_l", "foot_sole_r" ],
-    "armor": [ { "parts": [ "foot_l", "foot_r" ], "bash": 1 } ],
-    "attacks": {
-      "attack_text_u": "You kick %s with your hooves!",
-      "attack_text_npc": "%1$s kicks %2$s with their hooves!",
-      "chance": 15,
-      "strength_damage": { "damage_type": "bash", "amount": 3 }
-    },
+    "integrated_armor": [ "integrated_hooves" ],
     "wet_protection": [ { "part": "foot_l", "neutral": 10 }, { "part": "foot_r", "neutral": 10 } ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Balance "Techniqueify `HOOVES`"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

The way we represent mutation attacks is with a free attack in _addition_ to your normal attack, which is definitely weird and leads to scaling issues. I've seen a screenshot of someone simultaneously kicking, tail-whipping, goring, biting, and hitting with a normal melee attack all in the same second, which leads to insane damage bonuses. Bites were moved to a technique so it's no longer possible to do this, so we should do that with the other mutation attacks too.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Remove the `attacks` line from HOOVES and have them give you an integrated armor item. Have this item provide techniques: `HOOVES_KICK`, `HOOVES_KICK_NATURAL`, and `HOOVES_KICK_CRIT` (natural is in natural stance, aka on all fours, where kicking is much easier and presumably more common), plus `AGAINST_LARGE` versions of all of those.

Unlike biting, you can't kick while grabbed. 

Kicking has a chance to down opponents (100% chance on crit). This only applies to opponents your size or smaller (hence why there are 6 techniques and not 3, since tech_effects can't take a condition)
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Kicked some debug monsters around at various levels of Unarmed. Crit-kicked a hulk (and did not knock it down)

A few attacks were listed as kicks without hooves, but I think this is when shin is chosen as the attack vector (and obviously your hooves don't cover your shin)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
