### PR TITLE
Warn player on melee with gun without bayonet

### DIFF
--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -647,24 +647,47 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
         return false;
     }
 
-    if( is_avatar() && move_cost > 300 && calendar::turn > melee_warning_turn ) {
-        const std::string &action = query_popup()
-                                    .context( "CANCEL_ACTIVITY_OR_IGNORE_QUERY" )
-                                    .message( _( "<color_light_red>Attacking with your %1$s will take a long time.  "
-                                              "Are you sure you want to continue?</color>" ),
-                                              cur_weap.display_name() )
-                                    .option( "YES" )
-                                    .option( "NO" )
-                                    .option( "IGNORE" )
-                                    .query()
-                                    .action;
+    if( is_avatar() ) {
+        if( move_cost > 300 && calendar::turn > melee_warning_turn ) {
+            const std::string &action = query_popup()
+                                        .context( "CANCEL_ACTIVITY_OR_IGNORE_QUERY" )
+                                        .message( _( "<color_light_red>Attacking with your %1$s will take a long time.  "
+                                                  "Are you sure you want to continue?</color>" ),
+                                                  cur_weap.display_name() )
+                                        .option( "YES" )
+                                        .option( "NO" )
+                                        .option( "IGNORE" )
+                                        .query()
+                                        .action;
 
-        if( action == "NO" ) {
-            return false;
-        }
-        if( action == "IGNORE" ) {
-            if( melee_warning_turn == calendar::turn_zero || melee_warning_turn <= calendar::turn ) {
-                melee_warning_turn = calendar::turn + 50_turns;
+            if( action == "NO" ) {
+                return false;
+            }
+            if( action == "IGNORE" ) {
+                if( melee_warning_turn == calendar::turn_zero || melee_warning_turn <= calendar::turn ) {
+                    melee_warning_turn = calendar::turn + 50_turns;
+                }
+            }
+        } else if( cur_weap.is_gun() && !cur_weap.is_melee( damage_stab ) &&
+                   calendar::turn > melee_warning_turn ) {
+            const std::string &action = query_popup()
+                                        .context( "CANCEL_ACTIVITY_OR_IGNORE_QUERY" )
+                                        .message( _( "<color_light_red>Your %1$s is not well suited for melee and may get damaged.  "
+                                                  "Are you sure you want to continue?</color>" ),
+                                                  cur_weap.display_name() )
+                                        .option( "YES" )
+                                        .option( "NO" )
+                                        .option( "IGNORE" )
+                                        .query()
+                                        .action;
+
+            if( action == "NO" ) {
+                return false;
+            }
+            if( action == "IGNORE" ) {
+                if( melee_warning_turn == calendar::turn_zero || melee_warning_turn <= calendar::turn ) {
+                    melee_warning_turn = calendar::turn + 50_turns;
+                }
             }
         }
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Interface "Warn player on melee with gun without bayonet"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
With introduction of simple faults gun malfunctions became significantly more frequent on damaged guns and require more time to fix. Which made damaging your gun buy accidentally hitting an enemy with it in melee into something you really want to avoid.

Also guns without bayonet are not all that good at melee. Rock, stick, chair leg - pretty much anything is more useful.
<img width="845" height="233" alt="melee" src="https://github.com/user-attachments/assets/cf0a803c-4a31-4c36-b211-854d4ec8aad4" />

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add a warning prompt on attempted melee attack with gun without a bayonet.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
N/A
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Attack enemy with a stick. Attack goes through.
Attack enemy with a gun with bayonet. Attack goes through.
Attack enemy with a gun without bayonet. Warned about possible damage to the gun.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
N/A
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
