### PR TITLE
More input popup migration

### DIFF
--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -33,6 +33,7 @@
 #include "game.h"
 #include "game_constants.h"
 #include "input_enums.h"
+#include "input_popup.h"
 #include "item.h"
 #include "level_cache.h"
 #include "line.h"
@@ -52,7 +53,6 @@
 #include "scent_map.h"
 #include "shadowcasting.h"
 #include "string_formatter.h"
-#include "string_input_popup.h"
 #include "submap.h"
 #include "translation.h"
 #include "translations.h"
@@ -145,11 +145,9 @@ void edit_json( SAVEOBJ &it )
             }
             fs2.clear();
         } else if( tmret == 1 ) {
-            string_input_popup popup;
-            std::string ret = popup
-                              .text( save1 )
-                              .query_string();
-            if( popup.confirmed() ) {
+            string_input_popup_imgui popup( 50, save1 );
+            std::string ret = popup.query();
+            if( !popup.cancelled() ) {
                 fs1 = fld_string( ret, TERMX - 10 );
                 save1 = ret;
                 tmret = -2;
@@ -1483,20 +1481,18 @@ void editmap::edit_itm()
                             } );
                             break;
                     }
-                    string_input_popup popup;
                     int retval = 0;
                     bool confirmed = false;
                     if( imenu.ret < imenu_tags ) {
                         retval = intval;
                         confirmed = query_int( retval, true, "set:" );
                     } else if( imenu.ret == imenu_tags ) {
-                        strval = popup
-                                 .title( _( "Flags:" ) )
-                                 .description( "UPPERCASE, no quotes, separate with spaces:" )
-                                 .text( strval )
-                                 .query_string();
+                        string_input_popup_imgui popup( 50, strval, _( "Flags:" ) );
+                        popup.set_description( "UPPERCASE, no quotes, separate with spaces:" );
+                        strval = popup.query();
+                        confirmed = !popup.cancelled();
                     }
-                    if( popup.confirmed() || confirmed ) {
+                    if( confirmed ) {
                         switch( imenu.ret ) {
                             case imenu_bday:
                                 it.set_birthday( time_point::from_turn( retval ) );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6155,11 +6155,9 @@ look_around_result game::look_around(
             creature_tracker &creatures = get_creature_tracker();
             monster *const mon = creatures.creature_at<monster>( lp, true );
             if( mon ) {
-                string_input_popup popup;
-                popup
-                .title( _( "Nickname:" ) )
-                .width( 85 )
-                .edit( mon->nickname );
+                string_input_popup_imgui popup( 50, mon->nickname );
+                popup.set_label( _( "Nickname:" ) );
+                mon->nickname = popup.query();
             }
         } else if( action == "CENTER" ) {
             center = u.pos_bub();

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -51,6 +51,7 @@
 #include "help.h"
 #include "input_context.h"
 #include "input_enums.h"
+#include "input_popup.h"
 #include "inventory_ui.h"
 #include "item.h"
 #include "item_group.h"
@@ -87,7 +88,6 @@
 #include "sleep.h"
 #include "sounds.h"
 #include "string_formatter.h"
-#include "string_input_popup.h"
 #include "timed_event.h"
 #include "translation.h"
 #include "translations.h"
@@ -919,16 +919,14 @@ static void haul()
         case 3:
             autohaul ? player_character.stop_autohaul() : player_character.start_autohaul();
             break;
-        case 4:
-            string_input_popup()
-            .title( _( "Filter:" ) )
-            .width( 55 )
-            .description( item_filter_rule_string( item_filter_type::FILTER ) )
-            .desc_color( c_white )
-            .identifier( "item_filter" )
-            .max_length( 256 )
-            .edit( player_character.hauling_filter );
-            break;
+        case 4: {
+            string_input_popup_imgui filter_popup( 50, player_character.hauling_filter );
+            filter_popup.set_label( _( "Filter:" ) );
+            filter_popup.set_description( item_filter_rule_string( item_filter_type::FILTER ), c_white, true );
+            filter_popup.set_identifier( "item_filter" );
+            player_character.hauling_filter = filter_popup.query();
+        }
+        break;
         case 9:
         default:
             break;

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -47,6 +47,7 @@
 #include "harvest.h"
 #include "input_context.h"
 #include "input_enums.h"
+#include "input_popup.h"
 #include "inventory.h"
 #include "item.h"
 #include "item_components.h"
@@ -79,7 +80,6 @@
 #include "rng.h"
 #include "sounds.h"
 #include "string_formatter.h"
-#include "string_input_popup.h"
 #include "talker.h"  // IWYU pragma: keep
 #include "tileray.h"
 #include "timed_event.h"
@@ -5264,10 +5264,10 @@ void iexamine::sign( Character &you, const tripoint_bub_ms &examp )
                                         _( "Add a message to the sign?" );
             std::string ignore_message = _( "You leave the sign alone." );
             if( query_yn( query_message ) ) {
-                std::string signage = string_input_popup()
-                                      .title( _( "Write what?" ) )
-                                      .identifier( "signage" )
-                                      .query_string();
+                string_input_popup_imgui write_popup( 50 );
+                write_popup.set_label( _( "Write what?" ) );
+                write_popup.set_identifier( "signage" );
+                std::string signage = write_popup.query();
                 if( signage.empty() ) {
                     you.add_msg_if_player( m_neutral, ignore_message );
                 } else {

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -63,6 +63,7 @@
 #include "iexamine.h"
 #include "input_context.h"
 #include "input_enums.h"
+#include "input_popup.h"
 #include "inventory.h"
 #include "inventory_ui.h"
 #include "item.h"
@@ -112,7 +113,6 @@
 #include "speech.h"
 #include "stomach.h"
 #include "string_formatter.h"
-#include "string_input_popup.h"
 #include "teleport.h"
 #include "text_snippets.h"
 #include "translation.h"
@@ -4915,13 +4915,12 @@ std::optional<int> iuse::spray_can( Character *p, item *it, const tripoint_bub_m
 std::optional<int> iuse::handle_ground_graffiti( Character &p, item *it, const std::string &prefix,
         map *here, const tripoint_bub_ms &where )
 {
-    string_input_popup popup;
-    std::string message = popup
-                          .description( prefix + " " + _( "(To delete, clear the text and confirm)" ) )
-                          .text( here->has_graffiti_at( where ) ? here->graffiti_at( where ) : std::string() )
-                          .identifier( "graffiti" )
-                          .query_string();
-    if( popup.canceled() ) {
+    string_input_popup_imgui popup( 50,
+                                    here->has_graffiti_at( where ) ? here->graffiti_at( where ) : std::string() );
+    popup.set_description( prefix + " " + _( "(To delete, clear the text and confirm)" ) );
+    popup.set_identifier( "graffiti" );
+    std::string message = popup.query();
+    if( popup.cancelled() ) {
         return std::nullopt;
     }
 

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -47,6 +47,7 @@
 #include "generic_factory.h"
 #include "iexamine.h"
 #include "inventory.h"
+#include "input_popup.h"
 #include "item.h"
 #include "item_components.h"
 #include "item_contents.h"
@@ -85,7 +86,6 @@
 #include "safe_reference.h"
 #include "sounds.h"
 #include "string_formatter.h"
-#include "string_input_popup.h"
 #include "talker.h"
 #include "translations.h"
 #include "trap.h"
@@ -2081,18 +2081,14 @@ bool inscribe_actor::item_inscription( item &tool, item &cut ) const
                                 string_format( pgettext( "carving", "%1$s on the %2$s is: " ),
                                         gerund, cut.type_name() );
 
-    string_input_popup popup;
-    popup.title( string_format( _( "%s what?" ), verb ) )
-    .width( 64 )
-    .text( hasnote ? cut.get_var( carving ) : std::string() )
-    .description( messageprefix )
-    .identifier( "inscribe_item" )
-    .max_length( 128 )
-    .query();
-    if( popup.canceled() ) {
+    string_input_popup_imgui popup( 50, hasnote ? cut.get_var( carving ) : std::string() );
+    popup.set_label( string_format( _( "%s what?" ), verb ) );
+    popup.set_description( messageprefix );
+    popup.set_identifier( "inscribe_item" );
+    const std::string message = popup.query();
+    if( popup.cancelled() ) {
         return false;
     }
-    const std::string message = popup.text();
     if( message.empty() ) {
         cut.erase_var( carving );
         cut.erase_var( carving_tool );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Migrate more input popups.

#### Describe the solution

Migrated:
- map editor edit json and set item flags
- look around change monster nickname
- hauling item filter
- add/overwrite sign message
- spray graffiti
- inscribe item

#### Describe alternatives you've considered



#### Testing

Used all the popups.

#### Additional context

