### PR TITLE
add `instant_death_chance` for weakpoints

### DIFF
--- a/data/mods/aftershock_exoplanet/EOC/monster_weakpoint_eocs.json
+++ b/data/mods/aftershock_exoplanet/EOC/monster_weakpoint_eocs.json
@@ -1,12 +1,6 @@
 [
   {
     "type": "effect_on_condition",
-    "id": "EOC_AFS_INSTANT_DEATH",
-    "condition": "has_beta",
-    "effect": [ "npc_die" ]
-  },
-  {
-    "type": "effect_on_condition",
     "id": "EOC_AFS_REACTOR_MELTDOWN",
     "condition": "has_beta",
     "effect": [

--- a/data/mods/aftershock_exoplanet/monsters/monster_weakpoints/robot_weakpoints.json
+++ b/data/mods/aftershock_exoplanet/monsters/monster_weakpoints/robot_weakpoints.json
@@ -13,7 +13,7 @@
         "armor_mult": { "all": 1.5 },
         "effects": [
           {
-            "effect_on_conditions": [ "EOC_AFS_INSTANT_DEATH" ],
+            "instant_death_chance": 100,
             "message": "The %s power plants sparks and smokes.",
             "chance": 100,
             "damage_required": [ 1, 100 ]
@@ -29,7 +29,7 @@
         "armor_mult": { "all": 2 },
         "effects": [
           {
-            "effect_on_conditions": [ "EOC_AFS_INSTANT_DEATH" ],
+            "instant_death_chance": 100,
             "message": "The %s processor is completely destroyed!",
             "chance": 100,
             "damage_required": [ 1, 100 ]
@@ -366,7 +366,7 @@
         "coverage": 60,
         "armor_mult": { "all": 0.1 },
         "condition": { "npc_has_any_effect": [ "maimed_armor" ] },
-        "effects": [ { "effect_on_conditions": [ "EOC_AFS_INSTANT_DEATH" ], "chance": 100, "damage_required": [ 1, 100 ] } ]
+        "effects": [ { "instant_death_chance": 100, "chance": 100, "damage_required": [ 1, 100 ] } ]
       }
     ]
   }

--- a/doc/JSON/MONSTERS.md
+++ b/doc/JSON/MONSTERS.md
@@ -437,7 +437,8 @@ Field              | Description
 `duration`         | The duration of the effect. Either a (min, max) pair or a single value.
 `permanent`        | Whether the effect is permanent.
 `intensity`        | The intensity of the effect. Either a (min, max) pair or a single value.
-`damage_required`  | The range of damage, as a percentage of max health, required to trigger the effect.
+`intensity`        | The intensity of the effect. Either a (min, max) pair or a single value.
+`instant_death_chance` | Probability out of 100 to instantly kill a monster, if this weakpoint is hit. Can be a two numbers to roll between
 `message`          | The message to print, if the player triggers the effect. Should take a single template parameter, referencing the monster's name.
 
 The `coverage_mult` and `difficulty` objects support the following subfields:

--- a/doc/JSON/MONSTERS.md
+++ b/doc/JSON/MONSTERS.md
@@ -437,7 +437,7 @@ Field              | Description
 `duration`         | The duration of the effect. Either a (min, max) pair or a single value.
 `permanent`        | Whether the effect is permanent.
 `intensity`        | The intensity of the effect. Either a (min, max) pair or a single value.
-`intensity`        | The intensity of the effect. Either a (min, max) pair or a single value.
+`damage_required`  | The range of damage, as a percentage of max health, required to trigger the effect.
 `instant_death_chance` | Probability out of 100 to instantly kill a monster, if this weakpoint is hit. Can be a two numbers to roll between
 `message`          | The message to print, if the player triggers the effect. Should take a single template parameter, referencing the monster's name.
 

--- a/src/weakpoint.cpp
+++ b/src/weakpoint.cpp
@@ -18,6 +18,7 @@
 #include "effect_source.h"
 #include "enums.h"
 #include "flexbuffer_json.h"
+#include "map.h"
 #include "generic_factory.h"
 #include "item.h"
 #include "magic_enchantment.h"
@@ -314,6 +315,10 @@ void weakpoint_effect::apply_to( Creature &target, int total_damage,
         eoc->activate( d );
     }
 
+    if( x_in_y( rng( instant_death_chance.first, instant_death_chance.second ), 100 ) ) {
+        target.die( &get_map(), attack.source == nullptr ? nullptr : attack.source );
+    }
+
     if( !get_message().empty() && attack.source != nullptr && attack.source->is_avatar() ) {
         add_msg_if_player_sees( target, m_good, get_message(), target.get_name() );
     }
@@ -326,6 +331,7 @@ void weakpoint_effect::load( const JsonObject &jo )
     optional( jo, false, "chance", chance, numeric_bound_reader{0.f, 100.f} );
     optional( jo, false, "permanent", permanent );
     optional( jo, false, "message", message );
+    optional( jo, false, "instant_death_chance", instant_death_chance, pair_reader<int> {} );
     optional( jo, false, "duration", duration, pair_reader<int> {} );
     optional( jo, false, "intensity", intensity, pair_reader<int> {} );
     optional( jo, false, "damage_required", damage_required, pair_reader<float> {} );

--- a/src/weakpoint.h
+++ b/src/weakpoint.h
@@ -74,6 +74,8 @@ struct weakpoint_effect {
     float chance;
     // Whether the effect is permanent.
     bool permanent;
+    // Chance to instantly kill the monster on attack, percent from 1 to 100
+    std::pair<int, int> instant_death_chance;
     // The range of the durations (in turns) of the effect.
     std::pair<int, int> duration;
     // The range of the intensities of the effect.


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Worked on some wp stuff, found a need to add a field like this
#### Describe the solution
Add a field
Replace AFS using of custom EOC with this field
#### Testing
Monsters drop dead after being hit in this WP