### PR TITLE
[Xedra Evolved] Fix Dreamer regen

### DIFF
--- a/data/mods/Xedra_Evolved/enchantments/dream_magick.json
+++ b/data/mods/Xedra_Evolved/enchantments/dream_magick.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "dreamer_regen_no",
+    "name": { "str": "Calm or Bored" },
+    "description": "Your mood is stable and stilled.  Your ability to regenerate mana is nonexistent.",
+    "type": "enchantment",
+    "has": "HELD",
+    "condition": { "and": [ { "math": [ "u_val('morale') >= -34" ] }, { "math": [ "u_val('morale') <= 34" ] } ] },
+    "values": [ { "value": "REGEN_MANA", "multiply": -1 } ]
+  },
+  {
+    "id": "dreamer_regen_yes",
+    "name": { "str": "Passionate" },
+    "description": "You can feel your emotions filling your reservoirs of magickal energy.",
+    "type": "enchantment",
+    "has": "HELD",
+    "condition": { "or": [ { "math": [ "u_val('morale') < -34" ] }, { "math": [ "u_val('morale') > 34" ] } ] },
+    "values": [ { "value": "REGEN_MANA", "multiply": { "math": [ "abs(u_val('morale') ) /41" ] } } ]
+  }
+]

--- a/data/mods/Xedra_Evolved/mutations/classes.json
+++ b/data/mods/Xedra_Evolved/mutations/classes.json
@@ -8,7 +8,7 @@
     "starting_trait": false,
     "purifiable": false,
     "valid": false,
-    "enchantments": [ "BONUS_DREAMER", "DREAMER_NO_REGEN" ],
+    "enchantments": [ "BONUS_DREAMER", "dreamer_regen_yes", "dreamer_regen_no" ],
     "cancels": [ "EATER" ],
     "moncams": [
       [ "mon_shifter", 100 ],
@@ -21,32 +21,6 @@
     "//": "1 vit each 18 minutes, 80 per day, 12,5 days to full",
     "spells_learned": [ [ "create_dream_dross", 0 ], [ "dreamer_artifact", 0 ], [ "return_critters", 0 ] ],
     "flags": [ "ATTUNEMENT" ]
-  },
-  {
-    "type": "mutation",
-    "id": "DREAMER_NO_REGEN",
-    "name": { "str": "Calm or Bored" },
-    "description": "Your mood is stable and stilled.  Your ability to regenerate mana is nonexistent.",
-    "starting_trait": false,
-    "purifiable": false,
-    "valid": false,
-    "points": 0,
-    "transform": { "target": "DREAMER_YES_REGEN", "msg_transform": "Your passions fill you.", "active": false },
-    "enchantments": [ { "values": [ { "value": "REGEN_MANA", "multiply": -1 } ] } ],
-    "triggers": [ [ { "condition": { "or": [ { "math": [ "u_val('morale') < -34" ] }, { "math": [ "u_val('morale') > 34" ] } ] } } ] ]
-  },
-  {
-    "type": "mutation",
-    "id": "DREAMER_YES_REGEN",
-    "name": { "str": "Passionate" },
-    "description": "You can feel your emotions filling your reservoirs of magickal energy.",
-    "starting_trait": false,
-    "purifiable": false,
-    "valid": false,
-    "points": 0,
-    "transform": { "target": "DREAMER_NO_REGEN", "msg_transform": "Your passions subside.", "active": false, "moves": 10 },
-    "enchantments": [ { "values": [ { "value": "REGEN_MANA", "multiply": { "math": [ "abs(u_val('morale') ) /41" ] } } ] } ],
-    "triggers": [ [ { "condition": { "and": [ { "math": [ "u_val('morale') > -35" ] }, { "math": [ "u_val('morale') < 35" ] } ] } } ] ]
   },
   {
     "type": "mutation",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "[Xedra Evolved] Fix Dreamer regen"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Dreamer called a mutation in the enchantment field, which doesn't work. And applying a transformation mutation through enchantment also does not work (see #84093) 

Fixes #84689
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Convert the regen traits into regen enchantments, `dreamer_regen_no` and `dreamer_regen_yes`. You get _no when you are within 34 morale of 100, and you get yes when you're 35+ morale on either side.

You might think "Oh I'll just be miserable" but you regenerate much more mana at high morale than at low morale.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Created a member of Mobile Task Force  Theta 1: Middle Management. Had 1000 out of 1400 max mana, did not regenerate any of it.

Killed and dissected a feral, tanking my morale. Began to regenerate mana. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
