### PR TITLE
Sidebar headers to differentiate terrain vs furniture

### DIFF
--- a/src/game_ui_tile_info.cpp
+++ b/src/game_ui_tile_info.cpp
@@ -193,6 +193,7 @@ void game::print_terrain_info( const tripoint_bub_ms &lp, const catacurses::wind
         area = e->string_id;
     }
     mvwprintz( w_look, point( column, line++ ), c_yellow, area );
+    mvwprintz( w_look, point( column, line++ ), c_light_blue, _( "-----TERRAIN-----" ) );
     mvwprintz( w_look, point( column, line++ ), c_white, tile );
     std::string desc = string_format( here.ter( lp ).obj().description );
     std::vector<std::string> lines = foldstring( desc, max_width );
@@ -281,6 +282,11 @@ void game::print_furniture_info( const tripoint_bub_ms &lp, const catacurses::wi
         return;
     }
     const int max_width = getmaxx( w_look ) - column - 1;
+
+    // Print an empty line as padding IF and only if we're going to print any furniture info.
+    mvwprintw( w_look, point( column, line++ ), "" );
+
+    mvwprintz( w_look, point( column, line++ ), c_light_blue, _( "-----FURNITURE-----" ) );
 
     // Print furniture name in white
     std::string desc = uppercase_first_letter( here.furnname( lp ) );


### PR DESCRIPTION
#### Summary
Interface "Sidebar headers to differentiate terrain vs furniture"

#### Purpose of change
I've realized a while ago that nowhere in the game do we specify exactly what a furniture is vs what a terrain is, despite their huge gameplay implications. The only way for a player to know that "Cupboard" is a furniture and not a terrain is rote memorization, and seeing where it appears in the sidebar.

#### Describe the solution
Instead, let's just make it explicit.
<img width="258" height="335" alt="image" src="https://github.com/user-attachments/assets/40c41100-70a0-47d0-b861-b557d0ed4305" />


#### Describe alternatives you've considered
Even more headers? For fields/items/etc?

#### Testing
<img width="258" height="335" alt="image" src="https://github.com/user-attachments/assets/2abb858b-beb3-419e-ba4d-6dc0029a7b1e" />


#### Additional context
This is a very basic implementation. We could use ncurses to draw a box around each element, but uhhhh that's a lot of effort. And I don't want to put a lot of effort into ncurses when it'll be moving to imgui sooner or later anyway.
