### PR TITLE
Print "taming" foods for monsters

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -41,10 +41,12 @@
 #include "harvest.h"
 #include "imgui/imgui.h"
 #include "item.h"
+#include "item_factory.h"
 #include "item_group.h"
 #include "item_location.h"
 #include "item_pocket.h"
 #include "itype.h"
+#include "iuse.h"
 #include "magic.h"
 #include "magic_enchantment.h"
 #include "map.h"
@@ -902,6 +904,22 @@ int monster::print_info( const catacurses::window &w, int vStart, int vLines, in
         }
     }
     wattroff( w, c_light_gray );
+
+    // Print "taming" food information
+    if( !type->petfood.food.empty() ) {
+        vStart += fold_and_print( w, point( column, vStart ), max_width, c_light_blue,
+                                  _( "Seems to be familiar with people and could be tamed with:" ) );
+
+        for( std::string food_category : type->petfood.food ) {
+            std::vector<const itype *> food_items = Item_factory::find( [&]( const itype & t ) {
+                return t.use_methods.count( "PETFOOD" ) && t.comestible &&
+                       t.comestible->petfood.count( food_category );
+            } );
+            for( const itype *food_item_type : food_items ) {
+                mvwprintz( w, point( column, ++vStart ), c_white, food_item_type->nname( 1 ) );
+            }
+        }
+    }
 
     // Riding indicator on next line after description.
     if( has_effect( effect_ridden ) && mounted_player ) {


### PR DESCRIPTION
#### Summary
Interface "Print 'taming' foods for monsters"

#### Purpose of change
Many, many endless questions about what food(s) can be used to "tame" an animal

#### Describe the solution
Put this information in the UI

<img width="269" height="312" alt="image" src="https://github.com/user-attachments/assets/3593fc9a-1693-4429-a1f6-242a46bd325d" />


It's separated out into different lines so I don't have to figure out how to concatenate a list of items of unknown size (lazy approach)

#### Describe alternatives you've considered
Put it on the item instead? But that could be a very long list. (e.g. wet dog food tames like 20 different kinds of dog)

#### Testing
<img width="269" height="312" alt="image" src="https://github.com/user-attachments/assets/b66cbaf8-2ffa-4240-8a61-bfddd6b7b269" />



#### Additional context
Including item factory just for this, ugh