### PR TITLE
Mention how much food is skipped when camp distribution fails

### DIFF
--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -5709,6 +5709,7 @@ bool basecamp::distribute_food( bool player_command )
     // @FIXME: items under a vehicle cargo part will get taken even if there's no non-vehicle zone there
     // @FIXME: items in a vehicle cargo part will get taken even if the zone is on the ground underneath
     std::map<time_point, nutrients> all_nutrients;
+    int num_skipped = 0;
     for( const tripoint_abs_ms &p_food_stock_abs : z_food ) {
         const tripoint_bub_ms p_food_stock = here.get_bub( p_food_stock_abs );
         map_stack items = here.i_at( p_food_stock );
@@ -5718,6 +5719,7 @@ bool basecamp::distribute_food( bool player_command )
             if( ret.success() ) {
                 iter = items.erase( iter );
             } else {
+                num_skipped++;
                 ++iter;
             }
             for( const std::pair<const time_point, nutrients> &entry : ret.value() ) {
@@ -5732,6 +5734,7 @@ bool basecamp::distribute_food( bool player_command )
                 if( ret.success() ) {
                     iter = items.erase( iter );
                 } else {
+                    num_skipped++;
                     ++iter;
                 }
                 for( const std::pair<const time_point, nutrients> &entry : ret.value() ) {
@@ -5743,7 +5746,12 @@ bool basecamp::distribute_food( bool player_command )
 
     if( all_nutrients.empty() ) {
         if( player_command ) {
-            popup( _( "No suitable items are located at the drop points…" ) );
+            std::string fail_msg = _( "No suitable items are located at the drop points…" );
+            fail_msg += "\n\n";
+            fail_msg += string_format(
+                            _( "%d items were skipped for being unsuitable (not food, or too disgusting to eat, or already rotten, etc. )" ),
+                            num_skipped );
+            popup( fail_msg );
         }
         return false;
     }

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -5749,7 +5749,7 @@ bool basecamp::distribute_food( bool player_command )
             std::string fail_msg = _( "No suitable items are located at the drop points…" );
             fail_msg += "\n\n";
             fail_msg += string_format(
-                            _( "%d items were skipped for being unsuitable (not food, or too disgusting to eat, or already rotten, etc. )" ),
+                            _( "%d items were skipped for being unsuitable (not food, or too disgusting to eat, or already rotten, etc.  )" ),
                             num_skipped );
             popup( fail_msg );
         }


### PR DESCRIPTION
#### Summary
Interface "Mention how much food is skipped when camp distribution fails"

#### Purpose of change
Many, many people have questions about how food distribution works at camps

Right now there are several ways an item is rejected for being put into the camp, but to the player it's opaque. Oftentimes they get confused and don't understand what items are in the zone, or what counts as acceptable.

#### Describe the solution
Print some more helpful information when it fails. Mention the number of items that are actually skipped, and give some general information about why items are skipped.

The number of items helps players know that their items are (or aren't!) in the right place. The mentions of what counts as unacceptable gives some insight into why items are rejected.

#### Describe alternatives you've considered
Have nutrients_from() return a string along with make_failure and use that string to inform the reasons why. So instead of saying "In general, only food items work", we can point and say "You have 47 items which are not food, 13 items which are rotten, 12 items which are alcohol and therefore not valid", etc.

#### Testing
Placed 100 "chunks of mutant meat" into the zone and pressed the button.
<img width="803" height="294" alt="image" src="https://github.com/user-attachments/assets/3651f61c-daf0-4836-bd95-ad580a1a41f4" />


#### Additional context

