### PR TITLE
Fix x-ray vision of NPC underwear

### DIFF
--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -1034,7 +1034,7 @@ bool outfit::is_worn_item_visible( std::list<item>::const_iterator worn_item,
     [this, &worn_item]( const bodypart_str_id & bp ) {
         // no need to check items that are worn under worn_item in the armor sort order
         for( auto i = std::next( worn_item ), end = worn.end(); i != end; ++i ) {
-            if( i->covers( bp ) && i->has_layer( { layer_level::BELTED, layer_level::WAIST } ) &&
+            if( i->covers( bp ) && !i->has_layer( { layer_level::BELTED, layer_level::WAIST } ) &&
                 i->get_coverage( bp ) >= worn_item->get_coverage( bp ) ) {
                 return false;
             }


### PR DESCRIPTION
#### Summary
Bugfixes "Fix x-ray vision of NPC underwear"

#### Purpose of change
You could see everyones' knickers.

#### Describe the solution
Now you can't. Unless they're not wearing anything on top, then of course you can.

For some reason in https://github.com/CleverRaven/Cataclysm-DDA/commit/99a62861eb1aaecca1932f84cefd079ddead99dc @KorGgenT removed the NOT while porting the code. I have not been able to find any reason for this, and their change is prima facie wrong, so I have simply changed it back.

**This will cause some changes with how the "Set of Clothes" item works.**

Basically the "Set of Clothes" will now change only visible items, as it was intended to do.

So if you're wearing a set of fully-enclosed plate armor and a backpack over some casual clothes, then using an empty set of clothes will remove your plate mail and backpack - but not anything underneath. Because the backpack was clearly visible as the most exterior item, and the platemail was clearly visible "underneath" the backpack (coverage of backpack < coverage of platemail), but your casual clothes are not visible underneath the fully-enclosed plate armor.

If you then used a *second* empty set of clothes, then your casual clothes would be taken off, but not your underwear. Because the underwear are not visible underneath your casual clothes! It actually swaps an "outfit".

#### Describe alternatives you've considered


#### Testing
Pre-patch, notice I can see this NPC's briefs:
<img width="2560" height="1400" alt="image" src="https://github.com/user-attachments/assets/604a9c66-d875-4849-84ec-435be5854939" />

Post-patch, notice I cannot see their briefs:
<img width="2560" height="1400" alt="image" src="https://github.com/user-attachments/assets/1aacd497-e74e-4715-9596-9b4a17270b51" />


#### Additional context
This PR title was chosen because it brings a tiny bit of humor.