### PR TITLE
Move shirts to NORMAL layer and hoodies to OUTER layer

### DIFF
--- a/data/json/items/armor/torso_clothes.json
+++ b/data/json/items/armor/torso_clothes.json
@@ -1199,7 +1199,7 @@
     "warmth": 20,
     "material_thickness": 1,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "VARSIZE", "POCKETS", "HOOD" ],
+    "flags": [ "VARSIZE", "POCKETS", "HOOD", "OUTER" ],
     "variant_type": "generic",
     "variants": [
       {
@@ -2339,7 +2339,7 @@
         "append": true
       }
     ],
-    "flags": [ "VARSIZE", "SKINTIGHT" ],
+    "flags": [ "VARSIZE" ],
     "armor": [
       { "coverage": 90, "covers": [ "torso" ] },
       {
@@ -2565,7 +2565,7 @@
     "warmth": 35,
     "material_thickness": 1,
     "valid_mods": [ "steel_padded" ],
-    "flags": [ "VARSIZE", "POCKETS", "HOOD" ]
+    "flags": [ "VARSIZE", "POCKETS", "HOOD", "OUTER" ]
   },
   {
     "id": "bunny_suit_playboy",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
T-shirts are nooooooooot underwear!

You can wear a bra under a t-shirt! (You can also *not* wear one, though YMMV)

The confusion seems to stem from people not being familiar with an "[undershirt](https://en.wikipedia.org/wiki/Undershirt)". It *looks* like a t-shirt! Except it's much tighter, (usually) masculine, and meant to to be worn under more formal clothes or when layering is needed. Those are tight enough to conflicts with a bra, sure! [But undershirts are already a completely different item for that reason.](https://cdda-guide.nornagon.net/item/undershirt)

This for example is shaped like a t-shirt but notice how it sticks to his chest and (frankly) the nipples are clearly visible because of how tight it is
This is an undershirt. It is NOT a t-shirt
<img width="1280" height="1271" alt="image" src="https://github.com/user-attachments/assets/418ddc82-8b9b-462a-8ad7-0a66ec4bebc7" />

#### Describe the solution
* Partially reverts #55408

Moving to new armor coverage is good, but the layering changes are backwards. So just rescind those.

T-shirts --> Normal layer

Hoodies --> Outer layer

Undershirt --> **Stays on** SKINTIGHT layer (no changes)

#### Describe alternatives you've considered
Wool hoodie should probably copy-from existing hoodie, but it wasn't already set up that way...

#### Testing
Bra and t-shirt worn without conflicting penalty
<img width="2560" height="1400" alt="image" src="https://github.com/user-attachments/assets/013bbba0-4d18-44ec-aaa4-aea2df097584" />


#### Additional context

