### PR TITLE
Makes minimum ocean distance closer to spawn

### DIFF
--- a/data/json/region_settings/region_settings/regional_map_settings.json
+++ b/data/json/region_settings/region_settings/regional_map_settings.json
@@ -81,7 +81,7 @@
     "ocean_start_north": 500,
     "ocean_start_east": 10,
     "ocean_start_west": 1000,
-    "ocean_start_south": 0,
+    "ocean_start_south": null,
     "sandy_beach_width": 6
   },
   {

--- a/data/mods/TropiCataclysm/region_settings/tropical_regional_map_settings.json
+++ b/data/mods/TropiCataclysm/region_settings/tropical_regional_map_settings.json
@@ -11,8 +11,8 @@
     "copy-from": "default",
     "ocean_start_north": 10,
     "ocean_start_east": 100,
-    "ocean_start_west": 0,
-    "ocean_start_south": 0
+    "ocean_start_west": null,
+    "ocean_start_south": null
   },
   {
     "type": "region_settings_forest",

--- a/data/mods/rural_biome/region_settings/region_settings/rural_regional_map_settings.json
+++ b/data/mods/rural_biome/region_settings/region_settings/rural_regional_map_settings.json
@@ -34,7 +34,7 @@
     "ocean_start_north": 500,
     "ocean_start_east": 10,
     "ocean_start_west": 1000,
-    "ocean_start_south": 0,
+    "ocean_start_south": null,
     "sandy_beach_width": 6
   },
   {

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -3847,10 +3847,13 @@ void overmap::place_mongroups()
         const region_settings_ocean &settings_ocean = settings->get_settings_ocean();
         const om_noise::om_noise_layer_ocean f( global_base_point(), g->get_seed() );
         const point_abs_om this_om = pos();
-        const int northern_ocean = settings_ocean.ocean_start_north;
-        const int eastern_ocean = settings_ocean.ocean_start_east;
-        const int western_ocean = settings_ocean.ocean_start_west;
-        const int southern_ocean = settings_ocean.ocean_start_south;
+        const int northern_ocean = settings_ocean.ocean_start_north.value_or( INT_MAX );
+        const int eastern_ocean = settings_ocean.ocean_start_east.value_or( INT_MAX );
+        const int western_ocean = settings_ocean.ocean_start_west.value_or( INT_MAX );
+        const int southern_ocean = settings_ocean.ocean_start_south.value_or( INT_MAX );
+        const bool oceans_disabled = ( !settings_ocean.ocean_start_north.has_value() &&
+                                       !settings_ocean.ocean_start_east.has_value() &&
+                                       !settings_ocean.ocean_start_west.has_value() && !settings_ocean.ocean_start_south.has_value() );
 
         // noise threshold adjuster for deep ocean. Increase to make deep ocean move further from the shore.
         constexpr float DEEP_OCEAN_THRESHOLD_ADJUST = 1.25;
@@ -3858,7 +3861,7 @@ void overmap::place_mongroups()
         // code taken from place_oceans, but noise threshold increased to determine "deep ocean".
         const auto is_deep_ocean = [&]( const point_om_omt & p ) {
             // credit to ehughsbaird for thinking up this inbounds solution to infinite flood fill lag.
-            if( northern_ocean == 0 && eastern_ocean == 0 && western_ocean == 0 && southern_ocean == 0 ) {
+            if( oceans_disabled ) {
                 // you know you could just turn oceans off in global_settings.json right?
                 return false;
             }

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -3847,9 +3847,9 @@ void overmap::place_mongroups()
         const region_settings_ocean &settings_ocean = settings->get_settings_ocean();
         const om_noise::om_noise_layer_ocean f( global_base_point(), g->get_seed() );
         const point_abs_om this_om = pos();
-        const bool oceans_disabled = ( !settings_ocean.ocean_start_north.has_value() &&
-                                       !settings_ocean.ocean_start_east.has_value() &&
-                                       !settings_ocean.ocean_start_west.has_value() && !settings_ocean.ocean_start_south.has_value() );
+        const bool oceans_disabled = !settings_ocean.ocean_start_north.has_value() &&
+                                     !settings_ocean.ocean_start_east.has_value() &&
+                                     !settings_ocean.ocean_start_west.has_value() && !settings_ocean.ocean_start_south.has_value();
 
         // noise threshold adjuster for deep ocean. Increase to make deep ocean move further from the shore.
         constexpr float DEEP_OCEAN_THRESHOLD_ADJUST = 1.25;

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -3847,10 +3847,6 @@ void overmap::place_mongroups()
         const region_settings_ocean &settings_ocean = settings->get_settings_ocean();
         const om_noise::om_noise_layer_ocean f( global_base_point(), g->get_seed() );
         const point_abs_om this_om = pos();
-        const int northern_ocean = settings_ocean.ocean_start_north.value_or( INT_MAX );
-        const int eastern_ocean = settings_ocean.ocean_start_east.value_or( INT_MAX );
-        const int western_ocean = settings_ocean.ocean_start_west.value_or( INT_MAX );
-        const int southern_ocean = settings_ocean.ocean_start_south.value_or( INT_MAX );
         const bool oceans_disabled = ( !settings_ocean.ocean_start_north.has_value() &&
                                        !settings_ocean.ocean_start_east.has_value() &&
                                        !settings_ocean.ocean_start_west.has_value() && !settings_ocean.ocean_start_south.has_value() );

--- a/src/overmap_highway.cpp
+++ b/src/overmap_highway.cpp
@@ -534,14 +534,10 @@ std::pair<bool, std::bitset<HIGHWAY_MAX_CONNECTIONS>> overmap::highway_handle_oc
     if( settings->overmap_ocean ) {
         const region_settings_ocean &settings_ocean = settings->get_settings_ocean();
         // Not ideal as oceans can start later than these settings but it's at least reliably stopping before them
-        const int ocean_start_north = settings_ocean.ocean_start_north == 0 ? INT_MAX :
-                                      settings_ocean.ocean_start_north;
-        const int ocean_start_east = settings_ocean.ocean_start_east == 0 ? INT_MAX :
-                                     settings_ocean.ocean_start_east;
-        const int ocean_start_west = settings_ocean.ocean_start_west == 0 ? INT_MAX :
-                                     settings_ocean.ocean_start_west;
-        const int ocean_start_south = settings_ocean.ocean_start_south == 0 ? INT_MAX :
-                                      settings_ocean.ocean_start_south;
+        const int ocean_start_north = settings_ocean.ocean_start_north.value_or( INT_MAX );
+        const int ocean_start_east = settings_ocean.ocean_start_east.value_or( INT_MAX );
+        const int ocean_start_west = settings_ocean.ocean_start_west.value_or( INT_MAX );
+        const int ocean_start_south = settings_ocean.ocean_start_south.value_or( INT_MAX );
         // Don't place highways over the ocean
         if( this_om.y() <= -ocean_start_north || this_om.x() >= ocean_start_east ||
             this_om.y() >= ocean_start_south || this_om.x() <= -ocean_start_west ) {

--- a/src/overmap_water.cpp
+++ b/src/overmap_water.cpp
@@ -372,10 +372,10 @@ void overmap::place_lakes( const std::vector<const overmap *> &neighbor_overmaps
 float overmap::calculate_ocean_gradient( const point_om_omt &p, const point_abs_om this_om )
 {
     const region_settings_ocean &settings_ocean = settings->get_settings_ocean();
-    const int northern_ocean = settings_ocean.ocean_start_north;
-    const int eastern_ocean = settings_ocean.ocean_start_east;
-    const int western_ocean = settings_ocean.ocean_start_west;
-    const int southern_ocean = settings_ocean.ocean_start_south;
+    const int northern_ocean = settings_ocean.ocean_start_north.value_or( INT_MAX );
+    const int eastern_ocean = settings_ocean.ocean_start_east.value_or( INT_MAX );
+    const int western_ocean = settings_ocean.ocean_start_west.value_or( INT_MAX );
+    const int southern_ocean = settings_ocean.ocean_start_south.value_or( INT_MAX );
 
     float ocean_adjust_N = 0.0f;
     float ocean_adjust_E = 0.0f;
@@ -386,7 +386,8 @@ float overmap::calculate_ocean_gradient( const point_om_omt &p, const point_abs_
                          + std::abs( ( this_om.y() + northern_ocean - OCEAN_INDENT ) * OMAPY ) );
     }
     if( eastern_ocean > 0 && this_om.x() >= eastern_ocean - OCEAN_INDENT ) {
-        ocean_adjust_E = 0.0005f * static_cast<float>( p.x() + ( this_om.x() - eastern_ocean + OCEAN_INDENT )
+        ocean_adjust_E = 0.0005f * static_cast<float>( p.x() + ( this_om.x() - eastern_ocean +
+                         OCEAN_INDENT )
                          * OMAPX );
     }
     if( western_ocean > 0 && this_om.x() <= ( western_ocean - OCEAN_INDENT ) * -1 ) {
@@ -394,7 +395,8 @@ float overmap::calculate_ocean_gradient( const point_om_omt &p, const point_abs_
                          + std::abs( ( this_om.x() + western_ocean - OCEAN_INDENT ) * OMAPX ) );
     }
     if( southern_ocean > 0 && this_om.y() >= southern_ocean - OCEAN_INDENT ) {
-        ocean_adjust_S = 0.0005f * static_cast<float>( p.y() + ( this_om.y() - southern_ocean + OCEAN_INDENT ) * OMAPY );
+        ocean_adjust_S = 0.0005f * static_cast<float>( p.y() + ( this_om.y() - southern_ocean +
+                         OCEAN_INDENT ) * OMAPY );
     }
     return std::max( { ocean_adjust_N, ocean_adjust_E, ocean_adjust_W, ocean_adjust_S } );
 }
@@ -402,18 +404,21 @@ float overmap::calculate_ocean_gradient( const point_om_omt &p, const point_abs_
 void overmap::place_oceans( const std::vector<const overmap *> &neighbor_overmaps )
 {
     const region_settings_ocean &settings_ocean = settings->get_settings_ocean();
-    const int northern_ocean = settings_ocean.ocean_start_north;
-    const int eastern_ocean = settings_ocean.ocean_start_east;
-    const int western_ocean = settings_ocean.ocean_start_west;
-    const int southern_ocean = settings_ocean.ocean_start_south;
+    const int northern_ocean = settings_ocean.ocean_start_north.value_or( INT_MAX );
+    const int eastern_ocean = settings_ocean.ocean_start_east.value_or( INT_MAX );
+    const int western_ocean = settings_ocean.ocean_start_west.value_or( INT_MAX );
+    const int southern_ocean = settings_ocean.ocean_start_south.value_or( INT_MAX );
     const int ocean_depth = settings_ocean.ocean_depth;
+    const bool oceans_disabled = ( !settings_ocean.ocean_start_north.has_value() &&
+                                   !settings_ocean.ocean_start_east.has_value() &&
+                                   !settings_ocean.ocean_start_west.has_value() && !settings_ocean.ocean_start_south.has_value() );
 
     const om_noise::om_noise_layer_ocean f( global_base_point(), g->get_seed() );
     const point_abs_om this_om = pos();
 
     const auto is_ocean = [&]( const point_om_omt & p ) {
         // credit to ehughsbaird for thinking up this inbounds solution to infinite flood fill lag.
-        if( northern_ocean == 0 && eastern_ocean == 0 && western_ocean == 0 && southern_ocean == 0 ) {
+        if( oceans_disabled ) {
             // you know you could just turn oceans off in global_settings.json right?
             return false;
         }

--- a/src/overmap_water.cpp
+++ b/src/overmap_water.cpp
@@ -42,8 +42,6 @@ static const oter_str_id oter_river_south( "river_south" );
 static const oter_str_id oter_river_sw( "river_sw" );
 static const oter_str_id oter_river_west( "river_west" );
 
-static const int OCEAN_INDENT = 2;
-
 void overmap::place_river( const std::vector<const overmap *> &neighbor_overmaps,
                            const overmap_river_node &initial_points, int river_scale, bool major_river )
 {
@@ -381,22 +379,20 @@ float overmap::calculate_ocean_gradient( const point_om_omt &p, const point_abs_
     float ocean_adjust_E = 0.0f;
     float ocean_adjust_W = 0.0f;
     float ocean_adjust_S = 0.0f;
-    if( northern_ocean > 0 && this_om.y() <= ( northern_ocean - OCEAN_INDENT ) * -1 ) {
+    if( this_om.y() <= northern_ocean * -1 ) {
         ocean_adjust_N = 0.0005f * static_cast<float>( OMAPY - p.y()
-                         + std::abs( ( this_om.y() + northern_ocean - OCEAN_INDENT ) * OMAPY ) );
+                         + std::abs( ( this_om.y() + northern_ocean ) * OMAPY ) );
     }
-    if( eastern_ocean > 0 && this_om.x() >= eastern_ocean - OCEAN_INDENT ) {
-        ocean_adjust_E = 0.0005f * static_cast<float>( p.x() + ( this_om.x() - eastern_ocean +
-                         OCEAN_INDENT )
+    if( this_om.x() >= eastern_ocean ) {
+        ocean_adjust_E = 0.0005f * static_cast<float>( p.x() + ( this_om.x() - eastern_ocean )
                          * OMAPX );
     }
-    if( western_ocean > 0 && this_om.x() <= ( western_ocean - OCEAN_INDENT ) * -1 ) {
+    if( this_om.x() <= western_ocean * -1 ) {
         ocean_adjust_W = 0.0005f * static_cast<float>( OMAPX - p.x()
-                         + std::abs( ( this_om.x() + western_ocean - OCEAN_INDENT ) * OMAPX ) );
+                         + std::abs( ( this_om.x() + western_ocean ) * OMAPX ) );
     }
-    if( southern_ocean > 0 && this_om.y() >= southern_ocean - OCEAN_INDENT ) {
-        ocean_adjust_S = 0.0005f * static_cast<float>( p.y() + ( this_om.y() - southern_ocean +
-                         OCEAN_INDENT ) * OMAPY );
+    if( this_om.y() >= southern_ocean ) {
+        ocean_adjust_S = 0.0005f * static_cast<float>( p.y() + ( this_om.y() - southern_ocean ) * OMAPY );
     }
     return std::max( { ocean_adjust_N, ocean_adjust_E, ocean_adjust_W, ocean_adjust_S } );
 }

--- a/src/overmap_water.cpp
+++ b/src/overmap_water.cpp
@@ -42,6 +42,8 @@ static const oter_str_id oter_river_south( "river_south" );
 static const oter_str_id oter_river_sw( "river_sw" );
 static const oter_str_id oter_river_west( "river_west" );
 
+static const int OCEAN_INDENT = 2;
+
 void overmap::place_river( const std::vector<const overmap *> &neighbor_overmaps,
                            const overmap_river_node &initial_points, int river_scale, bool major_river )
 {
@@ -379,20 +381,20 @@ float overmap::calculate_ocean_gradient( const point_om_omt &p, const point_abs_
     float ocean_adjust_E = 0.0f;
     float ocean_adjust_W = 0.0f;
     float ocean_adjust_S = 0.0f;
-    if( northern_ocean > 0 && this_om.y() <= northern_ocean * -1 ) {
+    if( northern_ocean > 0 && this_om.y() <= ( northern_ocean - OCEAN_INDENT ) * -1 ) {
         ocean_adjust_N = 0.0005f * static_cast<float>( OMAPY - p.y()
-                         + std::abs( ( this_om.y() + northern_ocean ) * OMAPY ) );
+                         + std::abs( ( this_om.y() + northern_ocean - OCEAN_INDENT ) * OMAPY ) );
     }
-    if( eastern_ocean > 0 && this_om.x() >= eastern_ocean ) {
-        ocean_adjust_E = 0.0005f * static_cast<float>( p.x() + ( this_om.x() - eastern_ocean )
+    if( eastern_ocean > 0 && this_om.x() >= eastern_ocean - OCEAN_INDENT ) {
+        ocean_adjust_E = 0.0005f * static_cast<float>( p.x() + ( this_om.x() - eastern_ocean + OCEAN_INDENT )
                          * OMAPX );
     }
-    if( western_ocean > 0 && this_om.x() <= western_ocean * -1 ) {
+    if( western_ocean > 0 && this_om.x() <= ( western_ocean - OCEAN_INDENT ) * -1 ) {
         ocean_adjust_W = 0.0005f * static_cast<float>( OMAPX - p.x()
-                         + std::abs( ( this_om.x() + western_ocean ) * OMAPX ) );
+                         + std::abs( ( this_om.x() + western_ocean - OCEAN_INDENT ) * OMAPX ) );
     }
-    if( southern_ocean > 0 && this_om.y() >= southern_ocean ) {
-        ocean_adjust_S = 0.0005f * static_cast<float>( p.y() + ( this_om.y() - southern_ocean ) * OMAPY );
+    if( southern_ocean > 0 && this_om.y() >= southern_ocean - OCEAN_INDENT ) {
+        ocean_adjust_S = 0.0005f * static_cast<float>( p.y() + ( this_om.y() - southern_ocean + OCEAN_INDENT ) * OMAPY );
     }
     return std::max( { ocean_adjust_N, ocean_adjust_E, ocean_adjust_W, ocean_adjust_S } );
 }

--- a/src/overmap_water.cpp
+++ b/src/overmap_water.cpp
@@ -403,9 +403,9 @@ void overmap::place_oceans( const std::vector<const overmap *> &neighbor_overmap
 {
     const region_settings_ocean &settings_ocean = settings->get_settings_ocean();
     const int ocean_depth = settings_ocean.ocean_depth;
-    const bool oceans_disabled = ( !settings_ocean.ocean_start_north.has_value() &&
-                                   !settings_ocean.ocean_start_east.has_value() &&
-                                   !settings_ocean.ocean_start_west.has_value() && !settings_ocean.ocean_start_south.has_value() );
+    const bool oceans_disabled = !settings_ocean.ocean_start_north.has_value() &&
+                                 !settings_ocean.ocean_start_east.has_value() &&
+                                 !settings_ocean.ocean_start_west.has_value() && !settings_ocean.ocean_start_south.has_value();
 
     const om_noise::om_noise_layer_ocean f( global_base_point(), g->get_seed() );
     const point_abs_om this_om = pos();

--- a/src/overmap_water.cpp
+++ b/src/overmap_water.cpp
@@ -1,8 +1,10 @@
 #include <algorithm>
 #include <array>
+#include <climits>
 #include <cmath>
 #include <cstdlib>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_set>
 #include <utility>
@@ -400,10 +402,6 @@ float overmap::calculate_ocean_gradient( const point_om_omt &p, const point_abs_
 void overmap::place_oceans( const std::vector<const overmap *> &neighbor_overmaps )
 {
     const region_settings_ocean &settings_ocean = settings->get_settings_ocean();
-    const int northern_ocean = settings_ocean.ocean_start_north.value_or( INT_MAX );
-    const int eastern_ocean = settings_ocean.ocean_start_east.value_or( INT_MAX );
-    const int western_ocean = settings_ocean.ocean_start_west.value_or( INT_MAX );
-    const int southern_ocean = settings_ocean.ocean_start_south.value_or( INT_MAX );
     const int ocean_depth = settings_ocean.ocean_depth;
     const bool oceans_disabled = ( !settings_ocean.ocean_start_north.has_value() &&
                                    !settings_ocean.ocean_start_east.has_value() &&

--- a/src/regional_settings.cpp
+++ b/src/regional_settings.cpp
@@ -516,11 +516,11 @@ void region_settings_ocean::load( const JsonObject &jo, std::string_view )
     optional( jo, was_loaded, "noise_threshold_ocean", noise_threshold_ocean );
     optional( jo, was_loaded, "ocean_size_min", ocean_size_min );
     optional( jo, was_loaded, "ocean_depth", ocean_depth );
-    optional( jo, was_loaded, "ocean_start_north", ocean_start_north );
-    optional( jo, was_loaded, "ocean_start_east", ocean_start_east );
-    optional( jo, was_loaded, "ocean_start_west", ocean_start_west );
-    optional( jo, was_loaded, "ocean_start_south", ocean_start_south );
-    optional( jo, was_loaded, "sandy_beach_width", sandy_beach_width );
+    optional( jo, was_loaded, "ocean_start_north", ocean_start_north, std::nullopt );
+    optional( jo, was_loaded, "ocean_start_east", ocean_start_east, std::nullopt );
+    optional( jo, was_loaded, "ocean_start_west", ocean_start_west, std::nullopt );
+    optional( jo, was_loaded, "ocean_start_south", ocean_start_south, std::nullopt );
+    optional( jo, was_loaded, "sandy_beach_width", sandy_beach_width, std::nullopt );
 }
 
 void region_settings_highway::load( const JsonObject &jo, std::string_view )

--- a/src/regional_settings.cpp
+++ b/src/regional_settings.cpp
@@ -516,11 +516,11 @@ void region_settings_ocean::load( const JsonObject &jo, std::string_view )
     optional( jo, was_loaded, "noise_threshold_ocean", noise_threshold_ocean );
     optional( jo, was_loaded, "ocean_size_min", ocean_size_min );
     optional( jo, was_loaded, "ocean_depth", ocean_depth );
-    optional( jo, was_loaded, "ocean_start_north", ocean_start_north, std::nullopt );
-    optional( jo, was_loaded, "ocean_start_east", ocean_start_east, std::nullopt );
-    optional( jo, was_loaded, "ocean_start_west", ocean_start_west, std::nullopt );
-    optional( jo, was_loaded, "ocean_start_south", ocean_start_south, std::nullopt );
-    optional( jo, was_loaded, "sandy_beach_width", sandy_beach_width, std::nullopt );
+    optional( jo, was_loaded, "ocean_start_north", ocean_start_north );
+    optional( jo, was_loaded, "ocean_start_east", ocean_start_east );
+    optional( jo, was_loaded, "ocean_start_west", ocean_start_west );
+    optional( jo, was_loaded, "ocean_start_south", ocean_start_south );
+    optional( jo, was_loaded, "sandy_beach_width", sandy_beach_width );
 }
 
 void region_settings_highway::load( const JsonObject &jo, std::string_view )

--- a/src/regional_settings.h
+++ b/src/regional_settings.h
@@ -291,10 +291,10 @@ struct region_settings_ocean {
     double noise_threshold_ocean = 0.25;
     int ocean_size_min = 100;
     int ocean_depth = -9;
-    int ocean_start_north = 0;
-    int ocean_start_east = 10;
-    int ocean_start_west = 0;
-    int ocean_start_south = 0;
+    std::optional<int> ocean_start_north = NULL;
+    std::optional<int> ocean_start_east = 10;
+    std::optional<int> ocean_start_west = NULL;
+    std::optional<int> ocean_start_south = NULL;
     int sandy_beach_width = 2;
 
     bool was_loaded = false;

--- a/src/regional_settings.h
+++ b/src/regional_settings.h
@@ -291,10 +291,10 @@ struct region_settings_ocean {
     double noise_threshold_ocean = 0.25;
     int ocean_size_min = 100;
     int ocean_depth = -9;
-    std::optional<int> ocean_start_north = NULL;
-    std::optional<int> ocean_start_east = 10;
-    std::optional<int> ocean_start_west = NULL;
-    std::optional<int> ocean_start_south = NULL;
+    std::optional<int> ocean_start_north;
+    std::optional<int> ocean_start_east;
+    std::optional<int> ocean_start_west;
+    std::optional<int> ocean_start_south;
     int sandy_beach_width = 2;
 
     bool was_loaded = false;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I wanted a dimension that is a small-ish island surrounded by oceans, but it turns out that the minimum ocean distance settings possible still places the oceans quite far away from spawn.
Thus I changed so that you use `"ocean_start_south": null,` do declare that there are no oceans south, rather than the old way which was `"ocean_start_south": 0,`.
Ocean start distances now accepts 0 and negative values, which allows you to generate the world as a small island.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Use `std::optional<int>` instead of `int` for the ocean start distance values
Use .has_value() instead of checking if the value is more than 0 to check if the ocean is disabled.
Updated in-repo mods to use null instead of 0
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Hard-code that the ocean is 2 overmaps closer. But that is not as elegant, and would potentialkly break existing worlds.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested a bunch, seems to work.
Lower values seem to work. Old values seem to work.
Haven't tested the latest changes yet (removing default values and onward)
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
<img width="1455" height="964" alt="image" src="https://github.com/user-attachments/assets/4a4736cd-fda0-4a45-be91-66775ec9872c" />
<img width="1392" height="503" alt="image" src="https://github.com/user-attachments/assets/7f8ef78b-5950-44b2-9020-987e38421592" />

A small world

For testing purposes I also changed this line to make the game lag less when it tries and fails to place overmap specials

` "feature_flag_settings": { "blacklist": [  ], "whitelist": [ "HIGHLANDS" ] },`

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
