### PR TITLE
Validate spell ids in learn_spell use_action

### DIFF
--- a/data/mods/Magiclysm/items/spellbooks.json
+++ b/data/mods/Magiclysm/items/spellbooks.json
@@ -376,7 +376,7 @@
     "color": "green",
     "use_action": {
       "type": "learn_spell",
-      "spells": [ "druid_veggrasp", "druid_summon_brambles", "seed_of_growth", "druid_natures_commune", "druid_healing_herb" ]
+      "spells": [ "druid_veggrasp", "druid_summon_brambles", "druid_growth", "druid_natures_commune", "druid_healing_herb" ]
     }
   },
   {
@@ -1345,7 +1345,7 @@
       "type": "learn_spell",
       "spells": [
         "kelvinist_firebolt",
-        "spell_scroll_point_flare",
+        "point_flare",
         "kelvinist_extinguish_fire_spell",
         "create_lighter",
         "kelvinist_heat_food",

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2539,6 +2539,17 @@ void Item_factory::check_definitions() const
             if( type->can_use( "MA_MANUAL" ) && !type->book->martial_art ) {
                 msg += "has use_action MA_MANUAL but does not specify a martial art\n";
             }
+            if( type->can_use( "learn_spell" ) ) {
+                const use_function learn_spell_action = *type->get_use( "learn_spell" );
+                const learn_spell_actor *actor_ptr = static_cast<const learn_spell_actor *>
+                                                     ( learn_spell_action.get_actor_ptr() );
+                for( const std::string &spell_str : actor_ptr->spells ) {
+                    const spell_id sp( spell_str );
+                    if( !sp.is_valid() ) {
+                        msg += string_format( "lists invalid spell in learn_spell use_action: '%s'\n", spell_str );
+                    }
+                }
+            }
         }
         if( type->can_use( "MA_MANUAL" ) && !type->book ) {
             msg += "has use_action MA_MANUAL but is not a book\n";


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fix #84696
#### Describe the solution
Add a check to validate spell id in spell learning use action
Fix two magiclyls spells found by validation
#### Testing
Since it found point_flare issue, i think that's a success