### PR TITLE
Fix behavior when many dialogue options are present. (ncurses only issue)

### DIFF
--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -3029,6 +3029,9 @@ talk_topic dialogue::opt( dialogue_window &d_win, const talk_topic &topic )
             input_event evt;
             action = ctxt.handle_input();
             evt = ctxt.get_raw_input();
+            if( evt.type == input_event_t::error || evt.type == input_event_t::timeout ) {
+                continue;
+            }
             d_win.handle_scrolling( action, ctxt );
             talk_topic st = special_talk( action );
             if( st.id != "TALK_NONE" ) {


### PR DESCRIPTION
#### Summary
Bugfixes "Fixes a wrong behavior when many dialogue options are present where the first one without a keybind will be selected by default."


#### Purpose of change
This was happening on experimental latest using the ncurses backend.
Opening the Bombastic perks menu would drop you instantly into the "buy specific perk" screen for the blood drinker perk, rather than show the list of perks. We were also unable to go back to the perk list menu from that point, because a frame later it would drop you right back into the same menu.
#### Describe the solution

When reading the key input during the dialogue menu handling, we now check if the input we got was an error or a timeout. If that's not done, the code would go grab the first options without a keybind, because the event type was input_event_t::error.

#### Describe alternatives you've considered

Not creating keybinds with input_event_t::error. However the dialogue handling code would need to be refactored to take this into account. The simpler solution is to just skip if the input event is wrong.

#### Testing

Open game with bombastic perks, mom and sky island. Open perks menu (mutation -> open perks menu).
Notice how we now see the menu instead of being dropped into one of the perks instantly and being stuck inside of it.

#### Additional context

The difference between tiles and ncurses might be caused by the ncurses backend returning input_event_t::error during read event raw while tiles doesn't. This is purely conjecture though.

