### PR TITLE
Support fmtlib formatted translated strings with `_fmt()`

### DIFF
--- a/lang/update_pot.sh
+++ b/lang/update_pot.sh
@@ -18,6 +18,7 @@ xgettext --default-domain="cataclysm-dda" \
          --sort-by-file \
          --output="lang/po/base.pot" \
          --keyword="_" \
+         --keyword="_fmt" \
          --keyword="pgettext:1c,2" \
          --keyword="n_gettext:1,2" \
          --keyword="npgettext:1c,2,3" \

--- a/pch/main-pch.hpp
+++ b/pch/main-pch.hpp
@@ -83,6 +83,8 @@
 #include <utility>
 #include <vector>
 #include <flatbuffers/flexbuffers.h>
+#include <fmt/format.h>
+#include <fmt/printf.h>
 
 #if defined(_MSC_VER)
 #   include "platform_win.h"

--- a/src/cata_path.h
+++ b/src/cata_path.h
@@ -7,6 +7,8 @@
 
 #include <filesystem>
 
+#include <fmt/format.h>
+
 /**
  * One of the problems of filesystem paths is they lack contextual awareness
  * of 'where' they are. They're just a list of segments pointing into the
@@ -160,6 +162,13 @@ class cata_path
         as_fs_path( T &&path ) {
             return std::filesystem::u8path( std::forward<T>( path ) );
         }
+};
+
+template <>
+struct fmt::formatter<cata_path> : formatter<std::string_view> {
+    auto format( const cata_path &path, fmt::format_context &ctx ) const {
+        return formatter<std::string_view>::format( path.generic_u8string(), ctx );
+    }
 };
 
 #endif // CATA_SRC_CATA_PATH_H

--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -383,8 +383,7 @@ submap *mapbuffer::unserialize_submaps( const tripoint_abs_sm &p )
             std::optional<zzip> z = zzip::load( zzip_name.get_unrelative_path(),
                                                 ( PATH_INFO::world_base_save_path() / "maps.dict" ).get_unrelative_path() );
             if( !z ) {
-                debugmsg( "Failed to load submaps from %s, could not open zzip.",
-                          zzip_name.generic_u8string().c_str() );
+                debugmsg( _fmt( "Failed to load submaps from {0}, could not open zzip.", zzip_name ) );
                 return false;
             }
             if( !z->has_file( file_name_path ) ) {

--- a/src/string_formatter.cpp
+++ b/src/string_formatter.cpp
@@ -2,11 +2,22 @@
 
 #include <exception>
 
+#include <fmt/format.h>
 #include <fmt/printf.h>
 
 #include "cata_path.h"
 #include "debug.h"
 #include "translation.h"
+
+std::string string_vfmt( fmt::string_view format, fmt::format_args args )
+{
+    try {
+        return fmt::vformat( format, args );
+    } catch( const std::exception &err ) {
+        debugmsg( std::string{ err.what() } + ": " + std::string{ format.data(), format.size() } );
+        return err.what();
+    }
+}
 
 const char *printf_converter<cata_path>::convert( const cata_path &p )
 {

--- a/src/string_formatter.h
+++ b/src/string_formatter.h
@@ -8,24 +8,11 @@
 
 #include "printf_converter.h"
 
+// #include <fmt/format.h>
 #include <fmt/printf.h>
 
-/*
-template<typename T, typename = std::enable_if_t<std::is_enum_v<T>>>
-         inline auto format_as( T e )
-{
-    return static_cast<std::underlying_type_t<T>>( e );
-}
+extern std::string string_vfmt( fmt::string_view format, fmt::format_args args );
 
-namespace cata
-{
-template<typename T, typename = std::enable_if_t<std::is_enum_v<T>>>
-         inline auto format_as( T e )
-{
-    return static_cast<std::underlying_type_t<T>>( e );
-}
-} // namespace cata
-*/
 extern std::string string_vprintf( fmt::string_view format, fmt::printf_args args );
 
 template<typename ...Args>

--- a/src/translation.h
+++ b/src/translation.h
@@ -5,8 +5,6 @@
 #include <optional>
 #include <string>
 
-#include <fmt/printf.h>
-
 #include "translation_cache.h"
 #include "value_ptr.h"
 

--- a/tools/spell_checker/dictionary.txt
+++ b/tools/spell_checker/dictionary.txt
@@ -7205,4 +7205,5 @@ zweihänders
 zweitimber
 zweitimbers
 zygomaticus
+zzip
 zzz


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Infrastructure "Add support for fstring style placeholders in translated strings."

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
#84332 deprecated `string_formatter`'s runtime type conversion. This is because we now have `fmtlib` which is a more powerful implementation of similar functionality, with the added bonus of compile time type checking, and smaller binary size and runtime code generation to boot. But we only did it halfway because migrating the entire codebase to fstrings at once is infeasible. Instead we used the printf compatible api to support existing strings as best as we could, with runtime type checking.

We should really use compile time type checking though.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add support for `fmtlib`'s primary api with the `_fmt` macro. This macro typechecks the args against the original input string, then formats the translation of the string. This macro does not support all current use cases of `_()` - namely, it only supports string literals, because for static typechecking the args must be provided when the macro is invoked instead of after.

There is an escape hatch which triggers runtime typechecking, which will be investigated later for handling trickier cases. For now, get in one test case with a string literal to exercise the entire translation pipeline.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Ran `lang/update_pot.sh`, saw this in the output
```
#: src/mapbuffer.cpp:386
#, c++-format
msgid "Failed to load submaps from {0}, could not open zzip."
msgstr ""
```
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
