### PR TITLE
Make Exodii barter system much less stingy

### DIFF
--- a/data/json/npcs/exodii/exodii_merchant_definitions.json
+++ b/data/json/npcs/exodii/exodii_merchant_definitions.json
@@ -38,7 +38,6 @@
       { "group": "EXODII_Store_Salvage_Tech", "rigid": true, "trust": 20 },
       { "group": "EXODII_CBM_Store_Tier4", "rigid": true, "trust": 40, "strict": true },
       { "group": "EXODII_CBM_unlocks_weapons_heavy", "rigid": true, "trust": 40, "strict": true }
-
     ],
     "shopkeeper_consumption_rates": "basic_shop_rates",
     "weapon_override": "NC_EXODII_TYPE_1_carried",

--- a/data/json/npcs/exodii/exodii_merchant_definitions.json
+++ b/data/json/npcs/exodii/exodii_merchant_definitions.json
@@ -31,11 +31,14 @@
       { "group": "EXODII_Shop_Tier0", "rigid": true },
       { "group": "EXODII_Shop_NomadGear_Tier0", "rigid": true },
       { "group": "EXODII_CBM_Store_Tier1", "rigid": true },
-      { "group": "EXODII_CBM_Store_tier1_extra", "rigid": true, "trust": 1 },
       { "group": "EXODII_CBM_Store_Tier2", "rigid": true, "trust": 10 },
+      { "group": "EXODII_CBM_unlocks_weapons_light", "rigid": true, "trust": 10 },
       { "group": "EXODII_CBM_Store_Tier3", "rigid": true, "trust": 20, "strict": true },
+      { "group": "EXODII_CBM_unlocks_weapons_medium", "rigid": true, "trust": 20, "strict": true },
       { "group": "EXODII_Store_Salvage_Tech", "rigid": true, "trust": 20 },
-      { "group": "EXODII_CBM_Store_Tier4", "rigid": true, "trust": 40, "strict": true }
+      { "group": "EXODII_CBM_Store_Tier4", "rigid": true, "trust": 40, "strict": true },
+      { "group": "EXODII_CBM_unlocks_weapons_heavy", "rigid": true, "trust": 40, "strict": true }
+
     ],
     "shopkeeper_consumption_rates": "basic_shop_rates",
     "weapon_override": "NC_EXODII_TYPE_1_carried",

--- a/data/json/npcs/exodii/exodii_merchant_itemlist.json
+++ b/data/json/npcs/exodii/exodii_merchant_itemlist.json
@@ -469,7 +469,7 @@
   {
     "type": "item_group",
     "id": "EXODII_CBM_unlocks_weapons_medium",
-    "//": "Midgade, useful weapon-type CBMs the Exodii doles out more selectively",
+    "//": "Midgrade, useful weapon-type CBMs the Exodii doles out more selectively",
     "subtype": "collection",
     "items": [
       { "item": "bio_targeting", "prob": 100, "count": [ 1, 2 ] },

--- a/data/json/npcs/exodii/exodii_merchant_itemlist.json
+++ b/data/json/npcs/exodii/exodii_merchant_itemlist.json
@@ -66,32 +66,32 @@
     "//": "This stuff should be available in the Exodii store from the start.  This group includes common items used to craft nomad gear, which the Exodii are happy to offer, as well as blueprints for them.",
     "subtype": "collection",
     "items": [
-  		{ "item": "bp_nomad_cowl", "prob": 100 },
-  		{ "item": "bp_nomad_bodyglove", "prob": 100 },
-  		{ "item": "bp_nomad_jumpsuit", "prob": 100 },
-  		{ "item": "exodii_ac_kit", "prob": 100, "count": 5 },
-  		{ "item": "exodii_wire_kit", "prob": 100, "count": 10 },
-  		{ "item": "glasses_safety", "prob": 90 },
-  		{ "item": "goggles_chem", "prob": 90 },
-  		{ "item": "glasses_bal", "prob": 90 },
-  		{ "item": "cotton_patchwork", "prob": 30, "count": [ 3, 6 ] },
-  		{ "item": "leather", "prob": 90, "count": [ 5, 15 ] },
-  		{ "item": "tanned_hide", "prob": 80, "count": [ 1, 4 ] },
-  		{ "item": "thread_nomex", "prob": 90, "count": [ 1, 6 ] },
-  		{ "item": "thread_kevlar", "prob": 90, "count": [ 1, 6 ] },
-  		{ "item": "zipper_long_plastic", "prob": 90, "count": [ 3, 5 ] },
-  		{ "item": "snapfastener_steel", "prob": 80, "count": [ 5, 10 ] },
-  		{ "item": "chunk_rubber", "prob": 90, "count": [ 1, 2 ] },
-  		{ "group": "glue_strong_domestic", "prob": 90, "count": [ 1, 2 ] },
-  		{ "group": "glue_weak_domestic", "prob": 90, "count": [ 1, 2 ] },
-  		{ "item": "sheet_cotton_patchwork", "prob": 75, "count": [ 5, 15 ] },
-  		{ "item": "cotton_patchwork", "prob": 30, "count": [ 3, 6 ] },
-  		{ "item": "leather_pouch", "prob": 80, "count": [ 1, 2 ] },
-  		{ "item": "ragpouch", "prob": 80, "count": [ 1, 2 ] },
-  		{ "item": "tool_belt", "prob": 90 },
-  		{ "item": "leather_pouch", "prob": 10 },
-  		{ "group": "glue_strong_domestic", "prob": 15, "count": [ 1, 2 ] },
-  		{ "group": "glue_weak_domestic", "prob": 15, "count": [ 1, 2 ] }
+      { "item": "bp_nomad_cowl", "prob": 100 },
+      { "item": "bp_nomad_bodyglove", "prob": 100 },
+      { "item": "bp_nomad_jumpsuit", "prob": 100 },
+      { "item": "exodii_ac_kit", "prob": 100, "count": 5 },
+      { "item": "exodii_wire_kit", "prob": 100, "count": 10 },
+      { "item": "glasses_safety", "prob": 90 },
+      { "item": "goggles_chem", "prob": 90 },
+      { "item": "glasses_bal", "prob": 90 },
+      { "item": "cotton_patchwork", "prob": 30, "count": [ 3, 6 ] },
+      { "item": "leather", "prob": 90, "count": [ 5, 15 ] },
+      { "item": "tanned_hide", "prob": 80, "count": [ 1, 4 ] },
+      { "item": "thread_nomex", "prob": 90, "count": [ 1, 6 ] },
+      { "item": "thread_kevlar", "prob": 90, "count": [ 1, 6 ] },
+      { "item": "zipper_long_plastic", "prob": 90, "count": [ 3, 5 ] },
+      { "item": "snapfastener_steel", "prob": 80, "count": [ 5, 10 ] },
+      { "item": "chunk_rubber", "prob": 90, "count": [ 1, 2 ] },
+      { "group": "glue_strong_domestic", "prob": 90, "count": [ 1, 2 ] },
+      { "group": "glue_weak_domestic", "prob": 90, "count": [ 1, 2 ] },
+      { "item": "sheet_cotton_patchwork", "prob": 75, "count": [ 5, 15 ] },
+      { "item": "cotton_patchwork", "prob": 30, "count": [ 3, 6 ] },
+      { "item": "leather_pouch", "prob": 80, "count": [ 1, 2 ] },
+      { "item": "ragpouch", "prob": 80, "count": [ 1, 2 ] },
+      { "item": "tool_belt", "prob": 90 },
+      { "item": "leather_pouch", "prob": 10 },
+      { "group": "glue_strong_domestic", "prob": 15, "count": [ 1, 2 ] },
+      { "group": "glue_weak_domestic", "prob": 15, "count": [ 1, 2 ] }
     ]
   },
   {
@@ -100,19 +100,54 @@
     "//": "This stuff should be available in the Exodii store from the start.  This group includes guns and ammo the Exodii are happy to sell to noobs.",
     "subtype": "collection",
     "items": [
-  	  { "item": "brogyeki", "prob": 100, "count": [ 1, 2 ] },
-  	  { "item": "brogyaga", "prob": 100, "count": [ 1, 2 ] },
-  	  { "item": "pamd68", "prob": 100, "count": [ 1, 2 ] },
-  	  { "item": "pamd71z", "prob": 100, "count": [ 1, 2 ] },
-  	  { "item": "knife_combat_army", "variant": "exodiibayonet", "prob": 100, "count": [ 1, 2 ] },
-  	  { "item": "exodiiminimag", "prob": 100, "charges": 0, "count": [ 4, 6 ] },
-  	  { "item": "exodiiBRmag", "prob": 100, "charges": 0, "count": [ 3, 4 ] },
-  	  { "item": "exodiiBRmag_26", "prob": 100, "charges": 0, "count": [ 3, 4 ] },
-      { "item": "123ln", "container-item": "box_small_wood", "prob": 100, "count": [ 4, 5 ], "charges": 200, "sealed": true },
-      { "item": "273x110sluglight", "container-item": "box_small_wood", "prob": 100, "count": [ 4, 6 ], "charges": 25, "sealed": true },
-      { "item": "273x44trainer", "container-item": "box_small_wood", "prob": 100, "count": [ 6, 8 ], "charges": 40, "sealed": true },
-      { "item": "273x110flock", "container-item": "box_small_wood", "prob": 100, "count": [ 4, 6 ], "charges": 25, "sealed": true },
-      { "item": "273x44flare", "container-item": "box_small_wood", "prob": 100, "count": [ 4, 6 ], "charges": 40, "sealed": true }
+      { "item": "brogyeki", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "brogyaga", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "pamd68", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "pamd71z", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "knife_combat_army", "variant": "exodiibayonet", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "exodiiminimag", "prob": 100, "charges": 0, "count": [ 4, 6 ] },
+      { "item": "exodiiBRmag", "prob": 100, "charges": 0, "count": [ 3, 4 ] },
+      { "item": "exodiiBRmag_26", "prob": 100, "charges": 0, "count": [ 3, 4 ] },
+      {
+        "item": "123ln",
+        "container-item": "box_small_wood",
+        "prob": 100,
+        "count": [ 4, 5 ],
+        "charges": 200,
+        "sealed": true
+      },
+      {
+        "item": "273x110sluglight",
+        "container-item": "box_small_wood",
+        "prob": 100,
+        "count": [ 4, 6 ],
+        "charges": 25,
+        "sealed": true
+      },
+      {
+        "item": "273x44trainer",
+        "container-item": "box_small_wood",
+        "prob": 100,
+        "count": [ 6, 8 ],
+        "charges": 40,
+        "sealed": true
+      },
+      {
+        "item": "273x110flock",
+        "container-item": "box_small_wood",
+        "prob": 100,
+        "count": [ 4, 6 ],
+        "charges": 25,
+        "sealed": true
+      },
+      {
+        "item": "273x44flare",
+        "container-item": "box_small_wood",
+        "prob": 100,
+        "count": [ 4, 6 ],
+        "charges": 40,
+        "sealed": true
+      }
     ]
   },
   {
@@ -122,8 +157,22 @@
     "items": [
       { "item": "sapra", "prob": 100, "count": [ 1, 2 ] },
       { "item": "exodiisapramag5", "prob": 100, "charges": 0, "count": [ 3, 5 ] },
-      { "item": "273x110canister", "container-item": "box_small_wood", "prob": 100, "count": [ 4, 6 ], "charges": 25, "sealed": true },
-      { "item": "273x44HE", "container-item": "box_small_wood", "prob": 100, "count": [ 4, 6 ], "charges": 40, "sealed": true },
+      {
+        "item": "273x110canister",
+        "container-item": "box_small_wood",
+        "prob": 100,
+        "count": [ 4, 6 ],
+        "charges": 25,
+        "sealed": true
+      },
+      {
+        "item": "273x44HE",
+        "container-item": "box_small_wood",
+        "prob": 100,
+        "count": [ 4, 6 ],
+        "charges": 40,
+        "sealed": true
+      },
       { "item": "exodiiBRmag_153", "prob": 100, "charges": 0, "count": 3 },
       { "item": "exodii_prybar", "prob": 100, "count": [ 1, 2 ] },
       { "item": "exodii_digger", "prob": 100, "count": [ 1, 2 ] }
@@ -134,14 +183,35 @@
     "id": "EXODII_Shop_Guns_Tier2",
     "subtype": "collection",
     "items": [
-      { "item": "273x44thermobaric", "container-item": "box_small_wood", "prob": 100, "count": [ 4, 6 ], "charges": 25, "sealed": true },
-      { "item": "273x110slugmedium", "container-item": "box_small_wood", "prob": 100, "count": [ 4, 6 ], "charges": 25, "sealed": true },
+      {
+        "item": "273x44thermobaric",
+        "container-item": "box_small_wood",
+        "prob": 100,
+        "count": [ 4, 6 ],
+        "charges": 25,
+        "sealed": true
+      },
+      {
+        "item": "273x110slugmedium",
+        "container-item": "box_small_wood",
+        "prob": 100,
+        "count": [ 4, 6 ],
+        "charges": 25,
+        "sealed": true
+      },
       {
         "collection": [
           { "item": "ree_33", "prob": 100, "count": 1 },
           { "item": "ree_33_4_mag", "prob": 100, "count": [ 2, 3 ] },
           { "item": "ree_33_53_mag", "prob": 100, "count": [ 1, 2 ] },
-          { "item": "33naval_ball", "container-item": "box_medium_wood", "prob": 100, "charges": 200, "sealed": true, "count": 1 }
+          {
+            "item": "33naval_ball",
+            "container-item": "box_medium_wood",
+            "prob": 100,
+            "charges": 200,
+            "sealed": true,
+            "count": 1
+          }
         ],
         "prob": 100
       },
@@ -163,7 +233,14 @@
     "subtype": "collection",
     "items": [
       { "item": "273x44RG", "container-item": "box_medium_wood", "prob": 100, "count": 1, "charges": 100, "sealed": true },
-      { "item": "273x110slugheavy", "container-item": "box_small_wood", "prob": 100, "count": [ 4, 6 ], "charges": 25, "sealed": true }
+      {
+        "item": "273x110slugheavy",
+        "container-item": "box_small_wood",
+        "prob": 100,
+        "count": [ 4, 6 ],
+        "charges": 25,
+        "sealed": true
+      }
     ]
   },
   {
@@ -174,7 +251,14 @@
     "items": [
       { "item": "exodii_plasma_projectile", "prob": 100, "count": 1 },
       { "item": "caotel_plasma_ring", "prob": 100, "count": 1 },
-      { "item": "caotel_cell", "container-item": "box_small_wood", "prob": 100, "count": 2, "charges": 12, "sealed": true }
+      {
+        "item": "caotel_cell",
+        "container-item": "box_small_wood",
+        "prob": 100,
+        "count": 2,
+        "charges": 12,
+        "sealed": true
+      }
     ]
   },
   {
@@ -408,7 +492,7 @@
       { "item": "bio_emp_armgun", "prob": 100, "count": [ 1, 2 ] },
       { "item": "bio_shockwave", "prob": 100, "count": [ 1, 2 ] },
       { "item": "bio_emp", "prob": 100, "count": [ 1, 2 ] }
-	]
+    ]
   },
   {
     "type": "item_group",

--- a/data/json/npcs/exodii/exodii_merchant_itemlist.json
+++ b/data/json/npcs/exodii/exodii_merchant_itemlist.json
@@ -16,8 +16,8 @@
     "id": "EXODII_trade_Tier1",
     "subtype": "collection",
     "entries": [
-      { "group": "EXODII_CBM_Store_tier1_extra", "count": [ 1, 2 ], "prob": 100 },
-      { "group": "EXODII_Shop_Guns_Tier1", "count": [ 1, 2 ], "prob": 70 }
+      { "group": "EXODII_CBM_Store_tier1_extra", "count": 1, "prob": 100 },
+      { "group": "EXODII_Shop_Guns_Tier1", "count": 1, "prob": 100 }
     ]
   },
   {
@@ -25,8 +25,8 @@
     "id": "EXODII_trade_Tier2",
     "subtype": "collection",
     "entries": [
-      { "group": "EXODII_CBM_Store_Tier2", "count": [ 1, 2 ], "prob": 100 },
-      { "group": "EXODII_Shop_Guns_Tier2", "count": [ 1, 2 ], "prob": 80 }
+      { "group": "EXODII_CBM_Store_Tier2", "count": 1, "prob": 100 },
+      { "group": "EXODII_Shop_Guns_Tier2", "count": 1, "prob": 100 }
     ]
   },
   {
@@ -34,18 +34,8 @@
     "id": "EXODII_trade_Tier3",
     "subtype": "collection",
     "entries": [
-      { "group": "EXODII_CBM_Store_Tier3", "count": [ 1, 2 ], "prob": 100 },
-      { "group": "EXODII_Shop_Guns_Tier3", "count": [ 1, 2 ], "prob": 100 }
-    ]
-  },
-  {
-    "type": "item_group",
-    "//": "Spawn extra tier 1 CBMs and a bonus tier 2 if the Exodii don't dislike you.",
-    "id": "EXODII_CBM_Store_tier1_extra",
-    "subtype": "collection",
-    "entries": [
-      { "group": "EXODII_CBM_Store_Tier1", "count": [ 2, 4 ], "prob": 100 },
-      { "group": "EXODII_CBM_Store_Tier2", "count": 1, "prob": 25 }
+      { "group": "EXODII_CBM_Store_Tier3", "count": 1, "prob": 100 },
+      { "group": "EXODII_Shop_Guns_Tier3", "count": 1, "prob": 100 }
     ]
   },
   {
@@ -54,85 +44,54 @@
     "//": "This stuff should be available in the Exodii store from the start.",
     "subtype": "collection",
     "items": [
-      { "item": "thread", "prob": 75, "count": [ 10, 20 ] },
-      [ "vac_mold", 10 ],
-      [ "box_medium", 75 ],
-      [ "box_large", 25 ],
-      [ "pipe_fittings", 70 ],
-      [ "goggles_welding", 50 ],
-      [ "welding_mask", 30 ],
-      [ "jerrycan", 10 ],
-      [ "jerrycan_big", 10 ],
-      [ "metal_tank", 8 ],
-      [ "metal_tank_little", 8 ],
-      [ "cu_pipe", 25 ],
-      [ "plastic_sheet", 10 ],
-      [ "oxy_torch", 45 ],
-      { "item": "weldtank", "prob": 15, "count": [ 1, 2 ] },
-      { "item": "smallweldtank", "prob": 45, "count": [ 1, 3 ] },
-      { "item": "tinyweldtank", "prob": 45, "count": [ 1, 3 ] },
-      { "item": "oxygen_cylinder", "prob": 10, "count": [ 1, 2 ] }
+      { "item": "thread", "prob": 100, "count": [ 10, 20 ] },
+      { "item": "vac_mold", "prob": 75, "count": [ 1, 2 ] },
+      { "item": "welding_mask", "prob": 85, "count": [ 1, 5 ] },
+      { "item": "jerrycan", "prob": 65, "count": [ 1, 2 ] },
+      { "item": "jerrycan_big", "prob": 65, "count": [ 1, 3 ] },
+      { "item": "metal_tank", "prob": 65, "count": [ 1, 3 ] },
+      { "item": "metal_tank_little", "prob": 65, "count": [ 1, 4 ] },
+      { "item": "cu_pipe", "prob": 80, "count": [ 3, 9 ] },
+      { "item": "plastic_sheet", "prob": 65, "count": [ 1, 2 ] },
+      { "item": "oxy_torch", "prob": 90, "count": [ 1, 2 ] },
+      { "item": "weldtank", "prob": 75, "count": [ 1, 2 ] },
+      { "item": "smallweldtank", "prob": 80, "count": [ 1, 3 ] },
+      { "item": "tinyweldtank", "prob": 85, "count": [ 1, 3 ] },
+      { "item": "oxygen_cylinder", "prob": 90, "count": [ 1, 2 ] }
     ]
   },
   {
     "type": "item_group",
     "id": "EXODII_Shop_NomadGear_Tier0",
     "//": "This stuff should be available in the Exodii store from the start.  This group includes common items used to craft nomad gear, which the Exodii are happy to offer, as well as blueprints for them.",
-    "subtype": "distribution",
+    "subtype": "collection",
     "items": [
-      {
-        "collection": [
-          { "item": "bp_nomad_cowl", "prob": 100 },
-          { "item": "bp_nomad_bodyglove", "prob": 100 },
-          { "item": "bp_nomad_jumpsuit", "prob": 100 },
-          { "item": "exodii_ac_kit", "prob": 100, "count": 1 },
-          { "item": "exodii_wire_kit", "prob": 100, "count": 1 }
-        ],
-        "prob": 100
-      },
-      {
-        "collection": [
-          { "item": "leather", "prob": 50, "count": [ 2, 4 ] },
-          { "item": "tanned_hide", "prob": 30, "count": [ 1, 2 ] },
-          { "item": "glasses_safety", "prob": 30 },
-          { "item": "goggles_chem", "prob": 10 },
-          { "item": "glasses_bal", "prob": 10 }
-        ],
-        "prob": 50
-      },
-      {
-        "collection": [
-          { "item": "sheet_cotton_patchwork", "prob": 50, "count": [ 1, 4 ] },
-          { "item": "cotton_patchwork", "prob": 30, "count": [ 3, 6 ] },
-          { "item": "leather", "prob": 50, "count": [ 2, 4 ] },
-          { "item": "tanned_hide", "prob": 30, "count": [ 1, 2 ] },
-          { "item": "thread_nomex", "prob": 20, "count": [ 1, 6 ] },
-          { "item": "thread_kevlar", "prob": 20, "count": [ 1, 6 ] },
-          { "item": "zipper_long_plastic", "prob": 10, "count": [ 1, 2 ] },
-          { "item": "snapfastener_steel", "prob": 40, "count": [ 5, 10 ] },
-          { "item": "chunk_rubber", "prob": 50, "count": [ 1, 2 ] },
-          { "group": "glue_strong_domestic", "prob": 30, "count": [ 1, 2 ] },
-          { "group": "glue_weak_domestic", "prob": 40, "count": [ 1, 2 ] }
-        ],
-        "prob": 50
-      },
-      {
-        "collection": [
-          { "item": "exodii_ac_kit", "prob": 100, "count": 1 },
-          { "item": "exodii_wire_kit", "prob": 100, "count": [ 1, 3 ] },
-          { "item": "sheet_cotton_patchwork", "prob": 50, "count": [ 1, 4 ] },
-          { "item": "cotton_patchwork", "prob": 30, "count": [ 3, 6 ] },
-          { "item": "leather", "prob": 50, "count": [ 2, 4 ] },
-          { "item": "tanned_hide", "prob": 30, "count": [ 1, 2 ] },
-          { "item": "leather_pouch", "prob": 10, "count": [ 1, 2 ] },
-          { "item": "ragpouch", "prob": 40, "count": [ 1, 2 ] },
-          { "item": "tool_belt", "prob": 40 },
-          { "item": "leather_pouch", "prob": 10 },
-          { "group": "glue_strong_domestic", "prob": 15, "count": [ 1, 2 ] },
-          { "group": "glue_weak_domestic", "prob": 15, "count": [ 1, 2 ] }
-        ],
-        "prob": 50
-      }
+  		{ "item": "bp_nomad_cowl", "prob": 100 },
+  		{ "item": "bp_nomad_bodyglove", "prob": 100 },
+  		{ "item": "bp_nomad_jumpsuit", "prob": 100 },
+  		{ "item": "exodii_ac_kit", "prob": 100, "count": 5 },
+  		{ "item": "exodii_wire_kit", "prob": 100, "count": 10 },
+  		{ "item": "glasses_safety", "prob": 90 },
+  		{ "item": "goggles_chem", "prob": 90 },
+  		{ "item": "glasses_bal", "prob": 90 },
+  		{ "item": "cotton_patchwork", "prob": 30, "count": [ 3, 6 ] },
+  		{ "item": "leather", "prob": 90, "count": [ 5, 15 ] },
+  		{ "item": "tanned_hide", "prob": 80, "count": [ 1, 4 ] },
+  		{ "item": "thread_nomex", "prob": 90, "count": [ 1, 6 ] },
+  		{ "item": "thread_kevlar", "prob": 90, "count": [ 1, 6 ] },
+  		{ "item": "zipper_long_plastic", "prob": 90, "count": [ 3, 5 ] },
+  		{ "item": "snapfastener_steel", "prob": 80, "count": [ 5, 10 ] },
+  		{ "item": "chunk_rubber", "prob": 90, "count": [ 1, 2 ] },
+  		{ "group": "glue_strong_domestic", "prob": 90, "count": [ 1, 2 ] },
+  		{ "group": "glue_weak_domestic", "prob": 90, "count": [ 1, 2 ] },
+  		{ "item": "sheet_cotton_patchwork", "prob": 75, "count": [ 5, 15 ] },
+  		{ "item": "cotton_patchwork", "prob": 30, "count": [ 3, 6 ] },
+  		{ "item": "leather_pouch", "prob": 80, "count": [ 1, 2 ] },
+  		{ "item": "ragpouch", "prob": 80, "count": [ 1, 2 ] },
+  		{ "item": "tool_belt", "prob": 90 },
+  		{ "item": "leather_pouch", "prob": 10 },
+  		{ "group": "glue_strong_domestic", "prob": 15, "count": [ 1, 2 ] },
+  		{ "group": "glue_weak_domestic", "prob": 15, "count": [ 1, 2 ] }
     ]
   },
   {
@@ -141,27 +100,19 @@
     "//": "This stuff should be available in the Exodii store from the start.  This group includes guns and ammo the Exodii are happy to sell to noobs.",
     "subtype": "collection",
     "items": [
-      {
-        "distribution": [
-          { "item": "brogyeki", "prob": 20, "count": [ 1, 2 ] },
-          { "item": "brogyaga", "prob": 5, "count": [ 1, 2 ] },
-          { "item": "pamd68", "prob": 60, "count": [ 1, 2 ] },
-          { "item": "pamd71z", "prob": 10, "count": [ 1, 2 ] },
-          { "item": "knife_combat_army", "variant": "exodiibayonet", "prob": 50, "count": [ 1, 2 ] }
-        ]
-      },
-      {
-        "distribution": [
-          { "item": "exodiiminimag", "prob": 60, "charges": 0, "count": [ 1, 2 ] },
-          { "item": "exodiiBRmag", "prob": 10, "charges": 0, "count": [ 1, 2 ] },
-          { "item": "exodiiBRmag_26", "prob": 25, "charges": 0, "count": [ 2, 5 ] }
-        ]
-      },
-      { "item": "123ln", "container-item": "box_small", "prob": 60, "count": [ 2, 4 ], "sealed": true },
-      { "item": "273x110sluglight", "container-item": "box_small", "prob": 40, "count": [ 3, 4 ], "sealed": true },
-      { "item": "273x44trainer", "container-item": "box_small", "prob": 30, "count": [ 3, 5 ], "sealed": true },
-      { "item": "273x110flock", "container-item": "box_small", "prob": 10, "count": [ 1, 2 ], "sealed": true },
-      { "item": "273x44flare", "container-item": "box_small_wood", "prob": 5, "count": [ 1, 2 ], "sealed": true }
+  	  { "item": "brogyeki", "prob": 100, "count": [ 1, 2 ] },
+  	  { "item": "brogyaga", "prob": 100, "count": [ 1, 2 ] },
+  	  { "item": "pamd68", "prob": 100, "count": [ 1, 2 ] },
+  	  { "item": "pamd71z", "prob": 100, "count": [ 1, 2 ] },
+  	  { "item": "knife_combat_army", "variant": "exodiibayonet", "prob": 100, "count": [ 1, 2 ] },
+  	  { "item": "exodiiminimag", "prob": 100, "charges": 0, "count": [ 4, 6 ] },
+  	  { "item": "exodiiBRmag", "prob": 100, "charges": 0, "count": [ 3, 4 ] },
+  	  { "item": "exodiiBRmag_26", "prob": 100, "charges": 0, "count": [ 3, 4 ] },
+      { "item": "123ln", "container-item": "box_small_wood", "prob": 100, "count": [ 4, 5 ], "charges": 200, "sealed": true },
+      { "item": "273x110sluglight", "container-item": "box_small_wood", "prob": 100, "count": [ 4, 6 ], "charges": 25, "sealed": true },
+      { "item": "273x44trainer", "container-item": "box_small_wood", "prob": 100, "count": [ 6, 8 ], "charges": 40, "sealed": true },
+      { "item": "273x110flock", "container-item": "box_small_wood", "prob": 100, "count": [ 4, 6 ], "charges": 25, "sealed": true },
+      { "item": "273x44flare", "container-item": "box_small_wood", "prob": 100, "count": [ 4, 6 ], "charges": 40, "sealed": true }
     ]
   },
   {
@@ -169,13 +120,13 @@
     "id": "EXODII_Shop_Guns_Tier1",
     "subtype": "collection",
     "items": [
-      { "distribution": [ { "item": "sapra", "prob": 10, "count": [ 1, 2 ] } ] },
-      { "distribution": [ { "item": "exodiisapramag5", "prob": 10, "charges": 0, "count": [ 1, 2 ] } ] },
-      { "item": "273x110canister", "container-item": "box_small", "prob": 25, "count": [ 2, 4 ], "sealed": true },
-      { "item": "273x44HE", "container-item": "box_small_wood", "prob": 5, "count": [ 1, 3 ], "sealed": true },
-      { "item": "exodiiBRmag_153", "prob": 25, "charges": 0, "count": 1 },
-      { "item": "exodii_prybar", "prob": 40, "count": [ 1, 2 ] },
-      { "item": "exodii_digger", "prob": 35, "count": [ 1, 2 ] }
+      { "item": "sapra", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "exodiisapramag5", "prob": 100, "charges": 0, "count": [ 3, 5 ] },
+      { "item": "273x110canister", "container-item": "box_small_wood", "prob": 100, "count": [ 4, 6 ], "charges": 25, "sealed": true },
+      { "item": "273x44HE", "container-item": "box_small_wood", "prob": 100, "count": [ 4, 6 ], "charges": 40, "sealed": true },
+      { "item": "exodiiBRmag_153", "prob": 100, "charges": 0, "count": 3 },
+      { "item": "exodii_prybar", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "exodii_digger", "prob": 100, "count": [ 1, 2 ] }
     ]
   },
   {
@@ -183,27 +134,26 @@
     "id": "EXODII_Shop_Guns_Tier2",
     "subtype": "collection",
     "items": [
-      { "item": "273x44thermobaric", "container-item": "box_small_wood", "prob": 10, "count": [ 1, 2 ], "sealed": true },
-      { "item": "273x110slugmedium", "container-item": "box_small", "prob": 30, "count": [ 2, 4 ], "sealed": true },
+      { "item": "273x44thermobaric", "container-item": "box_small_wood", "prob": 100, "count": [ 4, 6 ], "charges": 25, "sealed": true },
+      { "item": "273x110slugmedium", "container-item": "box_small_wood", "prob": 100, "count": [ 4, 6 ], "charges": 25, "sealed": true },
       {
         "collection": [
-          { "item": "ree_33", "prob": 100, "count": [ 1, 3 ] },
-          { "item": "ree_33_4_mag", "prob": 100, "count": [ 2, 4 ] },
-          { "item": "ree_33_53_mag", "prob": 20, "count": [ 1, 3 ] },
-          { "item": "33naval_ball", "container-item": "box_medium_wood", "prob": 100, "charges": 200, "sealed": true },
-          { "item": "33naval_ball", "container-item": "box_medium_wood", "prob": 50, "charges": 200, "sealed": true }
+          { "item": "ree_33", "prob": 100, "count": 1 },
+          { "item": "ree_33_4_mag", "prob": 100, "count": [ 2, 3 ] },
+          { "item": "ree_33_53_mag", "prob": 100, "count": [ 1, 2 ] },
+          { "item": "33naval_ball", "container-item": "box_medium_wood", "prob": 100, "charges": 200, "sealed": true, "count": 1 }
         ],
-        "prob": 20
+        "prob": 100
       },
       {
         "collection": [
           { "item": "khuunaofaai", "prob": 100, "count": [ 1, 2 ] },
-          { "item": "exodii_khuunaofaai_mag_firework", "prob": 100, "count": [ 3, 4 ] },
-          { "item": "exodii_khuunaofaai_mag_incendiary", "prob": 50, "count": [ 1, 2 ] },
-          { "item": "exodii_khuunaofaai_mag_corrosive", "prob": 50, "count": [ 1, 2 ] },
-          { "item": "exodii_khuunaofaai_mag_adhesive", "prob": 50, "count": [ 1, 2 ] }
+          { "item": "exodii_khuunaofaai_mag_firework", "prob": 100, "count": [ 3, 5 ] },
+          { "item": "exodii_khuunaofaai_mag_incendiary", "prob": 100, "count": [ 2, 4 ] },
+          { "item": "exodii_khuunaofaai_mag_corrosive", "prob": 100, "count": [ 2, 4 ] },
+          { "item": "exodii_khuunaofaai_mag_adhesive", "prob": 100, "count": [ 2, 4 ] }
         ],
-        "prob": 25
+        "prob": 100
       }
     ]
   },
@@ -212,8 +162,8 @@
     "id": "EXODII_Shop_Guns_Tier3",
     "subtype": "collection",
     "items": [
-      { "item": "273x44RG", "container-item": "box_medium_wood", "prob": 10, "count": [ 1, 2 ], "sealed": true },
-      { "item": "273x110slugheavy", "container-item": "box_small", "prob": 30, "count": [ 1, 2 ], "sealed": true }
+      { "item": "273x44RG", "container-item": "box_medium_wood", "prob": 100, "count": 1, "charges": 100, "sealed": true },
+      { "item": "273x110slugheavy", "container-item": "box_small_wood", "prob": 100, "count": [ 4, 6 ], "charges": 25, "sealed": true }
     ]
   },
   {
@@ -224,7 +174,7 @@
     "items": [
       { "item": "exodii_plasma_projectile", "prob": 100, "count": 1 },
       { "item": "caotel_plasma_ring", "prob": 100, "count": 1 },
-      { "item": "caotel_cell", "container-item": "box_small", "prob": 100, "count": 2, "sealed": true }
+      { "item": "caotel_cell", "container-item": "box_small_wood", "prob": 100, "count": 2, "charges": 12, "sealed": true }
     ]
   },
   {
@@ -234,13 +184,13 @@
     "//2": "Ideally, the spear should be sold as a spearhead and the player crafts it by getting their own pole.",
     "subtype": "collection",
     "items": [
-      { "item": "gambeson", "prob": 40, "count": [ 1, 2 ] },
-      { "item": "armor_lorica", "prob": 20, "count": [ 1, 2 ] },
-      { "item": "helmet_corinthian", "prob": 60, "count": [ 1, 2 ] },
-      { "item": "armor_thessalonian", "prob": 80, "count": [ 1, 2 ] },
-      { "item": "leggings_thessalonian", "prob": 80, "count": [ 1, 2 ] },
-      { "item": "sword_xiphos", "prob": 50, "count": [ 1, 2 ] },
-      { "item": "spear_dory", "prob": 30, "count": [ 1, 2 ] }
+      { "item": "gambeson", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "armor_lorica", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "helmet_corinthian", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "armor_thessalonian", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "leggings_thessalonian", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "sword_xiphos", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "spear_dory", "prob": 100, "count": [ 1, 2 ] }
     ]
   },
   {
@@ -250,8 +200,8 @@
     "subtype": "collection",
     "items": [
       { "group": "EXODII_CBM_tier1_utility", "prob": 100 },
-      { "group": "EXODII_CBM_tier1_tools", "prob": 80 },
-      { "group": "EXODII_CBM_tier1_power", "prob": 50 },
+      { "group": "EXODII_CBM_tier1_tools", "prob": 100 },
+      { "group": "EXODII_CBM_tier1_power", "prob": 100 },
       { "group": "EXODII_CBM_tier1_fun", "prob": 100 }
     ]
   },
@@ -259,108 +209,118 @@
     "type": "item_group",
     "id": "EXODII_CBM_Store_Tier2",
     "//": "These CBMs should be available in the Exodii store after at least 2 weeks.",
+    "subtype": "collection",
     "items": [
-      [ "bio_tools", 10 ],
-      [ "bio_electrokit", 10 ],
-      [ "bio_ethanol", 10 ],
-      [ "bio_eye_optic", 10 ],
-      [ "bio_remote", 10 ],
-      [ "bio_torsionratchet", 10 ],
-      [ "bio_ears", 10 ],
-      [ "bio_fuel_cell_gasoline", 10 ],
-      [ "bio_lampoil", 10 ],
-      [ "bio_armor_arms", 10 ],
-      [ "bio_armor_eyes", 10 ],
-      [ "bio_armor_head", 10 ],
-      [ "bio_armor_legs", 10 ],
-      [ "bio_armor_torso", 10 ],
-      [ "bio_digestion", 10 ],
-      [ "bio_infrared", 10 ],
-      [ "bio_lockpick", 10 ],
-      [ "bio_night_vision", 10 ],
-      [ "bio_sonar", 10 ],
-      [ "bio_power_storage_mkII", 10 ],
-      [ "bio_scent_mask", 10 ],
-      [ "bio_jointservo", 10 ],
-      [ "bio_taste_blocker", 10 ],
-      [ "bio_ar", 10 ]
+      { "item": "bio_tools", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_electrokit", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_ethanol", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_eye_optic", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_remote", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_torsionratchet", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_ears", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_fuel_cell_gasoline", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_lampoil", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_armor_arms", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_armor_eyes", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_armor_head", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_armor_legs", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_armor_torso", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_digestion", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_infrared", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_lockpick", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_night_vision", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_sonar", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_power_storage_mkII", "prob": 100, "count": [ 4, 8 ] },
+      { "item": "bio_scent_mask", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_jointservo", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_taste_blocker", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_ar", "prob": 100, "count": [ 1, 2 ] }
     ]
   },
   {
     "type": "item_group",
     "id": "EXODII_CBM_Store_Tier3",
     "//": "These CBMs should be available in the Exodii store after at least 4 weeks.",
+    "subtype": "collection",
     "items": [
-      [ "bio_blood_filter", 10 ],
-      [ "bio_purifier", 10 ],
-      [ "bio_heatsink", 10 ],
-      [ "bio_climate", 10 ],
-      [ "bio_leukocyte", 10 ],
-      [ "bio_adrenaline", 10 ],
-      [ "bio_blood_anal", 10 ],
-      [ "bio_carbon", 10 ],
-      [ "bio_evap", 10 ],
-      [ "bio_face_mask", 10 ],
-      [ "bio_gills", 10 ],
-      [ "bio_hydraulics", 10 ],
-      [ "bio_membrane", 10 ],
-      [ "bio_painkiller", 10 ],
-      [ "bio_radscrubber", 10 ],
-      [ "bio_weight", 10 ],
-      [ "bio_synlungs", 10 ]
+      { "item": "bio_blood_filter", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_purifier", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_heatsink", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_climate", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_leukocyte", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_adrenaline", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_blood_anal", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_carbon", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_evap", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_face_mask", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_gills", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_hydraulics", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_membrane", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_painkiller", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_radscrubber", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_weight", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_synlungs", "prob": 100, "count": [ 1, 2 ] }
     ]
   },
   {
     "type": "item_group",
     "id": "EXODII_CBM_Store_Tier4",
     "//": "These CBMs should be available in the Exodii store after at least 8 weeks.",
+    "subtype": "collection",
     "items": [
-      [ "bio_surgical_razor", 10 ],
-      [ "bio_faraday", 10 ],
-      [ "bio_metabolics", 10 ],
-      [ "bio_ground_sonar", 10 ],
-      [ "bio_recycler", 10 ],
-      [ "bio_uncanny_dodge", 10 ],
-      [ "bio_eye_enhancer", 10 ],
-      [ "bio_dex_enhancer", 10 ],
-      [ "bio_heat_absorb", 10 ],
-      [ "bio_int_enhancer", 10 ],
-      [ "bio_memory", 10 ],
-      [ "bio_speed", 10 ],
-      [ "bio_str_enhancer", 10 ],
-      [ "bio_water_extractor", 10 ],
-      [ "bio_synaptic_regen", 10 ]
+      { "item": "bio_surgical_razor", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_faraday", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_metabolics", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_ground_sonar", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_recycler", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_uncanny_dodge", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_eye_enhancer", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_dex_enhancer", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_heat_absorb", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_int_enhancer", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_memory", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_speed", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_str_enhancer", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_water_extractor", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_synaptic_regen", "prob": 100, "count": [ 1, 2 ] }
     ]
   },
   {
     "type": "item_group",
     "id": "EXODII_CBM_tier1_utility",
+    "subtype": "collection",
     "items": [
-      [ "bio_watch", 10 ],
-      [ "bio_alarm", 10 ],
-      [ "bio_sunglasses", 10 ],
-      [ "bio_meteorologist", 10 ],
-      [ "bio_pitch_perfect", 10 ],
-      [ "bio_fitnessband", 10 ],
-      [ "bio_radio", 10 ]
+      { "item": "bio_watch", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_alarm", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_sunglasses", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_meteorologist", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_pitch_perfect", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_fitnessband", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_radio", "prob": 100, "count": [ 1, 2 ] }
     ]
   },
   {
     "type": "item_group",
     "id": "EXODII_CBM_tier1_power",
-    "items": [ [ "bio_power_storage", 30 ], [ "bio_batteries", 1 ], [ "bio_cable", 5 ] ]
+    "subtype": "collection",
+    "items": [
+      { "item": "bio_power_storage", "prob": 100, "count": [ 10, 20 ] },
+      { "item": "bio_batteries", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_cable", "prob": 100, "count": [ 1, 2 ] }
+    ]
   },
   {
     "type": "item_group",
     "id": "EXODII_CBM_tier1_tools",
+    "subtype": "collection",
     "items": [
-      [ "bio_syringe", 10 ],
-      [ "bio_flashlight", 10 ],
-      [ "bio_lighter", 10 ],
-      [ "bio_multimeter", 5 ],
-      [ "bio_magnet", 5 ],
-      [ "bio_fingerhack", 2 ],
-      [ "bio_geiger", 5 ]
+      { "item": "bio_syringe", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_flashlight", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_lighter", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_multimeter", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_magnet", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_fingerhack", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_geiger", "prob": 100, "count": [ 1, 2 ] }
     ]
   },
   {
@@ -401,33 +361,54 @@
   {
     "type": "item_group",
     "id": "EXODII_CBM_tier1_fun",
-    "items": [ [ "bio_tattoo_led", 10 ], [ "bio_nostril", 1 ], [ "bio_voice", 10 ], [ "bio_sleep_shutdown", 2 ] ]
+    "subtype": "collection",
+    "items": [
+      { "item": "bio_tattoo_led", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_voice", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_sleep_shutdown", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_voice_b", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_mp3", "prob": 100, "count": [ 1, 2 ] }
+    ]
   },
   {
     "type": "item_group",
     "id": "EXODII_CBM_unlocks_weapons_light",
-    "//": "To get items from this group in the Exodii CBM store requires finishing missions for their faction and earning their trust",
-    "items": [ [ "bio_blade", 10 ], [ "bio_claws", 10 ], [ "bio_cqb", 10 ], [ "bio_flashbang", 10 ], [ "bio_razors", 10 ] ]
+    "//": "Lower-powered or cheap weapon-type CBMs the Exodii is willing to sell fairly freely",
+    "subtype": "collection",
+    "items": [
+      { "item": "bio_taser", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_flashbang", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_shotgun", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_razors", "prob": 100, "count": [ 1, 2 ] }
+    ]
   },
   {
     "type": "item_group",
     "id": "EXODII_CBM_unlocks_weapons_medium",
-    "//": "To get items from this group in the Exodii CBM store requires finishing missions for their faction and earning their trust",
+    "//": "Midgade, useful weapon-type CBMs the Exodii doles out more selectively",
+    "subtype": "collection",
     "items": [
-      [ "bio_resonator", 10 ],
-      [ "bio_targeting", 15 ],
-      [ "bio_shotgun", 10 ],
-      [ "bio_laser", 5 ],
-      [ "bio_shock", 10 ],
-      [ "bio_recoil", 15 ],
-      [ "bio_taser", 10 ]
+      { "item": "bio_targeting", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_laser", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_claws", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_shock", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_recoil", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_blade", "prob": 100, "count": [ 1, 2 ] }
     ]
   },
   {
     "type": "item_group",
     "id": "EXODII_CBM_unlocks_weapons_heavy",
-    "//": "To get items from this group in the Exodii CBM store requires finishing missions for their faction and earning their trust",
-    "items": [ [ "bio_chain_lightning", 15 ], [ "bio_emp", 1 ], [ "bio_emp_armgun", 1 ], [ "bio_shockwave", 10 ] ]
+    "//": "Dangerous or exotic weapon-type CBMs that the Exodii only gives to a trusted ally",
+    "subtype": "collection",
+    "items": [
+      { "item": "bio_chain_lightning", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_cqb", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_resonator", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_emp_armgun", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_shockwave", "prob": 100, "count": [ 1, 2 ] },
+      { "item": "bio_emp", "prob": 100, "count": [ 1, 2 ] }
+	]
   },
   {
     "type": "item_group",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Balance "Exodii actually sell their goods"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Exodii wares were in a terrible state. Rubik often didn't sell the blueprints, medieval gear was missing despite the player commenting on it, they rarely actually sold their guns, and even more rarely sold magazines to go along with the guns they did decide to put on sale this week. The Exodii are described as being happy to trade munitions with survivors, so going to Nine and finding a couple guns, magazines for different guns, and ammo for _different_ guns, was nonsense.
Similarly, Rubik didn't sell the CBMs basically ever, forcing the player to either repeatedly ask Rubik every single week to hopefully get lucky and get some desirable CBM, despite the Exodii obviously having the CBMs in stock. It turned into a FOMO weekly rotating sale thing and is just... not fun, not realistic, and a big reason why people hate the Exodii - they claim to be the CBM guys, but anyone who wants CBMs is diving subway labs and never ever relying on the Exodii to give them a CBM.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Rubik now sells every non faulty CBM in the game. These are gated by faction trust, and thus time, so even though they are always sold, you won't have access to them until you prove yourself a useful ally to the Exodii. Rubik also sells  "supplies" (welding stuff, tools, etc) much more consistently.
Nine now is guaranteed to sell at least one gun of each kind, multiple magazines for that gun, and a usable amount of ammo for that gun. Exodii are manufacturing their ammo and have a lot of it, and even if they're not going to literally sell the entire stockpile all at once, they should be more than willing to trade for example a few hundred 12.3ln, with some cooldown (trade restock period). As with the CBMs, guns are also gated behind trust, so they will not just freely sell you everything right away, you have to prove you're a responsible and helpful sort to get your hands on one of their naval cannons.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Different ammo quantities.
I don't know if Exodii being the one stop shop for cbms is the best gameplay, and certainly some of the ones they're selling right now could be moved to the labyrinthine structure, but it's basically the only actual option due to cbms being written to be Exodii exclusive. If the Exodii are the established cyborg faction, then they need to have the CBMs. Even if it is a little boring to get everything from Rubik, scavenging CBMs and then doing DIY autodoc surgery is, essentially, a bug and shouldn't happen anymore.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded in game, tweaked until it felt about right.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Here's a max trust character going to buy ammo. Less trusted characters have fewer things on offer.

<img width="921" height="844" alt="image" src="https://github.com/user-attachments/assets/1a51e73d-ed10-41f3-907d-1ce7861987ce" />

This means we can probably actually, finally, get rid of the remaining cyborg vaults in the microlabs since they won't be the sole, exclusive means of getting actually useful cbms.

ALSO: We should probably adjust CBM prices, and determine what the Exodii want to buy so that you can't just convert infinite tampons into cybernetic augments. That's a different PR though.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
