### PR TITLE
[Bugfixes] Tiny bug in item debug info and i18n

### DIFF
--- a/src/item_info.cpp
+++ b/src/item_info.cpp
@@ -473,14 +473,14 @@ void item::debug_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
                 faults += colorize( fault.first.str() + string_format( " (%d, %d%%)\n", fault.second,
                                     weight_percent ), has_fault( fault.first ) ? c_yellow : c_white );
             }
-            info.emplace_back( "BASE", string_format( "faults: %s", faults ) );
+            info.emplace_back( "BASE", string_format( _( "faults: %s" ), faults ) );
 
             units::mass sum_of_components_weight;
             for( const item_comp &c : get_uncraft_components() ) {
                 sum_of_components_weight += c.type->weight * c.count;
             }
-            info.emplace_back( "BASE", string_format( "weight of uncraft components: %s grams",
-                               to_gram( sum_of_components_weight ) ) );
+            info.emplace_back( "BASE", string_format( _( "weight of uncraft components: %d grams" ),
+                               static_cast<int>( std::round( to_gram( sum_of_components_weight ) ) ) ) );
         }
     }
 }

--- a/tools/spell_checker/dictionary.txt
+++ b/tools/spell_checker/dictionary.txt
@@ -6556,6 +6556,7 @@ uncategorized
 uncontacted
 uncontrol
 uncorded
+uncrafted
 undeath
 underbarrel
 underbrushes


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Tiny bug in item debug info and i18n"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Remove the error report. (Not at all.)
Fixes #84694
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Alter way to turn weight to grams. And mark as i18n.
Should be related with #84332 #84729
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Testing
Done
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
<img width="632" height="205" alt="image" src="https://github.com/user-attachments/assets/e3e23c6a-e504-46d7-96f6-c197b24b445c" />

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
