### PR TITLE
Add two makeshift goedendags

### DIFF
--- a/data/json/items/melee/bludgeons.json
+++ b/data/json/items/melee/bludgeons.json
@@ -86,12 +86,21 @@
     "symbol": "/",
     "material": [ "wood" ],
     "techniques": [ "WBLOCK_1", "BRUTAL" ],
-    "flags": [ "DURABLE_MELEE", "NONCONDUCTIVE", "SHEATH_SPEAR" ],
+    "flags": [ "DURABLE_MELEE", "BELT_CLIP", "NONCONDUCTIVE" ],
     "volume": "1750 ml",
     "price": "160 USD",
     "melee_damage": { "bash": 22 },
     "faults": [ { "fault_group": "staff_short" } ],
     "weapon_category": [ "MACES" ]
+  },
+  {
+    "id": "goedendag_bat",
+    "copy-from": "bat",
+    "relative": { "melee_damage": { "bash": 2, "stab": 18 }, "weight": "730 g", "volume": "100 ml", "longest_side": "20 cm" },
+    "type": "ITEM",
+    "name": { "str": "goedendag bat" },
+    "description": "A baseball bat with a pipe fitting on one end, wedged by a spike.",
+    "material": [ { "type": "wood", "portion": 95 }, { "type": "iron", "portion": 5 } ]
   },
   {
     "type": "ITEM",
@@ -2120,16 +2129,5 @@
     "power_draw": "1200 W",
     "to_hit": { "grip": "weapon", "length": "long", "surface": "line", "balance": "clumsy" },
     "melee_damage": { "bash": 42, "cut": 16 }
-  },
-  {
-    "id": "goedendag_bat",
-    "copy-from": "bat",
-    "relative": { "melee_damage": { "bash": 2, "stab": 22 }, "weight": "730 g", "volume": "100 ml", "longest_side": "20 cm" },
-    "extend": { "flags": [ "SPEAR", "REACH_ATTACK" ] },
-    "type": "ITEM",
-    "name": { "str": "goedendag bat" },
-    "description": "A baseball bat with a length of steel pipe on one end, wedged by a spike, allowing you to use it as a spear in a pinch.",
-    "weapon_category": [ "MACES", "SPEARS" ],
-    "material": [ { "type": "wood", "portion": 95 }, { "type": "mc_steel", "portion": 5 } ]
   }
 ]

--- a/data/json/items/melee/bludgeons.json
+++ b/data/json/items/melee/bludgeons.json
@@ -2122,12 +2122,12 @@
     "melee_damage": { "bash": 42, "cut": 16 }
   },
   {
-    "id": "makeshift_goedendag",
+    "id": "goedendag_bat",
     "copy-from": "bat",
     "relative": { "melee_damage": { "bash": 2, "stab": 22 }, "weight": "750 g", "volume": "100 ml", "longest_side": "20 cm" },
     "extend": { "flags": [ "SPEAR", "REACH_ATTACK" ] },
     "type": "ITEM",
-    "name": { "str": "makeshift goedendag" },
+    "name": { "str": "goedendag bat" },
     "description": "A baseball bat with a length of steel pipe on one end, wedged by a spike, allowing you to use it as a spear in a pinch.",
     "weapon_category": [ "MACES", "SPEARS" ],
     "material": [ { "type": "wood", "portion": 95 }, { "type": "mc_steel", "portion": 5 } ]

--- a/data/json/items/melee/bludgeons.json
+++ b/data/json/items/melee/bludgeons.json
@@ -86,7 +86,7 @@
     "symbol": "/",
     "material": [ "wood" ],
     "techniques": [ "WBLOCK_1", "BRUTAL" ],
-    "flags": [ "DURABLE_MELEE", "BELT_CLIP", "NONCONDUCTIVE" ],
+    "flags": [ "DURABLE_MELEE", "BELT_CLIP" ],
     "volume": "1750 ml",
     "price": "160 USD",
     "melee_damage": { "bash": 22 },
@@ -96,10 +96,10 @@
   {
     "id": "goedendag_bat",
     "copy-from": "bat",
-    "relative": { "melee_damage": { "bash": 2, "stab": 18 }, "weight": "730 g", "volume": "100 ml", "longest_side": "20 cm" },
+    "relative": { "melee_damage": { "bash": 2, "stab": 6 }, "weight": "730 g", "volume": "100 ml", "longest_side": "20 cm" },
     "type": "ITEM",
     "name": { "str": "goedendag bat" },
-    "description": "A baseball bat with a pipe fitting on one end, wedged by a spike.",
+    "description": "A weaponized baseball bat with a metal cap and a spike protruding straight up from the top.",
     "material": [ { "type": "wood", "portion": 95 }, { "type": "iron", "portion": 5 } ]
   },
   {

--- a/data/json/items/melee/bludgeons.json
+++ b/data/json/items/melee/bludgeons.json
@@ -2124,7 +2124,7 @@
   {
     "id": "goedendag_bat",
     "copy-from": "bat",
-    "relative": { "melee_damage": { "bash": 2, "stab": 22 }, "weight": "750 g", "volume": "100 ml", "longest_side": "20 cm" },
+    "relative": { "melee_damage": { "bash": 2, "stab": 22 }, "weight": "730 g", "volume": "100 ml", "longest_side": "20 cm" },
     "extend": { "flags": [ "SPEAR", "REACH_ATTACK" ] },
     "type": "ITEM",
     "name": { "str": "goedendag bat" },

--- a/data/json/items/melee/bludgeons.json
+++ b/data/json/items/melee/bludgeons.json
@@ -86,7 +86,7 @@
     "symbol": "/",
     "material": [ "wood" ],
     "techniques": [ "WBLOCK_1", "BRUTAL" ],
-    "flags": [ "DURABLE_MELEE", "BELT_CLIP" ],
+    "flags": [ "DURABLE_MELEE", "NONCONDUCTIVE", "SHEATH_SPEAR" ],
     "volume": "1750 ml",
     "price": "160 USD",
     "melee_damage": { "bash": 22 },
@@ -2120,5 +2120,16 @@
     "power_draw": "1200 W",
     "to_hit": { "grip": "weapon", "length": "long", "surface": "line", "balance": "clumsy" },
     "melee_damage": { "bash": 42, "cut": 16 }
+  },
+  {
+    "id": "makeshift_goedendag",
+    "copy-from": "bat",
+    "relative": { "melee_damage": { "bash": 2, "stab": 22 }, "weight": "750 g", "volume": "100 ml", "longest_side": "20 cm" },
+    "extend": { "flags": [ "SPEAR", "REACH_ATTACK" ] },
+    "type": "ITEM",
+    "name": { "str": "makeshift goedendag" },
+    "description": "A baseball bat with a length of steel pipe on one end, wedged by a spike, allowing you to use it as a spear in a pinch.",
+    "weapon_category": [ "MACES", "SPEARS" ],
+    "material": [ { "type": "wood", "portion": 95 }, { "type": "mc_steel", "portion": 5 } ]
   }
 ]

--- a/data/json/items/melee/spears_and_polearms.json
+++ b/data/json/items/melee/spears_and_polearms.json
@@ -307,12 +307,12 @@
   {
     "id": "crude_goedendag",
     "copy-from": "spear_steel_crude",
-    "relative": { "melee_damage": { "bash": 20, "stab": -6 }, "longest_side": "-30 cm" },
+    "relative": { "melee_damage": { "bash": 18, "stab": -14 }, "longest_side": "-30 cm" },
     "techniques": [ "WBLOCK_1", "BRUTAL" ],
     "type": "ITEM",
     "name": { "str": "crude goedendag" },
-    "description": "A baseball bat with a pipe fitting on one end, wedged by a spike.",
-    "weapon_category": [ "MACES", "SPEARS" ],
+    "description": "A stout wooden pole, slightly thicker at the end, with a metal cap and a spike protruding straight up from the top.",
+    "weapon_category": [ "GREAT_HAMMERS", "SPEARS" ],
     "faults": [ { "fault_group": "handle_long" } ]
   },
   {

--- a/data/json/items/melee/spears_and_polearms.json
+++ b/data/json/items/melee/spears_and_polearms.json
@@ -291,7 +291,7 @@
     "color": "light_gray",
     "symbol": "/",
     "looks_like": "spear_steel",
-    "material": [ "steel", "wood" ],
+    "material": [ { "type": "wood", "portion": 95 }, { "type": "mc_steel", "portion": 5 } ],
     "techniques": [ "WBLOCK_1", "PENETRATE" ],
     "volume": "1350 ml",
     "longest_side": "180 cm",
@@ -303,6 +303,17 @@
     "qualities": [ [ "COOK", 1 ] ],
     "use_action": [ "HEAT_SOLID_ITEMS" ],
     "melee_damage": { "bash": 4, "stab": 24 }
+  },
+  {
+    "id": "crude_goedendag",
+    "copy-from": "spear_steel_crude",
+    "relative": { "melee_damage": { "bash": 20, "stab": -6 }, "longest_side": "-30 cm" },
+    "techniques": [ "WBLOCK_1", "BRUTAL" ],
+    "type": "ITEM",
+    "name": { "str": "crude goedendag" },
+    "description": "A baseball bat with a pipe fitting on one end, wedged by a spike.",
+    "weapon_category": [ "MACES", "SPEARS" ],
+    "faults": [ { "fault_group": "handle_long" } ]
   },
   {
     "type": "ITEM",

--- a/data/json/recipes/nested.json
+++ b/data/json/recipes/nested.json
@@ -7123,7 +7123,7 @@
       "spear_wood",
       "spear_wood_simple",
       "nested_pikes",
-      "makeshift_goedendag"
+      "crude_goedendag"
     ]
   },
   {
@@ -8385,7 +8385,7 @@
     "name": "bats",
     "description": "Recipes for making baseball bats and improving them with various materials.",
     "skill_used": "fabrication",
-    "nested_category_data": [ "bat", "bat_with_lathe", "nailbat", "bwirebat", "nutboltbat", "bat_metal_bolt", "makeshift_goedendag" ],
+    "nested_category_data": [ "bat", "bat_with_lathe", "nailbat", "bwirebat", "nutboltbat", "bat_metal_bolt", "goedendag_bat" ],
     "difficulty": 1
   },
   {

--- a/data/json/recipes/nested.json
+++ b/data/json/recipes/nested.json
@@ -7122,7 +7122,8 @@
       "spear_stone_simple",
       "spear_wood",
       "spear_wood_simple",
-      "nested_pikes"
+      "nested_pikes",
+      "makeshift_goedendag"
     ]
   },
   {
@@ -8384,7 +8385,7 @@
     "name": "bats",
     "description": "Recipes for making baseball bats and improving them with various materials.",
     "skill_used": "fabrication",
-    "nested_category_data": [ "bat", "bat_with_lathe", "nailbat", "bwirebat", "nutboltbat", "bat_metal_bolt" ],
+    "nested_category_data": [ "bat", "bat_with_lathe", "nailbat", "bwirebat", "nutboltbat", "bat_metal_bolt", "makeshift_goedendag" ],
     "difficulty": 1
   },
   {

--- a/data/json/recipes/weapon/bashing.json
+++ b/data/json/recipes/weapon/bashing.json
@@ -1703,11 +1703,11 @@
     "skill_used": "fabrication",
     "time": "30 m",
     "autolearn": true,
-    "qualities": [ { "id": "HAMMER", "level": 3 }, { "id": "SAW_M", "level": 2 }, { "id": "GRIND", "level": 2 } ],
+    "qualities": [ { "id": "HAMMER", "level": 3 }, { "id": "CUT", "level": 2 }, { "id": "GRIND", "level": 2 } ],
     "proficiencies": [ { "proficiency": "prof_carpentry_basic", "skill_penalty": 0 } ],
     "components": [
       [ [ "bat", 1 ] ],
-      [ [ "pipe", 1 ] ],
+      [ [ "pipe_fittings", 1 ] ],
       [ [ "spike", 1 ], [ "knife_small", 1 ], [ "knife_folding", 1 ], [ "scalpel", 1 ], [ "xacto", 1 ] ]
     ]
   }

--- a/data/json/recipes/weapon/bashing.json
+++ b/data/json/recipes/weapon/bashing.json
@@ -1697,7 +1697,7 @@
   {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
-    "result": "makeshift_goedendag",
+    "result": "goedendag_bat",
     "category": "CC_*",
     "subcategory": "CSC_*_NESTED",
     "skill_used": "fabrication",
@@ -1705,10 +1705,6 @@
     "autolearn": true,
     "qualities": [ { "id": "HAMMER", "level": 3 }, { "id": "CUT", "level": 2 }, { "id": "GRIND", "level": 2 } ],
     "proficiencies": [ { "proficiency": "prof_carpentry_basic", "skill_penalty": 0 } ],
-    "components": [
-      [ [ "bat", 1 ] ],
-      [ [ "pipe_fittings", 1 ] ],
-      [ [ "spike", 1 ], [ "knife_small", 1 ], [ "knife_folding", 1 ], [ "scalpel", 1 ], [ "xacto", 1 ] ]
-    ]
+    "components": [ [ [ "bat", 1 ] ], [ [ "pipe_fittings", 1 ] ], [ [ "spike", 1 ] ] ]
   }
 ]

--- a/data/json/recipes/weapon/bashing.json
+++ b/data/json/recipes/weapon/bashing.json
@@ -1693,5 +1693,18 @@
     "qualities": [ { "id": "GRIND", "level": 2 } ],
     "tools": [ [ [ "drift", -1 ] ] ],
     "components": [ [ [ "spear_shaft", 1 ] ], [ [ "fur", 2 ], [ "leather", 2 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "result": "makeshift_goedendag",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "fabrication",
+    "time": "30 m",
+    "autolearn": true,
+    "qualities": [ { "id": "HAMMER", "level": 3 }, { "id": "SAW_M", "level": 2 }, { "id": "GRIND", "level": 2 } ],
+    "proficiencies": [ { "proficiency": "prof_carpentry_basic", "skill_penalty": 0 } ],
+    "components": [ [ [ "bat", 1 ] ], [ [ "spike", 1 ] ], [ [ "pipe", 1 ] ] ]
   }
 ]

--- a/data/json/recipes/weapon/bashing.json
+++ b/data/json/recipes/weapon/bashing.json
@@ -1710,6 +1710,6 @@
       { "id": "DRILL", "level": 3 }
     ],
     "proficiencies": [ { "proficiency": "prof_carpentry_basic", "skill_penalty": 0 } ],
-    "components": [ [ [ "bat", 1 ] ], [ [ "pipe_fittings", 1 ] ], [ [ "spike", 1 ] ], [ [ "nails", 2, "LIST" ], [ "nuts_bolts", 2 ] ] ]
+    "components": [ [ [ "bat", 1 ] ], [ [ "pipe_fittings", 1 ] ], [ [ "spike", 1 ] ], [ [ "nuts_bolts", 2 ] ] ]
   }
 ]

--- a/data/json/recipes/weapon/bashing.json
+++ b/data/json/recipes/weapon/bashing.json
@@ -1703,8 +1703,13 @@
     "skill_used": "fabrication",
     "time": "30 m",
     "autolearn": true,
-    "qualities": [ { "id": "HAMMER", "level": 3 }, { "id": "CUT", "level": 2 }, { "id": "GRIND", "level": 2 } ],
+    "qualities": [
+      { "id": "HAMMER", "level": 3 },
+      { "id": "CUT", "level": 2 },
+      { "id": "GRIND", "level": 2 },
+      { "id": "DRILL", "level": 3 }
+    ],
     "proficiencies": [ { "proficiency": "prof_carpentry_basic", "skill_penalty": 0 } ],
-    "components": [ [ [ "bat", 1 ] ], [ [ "pipe_fittings", 1 ] ], [ [ "spike", 1 ] ] ]
+    "components": [ [ [ "bat", 1 ] ], [ [ "pipe_fittings", 1 ] ], [ [ "spike", 1 ] ], [ [ "nails", 2, "LIST" ], [ "nuts_bolts", 2 ] ] ]
   }
 ]

--- a/data/json/recipes/weapon/bashing.json
+++ b/data/json/recipes/weapon/bashing.json
@@ -1705,6 +1705,10 @@
     "autolearn": true,
     "qualities": [ { "id": "HAMMER", "level": 3 }, { "id": "SAW_M", "level": 2 }, { "id": "GRIND", "level": 2 } ],
     "proficiencies": [ { "proficiency": "prof_carpentry_basic", "skill_penalty": 0 } ],
-    "components": [ [ [ "bat", 1 ] ], [ [ "spike", 1 ] ], [ [ "pipe", 1 ] ] ]
+    "components": [
+      [ [ "bat", 1 ] ],
+      [ [ "pipe", 1 ] ],
+      [ [ "spike", 1 ], [ "knife_small", 1 ], [ "knife_folding", 1 ], [ "scalpel", 1 ], [ "xacto", 1 ] ]
+    ]
   }
 ]

--- a/data/json/recipes/weapon/piercing.json
+++ b/data/json/recipes/weapon/piercing.json
@@ -1591,7 +1591,17 @@
     "result": "crude_goedendag",
     "copy-from": "goedendag_bat",
     "type": "recipe",
-    "qualities": [ { "id": "HAMMER", "level": 3 }, { "id": "CUT", "level": 2 }, { "id": "GRIND", "level": 2 } ],
-    "components": [ [ [ "q_staff", 1 ] ], [ [ "pipe_fittings", 1 ] ], [ [ "spike", 1 ] ] ]
+    "qualities": [
+      { "id": "HAMMER", "level": 3 },
+      { "id": "CUT", "level": 2 },
+      { "id": "GRIND", "level": 2 },
+      { "id": "DRILL", "level": 3 }
+    ],
+    "components": [
+      [ [ "q_staff", 1 ] ],
+      [ [ "pipe_fittings", 1 ] ],
+      [ [ "spike", 1 ] ],
+      [ [ "nails", 2, "LIST" ], [ "nuts_bolts", 2 ] ]
+    ]
   }
 ]

--- a/data/json/recipes/weapon/piercing.json
+++ b/data/json/recipes/weapon/piercing.json
@@ -1586,5 +1586,12 @@
     "qualities": [ { "id": "GRIND", "level": 2 } ],
     "tools": [ [ [ "hotcut_any", 1, "LIST" ] ] ],
     "components": [ [ [ "plastic_chunk", 4 ] ] ]
+  },
+  {
+    "result": "crude_goedendag",
+    "copy-from": "goedendag_bat",
+    "type": "recipe",
+    "qualities": [ { "id": "HAMMER", "level": 3 }, { "id": "CUT", "level": 2 }, { "id": "GRIND", "level": 2 } ],
+    "components": [ [ [ "q_staff", 1 ] ], [ [ "pipe_fittings", 1 ] ], [ [ "spike", 1 ] ] ]
   }
 ]

--- a/data/json/recipes/weapon/piercing.json
+++ b/data/json/recipes/weapon/piercing.json
@@ -1597,11 +1597,6 @@
       { "id": "GRIND", "level": 2 },
       { "id": "DRILL", "level": 3 }
     ],
-    "components": [
-      [ [ "q_staff", 1 ] ],
-      [ [ "pipe_fittings", 1 ] ],
-      [ [ "spike", 1 ] ],
-      [ [ "nails", 2, "LIST" ], [ "nuts_bolts", 2 ] ]
-    ]
+    "components": [ [ [ "q_staff", 1 ] ], [ [ "pipe_fittings", 1 ] ], [ [ "spike", 1 ] ], [ [ "nuts_bolts", 2 ] ] ]
   }
 ]

--- a/tools/spell_checker/dictionary.txt
+++ b/tools/spell_checker/dictionary.txt
@@ -2337,6 +2337,7 @@ godesses
 Godfrey
 Godot
 Godwin
+goedendag
 Goethe
 Goldberg
 Goldstein

--- a/tools/spell_checker/dictionary.txt
+++ b/tools/spell_checker/dictionary.txt
@@ -2338,6 +2338,7 @@ Godfrey
 Godot
 Godwin
 goedendag
+goedendags
 Goethe
 Goldberg
 Goldstein


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Add two makeshift goedendags"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The goedendag is a pretty simple weapon in concept, in execution and in fabrication while, as a cross between a club and a spear, still being very effective in combat.

While a "proper" one would need a special head, it's extremely easy to make something very close with very common parts.

Those factors lead me to believe that those items would be desired as easy to craft, easy to replace and easy to use bespoke combat weapons. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add a "goedendag bat" weapon and its recipe. The weapon is basically a bat (it's mostly a copy-from in fact) that also deals pierce damage, the pierce damage is comparable although lower than a crude steel spear and the bash damage is slightly increased due to the added weight. The recipe involves simply wedging a pipe fitting around a bat by hammering a spike at the top, the purpose of the fitting here is mainly to reinforce the wood to prevent cracks during the wedging. I added a GRIND requirement to the recipe due to spike probably necessitating some sharpening after having been hammered into place.

Add a "crude goedendag" weapon and its recipe. This one is slightly more accurate to real goedendags due to it's length, it's a copy-from of a spear but shorter, dealing less pierce damage but more blunt damage. It also replace the IMPALE technique with the BRUTAL one. Contrary to the first one, this one preserve the ability to reach, similarly to a spear. The recipe is almost identical to the bat one except is uses a quarterstaff shaft as base instead of a bat.

Minor adjustments to the bat item, adding the nonconductive flag because it's made of wood. Minor adjustment to the crude steel spear, now being made of 95% wood and 5% medium steel instead of 50% wood 50% bad generic steel.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Add an "actual" goedendag. This would have involved additional work related to making steel variants, figuring the forging requirements etc. I'm too lazy to do it atm plus I was mainly interested in the crude and makeshift aspect of those weapons.
- Tweak the crude goedendag weight and volume instead of using the crude spear ones. So, the issue is that the goedendag is actually a very similar weapon to a spear in terms of shape and construction the only difference being using a slightly sturdier shaft and a having some additional thickness at the end, but since the weapon is also 30cm shorter and there is no "default" goedendag I figured making them identical on this end was fine, it would probably be debatable anyway.
- Make the bat have REACH. No, the bat is ~80cm, even adding 20 from the spike would make it merely 1m long, most of our reach weapon are more in the 180cm ballpark.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Spawned the weapons, compared them to their base and counterparts, looks fine.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

1. I'm expecting the density test to fail, I can't test it atm and the game doesn't check on load.
2. Those specific weapons are artificially made better than they should be due to how we simulate melee damage for melee weapons (blunt + pierce despite it being either one or the other in this case) and also due to how we don't differentiate a 180cm long spear from a 150cm one.

Source:

- [Wikipedia](https://en.wikipedia.org/wiki/Goedendag)
- [My armoury forum](http://myarmoury.com/talk/viewtopic.33646.html)
- [Youtube video of someone making one from spare parts](https://www.youtube.com/watch?v=3dFRR4ozy5Q)

What a high end one looks like

![custom935a_2048x2048](https://github.com/user-attachments/assets/9a202db1-23a5-41eb-9db7-7c16dfed3fd6)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
