### PR TITLE
Exodii do not pay for clothes or common kitchen goods

### DIFF
--- a/data/json/npcs/exodii/exodii_merchant_itemlist.json
+++ b/data/json/npcs/exodii/exodii_merchant_itemlist.json
@@ -438,5 +438,48 @@
       { "item": "exodii_wiring_kit_reference", "prob": 100 },
       { "item": "exodii_wire_kit", "prob": 100, "count": [ 1, 4 ] }
     ]
+  },
+  {
+    "id": "exodii_unwanted_bathroom_medicine",
+    "type": "item_group",
+    "//": "This group does not spawn anywhere, it exists only to set Exodii merchant prices",
+    "subtype": "collection",
+    "entries": [
+      { "distribution": [ { "group": "birth_control", "prob": 50 }, { "group": "estrogen_hrt", "prob": 3 } ], "prob": 95 },
+      { "item": "comb_lice", "prob": 10 },
+      { "item": "eyedrops", "prob": 15, "count": 10 },
+      { "item": "steroid_eyedrops", "prob": 5, "count": 5 },
+      { "item": "pepto", "prob": 60, "charges": [ 1, -1 ], "container-item": "bottle_plastic_small" },
+      { "prob": 60, "group": "tums_bottle_plastic_small_1_20" },
+      { "item": "inhaler", "prob": 25, "charges": [ 10, 100 ] },
+      { "group": "tampon_box_used", "prob": 20 },
+      { "group": "menstrual_pad_box_used", "prob": 20 },
+      { "item": "menstrual_cup", "prob": 2 },
+      { "group": "alcohol_wipes_box_used", "prob": 60 },
+      { "group": "alcohol_wipes_box_full", "prob": 20 },
+      {
+        "distribution": [
+          {
+            "item": "pills_sleep",
+            "prob": 60,
+            "count": [ 1, 10 ],
+            "container-item": "null",
+            "entry-wrapper": "bottle_plastic_pill_prescription"
+          },
+          {
+            "item": "melatonin_tablet",
+            "prob": 40,
+            "count": [ 1, 30 ],
+            "container-item": "null",
+            "entry-wrapper": "bottle_plastic_pill_prescription"
+          }
+        ],
+        "prob": 10
+      },
+      {
+        "distribution": [ { "item": "nyquil", "prob": 60, "charges": [ 1, -1 ] }, { "item": "dayquil", "prob": 20, "charges": [ 1, -1 ] } ],
+        "prob": 50
+      }
+    ]
   }
 ]

--- a/data/json/npcs/factions.json
+++ b/data/json/npcs/factions.json
@@ -1106,13 +1106,15 @@
       { "group": "games_board_all", "premium": 2.5 },
       { "category": "clothing", "price": 0 },
       { "group": "SUS_bathroom_sink", "price": 0 },
-      { "group": "SUS_bathroom_medicine", "price": 0 },
+      { "group": "exodii_unwanted_bathroom_medicine", "price": 0 },
       { "group": "SUS_toilet", "price": 0 },
       { "group": "SUS_bathroom_cabinet", "price": 0 },
       { "group": "SUS_dishes", "price": 0 },
       { "group": "SUS_cookware", "price": 0 },
       { "group": "SUS_utensils", "price": 0 },
       { "group": "SUS_junk_drawer", "price": 0 },
+      { "group": "SUS_junk_drawer_messy", "price": 0 },
+      { "group": "SUS_junk_drawer_artsy", "price": 0 },
       { "group": "SUS_kitchen_sink", "price": 0 }
     ],
     "relations": {

--- a/data/json/npcs/factions.json
+++ b/data/json/npcs/factions.json
@@ -1102,7 +1102,19 @@
     "power": 100,
     "fac_food_supply": [ [ 0, { "calories": 2700000000, "vitamins": { "iron": 86400, "calcium": 86400, "vitC": 86400 } } ] ],
     "wealth": 75000000,
-    "price_rules": [ { "group": "games_board_all", "premium": 2.5 } ],
+    "price_rules": [
+      { "group": "games_board_all", "premium": 2.5 },
+      { "category": "clothing", "price": 0 },
+      { "group": "SUS_bathroom_sink", "price": 0 },
+      { "group": "SUS_bathroom_medicine", "price": 0 },
+      { "group": "SUS_toilet", "price": 0 },
+      { "group": "SUS_bathroom_cabinet", "price": 0 },
+      { "group": "SUS_dishes", "price": 0 },
+      { "group": "SUS_cookware", "price": 0 },
+      { "group": "SUS_utensils", "price": 0 },
+      { "group": "SUS_junk_drawer", "price": 0 },
+      { "group": "SUS_kitchen_sink", "price": 0 }
+    ],
     "relations": {
       "free_merchants": {
         "kill on sight": false,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Balance "Exodii do not pay for clothes or common kitchen goods"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

For a while the glib description of the Exodii has been "drive up with a truck full of tampons, leave as a cyborg killing machine" because the Exodii will buy nearly anything and will sell life-changing cybernetic enhancements for basically pocket change. The latter is an entirely different issue, but there are quite a few things that the Exodii probably should not accept--things that they have no actual need themselves for, or for which they can quite easily supply what small need they have. I imagine they're not keeping a supply of stuff they don't need to trade to survivors--just skip the middleman, keep the useful stuff, and if the survivor brings even useful-er stuff, like ammo or a 6-inch-square tungsten cube, exchange some of your stockpile. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add several categories of items that the Exodii won't buy.

- Clothing:  There is tons of clothing everywhere and most of it absolutely will not fit a full conversion cyborg. The minimal need for cool hats and neckties can probably be filled by Exodii scavenging teams (or implemented as missions for specific Exodii)
- Kitchen utensils: The Exodii have no need for buckets of forks, knives, spoons, plates, etc. It's all extremely-common items that they could get in any ruined house, and they're not going to be melting down silverware for metal when cars are everywhere.
- Junk Drawer items: Flashlights, markers, candles, simple tools like hammers and scissors, balloons, loose buttons, bead necklaces, glue, letter openers, etc. Maybe batteries should be carved out as an exception
- Bathroom Sink/Cabinet items: Soap, cotton balls, tampons, cleaning chemicals, etc. The Exodii have pretty minimal need for all of these.
- Bathroom Medicine Cabinet: I've gone through here and only called out things that the Exodii wouldn't want, like lice combs, sleeping pills, and eyedrops. They'll still accept pain medication and antibiotics.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Add food and drink: I have no idea how much the Exodii actually need human foodstuffs

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

~~Drafted for discussion I need to make that medicine itemgroup~~ medicine itemgroup works. Went to the exodii and they would not buy my tshirts or my cotton balls. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
