### PR TITLE
UI: Allow utf-8 input in curses TUI

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -203,6 +203,10 @@ void cataimgui::client::process_input( void *input )
         } else {
             int ch = curses_input->get_first_input();
             if( ch != UNKNOWN_UNICODE ) {
+                // TODO: Check for proper way to detect non special-key multibyte input
+                if( ( ch & 0xffffff00 ) >> 8 != 1 ) {
+                    ch = utf8_wrapper( curses_input->text ).at( 0 );
+                }
                 imtui_events.push_back( std::pair<int, ImTui::mouse_event>( ch, new_mouse_event ) );
             }
         }

--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -203,7 +203,7 @@ void cataimgui::client::process_input( void *input )
         } else {
             int ch = curses_input->get_first_input();
             if( ch != UNKNOWN_UNICODE ) {
-                if( ch <= 0xff ) { // Values bigger than 1 byte represent function keys
+                if( ch > 127 && ch < 245 ) { // Values between 127 and 245 indicate UTF-8
                     ch = utf8_wrapper( curses_input->text ).at( 0 );
                 }
                 imtui_events.push_back( std::pair<int, ImTui::mouse_event>( ch, new_mouse_event ) );

--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -203,8 +203,7 @@ void cataimgui::client::process_input( void *input )
         } else {
             int ch = curses_input->get_first_input();
             if( ch != UNKNOWN_UNICODE ) {
-                // TODO: Check for proper way to detect non special-key multibyte input
-                if( ( ch & 0xffffff00 ) >> 8 != 1 ) {
+                if( ch <= 0xff ) { // Values bigger than 1 byte represent function keys
                     ch = utf8_wrapper( curses_input->text ).at( 0 );
                 }
                 imtui_events.push_back( std::pair<int, ImTui::mouse_event>( ch, new_mouse_event ) );


### PR DESCRIPTION
#### Summary
Interface "Allow input of utf-8 characters in curses UI"

#### Purpose of change
This change is intended to allow utf-8 input in the curses version of the UI.
When changing back to the TUI version from the Tiles version recently, I noticed that trying to input Japanese
results in garbled/random characters appearing instead.

#### Describe the solution

I'm actually not quite sure yet why/how it works exactly; that's why I'm opening it as a Draft for now.
I just did some debugging/testing and this is a solution that works for the cases that I tested;
the checking of bit 8 not being the only bit set in the upper 3 bytes was necessary to preserve the function of "special keys" like the arrow keys, backspace and enter.
I'm not confident at all that this solution works in all cases (and I find it incredibly ugly); I'll definitely have to check the utf-8 specification and how ncurses handles key inputs to understand how to properly implement this.

#### Describe alternatives you've considered

Maybe a better solution would be to have a look at [`input_manager::get_input_event()` in `src/ncurses_def.cpp`](https://github.com/CleverRaven/Cataclysm-DDA/blob/870fc6845ba47d859c7965311edf7d1d43b7c01f/src/ncurses_def.cpp#L429) and replace `getch()` with `get_wch()`? I'll have to try that; I'd definitely prefer that solution.

#### Testing

Other than running the tests, I only played the game for a few hours, while inputting Japanese into various textboxes during normal gameplay.

#### Additional context

If there's someone that knows more about utf-8 or ncurses, or has better ideas otherwise, suggestions are always welcome!