### PR TITLE
pants varients are clear and do not lie about function 

### DIFF
--- a/data/json/items/armor/legs_clothes.json
+++ b/data/json/items/armor/legs_clothes.json
@@ -974,63 +974,63 @@
       },
       {
         "id": "pants_blue",
-        "name": { "str_sp": "navy-blue pants" },
+        "name": { "str_sp": "navy-blue khaki pants" },
         "description": "A comfortable set of navy blue pants with large pockets, slightly thicker and warmer than regular jeans.",
         "color": "blue",
         "weight": 10
       },
       {
         "id": "pants_black",
-        "name": { "str_sp": "black pants" },
+        "name": { "str_sp": "black khaki pants" },
         "description": "A snappy set of black, neatly pressed trousers, perfect for formal events or looking professional.",
         "color": "dark_gray",
         "weight": 10
       },
       {
         "id": "pants_grey",
-        "name": { "str_sp": "gray pants" },
+        "name": { "str_sp": "gray khaki pants" },
         "description": "A set of storm gray pants speckled with dark stains so deeply assimilated into the fabric that they're nigh-irremovable.  You vehemently hope that they're just the mortal remains of some spilled beverage.",
         "color": "dark_gray",
         "weight": 10
       },
       {
         "id": "pants_red",
-        "name": { "str_sp": "burgundy pants" },
+        "name": { "str_sp": "burgundy khaki pants" },
         "description": "A pair of soft, comfortable burgundy trousers with a button-up fly and spacious pockets.",
         "color": "red",
         "weight": 10
       },
       {
         "id": "pants_purple",
-        "name": { "str_sp": "purple trackpants" },
-        "description": "A set of rugged and comfortable trousers dyed a soft shade of violet, these pants come equipped with an adjustable waistband.",
+        "name": { "str_sp": "purple khaki pants" },
+        "description": "A set of rugged and comfortable trousers dyed a soft shade of violet.",
         "color": "blue",
         "weight": 10
       },
       {
         "id": "pants_brown",
-        "name": { "str_sp": "brown pants" },
-        "description": "Boredom personified, this pair of corduroy pants is a dull hue of brown.",
+        "name": { "str_sp": "brown khaki pants" },
+        "description": "This pair of corduroy pants is a dull hue of brown.",
         "color": "brown",
         "weight": 10
       },
       {
         "id": "pants_cream",
-        "name": { "str_sp": "cream pants" },
-        "description": "A pair of milky, off-white pants dyed a shade of soft cream.  They're slightly warmer than jeans.",
+        "name": { "str_sp": "cream khaki pants" },
+        "description": "A pair of milky, off-white pants dyed a shade of soft cream.",
         "color": "white",
         "weight": 10
       },
       {
         "id": "pants_gray",
-        "name": { "str_sp": "gray pants" },
-        "description": "A business-like set of stone-gray trousers for business-like people, these pants are the same hue as concrete and are relatively warm.",
+        "name": { "str_sp": "gray khaki pants" },
+        "description": "A business-like set of stone-gray trousers for business-like people, these pants are the same hue as concrete.",
         "color": "light_gray",
         "weight": 10
       },
       {
         "id": "pants_british_khaki",
-        "name": { "str_sp": "British-khaki pants" },
+        "name": { "str_sp": "British khaki pants" },
         "description": "While these pants might not be English, their color certainly is.  More specifically, these comfortable trousers are a shade of British-khaki, a type of brownish-yellow hue developed by the empire's military for use in service uniforms.",
         "color": "brown",
         "weight": 8
@@ -1044,99 +1044,99 @@
       },
       {
         "id": "pants_hot_pink",
-        "name": { "str_sp": "hot-pink pants" },
-        "description": "Flaunting an almost aggressively vibrant shade of bright pink, this pair of soft, plush pants is slightly warmer than far duller jeans and makes a bold statement to any onlookers: human, zombie, or otherwise.  Though, perhaps dressing up like an anthropomorphic Easter egg isn't, in retrospect, the wisest way to prolong your time on this earth.",
+        "name": { "str_sp": "hot-pink khaki pants" },
+        "description": "Flaunting an almost aggressively vibrant shade of bright pink, this pair of soft, plush pants that make a bold statement to any onlookers: human, zombie, or otherwise.  Though, perhaps dressing up like an anthropomorphic Easter egg isn't, in retrospect, the wisest way to prolong your time on this earth.",
         "color": "pink",
         "weight": 8
       },
       {
         "id": "pants_maroon",
-        "name": { "str_sp": "maroon sweatpants" },
-        "description": "A visually appealing and subtle blend of browns and deep reds characterizes this pair of pants, which come equipped with a drawstring at the waist, elastic cuffs, and zip-up pockets.  An energetic and sporting set of pants for high-energy situations.",
+        "name": { "str_sp": "maroon khaki pants" },
+        "description": "A visually appealing and subtle blend of browns and deep reds characterizes this pair of pants.  An energetic and sporting set of pants for high-energy situations.",
         "color": "red",
         "weight": 8
       },
       {
         "id": "pants_od",
-        "name": { "str_sp": "olive-drab pants" },
-        "description": "While these aren't US-issued military trousers or even civilian tactical pants, this article of clothing possesses a blend of dark greens, browns, and blacks identical to the camouflage pattern of Vietnam-era army uniforms.  Slightly warmer than regular jeans, it's a decent piece of faux-military kit for those unwilling to shill out on a pair of actual BDU pants.",
+        "name": { "str_sp": "olive-drab khaki pants" },
+        "description": "While these aren't US-issued military trousers or even civilian tactical pants, this article of clothing possesses a blend of dark greens, browns, and blacks identical to the camouflage pattern of Vietnam-era army uniforms.",
         "color": "green",
         "weight": 8
       },
       {
         "id": "pants_woodland",
-        "name": { "str_sp": "woodland-camo pants" },
-        "description": "Not too dissimilar from the pattern adopted by older US Marine uniforms, this pair of otherwise conventional civilian pants is printed with a green, brown, and black woodland camouflage pattern.",
+        "name": { "str_sp": "woodland-camo khaki pants" },
+        "description": "Not too dissimilar from the pattern adopted by older US Marine uniforms, this pair of otherwise conventional civilian khaki pants is printed with a green, brown, and black woodland camouflage pattern.",
         "color": "green",
         "weight": 6
       },
       {
         "id": "pants_jungle",
-        "name": { "str_sp": "jungle-camo pants" },
-        "description": "Similar in color to the old frog skin uniforms issued to Marine Raiders during the Second World War, this pair of warm, comfortable trousers is dyed a greenish gray hue.  Completely conventional in every other respect, the patterning would be incredibly helpful if you were planning to take a trip down to the Amazon any time soon.",
+        "name": { "str_sp": "jungle-camo khaki pants" },
+        "description": "Similar in color to the old frog skin uniforms issued to Marine Raiders during the Second World War, comfortable khaki trousers is dyed a greenish gray hue.  Completely conventional in every other respect, the patterning would be incredibly helpful if you were planning to take a trip down to the Amazon any time soon.",
         "color": "green",
         "weight": 6
       },
       {
         "id": "pants_grassland",
-        "name": { "str_sp": "grassland-camo pants" },
-        "description": "Possessing reinforced knees and a hardy construction, this set of trousers is resplendent in a camouflage pattern of mixed light greens, browns, and beige tones.  With a set of deep pockets and an insulated design, it's an ideal piece of legwear for outdoor ventures.",
+        "name": { "str_sp": "grassland-camo khaki pants" },
+        "description": "This set of khaki trousers is resplendent in a camouflage pattern of mixed light greens, browns, and beige tones.",
         "color": "green",
         "weight": 6
       },
       {
         "id": "pants_marshland",
-        "name": { "str_sp": "marshland-camo pants" },
-        "description": "The faithful friend of waterfowl hunters, this pair of pants is printed with a brown, gray, tan, and green camouflage pattern designed to blend in with the vegetation and reeds present in swamps and marshlands.",
+        "name": { "str_sp": "marshland-camo khaki pants" },
+        "description": "The faithful friend of waterfowl hunters, these khaki trousers are printed with a brown, gray, tan, and green camouflage pattern designed to blend in with the vegetation and reeds present in swamps and marshlands.",
         "color": "brown",
         "weight": 6
       },
       {
         "id": "pants_desert",
-        "name": { "str_sp": "desert-camo pants" },
-        "description": "Dyed a mix of brown, tan, and yellowish beige hues, this pair of hardy trousers is designed to seamlessly blend into arid environments.  That being said, the fact that New England is famously devoid of deserts means that the pattern's only utility is in looking cool.",
+        "name": { "str_sp": "desert-camo khaki pants" },
+        "description": "Dyed a mix of brown, tan, and yellowish beige hues, this pair of trousers is designed to seamlessly blend into arid environments.  That being said, the fact that New England is famously devoid of deserts means that the pattern's only utility is in looking cool.",
         "color": "brown",
         "weight": 6
       },
       {
         "id": "pants_alpine",
-        "name": { "str_sp": "alpine-camo pants" },
+        "name": { "str_sp": "alpine-camo khaki pants" },
         "description": "The companion of aspiring mountaineers and alpine hunters, these brown, gray, and white dyed pants possess a network of jagged shapes and mottled lines, designed to break up the wearer's profile and better conceal them against the background landscape of mountains.",
         "color": "light_gray",
         "weight": 6
       },
       {
         "id": "pants_urban",
-        "name": { "str_sp": "urban-camo pants" },
+        "name": { "str_sp": "urban-camo khaki pants" },
         "description": "A set of rugged yet comfortable pants dyed in various scales of gray, black, and dirty white, possessing a set of sizable pockets, and printed with squares and irregular polygons to disrupt a wearer's silhouette within man-made environments.  You would honestly not be surprised if you learned that this singular pair of trousers contains 50 shades of gray.",
         "color": "dark_gray",
         "weight": 6
       },
       {
         "id": "pants_arctic",
-        "name": { "str_sp": "arctic-camo pants" },
+        "name": { "str_sp": "arctic-camo khaki pants" },
         "description": "Featuring a camouflage pattern consisting of white, shades of gray, and a slight tinge of brown, this pair of rugged pants is fit for snowy tundra and polar regions—or it would be, had the garment not been only moderately warmer than jeans.  You have yet to grasp their point for existing.",
         "color": "white",
         "weight": 6
       },
       {
         "id": "pants_black_camo",
-        "name": { "str_sp": "black-camo pants" },
-        "description": "Dyed a deep hue of urban black, this pair of hardwearing pants is designed to assist a wearer in concealing themselves within nighttime environments and low-light conditions.  While they're simple civilian trousers given a stealth-black paint job and don't hold a candle to their more marshal brothers, they still look cool and are great at making you feel like you're Spetsnaz.",
+        "name": { "str_sp": "black-camo khaki pants" },
+        "description": "Dyed a deep hue of urban black, this pair of pants is designed to assist a wearer in concealing themselves within nighttime environments and low-light conditions.  While they're simple civilian trousers given a stealth-black paint job and don't hold a candle to their more marshal brothers, they still look cool and are great at making you feel like you're Spetsnaz.",
         "color": "dark_gray",
         "weight": 6
       },
       {
         "id": "pants_white",
-        "name": { "str_sp": "white pants" },
+        "name": { "str_sp": "white khaki pants" },
         "description": "Notorious for either looking fabulous or disastrous with little in between, this stylish pair of boot-cut white trousers will almost certainly gain a plethora of irremovable stains as soon as you set foot beyond the threshold of your abode.",
         "color": "white",
         "weight": 6
       },
       {
         "id": "pants_orange",
-        "name": { "str_sp": "orange trackpants" },
-        "description": "Reminiscent of the color of flames, this pair of cotton trackpants is, perhaps optimistically, dyed a muted shade of burned orange.",
+        "name": { "str_sp": "orange khaki pants" },
+        "description": "Reminiscent of the color of flames, this pair of cotton pants is, perhaps optimistically, dyed a muted shade of burned orange.",
         "color": "red",
         "weight": 4
       },

--- a/data/json/items/armor/legs_clothes.json
+++ b/data/json/items/armor/legs_clothes.json
@@ -1101,14 +1101,14 @@
       {
         "id": "pants_alpine",
         "name": { "str_sp": "alpine-camo khaki pants" },
-        "description": "The companion of aspiring mountaineers and alpine hunters, these brown, gray, and white dyed pants possess a network of jagged shapes and mottled lines, designed to break up the wearer's profile and better conceal them against the background landscape of mountains.",
+        "description": "The companion of aspiring mountaineers and alpine hunters, these brown, gray, and white dyed khaki pants possess a network of jagged shapes and mottled lines, designed to break up the wearer's profile and better conceal them against the background landscape of mountains.",
         "color": "light_gray",
         "weight": 6
       },
       {
         "id": "pants_urban",
         "name": { "str_sp": "urban-camo khaki pants" },
-        "description": "A set of rugged yet comfortable pants dyed in various scales of gray, black, and dirty white, possessing a set of sizable pockets, and printed with squares and irregular polygons to disrupt a wearer's silhouette within man-made environments.  You would honestly not be surprised if you learned that this singular pair of trousers contains 50 shades of gray.",
+        "description": "A set of comfortable pants dyed in various scales of gray, black, and dirty white, printed with squares and irregular polygons to disrupt a wearer's silhouette within man-made environments.  You would honestly not be surprised if you learned that this singular pair of trousers contains 50 shades of gray.",
         "color": "dark_gray",
         "weight": 6
       },

--- a/data/json/items/armor/legs_clothes.json
+++ b/data/json/items/armor/legs_clothes.json
@@ -1010,7 +1010,7 @@
       {
         "id": "pants_brown",
         "name": { "str_sp": "brown khaki pants" },
-        "description": "This pair of corduroy pants is a pleasent but dull hue of brown.",
+        "description": "This pair of corduroy pants is a pleasant but dull hue of brown.",
         "color": "brown",
         "weight": 10
       },

--- a/data/json/items/armor/legs_clothes.json
+++ b/data/json/items/armor/legs_clothes.json
@@ -1010,7 +1010,7 @@
       {
         "id": "pants_brown",
         "name": { "str_sp": "brown khaki pants" },
-        "description": "This pair of corduroy pants is a dull hue of brown.",
+        "description": "This pair of corduroy pants is a pleasent but dull hue of brown.",
         "color": "brown",
         "weight": 10
       },

--- a/data/json/items/armor/legs_clothes.json
+++ b/data/json/items/armor/legs_clothes.json
@@ -1115,7 +1115,7 @@
       {
         "id": "pants_arctic",
         "name": { "str_sp": "arctic-camo khaki pants" },
-        "description": "Featuring a camouflage pattern consisting of white, shades of gray, and a slight tinge of brown, this pair of rugged pants is fit for snowy tundra and polar regions—or it would be, had the garment not been only moderately warmer than jeans.  You have yet to grasp their point for existing.",
+        "description": "Featuring a camouflage pattern consisting of white, shades of gray, and a slight tinge of brown, this pair of pants is fit for snowy tundra and polar regions—or it would be, had the garment not been only moderately warmer than jeans.  You have yet to grasp their point for existing.",
         "color": "white",
         "weight": 6
       },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Clean up pant variants"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

CDDA is a game with so many items. We also have variants. CDDA is also a game in which small changes in items stats matter - cargo pants vs tactical vs 'regular' pants vs jeans are all different items. We have enough detail to differentiate items based upon pockets and reinforced knees for examples. 

However, many pants variants actively went against this. Worst examples were the woodland pants which describe a reinforced knee - which they do in fact not have.

Similarly, many pants were labeled as sweat pants, despite being identical to khaki pants and not sweat/cargo pants. These should be variants of cargo pants - or renamed to remove the sweat pants (what I did).

I also dont think we need to note that these are slightly warmer then jeans in every description - players can read the warmth stat - it makes sense with like winter clothes but for regular pants its not a substantial thing to note 


<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

I tried to clean up the descriptions to make it clear that all variants are functionally identical to khaki pants. I tried to pre-serve as much as the original description as I could while removing any references to functional differences. 

I also changed the desc. for brown pants - someone had a real bone to pick with brown pants for some reason - I dont think we need to be brown pants haters here -_- 

#### Describe alternatives you've considered

Removing many of the offending variants - personally I'm not fan of this system in general - outside of like basic colors etc- but I know many like it and dont want to remove others work when adjusting is an option. 

#### Testing
opened the game - no further testing needed as only desc changes 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
NA

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
