### PR TITLE
Move void spider lair obsoletion to correct folder and fix omt ids

### DIFF
--- a/data/json/obsoletion_and_migration_0.I/obsolete_overmap_special.json
+++ b/data/json/obsoletion_and_migration_0.I/obsolete_overmap_special.json
@@ -16,10 +16,6 @@
   },
   {
     "type": "overmap_special_migration",
-    "id": "void_spider_lair"
-  },
-  {
-    "type": "overmap_special_migration",
     "id": "house_05ab",
     "new_id": "house_05"
   },

--- a/data/json/obsoletion_and_migration_0.I/obsolete_overmap_terrain.json
+++ b/data/json/obsoletion_and_migration_0.I/obsolete_overmap_terrain.json
@@ -566,10 +566,5 @@
       "outpost_cross_roof_east": "outpost_roof_east",
       "outpost_cross_roof_west": "outpost_roof_west"
     }
-  },
-  {
-    "type": "oter_id_migration",
-    "//": "migrated in 0.I",
-    "oter_ids": { "void_spider_lair_entrance": "deep_rock", "void_spider_lair_a1": "deep_rock", "void_spider_lair_a2": "deep_rock" }
   }
 ]

--- a/data/json/obsoletion_and_migration_0.J/obsolete_overmap_special.json
+++ b/data/json/obsoletion_and_migration_0.J/obsolete_overmap_special.json
@@ -95,5 +95,10 @@
     "type": "overmap_special_migration",
     "id": "Evac Shelter Unfinished 2",
     "new_id": "Evac Shelter Unfinished"
+  },
+  {
+    "type": "overmap_special_migration",
+    "id": "void_spider_lair",
+    "//": "Migrated to its own region in 0.J experimental"
   }
 ]

--- a/data/json/obsoletion_and_migration_0.J/obsolete_overmap_terrain.json
+++ b/data/json/obsoletion_and_migration_0.J/obsolete_overmap_terrain.json
@@ -328,5 +328,23 @@
       "LIXA_road_guard_south": "omt_obsolete",
       "LIXA_road_guard_roof_south": "omt_obsolete"
     }
+  },
+  {
+    "type": "oter_id_migration",
+    "//": "Migrated to its own region in 0.J experimental",
+    "oter_ids": {
+      "void_spider_lair_entrance_north": "deep_rock",
+      "void_spider_lair_a1_north": "deep_rock",
+      "void_spider_lair_a2_north": "deep_rock",
+      "void_spider_lair_entrance_east": "deep_rock",
+      "void_spider_lair_a1_east": "deep_rock",
+      "void_spider_lair_a2_east": "deep_rock",
+      "void_spider_lair_entrance_south": "deep_rock",
+      "void_spider_lair_a1_south": "deep_rock",
+      "void_spider_lair_a2_south": "deep_rock",
+      "void_spider_lair_entrance_west": "deep_rock",
+      "void_spider_lair_a1_west": "deep_rock",
+      "void_spider_lair_a2_west": "deep_rock"
+    }
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Migrated in the wrong version folder and without using the right omt id suffixes
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Bothering to add support for migrating rotatable ids without needing to specify the rotations using something like
```json
"oter_ids": {
      "old_omt_that_rotates_north": "deep_rock",
      "old_omt_that_rotates_east": "deep_rock",
      "old_omt_that_rotates_south": "deep_rock",
      "old_omt_that_rotates_west": "deep_rock",
      "old_omt_that_doesnt_rotate": "deep_rock"
}
```
->
```json
"oter_ids": [
      "old_omt_that_rotates": "deep_rock",
      { "old_omt_that_doesnt_rotate": "deep_rock", "rotates": false }
]
```
It's not trivial tho bc it needs to handle the new id potentially having rotation and would also want support for rotating 90/180/270° while migrating, I might get to it at some point

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Opening the save from #84731 no longer triggers errors
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
