### PR TITLE
Downgrade error message on loading to debug log warning

### DIFF
--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -7,6 +7,7 @@
 #include <iterator>
 #include <map>
 #include <numeric>
+#include <ostream>
 #include <string>
 #include <tuple>
 #include <type_traits>
@@ -735,8 +736,8 @@ void item_contents::combine( const item_contents &read_input, const bool convert
                                                  into_bottom, restack_charges, ignore_contents );
                 if( !inserted.success() ) {
                     uninserted_items.push_back( *it );
-                    debugmsg( "error: item %s cannot fit into pocket while loading: %s",
-                              it->typeId().str(), inserted.str() );
+                    DebugLog( DebugLevel::D_WARNING, DebugClass::D_GAME ) <<
+                            "error: item " << it->typeId().str() << "cannot fit into pocket while loading: " << inserted.str();
                 }
             }
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
"error: item blah cannot fit into pocket while loading: something changed in the game which receives a dozen updates per day!"

Well of course it did, the game updates all the time and item definitions change along with it. It happens all the time!

If it was in the pocket in the first, then it fit. Just because it doesn't fit NOW does not mean there's an error, it just means that it changed.  This is not an actionable error in any way!

#### Describe the solution
Stop spamming people with this error, keep it in the debug log just in case. But otherwise silence it.

#### Describe alternatives you've considered
A regular log message maybe

#### Testing
Not testing, simple change. If it compiles it's good to go

#### Additional context

