### PR TITLE
Check for const_talker nullptrs in maybe_read_var_value

### DIFF
--- a/src/dialogue_helpers.cpp
+++ b/src/dialogue_helpers.cpp
@@ -31,10 +31,14 @@ diag_value const *maybe_read_var_value( const var_info &info, const_dialogue con
             return globvars.maybe_get_global_value( info.name );
         case var_type::context:
             return d.maybe_get_value( info.name );
-        case var_type::u:
-            return d.const_actor( false )->maybe_get_value( info.name );
-        case var_type::npc:
-            return d.const_actor( true )->maybe_get_value( info.name );
+        case var_type::u: {
+            const_talker const *alpha = d.const_actor( false );
+            return alpha ? alpha->maybe_get_value( info.name ) : nullptr;
+        }
+        case var_type::npc: {
+            const_talker const *beta = d.const_actor( true );
+            return beta ? beta->maybe_get_value( info.name ) : nullptr;
+        }
         case var_type::var: {
             diag_value const *const var_val = d.maybe_get_value( info.name );
             return var_val ? maybe_read_var_value( process_variable( var_val->str() ), d ) : nullptr;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Partially addresses #84731
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
~~Also alters the reported EOC so the item rather than the holder have the counter and then the triggered EOC only triggers if being held by the player (I don't imagine anyone was going to like activate it and then trade it to an NPC at the top of the tower to yeet them but yknow, might as well check that too)~~ Nvm Blueflowerss got there first
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
u_message is erroring without CTDing "correctly" here but I really don't like the fallback handling in place here for general usages
https://github.com/CleverRaven/Cataclysm-DDA/blob/2aff1fb7ae649ee1e6e6e3885186d1b8f1a4a617/src/npctalk.cpp#L2747-L2758
Falling back to the other actor causes unexpected behaviour leading to confusion and could (have already) lead to unhelpful issues being opened where the true issue is masked, secondly it doesn't cover the case where there's no actors at all, as well as not providing the caller any knowledge that something has gone wrong.
(Comment adding the current fallback https://github.com/CleverRaven/Cataclysm-DDA/pull/50757#discussion_r688813094)
I'm not sure whether we intentionally don't want to return nullptr and have it be the caller's responsibility in which case I think returning a pointer to a dummy talker would make more sense otherwise I'd be quite happy to go through and mask all the calls with nullptr checks and sensible fallback behaviours.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
CTD is replaced by a second ignorable error
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
