### PR TITLE
make glock 27 group contain glock 27

### DIFF
--- a/data/json/itemgroups/Weapons_Mods_Ammo/nested_guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/nested_guns.json
@@ -227,7 +227,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "glock_23", "charges": [ 0, 15 ], "ammo-item": "40sw" },
+      { "item": "glock_27", "charges": [ 0, 15 ], "ammo-item": "40sw" },
       { "item": "glock40mag_9", "ammo-item": "40sw" },
       { "item": "glock40mag_9", "ammo-item": "40sw", "prob": 50 },
       { "group": "on_hand_40" }


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Got lucky with my loot, but foung the gun spawned with incompatible magazines; after checking found an obvious typo
#### Describe the solution
make `nested_glock_27` contain `glock_27`, not `glock_23`