### PR TITLE
Add a new display mode to the construction menu: ready.

### DIFF
--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -345,7 +345,8 @@ static void load_available_constructions( std::vector<construction_group_str_id>
             ok = player_can_build( player_character, player_character.crafting_inventory(), it, true ) &&
                  !can_construct( it );
         } else if( filter_mode == 2 ) {
-            ok = player_can_build( player_character, player_character.crafting_inventory(), it, true ) && can_construct( it );
+            ok = player_can_build( player_character, player_character.crafting_inventory(), it, true ) &&
+                 can_construct( it );
         }
         if( !ok ) {
             continue;

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -614,7 +614,8 @@ construction_id construction_menu( const bool blueprint )
                 construction *current_con = *it;
                 if( filter_mode == 1 ) {
                     // show stages where skills & materials are satisfied but location is not
-                    if( !( player_can_build( player_character, total_inv, *current_con, true ) && !can_construct( *current_con ) ) ) {
+                    if( !( player_can_build( player_character, total_inv, *current_con, true ) &&
+                           !can_construct( *current_con ) ) ) {
                         continue;
                     }
                 } else if( filter_mode == 2 ) {

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -322,7 +322,7 @@ constructions_by_filter( std::function<bool( construction const & )> const &filt
 
 static void load_available_constructions( std::vector<construction_group_str_id> &available,
         std::map<construction_category_id, std::vector<construction_group_str_id>> &cat_available,
-        bool hide_unconstructable )
+        int filter_mode )
 {
     cat_available.clear();
     available.clear();
@@ -332,19 +332,33 @@ static void load_available_constructions( std::vector<construction_group_str_id>
     }
     avatar &player_character = get_avatar();
     for( construction &it : constructions ) {
-        if( it.on_display && ( !hide_unconstructable ||
-                               player_can_build( player_character, player_character.crafting_inventory(), it ) ) ) {
-            bool already_have_it = false;
-            for( auto &avail_it : available ) {
-                if( avail_it == it.group ) {
-                    already_have_it = true;
-                    break;
-                }
+        if( !it.on_display ) {
+            continue;
+        }
+        bool ok = false;
+        // filter_mode: 0 = all,
+        // 1 = ready (skills & materials satisfied, but location not satisfied),
+        // 2 = buildable here (skills & materials satisfied and location satisfied)
+        if( filter_mode == 0 ) {
+            ok = true;
+        } else if( filter_mode == 1 ) {
+            ok = player_can_build( player_character, player_character.crafting_inventory(), it, true ) && !can_construct( it );
+        } else if( filter_mode == 2 ) {
+            ok = player_can_build( player_character, player_character.crafting_inventory(), it, true ) && can_construct( it );
+        }
+        if( !ok ) {
+            continue;
+        }
+        bool already_have_it = false;
+        for( auto &avail_it : available ) {
+            if( avail_it == it.group ) {
+                already_have_it = true;
+                break;
             }
-            if( !already_have_it ) {
-                available.push_back( it.group );
-                cat_available[it.category].push_back( it.group );
-            }
+        }
+        if( !already_have_it ) {
+            available.push_back( it.group );
+            cat_available[it.category].push_back( it.group );
         }
     }
 }
@@ -488,11 +502,13 @@ construction_id construction_menu( const bool blueprint )
         debugmsg( "construction_menu called before finalization" );
         return construction_id( -1 );
     }
-    static bool hide_unconstructable = false;
+    // filter_mode: 0 = all, 1 = ready (skills & materials satisfied, but location not satisfied),
+    // 2 = buildable here (skills & materials satisfied and location satisfied)
+    static int filter_mode = 0;
     // only display constructions the player can theoretically perform
     std::vector<construction_group_str_id> available;
     std::map<construction_category_id, std::vector<construction_group_str_id>> cat_available;
-    load_available_constructions( available, cat_available, hide_unconstructable );
+    load_available_constructions( available, cat_available, filter_mode );
 
     if( available.empty() ) {
         popup( _( "You can not construct anything here." ) );
@@ -594,8 +610,16 @@ construction_id construction_menu( const bool blueprint )
                  it != options.end(); ++it ) {
                 stage_counter++;
                 construction *current_con = *it;
-                if( hide_unconstructable && !can_construct( *current_con ) ) {
-                    continue;
+                if( filter_mode == 1 ) {
+                    // show stages where skills & materials are satisfied but location is not
+                    if( !( player_can_build( player_character, total_inv, *current_con, true ) && !can_construct( *current_con ) ) ) {
+                        continue;
+                    }
+                } else if( filter_mode == 2 ) {
+                    // show stages that are buildable here (skills & materials + location)
+                    if( !( player_can_build( player_character, total_inv, *current_con, true ) && can_construct( *current_con ) ) ) {
+                        continue;
+                    }
                 }
                 // Update the cached availability of components and tools in the requirement object
                 current_con->requirements->can_make_with_inventory( total_inv, is_crafting_component, 1,
@@ -983,15 +1007,19 @@ construction_id construction_menu( const bool blueprint )
                                             ctxt.get_desc( "RIGHT" ) ) );
             notes.push_back( string_format( _( "Press [<color_yellow>%s</color>] to search." ),
                                             ctxt.get_desc( "FILTER" ) ) );
-            if( !hide_unconstructable ) {
-                notes.push_back( string_format(
-                                     _( "Press [<color_yellow>%s</color>] to hide unavailable constructions." ),
-                                     ctxt.get_desc( "TOGGLE_UNAVAILABLE_CONSTRUCTIONS" ) ) );
+            // show the current filter mode in the notes area
+            std::string mode_name;
+            if( filter_mode == 0 ) {
+                mode_name = _( "All" );
+            } else if( filter_mode == 1 ) {
+                mode_name = _( "Ready (missing location)" );
             } else {
-                notes.push_back( string_format(
-                                     _( "Press [<color_red>%s</color>] to show unavailable constructions." ),
-                                     ctxt.get_desc( "TOGGLE_UNAVAILABLE_CONSTRUCTIONS" ) ) );
+                mode_name = _( "Buildable here" );
             }
+            notes.push_back( string_format(
+                                 _( "Filter: %s — Press [<color_yellow>%s</color>] to cycle." ),
+                                 colorize( mode_name, c_light_green ),
+                                 ctxt.get_desc( "TOGGLE_UNAVAILABLE_CONSTRUCTIONS" ) ) );
             notes.push_back( string_format(
                                  _( "Press [<color_yellow>%s</color>] to view and edit keybindings." ),
                                  ctxt.get_desc( "HELP_KEYBINDINGS" ) ) );
@@ -1057,9 +1085,12 @@ construction_id construction_menu( const bool blueprint )
         } else if( action == "TOGGLE_UNAVAILABLE_CONSTRUCTIONS" ) {
             update_info = true;
             update_cat = true;
-            hide_unconstructable = !hide_unconstructable;
+            // cycle through filter modes: 0 -> 1 -> 2 -> 0
+            filter_mode = ( filter_mode + 1 ) % 3;
             offset = 0;
-            load_available_constructions( available, cat_available, hide_unconstructable );
+            load_available_constructions( available, cat_available, filter_mode );
+            // force main UI to refresh so the notes update immediately
+            g->invalidate_main_ui_adaptor();
         } else if( action == "CONFIRM" ) {
             if( constructs.empty() || select >= static_cast<int>( constructs.size() ) ) {
                 // Nothing to be done here

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -620,7 +620,8 @@ construction_id construction_menu( const bool blueprint )
                     }
                 } else if( filter_mode == 2 ) {
                     // show stages that are buildable here (skills & materials + location)
-                    if( !( player_can_build( player_character, total_inv, *current_con, true ) && can_construct( *current_con ) ) ) {
+                    if( !( player_can_build( player_character, total_inv, *current_con, true ) &&
+                           can_construct( *current_con ) ) ) {
                         continue;
                     }
                 }

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -342,7 +342,8 @@ static void load_available_constructions( std::vector<construction_group_str_id>
         if( filter_mode == 0 ) {
             ok = true;
         } else if( filter_mode == 1 ) {
-            ok = player_can_build( player_character, player_character.crafting_inventory(), it, true ) && !can_construct( it );
+            ok = player_can_build( player_character, player_character.crafting_inventory(), it, true ) &&
+                 !can_construct( it );
         } else if( filter_mode == 2 ) {
             ok = player_can_build( player_character, player_character.crafting_inventory(), it, true ) && can_construct( it );
         }

--- a/tools/spell_checker/dictionary.txt
+++ b/tools/spell_checker/dictionary.txt
@@ -873,6 +873,7 @@ bufo
 bufos
 bugfixes
 bugout
+Buildable
 Bukharin
 bulette
 bulettes


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Interface "Add a new display mode to the construction menu: ready."

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
A new display mode, "Ready," has been added to the crafting menu to show recipes where all materials and skills are available but the required terrain is incorrect, thereby making players aware of their capabilities.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Added a three-phase switch, simply integrating it with existing components.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Testing
Done.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
<img width="1723" height="363" alt="image" src="https://github.com/user-attachments/assets/72d68353-d3e1-4222-b54e-13ae2d60f117" />
<img width="1693" height="375" alt="image" src="https://github.com/user-attachments/assets/380d9be8-af7d-41a8-84c7-43ed5301d3bb" />

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
