### PR TITLE
Better furniture loading onto vehicles

### DIFF
--- a/data/json/vehicleparts/cargo.json
+++ b/data/json/vehicleparts/cargo.json
@@ -301,7 +301,7 @@
     "item": "nose_plate",
     "color": "light_gray",
     "variants": [ { "symbols": "L", "symbols_broken": "#" } ],
-    "flags": [ "BOARDABLE", "CARGO", "CARGO_PASSABLE", "FURNITURE_TIEDOWN" ],
+    "flags": [ "BOARDABLE", "CARGO", "CARGO_PASSABLE", "FURNITURE_TIEDOWN", "FURNITURE_LIFT_ASSIST" ],
     "//": "https://www.magliner.com/extruded-aluminum-nose-flush-mount-300248",
     "//1": "Rated for 500 lbs but LIFT/JACK 1 is 1000kg.  Volume of the nose plate's bounding box is about 12.5L.",
     "requirements": {

--- a/data/json/vehicleparts/vp_flags.json
+++ b/data/json/vehicleparts/vp_flags.json
@@ -121,6 +121,11 @@
     "info": "You can tie down a furniture here."
   },
   {
+    "id": "FURNITURE_LIFT_ASSIST",
+    "type": "json_flag",
+    "info": "It's much easier to tie down a furniture here."
+  },
+  {
     "id": "NO_LEAK",
     "type": "json_flag",
     "info": "Causes a boat hull to float even when damaged."

--- a/doc/JSON/JSON_FLAGS.md
+++ b/doc/JSON/JSON_FLAGS.md
@@ -1705,6 +1705,8 @@ Note: Vehicle parts requiring other parts is defined by setting a `requires_flag
 - ```FREEZER``` Can freeze items in below zero degrees Celsius temperature.
 - ```FRIDGE``` Can refrigerate items.
 - ```FUNNEL``` If installed over a vehicle tank, can collect rainwater during rains.
+- ```FURNITURE_LIFT_ASSIST``` This part has bonus effective strength when 'e'xamining it to load furniture onto it. Requires the part to also be FURNITURE_TIEDOWN. Bonus is currently set to 5.
+- ```FURNITURE_TIEDOWN``` This part can have furniture loaded onto it. Requires the part to also be CARGO.
 - ```HALF_CIRCLE_LIGHT``` Projects a directed half-circular radius of light when turned on.
 - ```HANDHELD_BATTERY_MOUNT``` Same as `BATTERY_MOUNT`, but for handheld battery mount.
 - ```HARNESS_bodytype``` Replace bodytype with `any` to accept any type, or with the targeted type.

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1673,12 +1673,17 @@ static void pickup_furniture_for_carry( map &here, vehicle_part &part )
     const furn_str_id picked_up_furn = here.furn( *selected_tile )->id;
 
     const Character &you = get_player_character();
-    const int lifting_str_available = you.get_lift_str() + you.get_lift_assist();
+    // FURNITURE_LIFT_ASSIST gives 5 bonus strength for the lift check
+    const int part_lifting_bonus = part.info().has_flag( "FURNITURE_LIFT_ASSIST" ) ? 5 : 0;
+    const int lifting_str_available = you.get_lift_str() + you.get_lift_assist() + part_lifting_bonus;
+
+    // This handles cranes, the actual "LIFT" quality, and all that. Sure, you can boom crane a freezer onto the back of a truck. Why not.
+    const bool crane_lift = you.best_nearby_lifting_assist() >= picked_up_furn->mass;
 
     if( picked_up_furn->move_str_req < 0 ) {
         add_msg( _( "That furniture can't be moved." ) );
         return;
-    } else if( picked_up_furn->move_str_req > lifting_str_available ) {
+    } else if( !crane_lift && picked_up_furn->move_str_req > lifting_str_available ) {
         if( you.get_lift_assist() > 0 ) {
             add_msg( string_format( _( "Even working together, you are unable to lift the %s." ),
                                     picked_up_furn->name() ) );


### PR DESCRIPTION
#### Summary
Features "Better furniture loading onto vehicles"

#### Purpose of change
Something I said I'd do but hadn't put in, since another contributor ended up implementing hand carts.

#### Describe the solution
Give hand carts a bonus for loading furniture onto/off them. This is with a simple flag, FURNITURE_LIFT_ASSIST, provides 5 bonus strength for that purpose.

Also since we have a simple function for it, allow the usage of all items with the LIFT quality as an *alternative*, completely separate calculation. So the dolly helps you manhandle it, and once you've got it back you can boom crane that freezer onto your truck. (Alternatively you can load the dolly right onto a bike rack...)

Also documented the FURNITURE_TIEDOWN flag since I apparently forgot to do that

#### Describe alternatives you've considered


#### Testing


#### Additional context
