### PR TITLE
Handle moving input_context invalidating the self-ref handle.

### DIFF
--- a/src/input_context.h
+++ b/src/input_context.h
@@ -69,7 +69,7 @@ class input_context
         // Whatever's on top is our current input context.
         static input_context_stack_impl input_context_stack;
 #endif
-        input_context() : registered_any_input( false ), category( "default" ),
+        input_context() : category( "default" ), registered_any_input( false ),
             coordinate_input_received( false ), handling_coordinate_input( false ) {
 #if defined(__ANDROID__) || defined(TILES)
             input_context_stack.push( handle );
@@ -83,7 +83,7 @@ class input_context
         // outside that window can be ignored
         explicit input_context( const std::string &category,
                                 const keyboard_mode preferred_keyboard_mode = keyboard_mode::keycode )
-            : registered_any_input( false ), category( category ),
+            : category( category ), registered_any_input( false ),
               coordinate_input_received( false ), handling_coordinate_input( false ),
               preferred_keyboard_mode( preferred_keyboard_mode ) {
 #if defined(__ANDROID__) || defined(TILES)
@@ -95,9 +95,48 @@ class input_context
             register_action( "toggle_language_to_en" );
         }
 
-#if defined(__ANDROID__) || defined(TILES)
-        virtual ~input_context() = default;
+        input_context( const input_context &other ) {
+            reassign( other );
+        }
+
+        input_context &operator=( const input_context &other ) {
+            if( this == &other ) {
+                return *this;
+            }
+            reassign( other );
+            return *this;
+        }
+
+        input_context( input_context &&other ) noexcept {
+            reassign( std::move( other ) );
+        }
+
+        input_context &operator=( input_context &&other ) noexcept {
+            reassign( std::move( other ) );
+            return *this;
+        }
+
+        template<typename Rhs>
+        void reassign( Rhs &&other ) {
+            // Don't touch the handle
+#if defined(__ANDROID__)
+            registered_manual_keys = std::forward<Rhs>( other ).registered_manual_keys;
 #endif
+            registered_actions = std::forward<Rhs>( other ).registered_actions;
+            edittext = std::forward<Rhs>( other ).edittext;
+            category = std::forward<Rhs>( other ).category;
+            coordinate = std::forward<Rhs>( other ).coordinate;
+            registered_any_input = std::forward<Rhs>( other ).registered_any_input;
+            coordinate_input_received = std::forward<Rhs>( other ).coordinate_input_received;
+            handling_coordinate_input = std::forward<Rhs>( other ).handling_coordinate_input;
+            iso_mode = std::forward<Rhs>( other ).iso_mode;
+            allow_text_entry = std::forward<Rhs>( other ).allow_text_entry;
+            next_action = std::forward<Rhs>( other ).next_action;
+            timeout = std::forward<Rhs>( other ).timeout;
+            preferred_keyboard_mode = std::forward<Rhs>( other ).preferred_keyboard_mode;
+            action_name_overrides = std::forward<Rhs>( other ).action_name_overrides;
+        }
+
 
 #if defined(__ANDROID__)
         // HACK: hack to allow creating manual keybindings for getch() instances, uilists etc. that don't use an input_context outside of the Android version
@@ -109,10 +148,6 @@ class input_context
                 return key == other.key && text == other.text;
             }
         };
-
-        // If true, prevent virtual keyboard from dismissing after a key press while this input context is active.
-        // NOTE: This won't auto-bring up the virtual keyboard, for that use sdltiles.cpp is_string_input()
-        bool allow_text_entry;
 
         void register_manual_key( manual_key mk );
         void register_manual_key( int key, const std::string text = "" );
@@ -138,22 +173,6 @@ class input_context
         bool is_action_registered( const std::string &action_descriptor ) const {
             return std::find( registered_actions.begin(), registered_actions.end(),
                               action_descriptor ) != registered_actions.end();
-        }
-
-        input_context &operator=( const input_context &other ) {
-            registered_actions = other.registered_actions;
-            registered_manual_keys = other.registered_manual_keys;
-            allow_text_entry = other.allow_text_entry;
-            registered_any_input = other.registered_any_input;
-            category = other.category;
-            coordinate = other.coordinate;
-            coordinate_input_received = other.coordinate_input_received;
-            handling_coordinate_input = other.handling_coordinate_input;
-            next_action = other.next_action;
-            iso_mode = other.iso_mode;
-            action_name_overrides = other.action_name_overrides;
-            timeout = other.timeout;
-            return *this;
         }
 
         bool operator==( const input_context &other ) const {
@@ -453,13 +472,20 @@ class input_context
         bool is_event_type_enabled( input_event_t type ) const;
         bool is_registered_action( const std::string &action_name ) const;
     private:
-        bool registered_any_input;
         std::string category; // The input category this context uses.
         point coordinate;
+
+        bool registered_any_input;
         bool coordinate_input_received;
         bool handling_coordinate_input;
-        input_event next_action;
         bool iso_mode = false; // should this context follow the game's isometric settings?
+
+    public:
+        // If true, prevent virtual keyboard from dismissing after a key press while this input context is active.
+        // NOTE: This won't auto-bring up the virtual keyboard, for that use sdltiles.cpp is_string_input()
+        bool allow_text_entry;
+    private:
+        input_event next_action;
         int timeout = -1;
         keyboard_mode preferred_keyboard_mode = keyboard_mode::keycode;
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #84680. Although the shared_ptr handle trick was a nice touch for fixing asan, it added its own issue which is the handles did not update when the owning input_context was moved. This would make them point into garbage memory, which matters on mobile where we try to copy the head of the stack to the touch input context object.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Implement moving for input_contexts. It does not move the moved-from handle, but just moves all the members the same as the copy operator copies all the members. Also rearrange some bools for better packing because there was a few words of wasted bytes.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Build & run on my android device, no crash.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
