### PR TITLE
Bugfix repetitive popup from Pat

### DIFF
--- a/data/json/effects_on_condition/item_eocs.json
+++ b/data/json/effects_on_condition/item_eocs.json
@@ -623,7 +623,7 @@
             "u_message": "You hear a chirp in your earpiece and Pat's voice comes over the line: \"What the hell, pal, I thought you fell off that radio tower.  What happened?  Wait, wait, wait image coming through now.  It looks broken?  Where the hell were you?  Over.\"",
             "popup": true
           },
-          { "math": [ "robofac_pat_lost_signal_highlands = 0" ] }
+          { "math": [ "robofac_pat_lost_signal_radiosphere = 0" ] }
         ]
       },
       {
@@ -633,7 +633,7 @@
             "u_message": "You hear a chirp in your earpiece and Pat's voice comes over the line: \"Well, welcome back.  I guess that robot wasn't kidding.  Your radio signal vanished.  I'll record all the data as it comes through.\"",
             "popup": true
           },
-          { "math": [ "robofac_pat_lost_signal_labyrinth = 1" ] }
+          { "math": [ "robofac_pat_lost_signal_labyrinth = 0" ] }
         ]
       },
       {
@@ -645,7 +645,7 @@
             "u_message": "You hear a chirp in your earpiece and Pat's voice comes over the line: \"I thought maybe you fell off that roof.  You alright?  I'm getting a backed up stream of shitty images now.  I'll record whatever the hell happened, I guess.  Over.\"",
             "popup": true
           },
-          { "math": [ "robofac_pat_lost_signal_cabin_reverb = 1" ] }
+          { "math": [ "robofac_pat_lost_signal_cabin_reverb = 0" ] }
         ]
       }
     ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Pat won't repeat themselves after otherworldly travel"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Pat had a few variable that weren't getting properly set, making a few messages repeat if you kept walking around after visiting another dimension.  This fixes it.  (I missed it because I just checked for the popups in testing, and didn't walk around more after).

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Make the variables set properly after the message displays.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

none

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Warped to other dimensions, saw correct message, warped back, saw correct message, then walked around a while and warped back and forth to make sure it doesn't come back.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
