### PR TITLE
Move ACT_TRAIN handler to activity_actor, obsolete ACT_TRAIN_TEACHER

### DIFF
--- a/data/json/obsoletion_and_migration_0.J/player_activities.json
+++ b/data/json/obsoletion_and_migration_0.J/player_activities.json
@@ -44,5 +44,13 @@
     "verb": "fiddling with your clothes",
     "based_on": "time",
     "can_resume": false
+  },
+  {
+    "id": "ACT_TRAIN_TEACHER",
+    "type": "activity_type",
+    "activity_level": "ACTIVE_EXERCISE",
+    "verb": "teaching",
+    "based_on": "speed",
+    "can_resume": false
   }
 ]

--- a/data/json/player_activities.json
+++ b/data/json/player_activities.json
@@ -380,14 +380,6 @@
     "based_on": "speed"
   },
   {
-    "id": "ACT_TRAIN_TEACHER",
-    "type": "activity_type",
-    "activity_level": "ACTIVE_EXERCISE",
-    "verb": "teaching",
-    "based_on": "speed",
-    "can_resume": false
-  },
-  {
     "id": "ACT_SOCIALIZE",
     "type": "activity_type",
     "activity_level": "NO_EXERCISE",

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -35,6 +35,7 @@
 #include "cata_utility.h"
 #include "character.h"
 #include "character_id.h"
+#include "character_martial_arts.h"
 #include "clzones.h"
 #include "construction.h"
 #include "contents_change_handler.h"
@@ -87,6 +88,7 @@
 #include "monster.h"
 #include "mtype.h"
 #include "npc.h"
+#include "npctalk.h"
 #include "npc_opinion.h"
 #include "omdata.h"
 #include "options.h"
@@ -99,6 +101,7 @@
 #include "player_activity.h"
 #include "pocket_type.h"
 #include "point.h"
+#include "proficiency.h"
 #include "ranged.h"
 #include "recipe.h"
 #include "requirements.h"
@@ -212,6 +215,7 @@ static const activity_id ACT_STUDY_SPELL( "ACT_STUDY_SPELL" );
 static const activity_id ACT_TENT_DECONSTRUCT( "ACT_TENT_DECONSTRUCT" );
 static const activity_id ACT_TENT_PLACE( "ACT_TENT_PLACE" );
 static const activity_id ACT_TIDY_UP( "ACT_TIDY_UP" );
+static const activity_id ACT_TRAIN( "ACT_TRAIN" );
 static const activity_id ACT_TREE_COMMUNION( "ACT_TREE_COMMUNION" );
 static const activity_id ACT_TRY_SLEEP( "ACT_TRY_SLEEP" );
 static const activity_id ACT_UNLOAD( "ACT_UNLOAD" );
@@ -10465,6 +10469,157 @@ std::unique_ptr<activity_actor> socialize_activity_actor::deserialize( JsonValue
     return actor.clone();
 }
 
+void training_activity_actor::start( player_activity &act, Character & )
+{
+    act.moves_total = to_moves<int>( initial_moves );
+    act.moves_left = act.moves_total;
+}
+
+void training_activity_actor::train_skill( Character &who, skill_id trained_skill )
+{
+    const Skill &skill = trained_skill.obj();
+    std::string skill_name = skill.name();
+    int old_skill_level = who.get_knowledge_level( trained_skill );
+    who.practice( trained_skill, 100, old_skill_level + 2 );
+    int new_skill_level = who.get_knowledge_level( trained_skill );
+    if( old_skill_level != new_skill_level ) {
+        if( who.is_avatar() ) {
+            add_msg( m_good, _( "You finish training %s to level %d." ),
+                     skill_name, new_skill_level );
+        }
+        get_event_bus().send<event_type::gains_skill_level>( who.getID(), trained_skill, new_skill_level );
+    } else if( who.is_avatar() ) {
+        add_msg( m_good, _( "You get some training in %s." ), skill_name );
+    }
+}
+
+void training_activity_actor::train_proficiency( Character &who,
+        proficiency_id trained_proficiency )
+{
+    who.practice_proficiency( trained_proficiency, 15_minutes );
+    if( who.is_avatar() ) {
+        add_msg( m_good, _( "You get some training in %s." ), trained_proficiency->name() );
+    }
+}
+
+void training_activity_actor::train_martial_art( Character &who, matype_id trained_martial_art )
+{
+    get_event_bus().send<event_type::learns_martial_art>( who.getID(), trained_martial_art );
+    who.martial_arts_data->learn_style( trained_martial_art, who.is_avatar() );
+}
+
+void training_activity_actor::train_spell( Character &who, spell_id trained_spell )
+{
+
+    const spell_id &sp_id = trained_spell;
+    const bool knows = who.magic->knows_spell( sp_id );
+    if( knows ) {
+        spell &studying = who.magic->get_spell( sp_id );
+
+        Character *teacher_valid = g->critter_by_id<Character>( teacher );
+        int expert_multiplier = 0;
+        if( teacher_valid ) {
+            const spell &temp_spell = teacher_valid->magic->get_spell( sp_id );
+            expert_multiplier = knows ? temp_spell.get_level() -
+                                who.magic->get_spell( sp_id ).get_level() : 1;
+        }
+        const int xp = roll_remainder( studying.exp_modifier( who ) * expert_multiplier );
+        studying.gain_exp( who, xp );
+        who.add_msg_player_or_npc( m_good, _( "You learn a little about the spell: %s" ),
+                                   _( "<npcname> learns a little about the spell: %s" ), sp_id->name );
+    } else {
+        who.magic->learn_spell( trained_spell, who );
+        // the learned spell from the above line may be cancelled, as it may lock you out of other magic.
+        // therefore, re-evaluate knows_spell
+        if( who.magic->knows_spell( sp_id ) ) {
+            who.add_msg_player_or_npc( m_good, _( "You learn %s." ),
+                                       _( "<npcname> learns %s." ), sp_id->name.translated() );
+        }
+    }
+}
+
+void training_activity_actor::canceled( player_activity &act, Character & )
+{
+    if( teaching ) {
+        for( const character_id trainee : trainees ) {
+            Character *trainee_valid = g->critter_by_id<Character>( trainee );
+            if( trainee_valid && trainee_valid->activity.id() == ACT_TRAIN ) {
+                trainee_valid->cancel_activity();
+            }
+        }
+    }
+    act.set_to_null();
+}
+
+void training_activity_actor::do_turn( player_activity &, Character &who )
+{
+    if( teaching ) {
+        bool all_students_done = true;
+        for( const character_id trainee : trainees ) {
+            Character *trainee_valid = g->critter_by_id<Character>( trainee );
+            /*
+            because activities handled by NPCs are not continuous like the avatar's,
+            this activity check isn't useful for an avatar teaching.
+            The NPC may still have ACT_TRAIN but could be e.g. running away from a monster.
+            */
+            if( trainee_valid && trainee_valid->activity.id() == ACT_TRAIN ) {
+                all_students_done = false;
+                break;
+            }
+        }
+
+        if( all_students_done ) {
+            who.cancel_activity();
+            return;
+        }
+    }
+}
+
+void training_activity_actor::finish( player_activity &act, Character &who )
+{
+    if( !teaching ) {
+
+        if( subject.skill.is_valid() ) {
+            train_skill( who, subject.skill );
+        } else if( subject.prof.is_valid() ) {
+            train_proficiency( who, subject.prof );
+        } else if( subject.style.is_valid() ) {
+            train_martial_art( who, subject.style );
+        } else if( subject.spell.is_valid() ) {
+            train_spell( who, subject.spell );
+        }
+    } else {
+        const std::string subject_name = subject.to_string();
+        if( who.is_avatar() ) {
+            add_msg( m_good, _( "You finish teaching %s." ), subject_name );
+        } else {
+            add_msg( m_good, _( "%s finishes teaching %s." ), who.disp_name(), subject_name );
+        }
+    }
+    act.set_to_null();
+}
+
+void training_activity_actor::serialize( JsonOut &jsout ) const
+{
+    jsout.start_object();
+    jsout.member( "subject", subject );
+    jsout.member( "teaching", teaching );
+    jsout.member( "teacher", teacher );
+    jsout.member( "trainees", trainees );
+    jsout.end_object();
+}
+
+std::unique_ptr<activity_actor> training_activity_actor::deserialize( JsonValue &jsin )
+{
+    training_activity_actor actor;
+    JsonObject data = jsin.get_object();
+    data.read( "subject", actor.subject );
+    data.read( "teaching", actor.teaching );
+    data.read( "teacher", actor.teacher );
+    data.read( "trainees", actor.trainees );
+    return actor.clone();
+}
+
 void generic_entertainment_activity_actor::start( player_activity &act, Character & )
 {
     act.moves_total = to_moves<int>( entertain_duration );
@@ -11837,6 +11992,7 @@ deserialize_functions = {
     { ACT_STUDY_SPELL, &study_spell_activity_actor::deserialize },
     { ACT_TENT_DECONSTRUCT, &tent_deconstruct_activity_actor::deserialize },
     { ACT_TENT_PLACE, &tent_placement_activity_actor::deserialize },
+    { ACT_TRAIN, &training_activity_actor::deserialize },
     { ACT_TREE_COMMUNION, &tree_communion_activity_actor::deserialize },
     { ACT_TRY_SLEEP, &try_sleep_activity_actor::deserialize },
     { ACT_UNLOAD, &unload_activity_actor::deserialize },

--- a/src/activity_handlers.h
+++ b/src/activity_handlers.h
@@ -228,9 +228,7 @@ void mend_item_finish( player_activity *act, Character *you );
 void pull_creature_finish( player_activity *act, Character *you );
 void repair_item_finish( player_activity *act, Character *you );
 void start_fire_finish( player_activity *act, Character *you );
-void teach_finish( player_activity *act, Character *you );
 void toolmod_add_finish( player_activity *act, Character *you );
-void train_finish( player_activity *act, Character *you );
 
 int move_cost( const item &it, const tripoint_bub_ms &src, const tripoint_bub_ms &dest );
 int move_cost_cart( const item &it, const tripoint_bub_ms &src, const tripoint_bub_ms &dest,

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -231,8 +231,6 @@
 #define UNUSED
 #endif
 
-static const activity_id ACT_TRAIN( "ACT_TRAIN" );
-static const activity_id ACT_TRAIN_TEACHER( "ACT_TRAIN_TEACHER" );
 static const activity_id ACT_TRAVELLING( "ACT_TRAVELLING" );
 
 static const bionic_id bio_jointservo( "bio_jointservo" );
@@ -251,7 +249,6 @@ static const damage_type_id damage_cut( "cut" );
 static const damage_type_id damage_stab( "stab" );
 
 static const efftype_id effect_adrenaline_mycus( "adrenaline_mycus" );
-static const efftype_id effect_asked_to_train( "asked_to_train" );
 static const efftype_id effect_bouldering( "bouldering" );
 static const efftype_id effect_contacts( "contacts" );
 static const efftype_id effect_cramped_space( "cramped_space" );
@@ -1559,24 +1556,6 @@ bool game::cancel_activity_query( const std::string &text )
     }
     g->invalidate_main_ui_adaptor();
     if( query_yn( "%s %s", text, u.activity.get_stop_phrase() ) ) {
-        if( u.activity.id() == ACT_TRAIN_TEACHER ) {
-            for( npc &n : all_npcs() ) {
-                // Also cancel activities for students
-                for( const int st_id : u.activity.values ) {
-                    if( n.getID().get_value() == st_id ) {
-                        n.cancel_activity();
-                    }
-                }
-            }
-            u.remove_effect( effect_asked_to_train );
-        } else if( u.activity.id() == ACT_TRAIN ) {
-            for( npc &n : all_npcs() ) {
-                // If the player is the only student, cancel the teacher's activity
-                if( n.getID().get_value() == u.activity.index && n.activity.values.size() == 1 ) {
-                    n.cancel_activity();
-                }
-            }
-        }
         u.cancel_activity();
         u.abort_automove();
         u.resume_backlog_activity();

--- a/src/npctalk.h
+++ b/src/npctalk.h
@@ -10,6 +10,8 @@
 
 class Character;
 class item;
+class JsonOut;
+class JsonValue;
 class json_talk_topic;
 class npc;
 class time_duration;
@@ -17,11 +19,16 @@ class time_duration;
 namespace talk_function
 {
 
+// anything that can be taught with training_activity_actor
+// only one of the given IDs should ever have contents
 struct teach_domain {
     skill_id skill;
     matype_id style;
     spell_id spell;
     proficiency_id prof;
+    std::string to_string() const;
+    void serialize( JsonOut &jsout ) const;
+    void deserialize( const JsonValue &jsin );
 };
 
 void nothing( npc & );

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -31,13 +31,16 @@
 #include "event.h"
 #include "event_bus.h"
 #include "faction.h"
+#include "flexbuffer_json.h"
 #include "game.h"
 #include "game_constants.h"
 #include "game_inventory.h"
 #include "item.h"
 #include "item_location.h"
+#include "json.h"
 #include "magic.h"
 #include "map.h"
+#include "martialarts.h"
 #include "messages.h"
 #include "mission.h"
 #include "monster.h"
@@ -50,10 +53,12 @@
 #include "overmap_ui.h"
 #include "overmapbuffer.h"
 #include "pimpl.h"
-#include "player_activity.h"
 #include "point.h"
+#include "proficiency.h"
 #include "rng.h"
+#include "skill.h"
 #include "simple_pathfinding.h"
+#include "translation.h"
 #include "translations.h"
 #include "uilist.h"
 #include "viewer.h"
@@ -70,8 +75,6 @@ static const activity_id ACT_MULTIPLE_MINE( "ACT_MULTIPLE_MINE" );
 static const activity_id ACT_MULTIPLE_MOP( "ACT_MULTIPLE_MOP" );
 static const activity_id ACT_MULTIPLE_READ( "ACT_MULTIPLE_READ" );
 static const activity_id ACT_MULTIPLE_STUDY( "ACT_MULTIPLE_STUDY" );
-static const activity_id ACT_TRAIN( "ACT_TRAIN" );
-static const activity_id ACT_TRAIN_TEACHER( "ACT_TRAIN_TEACHER" );
 static const activity_id ACT_VEHICLE_DECONSTRUCTION( "ACT_VEHICLE_DECONSTRUCTION" );
 static const activity_id ACT_VEHICLE_REPAIR( "ACT_VEHICLE_REPAIR" );
 
@@ -1061,6 +1064,43 @@ bool npc_trading::pay_npc( npc &np, int cost )
     return npc_trading::trade( np, cost, _( "Pay:" ) );
 }
 
+namespace talk_function
+{
+std::string teach_domain::to_string() const
+{
+    std::string subject_name;
+    if( skill.is_valid() ) {
+        subject_name = skill->name();
+    } else if( prof.is_valid() ) {
+        subject_name = prof->name();
+    } else if( style.is_valid() ) {
+        subject_name = style->name.translated();
+    } else if( spell.is_valid() ) {
+        subject_name = spell->name.translated();
+    }
+    return subject_name;
+}
+
+void teach_domain::serialize( JsonOut &jsout ) const
+{
+    jsout.start_object();
+    jsout.member( "skill", skill );
+    jsout.member( "prof", prof );
+    jsout.member( "style", style );
+    jsout.member( "spell", spell );
+    jsout.end_object();
+}
+
+void teach_domain::deserialize( const JsonValue &jsin )
+{
+    JsonObject data = jsin.get_object();
+    data.read( "skill", skill );
+    data.read( "prof", prof );
+    data.read( "style", style );
+    data.read( "spell", spell );
+}
+} //namespace talk_function
+
 void talk_function::start_training_npc( npc &p )
 {
     teach_domain d;
@@ -1143,7 +1183,6 @@ void talk_function::start_training_gen( Character &teacher, std::vector<Characte
     const matype_id &style = d.style;
     const spell_id &sp_id = d.spell;
     const proficiency_id &proficiency = d.prof;
-    int expert_multiplier = 1;
     bool player_is_student = false;
 
     for( Character *student : students ) {
@@ -1156,25 +1195,17 @@ void talk_function::start_training_gen( Character &teacher, std::vector<Characte
             student->get_knowledge_level( skill ) < teacher.get_knowledge_level( skill ) ) {
             tmp_cost = calc_skill_training_cost_char( teacher, *student, skill );
             tmp_time = calc_skill_training_time_char( teacher, *student, skill );
-            name = skill.str();
         } else if( style != matype_id() &&
                    !student->martial_arts_data->has_martialart( style ) ) {
             tmp_cost = calc_ma_style_training_cost( teacher, *student, style );
             tmp_time = calc_ma_style_training_time( teacher, *student, style );
-            name = style.str();
         } else if( sp_id != spell_id() ) {
             // already checked if can learn this spell in npctalk.cpp
             tmp_cost = calc_spell_training_cost( teacher, *student, sp_id );
             tmp_time = calc_spell_training_time( teacher, *student, sp_id );
-            name = sp_id.str();
-            const spell &temp_spell = teacher.magic->get_spell( sp_id );
-            const bool knows = student->magic->knows_spell( sp_id );
-            expert_multiplier = knows ? temp_spell.get_level() -
-                                student->magic->get_spell( sp_id ).get_level() : 1;
         } else if( proficiency != proficiency_id() ) {
             tmp_cost = calc_proficiency_training_cost( teacher, *student, proficiency );
             tmp_time = calc_proficiency_training_time( teacher, *student, proficiency );
-            name = proficiency.str();
         } else {
             debugmsg( "start_training with no valid skill or style set" );
             return;
@@ -1195,17 +1226,18 @@ void talk_function::start_training_gen( Character &teacher, std::vector<Characte
             return;
         }
     }
-    const int teacher_id = teacher.getID().get_value();
-    player_activity tact( ACT_TRAIN_TEACHER, to_moves<int>( time ), teacher_id, 0, name );
+    std::vector<character_id> student_ids;
+    student_ids.reserve( students.size() );
     for( Character *student : students ) {
-        player_activity act( ACT_TRAIN, to_moves<int>( time ), teacher_id, 0, name );
-        act.values.push_back( expert_multiplier );
-        student->assign_activity( act );
-        tact.values.push_back( student->getID().get_value() );
+        student_ids.emplace_back( student->getID() );
     }
-    teacher.assign_activity( tact );
 
+    const character_id teacher_id = teacher.getID();
+    teacher.assign_activity( training_activity_actor( time, d, student_ids ) );
     teacher.add_effect( effect_asked_to_train, 6_hours );
+    for( Character *student : students ) {
+        student->assign_activity( training_activity_actor( time, d, teacher_id ) );
+    }
 }
 
 npc *pick_follower()

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -413,7 +413,8 @@ void player_activity::deserialize( const JsonObject &data )
         "ACT_CONSUME_FOOD_MENU", // Remove after 0.J
         "ACT_CONSUME_DRINK_MENU", // Remove after 0.J
         "ACT_CONSUME_MEDS_MENU", // Remove after 0.J
-        "ACT_ARMOR_LAYERS" // Remove after 0.J
+        "ACT_ARMOR_LAYERS", // Remove after 0.J
+        "ACT_TRAIN_TEACHER" // Remove after 0.J
     };
     if( !data.read( "type", tmptype ) ) {
         // Then it's a legacy save.

--- a/src/savegame_legacy.cpp
+++ b/src/savegame_legacy.cpp
@@ -25,7 +25,6 @@ static const activity_id ACT_PULP( "ACT_PULP" );
 static const activity_id ACT_RELOAD( "ACT_RELOAD" );
 static const activity_id ACT_REPAIR_ITEM( "ACT_REPAIR_ITEM" );
 static const activity_id ACT_START_FIRE( "ACT_START_FIRE" );
-static const activity_id ACT_TRAIN( "ACT_TRAIN" );
 
 namespace std
 {
@@ -207,7 +206,7 @@ void player_activity::deserialize_legacy_type( int legacy_type, activity_id &des
         activity_id::NULL_ID(), // ACT_BUILD is an actor now
         activity_id::NULL_ID(), // ACT_VEHICLE is an actor now
         activity_id::NULL_ID(), // ACT_REFILL_VEHICLE is deprecated
-        ACT_TRAIN,
+        activity_id::NULL_ID(), // ACT_TRAIN is an actor now
         activity_id::NULL_ID(), // ACT_WAIT_WEATHER is an actor now
         activity_id::NULL_ID(), // ACT_FIRSTAID is an actor now
         activity_id::NULL_ID(), // ACT_FISH is an actor now


### PR DESCRIPTION

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Infrastructure "Move ACT_TRAIN handler to activity_actor, obsolete ACT_TRAIN_TEACHER"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Update legacy activities.

- Fixes #75799

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

See title and attached issue. 

Selecting everyone for training did not check whether an NPC could initially be selected. The issue was more extensive than reported in 75799, sometimes causing segfaults.

ACT_TRAIN_TEACHER was similar enough to ACT_TRAIN that the two could be combined.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Tested training with avatar as the teacher for several NPCs with the given topics:
  - skill
  - spell
  - martial art
  - proficiency

Tested training with an NPC as the teacher:
- skill
- spell
    - then when rejecting learned spell
- martial art
- proficiency

Also successfully tested:
- avatar can cancel teaching, NPCs also cancel and don't learn anything 
  - teacher stops on any turn once all students are gone/done
- avatar can interrupt NPC teaching a training seminar, not learning anything
- 0.H autosave, loaded in this branch for avatar teaching (covers both ACT_TRAIN and ACT_TRAIN_TEACHER)
- Selecting "everyone" for a training seminar does not select ineligible NPCs, but eligible NPCs can still be toggled

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
