### PR TITLE
Use `EXTRADIMENSIONAL` flag as a catch-all for other-dimensional specials

### DIFF
--- a/data/json/overmap/overmap_mutable/roman_road.json
+++ b/data/json/overmap/overmap_mutable/roman_road.json
@@ -7,7 +7,7 @@
     "city_distance": [ 0, -1 ],
     "city_sizes": [ 0, -1 ],
     "occurrences": [ 0, 4 ],
-    "flags": [ "HIGHLANDS", "MAN_MADE" ],
+    "flags": [ "HIGHLANDS", "MAN_MADE", "EXTRADIMENSIONAL" ],
     "check_for_locations": [
       [ [ 0, 0, 0 ], [ "land" ] ],
       [ [ 1, 0, 0 ], [ "land" ] ],

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -848,7 +848,7 @@
     "locations": [ "land" ],
     "city_distance": [ 0, -1 ],
     "occurrences": [ 0, 4 ],
-    "flags": [ "WILDERNESS", "HIGHLANDS" ]
+    "flags": [ "WILDERNESS", "HIGHLANDS", "EXTRADIMENSIONAL" ]
   },
   {
     "type": "overmap_special",
@@ -858,7 +858,7 @@
     "city_distance": [ 0, -1 ],
     "occurrences": [ 0, 4 ],
     "rotate": false,
-    "flags": [ "CLASSIC", "WILDERNESS", "HIGHLANDS" ]
+    "flags": [ "CLASSIC", "WILDERNESS", "HIGHLANDS", "EXTRADIMENSIONAL" ]
   },
   {
     "type": "overmap_special",

--- a/data/json/region_settings/region_settings/regional_map_settings.json
+++ b/data/json/region_settings/region_settings/regional_map_settings.json
@@ -39,7 +39,7 @@
       "deep_rock"
     ],
     "default_groundcover": [ [ "t_region_groundcover", 1 ] ],
-    "feature_flag_settings": { "blacklist": [ "HIGHLANDS" ], "whitelist": [  ] },
+    "feature_flag_settings": { "blacklist": [ "EXTRADIMENSIONAL" ], "whitelist": [  ] },
     "connections": {
       "intra_city_road_connection": "local_road",
       "inter_city_road_connection": "local_road",

--- a/data/mods/MindOverMatter/dimensions/innawood_mom.json
+++ b/data/mods/MindOverMatter/dimensions/innawood_mom.json
@@ -6,6 +6,6 @@
     "cities": null,
     "highways": null,
     "place_roads": false,
-    "feature_flag_settings": { "blacklist": [ "LAB", "MAN_MADE", "MILITARY", "URBAN", "FARM", "EXODII", "HIGHLANDS" ], "whitelist": [  ] }
+    "feature_flag_settings": { "blacklist": [ "LAB", "MAN_MADE", "MILITARY", "URBAN", "FARM", "EXODII", "EXTRADIMENSIONAL" ], "whitelist": [  ] }
   }
 ]

--- a/data/mods/MindOverMatter/dimensions/innawood_rainy_mom.json
+++ b/data/mods/MindOverMatter/dimensions/innawood_rainy_mom.json
@@ -7,7 +7,7 @@
     "highways": null,
     "place_roads": false,
     "weather": "mom_innawood_rainy",
-    "feature_flag_settings": { "blacklist": [ "LAB", "MAN_MADE", "MILITARY", "URBAN", "FARM", "EXODII", "HIGHLANDS" ], "whitelist": [  ] }
+    "feature_flag_settings": { "blacklist": [ "LAB", "MAN_MADE", "MILITARY", "URBAN", "FARM", "EXODII", "EXTRADIMENSIONAL" ], "whitelist": [  ] }
   },
   {
     "type": "weather_generator",

--- a/data/mods/MindOverMatter/dimensions/mycus_world/region_settings.json
+++ b/data/mods/MindOverMatter/dimensions/mycus_world/region_settings.json
@@ -38,7 +38,7 @@
       "deep_rock"
     ],
     "default_groundcover": [ [ "t_region_groundcover", 1 ] ],
-    "feature_flag_settings": { "blacklist": [ "LAB", "MAN_MADE", "MILITARY", "URBAN", "FARM", "EXODII", "HIGHLANDS" ], "whitelist": [ "FUNGAL" ] }
+    "feature_flag_settings": { "blacklist": [  ], "whitelist": [ "FUNGAL" ] }
   },
   {
     "type": "region_settings_terrain_furniture",

--- a/data/mods/desert_region/region_settings/region_settings/desert_regional_map_settings.json
+++ b/data/mods/desert_region/region_settings/region_settings/desert_regional_map_settings.json
@@ -625,6 +625,6 @@
       "deep_rock"
     ],
     "default_groundcover": [ [ "t_region_groundcover", 1 ] ],
-    "feature_flag_settings": { "blacklist": [ "WASP", "BEE", "ANT", "FUNGAL", "TRIFFID", "FARM", "HIGHLANDS" ], "whitelist": [  ] }
+    "feature_flag_settings": { "blacklist": [ "WASP", "BEE", "ANT", "FUNGAL", "TRIFFID", "FARM", "EXTRADIMENSIONAL" ], "whitelist": [  ] }
   }
 ]

--- a/data/mods/innawood/region_settings/region_settings/region_overlay.json
+++ b/data/mods/innawood/region_settings/region_settings/region_overlay.json
@@ -91,6 +91,6 @@
     "cities": null,
     "highways": null,
     "place_roads": false,
-    "feature_flag_settings": { "blacklist": [ "LAB", "MAN_MADE", "MILITARY", "URBAN", "FARM", "EXODII", "HIGHLANDS" ], "whitelist": [  ] }
+    "feature_flag_settings": { "blacklist": [ "LAB", "MAN_MADE", "MILITARY", "URBAN", "FARM", "EXODII", "EXTRADIMENSIONAL" ], "whitelist": [  ] }
   }
 ]

--- a/doc/JSON/REGION_SETTINGS.md
+++ b/doc/JSON/REGION_SETTINGS.md
@@ -611,3 +611,7 @@ This is currently used to provide a mechanism for whitelisting and blacklisting 
     "feature_flag_settings": { "extend": { "blacklist": [ "HIGHLANDS" ] }, "delete": { "whitelist" : [ "CLASSIC" ]} }
   }
 ```
+
+### The EXTRADIMENSIONAL flag
+
+At the moment, the EXTRADIMENSIONAL flag is used to prevent locations from spawning in the default dimension.  An additional flag (for example, `HIGHLANDS`) can be then whitelisted to allow extradimensional locations to spawn in the appropriate dinmension. 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Features "Use `EXTRADIMENSIONAL` flag as a catch-all for other-dimensional specials"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Discussion in #84637 led to this--blacklist `EXTRADIMENSIONAL` in the main dimension and tag all non-`default`-spawning specials with `EXTRADIMENSIONAL` and that way we won't have to blacklist more and more flags over time.

Right now, only the Highlands spawns specials that require this and every other dimension just repeats the base terrain to achieve its goals, but I imagine that will not be true for much longer. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the `EXTRADIMENSIONAL` flag to Highlands specials. Blacklist the `EXTRADIMENSIONAL`  in the default dimension (and mod default dimensions like Innawood that override the list) instead of the `HIGHLANDS` flag.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Spawned in vanilla, no cobblestone roads to be seen. 

Spawned Innawoods, also no cobblestone roads. 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
