### PR TITLE
[u] add captions under screenshots

### DIFF
--- a/data/xdg/org.cataclysmdda.CataclysmDDA.appdata.xml
+++ b/data/xdg/org.cataclysmdda.CataclysmDDA.appdata.xml
@@ -74,12 +74,15 @@
   <screenshots>
     <screenshot type="default">
       <image>https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/c0eed669da247c8e9be9a5176aaf3cbd922e48a7/data/screenshots/menu.png</image>
+      <caption>Main menu</caption>
     </screenshot>
     <screenshot>
       <image>https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/c0eed669da247c8e9be9a5176aaf3cbd922e48a7/data/screenshots/game.png</image>
+      <caption>In-game view</caption>
     </screenshot>
     <screenshot>
       <image>https://raw.githubusercontent.com/CleverRaven/Cataclysm-DDA/c0eed669da247c8e9be9a5176aaf3cbd922e48a7/data/screenshots/credits.png</image>
+      <caption>Credits screen</caption>
     </screenshot>
   </screenshots>
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Infrastructure "Add captions to AppStream screenshots to satisfy Flathub linter"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Flathub’s AppStream validation reports appstream-screenshot-missing-caption because screenshots in the metainfo file lack <caption> entries. This PR adds captions so the metadata passes Flathub linting.
https://github.com/flathub/org.cataclysmdda.CataclysmDDA/pull/26#issuecomment-3770321110

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Added a short <caption> for each <screenshot> entry in org.cataclysmdda.CataclysmDDA.appdata.xml.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Leaving captions out and ignoring the warning.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Additional context
No functional/gameplay changes; metadata-only update.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
