### PR TITLE
Updated logic for sunlight availability for planting

### DIFF
--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -2651,7 +2651,7 @@ void iexamine::dirtmound( Character &you, const tripoint_bub_ms &examp )
     }
     const itype_id &seed_id = std::get<0>( seed_entries[seed_index] );
 
-    ret_val<void>can_plant = warm_enough_to_plant( you.pos_bub(), seed_id );
+    ret_val<void>can_plant = warm_enough_to_plant( examp, seed_id );
     if( !can_plant.success() ) {
         you.add_msg_if_player( m_info, can_plant.c_str() );
         return;

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -906,9 +906,9 @@ static bool has_sunlight_access( const tripoint_bub_ms &pos )
         const bool should_check_above = pnt_above.z() < OVERMAP_HEIGHT;
         // If checking above would take us outside of game bounds, just assume that it's all open air up there.
         const bool transparent_roof = should_check_above ?
-                                      here.is_outside( pnt_above ) && here.has_flag_ter( "TRANSPARENT", pnt_above ) :
+                                      here.has_flag_ter( "NO_FLOOR", pnt_above ) || here.has_flag_ter( "TRANSPARENT_FLOOR", pnt_above ) :
                                       true;
-        if( !here.is_outside( checked_pnt ) || !transparent_roof ) {
+        if( !here.is_outside( checked_pnt ) && !transparent_roof ) {
             return false;
         }
         checked_pnt = pnt_above;


### PR DESCRIPTION

#### Summary
Bugfixes "Updated logic for sunlight availability for planting"


#### Purpose of change
In #83112 Renech introduced sunlight checks for planting but they did not work properly for planting underground. This is a fix for that and incidentally fixes the position used when checking to plant seeds using `e` on a mound of dirt


#### Describe the solution
Changes the flags checked for in the transparent roof portion to NO_FLOOR and TRANSPARENT_FLOOR. The previously used TRANSPARENT applies to a lot of terrain, presumably meaning you can see through that terrain tile, ie its open space, not necessarily that you can see through its floor. The new flags represent that based on the terrain they're applied to, namely open air and the skylight. 
The is outside check was also removed. Checking if the point above where we're trying to plant is outside would mean any point that is only under a single roof would still be allowed to plant. 


#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Planting above ground in the open still works as expected. Planting underground with open air and a skylight above works as expected, sunlight can reach those tiles. Planting on dirt underneath a roof does not work, as expected.
<img width="682" height="494" alt="image" src="https://github.com/user-attachments/assets/98d9be13-9902-4ac5-808e-3e63bb835b10" />
<img width="682" height="494" alt="image" src="https://github.com/user-attachments/assets/14b454df-8134-4a75-9600-cdd099a5092e" />


#### Additional context
There are other places `warm_enough_to_plant` (which calls the updated `has_sunlight_access`) is called that I do not have a suitable answer for, namely in vehicle code for the seed planter vehicle part is handled. It checks the player position for whether or not the player can activate/plant seeds with it instead of the location of the planter part itself. 

Hooray! My first c++ contribution!


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
