### PR TITLE
Migrate itype ids when loading pocket settings

### DIFF
--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -323,6 +323,15 @@ void item_pocket::favorite_settings::serialize( JsonOut &json ) const
     json.end_object();
 }
 
+static cata::flat_set<itype_id> migrate_ids( const cata::flat_set<itype_id> &list )
+{
+    cata::flat_set<itype_id> new_list;
+    for( const itype_id &it : list ) {
+        new_list.insert( item_controller->migrate_id( it ) );
+    }
+    return new_list;
+}
+
 void item_pocket::favorite_settings::deserialize( const JsonObject &data )
 {
     data.allow_omitted_members();
@@ -332,6 +341,8 @@ void item_pocket::favorite_settings::deserialize( const JsonObject &data )
     data.read( "priority", priority_rating );
     data.read( "item_whitelist", item_whitelist );
     data.read( "item_blacklist", item_blacklist );
+    item_whitelist = migrate_ids( item_whitelist );
+    item_blacklist = migrate_ids( item_blacklist );
     data.read( "category_whitelist", category_whitelist );
     data.read( "category_blacklist", category_blacklist );
     if( data.has_member( "collapsed" ) ) {


### PR DESCRIPTION
#### Summary
Bugfixes "Migrate itype ids when loading pocket settings"

#### Purpose of change

Fixes #84760
(Debugmsgs during an imgui draw cycle will still cause crashes.)

#### Describe the solution

Migrate itype ids after they were loaded.

#### Describe alternatives you've considered

Migrate them as they are loaded in `read`? Not sure that's possible safely.

#### Testing

Reproduction steps from the issue don't cause a debugmsg anymore, and no debugmsg means no crash.

#### Additional context

I very strongly suspect we load a lot more unmigrated obsoleted itype ids.