### PR TITLE
Seperate some wheel into rim and tire

### DIFF
--- a/data/json/recipes/recipe_vehicle.json
+++ b/data/json/recipes/recipe_vehicle.json
@@ -47,90 +47,106 @@
   {
     "type": "recipe",
     "activity_level": "MODERATE_EXERCISE",
-    "result": "wheel",
+    "result": "tire_medium",
+    "container": "wheel_rim_medium",
+    "contained": true,
     "category": "CC_*",
     "subcategory": "CSC_*_NESTED",
     "time": "15 m",
     "autolearn": true,
     "qualities": [ { "id": "PRESSURIZATION", "level": 1 } ],
-    "components": [ [ [ "deflated_wheel", 1 ] ] ]
+    "components": [ [ [ "wheel_rim_medium", 1 ] ], [ [ { "item": "tire_medium", "count": 1, "damage": [ 0, 0 ] } ] ] ]
   },
   {
     "type": "recipe",
     "activity_level": "MODERATE_EXERCISE",
-    "result": "wheel_slick",
+    "result": "tire_medium_slick",
+    "container": "wheel_rim_medium",
+    "contained": true,
     "category": "CC_*",
     "subcategory": "CSC_*_NESTED",
     "time": "15 m",
     "autolearn": true,
     "qualities": [ { "id": "PRESSURIZATION", "level": 1 } ],
-    "components": [ [ [ "deflated_wheel_slick", 1 ] ] ]
+    "components": [ [ [ "wheel_rim_medium", 1 ] ], [ [ { "item": "tire_medium_slick", "count": 1, "damage": [ 0, 0 ] } ] ] ]
   },
   {
     "type": "recipe",
     "activity_level": "MODERATE_EXERCISE",
-    "result": "wheel_motorbike",
+    "result": "tire_motorbike",
+    "container": "wheel_rim_motorbike",
+    "contained": true,
     "category": "CC_*",
     "subcategory": "CSC_*_NESTED",
     "time": "10 m",
     "autolearn": true,
     "qualities": [ { "id": "PRESSURIZATION", "level": 1 } ],
-    "components": [ [ [ "deflated_wheel_motorbike", 1 ] ] ]
+    "components": [ [ [ "wheel_rim_motorbike", 1 ] ], [ [ { "item": "tire_motorbike", "count": 1, "damage": [ 0, 0 ] } ] ] ]
   },
   {
     "type": "recipe",
     "activity_level": "MODERATE_EXERCISE",
-    "result": "wheel_motorbike_or",
+    "result": "tire_motorbike_or",
+    "container": "wheel_rim_motorbike",
+    "contained": true,
     "category": "CC_*",
     "subcategory": "CSC_*_NESTED",
     "time": "10 m",
     "autolearn": true,
     "qualities": [ { "id": "PRESSURIZATION", "level": 1 } ],
-    "components": [ [ [ "deflated_wheel_motorbike_or", 1 ] ] ]
+    "components": [ [ [ "wheel_rim_motorbike", 1 ] ], [ [ { "item": "tire_motorbike_or", "count": 1, "damage": [ 0, 0 ] } ] ] ]
   },
   {
     "type": "recipe",
     "activity_level": "MODERATE_EXERCISE",
-    "result": "wheel_wide",
+    "result": "tire_wide",
+    "container": "wheel_rim_wide",
+    "contained": true,
     "category": "CC_*",
     "subcategory": "CSC_*_NESTED",
     "time": "20 m",
     "autolearn": true,
     "qualities": [ { "id": "PRESSURIZATION", "level": 1 } ],
-    "components": [ [ [ "deflated_wheel_wide", 1 ] ] ]
+    "components": [ [ [ "wheel_rim_wide", 1 ] ], [ [ { "item": "tire_wide", "count": 1, "damage": [ 0, 0 ] } ] ] ]
   },
   {
     "type": "recipe",
     "activity_level": "MODERATE_EXERCISE",
-    "result": "wheel_wide_or",
+    "result": "tire_wide_or",
+    "container": "wheel_rim_wide",
+    "contained": true,
     "category": "CC_*",
     "subcategory": "CSC_*_NESTED",
     "time": "20 m",
     "autolearn": true,
     "qualities": [ { "id": "PRESSURIZATION", "level": 1 } ],
-    "components": [ [ [ "deflated_wheel_wide_or", 1 ] ] ]
+    "components": [ [ [ "wheel_rim_wide", 1 ] ], [ [ { "item": "tire_wide_or", "count": 1, "damage": [ 0, 0 ] } ] ] ]
   },
   {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
-    "result": "wheel_bicycle",
+    "result": "tire_bicycle",
+    "container": "wheel_rim_bicycle",
+    "contained": true,
     "category": "CC_*",
     "subcategory": "CSC_*_NESTED",
     "time": "5 m",
     "autolearn": true,
     "qualities": [ { "id": "PRESSURIZATION", "level": 1 } ],
-    "components": [ [ [ "deflated_wheel_bicycle", 1 ] ] ]
+    "components": [ [ [ "wheel_rim_bicycle", 1 ] ], [ [ { "item": "tire_bicycle", "count": 1, "damage": [ 0, 0 ] } ] ] ]
   },
   {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
-    "result": "wheel_bicycle_or",
+    "result": "tire_bicycle_or",
+    "container": "wheel_rim_bicycle",
+    "contained": true,
     "category": "CC_*",
     "subcategory": "CSC_*_NESTED",
     "time": "5 m",
     "autolearn": true,
     "qualities": [ { "id": "PRESSURIZATION", "level": 1 } ],
-    "components": [ [ [ "deflated_wheel_bicycle_or", 1 ] ] ]
+    "components": [ [ [ "wheel_rim_bicycle", 1 ] ], [ [ { "item": "tire_bicycle_or", "count": 1, "damage": [ 0, 0 ] } ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/vehicleparts/vp_flags.json
+++ b/data/json/vehicleparts/vp_flags.json
@@ -198,6 +198,16 @@
     "info": "If the center of balance of your vehicle is between all the wheels, the vehicle will be able to move, provided it has an active engine or motor with enough power to move the vehicle."
   },
   {
+    "id": "TIRE",
+    "type": "json_flag",
+    "info": "A rubber tire mounted on a wheel rim. Tire damage is tracked separately from the rim."
+  },
+  {
+    "id": "RIM",
+    "type": "json_flag",
+    "info": "A wheel rim. Rim damage is tracked separately from the tire."
+  },
+  {
     "id": "WIND_TURBINE",
     "type": "json_flag",
     "info": "Provides <color_green>%dW</color> of electrical power to the vehicle for every 1 m/s of wind the vehicle is exposed to."

--- a/data/json/vehicleparts/wheel.json
+++ b/data/json/vehicleparts/wheel.json
@@ -226,6 +226,10 @@
     },
     "flags": [ "RIM", "UNSTABLE_WHEEL", "NEEDS_JACKING", "NEEDS_WHEEL_MOUNT_MEDIUM" ],
     "tires": [ "tire_medium", "tire_medium_slick", "tire_medium_deflated", "tire_medium_slick_deflated" ],
+    "pocket": {
+      "max_item_count": 1,
+      "allowed_items": [ "tire_medium", "tire_medium_slick", "tire_medium_deflated", "tire_medium_slick_deflated" ]
+    },
     "damage_reduction": { "bash": 20 },
     "variants": [ { "symbols": "0", "symbols_broken": "x" } ]
   },
@@ -316,6 +320,10 @@
     },
     "flags": [ "RIM", "UNSTABLE_WHEEL", "NEEDS_JACKING", "NEEDS_WHEEL_MOUNT_LIGHT" ],
     "tires": [ "tire_bicycle", "tire_bicycle_or", "tire_bicycle_deflated", "tire_bicycle_or_deflated" ],
+    "pocket": {
+      "max_item_count": 1,
+      "allowed_items": [ "tire_bicycle", "tire_bicycle_or", "tire_bicycle_deflated", "tire_bicycle_or_deflated" ]
+    },
     "damage_reduction": { "bash": 6 },
     "variants": [
       { "id": "front", "label": "Front", "symbols": "|\\-/|\\-/", "symbols_broken": "x" },
@@ -485,6 +493,10 @@
     "wheel_offroad_rating": 0.015,
     "wheel_terrain_modifiers": { "FLAT": [ 2, 9 ], "ROAD": [ 1, 5 ] },
     "tires": [ "tire_motorbike", "tire_motorbike_or", "tire_motorbike_deflated", "tire_motorbike_or_deflated" ],
+    "pocket": {
+      "max_item_count": 1,
+      "allowed_items": [ "tire_motorbike", "tire_motorbike_or", "tire_motorbike_deflated", "tire_motorbike_or_deflated" ]
+    },
     "requirements": {
       "install": { "skills": [ [ "mechanics", 0 ] ], "time": "15 m", "using": [ [ "vehicle_fasten", 1 ] ] },
       "removal": { "skills": [ [ "mechanics", 0 ] ], "time": "15 m", "using": [ [ "vehicle_fasten", 1 ] ] },
@@ -643,6 +655,7 @@
     "wheel_offroad_rating": 0.02,
     "wheel_terrain_modifiers": { "FLAT": [ 2, 7 ], "ROAD": [ 1, 3 ] },
     "tires": [ "tire_wide", "tire_wide_or", "tire_wide_deflated", "tire_wide_or_deflated" ],
+    "pocket": { "max_item_count": 1, "allowed_items": [ "tire_wide", "tire_wide_or", "tire_wide_deflated", "tire_wide_or_deflated" ] },
     "requirements": {
       "install": { "skills": [ [ "mechanics", 0 ] ], "time": "15 m", "using": [ [ "vehicle_fasten", 1 ] ] },
       "removal": { "skills": [ [ "mechanics", 0 ] ], "time": "15 m", "using": [ [ "vehicle_fasten", 1 ] ] },

--- a/data/json/vehicleparts/wheel.json
+++ b/data/json/vehicleparts/wheel.json
@@ -225,7 +225,6 @@
       "repair": { "skills": [ [ "mechanics", 4 ] ], "time": "10 m", "using": [ [ "repair_welding_standard", 3 ] ] }
     },
     "flags": [ "RIM", "UNSTABLE_WHEEL", "NEEDS_JACKING", "NEEDS_WHEEL_MOUNT_MEDIUM" ],
-    "tires": [ "tire_medium", "tire_medium_slick", "tire_medium_deflated", "tire_medium_slick_deflated" ],
     "pocket": {
       "max_item_count": 1,
       "allowed_items": [ "tire_medium", "tire_medium_slick", "tire_medium_deflated", "tire_medium_slick_deflated" ]
@@ -319,7 +318,6 @@
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "5 m", "using": [ [ "repair_welding_standard", 2 ] ] }
     },
     "flags": [ "RIM", "UNSTABLE_WHEEL", "NEEDS_JACKING", "NEEDS_WHEEL_MOUNT_LIGHT" ],
-    "tires": [ "tire_bicycle", "tire_bicycle_or", "tire_bicycle_deflated", "tire_bicycle_or_deflated" ],
     "pocket": {
       "max_item_count": 1,
       "allowed_items": [ "tire_bicycle", "tire_bicycle_or", "tire_bicycle_deflated", "tire_bicycle_or_deflated" ]
@@ -492,7 +490,6 @@
     "contact_area": 66,
     "wheel_offroad_rating": 0.015,
     "wheel_terrain_modifiers": { "FLAT": [ 2, 9 ], "ROAD": [ 1, 5 ] },
-    "tires": [ "tire_motorbike", "tire_motorbike_or", "tire_motorbike_deflated", "tire_motorbike_or_deflated" ],
     "pocket": {
       "max_item_count": 1,
       "allowed_items": [ "tire_motorbike", "tire_motorbike_or", "tire_motorbike_deflated", "tire_motorbike_or_deflated" ]
@@ -654,7 +651,6 @@
     "contact_area": 360,
     "wheel_offroad_rating": 0.02,
     "wheel_terrain_modifiers": { "FLAT": [ 2, 7 ], "ROAD": [ 1, 3 ] },
-    "tires": [ "tire_wide", "tire_wide_or", "tire_wide_deflated", "tire_wide_or_deflated" ],
     "pocket": { "max_item_count": 1, "allowed_items": [ "tire_wide", "tire_wide_or", "tire_wide_deflated", "tire_wide_or_deflated" ] },
     "requirements": {
       "install": { "skills": [ [ "mechanics", 0 ] ], "time": "15 m", "using": [ [ "vehicle_fasten", 1 ] ] },

--- a/data/json/vehicleparts/wheel.json
+++ b/data/json/vehicleparts/wheel.json
@@ -202,10 +202,10 @@
     "variants": [ { "symbols": "B", "symbols_broken": "E" } ]
   },
   {
-    "id": "wheel",
+    "id": "rim",
     "type": "vehicle_part",
-    "item": "wheel",
-    "description": "A car wheel.",
+    "item": "rim",
+    "description": "A car rim.",
     "location": "under",
     "categories": [ "movement" ],
     "color": "dark_gray",
@@ -214,32 +214,18 @@
     "breaks_into": [
       { "item": "mc_steel_lump", "count": [ 1, 2 ] },
       { "item": "mc_steel_chunk", "count": [ 1, 2 ] },
-      { "item": "scrap", "count": [ 1, 2 ] },
-      { "item": "rubber_tire_chunk", "count": [ 0, 1 ] },
-      { "item": "chunk_rubber", "count": [ 8, 19 ] },
-      { "item": "shredded_rubber", "charges": [ 8, 20 ] }
+      { "item": "scrap", "count": [ 1, 2 ] }
     ],
-    "wheel_terrain_modifiers": { "FLAT": [ 0, 4 ], "ROAD": [ 0, 2 ] },
     "contact_area": 153,
     "requirements": {
       "install": { "skills": [ [ "mechanics", 0 ] ], "time": "15 m", "using": [ [ "vehicle_fasten", 1 ] ] },
       "removal": { "skills": [ [ "mechanics", 0 ] ], "time": "15 m", "using": [ [ "vehicle_fasten", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 4 ] ], "time": "10 m", "using": [ [ "adhesive_rubber", 1 ], [ "tire_rubber", 1 ] ] }
+      "repair": { "skills": [ [ "mechanics", 4 ] ], "time": "10 m", "using": [ [ "repair_welding_standard", 3 ] ] }
     },
-    "flags": [ "WHEEL", "UNSTABLE_WHEEL", "NEEDS_JACKING", "NEEDS_WHEEL_MOUNT_MEDIUM" ],
+    "flags": [ "RIM", "UNSTABLE_WHEEL", "NEEDS_JACKING", "NEEDS_WHEEL_MOUNT_MEDIUM" ],
+    "tires": [ "tire_medium", "tire_medium_slick" ],
     "damage_reduction": { "bash": 20 },
     "variants": [ { "symbols": "0", "symbols_broken": "x" } ]
-  },
-  {
-    "id": "wheel_slick",
-    "copy-from": "wheel",
-    "type": "vehicle_part",
-    "item": "wheel_slick",
-    "description": "A wide, smooth wheel intended for racing.  The slick surface provides better speed on pavement but penalizes off-road speed.",
-    "wheel_offroad_rating": 0.3,
-    "wheel_terrain_modifiers": { "FLAT": [ 0, 5 ], "ROAD": [ 0, 2 ] },
-    "contact_area": 180,
-    "damage_reduction": { "bash": 12 }
   },
   {
     "id": "wheel_armor",
@@ -302,10 +288,10 @@
     "variants": [ { "symbols": "o", "symbols_broken": "x" } ]
   },
   {
-    "id": "wheel_bicycle",
+    "id": "rim_bicycle",
     "type": "vehicle_part",
-    "item": "wheel_bicycle",
-    "description": "A thin bicycle wheel.",
+    "item": "rim_bicycle",
+    "description": "A thin bicycle rim.",
     "location": "under",
     "categories": [ "movement" ],
     "color": "dark_gray",
@@ -315,35 +301,22 @@
     "breaks_into": [
       { "item": "mc_steel_lump", "prob": 50 },
       { "item": "mc_steel_chunk", "count": [ 1, 2 ] },
-      { "item": "scrap", "count": [ 1, 2 ] },
-      { "item": "rubber_tire_chunk", "count": [ 0, 1 ] },
-      { "item": "chunk_rubber", "count": [ 4, 13 ] },
-      { "item": "shredded_rubber", "charges": [ 5, 12 ] }
+      { "item": "scrap", "count": [ 1, 2 ] }
     ],
     "rolling_resistance": 0.45,
-    "wheel_terrain_modifiers": { "FLAT": [ 0, 4 ], "ROAD": [ 0, 2 ] },
     "contact_area": 40,
     "requirements": {
       "install": { "skills": [ [ "mechanics", 0 ] ], "time": "5 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
       "removal": { "skills": [ [ "mechanics", 0 ] ], "time": "5 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "5 m", "using": [ [ "adhesive_rubber", 1 ], [ "tire_rubber", 1 ] ] }
+      "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "5 m", "using": [ [ "repair_welding_standard", 2 ] ] }
     },
-    "flags": [ "WHEEL", "UNSTABLE_WHEEL", "NEEDS_JACKING", "NEEDS_WHEEL_MOUNT_LIGHT" ],
+    "flags": [ "RIM", "UNSTABLE_WHEEL", "NEEDS_JACKING", "NEEDS_WHEEL_MOUNT_LIGHT" ],
+    "tires": [ "tire_bicycle", "tire_bicycle_or" ],
     "damage_reduction": { "bash": 6 },
     "variants": [
       { "id": "front", "label": "Front", "symbols": "|\\-/|\\-/", "symbols_broken": "x" },
       { "id": "rear", "label": "Rear", "symbols": "|\\-/|\\-/", "symbols_broken": "x" }
     ]
-  },
-  {
-    "id": "wheel_bicycle_or",
-    "copy-from": "wheel_bicycle",
-    "type": "vehicle_part",
-    "item": "wheel_bicycle_or",
-    "description": "A wide, studded bicycle wheel intended for off-road biking.",
-    "contact_area": 36,
-    "wheel_offroad_rating": 0.7,
-    "wheel_terrain_modifiers": { "FLAT": [ 0, 3 ], "ROAD": [ 0, 1 ] }
   },
   {
     "id": "wheel_caster",
@@ -488,10 +461,10 @@
     "variants": [ { "symbols": "-", "symbols_broken": "X" } ]
   },
   {
-    "id": "wheel_motorbike",
+    "id": "rim_motorbike",
     "type": "vehicle_part",
-    "item": "wheel_motorbike",
-    "description": "A small wheel from a motorcycle.",
+    "item": "rim_motorbike",
+    "description": "A small rim from a motorcycle.",
     "location": "under",
     "looks_like": "wheel",
     "categories": [ "movement" ],
@@ -501,44 +474,22 @@
     "breaks_into": [
       { "item": "mc_steel_lump", "count": [ 1, 3 ] },
       { "item": "mc_steel_chunk", "count": [ 1, 3 ] },
-      { "item": "scrap", "count": [ 1, 3 ] },
-      { "item": "rubber_tire_chunk", "count": [ 0, 1 ] },
-      { "item": "chunk_rubber", "count": [ 8, 19 ] },
-      { "item": "shredded_rubber", "charges": [ 8, 20 ] }
+      { "item": "scrap", "count": [ 1, 3 ] }
     ],
     "rolling_resistance": 1.9,
-    "wheel_terrain_modifiers": { "FLAT": [ 0, 4 ], "ROAD": [ 0, 2 ] },
     "contact_area": 66,
+    "tires": [ "tire_motorbike", "tire_motorbike_or" ],
     "requirements": {
       "install": { "skills": [ [ "mechanics", 0 ] ], "time": "15 m", "using": [ [ "vehicle_fasten", 1 ] ] },
       "removal": { "skills": [ [ "mechanics", 0 ] ], "time": "15 m", "using": [ [ "vehicle_fasten", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "5 m", "using": [ [ "adhesive_rubber", 1 ], [ "tire_rubber", 1 ] ] }
+      "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "5 m", "using": [ [ "repair_welding_standard", 2 ] ] }
     },
-    "flags": [ "WHEEL", "UNSTABLE_WHEEL", "NEEDS_JACKING", "NEEDS_WHEEL_MOUNT_LIGHT" ],
+    "flags": [ "RIM", "UNSTABLE_WHEEL", "NEEDS_JACKING", "NEEDS_WHEEL_MOUNT_LIGHT" ],
     "damage_reduction": { "bash": 10 },
     "variants": [
       { "id": "front", "label": "Front", "symbols": "o", "symbols_broken": "x" },
       { "id": "rear", "label": "Rear", "symbols": "o", "symbols_broken": "x" }
     ]
-  },
-  {
-    "id": "wheel_motorbike_or",
-    "copy-from": "wheel_motorbike",
-    "type": "vehicle_part",
-    "item": "wheel_motorbike_or",
-    "description": "A motorbike wheel, studded for improved off-road performance.",
-    "contact_area": 60,
-    "breaks_into": [
-      { "item": "mc_steel_lump", "count": [ 1, 3 ] },
-      { "item": "mc_steel_chunk", "count": [ 1, 3 ] },
-      { "item": "scrap", "count": [ 1, 3 ] },
-      { "item": "rubber_tire_chunk", "count": [ 0, 1 ] },
-      { "item": "chunk_rubber", "count": [ 9, 25 ] },
-      { "item": "shredded_rubber", "charges": [ 8, 20 ] }
-    ],
-    "wheel_offroad_rating": 0.7,
-    "wheel_terrain_modifiers": { "FLAT": [ 0, 3 ], "ROAD": [ 0, 1 ] },
-    "damage_reduction": { "bash": 10, "cut": 8, "stab": 4 }
   },
   {
     "id": "wheel_small",
@@ -666,10 +617,10 @@
     "variants": [ { "symbols": "|", "symbols_broken": "x" } ]
   },
   {
-    "id": "wheel_wide",
+    "id": "rim_wide",
     "type": "vehicle_part",
-    "item": "wheel_wide",
-    "description": "A wide wheel.  \\o/ This wide.  Provides more traction and better off-road performance.",
+    "item": "rim_wide",
+    "description": "A wide rim.  \\o/ This wide.  Provides more traction and better off-road performance.",
     "location": "under",
     "looks_like": "wheel",
     "categories": [ "movement" ],
@@ -679,33 +630,19 @@
     "breaks_into": [
       { "item": "mc_steel_lump", "count": [ 2, 3 ] },
       { "item": "mc_steel_chunk", "count": [ 2, 3 ] },
-      { "item": "scrap", "count": [ 2, 3 ] },
-      { "item": "rubber_tire_chunk", "count": [ 1, 3 ] },
-      { "item": "chunk_rubber", "count": [ 8, 24 ] },
-      { "item": "shredded_rubber", "charges": [ 8, 20 ] }
+      { "item": "scrap", "count": [ 2, 3 ] }
     ],
     "rolling_resistance": 0.575,
-    "wheel_terrain_modifiers": { "FLAT": [ 0, 4 ], "ROAD": [ 0, 2 ] },
     "contact_area": 360,
+    "tires": [ "tire_wide", "tire_wide_or" ],
     "requirements": {
       "install": { "skills": [ [ "mechanics", 0 ] ], "time": "15 m", "using": [ [ "vehicle_fasten", 1 ] ] },
       "removal": { "skills": [ [ "mechanics", 0 ] ], "time": "15 m", "using": [ [ "vehicle_fasten", 1 ] ] },
-      "repair": { "skills": [ [ "mechanics", 4 ] ], "time": "10 m", "using": [ [ "adhesive_rubber", 1 ], [ "tire_rubber", 1 ] ] }
+      "repair": { "skills": [ [ "mechanics", 4 ] ], "time": "10 m", "using": [ [ "repair_welding_standard", 4 ] ] }
     },
-    "flags": [ "WHEEL", "UNSTABLE_WHEEL", "NEEDS_JACKING", "NEEDS_WHEEL_MOUNT_MEDIUM" ],
+    "flags": [ "RIM", "UNSTABLE_WHEEL", "NEEDS_JACKING", "NEEDS_WHEEL_MOUNT_MEDIUM" ],
     "damage_reduction": { "bash": 25 },
     "variants": [ { "symbols": "O", "symbols_broken": "x" } ]
-  },
-  {
-    "id": "wheel_wide_or",
-    "copy-from": "wheel_wide",
-    "type": "vehicle_part",
-    "item": "wheel_wide_or",
-    "description": "A wide wheel.  \\o/ This wide.  It's studded to provide better grip off-road at the cost of some performance on pavement.",
-    "wheel_offroad_rating": 0.7,
-    "wheel_terrain_modifiers": { "FLAT": [ 0, 3 ], "ROAD": [ 0, 1 ] },
-    "contact_area": 320,
-    "damage_reduction": { "bash": 20, "cut": 15, "stab": 10 }
   },
   {
     "id": "wheel_wood",
@@ -781,5 +718,100 @@
     "contact_area": 60,
     "flags": [ "WHEEL", "UNSTABLE_WHEEL", "NEEDS_WHEEL_MOUNT_CONCRETE_MIX", "NO_INSTALL_HIDDEN" ],
     "variants": [ { "symbols": "o", "symbols_broken": "x" } ]
+  },
+  {
+    "type": "vehicle_part",
+    "id": "tire_medium",
+    "item": "tire_medium",
+    "description": "A standard car tire.",
+    "location": "under",
+    "categories": [ "movement" ],
+    "durability": 120,
+    "damage_modifier": 40,
+    "breaks_into": [
+      { "item": "rubber_tire_chunk", "count": [ 0, 1 ] },
+      { "item": "chunk_rubber", "count": [ 6, 18 ] },
+      { "item": "shredded_rubber", "charges": [ 6, 18 ] }
+    ],
+    "flags": [ "TIRE", "NEEDS_WHEEL_MOUNT_MEDIUM" ],
+    "wheel_terrain_modifiers": { "FLAT": [ 0, 4 ], "ROAD": [ 0, 2 ] },
+    "variants": [ { "symbols": "=", "symbols_broken": "." } ]
+  },
+  {
+    "type": "vehicle_part",
+    "id": "tire_medium_slick",
+    "item": "tire_medium_slick",
+    "description": "A slick racing car tire.",
+    "location": "under",
+    "categories": [ "movement" ],
+    "durability": 140,
+    "damage_modifier": 40,
+    "breaks_into": [ { "item": "rubber_tire_chunk", "count": [ 0, 1 ] }, { "item": "chunk_rubber", "count": [ 8, 20 ] } ],
+    "flags": [ "TIRE", "NEEDS_WHEEL_MOUNT_MEDIUM" ],
+    "wheel_offroad_rating": 0.3,
+    "wheel_terrain_modifiers": { "FLAT": [ 0, 5 ], "ROAD": [ 0, 2 ] }
+  },
+  {
+    "type": "vehicle_part",
+    "id": "tire_motorbike",
+    "item": "tire_motorbike",
+    "description": "A motorbike tire.",
+    "location": "under",
+    "categories": [ "movement" ],
+    "durability": 80,
+    "damage_modifier": 40,
+    "breaks_into": [ { "item": "rubber_tire_chunk", "count": [ 0, 1 ] }, { "item": "chunk_rubber", "count": [ 4, 12 ] } ],
+    "flags": [ "TIRE", "NEEDS_WHEEL_MOUNT_LIGHT" ],
+    "wheel_terrain_modifiers": { "FLAT": [ 0, 4 ], "ROAD": [ 0, 2 ] }
+  },
+  {
+    "type": "vehicle_part",
+    "id": "tire_wide",
+    "item": "tire_wide",
+    "description": "A wide tire for large wheels.",
+    "location": "under",
+    "categories": [ "movement" ],
+    "durability": 240,
+    "damage_modifier": 40,
+    "breaks_into": [ { "item": "rubber_tire_chunk", "count": [ 1, 3 ] }, { "item": "chunk_rubber", "count": [ 8, 24 ] } ],
+    "flags": [ "TIRE", "NEEDS_WHEEL_MOUNT_MEDIUM" ],
+    "wheel_terrain_modifiers": { "FLAT": [ 0, 4 ], "ROAD": [ 0, 2 ] }
+  },
+  {
+    "type": "vehicle_part",
+    "id": "tire_bicycle",
+    "item": "tire_bicycle",
+    "description": "A bicycle tire.",
+    "location": "under",
+    "categories": [ "movement" ],
+    "durability": 30,
+    "damage_modifier": 40,
+    "breaks_into": [ { "item": "rubber_tire_chunk", "count": [ 0, 1 ] }, { "item": "chunk_rubber", "count": [ 2, 8 ] } ],
+    "flags": [ "TIRE", "NEEDS_WHEEL_MOUNT_LIGHT" ],
+    "wheel_terrain_modifiers": { "FLAT": [ 0, 4 ], "ROAD": [ 0, 2 ] }
+  },
+  {
+    "type": "vehicle_part",
+    "id": "tire_wide_or",
+    "copy-from": "tire_wide",
+    "description": "A studded wide tire for off-road use.",
+    "wheel_offroad_rating": 0.7,
+    "wheel_terrain_modifiers": { "FLAT": [ 0, 3 ], "ROAD": [ 0, 1 ] }
+  },
+  {
+    "type": "vehicle_part",
+    "id": "tire_motorbike_or",
+    "copy-from": "tire_motorbike",
+    "description": "A studded motorbike tire for off-road use.",
+    "wheel_offroad_rating": 0.7,
+    "wheel_terrain_modifiers": { "FLAT": [ 0, 3 ], "ROAD": [ 0, 1 ] }
+  },
+  {
+    "type": "vehicle_part",
+    "id": "tire_bicycle_or",
+    "copy-from": "tire_bicycle",
+    "description": "A studded bicycle tire for off-road use.",
+    "wheel_offroad_rating": 0.7,
+    "wheel_terrain_modifiers": { "FLAT": [ 0, 3 ], "ROAD": [ 0, 1 ] }
   }
 ]

--- a/data/json/vehicleparts/wheel.json
+++ b/data/json/vehicleparts/wheel.json
@@ -217,13 +217,15 @@
       { "item": "scrap", "count": [ 1, 2 ] }
     ],
     "contact_area": 153,
+    "wheel_offroad_rating": 0.02,
+    "wheel_terrain_modifiers": { "FLAT": [ 2, 8 ], "ROAD": [ 1, 4 ] },
     "requirements": {
       "install": { "skills": [ [ "mechanics", 0 ] ], "time": "15 m", "using": [ [ "vehicle_fasten", 1 ] ] },
       "removal": { "skills": [ [ "mechanics", 0 ] ], "time": "15 m", "using": [ [ "vehicle_fasten", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 4 ] ], "time": "10 m", "using": [ [ "repair_welding_standard", 3 ] ] }
     },
     "flags": [ "RIM", "UNSTABLE_WHEEL", "NEEDS_JACKING", "NEEDS_WHEEL_MOUNT_MEDIUM" ],
-    "tires": [ "tire_medium", "tire_medium_slick" ],
+    "tires": [ "tire_medium", "tire_medium_slick", "tire_medium_deflated", "tire_medium_slick_deflated" ],
     "damage_reduction": { "bash": 20 },
     "variants": [ { "symbols": "0", "symbols_broken": "x" } ]
   },
@@ -305,13 +307,15 @@
     ],
     "rolling_resistance": 0.45,
     "contact_area": 40,
+    "wheel_offroad_rating": 0.01,
+    "wheel_terrain_modifiers": { "FLAT": [ 3, 10 ], "ROAD": [ 2, 6 ] },
     "requirements": {
       "install": { "skills": [ [ "mechanics", 0 ] ], "time": "5 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
       "removal": { "skills": [ [ "mechanics", 0 ] ], "time": "5 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "5 m", "using": [ [ "repair_welding_standard", 2 ] ] }
     },
     "flags": [ "RIM", "UNSTABLE_WHEEL", "NEEDS_JACKING", "NEEDS_WHEEL_MOUNT_LIGHT" ],
-    "tires": [ "tire_bicycle", "tire_bicycle_or" ],
+    "tires": [ "tire_bicycle", "tire_bicycle_or", "tire_bicycle_deflated", "tire_bicycle_or_deflated" ],
     "damage_reduction": { "bash": 6 },
     "variants": [
       { "id": "front", "label": "Front", "symbols": "|\\-/|\\-/", "symbols_broken": "x" },
@@ -478,7 +482,9 @@
     ],
     "rolling_resistance": 1.9,
     "contact_area": 66,
-    "tires": [ "tire_motorbike", "tire_motorbike_or" ],
+    "wheel_offroad_rating": 0.015,
+    "wheel_terrain_modifiers": { "FLAT": [ 2, 9 ], "ROAD": [ 1, 5 ] },
+    "tires": [ "tire_motorbike", "tire_motorbike_or", "tire_motorbike_deflated", "tire_motorbike_or_deflated" ],
     "requirements": {
       "install": { "skills": [ [ "mechanics", 0 ] ], "time": "15 m", "using": [ [ "vehicle_fasten", 1 ] ] },
       "removal": { "skills": [ [ "mechanics", 0 ] ], "time": "15 m", "using": [ [ "vehicle_fasten", 1 ] ] },
@@ -634,7 +640,9 @@
     ],
     "rolling_resistance": 0.575,
     "contact_area": 360,
-    "tires": [ "tire_wide", "tire_wide_or" ],
+    "wheel_offroad_rating": 0.02,
+    "wheel_terrain_modifiers": { "FLAT": [ 2, 7 ], "ROAD": [ 1, 3 ] },
+    "tires": [ "tire_wide", "tire_wide_or", "tire_wide_deflated", "tire_wide_or_deflated" ],
     "requirements": {
       "install": { "skills": [ [ "mechanics", 0 ] ], "time": "15 m", "using": [ [ "vehicle_fasten", 1 ] ] },
       "removal": { "skills": [ [ "mechanics", 0 ] ], "time": "15 m", "using": [ [ "vehicle_fasten", 1 ] ] },

--- a/data/json/vehicleparts/wheel.json
+++ b/data/json/vehicleparts/wheel.json
@@ -202,9 +202,9 @@
     "variants": [ { "symbols": "B", "symbols_broken": "E" } ]
   },
   {
-    "id": "rim",
+    "id": "wheel_rim",
     "type": "vehicle_part",
-    "item": "rim",
+    "item": "wheel_rim",
     "description": "A car rim.",
     "location": "under",
     "categories": [ "movement" ],
@@ -288,9 +288,9 @@
     "variants": [ { "symbols": "o", "symbols_broken": "x" } ]
   },
   {
-    "id": "rim_bicycle",
+    "id": "wheel_rim_bicycle",
     "type": "vehicle_part",
-    "item": "rim_bicycle",
+    "item": "wheel_rim_bicycle",
     "description": "A thin bicycle rim.",
     "location": "under",
     "categories": [ "movement" ],
@@ -461,9 +461,9 @@
     "variants": [ { "symbols": "-", "symbols_broken": "X" } ]
   },
   {
-    "id": "rim_motorbike",
+    "id": "wheel_rim_motorbike",
     "type": "vehicle_part",
-    "item": "rim_motorbike",
+    "item": "wheel_rim_motorbike",
     "description": "A small rim from a motorcycle.",
     "location": "under",
     "looks_like": "wheel",
@@ -617,9 +617,9 @@
     "variants": [ { "symbols": "|", "symbols_broken": "x" } ]
   },
   {
-    "id": "rim_wide",
+    "id": "wheel_rim_wide",
     "type": "vehicle_part",
-    "item": "rim_wide",
+    "item": "wheel_rim_wide",
     "description": "A wide rim.  \\o/ This wide.  Provides more traction and better off-road performance.",
     "location": "under",
     "looks_like": "wheel",
@@ -813,5 +813,62 @@
     "description": "A studded bicycle tire for off-road use.",
     "wheel_offroad_rating": 0.7,
     "wheel_terrain_modifiers": { "FLAT": [ 0, 3 ], "ROAD": [ 0, 1 ] }
+  },
+  {
+    "type": "vehicle_part",
+    "id": "tire_medium_deflated",
+    "copy-from": "tire_medium",
+    "item": "deflated_wheel",
+    "description": "A standard car tire. It is currently deflated and will need to be inflated to be used properly.",
+    "variants": [ { "symbols": "=", "symbols_broken": "." } ]
+  },
+  {
+    "type": "vehicle_part",
+    "id": "tire_medium_slick_deflated",
+    "copy-from": "tire_medium_slick",
+    "item": "deflated_wheel_slick",
+    "description": "A slick racing tire. It is currently deflated and will need to be inflated to be used properly."
+  },
+  {
+    "type": "vehicle_part",
+    "id": "tire_motorbike_deflated",
+    "copy-from": "tire_motorbike",
+    "item": "deflated_wheel_motorbike",
+    "description": "A motorbike tire. It is currently deflated and will need to be inflated to be used properly."
+  },
+  {
+    "type": "vehicle_part",
+    "id": "tire_motorbike_or_deflated",
+    "copy-from": "tire_motorbike_or",
+    "item": "deflated_wheel_motorbike_or",
+    "description": "A studded motorbike tire for off-road use. It is currently deflated and will need to be inflated to be used properly."
+  },
+  {
+    "type": "vehicle_part",
+    "id": "tire_wide_deflated",
+    "copy-from": "tire_wide",
+    "item": "deflated_wheel_wide",
+    "description": "A wide tire for large wheels. It is currently deflated and will need to be inflated to be used properly."
+  },
+  {
+    "type": "vehicle_part",
+    "id": "tire_wide_or_deflated",
+    "copy-from": "tire_wide_or",
+    "item": "deflated_wheel_wide_or",
+    "description": "A studded wide tire for off-road use. It is currently deflated and will need to be inflated to be used properly."
+  },
+  {
+    "type": "vehicle_part",
+    "id": "tire_bicycle_deflated",
+    "copy-from": "tire_bicycle",
+    "item": "deflated_wheel_bicycle",
+    "description": "A bicycle tire. It is currently deflated and will need to be inflated to be used properly."
+  },
+  {
+    "type": "vehicle_part",
+    "id": "tire_bicycle_or_deflated",
+    "copy-from": "tire_bicycle_or",
+    "item": "deflated_wheel_bicycle_or",
+    "description": "A studded bicycle tire for off-road use. It is currently deflated and will need to be inflated to be used properly."
   }
 ]

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2288,7 +2288,7 @@ bool vehicle::remove_part( vehicle_part &vp, RemovePartHandler &handler )
     remove_dependent_part( "SEAT", "SEATBELT" );
     remove_dependent_part( "BATTERY_MOUNT", "NEEDS_BATTERY_MOUNT" );
     remove_dependent_part( "HANDHELD_BATTERY_MOUNT", "NEEDS_HANDHELD_BATTERY_MOUNT" );
-    
+
     if( vpi.has_flag( "RIM" ) ) {
         // If removing a rim, look for a tire at the same mount and move the
         // tire item into the rim's pocket before removing the tire part.

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -154,6 +154,16 @@ static const translation power_grid_name = to_translation( "power grid" );
 static bool is_sm_tile_outside( const tripoint_abs_ms &real_global_pos );
 static bool is_sm_tile_over_water( const tripoint_abs_ms &real_global_pos );
 
+// Helper: determine whether a vehicle_part represents a tire (as opposed to rim/etc).
+static bool is_tire_part( const vehicle_part &pt )
+{
+    const vpart_info &vpi = pt.info();
+    if( vpi.has_flag( "TIRE" ) ) {
+        return true;
+    }
+    return false;
+}
+
 static const int MAX_WIRE_VEHICLE_SIZE = 24;
 
 void DefaultRemovePartHandler::removed( map *here, vehicle &veh, const int part )


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Features "Seperate some wheel into rim and tire"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Seperate some wheel into rim and tire, To more accurately indicate the relationship between the rim and tire.
This appears to conflict with PR #84775.
His approach is slightly less invasive than mine, so I'm now debating whether to proceed.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Disassembling the four types of wheels commonly used on large vehicles into rims and tires. 
Then add a _deflated version for the corresponding tire.
In most cases, damage will reduce tire durability and cause deflation.
Direct contact between the rim and the ground will incur massive penalties.
Add a pocket to the rim that can only hold specific types of tires. 
Removing a tire from the pocket yields a deflated tire, while using the inflation recipe yields a rim with a tire mounted.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
There are quite a few changes needed. 
Maybe I should put this on hold for now and wait until the Guardian's PR is finalized.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Not even once.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
