### PR TITLE
[Xedra Evolved] Add `former OA field agent` zombie to labs

### DIFF
--- a/data/mods/Xedra_Evolved/itemgroups/monster_drops.json
+++ b/data/mods/Xedra_Evolved/itemgroups/monster_drops.json
@@ -647,5 +647,68 @@
       { "group": "underwear", "damage": [ 1, 4 ] },
       { "item": "boots_plate", "damage": [ 1, 4 ] }
     ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "mon_zombie_oa_agent_death_drops",
+    "magazine": 100,
+    "ammo": 60,
+    "entries": [
+      {
+        "distribution": [
+          { "group": "clothing_soldier_set", "prob": 65, "damage": [ 1, 4 ] },
+          { "group": "clothing_soldier_winter_set", "prob": 35, "damage": [ 1, 4 ] }
+        ]
+      },
+      { "item": "xedra_jumpsuit", "variant": "xedra_jumpsuit_offworld", "damage": [ 1, 4 ] },
+      {
+        "distribution": [
+          {
+            "group": "military_standard_assault_rifles",
+            "contents-group": "sopmod",
+            "prob": 75,
+            "damage": [ 0, 4 ],
+            "dirt": [ 0, 6000 ]
+          },
+          {
+            "group": "military_standard_lmgs",
+            "contents-item": "shoulder_strap",
+            "prob": 4,
+            "damage": [ 0, 4 ],
+            "dirt": [ 0, 6000 ]
+          },
+          {
+            "group": "military_standard_lmgs",
+            "contents-item": [ "shoulder_strap", "acog_scope" ],
+            "prob": 6,
+            "damage": [ 0, 4 ],
+            "dirt": [ 0, 6000 ]
+          },
+          {
+            "group": "military_standard_shotguns",
+            "contents-item": "shoulder_strap",
+            "prob": 5,
+            "damage": [ 0, 4 ],
+            "dirt": [ 0, 6000 ]
+          }
+        ],
+        "prob": 10
+      },
+      { "group": "infantry_common_gear" },
+      {
+        "distribution": [
+          { "group": "military_standard_grenades", "count": [ 1, 3 ], "prob": 80 },
+          { "item": "40x46mm_m433", "charges": [ 1, 3 ], "prob": 20 }
+        ],
+        "prob": 20
+      },
+      { "group": "military_patrol_food" },
+      {
+        "collection": [ { "group": "infantry_officer_gear", "prob": 90 }, { "group": "infantry_medical_gear", "prob": 80 } ]
+      },
+      { "group": "wallets", "prob": 10 },
+      { "item": "dog_tag", "prob": 40 }
+    ]
   }
 ]

--- a/data/mods/Xedra_Evolved/monsters/monstergroup.json
+++ b/data/mods/Xedra_Evolved/monsters/monstergroup.json
@@ -503,12 +503,12 @@
   {
     "type": "monstergroup",
     "id": "GROUP_CENTRAL_LAB",
-    "monsters": [ { "monster": "mon_zombie_oa_agent", "weight": 15, "cost_multiplier": 50 } ]
+    "monsters": [ { "monster": "mon_zombie_oa_agent", "weight": 50, "cost_multiplier": 50 } ]
   },
   {
     "type": "monstergroup",
     "id": "GROUP_LAB",
-    "monsters": [ { "monster": "mon_zombie_oa_agent", "weight": 20, "cost_multiplier": 5 } ]
+    "monsters": [ { "monster": "mon_zombie_oa_agent", "weight": 50, "cost_multiplier": 5 } ]
   },
   {
     "type": "monstergroup",

--- a/data/mods/Xedra_Evolved/monsters/monstergroup.json
+++ b/data/mods/Xedra_Evolved/monsters/monstergroup.json
@@ -499,5 +499,25 @@
     "id": "GROUP_TRIFFID_MAGES",
     "default": "mon_triffid",
     "monsters": [ { "monster": "mon_triffid_greenseer", "weight": 1 } ]
+  },
+  {
+    "type": "monstergroup",
+    "id": "GROUP_CENTRAL_LAB",
+    "monsters": [ { "monster": "mon_zombie_oa_agent", "weight": 15, "cost_multiplier": 50 } ]
+  },
+  {
+    "type": "monstergroup",
+    "id": "GROUP_LAB",
+    "monsters": [ { "monster": "mon_zombie_oa_agent", "weight": 20, "cost_multiplier": 5 } ]
+  },
+  {
+    "type": "monstergroup",
+    "id": "GROUP_LAB_SURFACE",
+    "monsters": [ { "monster": "mon_zombie_oa_agent", "weight": 20, "cost_multiplier": 5 } ]
+  },
+  {
+    "type": "monstergroup",
+    "id": "GROUP_LAB_SECURITY",
+    "monsters": [ { "monster": "mon_zombie_oa_agent", "weight": 20, "cost_multiplier": 5 } ]
   }
 ]

--- a/data/mods/Xedra_Evolved/monsters/zombies.json
+++ b/data/mods/Xedra_Evolved/monsters/zombies.json
@@ -99,5 +99,32 @@
     "delete": { "special_attacks": [ "boomer_bile" ] },
     "extend": { "flags": [ "STABILIZED_TIMELINE" ] },
     "upgrades": false
+  },
+  {
+    "id": "mon_zombie_oa_agent",
+    "looks_like": "mon_zombie_bio_op",
+    "type": "MONSTER",
+    "name": { "str": "former OA field agent" },
+    "description": "This armored soldier zombie appears to have been some sort of special forces agent, with the letters \"OA\" prominently written on its armor.  The occasional odd spark emits from a rent in its armor.",
+    "copy-from": "mon_zombie_base",
+    "diff": 5,
+    "hp": 120,
+    "speed": 95,
+    "color": "red_cyan",
+    "melee_skill": 5,
+    "melee_dice": 2,
+    "melee_dice_sides": 6,
+    "melee_damage": [ { "damage_type": "electric", "amount": 4 } ],
+    "luminance": 4,
+    "//": "Keep zapback, remove the zombie suplexing you thing",
+    "special_when_hit": [ "ZAPBACK", 75 ],
+    "death_drops": "mon_zombie_oa_agent_death_drops",
+    "armor": { "bash": 10, "cut": 18, "stab": 18, "bullet": 25, "electric": 3 },
+    "dissect": "dissect_mon_zomborg",
+    "extend": {
+      "weakpoint_sets": [ "wps_humanoid_body_armor", "wps_humanoid_open_helmet", "wps_humanoid_gasmask" ],
+      "families": [ "prof_wp_syn_armored" ],
+      "flags": [ "ELECTRIC" ]
+    }
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Xedra Evolved] Add `former OA field agent` zombie to labs"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Talking with Maleclypse about how in XE, some zombies would have CBMs--the zombies of former Offworld Acquisitions agent members.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the `former OA field agent` zombie to lab monster groups, mostly in microlabs but rarely in the research lab. This is modeled off the zombie bio-operator and uses the bio-operator sprite, but without the bio-operators "I know kung-fu" attacks--they have the standard zombie grab and bite, just with more armor and with the ZAPBACK attack (kept from their malfunctioning bionics). 

> "This armored soldier zombie appears to have been some sort of special forces agent, with the letters \"OA\" prominently written on its armor.  The occasional odd spark emits from a rent in its armor."

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Killed a  `former OA field agent` and dissected them (despite the great disgust this led to in my character):

<img width="476" height="73" alt="Untitled" src="https://github.com/user-attachments/assets/f7008ab3-6955-42c9-8894-b64bcc225e00" />


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Need to make it so if you self-install these CBMs in a lab you get the XEDRA Neurobionic Interface (and then the Exodii hate you)
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
