### PR TITLE
[Xedra Evolved] Extremely rare chance for zombie scientists to have CBMs

### DIFF
--- a/data/mods/Xedra_Evolved/dissect.json
+++ b/data/mods/Xedra_Evolved/dissect.json
@@ -49,7 +49,7 @@
         "base_num": [ 0, 1 ],
         "scale_num": [ 0.1, 0.3 ],
         "faults": [ "fault_bionic_salvaged" ]
-      }
+      },
       {
         "drop": "scientist_xe_base_CBM_power_harvest",
         "type": "bionic_group",
@@ -84,7 +84,7 @@
         "max": 5
       }
     ]
-  }
+  },
   {
     "id": "dissect_ierde_single",
     "type": "harvest",

--- a/data/mods/Xedra_Evolved/dissect.json
+++ b/data/mods/Xedra_Evolved/dissect.json
@@ -38,6 +38,29 @@
     ]
   },
   {
+    "id": "dissect_mon_zombie_scientist_xe",
+    "type": "harvest",
+    "message": "You cut into the zombir scientist, carefully removing layers of tissue.",
+    "entries": [
+      {
+        "drop": "scientist_xe_base_CBM_harvest",
+        "type": "bionic_group",
+        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
+        "base_num": [ 0, 1 ],
+        "scale_num": [ 0.1, 0.3 ],
+        "faults": [ "fault_bionic_salvaged" ]
+      }
+      {
+        "drop": "scientist_xe_base_CBM_power_harvest",
+        "type": "bionic_group",
+        "flags": [ "FILTHY", "NO_STERILE", "NO_PACKED" ],
+        "base_num": [ 0, 1 ],
+        "scale_num": [ 0.1, 0.3 ],
+        "faults": [ "fault_bionic_salvaged" ]
+      }
+    ]
+  },
+  {
     "id": "dissect_ierde_single",
     "type": "harvest",
     "message": "With cuts and pulls equally similar to both extraction and vandalism, you scrape together the most important parts of the creature.",

--- a/data/mods/Xedra_Evolved/dissect.json
+++ b/data/mods/Xedra_Evolved/dissect.json
@@ -40,7 +40,7 @@
   {
     "id": "dissect_mon_zombie_scientist_xe",
     "type": "harvest",
-    "message": "You cut into the zombir scientist, carefully removing layers of tissue.",
+    "message": "You cut into the undead scientist, carefully removing layers of tissue.",
     "entries": [
       {
         "drop": "scientist_xe_base_CBM_harvest",
@@ -63,7 +63,7 @@
   {
     "id": "dissect_mon_zombie_oa_agent",
     "type": "harvest",
-    "message": "You search through the remains of the strange soldier, lookinh for anything of interest.",
+    "message": "You search through the remains of the strange soldier, looking for anything of interest.",
     "entries": [
       {
         "drop": "zombie_oa_agent_CBM_harvest",

--- a/data/mods/Xedra_Evolved/dissect.json
+++ b/data/mods/Xedra_Evolved/dissect.json
@@ -61,6 +61,31 @@
     ]
   },
   {
+    "id": "dissect_mon_zombie_oa_agent",
+    "type": "harvest",
+    "message": "You search through the remains of the strange soldier, lookinh for anything of interest.",
+    "entries": [
+      {
+        "drop": "zombie_oa_agent_CBM_harvest",
+        "type": "bionic_group",
+        "flags": [ "NO_STERILE", "NO_PACKED", "FILTHY" ],
+        "faults": [ "fault_bionic_salvaged" ],
+        "base_num": [ 0, 2 ],
+        "scale_num": [ 0.1, 0.6 ],
+        "max": 5
+      },
+      {
+        "drop": "Zomborg_CBM_harvest_power",
+        "type": "bionic_group",
+        "flags": [ "NO_STERILE", "NO_PACKED", "FILTHY" ],
+        "faults": [ "fault_bionic_salvaged" ],
+        "base_num": [ 0, 2 ],
+        "scale_num": [ 0.1, 0.6 ],
+        "max": 5
+      }
+    ]
+  }
+  {
     "id": "dissect_ierde_single",
     "type": "harvest",
     "message": "With cuts and pulls equally similar to both extraction and vandalism, you scrape together the most important parts of the creature.",

--- a/data/mods/Xedra_Evolved/itemgroups/bionic_groups.json
+++ b/data/mods/Xedra_Evolved/itemgroups/bionic_groups.json
@@ -3,30 +3,22 @@
     "id": "scientist_xe_base_CBM_harvest",
     "type": "item_group",
     "subtype": "distribution",
-    "entries" [
-    { "item": "null", "prob": 195 },
-    { "group": "Zomborg_CBM_harvest_utility", "prob": 1 }
-    
-    ]
-    },
-    {
+    "entries": [ { "item": "null", "prob": 195 }, { "group": "Zomborg_CBM_harvest_utility", "prob": 1 } ]
+  },
+  {
     "id": "scientist_xe_base_CBM_power_harvest",
     "type": "item_group",
     "subtype": "distribution",
-    "entries" [
-    { "item": "null", "prob": 99 },
-    { "group": "Zomborg_CBM_harvest_power", "prob": 1 }
-    
-    ]
-    },
-    {
+    "entries": [ { "item": "null", "prob": 99 }, { "group": "Zomborg_CBM_harvest_power", "prob": 1 } ]
+  },
+  {
     "id": "zombie_oa_agent_CBM_harvest",
     "type": "item_group",
     "subtype": "collection",
     "entries": [
       { "group": "Zomborg_CBM_harvest_utility", "prob": 2 },
-      { "group": "Zomborg_CBM_harvest_structural", "prob":  3 },
+      { "group": "Zomborg_CBM_harvest_structural", "prob": 3 },
       { "group": "Zomborg_CBM_harvest_combat", "prob": 2 }
     ]
-  },
+  }
 ]

--- a/data/mods/Xedra_Evolved/itemgroups/bionic_groups.json
+++ b/data/mods/Xedra_Evolved/itemgroups/bionic_groups.json
@@ -18,5 +18,15 @@
     { "group": "Zomborg_CBM_harvest_power", "prob": 1 }
     
     ]
-    }
+    },
+    {
+    "id": "zombie_oa_agent_CBM_harvest",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [
+      { "group": "Zomborg_CBM_harvest_utility", "prob": 2 },
+      { "group": "Zomborg_CBM_harvest_structural", "prob":  3 },
+      { "group": "Zomborg_CBM_harvest_combat", "prob": 2 }
+    ]
+  },
 ]

--- a/data/mods/Xedra_Evolved/itemgroups/bionic_groups.json
+++ b/data/mods/Xedra_Evolved/itemgroups/bionic_groups.json
@@ -3,13 +3,13 @@
     "id": "scientist_xe_base_CBM_harvest",
     "type": "item_group",
     "subtype": "distribution",
-    "entries": [ { "item": "null", "prob": 195 }, { "group": "Zomborg_CBM_harvest_utility", "prob": 1 } ]
+    "entries": [ { "item": "null", "prob": 80 }, { "group": "Zomborg_CBM_harvest_utility", "prob": 1 } ]
   },
   {
     "id": "scientist_xe_base_CBM_power_harvest",
     "type": "item_group",
     "subtype": "distribution",
-    "entries": [ { "item": "null", "prob": 99 }, { "group": "Zomborg_CBM_harvest_power", "prob": 1 } ]
+    "entries": [ { "item": "null", "prob": 40 }, { "group": "Zomborg_CBM_harvest_power", "prob": 1 } ]
   },
   {
     "id": "zombie_oa_agent_CBM_harvest",

--- a/data/mods/Xedra_Evolved/itemgroups/bionic_groups.json
+++ b/data/mods/Xedra_Evolved/itemgroups/bionic_groups.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": "scientist_xe_base_CBM_harvest",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries" [
+    { "item": "null", "prob": 195 },
+    { "group": "Zomborg_CBM_harvest_utility", "prob": 1 }
+    
+    ]
+    },
+    {
+    "id": "scientist_xe_base_CBM_power_harvest",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries" [
+    { "item": "null", "prob": 99 },
+    { "group": "Zomborg_CBM_harvest_power", "prob": 1 }
+    
+    ]
+    }
+]

--- a/data/mods/Xedra_Evolved/monsters/zombies.json
+++ b/data/mods/Xedra_Evolved/monsters/zombies.json
@@ -120,7 +120,7 @@
     "special_when_hit": [ "ZAPBACK", 75 ],
     "death_drops": "mon_zombie_oa_agent_death_drops",
     "armor": { "bash": 10, "cut": 18, "stab": 18, "bullet": 25, "electric": 3 },
-    "dissect": "dissect_mon_zomborg",
+    "dissect": "dissect_mon_zombie_oa_agent",
     "extend": {
       "weakpoint_sets": [ "wps_humanoid_body_armor", "wps_humanoid_open_helmet", "wps_humanoid_gasmask" ],
       "families": [ "prof_wp_syn_armored" ],

--- a/data/mods/Xedra_Evolved/monsters/zombies.json
+++ b/data/mods/Xedra_Evolved/monsters/zombies.json
@@ -129,7 +129,7 @@
   },
   {
     "id": "mon_zombie_scientist",
-    "copy_from": "mon_zombie_scientist",
+    "copy-from": "mon_zombie_scientist",
     "type": "MONSTER",
     "dissect": "dissect_mon_zombie_scientist_xe"
   }

--- a/data/mods/Xedra_Evolved/monsters/zombies.json
+++ b/data/mods/Xedra_Evolved/monsters/zombies.json
@@ -126,5 +126,11 @@
       "families": [ "prof_wp_syn_armored" ],
       "flags": [ "ELECTRIC" ]
     }
-  }
+  },
+  {
+    "id": "mon_zombie_scientist",
+    "copy_from": "mon_zombie_scientist",
+    "type": "MONSTER",
+    "dissect": "dissect_mon_zombie_scientist_xe",
+  } 
 ]

--- a/data/mods/Xedra_Evolved/monsters/zombies.json
+++ b/data/mods/Xedra_Evolved/monsters/zombies.json
@@ -131,6 +131,6 @@
     "id": "mon_zombie_scientist",
     "copy_from": "mon_zombie_scientist",
     "type": "MONSTER",
-    "dissect": "dissect_mon_zombie_scientist_xe",
-  } 
+    "dissect": "dissect_mon_zombie_scientist_xe"
+  }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Xedra Evolved] Extremely rare chance for zombie scientists to have CBMs"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Follow-up to #84818, there is one other class of zombies that might have CBMs--scientists who worked with Offworld Acquisitions, who would have a use for some of the CBMs that the field agents might not. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add an extremely small chance for zombie scientists to drop CBMs. They can only drop CBMs from the Zomborg "utility" list and power storage CBMs, things like the syringe, geiger counter, alarm, stat enhancements, radscrubber, augmented reality, and so on. Nothing with direct combat capability--that all went to the field agents.

As such, rework the field agent weights so they're more likely to have direct combat-applicable CBMs on their drop lists, like armor and weapons. 

The way I did the "rare chance" is with a gateway itemgroup that mostly returns nothing, so even if you dissect every zombie scientist you won't get much. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Add a specific OA scientist--thanks to the sidebar telling you what mod something comes from, this would make it very obvious which scientists might have bionics.

Blacklist normal scientists and add OA and MAJESTIC scientists--closer, but we would want some mi-go biotech for the MAJESTIC scientists and currently we don't have any. This one might work better if we can get separate MAJESTIC labs that aren't related to the portal labs. 

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Raised the odds for testing purposes, dissected some scientists, received bionics.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

OA-specific scientists would still work in an explicit OA base, like a Materials Processing facility or an agent training ground or something. 

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
