### PR TITLE
Fix field debug info format specifiers

### DIFF
--- a/src/game_ui_tile_info.cpp
+++ b/src/game_ui_tile_info.cpp
@@ -495,9 +495,9 @@ void game::print_debug_info( const tripoint_bub_ms &lp, const catacurses::window
             mvwprintz( w_look, point( column, ++line ), c_white, "field: " );
             mvwprintz( w_look, point( column + utf8_width( "field: " ), line ), c_yellow, "%s",
                        fd.first.id().c_str() );
-            mvwprintz( w_look, point( column, ++line ), c_white, "age: %s (%s seconds)",
+            mvwprintz( w_look, point( column, ++line ), c_white, "age: %s (%d seconds)",
                        to_string( fd.second.get_field_age() ), to_seconds<int>( fd.second.get_field_age() ) );
-            mvwprintz( w_look, point( column, ++line ), c_white, "intensity: %s",
+            mvwprintz( w_look, point( column, ++line ), c_white, "intensity: %d",
                        fd.second.get_field_intensity() );
             mvwprintz( w_look, point( column, ++line ), c_white, "causer: %s",
                        fd.second.get_causer() == nullptr ? "none" : fd.second.get_causer()->disp_name() );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fix errors.

#### Describe the solution

Use %d for numbers.

#### Describe alternatives you've considered



#### Testing

No more errors when hovering over fields with debug mode enabled.

#### Additional context

