### PR TITLE
Set of clothes --> Takes off ALL items, always

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -7670,7 +7670,7 @@ void outfit_swap_actor::finish( player_activity &act, Character &who )
     }
     // Taken-off items are put in this temporary list, then naturally deleted from the world when the function returns.
     std::list<item> it_list;
-    for( item_location &worn_item : who.get_visible_worn_items() ) {
+    for( item_location &worn_item : who.top_items_loc() ) {
         if( !static_cast<bool>( worn_item ) ) {
             //Due to the eoc triggered who.takeoff, the item may become invalid.
             continue;


### PR DESCRIPTION
#### Summary
Features "Set of clothes takes off ALL items, always"

#### Purpose of change
Ehhh an "outfit" being comprised of all visible clothes is a fine idea, but it's finnicky in practice. Especially when "Reversing" the outfit, you'll end up putting on or taking off things differently on the second pass.

That's very difficult to work with! And the point of this item is to make it *easy*, so we don't want it to be difficult, or terribly complicated.

#### Describe the solution
Make it as simple as possible: Always swaps all clothes.

This means you'll have to stash a pair of underwear in your 'battle outfit', but I'm sure people can manage that.

#### Describe alternatives you've considered
Always swap all clothes *except* SKINTIGHT (underwear)?

#### Testing
Swapped outfits a few times in varying conditions with layers and stuff.

Swapped out of an outfit while carrying items in pockets. Swapped back to it. Confirmed items were still in pockets.

#### Additional context
