### PR TITLE
Disable invalid file operations for empty e-devices

### DIFF
--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -5712,13 +5712,17 @@ std::optional<int> iuse::efiledevice( Character *p, item *it, const tripoint_bub
     amenu.addentry( efd_combo_bm, true, 'a', _( "Browse + move files from all devices" ) );
     amenu.addentry( efd_browse, true, 'b', _( "Browse devices" ) );
     if( used_edevice->is_browsed() ) {
-        amenu.addentry( efd_read_this, true, 'r', _( "Read files on this device" ) );
+        if( !used_edevice->efiles().empty() ) {
+            amenu.addentry( efd_read_this, true, 'r', _( "Read files on this device" ) );
+        }
         amenu.addentry( efd_read_external, true, 'e', _( "Read files on external devices" ) );
         amenu.addentry( efd_move_onto_this, true, 'm', _( "Move files onto this device" ) );
-        amenu.addentry( efd_move_off_this, true, 'k', _( "Move files off of this device" ) );
         amenu.addentry( efd_copy_onto_this, true, 'c', _( "Copy files onto this device" ) );
-        amenu.addentry( efd_copy_from_this, true, 'f', _( "Copy files off of this device" ) );
-        amenu.addentry( efd_wipe, true, 'W', _( "Wipe files from devices" ) );
+        if( !used_edevice->efiles().empty() ) {
+            amenu.addentry( efd_move_off_this, true, 'k', _( "Move files off of this device" ) );
+            amenu.addentry( efd_copy_from_this, true, 'f', _( "Copy files off of this device" ) );
+            amenu.addentry( efd_wipe, true, 'W', _( "Wipe files from devices" ) );
+        }
     }
 
     amenu.query();

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -5711,18 +5711,15 @@ std::optional<int> iuse::efiledevice( Character *p, item *it, const tripoint_bub
     amenu.text = _( "Select operation:" );
     amenu.addentry( efd_combo_bm, true, 'a', _( "Browse + move files from all devices" ) );
     amenu.addentry( efd_browse, true, 'b', _( "Browse devices" ) );
+    const bool has_files = !used_edevice->efiles().empty();
     if( used_edevice->is_browsed() ) {
-        if( !used_edevice->efiles().empty() ) {
-            amenu.addentry( efd_read_this, true, 'r', _( "Read files on this device" ) );
-        }
+        amenu.addentry( efd_read_this, has_files, 'r', _( "Read files on this device" ) );
         amenu.addentry( efd_read_external, true, 'e', _( "Read files on external devices" ) );
         amenu.addentry( efd_move_onto_this, true, 'm', _( "Move files onto this device" ) );
         amenu.addentry( efd_copy_onto_this, true, 'c', _( "Copy files onto this device" ) );
-        if( !used_edevice->efiles().empty() ) {
-            amenu.addentry( efd_move_off_this, true, 'k', _( "Move files off of this device" ) );
-            amenu.addentry( efd_copy_from_this, true, 'f', _( "Copy files off of this device" ) );
-            amenu.addentry( efd_wipe, true, 'W', _( "Wipe files from devices" ) );
-        }
+        amenu.addentry( efd_move_off_this, has_files, 'k', _( "Move files off of this device" ) );
+        amenu.addentry( efd_copy_from_this, has_files, 'f', _( "Copy files off of this device" ) );
+        amenu.addentry( efd_wipe, true, 'W', _( "Wipe files from devices" ) );
     }
 
     amenu.query();


### PR DESCRIPTION
#### Summary
Interface "Disable invalid file operations for empty e-devices"

#### Purpose of change

When using blank e-devices, there are several options presented to the player that are not valid.

#### Describe the solution

When the device is empty, disable "Read files on this device", "Move files off of this device", and "Copy files off of this device".

#### Describe alternatives you've considered

1. I'd like to enumerate the nearby devices to remove other options that are contextually invalid, but the logic for enumeration is conflated with the selection menus.  I decided not to refactor it out for the sake of a smarter menu.
2. While I'm touching the menu, I'd personally prefer "Read files on this device" to come first in the list because that's what I usually want to do when playing.

#### Testing

Ran `nice make -j10 ASTYLE=1 && ./cataclysm-launcher`, made a new character with a smartphone that contained a file, browsed it, looked at the file menu, wiped the only file, looked at the file menu again.

1. Unbrowsed device still has only options to browse.

---

2. Browsed device with a file has all the options: <img width="267" height="143" alt="image" src="https://github.com/user-attachments/assets/61dce48b-5ebc-4a3d-80f1-b8baa8e04a09" />

---

3. Browsed device without files has disabled options: <img width="266" height="143" alt="image" src="https://github.com/user-attachments/assets/d1f55b47-30b8-464b-847f-199b3ed0234e" />

#### Additional context
None.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
