### PR TITLE
Fix bandages or disinfectant could apply bonus healing to other body parts

### DIFF
--- a/src/character_health.cpp
+++ b/src/character_health.cpp
@@ -2021,8 +2021,8 @@ float Character::healing_rate_medicine( float at_rest_quality, const bodypart_id
     // Sufficiently negative rest quality can completely eliminate your healing, but never turn it negative.
     rate_medicine *= 1.0f + std::max( at_rest_quality, -1.0f );
 
-    // increase healing if character has both effects
-    if( has_effect( effect_bandaged ) && has_effect( effect_disinfected ) ) {
+    // Increase healing if character has both effects on this body part.
+    if( has_effect( effect_bandaged, bp ) && has_effect( effect_disinfected, bp ) ) {
         rate_medicine *= 1.25;
     }
 


### PR DESCRIPTION
#### Summary
Bugfixes "Fix bandages or disinfectant could apply bonus healing to other body parts"

#### Purpose of change

The 125% healing rate bonus for having both bandages and disinfectant doesn't check that you have both of them on the body part that's being healed.

#### Describe the solution

Add a test, fix the bug.

#### Describe alternatives you've considered

This is basically unnoticeable so don't bother fixing it.

#### Testing

New test before the src change:
```
$ nice make -j10 ASTYLE=1 TESTS=1 && ./tests/cata_test "healing_rate_medicine_with_bandages_and/or_disinfectant"
…
Filters: healing_rate_medicine_with_bandages_and/or_disinfectant

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cata_test is a Catch v2.13.7 host application.
Run with -? for options

-------------------------------------------------------------------------------
healing_rate_medicine_with_bandages_and/or_disinfectant
  bandages only
  awake
  other bodyparts are also treated
-------------------------------------------------------------------------------
../tests/char_healing_test.cpp:361
...............................................................................

../tests/char_healing_test.cpp:363: FAILED:
  CHECK( bandaged_rate_with_extras( "head", { "arm_l", "arm_r", "leg_l", "leg_r", "torso" }, awake_rest ) == Approx( 1.0f * hp_per_day ) )
with expansion:
  0.00001f == Approx( 0.0000115741 )

===============================================================================
test cases:  1 |  0 passed | 1 failed
assertions: 51 | 50 passed | 1 failed
```

This PR:
```
$ nice make -j10 ASTYLE=1 TESTS=1 && ./tests/cata_test "healing_rate_medicine_with_bandages_and/or_disinfectant"
…
Filters: healing_rate_medicine_with_bandages_and/or_disinfectant
===============================================================================
All tests passed (51 assertions in 1 test case)
```

#### Additional context

None.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
