### PR TITLE
Natural healing instead of medicine damages health

### DIFF
--- a/src/character_health.cpp
+++ b/src/character_health.cpp
@@ -1207,9 +1207,9 @@ void Character::regen( int rate_multiplier )
     float heal_rate = healing_rate( rest ) * to_turns<int>( 5_minutes );
     if( heal_rate > 0.0f ) {
         int healing_apply = roll_remainder( rate_multiplier * heal_rate );
-        while ( healing_apply-- > 0 ) {
+        while( healing_apply-- > 0 ) {
             for( const bodypart_id &healed : get_all_body_parts( get_body_part_flags::only_main ) ) {
-                if ( get_part_hp_max( healed ) > get_part_hp_cur( healed ) ) {
+                if( get_part_hp_max( healed ) > get_part_hp_cur( healed ) ) {
                     heal( healed, 1 );
                     // Consume 1 "health" for every Hit Point healed via non-medicine healing.
                     // Using medicine reduces the ratio of health consumed to damage healed.

--- a/src/character_health.cpp
+++ b/src/character_health.cpp
@@ -1207,13 +1207,16 @@ void Character::regen( int rate_multiplier )
     float heal_rate = healing_rate( rest ) * to_turns<int>( 5_minutes );
     if( heal_rate > 0.0f ) {
         int healing_apply = roll_remainder( rate_multiplier * heal_rate );
-        while( healing_apply-- > 0 ) {
-            for( const bodypart_id &healed : get_all_body_parts( get_body_part_flags::only_main ) ) {
-                if( get_part_hp_max( healed ) > get_part_hp_cur( healed ) ) {
-                    heal( healed, 1 );
+        if( healing_apply > 0 ) {
+            for( const bodypart_id &healed_part : get_all_body_parts() ) {
+                int part_healing = std::min( healing_apply,
+                        get_part_hp_max( healed_part ) - get_part_hp_cur( healed_part ) );
+                if( part_healing > 0 ) {
+                    mod_part_healed_total( healed_part, part_healing );
+                    heal( healed_part, part_healing );
                     // Consume 1 "health" for every Hit Point healed via non-medicine healing.
                     // Using medicine reduces the ratio of health consumed to damage healed.
-                    mod_daily_health( -1, -200 );
+                    mod_daily_health( -part_healing, -200 );
                 }
             }
         }

--- a/src/character_health.cpp
+++ b/src/character_health.cpp
@@ -1210,7 +1210,7 @@ void Character::regen( int rate_multiplier )
         if( healing_apply > 0 ) {
             for( const bodypart_id &healed_part : get_all_body_parts() ) {
                 int part_healing = std::min( healing_apply,
-                        get_part_hp_max( healed_part ) - get_part_hp_cur( healed_part ) );
+                                             get_part_hp_max( healed_part ) - get_part_hp_cur( healed_part ) );
                 if( part_healing > 0 ) {
                     mod_part_healed_total( healed_part, part_healing );
                     heal( healed_part, part_healing );


### PR DESCRIPTION
#### Summary
Balance "Natural healing degrades health but medical healing does not"

#### Purpose of change

The changes in https://github.com/CleverRaven/Cataclysm-DDA/pull/84277 cause it to be more beneficial to your health to not use medical care when injured. 

- Fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/84420

#### Describe the solution

Make healing _without_ medicine damage Health and healing _with_ medicine not damage health.  For characters who bandage and disinfect all of their injuries, this will reduce the current healing lifestyle penalties by a factor of 5 or so.  Characters who do not treat their injuries will suffer severe health damage.

#### Describe alternatives you've considered

1. Implement `(total max HP - total current HP)/1000%` chance each minute for health damage as described in https://github.com/CleverRaven/Cataclysm-DDA/issues/37446
2. Add a `one_in_n` chance based on the quality of bandage and disinfectant before degrading health.  Discarded this idea when I realized the current approach _only_ penalizes medical care.
3. Wait for someone else to take the heat from touching a controversial mechanic.
4. Add a message about your wounds aching as health is damaged? Maybe 1 in 20 times or so?

#### Testing

I didn't test this beyond compiling and running the automated tests, which do not exercise this change AFAICT.

#### Additional context

See links above.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
