### PR TITLE
Don't double assign melee actor range

### DIFF
--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -443,7 +443,6 @@ void melee_actor::load_internal( const JsonObject &obj, const std::string & )
     optional( obj, was_loaded, "effects_require_dmg", effects_require_dmg, true );
     optional( obj, was_loaded, "effects_require_organic", effects_require_organic, false );
     optional( obj, was_loaded, "grab", is_grab, false );
-    optional( obj, was_loaded, "range", range, 1 );
     optional( obj, was_loaded, "throw_strength", throw_strength, 0 );
 
     optional( obj, was_loaded, "eoc", eoc );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Was double-checking some code, and found that range is loaded and assigned twice (oops)
<img width="1081" height="273" alt="image" src="https://github.com/user-attachments/assets/bd4827d7-860c-4952-8cd1-f6e7557953f1" />


#### Describe the solution
Only load it once. Remove one of the two

#### Describe alternatives you've considered
Big effort removal: Blame which has less history and remove that one. Too lazy

#### Testing
If it passes CI it's good to go

#### Additional context

