### PR TITLE
Devourers gain abilities and resilience from devouring

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -618,6 +618,7 @@
     "//2": "/50 HP: +0,5 melee_skill, +5 Speed (bigger steps&more to attack with), +4 bash",
     "//3": "/250 HP: +1 size",
     "max_intensity": 500,
+    "//4": "Effective max intensity is currently 320.",
     "base_mods": { "hit_mod": [ 0.01 ], "bash_mod": [ 0.08 ] },
     "scaling_mods": { "hit_mod": [ 0.01 ], "bash_mod": [ 0.08 ], "size_mod": [ 0.004 ] },
     "int_decay_step": 0,
@@ -625,14 +626,14 @@
       {
         "condition": "ALWAYS",
         "incoming_damage_mod": [
-          { "type": "bash", "multiply": { "math": [ "u_effect_intensity('grown_of_fuse') / -1250" ] } },
-          { "type": "cut", "multiply": { "math": [ "u_effect_intensity('grown_of_fuse') / -2000" ] } },
-          { "type": "stab", "multiply": { "math": [ "u_effect_intensity('grown_of_fuse') / -2000" ] } },
-          { "type": "bullet", "multiply": { "math": [ "u_effect_intensity('grown_of_fuse') / -1000" ] } }
+          { "type": "bash", "multiply": { "math": [ "u_effect_intensity('grown_of_fuse') / -900" ] } },
+          { "type": "cut", "multiply": { "math": [ "u_effect_intensity('grown_of_fuse') / -1500" ] } },
+          { "type": "stab", "multiply": { "math": [ "u_effect_intensity('grown_of_fuse') / -1500" ] } },
+          { "type": "bullet", "multiply": { "math": [ "u_effect_intensity('grown_of_fuse') / -650" ] } }
         ],
         "values": [
-          { "value": "REGEN_HP", "multiply": { "math": [ "u_effect_intensity('grown_of_fuse') / 50" ] } },
-          { "value": "SPEED", "add": { "math": [ "u_effect_intensity('grown_of_fuse') * 0.05" ] } }
+          { "value": "REGEN_HP", "multiply": { "math": [ "u_effect_intensity('grown_of_fuse') / 32" ] } },
+          { "value": "SPEED", "add": { "math": [ "u_effect_intensity('grown_of_fuse') * 0.06" ] } }
         ]
       },
       {

--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -615,32 +615,12 @@
     ],
     "//": "stats modified by the zombie_fuse special attack.",
     "//1": "scaling:",
-    "//2": "/50 HP: +0,5 melee_skill, +0,5 dodge_skill (unexpected movement), +5 Speed (bigger steps&more to attack with), +4 bash",
+    "//2": "/50 HP: +0,5 melee_skill, +5 Speed (bigger steps&more to attack with), +4 bash",
     "//3": "/250 HP: +1 size",
     "max_intensity": 500,
-    "base_mods": { "hit_mod": [ 0.01 ], "dodge_mod": [ 0.01 ], "speed_mod": [ 0.1 ], "bash_mod": [ 0.08 ] },
-    "scaling_mods": { "hit_mod": [ 0.01 ], "dodge_mod": [ 0.01 ], "speed_mod": [ 0.1 ], "bash_mod": [ 0.08 ], "size_mod": [ 0.004 ] },
-    "int_decay_step": 0
-  },
-  {
-    "type": "effect_type",
-    "id": "absorbed_acidic",
-    "//": "This tells a devourer that it has absorbed an acidic monster (one with the flag ACID_BLOOD or ACIDTRAIL)"
-  },
-  {
-    "type": "effect_type",
-    "id": "absorbed_electric",
-    "//": "This tells a devourer that it has absorbed an electric monster (one with the flag ELECTRIC)"
-  },
-  {
-    "type": "effect_type",
-    "id": "absorbed_pupating",
-    "//": "This tells a devourer that it has absorbed a pupating zombie and can now produce flesh raptors"
-  },
-  {
-    "type": "effect_type",
-    "id": "effect_devourer_armor_buff",
-    "//": "This gives the devourer an armor buff based on how many zombies it has absorbed",
+    "base_mods": { "hit_mod": [ 0.01 ], "speed_mod": [ 0.05 ], "bash_mod": [ 0.08 ] },
+    "scaling_mods": { "hit_mod": [ 0.01 ], "speed_mod": [ 0.05 ], "bash_mod": [ 0.08 ], "size_mod": [ 0.004 ] },
+    "int_decay_step": 0,
     "enchantments": [
       {
         "condition": "ALWAYS",
@@ -660,6 +640,21 @@
         "incoming_damage_mod": [ { "type": "acid", "multiply": -1 } ]
       }
     ]
+  },
+  {
+    "type": "effect_type",
+    "id": "absorbed_acidic",
+    "//": "This tells a devourer that it has absorbed an acidic monster (one with the flag ACID_BLOOD or ACIDTRAIL)"
+  },
+  {
+    "type": "effect_type",
+    "id": "absorbed_electric",
+    "//": "This tells a devourer that it has absorbed an electric monster (one with the flag ELECTRIC)"
+  },
+  {
+    "type": "effect_type",
+    "id": "absorbed_pupating",
+    "//": "This tells a devourer that it has absorbed a pupating zombie and can now produce flesh raptors"
   },
   {
     "id": "Shadow_Reveal",

--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -618,8 +618,8 @@
     "//2": "/50 HP: +0,5 melee_skill, +5 Speed (bigger steps&more to attack with), +4 bash",
     "//3": "/250 HP: +1 size",
     "max_intensity": 500,
-    "base_mods": { "hit_mod": [ 0.01 ], "speed_mod": [ 0.05 ], "bash_mod": [ 0.08 ] },
-    "scaling_mods": { "hit_mod": [ 0.01 ], "speed_mod": [ 0.05 ], "bash_mod": [ 0.08 ], "size_mod": [ 0.004 ] },
+    "base_mods": { "hit_mod": [ 0.01 ], "bash_mod": [ 0.08 ] },
+    "scaling_mods": { "hit_mod": [ 0.01 ], "bash_mod": [ 0.08 ], "size_mod": [ 0.004 ] },
     "int_decay_step": 0,
     "enchantments": [
       {
@@ -629,6 +629,10 @@
           { "type": "cut", "multiply": { "math": [ "u_effect_intensity('grown_of_fuse') / -2000" ] } },
           { "type": "stab", "multiply": { "math": [ "u_effect_intensity('grown_of_fuse') / -2000" ] } },
           { "type": "bullet", "multiply": { "math": [ "u_effect_intensity('grown_of_fuse') / -1000" ] } }
+        ],
+        "values": [
+          { "value": "REGEN_HP", "multiply": { "math": [ "u_effect_intensity('grown_of_fuse') / 50" ] } },
+          { "value": "SPEED", "add": { "math": [ "u_effect_intensity('grown_of_fuse') * 0.05" ] } }
         ]
       },
       {

--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -633,6 +633,35 @@
     "//": "This tells a devourer that it has absorbed an electric monster (one with the flag ELECTRIC)"
   },
   {
+    "type": "effect_type",
+    "id": "absorbed_pupating",
+    "//": "This tells a devourer that it has absorbed a pupating zombie and can now produce flesh raptors"
+  },
+  {
+    "type": "effect_type",
+    "id": "effect_devourer_armor_buff",
+    "//": "This gives the devourer an armor buff based on how many zombies it has absorbed",
+    "enchantments": [
+      {
+        "condition": "ALWAYS",
+        "incoming_damage_mod": [
+          { "type": "bash", "multiply": { "math": [ "u_effect_intensity('grown_of_fuse') / -1250" ] } },
+          { "type": "cut", "multiply": { "math": [ "u_effect_intensity('grown_of_fuse') / -2000" ] } },
+          { "type": "stab", "multiply": { "math": [ "u_effect_intensity('grown_of_fuse') / -2000" ] } },
+          { "type": "bullet", "multiply": { "math": [ "u_effect_intensity('grown_of_fuse') / -1000" ] } }
+        ]
+      },
+      {
+        "condition": { "u_has_effect": "absorbed_electric" },
+        "incoming_damage_mod": [ { "type": "electric", "multiply": -1 } ]
+      },
+      {
+        "condition": { "u_has_effect": "absorbed_acidic" },
+        "incoming_damage_mod": [ { "type": "acid", "multiply": -1 } ]
+      }
+    ]
+  },
+  {
     "id": "Shadow_Reveal",
     "type": "effect_type",
     "max_duration": "60 s",

--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -623,6 +623,16 @@
     "int_decay_step": 0
   },
   {
+    "type": "effect_type",
+    "id": "absorbed_acidic",
+    "//": "This tells a devourer that it has absorbed an acidic monster (one with the flag ACID_BLOOD or ACIDTRAIL)"
+  },
+  {
+    "type": "effect_type",
+    "id": "absorbed_electric",
+    "//": "This tells a devourer that it has absorbed an electric monster (one with the flag ELECTRIC)"
+  },
+  {
     "id": "Shadow_Reveal",
     "type": "effect_type",
     "max_duration": "60 s",

--- a/data/json/effects_on_condition/general_conditions.json
+++ b/data/json/effects_on_condition/general_conditions.json
@@ -9,7 +9,8 @@
         { "npc_has_species": "ROBOT_FLYING" },
         { "npc_has_species": "LEECH_PLANT" },
         { "npc_has_flag": "ELECTRIC" },
-        { "npc_has_any_trait": [ "EXODII_BODY_1", "EXODII_BODY_2", "EXODII_BODY_9" ] }
+        { "npc_has_any_trait": [ "EXODII_BODY_1", "EXODII_BODY_2", "EXODII_BODY_9" ] },
+        { "npc_has_effect": "absorbed_electric" }
       ]
     }
   }

--- a/data/json/monster_special_attacks/spells.json
+++ b/data/json/monster_special_attacks/spells.json
@@ -1357,18 +1357,5 @@
       { "u_location_variable": { "context_val": "zombie_horde_target" } },
       { "signal_hordes": { "context_val": "zombie_horde_target" }, "signal_power": { "math": [ "_summon_effect" ] } }
     ]
-  },
-  {
-    "type": "SPELL",
-    "id": "devourer_apply_armor_buff_spell",
-    "name": { "str": "Devourer Armor Buff", "//~": "NO_I18N" },
-    "description": { "str": "Adds minor radiation to player.", "//~": "NO_I18N" },
-    "flags": [ "NO_PROJECTILE", "SILENT", "NO_EXPLOSION_SFX" ],
-    "effect": "attack",
-    "effect_str": "effect_devourer_armor_buff",
-    "valid_targets": [ "self" ],
-    "shape": "blast",
-    "min_duration": 86400000,
-    "max_duration": 86400000
   }
 ]

--- a/data/json/monster_special_attacks/spells.json
+++ b/data/json/monster_special_attacks/spells.json
@@ -1357,5 +1357,18 @@
       { "u_location_variable": { "context_val": "zombie_horde_target" } },
       { "signal_hordes": { "context_val": "zombie_horde_target" }, "signal_power": { "math": [ "_summon_effect" ] } }
     ]
+  },
+  {
+    "type": "SPELL",
+    "id": "devourer_apply_armor_buff_spell",
+    "name": { "str": "Devourer Armor Buff", "//~": "NO_I18N" },
+    "description": { "str": "Adds minor radiation to player.", "//~": "NO_I18N" },
+    "flags": [ "NO_PROJECTILE", "SILENT", "NO_EXPLOSION_SFX" ],
+    "effect": "attack",
+    "effect_str": "effect_devourer_armor_buff",
+    "valid_targets": [ "self" ],
+    "shape": "blast",
+    "min_duration": 86400000,
+    "max_duration": 86400000
   }
 ]

--- a/data/json/monsters/zed_fusion.json
+++ b/data/json/monsters/zed_fusion.json
@@ -119,6 +119,48 @@
         "no_dmg_msg_npc": "A tangle of flesh covered in maws shoots out from %1$s, but glances off <npcname>'s armor.",
         "miss_msg_u": "A tangle of flesh covered in maws shoots out from %1$s, but you dodge!",
         "miss_msg_npc": "A tangle of flesh covered in maws shoots out from %1$s, but <npcname> dodges!"
+      },
+      {
+        "id": "acid_charge",
+        "condition": { "and": [ { "not": { "u_has_effect": "maimed_acid_gland" } }, { "u_has_effect": "absorbed_acidic" } ] }
+      },
+      {
+        "id": "acid_slash",
+        "condition": {
+          "and": [
+            { "not": { "u_has_effect": "maimed_acid_gland" } },
+            { "not": { "u_has_effect": "maimed_claws" } },
+            { "not": { "u_has_effect": "maimed_arm" } },
+            { "u_has_effect": "absorbed_acidic" },
+            { "u_has_effect": "acid_charged" }
+          ]
+        }
+      },
+      {
+        "type": "monster_attack",
+        "id": "devourer_spawn_raptors",
+        "range": 8,
+        "cooldown": 180,
+        "blockable": false,
+        "dodgeable": false,
+        "condition": { "u_has_effect": "absorbed_pupating" },
+        "damage_max_instance": [ { "damage_type": "pure", "amount": 0 } ],
+        "eoc": [ "EOC_DEVOURER_SPAWN_RAPTORS" ],
+        "hit_dmg_u": "A bubo on the side of %s swells and bursts bursts, and gore-smeared winged beasts hurl themselves into the air!",
+        "hit_dmg_npc": "A bubo on the side of %s swells and bursts bursts, and gore-smeared winged beasts hurl themselves into the air!",
+        "no_dmg_msg_u": "A bubo on the side of %s swells and bursts bursts, and gore-smeared winged beasts hurl themselves into the air!",
+        "no_dmg_msg_npc": "A bubo on the side of %s swells and bursts bursts, and gore-smeared winged beasts hurl themselves into the air!",
+        "miss_msg_u": "A bubo on the side of %s swells and bursts bursts, and gore-smeared winged beasts hurl themselves into the air!",
+        "miss_msg_npc": "A bubo on the side of %s swells and bursts bursts, and gore-smeared winged beasts hurl themselves into the air!"
+      },
+      {
+        "id": "devourer_apply_armor_buff",
+        "type": "spell",
+        "spell_data": { "id": "devourer_apply_armor_buff_spell", "hit_self": true },
+        "cooldown": 1,
+        "allow_no_target": true,
+        "condition": { "not": { "u_has_effect": "effect_devourer_armor_buff" } },
+        "monster_message": ""
       }
     ],
     "death_drops": {
@@ -142,6 +184,13 @@
       "FILTHY"
     ],
     "armor": { "bash": 5, "cut": 5, "bullet": 4, "electric": 3 }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_DEVOURER_SPAWN_RAPTORS",
+    "effect": [
+      { "u_spawn_monster": "mon_spawn_raptor", "real_count": { "math": [ "2 + rand(2)" ] }, "min_radius": 1, "max_radius": 3 }
+    ]
   },
   {
     "id": "mon_devourer_lab_sec",

--- a/data/json/monsters/zed_fusion.json
+++ b/data/json/monsters/zed_fusion.json
@@ -59,8 +59,8 @@
       { "id": "grab", "cooldown": 7 },
       { "id": "scratch" },
       [ "ZOMBIE_FUSE", 80 ],
-      { "id": "grab_2", "condition": { "math": [ "u_effect_intensity('grown_of_fuse') > 100" ] } },
-      { "id": "grab_3", "condition": { "math": [ "u_effect_intensity('grown_of_fuse') > 250" ] } },
+      { "id": "grab_2", "accuracy": 5, "condition": { "math": [ "u_effect_intensity('grown_of_fuse') > 100" ] } },
+      { "id": "grab_3", "accuracy": 6, "condition": { "math": [ "u_effect_intensity('grown_of_fuse') > 250" ] } },
       {
         "type": "monster_attack",
         "attack_type": "bite",
@@ -81,6 +81,7 @@
         "type": "monster_attack",
         "attack_type": "bite",
         "id": "bite_devourer_2",
+        "accuracy": 5,
         "condition": {
           "and": [
             { "u_has_flag": "GRAB_FILTER" },
@@ -88,7 +89,7 @@
             { "math": [ "u_effect_intensity('grown_of_fuse') > 150" ] }
           ]
         },
-        "damage_max_instance": [ { "damage_type": "stab", "amount": 20, "armor_penetration": 5 } ],
+        "damage_max_instance": [ { "damage_type": "stab", "amount": 22, "armor_penetration": 5 } ],
         "infection_chance": 20,
         "cooldown": 4,
         "move_cost": 150
@@ -97,6 +98,7 @@
         "type": "monster_attack",
         "attack_type": "bite",
         "id": "bite_devourer_3",
+        "accuracy": 4,
         "condition": {
           "and": [
             { "u_has_flag": "GRAB_FILTER" },
@@ -104,15 +106,16 @@
             { "math": [ "u_effect_intensity('grown_of_fuse') > 250" ] }
           ]
         },
-        "damage_max_instance": [ { "damage_type": "stab", "amount": 25, "armor_penetration": 5 } ],
+        "damage_max_instance": [ { "damage_type": "stab", "amount": 35, "armor_penetration": 10 } ],
         "infection_chance": 15,
         "cooldown": 4,
         "move_cost": 150
       },
       {
         "id": "stretch_bite",
-        "condition": { "math": [ "u_effect_intensity('grown_of_fuse') > 350" ] },
-        "damage_max_instance": [ { "damage_type": "stab", "amount": 25, "armor_penetration": 5 } ],
+        "accuracy": 6,
+        "condition": { "math": [ "u_effect_intensity('grown_of_fuse') > 300" ] },
+        "damage_max_instance": [ { "damage_type": "stab", "amount": 25, "armor_penetration": 10 } ],
         "hit_dmg_u": "A tangle of flesh covered in maws shoots out from %1$s, and its teeth sink into your %2$s!",
         "hit_dmg_npc": "A tangle of flesh covered in maws shoots out from %1$s, and its teeth sink into <npcname>'s %2$s!",
         "no_dmg_msg_u": "A tangle of flesh covered in maws shoots out from %1$s, but glances off your armor.",
@@ -123,10 +126,11 @@
       {
         "id": "smash",
         "throw_strength": 70,
+        "accuracy": 7,
         "range": 2,
         "cooldown": 30,
         "blockable": false,
-        "condition": { "math": [ "u_effect_intensity('grown_of_fuse') > 450" ] },
+        "condition": { "math": [ "u_effect_intensity('grown_of_fuse') > 400" ] },
         "hit_dmg_u": "A meaty tendril slams into your %2$s, sending you flying!",
         "hit_dmg_npc": "A meaty tendril slams into <npcname>'s %2$s, sending them flying!",
         "no_dmg_msg_u": "A meaty tendril slams into your %2$s, but does no damage!",
@@ -167,15 +171,6 @@
         "no_dmg_msg_npc": "A bubo on the side of %s swells and bursts bursts, and gore-smeared winged beasts hurl themselves into the air!",
         "miss_msg_u": "A bubo on the side of %s swells and bursts bursts, and gore-smeared winged beasts hurl themselves into the air!",
         "miss_msg_npc": "A bubo on the side of %s swells and bursts bursts, and gore-smeared winged beasts hurl themselves into the air!"
-      },
-      {
-        "id": "devourer_apply_armor_buff",
-        "type": "spell",
-        "spell_data": { "id": "devourer_apply_armor_buff_spell", "hit_self": true },
-        "cooldown": 1,
-        "allow_no_target": true,
-        "condition": { "not": { "u_has_effect": "effect_devourer_armor_buff" } },
-        "monster_message": ""
       }
     ],
     "death_drops": {

--- a/data/json/monsters/zed_fusion.json
+++ b/data/json/monsters/zed_fusion.json
@@ -55,7 +55,72 @@
     "decay": "zombie_decay_bone_human_skull_multiple",
     "//grab": "All these arms to grab you with",
     "grab_strength": 50,
-    "special_attacks": [ { "id": "grab", "cooldown": 7 }, { "id": "scratch" }, [ "ZOMBIE_FUSE", 80 ] ],
+    "special_attacks": [
+      { "id": "grab", "cooldown": 7 },
+      { "id": "scratch" },
+      [ "ZOMBIE_FUSE", 80 ],
+      { "id": "grab_2", "condition": { "math": [ "u_effect_intensity('grown_of_fuse') > 100" ] } },
+      { "id": "grab_3", "condition": { "math": [ "u_effect_intensity('grown_of_fuse') > 250" ] } },
+      {
+        "type": "monster_attack",
+        "attack_type": "bite",
+        "id": "bite_devourer_1",
+        "condition": {
+          "and": [
+            { "u_has_flag": "GRAB_FILTER" },
+            { "npc_has_flag": "GRAB" },
+            { "math": [ "u_effect_intensity('grown_of_fuse') > 75" ] }
+          ]
+        },
+        "damage_max_instance": [ { "damage_type": "stab", "amount": 15 } ],
+        "infection_chance": 15,
+        "cooldown": 4,
+        "move_cost": 150
+      },
+      {
+        "type": "monster_attack",
+        "attack_type": "bite",
+        "id": "bite_devourer_2",
+        "condition": {
+          "and": [
+            { "u_has_flag": "GRAB_FILTER" },
+            { "npc_has_flag": "GRAB" },
+            { "math": [ "u_effect_intensity('grown_of_fuse') > 150" ] }
+          ]
+        },
+        "damage_max_instance": [ { "damage_type": "stab", "amount": 20, "armor_penetration": 5 } ],
+        "infection_chance": 20,
+        "cooldown": 4,
+        "move_cost": 150
+      },
+      {
+        "type": "monster_attack",
+        "attack_type": "bite",
+        "id": "bite_devourer_3",
+        "condition": {
+          "and": [
+            { "u_has_flag": "GRAB_FILTER" },
+            { "npc_has_flag": "GRAB" },
+            { "math": [ "u_effect_intensity('grown_of_fuse') > 250" ] }
+          ]
+        },
+        "damage_max_instance": [ { "damage_type": "stab", "amount": 25, "armor_penetration": 5 } ],
+        "infection_chance": 15,
+        "cooldown": 4,
+        "move_cost": 150
+      },
+      {
+        "id": "stretch_bite",
+        "condition": { "math": [ "u_effect_intensity('grown_of_fuse') > 350" ] },
+        "damage_max_instance": [ { "damage_type": "stab", "amount": 25, "armor_penetration": 5 } ],
+        "hit_dmg_u": "A tangle of flesh covered in maws shoots out from %1$s, and its teeth sink into your %2$s!",
+        "hit_dmg_npc": "A tangle of flesh covered in maws shoots out from %1$s, and its teeth sink into <npcname>'s %2$s!",
+        "no_dmg_msg_u": "A tangle of flesh covered in maws shoots out from %1$s, but glances off your armor.",
+        "no_dmg_msg_npc": "A tangle of flesh covered in maws shoots out from %1$s, but glances off <npcname>'s armor.",
+        "miss_msg_u": "A tangle of flesh covered in maws shoots out from %1$s, but you dodge!",
+        "miss_msg_npc": "A tangle of flesh covered in maws shoots out from %1$s, but <npcname> dodges!"
+      }
+    ],
     "death_drops": {
       "subtype": "collection",
       "groups": [ "default_zombie_death_drops", "default_zombie_death_drops", "default_zombie_death_drops" ]

--- a/data/json/monsters/zed_fusion.json
+++ b/data/json/monsters/zed_fusion.json
@@ -165,12 +165,12 @@
         "condition": { "u_has_effect": "absorbed_pupating" },
         "damage_max_instance": [ { "damage_type": "pure", "amount": 0 } ],
         "eoc": [ "EOC_DEVOURER_SPAWN_RAPTORS" ],
-        "hit_dmg_u": "A bubo on the side of %s swells and bursts bursts, and gore-smeared winged beasts hurl themselves into the air!",
-        "hit_dmg_npc": "A bubo on the side of %s swells and bursts bursts, and gore-smeared winged beasts hurl themselves into the air!",
-        "no_dmg_msg_u": "A bubo on the side of %s swells and bursts bursts, and gore-smeared winged beasts hurl themselves into the air!",
-        "no_dmg_msg_npc": "A bubo on the side of %s swells and bursts bursts, and gore-smeared winged beasts hurl themselves into the air!",
-        "miss_msg_u": "A bubo on the side of %s swells and bursts bursts, and gore-smeared winged beasts hurl themselves into the air!",
-        "miss_msg_npc": "A bubo on the side of %s swells and bursts bursts, and gore-smeared winged beasts hurl themselves into the air!"
+        "hit_dmg_u": "A bubo on the side of %s swells and bursts, and gore-smeared winged beasts hurl themselves into the air!",
+        "hit_dmg_npc": "A bubo on the side of %s swells and bursts, and gore-smeared winged beasts hurl themselves into the air!",
+        "no_dmg_msg_u": "A bubo on the side of %s swells and bursts, and gore-smeared winged beasts hurl themselves into the air!",
+        "no_dmg_msg_npc": "A bubo on the side of %s swells and bursts, and gore-smeared winged beasts hurl themselves into the air!",
+        "miss_msg_u": "A bubo on the side of %s swells and bursts, and gore-smeared winged beasts hurl themselves into the air!",
+        "miss_msg_npc": "A bubo on the side of %s swells and bursts, and gore-smeared winged beasts hurl themselves into the air!"
       }
     ],
     "death_drops": {

--- a/data/json/monsters/zed_fusion.json
+++ b/data/json/monsters/zed_fusion.json
@@ -121,6 +121,20 @@
         "miss_msg_npc": "A tangle of flesh covered in maws shoots out from %1$s, but <npcname> dodges!"
       },
       {
+        "id": "smash",
+        "throw_strength": 70,
+        "range": 2,
+        "cooldown": 30,
+        "blockable": false,
+        "condition": { "math": [ "u_effect_intensity('grown_of_fuse') > 450" ] },
+        "hit_dmg_u": "A meaty tendril slams into your %2$s, sending you flying!",
+        "hit_dmg_npc": "A meaty tendril slams into <npcname>'s %2$s, sending them flying!",
+        "no_dmg_msg_u": "A meaty tendril slams into your %2$s, but does no damage!",
+        "no_dmg_msg_npc": "A meaty tendril slams into <npcname>'s %2$s, but does no damage!",
+        "miss_msg_u": "%1$s swings a meaty tendril at you, but you dodge!",
+        "miss_msg_npc": "%1$s swings a meaty tendril at <npcname>, but they dodge!"
+      },
+      {
         "id": "acid_charge",
         "condition": { "and": [ { "not": { "u_has_effect": "maimed_acid_gland" } }, { "u_has_effect": "absorbed_acidic" } ] }
       },
@@ -139,6 +153,7 @@
       {
         "type": "monster_attack",
         "id": "devourer_spawn_raptors",
+        "attack_type": "melee",
         "range": 8,
         "cooldown": 180,
         "blockable": false,

--- a/data/json/monsters/zed_fusion.json
+++ b/data/json/monsters/zed_fusion.json
@@ -114,7 +114,7 @@
       {
         "id": "stretch_bite",
         "accuracy": 6,
-        "condition": { "math": [ "u_effect_intensity('grown_of_fuse') > 300" ] },
+        "condition": { "math": [ "u_effect_intensity('grown_of_fuse') > 200" ] },
         "damage_max_instance": [ { "damage_type": "stab", "amount": 25, "armor_penetration": 10 } ],
         "hit_dmg_u": "A tangle of flesh covered in maws shoots out from %1$s, and its teeth sink into your %2$s!",
         "hit_dmg_npc": "A tangle of flesh covered in maws shoots out from %1$s, and its teeth sink into <npcname>'s %2$s!",
@@ -130,7 +130,7 @@
         "range": 2,
         "cooldown": 30,
         "blockable": false,
-        "condition": { "math": [ "u_effect_intensity('grown_of_fuse') > 400" ] },
+        "condition": { "math": [ "u_effect_intensity('grown_of_fuse') > 300" ] },
         "hit_dmg_u": "A meaty tendril slams into your %2$s, sending you flying!",
         "hit_dmg_npc": "A meaty tendril slams into <npcname>'s %2$s, sending them flying!",
         "no_dmg_msg_u": "A meaty tendril slams into your %2$s, but does no damage!",

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -103,6 +103,7 @@ static const damage_type_id damage_stab( "stab" );
 
 static const efftype_id effect_absorbed_acidic( "absorbed_acidic");
 static const efftype_id effect_absorbed_electric( "absorbed_electric");
+static const efftype_id effect_absorbed_pupating( "absorbed_pupating");
 static const efftype_id effect_assisted( "assisted" );
 static const efftype_id effect_bite( "bite" );
 static const efftype_id effect_bleed( "bleed" );
@@ -4574,6 +4575,9 @@ bool mattack::zombie_fuse( monster *z )
         z->add_effect( effect_absorbed_electric, 60_days, true );
     } else if ( critter->has_flag (mon_flag_ACIDTRAIL ) || critter->has_flag (mon_flag_ACID_BLOOD ) ) {
         z->add_effect( effect_absorbed_acidic, 60_days, true );
+        // Use SMALLSLUDGETRAIL because pupating zombies have that in common
+    } else if ( critter->has_flag (mon_flag_SMALLSLUDGETRAIL) ) {
+        z->add_effect( effect_absorbed_pupating, 60_days, true );
     }
 
     z->heal( critter->get_hp(), true );

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -101,9 +101,9 @@ static const damage_type_id damage_cut( "cut" );
 static const damage_type_id damage_electric( "electric" );
 static const damage_type_id damage_stab( "stab" );
 
-static const efftype_id effect_absorbed_acidic( "absorbed_acidic");
-static const efftype_id effect_absorbed_electric( "absorbed_electric");
-static const efftype_id effect_absorbed_pupating( "absorbed_pupating");
+static const efftype_id effect_absorbed_acidic( "absorbed_acidic" );
+static const efftype_id effect_absorbed_electric( "absorbed_electric" );
+static const efftype_id effect_absorbed_pupating( "absorbed_pupating" );
 static const efftype_id effect_assisted( "assisted" );
 static const efftype_id effect_bite( "bite" );
 static const efftype_id effect_bleed( "bleed" );

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -4572,7 +4572,7 @@ bool mattack::zombie_fuse( monster *z )
     }
     if ( critter->has_flag (mon_flag_ELECTRIC) ) {
         z->add_effect( effect_absorbed_electric, 60_days, true );
-    } else if ( critter->has_flag (mon_flag_ACIDTRAIL ) ) {
+    } else if ( critter->has_flag (mon_flag_ACIDTRAIL ) || critter->has_flag (mon_flag_ACID_BLOOD ) ) {
         z->add_effect( effect_absorbed_acidic, 60_days, true );
     }
 

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -101,6 +101,8 @@ static const damage_type_id damage_cut( "cut" );
 static const damage_type_id damage_electric( "electric" );
 static const damage_type_id damage_stab( "stab" );
 
+static const efftype_id effect_absorbed_acidic( "absorbed_acidic");
+static const efftype_id effect_absorbed_electric( "absorbed_electric");
 static const efftype_id effect_assisted( "assisted" );
 static const efftype_id effect_bite( "bite" );
 static const efftype_id effect_bleed( "bleed" );
@@ -4563,11 +4565,17 @@ bool mattack::zombie_fuse( monster *z )
                             critter->name(), z->name() );
     z->mod_moves( -to_moves<int>( 2_seconds ) );
     if( z->get_size() < creature_size::huge ) {
-        z->add_effect( effect_grown_of_fuse, 10_days, true,
+        z->add_effect( effect_grown_of_fuse, 60_days, true,
                        std::min( critter->get_hp_max(),
                                  ( 80 * ( critter->get_volume() / 62500_ml ) ) )
                        + z->get_effect( effect_grown_of_fuse ).get_intensity() );
     }
+    if ( critter->has_flag (mon_flag_ELECTRIC) ) {
+        z->add_effect( effect_absorbed_electric, 60_days, true );
+    } else if ( critter->has_flag (mon_flag_ACIDTRAIL ) ) {
+        z->add_effect( effect_absorbed_acidic, 60_days, true );
+    }
+
     z->heal( critter->get_hp(), true );
     if( mission::on_creature_fusion( *z, *critter ) ) {
         z->mission_fused.emplace_back( critter->name() );

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -4565,11 +4565,20 @@ bool mattack::zombie_fuse( monster *z )
     add_msg_if_player_sees( *z, _( "The %1$s fuses with the %2$s." ),
                             critter->name(), z->name() );
     z->mod_moves( -to_moves<int>( 2_seconds ) );
+    int hp_or_vlm = std::min( critter->get_hp_max(), ( 80 * ( critter->get_volume() / 62500_ml ) ) );
+    const int existing_intensity = z->has_effect( effect_grown_of_fuse ) ?
+                                   z->get_effect( effect_grown_of_fuse ).get_intensity() :
+                                   0;
+    const int new_intensity = hp_or_vlm + existing_intensity;
+    add_msg_debug( debugmode::DF_MATTACK,
+                   "%s adding %d total grown_of_fuse intensity from %d hp/volume and %d existing intensity",
+                   z->name(),
+                   new_intensity,
+                   hp_or_vlm,
+                   existing_intensity );
+
     if( z->get_size() < creature_size::huge ) {
-        z->add_effect( effect_grown_of_fuse, 60_days, true,
-                       std::min( critter->get_hp_max(),
-                                 ( 80 * ( critter->get_volume() / 62500_ml ) ) )
-                       + z->get_effect( effect_grown_of_fuse ).get_intensity() );
+        z->add_effect( effect_grown_of_fuse, 10_days, true, new_intensity );
     }
     if( critter->has_flag( mon_flag_ELECTRIC ) ) {
         z->add_effect( effect_absorbed_electric, 60_days, true );

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -4571,7 +4571,7 @@ bool mattack::zombie_fuse( monster *z )
                                  ( 80 * ( critter->get_volume() / 62500_ml ) ) )
                        + z->get_effect( effect_grown_of_fuse ).get_intensity() );
     }
-    if ( critter->has_flag (mon_flag_ELECTRIC) ) {
+    if( critter->has_flag( mon_flag_ELECTRIC ) ) {
         z->add_effect( effect_absorbed_electric, 60_days, true );
     } else if ( critter->has_flag (mon_flag_ACIDTRAIL ) || critter->has_flag (mon_flag_ACID_BLOOD ) ) {
         z->add_effect( effect_absorbed_acidic, 60_days, true );

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -4576,7 +4576,7 @@ bool mattack::zombie_fuse( monster *z )
     } else if( critter->has_flag( mon_flag_ACIDTRAIL ) || critter->has_flag( mon_flag_ACID_BLOOD ) ) {
         z->add_effect( effect_absorbed_acidic, 60_days, true );
         // Use SMALLSLUDGETRAIL because pupating zombies have that in common
-    } else if ( critter->has_flag (mon_flag_SMALLSLUDGETRAIL) ) {
+    } else if( critter->has_flag( mon_flag_SMALLSLUDGETRAIL ) ) {
         z->add_effect( effect_absorbed_pupating, 60_days, true );
     }
 

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -4573,7 +4573,7 @@ bool mattack::zombie_fuse( monster *z )
     }
     if( critter->has_flag( mon_flag_ELECTRIC ) ) {
         z->add_effect( effect_absorbed_electric, 60_days, true );
-    } else if ( critter->has_flag (mon_flag_ACIDTRAIL ) || critter->has_flag (mon_flag_ACID_BLOOD ) ) {
+    } else if( critter->has_flag( mon_flag_ACIDTRAIL ) || critter->has_flag( mon_flag_ACID_BLOOD ) ) {
         z->add_effect( effect_absorbed_acidic, 60_days, true );
         // Use SMALLSLUDGETRAIL because pupating zombies have that in common
     } else if ( critter->has_flag (mon_flag_SMALLSLUDGETRAIL) ) {

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -58,8 +58,8 @@
 static const damage_type_id damage_bash( "bash" );
 static const damage_type_id damage_cut( "cut" );
 
-static const efftype_id effect_absorbed_acidic( "absorbed_acidic");
-static const efftype_id effect_absorbed_electric( "absorbed_electric");
+static const efftype_id effect_absorbed_acidic( "absorbed_acidic" );
+static const efftype_id effect_absorbed_electric( "absorbed_electric" );
 static const efftype_id effect_bouldering( "bouldering" );
 static const efftype_id effect_countdown( "countdown" );
 static const efftype_id effect_cramped_space( "cramped_space" );

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -58,6 +58,8 @@
 static const damage_type_id damage_bash( "bash" );
 static const damage_type_id damage_cut( "cut" );
 
+static const efftype_id effect_absorbed_acidic( "absorbed_acidic");
+static const efftype_id effect_absorbed_electric( "absorbed_electric");
 static const efftype_id effect_bouldering( "bouldering" );
 static const efftype_id effect_countdown( "countdown" );
 static const efftype_id effect_cramped_space( "cramped_space" );
@@ -122,13 +124,13 @@ bool monster::is_immune_field( const field_type_id &fid ) const
         return has_flag( mon_flag_NO_BREATHE );
     }
     if( ft.has_acid ) {
-        return has_flag( mon_flag_ACIDPROOF ) || flies();
+        return has_flag( mon_flag_ACIDPROOF ) || flies() || has_effect( effect_absorbed_acidic );
     }
     if( ft.has_fire ) {
         return has_flag( mon_flag_FIREPROOF );
     }
     if( ft.has_elec ) {
-        return has_flag( mon_flag_ELECTRIC );
+        return has_flag( mon_flag_ELECTRIC ) || has_effect( effect_absorbed_electric );
     }
     if( ft.immune_mtypes.count( type->id ) > 0 ) {
         return true;

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -100,6 +100,7 @@ static const damage_type_id damage_electric( "electric" );
 static const damage_type_id damage_heat( "heat" );
 static const damage_type_id damage_stab( "stab" );
 
+static const efftype_id effect_absorbed_electric( "absorbed_electric");
 static const efftype_id effect_badpoison( "badpoison" );
 static const efftype_id effect_beartrap( "beartrap" );
 static const efftype_id effect_bleed( "bleed" );
@@ -3674,7 +3675,7 @@ bool monster::is_hallucination() const
 
 bool monster::is_electrical() const
 {
-    return in_species( species_ROBOT ) || has_flag( mon_flag_ELECTRIC ) || in_species( species_CYBORG );
+    return in_species( species_ROBOT ) || has_flag( mon_flag_ELECTRIC ) || in_species( species_CYBORG ) || has_effect( effect_absorbed_electric );
 }
 
 bool monster::is_fae() const

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -100,7 +100,7 @@ static const damage_type_id damage_electric( "electric" );
 static const damage_type_id damage_heat( "heat" );
 static const damage_type_id damage_stab( "stab" );
 
-static const efftype_id effect_absorbed_electric( "absorbed_electric");
+static const efftype_id effect_absorbed_electric( "absorbed_electric" );
 static const efftype_id effect_badpoison( "badpoison" );
 static const efftype_id effect_beartrap( "beartrap" );
 static const efftype_id effect_bleed( "bleed" );

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3675,7 +3675,8 @@ bool monster::is_hallucination() const
 
 bool monster::is_electrical() const
 {
-    return in_species( species_ROBOT ) || has_flag( mon_flag_ELECTRIC ) || in_species( species_CYBORG ) || has_effect( effect_absorbed_electric );
+    return in_species( species_ROBOT ) || has_flag( mon_flag_ELECTRIC ) ||
+           in_species( species_CYBORG ) || has_effect( effect_absorbed_electric );
 }
 
 bool monster::is_fae() const

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -483,6 +483,14 @@ void debug_menu::wisheffect( Creature &p )
             descstr << eff.disp_name() << '\n';
         }
 
+        descstr << _( "Current intensity: " );
+        descstr << eff.get_intensity();
+
+        descstr << _( " Max intensity: " );
+        descstr << eff.get_max_intensity();
+
+        descstr << '\n';
+
         descstr << _( "Intensity threshold: " );
         descstr <<  colorize( std::to_string( to_seconds<int>( efft.intensity_duration() ) ),
                               c_yellow );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Balance "Devourers gain abilities and resilience from devouring"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Right now, the pro strat is to lure other zombies to the devourers, because devourers get more HP when they absorb other zombies but...that's it. Whatever special abilities those other zombies had just go poof into the ether. 

No more (mostly)
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Give devourers a _bunch_ of new attacks that key off how many HP of zombies they've absorbed. They get more grabs and some bites (including one ranged bite, mouths on a pillar of flesh), and at very high HP they get a ranged `smash` attack (just an arm made of multiple entire zombie hitting you, no biggie). 

In addition, track some types of absorptions. If the devourer absorbs an acid zombie, they become immune to acid and gain an acid claw attack. If they absorb a shocker zombie, they become immune to electricity and will gain a charge up zap attack once #84679 is finished. If they absorb a pupating zombie, they can launch out flesh raptors (and do it repeatedly--after all, they have regeneration, so they don't need to explode to do it). 

Finally, devourers take less physical damage the more zombies they've absorbed in addition to gaining more HP. 

Edit: Not finally, it turns out devourers have been broken for who knows how long, possibly since they were added. They're supposed to gain bonus stats from the `grown_of_fuse` effect, which is supposed to increase in intensity as the devourer absorbs more creatures, but since the fusion attack is bugged and only ever added `grown_of_fuse` at intensity 1, the only bonus they gain is HP. So fix that. Key the armor increase and speed increase directly into `grown_of_fuse`, and add a regen buff as well. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Well, I killed one but:

<img width="188" height="117" alt="image" src="https://github.com/user-attachments/assets/50bdaa0c-9bd2-4d16-80a4-899ce92a79f8" />

(I also wasn't wearing armor...but also the one I was fighting didn't have any pupating, electric, or acid attacks)
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
