### PR TITLE
Knife sharpeners

### DIFF
--- a/data/json/faults/fault_fixes_melee.json
+++ b/data/json/faults/fault_fixes_melee.json
@@ -8,7 +8,7 @@
     "faults_removed": [ "fault_blade_rolled_edge", "fault_blade_chipped", "fault_blade_broken_tip", "fault_blade_bent_tip" ],
     "mod_damage": -1000,
     "mod_degradation": 5,
-    "requirements": [ { "qualities": [ { "id": "GRIND", "level": 2 } ] } ]
+    "requirements": [ { "qualities": [ { "id": "GRIND", "level": 1 } ] } ]
   },
   {
     "type": "fault_fix",
@@ -19,7 +19,7 @@
     "faults_removed": [ "fault_spearhead_fracture", "fault_spearhead_warped", "fault_spearhead_chipping" ],
     "mod_damage": -1000,
     "mod_degradation": 5,
-    "requirements": [ { "qualities": [ { "id": "GRIND", "level": 2 } ] } ]
+    "requirements": [ { "qualities": [ { "id": "GRIND", "level": 1 } ] } ]
   },
   {
     "type": "fault_fix",

--- a/data/json/itemgroups/SUS/domestic.json
+++ b/data/json/itemgroups/SUS/domestic.json
@@ -101,7 +101,10 @@
       { "item": "scissors", "prob": 80 },
       { "item": "peeler", "prob": 75, "count": [ 1, 2 ] },
       { "item": "cutting_board", "count": [ 1, 2 ] },
-      { "item": "cutting_board", "prob": 75 }
+      { "item": "cutting_board", "prob": 75 },
+      {
+        "distribution": [ { "item": "metal_honing_rod", "prob": 35 }, { "item": "knife_sharpener_handheld", "prob": 60 } ]
+      }
     ]
   },
   {

--- a/data/json/items/tool/cooking.json
+++ b/data/json/items/tool/cooking.json
@@ -1158,7 +1158,8 @@
     "material": [ "lc_steel" ],
     "symbol": ";",
     "color": "light_gray",
-    "qualities": [ [ "GRIND", 1 ] ]
+    "qualities": [ [ "GRIND", 1 ] ],
+    "flags": [ "NO_SALVAGE" ]
   },
   {
     "id": "knife_sharpener_handheld",
@@ -1174,6 +1175,7 @@
     "material": [ "lc_steel" ],
     "symbol": ";",
     "color": "light_gray",
-    "qualities": [ [ "GRIND", 1 ] ]
+    "qualities": [ [ "GRIND", 1 ] ],
+    "flags": [ "NO_SALVAGE" ]
   }
 ]

--- a/data/json/items/tool/cooking.json
+++ b/data/json/items/tool/cooking.json
@@ -1143,5 +1143,37 @@
     "countdown_interval": "14 days",
     "revert_to": "sugar",
     "flags": [ "NO_SALVAGE", "WATER_DISSOLVE", "SPAWN_ACTIVE" ]
+  },
+  {
+    "id": "metal_honing_rod",
+    "type": "ITEM",
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "honing rod" },
+    "description": "A steel rod with fine grit used to hone the edge of knives.",
+    "weight": "76 g",
+    "volume": "250 ml",
+    "longest_side": "30 cm",
+    "price": "15 USD",
+    "price_postapoc": "1 USD",
+    "material": [ "lc_steel" ],
+    "symbol": ";",
+    "color": "light_gray",
+    "qualities": [ [ "GRIND", 1 ] ]
+  },
+  {
+    "id": "knife_sharpener_handheld",
+    "type": "ITEM",
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "handheld knife sharpener" },
+    "description": "A tool with slots of grits for sharpening knives.",
+    "weight": "180 g",
+    "volume": "150 ml",
+    "longest_side": "20 cm",
+    "price": "18 USD",
+    "price_postapoc": "1 USD",
+    "material": [ "lc_steel" ],
+    "symbol": ";",
+    "color": "light_gray",
+    "qualities": [ [ "GRIND", 1 ] ]
   }
 ]


### PR DESCRIPTION

#### Summary
None

#### Purpose of change

Adds some Grinding 1 tools and change the "Grind the edge" fault fix to require atleast Grinding one.

#### Describe the solution
- Adds knife sharpener and honing rod
- put it in the SUS knife drawer itemgroup
- change "Grind the edge" fault fix requirement to use atleast Grinding 1

#### Describe alternatives you've considered

Not doing so.
#### Testing
![Screenshot_20260123_074317](https://github.com/user-attachments/assets/130d1f66-186f-4d30-99f2-b27f23f3aae2)
![Screenshot_20260123_073513](https://github.com/user-attachments/assets/39e608d7-e5c8-4a95-9963-cbd59382d5e3)
![Screenshot_20260123_030026](https://github.com/user-attachments/assets/03a42a6e-4d12-4a8b-a8e8-52d07e15d222)


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
