### PR TITLE
nomad utility belt blowers make noise + 2 variants

### DIFF
--- a/data/json/items/armor/bespoke_armor/utility.json
+++ b/data/json/items/armor/bespoke_armor/utility.json
@@ -206,12 +206,12 @@
     "type": "ITEM",
     "subtypes": [ "ARMOR", "TOOL" ],
     "name": { "str": "nomad utility belt" },
-    "description": "A sturdy leather belt and powered air purifying respirator blower designed for exploring the apocalyptic wasteland.  On one side hangs an archaic dagger sheath.  The other side is lined with 10 cartridge loops fit for 27.3x110 Diyua shells.  Mounted to the back is a spartan PAPR blower, shielded in plastic, with connections for a bionic interface.  Paired with a PAPR mask this will protect from all manner of post-apocalyptic environmental threats.  Activate it to turn it on.",
+    "description": "A sturdy leather belt and powered air purifying respirator blower designed for exploring the apocalyptic wasteland.  On one side hangs an archaic dagger sheath.  The other side is lined with 10 cartridge loops fit for 27.3x110 Diyua shotshells.  Mounted to the back is a spartan PAPR blower, shielded in plastic, with connections for a bionic interface.  Paired with a PAPR mask this will protect from all manner of post-apocalyptic environmental threats.  Activate it to turn it on.",
     "weight": "1549 g",
     "volume": "2250 ml",
     "price": "150 USD",
     "price_postapoc": "25 USD",
-    "material": [ "leather" ],
+    "material": [ "leather", "plastic" ],
     "symbol": "[",
     "looks_like": "holster",
     "color": "brown",
@@ -241,11 +241,40 @@
   },
   {
     "id": "nomad_papr_blower_273diyua_on",
-    "//": "The exodii PAPR, with space for a baselard and handcanon shells",
     "type": "ITEM",
     "subtypes": [ "ARMOR", "TOOL" ],
+    "copy-from": "nomad_papr_blower_273diyua_off",
     "name": { "str": "nomad utility belt (on)", "str_pl": "nomad utility belts (on)" },
-    "description": "A sturdy leather belt and powered air purifying respirator blower designed for exploring the apocalyptic wasteland.  On one side hangs an archaic dagger sheath.  The other side is lined with 10 cartridge loops fit for 27.3x110 Diyua shells.  Mounted to the back is a spartan PAPR blower, shielded in plastic, with connections for a bionic interface.  Paired with a PAPR mask this will protect from all manner of post-apocalyptic environmental threats.  Activate it to turn it on.",
+    "description": "A sturdy leather belt and powered air purifying respirator blower designed for exploring the apocalyptic wasteland.  On one side hangs an archaic dagger sheath.  The other side is lined with 10 cartridge loops fit for 27.3x110 Diyua shotshells.  Mounted to the back is a spartan PAPR blower, shielded in plastic, with connections for a bionic interface.  Paired with a PAPR mask this will protect from all manner of post-apocalyptic environmental threats.  The blower is active and draining power.  Activate it to turn it off.",
+    "use_action": [
+      { "type": "holster", "holster_prompt": "Store item", "holster_msg": "You put your %1$s in your %2$s" },
+      {
+        "menu_text": "Turn off",
+        "type": "transform",
+        "msg": "You turn the PAPR blower on the %s off.",
+        "target": "nomad_papr_blower_273diyua_off",
+        "ammo_scale": 0
+      }
+    ],
+    "power_draw": "4000 mW",
+    "revert_to": "nomad_papr_blower_273diyua_off",
+    "tick_action": {
+      "type": "sound",
+      "sound_type": "movement",
+      "sound_message": "whooooo…",
+      "sound_id": "humming",
+      "sound_variant": "machinery",
+      "sound_volume": 12
+    },
+    "extend": { "flags": [ "PAPR_BLOWER", "TRADER_AVOID", "SPAWN_ACTIVE" ] }
+  },
+  {
+    "id": "nomad_papr_blower_magpouch_off",
+    "//": "The exodii PAPR, with space for a baselard and battle rifle mags",
+    "type": "ITEM",
+    "subtypes": [ "ARMOR", "TOOL" ],
+    "name": { "str": "nomad utility belt" },
+    "description": "A sturdy leather belt and powered air purifying respirator blower designed for exploring the apocalyptic wasteland.  On one side hangs an archaic dagger sheath.  The other side has three pouches, each fit for a 26-round PA md. 68 box magazine (although anything that size or smaller will fit).  Mounted to the back is a spartan PAPR blower, shielded in plastic, with connections for a bionic interface.  Paired with a PAPR mask this will protect from all manner of post-apocalyptic environmental threats.  Activate it to turn it on.",
     "weight": "1549 g",
     "volume": "2250 ml",
     "price": "150 USD",
@@ -264,22 +293,141 @@
         "moves": 20,
         "flag_restriction": [ "SHEATH_KNIFE" ]
       },
-      { "ammo_restriction": { "273x110": 10 }, "moves": 25, "volume_encumber_modifier": 0.3 }
+      {
+        "pocket_type": "CONTAINER",
+        "max_item_length": "255 mm",
+        "max_contains_volume": "400 ml",
+        "max_contains_weight": "2 kg",
+        "moves": 40,
+        "flag_restriction": [ "MAG_COMPACT" ],
+        "volume_encumber_modifier": 0.3
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "max_item_length": "255 mm",
+        "max_contains_volume": "400 ml",
+        "max_contains_weight": "2 kg",
+        "moves": 40,
+        "flag_restriction": [ "MAG_COMPACT" ],
+        "volume_encumber_modifier": 0.3
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "max_item_length": "255 mm",
+        "max_contains_volume": "400 ml",
+        "max_contains_weight": "2 kg",
+        "moves": 40,
+        "flag_restriction": [ "MAG_COMPACT" ],
+        "volume_encumber_modifier": 0.3
+      }
     ],
     "tool_ammo": [ "battery" ],
+    "use_action": [
+      { "type": "holster", "holster_prompt": "Store item", "holster_msg": "You put your %1$s in your %2$s" },
+      {
+        "type": "transform",
+        "msg": "You activate the PAPR blower on your %s.",
+        "target": "nomad_papr_blower_magpouch_on"
+      }
+    ],
+    "flags": [ "WATER_FRIENDLY", "STURDY", "BELTED", "OVERSIZE", "USES_BIONIC_POWER" ],
+    "armor": [ { "encumbrance": [ 2, 6 ], "coverage": 100, "covers": [ "torso" ], "specifically_covers": [ "torso_waist" ] } ]
+  },
+  {
+    "id": "nomad_papr_blower_magpouch_on",
+    "type": "ITEM",
+    "subtypes": [ "ARMOR", "TOOL" ],
+    "copy-from": "nomad_papr_blower_magpouch_off",
+    "name": { "str": "nomad utility belt (on)", "str_pl": "nomad utility belts (on)" },
+    "description": "A sturdy leather belt and powered air purifying respirator blower designed for exploring the apocalyptic wasteland.  On one side hangs an archaic dagger sheath.  The other side has three pouches made to snugly and securely hold 26-round PA md. 68 box magazines, although anything that size or smaller will fit.  Mounted to the back is a spartan PAPR blower, shielded in plastic, with connections for a bionic interface.  Paired with a PAPR mask this will protect from all manner of post-apocalyptic environmental threats.  The blower is active and draining power.  Activate it to turn it off.",
     "use_action": [
       { "type": "holster", "holster_prompt": "Store item", "holster_msg": "You put your %1$s in your %2$s" },
       {
         "menu_text": "Turn off",
         "type": "transform",
         "msg": "You turn the PAPR blower on the %s off.",
-        "target": "nomad_papr_blower_273diyua_off",
+        "target": "nomad_papr_blower_magpouch_off",
         "ammo_scale": 0
       }
     ],
     "power_draw": "4000 mW",
-    "revert_to": "nomad_papr_blower_273diyua_off",
-    "flags": [ "WATER_FRIENDLY", "STURDY", "BELTED", "OVERSIZE", "USES_BIONIC_POWER", "PAPR_BLOWER", "TRADER_AVOID", "SPAWN_ACTIVE" ],
+    "revert_to": "nomad_papr_blower_magpouch_off",
+    "tick_action": {
+      "type": "sound",
+      "sound_type": "movement",
+      "sound_message": "whooooo…",
+      "sound_id": "humming",
+      "sound_variant": "machinery",
+      "sound_volume": 12
+    },
+    "extend": { "flags": [ "PAPR_BLOWER", "TRADER_AVOID", "SPAWN_ACTIVE" ] }
+  },
+  {
+    "id": "nomad_papr_blower_273grenade_off",
+    "//": "The exodii PAPR, with space for a baselard and Diyua grenade shells",
+    "type": "ITEM",
+    "subtypes": [ "ARMOR", "TOOL" ],
+    "name": { "str": "nomad utility belt" },
+    "description": "A sturdy leather belt and powered air purifying respirator blower designed for exploring the apocalyptic wasteland.  On one side hangs an archaic dagger sheath.  The other side is lined with 10 leather and plastic clips fit for 27.3x Diyua grenades.  Mounted to the back is a spartan PAPR blower, shielded in plastic, with connections for a bionic interface.  Paired with a PAPR mask this will protect from all manner of post-apocalyptic environmental threats.  Activate it to turn it on.",
+    "weight": "1549 g",
+    "volume": "2250 ml",
+    "price": "150 USD",
+    "price_postapoc": "25 USD",
+    "material": [ "leather", "plastic" ],
+    "symbol": "[",
+    "looks_like": "holster",
+    "color": "brown",
+    "material_thickness": 2,
+    "pocket_data": [
+      {
+        "holster": true,
+        "max_contains_volume": "1 L",
+        "max_contains_weight": "2 kg",
+        "max_item_length": "70 cm",
+        "moves": 20,
+        "flag_restriction": [ "SHEATH_KNIFE" ]
+      },
+      { "ammo_restriction": { "273x44": 10 }, "moves": 25, "volume_encumber_modifier": 0.3 }
+    ],
+    "tool_ammo": [ "battery" ],
+    "use_action": [
+      { "type": "holster", "holster_prompt": "Store item", "holster_msg": "You put your %1$s in your %2$s" },
+      {
+        "type": "transform",
+        "msg": "You activate the PAPR blower on your %s.",
+        "target": "nomad_papr_blower_273grenade_on"
+      }
+    ],
+    "flags": [ "WATER_FRIENDLY", "STURDY", "BELTED", "OVERSIZE", "USES_BIONIC_POWER" ],
     "armor": [ { "encumbrance": [ 2, 6 ], "coverage": 100, "covers": [ "torso" ], "specifically_covers": [ "torso_waist" ] } ]
+  },
+  {
+    "id": "nomad_papr_blower_273grenade_on",
+    "type": "ITEM",
+    "subtypes": [ "ARMOR", "TOOL" ],
+    "copy-from": "nomad_papr_blower_273grenade_off",
+    "name": { "str": "nomad utility belt (on)", "str_pl": "nomad utility belts (on)" },
+    "description": "A sturdy leather belt and powered air purifying respirator blower designed for exploring the apocalyptic wasteland.  On one side hangs an archaic dagger sheath.  The other side is lined with 10 leather and plastic clips fit for 27.3x Diyua grenades.  Mounted to the back is a spartan PAPR blower, shielded in plastic, with connections for a bionic interface.  Paired with a PAPR mask this will protect from all manner of post-apocalyptic environmental threats.  The blower is active and draining power.  Activate it to turn it off.",
+    "use_action": [
+      { "type": "holster", "holster_prompt": "Store item", "holster_msg": "You put your %1$s in your %2$s" },
+      {
+        "menu_text": "Turn off",
+        "type": "transform",
+        "msg": "You turn the PAPR blower on the %s off.",
+        "target": "nomad_papr_blower_273grenade_off",
+        "ammo_scale": 0
+      }
+    ],
+    "power_draw": "4000 mW",
+    "revert_to": "nomad_papr_blower_273grenade_off",
+    "tick_action": {
+      "type": "sound",
+      "sound_type": "movement",
+      "sound_message": "whooooo…",
+      "sound_id": "humming",
+      "sound_variant": "machinery",
+      "sound_volume": 12
+    },
+    "extend": { "flags": [ "PAPR_BLOWER", "TRADER_AVOID", "SPAWN_ACTIVE" ] }
   }
 ]

--- a/data/json/recipes/armor/bespoke_armor/nomad.json
+++ b/data/json/recipes/armor/bespoke_armor/nomad.json
@@ -278,6 +278,64 @@
     "flags": [ "SECRET" ]
   },
   {
+    "result": "nomad_papr_blower_273grenade_off",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_STORAGE",
+    "activity_level": "LIGHT_EXERCISE",
+    "skill_used": "tailor",
+    "difficulty": 6,
+    "skills_required": [ "electronics", 3 ],
+    "time": "5 h",
+    "book_learn": [ [ "bp_nomad_jumpsuit", 4 ] ],
+    "using": [ [ "filament_canvas", 150 ], [ "soldering_standard", 10 ] ],
+    "proficiencies": [
+      { "proficiency": "prof_leatherworking_basic" },
+      { "proficiency": "prof_leatherworking" },
+      { "proficiency": "prof_closures_waterproofing" }
+    ],
+    "qualities": [ { "id": "LEATHER_AWL", "level": 1 }, { "id": "SEW", "level": 2 }, { "id": "FABRIC_CUT", "level": 1 } ],
+    "components": [
+      [ [ "leather", 4 ], [ "tanned_hide", 1 ], [ "sheet_leather", 1 ], [ "sheet_leather_patchwork", 1 ] ],
+      [ [ "sheath", 1 ] ],
+      [ [ "exodii_wire_kit", 1 ] ],
+      [ [ "basic_papr_belt_off", 1 ], [ "military_papr_blower_off", 1 ], [ "molle_papr_blower_off", 1 ] ],
+      [ [ "plastic_sheet", 2 ] ],
+      [ [ "tool_belt", 1 ] ]
+    ],
+    "byproducts": [ [ "scrap_leather", 11 ] ],
+    "flags": [ "SECRET" ]
+  },
+  {
+    "result": "nomad_papr_blower_magpouch_off",
+    "type": "recipe",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_STORAGE",
+    "activity_level": "LIGHT_EXERCISE",
+    "skill_used": "tailor",
+    "difficulty": 6,
+    "skills_required": [ "electronics", 3 ],
+    "time": "5 h",
+    "book_learn": [ [ "bp_nomad_jumpsuit", 4 ] ],
+    "using": [ [ "filament_canvas", 150 ], [ "soldering_standard", 10 ] ],
+    "proficiencies": [
+      { "proficiency": "prof_leatherworking_basic" },
+      { "proficiency": "prof_leatherworking" },
+      { "proficiency": "prof_closures_waterproofing" }
+    ],
+    "qualities": [ { "id": "LEATHER_AWL", "level": 1 }, { "id": "SEW", "level": 2 }, { "id": "FABRIC_CUT", "level": 1 } ],
+    "components": [
+      [ [ "leather", 4 ], [ "tanned_hide", 1 ], [ "sheet_leather", 1 ], [ "sheet_leather_patchwork", 1 ] ],
+      [ [ "sheath", 1 ] ],
+      [ [ "exodii_wire_kit", 1 ] ],
+      [ [ "basic_papr_belt_off", 1 ], [ "military_papr_blower_off", 1 ], [ "molle_papr_blower_off", 1 ] ],
+      [ [ "plastic_sheet", 2 ] ],
+      [ [ "tool_belt", 1 ] ]
+    ],
+    "byproducts": [ [ "scrap_leather", 11 ] ],
+    "flags": [ "SECRET" ]
+  },
+  {
     "result": "helmet_nomad_papr",
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "2 more nomad PAPR blowers + noise"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

 #84421 predated and was merged after #84615, so the exodii PAPR belts didn't make noise.  They also came in one flavor, which held hand cannon shells.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Added noise to the active items (12, like other PAPR items).

Added 2 new variants.  One that holds 10 Diyua grenades, and another that holds 3 battle rifle magazines.  Crafts are learned all together from the same blueprint as before.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Different names for the variants, but players will presumably only have 1 at a time, and can parse them by description/pockets.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Spawned items, turned on and off, loaded with things.  Checked crafts.  Learned crafts from books.  Crafted items.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I also simplified the (on) variant entries to copy-from the off entries.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
