### PR TITLE
Reduce the rate of siphoning/drawing liquids from vehicles 

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -247,7 +247,10 @@ void activity_handlers::fill_liquid_do_turn( player_activity *act, Character *yo
                 break;
         }
 
-        static const units::volume volume_per_second = units::from_liter( 4.0F / 6.0F );
+        // Vehicle siphoning is slower than other liquid transfers
+        const units::volume volume_per_second = source_type == liquid_source_type::VEHICLE
+                                                ? units::from_liter( 0.25F )
+                                                : units::from_liter( 4.0F / 6.0F );
         const int charges_per_second = std::max( 1, liquid.charges_per_volume( volume_per_second ) );
         liquid.charges = std::min( charges_per_second, liquid.charges );
         const int original_charges = liquid.charges;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Balance "Reduce the rate of siphoning and drawing a liquid from vehicle from 0.66L to 0.25L per second"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Make it more realistic
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
0.25L or 15L per minute is still too fast, but it's a good enough value. The flow rate of an RV tap goes from 3 to 12 liters per minute, a super optimistic flow rate of siphoning gas from a gas tank with a hose is maybe 10 liters per minute.

0.25L will help keep consistency between 0.25L liquids (like water with 4 charges per liter) and more granular liquids (like gas with 1000 charges per liter)
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
1) Lower it even further, it'll create a discrepancy between water and granular liquid flow rate which is probably fine but a bit silly
or
2) change the logic from charges_per_second to some sort of seconds_per_volume, too complicated
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Before - siphoning 60L took 1.5 minutes -> 40L per minute

Drawing from a standing tank - no change, as expected
Drawing from a gas pump - no change, as expected
Drawing from an RV faucet by interacting with the vehicle component - 60L took 4 minutes -> 15L per minute
Siphoning gas from vehicle's gas tank - 60L took 4 minutes -> 15L per minute
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
