### PR TITLE
Show time to complete in hotwire option

### DIFF
--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -2060,15 +2060,18 @@ void vehicle::build_interact_menu( veh_menu &menu, map *here, const tripoint_bub
 
     if( ( is_locked || has_security_working( *here ) ) && controls_here ) {
         if( player_inside ) {
+            ///\EFFECT_MECHANICS speeds up vehicle hotwiring
+            const float skill = std::max( 1.0f, get_player_character().get_skill_level( skill_mechanics ) );
+            const time_duration required_time = 6000_seconds / skill;
+            const std::string time_string = colorize( to_string( required_time, true ), c_light_gray );
+
             menu.add( _( "Hotwire" ) )
             .enable( get_player_character().crafting_inventory().has_quality( qual_SCREW ) )
-            .desc( _( "Attempt to hotwire the car using a screwdriver." ) )
+            .desc( _( "Attempt to hotwire the car using a screwdriver.\nTime to complete: " ) + time_string )
             .skip_locked_check()
             .hotkey( "HOTWIRE" )
-            .on_submit( [this] {
-                ///\EFFECT_MECHANICS speeds up vehicle hotwiring
-                const float skill = std::max( 1.0f, get_player_character().get_skill_level( skill_mechanics ) );
-                const int moves = to_moves<int>( 6000_seconds / skill );
+            .on_submit( [this, required_time] {
+                const int moves = to_moves<int>( required_time );
                 const tripoint_abs_ms target = pos_abs() + coord_translate( parts[0].mount );
                 const hotwire_car_activity_actor hotwire_act( moves, target );
                 get_player_character().assign_activity( hotwire_act );

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -2064,10 +2064,14 @@ void vehicle::build_interact_menu( veh_menu &menu, map *here, const tripoint_bub
             const float skill = std::max( 1.0f, get_player_character().get_skill_level( skill_mechanics ) );
             const time_duration required_time = 6000_seconds / skill;
             const std::string time_string = colorize( to_string( required_time, true ), c_light_gray );
+            std::string description = _( "Attempt to hotwire the car using a screwdriver." );
+            description += "\n";
+            description += _( "Time to complete: " );
+            description += time_string;
 
             menu.add( _( "Hotwire" ) )
             .enable( get_player_character().crafting_inventory().has_quality( qual_SCREW ) )
-            .desc( _( "Attempt to hotwire the car using a screwdriver.\nTime to complete: " ) + time_string )
+            .desc( description )
             .skip_locked_check()
             .hotkey( "HOTWIRE" )
             .on_submit( [this, required_time] {


### PR DESCRIPTION
#### Summary
Interface "Show time required to hotwire a car"

#### Purpose of change

Hotwiring a car takes a non-trivial amount of time.  We should expose that to the player as we would for an extended crafting action so they can make informed decisions.

#### Describe the solution

Add "Time to complete: …" to the description of the hotwiring option.

#### Describe alternatives you've considered

Try to fuzz out the time estimate to be less precise.  We don't do this for crafting, so I see no need to do it here.

#### Testing

Spawned a car and checked the hotwire description with different skill levels.  Practical 2.23 gives this:
<img width="290" height="187" alt="image" src="https://github.com/user-attachments/assets/cf7b747a-0111-469c-9a80-c8fd92303b40" />

There's a stray `.` above the last `r` in screwdriver in curses.  I'm not sure what's causing that but I don't think it should block this change.

#### Additional context

I'd like to add durations to many extended activities when a player is deciding to commit to them.  Picking locks and `iuse::hacksaw` come to mind.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
