### PR TITLE
10 more shipping container content nests

### DIFF
--- a/data/json/mapgen_palettes/container_yard.json
+++ b/data/json/mapgen_palettes/container_yard.json
@@ -848,18 +848,12 @@
   {
     "type": "mapgen",
     "nested_mapgen_id": "shipping_container_wardrobe_1x1",
-    "object": {
-      "mapgensize": [ 1, 1 ],
-      "furniture": { " ": "f_wardrobe" }
-    }
+    "object": { "mapgensize": [ 1, 1 ], "furniture": { " ": "f_wardrobe" } }
   },
   {
     "type": "mapgen",
     "nested_mapgen_id": "shipping_container_utility_shelf_1x1",
-    "object": {
-      "mapgensize": [ 1, 1 ],
-      "furniture": { " ": "f_utility_shelf" }
-    }
+    "object": { "mapgensize": [ 1, 1 ], "furniture": { " ": "f_utility_shelf" } }
   },
   {
     "type": "mapgen",
@@ -882,10 +876,7 @@
   {
     "type": "mapgen",
     "nested_mapgen_id": "shipping_container_vending_1x1",
-    "object": {
-      "mapgensize": [ 1, 1 ],
-      "furniture": { " ": "f_vending_c_off" }
-    }
+    "object": { "mapgensize": [ 1, 1 ], "furniture": { " ": "f_vending_c_off" } }
   },
   {
     "type": "mapgen",

--- a/data/json/mapgen_palettes/container_yard.json
+++ b/data/json/mapgen_palettes/container_yard.json
@@ -84,7 +84,17 @@
             [ "shipping_container_wind_instrument_1x1", 5 ],
             [ "shipping_container_string_instrument_1x1", 5 ],
             [ "shipping_container_fertilizer_1x1", 5 ],
-            [ "shipping_container_wine_keg_1x1", 5 ]
+            [ "shipping_container_wine_keg_1x1", 5 ],
+            [ "shipping_container_bedding_1x1", 5 ],
+            [ "shipping_container_stereos_1x1", 5 ],
+            [ "shipping_container_barrels_1x1", 5 ],
+            [ "shipping_container_barstools_1x1", 5 ],
+            [ "shipping_container_wardrobe_1x1", 5 ],
+            [ "shipping_container_television_1x1", 5 ],
+            [ "shipping_container_dentist_1x1", 5 ],
+            [ "shipping_container_vending_1x1", 5 ],
+            [ "shipping_container_gunmod_common_1x1", 2 ],
+            [ "shipping_container_gunmod_rare_1x1", 1 ]
           ]
         }
       },
@@ -798,5 +808,101 @@
     "type": "mapgen",
     "nested_mapgen_id": "shipping_container_wine_keg_1x1",
     "object": { "mapgensize": [ 1, 1 ], "items": { " ": { "item": "keg_wine_intact", "chance": 95 } } }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "shipping_container_bedding_1x1",
+    "object": {
+      "mapgensize": [ 1, 1 ],
+      "furniture": { " ": [ [ "f_crate_c", 70 ], [ "f_cardboard_box", 30 ] ] },
+      "items": { " ": { "item": "bed", "chance": 95 } }
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "shipping_container_stereos_1x1",
+    "object": {
+      "mapgensize": [ 1, 1 ],
+      "furniture": { " ": [ [ "f_crate_c", 70 ], [ "f_cardboard_box", 30 ] ] },
+      "item": { " ": { "item": "stereo", "chance": 85, "amount": [ 1, 2 ] } }
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "shipping_container_barrels_1x1",
+    "object": {
+      "mapgensize": [ 1, 1 ],
+      "furniture": { " ": [ [ "f_crate_c", 70 ], [ "f_cardboard_box", 30 ] ] },
+      "items": { " ": { "item": "barrels", "chance": 95 } }
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "shipping_container_barstools_1x1",
+    "object": {
+      "mapgensize": [ 1, 1 ],
+      "furniture": { " ": [ [ "f_crate_c", 70 ], [ "f_cardboard_box", 30 ] ] },
+      "item": { " ": { "item": "barstool", "chance": 85, "amount": [ 1, 5 ] } }
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "shipping_container_wardrobe_1x1",
+    "object": {
+      "mapgensize": [ 1, 1 ],
+      "furniture": { " ": "f_wardrobe" }
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "shipping_container_utility_shelf_1x1",
+    "object": {
+      "mapgensize": [ 1, 1 ],
+      "furniture": { " ": "f_utility_shelf" }
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "shipping_container_television_1x1",
+    "object": {
+      "mapgensize": [ 1, 1 ],
+      "furniture": { " ": "f_pallet_belted" },
+      "item": { " ": { "item": "television", "chance": 95, "amount": 2 } }
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "shipping_container_dentist_1x1",
+    "object": {
+      "mapgensize": [ 1, 1 ],
+      "furniture": { " ": [ [ "f_crate_c", 70 ], [ "f_cardboard_box", 30 ] ] },
+      "items": { " ": { "item": "dentist_supplies", "chance": 95, "repeat": [ 10, 20 ] } }
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "shipping_container_vending_1x1",
+    "object": {
+      "mapgensize": [ 1, 1 ],
+      "furniture": { " ": "f_vending_c_off" }
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "shipping_container_gunmod_common_1x1",
+    "object": {
+      "mapgensize": [ 1, 1 ],
+      "furniture": { " ": [ [ "f_crate_c", 70 ], [ "f_cardboard_box", 30 ] ] },
+      "items": { " ": { "item": "gunmod_common", "chance": 95, "repeat": [ 5, 10 ] } }
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "shipping_container_gunmod_rare_1x1",
+    "object": {
+      "mapgensize": [ 1, 1 ],
+      "furniture": { " ": [ [ "f_crate_c", 70 ], [ "f_cardboard_box", 30 ] ] },
+      "items": { " ": { "item": "gunmod_rare", "chance": 95, "repeat": [ 5, 10 ] } }
+    }
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "10 more shipping containers (85 total)"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Need more container variants.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Added 10 more, bringing total to 85 (+ empty containers).  Added benefits of making rarer containers rarer, which is good:

- bedding
- stereo systems
- barrels
- barstools
- wardrobe
- TVs
- dentistry supplies
- vending machines
- gunmods common (rare)
- gunmods rare (very rare)

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Different variants

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Loaded up, checked containers.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
