### PR TITLE
Clarify typos contained in long strings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 79

--- a/tools/spell_check_pr.py
+++ b/tools/spell_check_pr.py
@@ -27,7 +27,9 @@ for message in diff["added"]:
         bold_typo = "**" + typo + "**"
         if long_message:
             bold_typos.append(bold_typo)
-        message = '"' + re.sub(re.escape(typo), lambda _: bold_typo, message) + '"'
+        message = (
+            '"' + re.sub(re.escape(typo), lambda _: bold_typo, message) + '"'
+        )
     if long_message:
         message = " and ".join(bold_typos) + " in string: " + message
     errors.append(message)

--- a/tools/spell_check_pr.py
+++ b/tools/spell_check_pr.py
@@ -20,10 +20,16 @@ for message in diff["added"]:
     typos = set(spell_check(message))
     if len(typos) == 0:
         continue
-    message = message.replace('\n', "\\n")
+    long_message = len(message) > 125
+    message = message.replace("\n", "\\n")
+    bold_typos = []
     for typo in typos:
-        bold = "**" + typo + "**"
-        message = re.sub(re.escape(typo), lambda _: bold, message)
+        bold_typo = "**" + typo + "**"
+        if long_message:
+            bold_typos.append(bold_typo)
+        message = '"' + re.sub(re.escape(typo), lambda _: bold_typo, message) + '"'
+    if long_message:
+        message = " and ".join(bold_typos) + " in string: " + message
     errors.append(message)
 if errors:
     print("Spell checker encountered unrecognized words in the in-game text"


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Closes #67442
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
If a string containing one or more typos is greater than 125 characters the bot prepends the string with the typo(s) so you don't have to search for the bold word in some of our giant strings.
Also adds an override for python blacks autoformatting so I don't have to remember to change it myself for this project and maybe it'll be convenient for like 2 other peeps ever
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not making it conditional on length
If github just allowed colours this wouldn't be needed
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<details>
<summary>Test code</summary>

```py
import re

typosA = ["conectors"]
messageA = "An experimental and cumbersome augmented reality headset developed for the military.  It consists of a broad eyepiece, a rugged multi-camera array, and a puck computer, all designed to be strapped over a helmet.  The lenses are equipped with adaptive light correction, light amplification and thermal imaging, and an augmented reality overlay equipped with various gadgets, including a rangefinder and adaptive targeting system, making target acquisition quicker.  It has a few small conectors for external devices.  The AR system is currently turned on, and is continually draining batteries.  Use it to turn it off."

typosB = ["conectors", "continualy"]
messageB = "An experimental and cumbersome augmented reality headset developed for the military.  It consists of a broad eyepiece, a rugged multi-camera array, and a puck computer, all designed to be strapped over a helmet.  The lenses are equipped with adaptive light correction, light amplification and thermal imaging, and an augmented reality overlay equipped with various gadgets, including a rangefinder and adaptive targeting system, making target acquisition quicker.  It has a few small conectors for external devices.  The AR system is currently turned on, and is continualy draining batteries.  Use it to turn it off."

typosC = ["cumbursome"]
messageC = "An experimental and cumbursome augmented reality headset developed for the military."

typosD = ["cumbursome"]
messageD = "An experimental and cumbursome augmented reality headset developed for the military. An experimental and cumbursome augmented reality headset developed for the military."

def typo_message(typos, message):
    long_message = len(message) > 125
    message = message.replace("\n", "\\n")
    bold_typos = []
    for typo in typos:
        bold_typo = "**" + typo + "**"
        if long_message:
            bold_typos.append(bold_typo)
        message = '"' + re.sub(re.escape(typo), lambda _: bold_typo, message) + '"'
    if long_message:
        message = " and ".join(bold_typos) + " in string: " + message
    return message

print("*", typo_message(typosA, messageA))
print("*", typo_message(typosB, messageB))
print("*", typo_message(typosC, messageC))
print("*", typo_message(typosD, messageD))
```

</details>

<details>
<summary>Test output</summary>

* **conectors** in string: "An experimental and cumbersome augmented reality headset developed for the military.  It consists of a broad eyepiece, a rugged multi-camera array, and a puck computer, all designed to be strapped over a helmet.  The lenses are equipped with adaptive light correction, light amplification and thermal imaging, and an augmented reality overlay equipped with various gadgets, including a rangefinder and adaptive targeting system, making target acquisition quicker.  It has a few small **conectors** for external devices.  The AR system is currently turned on, and is continually draining batteries.  Use it to turn it off."
* **conectors** and **continualy** in string: ""An experimental and cumbersome augmented reality headset developed for the military.  It consists of a broad eyepiece, a rugged multi-camera array, and a puck computer, all designed to be strapped over a helmet.  The lenses are equipped with adaptive light correction, light amplification and thermal imaging, and an augmented reality overlay equipped with various gadgets, including a rangefinder and adaptive targeting system, making target acquisition quicker.  It has a few small **conectors** for external devices.  The AR system is currently turned on, and is **continualy** draining batteries.  Use it to turn it off.""
* "An experimental and **cumbursome** augmented reality headset developed for the military."
* **cumbursome** in string: "An experimental and **cumbursome** augmented reality headset developed for the military. An experimental and **cumbursome** augmented reality headset developed for the military."

</details>

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
