### PR TITLE
Clean up heat_activity_actor

### DIFF
--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -2757,8 +2757,9 @@ class heat_activity_actor : public activity_actor
     public:
         heat_activity_actor( drop_locations to_heat,
                              heating_requirements &requirements,
-                             heater h ) :
-            to_heat( std::move( to_heat ) ), requirements( requirements ), h( std::move( h ) ) {};
+                             heater heater_data ) :
+            to_heat( std::move( to_heat ) ), requirements( requirements ),
+            heater_data( std::move( heater_data ) ) {};
 
         const activity_id &get_type() const override {
             static const activity_id ACT_HEATING( "ACT_HEATING" );
@@ -2779,7 +2780,7 @@ class heat_activity_actor : public activity_actor
     private:
         drop_locations to_heat;
         heating_requirements requirements;
-        heater h;
+        heater heater_data;
 };
 
 class wear_activity_actor : public activity_actor

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -63,7 +63,6 @@ static const activity_id ACT_FERTILIZE_PLOT( "ACT_FERTILIZE_PLOT" );
 static const activity_id ACT_FETCH_REQUIRED( "ACT_FETCH_REQUIRED" );
 static const activity_id ACT_FILL_LIQUID( "ACT_FILL_LIQUID" );
 static const activity_id ACT_FIND_MOUNT( "ACT_FIND_MOUNT" );
-static const activity_id ACT_HEATING( "ACT_HEATING" );
 static const activity_id ACT_MULTIPLE_BUTCHER( "ACT_MULTIPLE_BUTCHER" );
 static const activity_id ACT_MULTIPLE_CHOP_PLANKS( "ACT_MULTIPLE_CHOP_PLANKS" );
 static const activity_id ACT_MULTIPLE_CHOP_TREES( "ACT_MULTIPLE_CHOP_TREES" );
@@ -140,8 +139,7 @@ activity_handlers::do_turn_functions = {
 const std::map< activity_id, std::function<void( player_activity *, Character * )> >
 activity_handlers::finish_functions = {
     { ACT_START_FIRE, start_fire_finish },
-    { ACT_REPAIR_ITEM, repair_item_finish },
-    { ACT_HEATING, heat_item_finish }
+    { ACT_REPAIR_ITEM, repair_item_finish }
 };
 
 static void assign_multi_activity( Character &you, const player_activity &act )
@@ -871,39 +869,6 @@ void repair_item_finish( player_activity *act, Character *you, bool no_menu )
     }
     // Otherwise keep retrying
     act->moves_left = actor->move_cost;
-}
-
-void activity_handlers::heat_item_finish( player_activity *act, Character *you )
-{
-    act->set_to_null();
-    if( act->targets.size() != 1 ) {
-        debugmsg( "invalid arguments to ACT_HEATING" );
-        return;
-    }
-    item_location &loc = act->targets[ 0 ];
-    item *const heat = loc.get_item();
-    if( heat == nullptr ) {
-        return;
-    }
-    if( !heat->has_temperature() ) {
-        debugmsg( "item %s is not heatable", heat->typeId().str() );
-        return;
-    }
-    item &target = *heat;
-    if( target.has_own_flag( flag_FROZEN ) ) {
-        target.apply_freezerburn();
-        if( target.has_flag( flag_EATEN_COLD ) ) {
-            target.cold_up();
-            you->add_msg_if_player( m_info,
-                                    _( "You defrost the food, but don't heat it up, since you enjoy it cold." ) );
-        } else {
-            target.heat_up();
-            you->add_msg_if_player( m_info, _( "You defrost and heat up the food." ) );
-        }
-    } else {
-        target.heat_up();
-        you->add_msg_if_player( m_info, _( "You heat up the food." ) );
-    }
 }
 
 void activity_handlers::travel_do_turn( player_activity *act, Character *you )

--- a/src/activity_handlers.h
+++ b/src/activity_handlers.h
@@ -220,7 +220,6 @@ extern const std::map< activity_id, std::function<void( player_activity *, Chara
 do_turn_functions;
 
 /** activity_finish functions: */
-void heat_item_finish( player_activity *act, Character *you );
 void repair_item_finish( player_activity *act, Character *you );
 void start_fire_finish( player_activity *act, Character *you );
 

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -8181,6 +8181,27 @@ static std::optional<std::pair<tripoint_bub_ms, itype_id>> appliance_heater_sele
 
 }
 
+void heater::serialize( JsonOut &jsout ) const
+{
+    jsout.start_object();
+    jsout.member( "heating_effect", heating_effect );
+    jsout.member( "loc", loc );
+    jsout.member( "consume_flag", consume_flag );
+    jsout.member( "pseudo_flag", pseudo_flag );
+    jsout.member( "vpt", vpt );
+    jsout.end_object();
+}
+
+void heater::deserialize( const JsonValue &jsin )
+{
+    JsonObject data = jsin.get_object();
+    data.read( "heating_effect", heating_effect );
+    data.read( "loc", loc );
+    data.read( "consume_flag", consume_flag );
+    data.read( "pseudo_flag", pseudo_flag );
+    data.read( "vpt", vpt );
+}
+
 heater find_heater( Character *p, item *it, bool force_use_it )
 {
     map &here = get_map();
@@ -8270,8 +8291,8 @@ static bool heat_items( Character *p, item *it, bool liquid_items, bool solid_it
     map &here = get_map();
 
     p->inv->restack( *p );
-    heater h = find_heater( p, it, force_use_it );
-    if( h.available_heater == -1 ) {
+    heater heater_data = find_heater( p, it, force_use_it );
+    if( heater_data.available_heater == -1 ) {
         add_msg( m_info, _( "Never mind." ) );
         return false;
     }
@@ -8302,7 +8323,7 @@ static bool heat_items( Character *p, item *it, bool liquid_items, bool solid_it
                      ( solid_items && !location->made_of_from_type( phase_id::LIQUID ) ) );
         } );
         auto make_raw_stats = [available_volume,
-                               h]( const std::vector<std::pair<item_location, int>> &locs
+                               heater_data]( const std::vector<std::pair<item_location, int>> &locs
         ) {
             units::volume used_volume = 0_ml;
             units::mass frozen_weight = 0_gram;
@@ -8338,8 +8359,8 @@ static bool heat_items( Character *p, item *it, bool liquid_items, bool solid_it
             const std::string volume = string_join( display_stat( "", used_volume.value(),
                                                     available_volume.value(),
                                                     to_string ), "" );
-            const std::string ammo = string_join( display_stat( "", required.ammo * h.heating_effect,
-                                                  h.available_heater,
+            const std::string ammo = string_join( display_stat( "", required.ammo * heater_data.heating_effect,
+                                                  heater_data.available_heater,
                                                   to_string ), "" );
             using stats = inventory_selector::stats;
             return inventory_selector::convert_stats_to_header_stats( stats{{
@@ -8385,7 +8406,7 @@ static bool heat_items( Character *p, item *it, bool liquid_items, bool solid_it
     if( multiple ? used_volume > available_volume : false ) {
         p->add_msg_if_player( _( "You need more space to contain these items." ) );
         return false;
-    } else if( h.available_heater < required.ammo * h.heating_effect ) {
+    } else if( heater_data.available_heater < required.ammo * heater_data.heating_effect ) {
         p->add_msg_if_player( _( "You need more energy to heat these items." ) );
         return false;
     }
@@ -8395,7 +8416,7 @@ static bool heat_items( Character *p, item *it, bool liquid_items, bool solid_it
     for( std::size_t i = 0; i < helpersize; i++ ) {
         add_msg( m_info, _( "%s helps with this task…" ), helpers[i]->get_name() );
     }
-    p->assign_activity( heat_activity_actor( to_heat, required, h ) );
+    p->assign_activity( heat_activity_actor( to_heat, required, heater_data ) );
     return true;
 }
 

--- a/src/iuse.h
+++ b/src/iuse.h
@@ -17,6 +17,8 @@
 
 class Character;
 class JsonObject;
+class JsonOut;
+class JsonValue;
 class item;
 class map;
 class monster;
@@ -251,10 +253,12 @@ struct heating_requirements {
 struct heater {
     item_location loc;
     bool consume_flag;
-    int available_heater;
+    int available_heater; // NOLINT(cata-serialize)
     int heating_effect;
     tripoint_abs_ms vpt;
     bool pseudo_flag;
+    void serialize( JsonOut &jsout ) const;
+    void deserialize( const JsonValue &jsin );
 };
 heater find_heater( Character *, item *, bool force_use_it );
 heating_requirements heating_requirements_for_weight( const units::mass &,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Infrastructure "clean up heat_activity_actor"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Update legacy activities.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

- rename heat_activity_actor::h to heat_activity_actor::heater_data -- no single-letter class members, thank you
- serialize `heater` separately from heat_activity_actor -- much cleaner and simpler
- remove dead code for ACT_HEATING handler

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Unfortunately, there's a legacy variable in `heat_activity_actor` that I can't remove:
```c++
// use a hack in use_vehicle_tool vehicle_use.cpp
// this is to update the heater vehicle part position per-turn
if( !act.coords.empty() ) {
    heater_data.vpt = act.coords[0];
}
```
The solution is a serializable `item_location`-like structure that keeps track of a vehicle part. We have `vpart_position` and `vpart_reference`, and neither can be serialized.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

- Heated up water and cracklins in a Luxury RV successfully.
- Autosaved/loaded during above, no errors.
- Did the above in 0.H, autosaved/loaded, no errors, activity completed successfully.
- Did the above in a 12-01-25 experimental, autosaved/loaded, no errors, activity completed successfully.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
