### PR TITLE
Kitchen Knife Faults

### DIFF
--- a/data/json/items/tool/knives.json
+++ b/data/json/items/tool/knives.json
@@ -7,7 +7,8 @@
     "type": "ITEM",
     "material": [ "steel" ],
     "symbol": ";",
-    "color": "light_gray"
+    "color": "light_gray",
+    "faults": [ { "fault_group": "handle_short" }, { "fault_group": "blade_general", "weight_mult": 5 } ]
   },
   {
     "id": "knife_small",


### PR DESCRIPTION


#### Summary
None

#### Purpose of change
Noticed that kitchen knives don't have faults when working on #84857 , so i give them the faults.

#### Describe the solution

Give the faults on the kitchen knives' abstract.

#### Describe alternatives you've considered
Not doing so.

#### Testing
![Screenshot_20260124_131901](https://github.com/user-attachments/assets/e91fc699-24c5-4f63-bbea-e0904bd82cb6)


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
