### PR TITLE
Monster attacks allow to split damage evenly across all limbs

### DIFF
--- a/doc/JSON/MONSTER_SPECIAL_ATTACKS.md
+++ b/doc/JSON/MONSTER_SPECIAL_ATTACKS.md
@@ -197,6 +197,8 @@ These special attacks are defined in [JSON](/data/json/monster_special_attacks),
 | `dodgeable`                 | Boolean, default true. The attack can be dodged normally.
 | `uncanny_dodgeable`         | Boolean, defaults to the value of `dodgeable`. The attack can be dodged by the Uncanny Dodge bionic or by characters having the `UNCANNY_DODGE` character flag.  Uncanny dodging takes precedence over normal dodging.
 | `blockable`                 | Boolean, default true.  The attack can be blocked (after the dodge checks).
+| `attack_amount`             | Pair of integers, default 1.  Specifies if this attack will hit you once, or multiple times, in multiple limbs (or multiple times in the same limb, if you are unlucky). The total damage of attack will be split evenly across all hits.
+| `spread_damage`             | Boolean, default false.  If true, attack will damage all the limbs of character; The total damage of attack will be split evenly across all limbs
 | `effects_require_dmg`       | Boolean, default true.  Effects will only be applied if the attack successfully damaged the target.
 | `effects`				      | Array, defines additional effects for the attack to add.  See [MONSTERS.md](MONSTERS.md#attack_effs) for the exact syntax. Duration is in turns, not in movement points
 | `self_effects_always`        | Array of `effects` the monster applies to itself when doing this attack.

--- a/src/damage.cpp
+++ b/src/damage.cpp
@@ -705,6 +705,28 @@ int dealt_damage_instance::total_damage() const
     } );
 }
 
+dealt_damage_instance &dealt_damage_instance::operator+=( const dealt_damage_instance &rhs )
+{
+    for( auto&[dt_lhs, amt_lhs] : dealt_dams ) {
+        for( const auto&[dt_rhs, amt_rhs] : rhs.dealt_dams ) {
+            if( dt_lhs != dt_rhs ) {
+                continue;
+            }
+            amt_lhs += amt_rhs;
+        }
+
+        if( !rhs.bp_hit ) {
+            bp_hit = rhs.bp_hit;
+        }
+
+        if( !rhs.wp_hit.empty() ) {
+            wp_hit = rhs.wp_hit;
+        }
+    }
+
+    return *this;
+}
+
 int accumulate_to_bash_damage( int so_far, const std::pair<damage_type_id, int> &dam )
 {
     return so_far + ( dam.second * dam.first->bash_conversion_factor );

--- a/src/damage.h
+++ b/src/damage.h
@@ -215,6 +215,7 @@ class damage_over_time_data
 
 struct dealt_damage_instance {
     std::map<damage_type_id, int> dealt_dams;
+    // todo: make a map or vector
     bodypart_id bp_hit;
     std::string wp_hit;
 
@@ -222,6 +223,7 @@ struct dealt_damage_instance {
     void set_damage( const damage_type_id &dt, int amount );
     int type_damage( const damage_type_id &dt ) const;
     int total_damage() const;
+    dealt_damage_instance &operator+=( const dealt_damage_instance &rhs );
 };
 
 struct resistances {

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -443,6 +443,8 @@ void melee_actor::load_internal( const JsonObject &obj, const std::string & )
     optional( obj, was_loaded, "effects_require_dmg", effects_require_dmg, true );
     optional( obj, was_loaded, "effects_require_organic", effects_require_organic, false );
     optional( obj, was_loaded, "grab", is_grab, false );
+    optional( obj, was_loaded, "attack_amount", attack_amount, pair_reader<int> {}, {1, 1} );
+    optional( obj, was_loaded, "spread_damage", spread_damage, false );
     optional( obj, was_loaded, "throw_strength", throw_strength, 0 );
 
     optional( obj, was_loaded, "eoc", eoc );
@@ -802,16 +804,31 @@ bool melee_actor::call( monster &z ) const
     }
 
     // Dodge check
-
     const int acc = accuracy >= 0 ? accuracy : z.type->melee_skill;
     int hitspread = target->deal_melee_attack( &z, dice( acc, 10 ) );
 
-    // Pick body part
-    bodypart_str_id bp_hit = body_parts.empty() ?
-                             target->select_body_part( hitsize_min, hitsize_max, attack_upper, hitspread ).id() :
-                             *body_parts.pick();
+    // Pick bodyparts hit
+    std::vector<bodypart_id> bodyparts_hit;
+    const int attack_amt = rng( attack_amount.first, attack_amount.second );
+    if( spread_damage ) {
+        bodyparts_hit = target->get_all_body_parts();
+    } else if( !body_parts.empty() ) {
+        for( int i = 0; i < attack_amt; i++ ) {
+            bodyparts_hit.emplace_back( *body_parts.pick() );
+        }
+    } else {
+        for( int i = 0; i < attack_amt; i++ ) {
+            const bodypart_id &bp =
+                target->select_body_part( hitsize_min, hitsize_max, attack_upper, hitspread );
+            bodyparts_hit.emplace_back( bp );
+        }
+    }
 
-    bodypart_id bp_id = bodypart_id( bp_hit );
+    if( bodyparts_hit.empty() ) {
+        debugmsg( "Monster %s tries to attack, but fails to pick bodypart/bodyparts", z.type->id.c_str() );
+        return false;
+    }
+
     game_message_type msg_type = target->is_avatar() ? m_warning : m_info;
 
     add_msg_debug( debugmode::DF_MATTACK, "Accuracy %d, hitspread %d, dodgeable %s", acc, hitspread,
@@ -827,7 +844,7 @@ bool melee_actor::call( monster &z ) const
                                  sfx::get_heard_angle( z.pos_bub() ) );
         target->add_msg_player_or_npc( msg_type, miss_msg_u,
                                        get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ? miss_msg_npc : translation(),
-                                       z.name(), body_part_name_accusative( bp_id ) );
+                                       z.name(), body_part_name_accusative( bodyparts_hit.front() ) );
         return true;
     }
 
@@ -837,7 +854,7 @@ bool melee_actor::call( monster &z ) const
                                      sfx::get_heard_angle( z.pos_bub() ) );
             target->add_msg_player_or_npc( msg_type, miss_msg_u,
                                            get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ? miss_msg_npc : translation(),
-                                           mon_name, body_part_name_accusative( bp_id ) );
+                                           mon_name, body_part_name_accusative( bodyparts_hit.front() ) );
             return true;
         }
     }
@@ -846,6 +863,17 @@ bool melee_actor::call( monster &z ) const
     // But first we need to handle exclusive grabs etc.
     std::optional<bodypart_id> grabbed_bp_id;
     if( is_grab ) {
+        // grabs do not work with multiple attacks or spread_damage,
+        // so we just pick the first one and work with it
+        // obviously TODO
+
+        if( bodyparts_hit.size() > 1 ) {
+            debugmsg( "Monster %s tries to grab, but target multiple limbs.  Currently it is not supported, only limb %s will be picked.",
+                      z.type->id.c_str(), bodyparts_hit.front()->id.c_str() );
+        }
+        bodypart_id bp_id = bodyparts_hit.front();
+        bool switched_to_another_bp = false;
+
         int eff_grab_strength = grab_data.grab_strength == -1 ? z.get_grab_strength() :
                                 grab_data.grab_strength;
         add_msg_debug( debugmode::DF_MATTACK,
@@ -913,8 +941,8 @@ bool melee_actor::call( monster &z ) const
                                    bp->name );
                     continue;
                 } else {
-                    bp_hit = bp.id();
                     bp_id = bp;
+                    switched_to_another_bp = true;
                     add_msg_debug( debugmode::DF_MATTACK, "Retargeted to ungrabbed %s",
                                    bp->name );
                 }
@@ -933,6 +961,11 @@ bool melee_actor::call( monster &z ) const
             return true;
         }
         grabbed_bp_id = bp_id;
+
+        if( switched_to_another_bp ) {
+            bodyparts_hit.clear();
+            bodyparts_hit.emplace_back( bp_id );
+        }
     }
 
     // Damage instance calculation
@@ -942,17 +975,24 @@ bool melee_actor::call( monster &z ) const
                    min_mul, max_mul );
     damage.mult_damage( multiplier );
 
+    // split the damage between all the bodyparts we gonna hit
+    damage.mult_damage( 1.0 / bodyparts_hit.size() );
+
     // Block our hit
     if( blockable ) {
-        target->block_hit( &z, bp_id, damage );
+        for( bodypart_id &bp_id : bodyparts_hit ) {
+            target->block_hit( &z, bp_id, damage );
+        }
     }
 
-    // Take damage
-    dealt_damage_instance dealt_damage = target->deal_damage( &z, bp_id, damage );
-    dealt_damage.bp_hit = bp_id;
-
-    // On hit effects
-    target->on_hit( &here, &z, bp_id );
+    dealt_damage_instance dealt_damage;
+    for( bodypart_id &bp_id : bodyparts_hit ) {
+        // Take damage
+        dealt_damage += target->deal_damage( &z, bp_id, damage );
+        dealt_damage.bp_hit = bp_id;
+        // On hit effects
+        target->on_hit( &here, &z, bp_id );
+    }
 
     // Apply onhit self effects
     for( const mon_effect_data &eff : self_effects_onhit ) {
@@ -963,6 +1003,8 @@ bool melee_actor::call( monster &z ) const
             target->add_msg_if_player( msg_type, eff.message, mon_name );
         }
     }
+
+    // run on_damage() and apply effects
     int damage_total = dealt_damage.total_damage();
     add_msg_debug( debugmode::DF_MATTACK, "%s's melee_attack did %d damage", z.name(), damage_total );
     if( damage_total > 0 ) {
@@ -972,20 +1014,24 @@ bool melee_actor::call( monster &z ) const
                                  sfx::get_heard_angle( z.pos_bub() ) );
         target->add_msg_player_or_npc( msg_type, no_dmg_msg_u,
                                        get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ? no_dmg_msg_npc : translation(),
-                                       mon_name, body_part_name_accusative( grabbed_bp_id.value_or( bp_id ) ) );
+                                       mon_name, body_part_name_accusative( grabbed_bp_id.value_or( bodyparts_hit.front() ) ) );
         if( !effects_require_dmg ) {
             for( const mon_effect_data &eff : effects ) {
                 if( x_in_y( eff.chance, 100 ) ) {
-                    const bodypart_id affected_bp = eff.affect_hit_bp ? bp_id : eff.bp.id();
-                    if( !( effects_require_organic && affected_bp->has_flag( json_flag_BIONIC_LIMB ) ) ) {
-                        target->add_effect( eff.id, time_duration::from_turns( rng( eff.duration.first,
-                                            eff.duration.second ) ), affected_bp, eff.permanent, rng( eff.intensity.first,
-                                                    eff.intensity.second ) );
+                    for( bodypart_id &bp_id : bodyparts_hit ) {
+                        const bodypart_id affected_bp = eff.affect_hit_bp ? bp_id : eff.bp.id();
+                        if( !( effects_require_organic && affected_bp->has_flag( json_flag_BIONIC_LIMB ) ) ) {
+                            target->add_effect( eff.id, time_duration::from_turns( rng( eff.duration.first,
+                                                eff.duration.second ) ), affected_bp, eff.permanent, rng( eff.intensity.first,
+                                                        eff.intensity.second ) );
+                        }
                     }
                 }
             }
         }
     }
+
+    // throw
     if( throw_strength > 0 && !( target->has_flag( mon_flag_IMMOBILE ) ||
                                  target->has_effect_with_flag( json_flag_CANNOT_MOVE ) ) ) {
         if( g->fling_creature( target, coord_to_angle( z.pos_bub(), target->pos_bub() ),

--- a/src/mattack_actors.h
+++ b/src/mattack_actors.h
@@ -163,6 +163,8 @@ class melee_actor : public mattack_actor
         bool attack_upper = true;
         grab grab_data;
         bool is_grab = false;
+        std::pair<int, int> attack_amount = {1, 1};
+        bool spread_damage = false;
 
         std::vector<effect_on_condition_id> eoc;
 


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Supersedes #84668, see rationale there
#### Describe the solution
Make melee actor call pick not 1 bodypart to hit, but multiple, by setting attack_amount or spread_damage; 
adjust the rest of code to iterate over all bodyparts hit
#### Testing
![GIF 24-01-2026 13-55-35](https://github.com/user-attachments/assets/48595ce1-3cb2-470a-9039-c68a3eb5a533)

#### Additional context
~~It might have questionable effects if monster would try to grab more than 1 bodypart at once, but i still think it's kinda cool idea - monster that grabs 3-4 of your limbs at once~~ disabled because my code caused some friction the grab test didn't like