### PR TITLE
Add tileset support for pets wearing armor

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -4246,7 +4246,10 @@ static void add_item_overlay_id( const item &item,
 {
     const std::string overlay_id = "worn_" + item.typeId().str();
     for( const std::string &suffix : suffixes ) {
-        overlay_ids.emplace_back( overlay_id + "_" + suffix, "" );
+        std::string full_id = overlay_id;
+        full_id += "_";
+        full_id += suffix;
+        overlay_ids.emplace_back( std::move( full_id ), "" );
     }
 }
 
@@ -4255,7 +4258,10 @@ static void add_generic_overlay_id( const std::string &base_id,
                                     const std::vector<std::string> &suffixes )
 {
     for( const std::string &suffix : suffixes ) {
-        overlay_ids.emplace_back( base_id + "_" + suffix, "" );
+        std::string full_id = base_id;
+        full_id += "_";
+        full_id += suffix;
+        overlay_ids.emplace_back( std::move( full_id ), "" );
     }
 }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Infrastructure "Add tileset support for pets wearing armor"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
This will allow tilesets to overlay horse/cow/dog armor/saddle/bag over the animal sprite
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Expose monster armor as overlay ids, and add a general flag for bags and tacks 

# For tileset contributors 
The ids can be seen in debug mod in the extended monster description. Every armor is listed twice, for the general bodytype `overlay_worn_[item_id]_[bodytype]` and for the specific monster_id `overlay_worn_[item_id]_[mon_id]` (this handles different dog breeds). For tack it's `overlay_worn_tack_[bodytype]`, `overlay_worn_tack_[mon_id]`, for a bag attached it's `overlay_worn_storage_[bodytype]`, `overlay_worn_storage_[mon_id]` 
<img width="1728" height="89" alt="image" src="https://github.com/user-attachments/assets/94c64c70-dda9-46bf-8d76-a9d8caece801" />


<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Testing
Took a dog, cow and a horse and tried dressing and undressing them into different equipment. After i added overlay_worn_storage. overlay_worn_leather_armor_horse_horse, overlay_worn_storage_horse they started overlaying over the horse (not the case with other animals). I only have monster sprites at hand, so my horse is wearing 3 different monsters 
<img width="602" height="408" alt="horsing around" src="https://github.com/user-attachments/assets/1231c781-a235-48ae-9768-4f66f7d981ca" />

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
