### PR TITLE
Fix character rendering from complete zero when hit animation is played

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -4753,10 +4753,8 @@ void cata_tiles::draw_bullet_frame()
 }
 void cata_tiles::draw_hit_frame()
 {
-    std::string hit_overlay = "animation_hit";
+    const std::string hit_overlay = "animation_hit";
 
-    draw_from_id_string( hit_entity_id, TILE_CATEGORY::HIT_ENTITY, empty_string, hit_pos, 0, 0,
-                         lit_level::LIT, false );
     draw_from_id_string( hit_overlay, hit_pos, 0, 0, lit_level::LIT, false );
 }
 void cata_tiles::draw_line()

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1915,7 +1915,11 @@ bool monster::attack_at( const tripoint_bub_ms &p )
         Creature::Attitude attitude = attitude_to( mon );
         // mon_flag_ATTACKMON == hulk behavior, whack everything in your way
         if( attitude == Attitude::HOSTILE || has_flag( mon_flag_ATTACKMON ) ) {
-            return melee_attack( mon );
+            const bool attacked = melee_attack( mon );
+            if( attacked ) {
+                g->draw_hit_mon( p, mon, mon.is_dead() );
+            }
+            return attacked;
         }
 
         return false;


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Do you know when monster attacks you, and your character, for a brief second, changes it's skin color, gets naked and turn right?
<img width="93" height="70" alt="image" src="https://github.com/user-attachments/assets/5f47a90d-36ba-44d9-b868-984d95094964" />

Not anymore
#### Describe the solution
Remove the line that re-renders character when it gets damage
There is no explanation why it was added in the first place, but it was added in thousand line #2621; i also do not understand why no one fixed it for all this years
Also draw monster attacking another monster animation
#### Describe alternatives you've considered
Not fixing it?
#### Testing

<img width="78" height="57" alt="image" src="https://github.com/user-attachments/assets/83f2c4ff-071c-4e88-be8b-8f372821bea7" />

![GIF 24-01-2026 20-39-58](https://github.com/user-attachments/assets/e27a535c-5a20-4b56-a48e-3dc2f916d234)

#### Additional context
I initially thought that i broke the monster animation, when they attack monster, there is no animation drawn, but no, they simply do not have one; ~~I failed to find where it should be placed~~ found and commited