### PR TITLE
Show time to pick a lock in query string

### DIFF
--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -5615,5 +5615,21 @@
     "damage": { "damage_type": "heat", "amount": 15, "armor_penetration": 30 },
     "range": 6,
     "effects": [ "FLAME", "STREAM_BIG", "IGNITE", "NEVER_MISFIRES" ]
+  },
+  {
+    "id": "test_lockpick",
+    "type": "ITEM",
+    "subtypes": [ "TOOL" ],
+    "category": "tools",
+    "name": { "str": "test lockpick" },
+    "description": "A lockpick made specifically for testing lockpicking mechanics.",
+    "weight": "23 g",
+    "volume": "5 ml",
+    "price": "0 cent",
+    "price_postapoc": "0 cent",
+    "material": [ "steel" ],
+    "symbol": ";",
+    "color": "light_gray",
+    "qualities": [ [ "LOCKPICK", 3 ] ]
   }
 ]

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3251,7 +3251,7 @@ int lockpick_activity_actor::lockpicking_moves( const item_location &lockpick_lo
         return to_moves<int>(
                    std::max( 30_seconds,
                              ( 10_minutes - time_duration::from_minutes( qual + static_cast<float>( carrier->dex_cur ) / 4.0f +
-                                 weighted_skill_average ) ) * duration_proficiency_factor ) );
+                                     weighted_skill_average ) ) * duration_proficiency_factor ) );
     }
 }
 

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3197,11 +3197,12 @@ std::unique_ptr<activity_actor> boltcutting_activity_actor::deserialize( JsonVal
 
 lockpick_activity_actor lockpick_activity_actor::use_item(
     const item_location &lockpick,
-    const tripoint_abs_ms &target
+    const tripoint_abs_ms &target,
+    const Character &who
 )
 {
     return lockpick_activity_actor {
-        lockpicking_moves( lockpick ),
+        lockpicking_moves( lockpick, who ),
         lockpick,
         std::nullopt,
         target
@@ -3220,29 +3221,37 @@ lockpick_activity_actor lockpick_activity_actor::use_bionic(
     };
 }
 
-int lockpick_activity_actor::lockpicking_moves( const item_location &lockpick_location )
+int lockpick_activity_actor::lockpicking_moves(
+    const item_location &lockpick_location,
+    const Character &who
+)
 {
-    Character *carrier = lockpick_location.carrier();
     const item *lockpick = lockpick_location.get_item();
-    int qual = lockpick->get_quality( qual_LOCKPICK );
+    int qual;
+    if( !lockpick ) {
+        debugmsg( "Lost lockpick item for lockpicking activity." );
+        qual = 1;
+    } else {
+        qual = lockpick->get_quality( qual_LOCKPICK );
+    }
     if( qual < 1 ) {
         debugmsg( "Item %s with 'PICK_LOCK' use action requires LOCKPICK quality of at least 1.",
-                  lockpick->typeId().c_str() );
+                lockpick->typeId().c_str() );
         qual = 1;
     }
 
     /** @EFFECT_LOCKPICK speeds up door lock picking */
     int duration_proficiency_factor = 1;
-    if( !carrier->has_proficiency( proficiency_prof_lockpicking ) ) {
+    if( !who.has_proficiency( proficiency_prof_lockpicking ) ) {
         duration_proficiency_factor *= proficiency_prof_lockpicking->default_time_multiplier();
     }
-    if( !carrier->has_proficiency( proficiency_prof_lockpicking_expert ) ) {
+    if( !who.has_proficiency( proficiency_prof_lockpicking_expert ) ) {
         duration_proficiency_factor *= proficiency_prof_lockpicking_expert->default_time_multiplier();
     }
 
     // Weighting of skills that matches success calculations in finish()
-    const float weighted_skill_average = ( 3.0f * carrier->get_skill_level(
-            skill_traps ) + carrier->get_skill_level( skill_mechanics ) ) / 4.0f;
+    const float weighted_skill_average = ( 3.0f * who.get_skill_level(
+            skill_traps ) + who.get_skill_level( skill_mechanics ) ) / 4.0f;
 
     if( lockpick->has_flag( flag_PERFECT_LOCKPICK ) ) {
         return to_moves<int>( 5_seconds );
@@ -3250,7 +3259,7 @@ int lockpick_activity_actor::lockpicking_moves( const item_location &lockpick_lo
         /** @EFFECT_DEX speeds up door lock picking */
         return to_moves<int>(
                    std::max( 30_seconds,
-                             ( 10_minutes - time_duration::from_minutes( qual + static_cast<float>( carrier->dex_cur ) / 4.0f +
+                             ( 10_minutes - time_duration::from_minutes( qual + static_cast<float>( who.dex_cur ) / 4.0f +
                                      weighted_skill_average ) ) * duration_proficiency_factor ) );
     }
 }

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3196,13 +3196,13 @@ std::unique_ptr<activity_actor> boltcutting_activity_actor::deserialize( JsonVal
 }
 
 lockpick_activity_actor lockpick_activity_actor::use_item(
-    int moves_total,
     const item_location &lockpick,
-    const tripoint_abs_ms &target
+    const tripoint_abs_ms &target,
+    Character &who
 )
 {
     return lockpick_activity_actor {
-        moves_total,
+        lockpicking_moves( item( *lockpick ), who ),
         lockpick,
         std::nullopt,
         target
@@ -3221,7 +3221,7 @@ lockpick_activity_actor lockpick_activity_actor::use_bionic(
     };
 }
 
-time_duration lockpick_activity_actor::lockpicking_time( Character &who, item &lockpick )
+int lockpick_activity_actor::lockpicking_moves( const item &lockpick, Character &who )
 {
     int qual = lockpick.get_quality( qual_LOCKPICK );
     if( qual < 1 ) {
@@ -3244,12 +3244,13 @@ time_duration lockpick_activity_actor::lockpicking_time( Character &who, item &l
             skill_traps ) + who.get_skill_level( skill_mechanics ) ) / 4.0f;
 
     if( lockpick.has_flag( flag_PERFECT_LOCKPICK ) ) {
-        return 5_seconds;
+        return to_moves<int>( 5_seconds );
     } else {
         /** @EFFECT_DEX speeds up door lock picking */
-        return std::max( 30_seconds,
-                         ( 10_minutes - time_duration::from_minutes( qual + static_cast<float>( who.dex_cur ) / 4.0f +
-                                 weighted_skill_average ) ) * duration_proficiency_factor );
+        return to_moves<int>(
+                   std::max( 30_seconds,
+                             ( 10_minutes - time_duration::from_minutes( qual + static_cast<float>( who.dex_cur ) / 4.0f +
+                                 weighted_skill_average ) ) * duration_proficiency_factor ) );
     }
 }
 

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3231,12 +3231,12 @@ time_duration lockpick_activity_actor::lockpicking_time( Character &who, item &l
     }
 
     /** @EFFECT_LOCKPICK speeds up door lock picking */
-    int duration_proficiency_factor = 10;
-    if( who.has_proficiency( proficiency_prof_lockpicking ) ) {
-        duration_proficiency_factor = 5;
+    int duration_proficiency_factor = 1;
+    if( !who.has_proficiency( proficiency_prof_lockpicking ) ) {
+        duration_proficiency_factor *= proficiency_prof_lockpicking->default_time_multiplier();
     }
-    if( who.has_proficiency( proficiency_prof_lockpicking_expert ) ) {
-        duration_proficiency_factor = 1;
+    if( !who.has_proficiency( proficiency_prof_lockpicking_expert ) ) {
+        duration_proficiency_factor *= proficiency_prof_lockpicking_expert->default_time_multiplier();
     }
 
     // Weighting of skills that matches success calculations in finish()

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3236,7 +3236,7 @@ int lockpick_activity_actor::lockpicking_moves(
     }
     if( qual < 1 ) {
         debugmsg( "Item %s with 'PICK_LOCK' use action requires LOCKPICK quality of at least 1.",
-                lockpick->typeId().c_str() );
+                  lockpick->typeId().c_str() );
         qual = 1;
     }
 

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3338,18 +3338,18 @@ void lockpick_activity_actor::finish( player_activity &act, Character &who )
     // Get a bonus from your lockpick quality if the quality is higher than 3, or a penalty if it is lower. For a bobby pin this puts you at -2, for a locksmith kit, +2.
     const float tool_effect = ( it->get_quality( qual_LOCKPICK ) - 3 ) - ( it->damage() / 2000.0 );
 
-    // Without at least a basic lockpick proficiency, your skill level is effectively 6 levels lower.
-    int proficiency_effect = -3;
-    int duration_proficiency_factor = 10;
-    if( who.has_proficiency( proficiency_prof_lockpicking ) ) {
-        // If you have the basic lockpick prof, negate the above penalty
-        proficiency_effect = 0;
-        duration_proficiency_factor = 5;
+    // With both Proficiencies your skill is effectively 3 levels higher.
+    int proficiency_effect = 3;
+    int duration_proficiency_factor = 1;
+    if( !who.has_proficiency( proficiency_prof_lockpicking ) ) {
+        // Without any lockpick proficiency, your skill level is effectively 3 levels lower.
+        proficiency_effect -= 3;
+        duration_proficiency_factor *= proficiency_prof_lockpicking->default_time_multiplier();
     }
-    if( who.has_proficiency( proficiency_prof_lockpicking_expert ) ) {
-        // If you have the locksmith proficiency, your skill level is effectively 4 levels higher.
-        proficiency_effect = 3;
-        duration_proficiency_factor = 1;
+    if( !who.has_proficiency( proficiency_prof_lockpicking_expert ) ) {
+        // No bonus or penalty if you have only the basic proficiency.
+        proficiency_effect -= 3;
+        duration_proficiency_factor *= proficiency_prof_lockpicking_expert->default_time_multiplier();
     }
 
     // We get our average roll by adding the above factors together. For a person with no skill, average stats, no proficiencies, and an improvised lockpick, mean_roll will be 2.

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3249,7 +3249,7 @@ time_duration lockpick_activity_actor::lockpicking_time( Character &who, item &l
         /** @EFFECT_DEX speeds up door lock picking */
         return std::max( 30_seconds,
                          ( 10_minutes - time_duration::from_minutes( qual + static_cast<float>( who.dex_cur ) / 4.0f +
-                                weighted_skill_average ) ) * duration_proficiency_factor );
+                                 weighted_skill_average ) ) * duration_proficiency_factor );
     }
 }
 

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -868,8 +868,7 @@ class lockpick_activity_actor : public activity_actor
         /** Use regular lockpick. */
         static lockpick_activity_actor use_item(
             const item_location &lockpick,
-            const tripoint_abs_ms &target,
-            Character &who
+            const tripoint_abs_ms &target
         );
 
         /** Use bionic lockpick. */
@@ -877,7 +876,7 @@ class lockpick_activity_actor : public activity_actor
             const tripoint_abs_ms &target
         );
 
-        static int lockpicking_moves(const item &lockpick, Character &who );
+        static int lockpicking_moves(const item_location &lockpick );
 
         const activity_id &get_type() const override {
             static const activity_id ACT_LOCKPICK( "ACT_LOCKPICK" );

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -867,9 +867,9 @@ class lockpick_activity_actor : public activity_actor
     public:
         /** Use regular lockpick. */
         static lockpick_activity_actor use_item(
-            int moves_total,
             const item_location &lockpick,
-            const tripoint_abs_ms &target
+            const tripoint_abs_ms &target,
+            Character &who
         );
 
         /** Use bionic lockpick. */
@@ -877,7 +877,7 @@ class lockpick_activity_actor : public activity_actor
             const tripoint_abs_ms &target
         );
 
-        static time_duration lockpicking_time( Character &who, item &lockpick );
+        static int lockpicking_moves(const item &lockpick, Character &who );
 
         const activity_id &get_type() const override {
             static const activity_id ACT_LOCKPICK( "ACT_LOCKPICK" );

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -876,7 +876,7 @@ class lockpick_activity_actor : public activity_actor
             const tripoint_abs_ms &target
         );
 
-        static int lockpicking_moves(const item_location &lockpick );
+        static int lockpicking_moves( const item_location &lockpick );
 
         const activity_id &get_type() const override {
             static const activity_id ACT_LOCKPICK( "ACT_LOCKPICK" );

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -877,6 +877,8 @@ class lockpick_activity_actor : public activity_actor
             const tripoint_abs_ms &target
         );
 
+        static time_duration lockpicking_time( Character &who, item &lockpick );
+
         const activity_id &get_type() const override {
             static const activity_id ACT_LOCKPICK( "ACT_LOCKPICK" );
             return ACT_LOCKPICK;

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -868,7 +868,8 @@ class lockpick_activity_actor : public activity_actor
         /** Use regular lockpick. */
         static lockpick_activity_actor use_item(
             const item_location &lockpick,
-            const tripoint_abs_ms &target
+            const tripoint_abs_ms &target,
+            const Character &who
         );
 
         /** Use bionic lockpick. */
@@ -876,7 +877,7 @@ class lockpick_activity_actor : public activity_actor
             const tripoint_abs_ms &target
         );
 
-        static int lockpicking_moves( const item_location &lockpick );
+        static int lockpicking_moves( const item_location &lockpick, const Character &who );
 
         const activity_id &get_type() const override {
             static const activity_id ACT_LOCKPICK( "ACT_LOCKPICK" );

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -2012,7 +2012,8 @@ void iexamine::locked_object_pickable( Character &you, const tripoint_bub_ms &ex
     } );
 
     for( item *it : picklocks ) {
-        time_duration required_time = lockpick_activity_actor::lockpicking_time( you, *it );
+        int required_moves = lockpick_activity_actor::lockpicking_moves( *it, you );
+        time_duration required_time = time_duration::from_turns( required_moves / you.get_speed() );
         const std::string time_string = colorize( to_string( required_time, true ), c_light_gray );
         std::string query = string_format( _( "Pick the lock of %1$s using your %2$s?" ),
                                            target_name, it->tname() );

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -2015,9 +2015,9 @@ void iexamine::locked_object_pickable( Character &you, const tripoint_bub_ms &ex
         time_duration required_time = lockpick_activity_actor::lockpicking_time( you, *it );
         const std::string time_string = colorize( to_string( required_time, true ), c_light_gray );
         std::string query = string_format( _( "Pick the lock of %1$s using your %2$s?" ),
-                       target_name, it->tname() );
+                                           target_name, it->tname() );
         query += "\n";
-        query += _( "Time to complete: ");
+        query += _( "Time to complete: " );
         query += time_string;
         if( !query_yn( query ) ) {
             return;

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -2018,7 +2018,7 @@ void iexamine::locked_object_pickable( Character &you, const tripoint_bub_ms &ex
         std::string query = string_format( _( "Pick the lock of %1$s using your %2$s?" ),
                                            target_name, it->tname() );
         query += "\n";
-        query += _( "Time to complete: " );
+        query += _( "Time to attempt: " );
         query += time_string;
         if( !query_yn( query ) ) {
             return;

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -2012,7 +2012,7 @@ void iexamine::locked_object_pickable( Character &you, const tripoint_bub_ms &ex
     } );
 
     for( item *it : picklocks ) {
-        int required_moves = lockpick_activity_actor::lockpicking_moves( *it, you );
+        int required_moves = lockpick_activity_actor::lockpicking_moves( item_location{you, it} );
         time_duration required_time = time_duration::from_turns( required_moves / you.get_speed() );
         const std::string time_string = colorize( to_string( required_time, true ), c_light_gray );
         std::string query = string_format( _( "Pick the lock of %1$s using your %2$s?" ),

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -2012,8 +2012,14 @@ void iexamine::locked_object_pickable( Character &you, const tripoint_bub_ms &ex
     } );
 
     for( item *it : picklocks ) {
-        if( !query_yn( _( "Pick the lock of %1$s using your %2$s?" ),
-                       target_name, it->tname() ) ) {
+        time_duration required_time = lockpick_activity_actor::lockpicking_time( you, *it );
+        const std::string time_string = colorize( to_string( required_time, true ), c_light_gray );
+        std::string query = string_format( _( "Pick the lock of %1$s using your %2$s?" ),
+                       target_name, it->tname() );
+        query += "\n";
+        query += _( "Time to complete: ");
+        query += time_string;
+        if( !query_yn( query ) ) {
             return;
         }
         const use_function *iuse_fn = it->type->get_use( "PICK_LOCK" );

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -2012,7 +2012,7 @@ void iexamine::locked_object_pickable( Character &you, const tripoint_bub_ms &ex
     } );
 
     for( item *it : picklocks ) {
-        int required_moves = lockpick_activity_actor::lockpicking_moves( item_location{you, it} );
+        int required_moves = lockpick_activity_actor::lockpicking_moves( item_location{you, it}, you );
         time_duration required_time = time_duration::from_turns( required_moves / you.get_speed() );
         const std::string time_string = colorize( to_string( required_time, true ), c_light_gray );
         std::string query = string_format( _( "Pick the lock of %1$s using your %2$s?" ),

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -3186,7 +3186,8 @@ std::optional<int> iuse::pick_lock( Character *p, item *it, const tripoint_bub_m
     }
 
     you.assign_activity( lockpick_activity_actor::use_item( item_location( you, it ),
-                         get_map().get_abs( *target )
+                         get_map().get_abs( *target ),
+                         *p
                                                           ) );
     return 1;
 }

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -3191,8 +3191,7 @@ std::optional<int> iuse::pick_lock( Character *p, item *it, const tripoint_bub_m
     }
 
     you.assign_activity( lockpick_activity_actor::use_item( item_location( you, it ),
-                                                                get_map().get_abs( *target ),
-                                                                you
+                                                                get_map().get_abs( *target )
                                                                 ) );
     return 1;
 }

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -349,7 +349,6 @@ static const skill_id skill_fabrication( "fabrication" );
 static const skill_id skill_firstaid( "firstaid" );
 static const skill_id skill_mechanics( "mechanics" );
 static const skill_id skill_survival( "survival" );
-static const skill_id skill_traps( "traps" );
 
 static const species_id species_FUNGUS( "FUNGUS" );
 static const species_id species_HALLUCINATION( "HALLUCINATION" );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -3190,29 +3190,7 @@ std::optional<int> iuse::pick_lock( Character *p, item *it, const tripoint_bub_m
         return std::nullopt;
     }
 
-    int qual = it->get_quality( qual_LOCKPICK );
-    if( qual < 1 ) {
-        debugmsg( "Item %s with 'PICK_LOCK' use action requires LOCKPICK quality of at least 1.",
-                  it->typeId().c_str() );
-        qual = 1;
-    }
-
-    /** @EFFECT_DEX speeds up door lock picking */
-    /** @EFFECT_LOCKPICK speeds up door lock picking */
-    int duration_proficiency_factor = 10;
-
-    if( you.has_proficiency( proficiency_prof_lockpicking ) ) {
-        duration_proficiency_factor = 5;
-    }
-    if( you.has_proficiency( proficiency_prof_lockpicking_expert ) ) {
-        duration_proficiency_factor = 1;
-    }
-    time_duration duration = 5_seconds;
-    if( !it->has_flag( flag_PERFECT_LOCKPICK ) ) {
-        duration = std::max( 30_seconds,
-                             ( 10_minutes - time_duration::from_minutes( qual + static_cast<float>( you.dex_cur ) / 4.0f +
-                                     you.get_skill_level( skill_traps ) ) ) * duration_proficiency_factor );
-    }
+    time_duration duration = lockpick_activity_actor::lockpicking_time( you, *it );
 
     you.assign_activity( lockpick_activity_actor::use_item( to_moves<int>( duration ),
                          item_location( you, it ), get_map().get_abs( *target ) ) );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -336,13 +336,9 @@ static const mtype_id mon_vortex( "mon_vortex" );
 static const mutation_category_id mutation_category_CATTLE( "CATTLE" );
 static const mutation_category_id mutation_category_MYCUS( "MYCUS" );
 
-static const proficiency_id proficiency_prof_lockpicking( "prof_lockpicking" );
-static const proficiency_id proficiency_prof_lockpicking_expert( "prof_lockpicking_expert" );
-
 static const quality_id qual_AXE( "AXE" );
 static const quality_id qual_GLARE( "GLARE" );
 static const quality_id qual_HOTPLATE( "HOTPLATE" );
-static const quality_id qual_LOCKPICK( "LOCKPICK" );
 static const quality_id qual_PRY( "PRY" );
 static const quality_id qual_SCREW_FINE( "SCREW_FINE" );
 

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -3190,10 +3190,10 @@ std::optional<int> iuse::pick_lock( Character *p, item *it, const tripoint_bub_m
         return std::nullopt;
     }
 
-    time_duration duration = lockpick_activity_actor::lockpicking_time( you, *it );
-
-    you.assign_activity( lockpick_activity_actor::use_item( to_moves<int>( duration ),
-                         item_location( you, it ), get_map().get_abs( *target ) ) );
+    you.assign_activity( lockpick_activity_actor::use_item( item_location( you, it ),
+                                                                get_map().get_abs( *target ),
+                                                                you
+                                                                ) );
     return 1;
 }
 

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -3191,8 +3191,8 @@ std::optional<int> iuse::pick_lock( Character *p, item *it, const tripoint_bub_m
     }
 
     you.assign_activity( lockpick_activity_actor::use_item( item_location( you, it ),
-                                                                get_map().get_abs( *target )
-                                                                ) );
+                         get_map().get_abs( *target )
+                                                          ) );
     return 1;
 }
 

--- a/tests/player_activities_test.cpp
+++ b/tests/player_activities_test.cpp
@@ -93,6 +93,7 @@ static const itype_id itype_test_hacksaw( "test_hacksaw" );
 static const itype_id itype_test_hacksaw_elec( "test_hacksaw_elec" );
 static const itype_id itype_test_halligan( "test_halligan" );
 static const itype_id itype_test_halligan_no_nails( "test_halligan_no_nails" );
+static const itype_id itype_test_lockpick( "test_lockpick" );
 static const itype_id itype_test_oxytorch( "test_oxytorch" );
 static const itype_id itype_test_pipe( "test_pipe" );
 static const itype_id itype_test_rag( "test_rag" );
@@ -1961,7 +1962,12 @@ static const std::vector<std::function<player_activity()>> test_activities {
     //player_activity( harvest_activity_actor( p ) ),
     [] { return player_activity( hotwire_car_activity_actor( 1, get_avatar().pos_abs() ) ); },
     //player_activity( insert_item_activity_actor() ),
-    [] { return player_activity( lockpick_activity_actor::use_item( 1, item_location(), get_avatar().pos_abs() ) ); },
+    [] {
+        Character *dummy = get_avatar().as_character();
+        dummy->wear_item( item( itype_test_backpack ), false );
+        item_location lockpick_location = dummy->i_add( item( itype_test_lockpick, calendar::turn ) );
+        return player_activity( lockpick_activity_actor::use_item( lockpick_location, get_avatar().pos_abs() ) );
+    },
     //player_activity( longsalvage_activity_actor() ),
     [] { return player_activity( meditate_activity_actor() ); },
     [] { return player_activity( migration_cancel_activity_actor() ); },

--- a/tests/player_activities_test.cpp
+++ b/tests/player_activities_test.cpp
@@ -1966,7 +1966,7 @@ static const std::vector<std::function<player_activity()>> test_activities {
         Character *dummy = get_avatar().as_character();
         dummy->wear_item( item( itype_test_backpack ), false );
         item_location lockpick_location = dummy->i_add( item( itype_test_lockpick, calendar::turn ) );
-        return player_activity( lockpick_activity_actor::use_item( lockpick_location, get_avatar().pos_abs() ) );
+        return player_activity( lockpick_activity_actor::use_item( lockpick_location, get_avatar().pos_abs(), *dummy ) );
     },
     //player_activity( longsalvage_activity_actor() ),
     [] { return player_activity( meditate_activity_actor() ); },


### PR DESCRIPTION
#### Summary

Interface "Show time required to pick a lock"

#### Purpose of change

Picking a lock takes a non-trivial amount of time. We should expose that to the player as we would for an extended crafting action so they can make informed decisions.

#### Describe the solution

1. Add "Time to complete: …" to the lock picking `query_yn` prompt.
2. Also changed the skill weighting of lockpicking time to match the skill weighting of lockpicking success.
3. Change picking speed multipliers to the multipliers on the lockpicking proficiencies.

#### Describe alternatives you've considered

- Make lockpicking duration not fixed.  In `do_turn` you could have progress indicators like "You feel nothing on pin 2.", "You feel a click on pin 3…", and so forth along with a bunch of ways to screw up ("You thought you had it but the lock just won't rotate.", "None of the pins are moving.", etc) followed by starting over.

#### Testing

1. New prompt seems to work.
<img width="363" height="59" alt="image" src="https://github.com/user-attachments/assets/e986d91b-84e1-4f5f-96ae-299edc18d101" /> 
<img width="399" height="59" alt="image" src="https://github.com/user-attachments/assets/68fc72cc-6a2c-4d96-ac66-d0b08d3d9fef" />

2. Time before attempt 8:20:55 AM.  Prediction of "6 mins 25 secs" is 385 seconds. End time: 8:27:21 AM.  Actual time elapsed: 386 seconds.  One second is close enough. ✅

3. With both proficiencies: `1 min 46 secs`, without locksmith: `3 mins 32 secs`, without proficiencies: `7 mins 4 secs`.

#### Additional context

- Added time to hotwiring menu https://github.com/CleverRaven/Cataclysm-DDA/pull/84869
- I intend to add time info to more things that are slow.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
