### PR TITLE
[XE] Add three vampire hunter professions

### DIFF
--- a/data/mods/Xedra_Evolved/missions.json
+++ b/data/mods/Xedra_Evolved/missions.json
@@ -105,5 +105,51 @@
       "success_lie": "",
       "failure": ""
     }
+  },
+  {
+    "id": "MISSION_LOW_VAMPIRE_HUNTER",
+    "type": "mission_definition",
+    "name": { "str": "Kill a vampire" },
+    "description": "You prepared for so long to kill vampires, and there's no way you let all that preparation be for nothing.  Kill a vampire to show that you can and will hunt them!",
+    "goal": "MGOAL_KILL_MONSTER_SPEC",
+    "monster_species": "VAMPIRE",
+    "monster_kill_goal": 1,
+    "difficulty": 3,
+    "value": 0,
+    "end": {
+      "effect": [
+        {
+          "u_add_morale": "morale_feeling_good",
+          "bonus": 30,
+          "max_bonus": 50,
+          "duration": "24 hours",
+          "decay_start": "12 hours"
+        }
+      ]
+    },
+    "origins": [ "ORIGIN_GAME_START" ]
+  },
+  {
+    "id": "MISSION_VAMPIRE_HUNTER",
+    "type": "mission_definition",
+    "name": { "str": "Kill ten vampires" },
+    "description": "The end of society is no excuse to stop the hunt.  In fact, it's another reason to continue your work.  Kill ten vampires, so the world will be a little more free of them.",
+    "goal": "MGOAL_KILL_MONSTER_SPEC",
+    "monster_species": "VAMPIRE",
+    "monster_kill_goal": 10,
+    "difficulty": 5,
+    "value": 0,
+    "end": {
+      "effect": [
+        {
+          "u_add_morale": "morale_feeling_good",
+          "bonus": 30,
+          "max_bonus": 50,
+          "duration": "24 hours",
+          "decay_start": "12 hours"
+        }
+      ]
+    },
+    "origins": [ "ORIGIN_GAME_START" ]
   }
 ]

--- a/data/mods/Xedra_Evolved/player/professions.json
+++ b/data/mods/Xedra_Evolved/player/professions.json
@@ -1033,5 +1033,149 @@
     },
     "flags": [ "SCEN_ONLY" ],
     "chargen_allow_npc": false
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "quiver_crossbow_low_vampire_hunter",
+    "entries": [ { "item": "bolt_steel", "charges": 20 } ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "collection",
+    "id": "quiver_crossbow_vampire_hunter",
+    "entries": [ { "item": "bolt_cf", "charges": 20 } ]
+  },
+  {
+    "type": "profession",
+    "id": "low_vampire_hunter",
+    "name": "Novice Vampire Hunter",
+    "description": "Long ago, you stumbled upon the undead bloodsuckers and of their machinations aiming to subjugate all humans to their will.  Ever since then, you wanted to do something against them, if only to impede their attempts.  You barely had time to buy your gear when far worse things showed up and brought the collapse of society, but you want to at least kill a single vampire before something else kills you.",
+    "npc_background": "BG_survival_story_ECCENTRIC",
+    "//": "Intended as a regular inexperienced and untrained person in modern times buying some legal gear to go fight vampires, basing their choice of gear on fictional vampires.",
+    "points": 2,
+    "items": {
+      "both": {
+        "entries": [
+          { "item": "jeans" },
+          { "item": "longshirt" },
+          { "item": "socks" },
+          { "item": "sneakers" },
+          { "item": "sheath", "contents-item": "knife_hunting" },
+          { "group": "charged_smart_phone" },
+          { "group": "starter_wallet_full" },
+          { "item": "wristwatch" },
+          {
+            "item": "compcrossbow",
+            "ammo-item": "bolt_steel",
+            "charges": 1,
+            "contents-item": "shoulder_strap_simple",
+            "custom-flags": [ "no_auto_equip" ]
+          },
+          { "item": "quiver", "contents-group": "quiver_crossbow_low_vampire_hunter" }
+        ]
+      },
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
+    },
+    "missions": [ "MISSION_LOW_VAMPIRE_HUNTER" ]
+  },
+  {
+    "type": "profession",
+    "id": "medium_vampire_hunter",
+    "name": "Vampire Hunter",
+    "description": "Ever since you were confronted to the existence of vampires and their dark designs, you did what you could to fight back against them, killing any vampire you could find.  Finding them might be harder these days, but killing them is more necessary than ever.",
+    "npc_background": "BG_survival_story_ECCENTRIC",
+    "requirement": "achievement_kill_vampire",
+    "//": "Intended as someone who fought and killed a few vampires, but know little more about them.",
+    "//2": "Since the crossbow hunter has archer's form, the crossbow vampire hunters have it too.",
+    "points": 5,
+    "proficiencies": [ "prof_bow_expert", "prof_knives_pro", "prof_gross_anatomy", "prof_wp_demihuman" ],
+    "skills": [
+      { "level": 4, "name": "rifle" },
+      { "level": 4, "name": "gun" },
+      { "level": 3, "name": "melee" },
+      { "level": 3, "name": "stabbing" },
+      { "level": 2, "name": "dodge" },
+      { "level": 2, "name": "deduction" }
+    ],
+    "items": {
+      "both": {
+        "entries": [
+          { "item": "jeans" },
+          { "item": "longshirt" },
+          { "item": "socks" },
+          { "item": "sneakers" },
+          { "item": "sheath", "contents-item": "knife_combat_marine" },
+          { "group": "charged_smart_phone" },
+          { "group": "starter_wallet_full" },
+          { "item": "wristwatch" },
+          {
+            "item": "compcrossbow",
+            "ammo-item": "bolt_cf",
+            "charges": 1,
+            "contents-item": "shoulder_strap_simple",
+            "custom-flags": [ "no_auto_equip" ]
+          },
+          { "item": "quiver", "contents-group": "quiver_crossbow_vampire_hunter" },
+          { "item": "runner_bag" },
+          { "item": "lighter", "charges": 100 },
+          { "item": "molotov", "count": 4 }
+        ]
+      },
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
+    },
+    "missions": [ "MISSION_VAMPIRE_HUNTER" ]
+  },
+  {
+    "type": "profession",
+    "id": "high_vampire_hunter",
+    "name": "Experienced Vampire Hunter",
+    "description": "It has been years since you began fighting the leeches that want to turn humanity into their slaves, killing those who embrace the curse and curing those who don't.  You know more about vampires than most hunters do and managed to kill a few highly-powerful vampires before all went down.  They will not stop their efforts, but you won't stop yours until they're all gone or you're six feet underground.",
+    "npc_background": "BG_survival_story_ECCENTRIC",
+    "requirement": "achievement_kill_10_vampires",
+    "//": "Intended as someone who fought vampires in the past, has good combat abilities and knows about the cure, vampire weaknesses, the mentors and the bloodthorne.",
+    "//2": "When a hunter faction will be added, they will start with a mission to reach it as they knew about other hunters.",
+    "points": 7,
+    "proficiencies": [ "prof_bow_master", "prof_knives_master", "prof_gross_anatomy", "prof_wp_demihuman" ],
+    "skills": [
+      { "level": 6, "name": "rifle" },
+      { "level": 6, "name": "gun" },
+      { "level": 4, "name": "melee" },
+      { "level": 4, "name": "stabbing" },
+      { "level": 3, "name": "dodge" },
+      { "level": 5, "name": "deduction" }
+    ],
+    "items": {
+      "both": {
+        "entries": [
+          { "item": "jeans" },
+          { "item": "longshirt" },
+          { "item": "socks" },
+          { "item": "sneakers" },
+          { "item": "sheath", "contents-item": "knife_combat_marine" },
+          { "group": "charged_smart_phone" },
+          { "group": "starter_wallet_full" },
+          { "item": "wristwatch" },
+          {
+            "item": "compcrossbow",
+            "ammo-item": "bolt_cf",
+            "charges": 1,
+            "contents-item": "shoulder_strap_simple",
+            "custom-flags": [ "no_auto_equip" ]
+          },
+          { "item": "quiver", "contents-group": "quiver_crossbow_vampire_hunter" },
+          { "item": "runner_bag" },
+          { "item": "lighter", "charges": 100 },
+          { "item": "molotov", "count": 4 },
+          { "item": "grimy_recipe" },
+          { "item": "blood_treatment", "count": 5 }
+        ]
+      },
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
+    },
+    "missions": [ "MISSION_VAMPIRE_HUNTER" ]
   }
 ]

--- a/data/mods/Xedra_Evolved/player/professions.json
+++ b/data/mods/Xedra_Evolved/player/professions.json
@@ -1132,7 +1132,7 @@
     "type": "profession",
     "id": "high_vampire_hunter",
     "name": "Experienced Vampire Hunter",
-    "description": "It has been years since you began fighting the leeches that want to turn humanity into their slaves, killing those who embrace the curse and curing those who don't.  You know more about vampires than most hunters do and managed to kill a few highly-powerful vampires before all went down.  They will not stop their efforts, but you won't stop yours until they're all gone or you're six feet underground.",
+    "description": "It has been years since you began fighting the leeches that want to turn humanity into their slaves, killing those who embrace the curse and curing those who don't.  You know more about vampires than most hunters do and managed to kill a few highly-powerful vampires before it all went down.  They will not stop their efforts, but you won't stop yours until they're all gone or you're six feet underground.",
     "npc_background": "BG_survival_story_ECCENTRIC",
     "requirement": "achievement_kill_10_vampires",
     "//": "Intended as someone who fought vampires in the past, has good combat abilities and knows about the cure, vampire weaknesses, the mentors and the bloodthorne.",

--- a/data/mods/Xedra_Evolved/player/professions.json
+++ b/data/mods/Xedra_Evolved/player/professions.json
@@ -1050,7 +1050,7 @@
     "type": "profession",
     "id": "low_vampire_hunter",
     "name": "Novice Vampire Hunter",
-    "description": "Long ago, you stumbled upon the undead bloodsuckers and of their machinations aiming to subjugate all humans to their will.  Ever since then, you wanted to do something against them, if only to impede their attempts.  You barely had time to buy your gear when far worse things showed up and brought the collapse of society, but you want to at least kill a single vampire before something else kills you.",
+    "description": "Long ago, you stumbled upon the undead bloodsuckers and their machinations aiming to subjugate all humans to their will.  Ever since then you wanted to do something against them, if only to impede their attempts.  You barely had time to buy your gear when far worse things showed up and brought the collapse of society, but you want to at least kill a single vampire before something else kills you.",
     "npc_background": "BG_survival_story_ECCENTRIC",
     "//": "Intended as a regular inexperienced and untrained person in modern times buying some legal gear to go fight vampires, basing their choice of gear on fictional vampires.",
     "points": 2,


### PR DESCRIPTION
#### Summary
Mods "[XE] Add three vampire hunter professions"

#### Purpose of change

What story including vampires doesn't also include vampire hunters?

#### Describe the solution

Add the three following classes:
-Novice Vampire Hunter (unlocked right away) Random unskilled person who bought a crossbow to at least try to kill vampires.
-Vampire Hunter (locked behind killing one vampire) Decently skilled person that also has molotovs and a lighter.
-Experienced Vampire Hunter (locked behind killing 10 vampires) Regular hunter but with higher skills and knowledge of the cure.

#### Describe alternatives you've considered

Adding the hunter faction first.

Giving them a weapon that isn't a crossbow. The novice got a crossbow because of pop culture influence. The other picked a crossbow because vampires are very hard to kill with blunt weapons and bullets & being alone near a hostile vampire is a bad idea.

Modern times oblige, compound crossbows can be bought online and vampires aren't more vulnerable to bolts shot from wooden crossbows.

#### Testing

-Novice: Can start as novice. Attacked a moroi by shooting bolts. Got a 1-damage glancing hit shortly followed by a disgustingly strong critical hit that effectively one-shotted the moroi through sanguine resilience. Reliance on beginner's luck is expected from someone who might've never used said crossbow at all.
-Regular: Can start as regular after killing a vampire. Got some average bolt hits and killed a moroi after some kiting.
-Experienced: Can start as experienced after killing 10 vampires. Chained good bolt hits that quickly killed a moroi.

Missions are granted at start and can be completed.

#### Additional context
There is room to add more hunters, but let's start by adding three.