### PR TITLE
Fix update_mapgen in missions to use mission target as origin instead of player if possible

### DIFF
--- a/src/mission.h
+++ b/src/mission.h
@@ -150,9 +150,9 @@ tripoint_abs_omt target_closest_lab_entrance( const tripoint_abs_omt &origin, in
         mission *miss );
 bool reveal_road( const tripoint_abs_omt &source, const tripoint_abs_omt &dest,
                   overmapbuffer &omb );
-tripoint_abs_omt reveal_om_ter( const std::string &omter, int reveal_rad, bool must_see,
+tripoint_abs_omt reveal_om_ter( tripoint_abs_omt origin, const std::string &omter, int reveal_rad, bool must_see,
                                 int target_z = 0 );
-tripoint_abs_omt target_om_ter( const std::string &omter, int reveal_rad, mission *miss,
+tripoint_abs_omt target_om_ter( tripoint_abs_omt origin, const std::string &omter, int reveal_rad, mission *miss,
                                 bool must_see, int target_z = 0 );
 tripoint_abs_omt target_om_ter_random(
     const std::string &omter, int reveal_rad, mission *miss, bool must_see, int range,

--- a/src/mission.h
+++ b/src/mission.h
@@ -150,9 +150,11 @@ tripoint_abs_omt target_closest_lab_entrance( const tripoint_abs_omt &origin, in
         mission *miss );
 bool reveal_road( const tripoint_abs_omt &source, const tripoint_abs_omt &dest,
                   overmapbuffer &omb );
-tripoint_abs_omt reveal_om_ter( tripoint_abs_omt origin, const std::string &omter, int reveal_rad, bool must_see,
+tripoint_abs_omt reveal_om_ter( tripoint_abs_omt origin, const std::string &omter, int reveal_rad,
+                                bool must_see,
                                 int target_z = 0 );
-tripoint_abs_omt target_om_ter( tripoint_abs_omt origin, const std::string &omter, int reveal_rad, mission *miss,
+tripoint_abs_omt target_om_ter( tripoint_abs_omt origin, const std::string &omter, int reveal_rad,
+                                mission *miss,
                                 bool must_see, int target_z = 0 );
 tripoint_abs_omt target_om_ter_random(
     const std::string &omter, int reveal_rad, mission *miss, bool must_see, int range,

--- a/src/mission_util.cpp
+++ b/src/mission_util.cpp
@@ -487,7 +487,7 @@ bool mission_util::set_update_mapgen( const JsonObject &jo,
     if( jo.has_member( "om_terrain" ) ) {
         const std::string om_terrain = jo.get_string( "om_terrain" );
         auto mission_func = [update_map = std::move( update_map ), om_terrain]( mission * miss ) {
-            tripoint_abs_omt update_pos3 = mission_util::reveal_om_ter( miss->get_target(), om_terrain, 1, false );
+            tripoint_abs_omt update_pos3 = mission_util::reveal_om_ter( miss->has_target() ? miss->get_target() : get_player_character().pos_abs_omt(), om_terrain, 1, false );
             update_map( update_pos3, miss );
         };
         funcs.emplace_back( std::move( mission_func ) );

--- a/src/mission_util.cpp
+++ b/src/mission_util.cpp
@@ -104,13 +104,12 @@ bool mission_util::reveal_road( const tripoint_abs_omt &source, const tripoint_a
 /**
  * Reveal the cloest overmap terrain of a type and return the its location
  */
-tripoint_abs_omt mission_util::reveal_om_ter( const std::string &omter, int reveal_rad,
+tripoint_abs_omt mission_util::reveal_om_ter( tripoint_abs_omt origin, const std::string &omter, int reveal_rad,
         bool must_see, int target_z )
 {
     // Missions are normally on z-level 0, but allow an optional argument.
-    tripoint_abs_omt loc = get_player_character().pos_abs_omt();
-    loc.z() = target_z;
-    const tripoint_abs_omt place = overmap_buffer.find_closest( loc, omter, 0, must_see );
+    origin.z() = target_z;
+    const tripoint_abs_omt place = overmap_buffer.find_closest( origin, omter, 0, must_see );
     if( !place.is_invalid() && reveal_rad >= 0 ) {
         overmap_buffer.reveal( place, reveal_rad );
     }
@@ -354,9 +353,9 @@ tripoint_abs_omt mission_util::get_om_terrain_pos( const mission_target_params &
  * and returns the mission target.
 */
 tripoint_abs_omt mission_util::target_om_ter(
-    const std::string &omter, int reveal_rad, mission *miss, bool must_see, int target_z )
+    tripoint_abs_omt origin, const std::string &omter, int reveal_rad, mission *miss, bool must_see, int target_z )
 {
-    const tripoint_abs_omt place = reveal_om_ter( omter, reveal_rad, must_see, target_z );
+    const tripoint_abs_omt place = reveal_om_ter( origin, omter, reveal_rad, must_see, target_z );
     miss->set_target( place );
     return place;
 }
@@ -488,7 +487,7 @@ bool mission_util::set_update_mapgen( const JsonObject &jo,
     if( jo.has_member( "om_terrain" ) ) {
         const std::string om_terrain = jo.get_string( "om_terrain" );
         auto mission_func = [update_map = std::move( update_map ), om_terrain]( mission * miss ) {
-            tripoint_abs_omt update_pos3 = mission_util::reveal_om_ter( om_terrain, 1, false );
+            tripoint_abs_omt update_pos3 = mission_util::reveal_om_ter( miss->get_target(), om_terrain, 1, false );
             update_map( update_pos3, miss );
         };
         funcs.emplace_back( std::move( mission_func ) );

--- a/src/mission_util.cpp
+++ b/src/mission_util.cpp
@@ -104,7 +104,8 @@ bool mission_util::reveal_road( const tripoint_abs_omt &source, const tripoint_a
 /**
  * Reveal the cloest overmap terrain of a type and return the its location
  */
-tripoint_abs_omt mission_util::reveal_om_ter( tripoint_abs_omt origin, const std::string &omter, int reveal_rad,
+tripoint_abs_omt mission_util::reveal_om_ter( tripoint_abs_omt origin, const std::string &omter,
+        int reveal_rad,
         bool must_see, int target_z )
 {
     // Missions are normally on z-level 0, but allow an optional argument.
@@ -353,7 +354,8 @@ tripoint_abs_omt mission_util::get_om_terrain_pos( const mission_target_params &
  * and returns the mission target.
 */
 tripoint_abs_omt mission_util::target_om_ter(
-    tripoint_abs_omt origin, const std::string &omter, int reveal_rad, mission *miss, bool must_see, int target_z )
+    tripoint_abs_omt origin, const std::string &omter, int reveal_rad, mission *miss, bool must_see,
+    int target_z )
 {
     const tripoint_abs_omt place = reveal_om_ter( origin, omter, reveal_rad, must_see, target_z );
     miss->set_target( place );
@@ -487,7 +489,8 @@ bool mission_util::set_update_mapgen( const JsonObject &jo,
     if( jo.has_member( "om_terrain" ) ) {
         const std::string om_terrain = jo.get_string( "om_terrain" );
         auto mission_func = [update_map = std::move( update_map ), om_terrain]( mission * miss ) {
-            tripoint_abs_omt update_pos3 = mission_util::reveal_om_ter( miss->has_target() ? miss->get_target() : get_player_character().pos_abs_omt(), om_terrain, 1, false );
+            tripoint_abs_omt update_pos3 = mission_util::reveal_om_ter( miss->has_target() ? miss->get_target()
+                                           : get_player_character().pos_abs_omt(), om_terrain, 1, false );
             update_map( update_pos3, miss );
         };
         funcs.emplace_back( std::move( mission_func ) );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Fix update_mapgen in missions to use mission target as origin instead of player if possible"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The `update_mapgen` object in missions was using the players point to find the nearest overmap terrain to update instead of the mission target itself, if it has one
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Change `mission_util::reveal_om_ter` to accept an origin tripoint. This function is called by the `update_mapgen` code (and only by this code, normal mission target reveal code is separate)
If the mission has a target assigned, it will use that as the origin to search for overmap terrain to update, otherwise it defaults to the player's position. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested with missions that utilize `update_mapgen` and they still work as expected
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
mission_util could use an audit to possibly trim unused code. One of the functions I had to update isn't actually called anywhere.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
