### PR TITLE
Fix a V menu crash

### DIFF
--- a/src/surroundings_menu.cpp
+++ b/src/surroundings_menu.cpp
@@ -1090,6 +1090,9 @@ void surroundings_menu::draw_examine_info()
 {
     switch( selected_tab ) {
         case surroundings_menu_tab_enum::items: {
+            if( !item_data.selected_entry ) {
+                break;
+            }
             std::vector<iteminfo> selected_info;
             std::vector<iteminfo> dummy_info;
             const item *selected_item = item_data.selected_entry->get_selected_entity();


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Presumably fixes #84925
Unfortunately there wasn't enough info in the issue to determine the reason for the crash. This is a likely candidate, though.

#### Describe the solution

Don't try to draw the examine window, when no item is selected.

#### Describe alternatives you've considered



#### Testing

Apply a filter to make the item list show nothing, then hit the examine keybind. No more crash.

#### Additional context

