### PR TITLE
Account for pickup capability when determining if items in a tile can be sorted

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -12136,8 +12136,8 @@ bool zone_sort_activity_actor::stage_think( player_activity &act, Character &you
         if( pickup_failure && !pickup_failure_reported ) {
             pickup_failure_reported = true;
             add_msg_if_player_sees( you,
-                                    "At least one item to be sorted is too large/heavy for %s to sort.  "
-                                    "Emptying the inventory and freeing up the hands will allow for more efficient sorting.",
+                                    _( "At least one item to be sorted is too large/heavy for %s to sort.  "
+                                       "Emptying the inventory and freeing up the hands will allow for more efficient sorting." ),
                                     you.disp_name() );
         }
 
@@ -12374,6 +12374,7 @@ void zone_sort_activity_actor::serialize( JsonOut &jsout ) const
     jsout.member( "other_activity_items", other_activity_items );
     jsout.member( "picked_up_stuff", picked_up_stuff );
     jsout.member( "dropoff_coords", dropoff_coords );
+    jsout.member( "pickup_failure_reported", pickup_failure_reported );
 
     jsout.end_object();
 }
@@ -12392,7 +12393,10 @@ std::unique_ptr<activity_actor> zone_sort_activity_actor::deserialize( JsonValue
     data.read( "other_activity_items", actor.other_activity_items );
     data.read( "picked_up_stuff", actor.picked_up_stuff );
     data.read( "dropoff_coords", actor.dropoff_coords );
-
+    // Element introduced 2026-01-26. Existence check to be removed when support for older saves is dropped.
+    if( data.has_bool( "pickup_failure_reported" ) ) {
+        data.read( "pickup_failure_reported", actor.pickup_failure_reported );
+    }
     return actor.clone();
 }
 

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -3632,6 +3632,7 @@ class zone_sort_activity_actor : public zone_activity_actor
         std::vector<item_location> picked_up_stuff;
         // Place(s) that the current stuff can be dropped off at.
         std::vector<tripoint_abs_ms> dropoff_coords;
+        bool pickup_failure_reported = false;
 };
 
 #endif // CATA_SRC_ACTIVITY_ACTOR_DEFINITIONS_H

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -904,16 +904,23 @@ bool ignore_zone_position( Character &you, const tripoint_abs_ms &src,
 bool has_items_to_sort( Character &you, const tripoint_abs_ms &src,
                         unload_sort_options zone_unload_options,
                         const std::vector<item_location> &other_activity_items,
-                        const zone_items &items )
+                        const zone_items &items, bool *pickup_failure )
 {
     const zone_manager &mgr = zone_manager::get_manager();
     const faction_id fac_id = _fac_id( you );
     const tripoint_abs_ms &abspos = you.pos_abs();
 
+    *pickup_failure = false;
+
     for( std::pair<item *, bool> it_pair : items ) {
         item *it = it_pair.first;
         const zone_type_id zone_type_id = mgr.get_near_zone_type_for_item( *it, abspos,
                                           MAX_VIEW_DISTANCE, fac_id );
+
+        if( !you.can_add( *it ) ) {
+            *pickup_failure = true;
+            continue;
+        }
 
         if( sort_skip_item( you, it, other_activity_items,
                             zone_unload_options.ignore_favorite, src ) ) {

--- a/src/activity_item_handling.h
+++ b/src/activity_item_handling.h
@@ -100,10 +100,12 @@ bool ignore_contents( Character &you, const tripoint_abs_ms &src );
 bool ignore_zone_position( Character &you, const tripoint_abs_ms &src, bool ignore_contents );
 
 // of `items` at `src`, do any need to be sorted?
+// If pickup_failure is true on return, at least one item can't be sorted because it can't be picked up.
+// Note that this check is performed before the presence of a destination has been made.
 bool has_items_to_sort( Character &you, const tripoint_abs_ms &src,
                         zone_sorting::unload_sort_options zone_unload_options,
                         const std::vector<item_location> &other_activity_items,
-                        const zone_sorting::zone_items &items );
+                        const zone_sorting::zone_items &items, bool *pickup_failure );
 bool can_unload( item *it );
 void add_item( const std::optional<vpart_reference> &vp, const tripoint_bub_ms &src_bub,
                const item &it );

--- a/src/character.h
+++ b/src/character.h
@@ -2165,7 +2165,7 @@ class Character : public Creature, public visitable
                                const item *original_inventory_item = nullptr, bool allow_wield = true,
                                bool ignore_pkt_settings = false );
         /** Checks to see if it's possible to add an item to the inventory. */
-        bool can_add( item it, const item *avoid = nullptr,
+        bool can_add( const item &it, const item *avoid = nullptr,
                       bool allow_wield = true,
                       bool ignore_pkt_settings = false );
 

--- a/src/character.h
+++ b/src/character.h
@@ -2164,6 +2164,10 @@ class Character : public Creature, public visitable
         item_location try_add( item it, int &copies_remaining, const item *avoid = nullptr,
                                const item *original_inventory_item = nullptr, bool allow_wield = true,
                                bool ignore_pkt_settings = false );
+        /** Checks to see if it's possible to add an item to the inventory. */
+        bool can_add( item it, const item *avoid = nullptr,
+                      bool allow_wield = true,
+                      bool ignore_pkt_settings = false );
 
         ret_val<item_location> i_add_or_fill( item &it, bool should_stack = true,
                                               const item *avoid = nullptr,

--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -424,6 +424,25 @@ item_location Character::try_add( item it, int &copies_remaining, const item *av
     return first_item_added;
 }
 
+bool Character::can_add( item it, const item *avoid,
+                         bool allow_wield,
+                         bool ignore_pkt_settings )
+{
+    invalidate_inventory_validity_cache();
+    invalidate_leak_level_cache();
+
+    std::pair<item_location, item_pocket *> pocket = best_pocket( it, avoid, ignore_pkt_settings );
+    if( pocket.second == nullptr ) {
+        if( !has_weapon() && allow_wield && can_wield( it ).success() ) {
+            return true;
+        } else {
+            return false;
+        }
+    } else {
+        return true;
+    }
+}
+
 item_location Character::i_add( item it, bool /* should_stack */, const item *avoid,
                                 const item *original_inventory_item, const bool allow_drop,
                                 const bool allow_wield, bool ignore_pkt_settings )

--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -424,7 +424,7 @@ item_location Character::try_add( item it, int &copies_remaining, const item *av
     return first_item_added;
 }
 
-bool Character::can_add( item it, const item *avoid,
+bool Character::can_add( const item &it, const item *avoid,
                          bool allow_wield,
                          bool ignore_pkt_settings )
 {


### PR DESCRIPTION


<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #84891, i.e. ensure the character can actually pick up items that are to be sorted to avoid an infinite loop.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add a check to see if items can be picked up when determining which tiles contain items that can be sorted.
Also issue a message the first time such an item is encountered.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Chip away further of this mound of broken functionality, but KISS.
- Find a way to display the too large item message in a more prominent way.
- Add some kind of "minimum available inventory capacity" check and issue a warning message if a character with a lower capacity than that attempts to sort things. It's probably a good idea, but shouldn't be crammed into this PR.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
- Order the PC in the bug report save to sort out items.
- The message about inability to sort is issed, becase, for some reason, the PC has zero available inventory space (probably pocket stuff, which I don't know anything about and don't want to deal with), and the sorting "completes" immediately.
- Free up the PC's hands and order sorting.
- The bugger runs back and forth moving one item at a time.
- Cancel after a while, as I can't wait all day.
- Debug spawn cargo pants and dress the PC with them (with the bayonet back in the hands).
- Order sorting.
- See the PC run around and sort things out in what looks like multiple items per trip.
- See the message about large items in the middle of it.
- Cancel after a while, as I still don't have all day.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
There are a lot of things that should be done to get this to work in a somewhat reasonable manner.
- Fix outstanding bugs (that nobody have even bothered to confirm).
- Remove processed tiles from the set to process when nothing more can be done with them, rather than process them over and over again until none of them has anything that can be done one them.
- Introduce logic that ensures items can actually be stored on destination tiles. The somewhat sloppy logic used for direct teleportation doesn't cut it when the characters are to "carry" the items: You have to ensure the destination can receive all the items you designate for that tile, probably by limiting how much you pick up to not overflow the destination tile(s)'s capacity. Note that you still have to add overflow handing logic, because multiple characters sorting can have the destination(s) have less free space when the character arrives to deliver items to it that it had when the items were picked up, because other characters can have delivered items in the mean time (and the PC can move stuff around manually while companions are sorting). I believe there's an outstanding bug report for this (hanging when destination is full).
- The above is probably just a subset of what's needed to get things to work reliably.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
