### PR TITLE
Add a cooking recipe specifically to remove elderberries toxins

### DIFF
--- a/data/json/items/comestibles/fruit_dishes.json
+++ b/data/json/items/comestibles/fruit_dishes.json
@@ -595,5 +595,16 @@
     "//": "this item is intended to generally be inherited from the fruit and alcohol used.",
     "vitamins": [ [ "vitC", 20 ], [ "fruit_allergen", 1 ] ],
     "flags": [ "USE_EAT_VERB", "EATEN_COLD", "ALCOHOL" ]
+  },
+  {
+    "id": "cooked_elderberries",
+    "copy-from": "elderberries",
+    "type": "ITEM",
+    "subtypes": [ "COMESTIBLE" ],
+    "comestible_type": "FOOD",
+    "name": { "str_sp": "cooked elderberries" },
+    "description": "A serving of elderberries, cooked just enough to remove the toxins.",
+    "use_action": [  ],
+    "flags": [  ]
   }
 ]

--- a/data/json/recipes/food/fruit_dishes.json
+++ b/data/json/recipes/food/fruit_dishes.json
@@ -135,5 +135,18 @@
     "tools": [ [ [ "surface_heat", 2, "LIST" ] ] ],
     "//": "1u for fruit and 1u for sugar, you're basically just turning it into goop and not really cooking it",
     "components": [ [ [ "sweet_fruit", 1, "LIST" ] ], [ [ "sugar_powdered", 10, "LIST" ] ] ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "result": "cooked_elderberries",
+    "category": "CC_FOOD",
+    "subcategory": "CSC_FOOD_VEGGI",
+    "skill_used": "cooking",
+    "time": "5 m",
+    "autolearn": true,
+    "qualities": [ { "id": "COOK", "level": 2 } ],
+    "tools": [ [ [ "surface_heat", 2, "LIST" ] ] ],
+    "components": [ [ [ "elderberries", 1 ] ] ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I may have went a tiny bit overboard in #84861, there is one purpose of cooking fruit, and it's to remove toxins, specifically in the case of elderberries.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Revert (add) the cooked_fruit recipe except now it only allows cooking elderberries and the result is specifically a cooked_elderberries item which is a full copy-from of elderberries except without the flags and without the POISON use_action.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

1. Allow may apple: no source that I found corroborates that cooking mayapples removes their toxins. It seems to only be related to ripeness and what part of the fruit is used and in what quantity, cooking itself doesn't seem to do anything.
2. Allow other fruits: no, no one eats "just fruit except cooked until hot mush", that's not human food, add sugar you barbarian. 

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loads.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
If someone wants to add a recipe that's between "hot mush" and "jam" feel free to add it. Heck why not audit the jam recipe.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
