### PR TITLE
[Mods] Use external options in the manipulation of mods skills and proficiencies

### DIFF
--- a/data/mods/MindOverMatter/effectoncondition/eoc_misc.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_misc.json
@@ -15,7 +15,11 @@
     "condition": {
       "and": [ { "test_eoc": "EOC_CONDITION_SPELLCASTING_FINISH_TRAIT_AND_SCHOOL_LIST" }, { "math": [ "_success != false" ] } ]
     },
-    "effect": [ { "math": [ "u_skill_exp('metaphysics', 'format': 'raw') += (100 * _difficulty)" ] } ]
+    "effect": [
+      {
+        "math": [ "u_skill_exp('metaphysics', 'format': 'raw') += (100 * _difficulty * game_option('SKILL_TRAINING_SPEED'))" ]
+      }
+    ]
   },
   {
     "type": "effect_on_condition",
@@ -25,7 +29,11 @@
     "condition": {
       "and": [ { "test_eoc": "EOC_CONDITION_SPELLCASTING_FINISH_TRAIT_AND_SCHOOL_LIST" }, { "math": [ "_success == false" ] } ]
     },
-    "effect": [ { "math": [ "u_skill_exp('metaphysics', 'format': 'raw') += (25 * _difficulty)" ] } ]
+    "effect": [
+      {
+        "math": [ "u_skill_exp('metaphysics', 'format': 'raw') += (25 * _difficulty * game_option('SKILL_TRAINING_SPEED'))" ]
+      }
+    ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/MindOverMatter/effectoncondition/eoc_on_power_use_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_on_power_use_events.json
@@ -681,7 +681,11 @@
           "rng( 3,8 ) * (u_vitamin('vitamin_maintained_powers')) / concentration_calculations()"
         ]
       },
-      { "math": [ "u_skill_exp('metaphysics', 'format': 'raw') += (15 * u_latest_channeled_power_difficulty)" ] },
+      {
+        "math": [
+          "u_skill_exp('metaphysics', 'format': 'raw') += (15 * u_latest_channeled_power_difficulty * game_option('SKILL_TRAINING_SPEED'))"
+        ]
+      },
       { "run_eocs": "EOC_CONCENTRATION_CHECK_FOR_NETHER_ATTUNEMENT_BACKLASH" }
     ],
     "false_effect": [
@@ -695,7 +699,11 @@
           "EOC_CONCENTRATION_VS_LIMIT_CALCULATIONS"
         ]
       },
-      { "math": [ "u_skill_exp('metaphysics', 'format': 'raw') += (75 * u_latest_channeled_power_difficulty)" ] }
+      {
+        "math": [
+          "u_skill_exp('metaphysics', 'format': 'raw') += (75 * u_latest_channeled_power_difficulty * game_option('SKILL_TRAINING_SPEED'))"
+        ]
+      }
     ]
   },
   {
@@ -708,7 +716,13 @@
         { "math": [ "u_vitamin('vitamin_maintained_powers') > 0" ] }
       ]
     },
-    "effect": [ { "math": [ "u_proficiency('prof_concentration_basic', 'format': 'percent') += rand(4) / 24" ] } ],
+    "effect": [
+      {
+        "math": [
+          "u_proficiency('prof_concentration_basic', 'format': 'percent') += ( ( rand(4) / 24) * game_option('PROFICIENCY_TRAINING_SPEED') )"
+        ]
+      }
+    ],
     "//": "adds 0% - 0.16% experience per run",
     "false_effect": {
       "run_eocs": [
@@ -721,7 +735,13 @@
               { "math": [ "u_vitamin('vitamin_maintained_powers') > 0" ] }
             ]
           },
-          "effect": [ { "math": [ "u_proficiency('prof_concentration_intermediate', 'format': 'percent') += rand(4) / 48" ] } ],
+          "effect": [
+            {
+              "math": [
+                "u_proficiency('prof_concentration_intermediate', 'format': 'percent') += ( ( rand(4) / 48) * game_option('PROFICIENCY_TRAINING_SPEED') )"
+              ]
+            }
+          ],
           "false_effect": {
             "run_eocs": [
               {
@@ -733,7 +753,13 @@
                     { "math": [ "u_vitamin('vitamin_maintained_powers') > 0" ] }
                   ]
                 },
-                "effect": [ { "math": [ "u_proficiency('prof_concentration_master', 'format': 'percent') += rand(4) / 96" ] } ]
+                "effect": [
+                  {
+                    "math": [
+                      "u_proficiency('prof_concentration_master', 'format': 'percent') += ( ( rand(4) / 96 ) * game_option('PROFICIENCY_TRAINING_SPEED') )"
+                    ]
+                  }
+                ]
               }
             ]
           }

--- a/data/mods/MindOverMatter/powers/learning_eocs/overall.json
+++ b/data/mods/MindOverMatter/powers/learning_eocs/overall.json
@@ -70,7 +70,11 @@
       ]
     },
     "effect": [
-      { "math": [ "u_skill_exp('metaphysics', 'format': 'raw') += (35 * u_latest_studied_power_difficulty)" ] },
+      {
+        "math": [
+          "u_skill_exp('metaphysics', 'format': 'raw') += (35 * u_latest_studied_power_difficulty * game_option('SKILL_TRAINING_SPEED'))"
+        ]
+      },
       { "run_eocs": "EOC_PSI_STUDYING_POWER_METAPHYSICS_GAIN", "time_in_future": [ "30 seconds", "5 minutes" ] }
     ]
   },

--- a/data/mods/Xedra_Evolved/eocs/misc_eoc.json
+++ b/data/mods/Xedra_Evolved/eocs/misc_eoc.json
@@ -44,7 +44,7 @@
         }
       ]
     },
-    "effect": [ { "math": [ "u_skill_exp('deduction', 'format': 'raw') += 250" ] } ]
+    "effect": [ { "math": [ "u_skill_exp('deduction', 'format': 'raw') += 250 * game_option('SKILL_TRAINING_SPEED')" ] } ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/Xedra_Evolved/items/books_deduction.json
+++ b/data/mods/Xedra_Evolved/items/books_deduction.json
@@ -342,7 +342,11 @@
         },
         "then": { "math": [ "u_deduction_from_book_lies_counter += u_deduction_from_book_lies_counter" ] }
       },
-      { "math": [ "u_skill_exp('deduction', 'format': 'raw') += u_deduction_from_book_lies_counter" ] },
+      {
+        "math": [
+          "u_skill_exp('deduction', 'format': 'raw') += u_deduction_from_book_lies_counter * game_option('SKILL_TRAINING_SPEED')"
+        ]
+      },
       { "math": [ "u_deduction_from_book_lies_counter = 0" ] }
     ]
   }

--- a/data/mods/aftershock_exoplanet/EOC/esper_eoc.json
+++ b/data/mods/aftershock_exoplanet/EOC/esper_eoc.json
@@ -214,7 +214,13 @@
         { "math": [ "u_vitamin('vitamin_afs_maintained_powers') > 0" ] }
       ]
     },
-    "effect": [ { "math": [ "u_proficiency('prof_concentration_basic', 'format': 'percent') += rand(4) / 24" ] } ],
+    "effect": [
+      {
+        "math": [
+          "u_proficiency('prof_concentration_basic', 'format': 'percent') += ( ( rand(4) / 24) * game_option('PROFICIENCY_TRAINING_SPEED') )"
+        ]
+      }
+    ],
     "//": "adds 0% - 0.16% experience per run",
     "false_effect": {
       "run_eocs": [
@@ -226,7 +232,13 @@
               { "math": [ "u_vitamin('vitamin_afs_maintained_powers') > 0" ] }
             ]
           },
-          "effect": [ { "math": [ "u_proficiency('prof_concentration_intermediate', 'format': 'percent') += rand(4) / 48" ] } ],
+          "effect": [
+            {
+              "math": [
+                "u_proficiency('prof_concentration_intermediate', 'format': 'percent') += ( ( rand(4) / 48) * game_option('PROFICIENCY_TRAINING_SPEED') )"
+              ]
+            }
+          ],
           "false_effect": {
             "run_eocs": [
               {
@@ -237,7 +249,13 @@
                     { "math": [ "u_vitamin('vitamin_afs_maintained_powers') > 0" ] }
                   ]
                 },
-                "effect": [ { "math": [ "u_proficiency('prof_concentration_master', 'format': 'percent') += rand(4) / 96" ] } ]
+                "effect": [
+                  {
+                    "math": [
+                      "u_proficiency('prof_concentration_master', 'format': 'percent') += ( ( rand(4) / 96 ) * game_option('PROFICIENCY_TRAINING_SPEED') )"
+                    ]
+                  }
+                ]
               }
             ]
           }
@@ -267,7 +285,11 @@
     "effect": [
       { "u_message": "Your concentration breaks!", "type": "bad" },
       { "run_eocs": [ "EOC_AFS_END_PSI_POWERS_MAINTAINED" ] },
-      { "math": [ "u_skill_exp('metaphysics', 'format': 'raw') += (35 * u_latest_channeled_power_difficulty)" ] }
+      {
+        "math": [
+          "u_skill_exp('metaphysics', 'format': 'raw') += (35 * u_latest_channeled_power_difficulty * game_option('SKILL_TRAINING_SPEED'))"
+        ]
+      }
     ],
     "false_effect": [
       {
@@ -388,7 +410,13 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_AFS_PSI_SKILL_INCREASE_ON_USE_FINALIZE",
-    "effect": [ { "math": [ "u_skill_exp('metaphysics', 'format': 'raw') += 150 * u_latest_channeled_power_difficulty" ] } ]
+    "effect": [
+      {
+        "math": [
+          "u_skill_exp('metaphysics', 'format': 'raw') += 150 * u_latest_channeled_power_difficulty * game_option('SKILL_TRAINING_SPEED')"
+        ]
+      }
+    ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/aftershock_exoplanet/recipes/esper/practice_eocs.json
+++ b/data/mods/aftershock_exoplanet/recipes/esper/practice_eocs.json
@@ -46,7 +46,11 @@
       ]
     },
     "effect": [
-      { "math": [ "u_skill_exp('metaphysics', 'format': 'raw') += (35 * u_latest_studied_power_difficulty)" ] },
+      {
+        "math": [
+          "u_skill_exp('metaphysics', 'format': 'raw') += (35 * u_latest_studied_power_difficulty * game_option('SKILL_TRAINING_SPEED'))"
+        ]
+      },
       { "run_eocs": "EOC_AFS_ESPER_STUDYING_POWER_METAPHYSICS_GAIN", "time_in_future": [ "30 seconds", "5 minutes" ] }
     ]
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Mods] Use external options in the manipulation of mods skills and proficiencies"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Various mods like Aftershock and Xedra Evolved directly add to skills or proficiencies using EoCs at some points (usually when activating supernatural powers). However, these EoCs were not affected by the external settings for skill or proficiency speed, meaning they would level artificially fast or slow, depending on your setting.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Use the `game_option` math parameter and apply the appropriate external settings where appropriate.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Set skill speed to 10x normal and proficiency speed to 1/4x normal. Sat in a car and concentrated on Cloak of Warmth for 12 hours. Gained 3 levels of metaphysics and 1% toward Basic Concentration. 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

This explains why my Sky Island character (1/4th normal skill and proficiency speed) got metaphysics 10 so quickly. 

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
