### PR TITLE
[Aftershock] Make Cordless Drill Spawn on Salus IV

### DIFF
--- a/data/mods/aftershock_exoplanet/itemgroups/tool_groups.json
+++ b/data/mods/aftershock_exoplanet/itemgroups/tool_groups.json
@@ -91,6 +91,7 @@
       { "item": "soldering_iron", "prob": 30 },
       { "item": "soldering_iron_portable", "prob": 30, "charges": [ 0, 50 ] },
       { "item": "solder_wire", "prob": 30 },
+      { "item": "cordless_drill", "prob": 20 },
       { "group": "duct_tape_roll_part", "prob": 30, "count": [ 1, 2 ] }
     ]
   },
@@ -309,6 +310,7 @@
       { "item": "goggles_welding", "prob": 5 },
       { "item": "polisher", "prob": 20 },
       { "item": "angle_grinder", "prob": 20 },
+      { "item": "cordless_drill", "prob": 20 },
       [ "thread_cutting_set", 5 ],
       [ "hand_pump", 5 ],
       [ "jumper_cable", 10 ],


### PR DESCRIPTION
#### Summary
Mods "Makes cordless drill spawn in Aftershock"

#### Purpose of change
Handheld drills did not spawn anywhere in aftershock, the only source of drilling I could find was to either make your own manual (hand) drill, or use the drill press appliance. This is odd, especially as the drill is a needed tool to do any complex vehicle work, and there are garages everywhere

#### Describe the solution
Add drills to electrical repair itemgroup and vehicle bay itemgroup, so it spawns in vehicle bays, maintenance outposts, and SHOULD TODO spawn in exosuit garages and normal garages

#### Describe alternatives you've considered
Curse the miserable inhabitants of Salus IV to a life without hand drills

#### Testing
Loaded the game, works. Spawned itemgroups:

#### Additional context
You mean to tell me there is a garage, exosuit garage, or general store on every corner, and not one has a hand drill?

TODO:
Figure out exactly which itemgroups have these groups as upstreams (just electric, vehicle-bay is self contained I think)
Test every downstream itemgroup
Make garages/exosuit garages spawn drills (and maybe tools in general? probably out of scope) at a less miserable rate
Add the drill to the structural repair group so it will spawn in more places (including general stores)
Make some percentage of the drill spawns in the vehicle/exosuit garages be corded instead of cordless