### PR TITLE
Add Graphite and Feldspar to cave spawn pool (Innawood)

### DIFF
--- a/data/mods/innawood/mining/itemgroups/Location_MapExtras_locations.json
+++ b/data/mods/innawood/mining/itemgroups/Location_MapExtras_locations.json
@@ -25,7 +25,9 @@
         { "item": "chunk_cassiterite", "count": [ 2, 4 ], "prob": 10 },
         { "item": "chunk_galena", "count": [ 2, 4 ], "prob": 10 },
         { "item": "chunk_hematite", "count": [ 2, 2 ], "prob": 10 },
-        { "item": "chunk_magnetite", "count": [ 2, 2 ], "prob": 5 }
+        { "item": "chunk_magnetite", "count": [ 2, 2 ], "prob": 5 },
+        { "item": "chunk_graphite", "count": [ 0, 1 ], "prob": 2 },
+        { "item": "chunk_feldspar", "count": [ 2, 4 ], "prob": 10 }
       ]
     }
   }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "I am adding Graphite and Feldspar to the cave ore spawn pool"

#### Purpose of change

This change fixes #84108, which is about players not being able to find graphite in the game world to make a clay crucible. previously, it spawned only in the "outcrop" location,  with a very low spawn rate, which made it almost impossible to find. 
#### Describe the solution

this adds "chunk_graphite" and "chunk_feldspar" to the "cave_minerals" item group in the innawoods/mining/itemgroups folder

#### Describe alternatives you've considered

I considered buffing the graphite spawn rate for the outcrop location, but that doesnt deal with the issue of players not knowing it was there

i also considered adding a dialogue option to NPC's for where they have seen ore locations, which could give them a tip that graphite only spawns at outcrop locations, but even with that knowledge, that specific type of outcrop is exceptionally rare.

Lastly, i considered spawning the regular graphite materiel in small quantities, requiring the player to go to multiple caves to get enough. if graphite proves too easy to find, that may be something that is done.

#### Testing

Loaded up a new world, teleported around and made sure both graphite and feldspar spawned, as well as all the other expected ores inside of caves

#### Additional context

Since graphite is only used once, we may need to come back and nerf graphite spawn rate to make it a bit harder to find inside caves. most caves i went to had at least one chunk of graphite. 


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
