### PR TITLE
[Xedra Evolved] Fix elemental fae joining the Butlerian Jihad

### DIFF
--- a/data/mods/Xedra_Evolved/monsters/elementals.json
+++ b/data/mods/Xedra_Evolved/monsters/elementals.json
@@ -312,7 +312,7 @@
         "id": "mon_shabriri_blinding",
         "type": "spell",
         "spell_data": { "id": "mon_shabriri_blind_spell", "min_level": 0 },
-        "cooldown": 30,
+        "cooldown": 20,
         "monster_message": ""
       }
     ],

--- a/data/mods/Xedra_Evolved/monsters/monfaction.json
+++ b/data/mods/Xedra_Evolved/monsters/monfaction.json
@@ -33,7 +33,7 @@
     "name": "arvore",
     "base_faction": "changeling",
     "neutral": [ "small_animal", "fish" ],
-    "by_mood": [ "nether", "nightmares", "ierde", "undine", "sylph", "salamander", "changeling" ],
+    "by_mood": [ "nether", "nightmares", "ierde", "undine", "sylph", "salamander", "changeling", "robot" ],
     "hate": [ "zombie", "homullus", "thornbeast", "cult" ]
   },
   {
@@ -41,7 +41,7 @@
     "name": "ierde",
     "base_faction": "changeling",
     "friendly": [ "worm" ],
-    "neutral": [ "small_animal", "fish" ],
+    "neutral": [ "small_animal", "fish", "robot" ],
     "by_mood": [ "nether", "nightmares", "homullus", "arvore", "undine", "salamander", "changeling" ],
     "hate": [ "zombie", "sylph", "cult" ]
   },
@@ -49,7 +49,7 @@
     "type": "MONSTER_FACTION",
     "name": "undine",
     "base_faction": "changeling",
-    "neutral": [ "small_animal", "fish" ],
+    "neutral": [ "small_animal", "fish", "robot" ],
     "by_mood": [ "nether", "nightmares", "homullus", "arvore", "sylph", "ierde", "slime", "changeling" ],
     "hate": [ "zombie", "salamander", "cult" ]
   },
@@ -57,7 +57,7 @@
     "type": "MONSTER_FACTION",
     "name": "salamander",
     "base_faction": "changeling",
-    "neutral": [ "small_animal", "fish" ],
+    "neutral": [ "small_animal", "fish", "robot" ],
     "by_mood": [ "nether", "nightmares", "ierde", "arvore", "sylph", "homullus", "changeling" ],
     "hate": [ "zombie", "undine", "cult" ]
   },
@@ -65,6 +65,7 @@
     "type": "MONSTER_FACTION",
     "name": "homullus",
     "base_faction": "changeling",
+    "friendly": [ "robot" ],
     "neutral": [ "small_animal", "fish" ],
     "by_mood": [ "nether", "nightmares", "ierde", "arvore", "sylph", "salamander", "changeling" ],
     "hate": [ "zombie", "arvore", "cult" ]
@@ -73,9 +74,15 @@
     "type": "MONSTER_FACTION",
     "name": "sylph",
     "base_faction": "changeling",
-    "neutral": [ "small_animal", "fish" ],
+    "neutral": [ "small_animal", "fish", "robot" ],
     "by_mood": [ "nether", "nightmares", "homullus", "arvore", "undine", "salamander", "changeling" ],
     "hate": [ "zombie", "ierde", "cult" ]
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "robot",
+    "copy-from": "robot",
+    "extend": { "friendly": [ "homullus" ], "neutral": [ "sylph", "salamander", "undine", "ierde" ], "by_mood": [ "arvore" ] }
   },
   {
     "type": "MONSTER_FACTION",

--- a/data/mods/Xedra_Evolved/monsters/monfaction.json
+++ b/data/mods/Xedra_Evolved/monsters/monfaction.json
@@ -33,7 +33,7 @@
     "name": "arvore",
     "base_faction": "changeling",
     "neutral": [ "small_animal", "fish" ],
-    "by_mood": [ "nether", "nightmares", "ierde", "undine", "sylph", "salamander", "changeling", "robot" ],
+    "by_mood": [ "nether", "nightmares", "ierde", "undine", "sylph", "salamander", "changeling", "berserk_bot" ],
     "hate": [ "zombie", "homullus", "thornbeast", "cult" ]
   },
   {
@@ -41,7 +41,7 @@
     "name": "ierde",
     "base_faction": "changeling",
     "friendly": [ "worm" ],
-    "neutral": [ "small_animal", "fish", "robot" ],
+    "neutral": [ "small_animal", "fish", "berserk_bot" ],
     "by_mood": [ "nether", "nightmares", "homullus", "arvore", "undine", "salamander", "changeling" ],
     "hate": [ "zombie", "sylph", "cult" ]
   },
@@ -49,7 +49,7 @@
     "type": "MONSTER_FACTION",
     "name": "undine",
     "base_faction": "changeling",
-    "neutral": [ "small_animal", "fish", "robot" ],
+    "neutral": [ "small_animal", "fish", "berserk_bot" ],
     "by_mood": [ "nether", "nightmares", "homullus", "arvore", "sylph", "ierde", "slime", "changeling" ],
     "hate": [ "zombie", "salamander", "cult" ]
   },
@@ -57,7 +57,7 @@
     "type": "MONSTER_FACTION",
     "name": "salamander",
     "base_faction": "changeling",
-    "neutral": [ "small_animal", "fish", "robot" ],
+    "neutral": [ "small_animal", "fish", "berserk_bot" ],
     "by_mood": [ "nether", "nightmares", "ierde", "arvore", "sylph", "homullus", "changeling" ],
     "hate": [ "zombie", "undine", "cult" ]
   },
@@ -65,7 +65,7 @@
     "type": "MONSTER_FACTION",
     "name": "homullus",
     "base_faction": "changeling",
-    "friendly": [ "robot" ],
+    "friendly": [ "berserk_bot" ],
     "neutral": [ "small_animal", "fish" ],
     "by_mood": [ "nether", "nightmares", "ierde", "arvore", "sylph", "salamander", "changeling" ],
     "hate": [ "zombie", "arvore", "cult" ]
@@ -74,14 +74,14 @@
     "type": "MONSTER_FACTION",
     "name": "sylph",
     "base_faction": "changeling",
-    "neutral": [ "small_animal", "fish", "robot" ],
+    "neutral": [ "small_animal", "fish", "berserk_bot" ],
     "by_mood": [ "nether", "nightmares", "homullus", "arvore", "undine", "salamander", "changeling" ],
     "hate": [ "zombie", "ierde", "cult" ]
   },
   {
     "type": "MONSTER_FACTION",
-    "name": "robot",
-    "copy-from": "robot",
+    "name": "berserk_bot",
+    "copy-from": "berserk_bot",
     "extend": { "friendly": [ "homullus" ], "neutral": [ "sylph", "salamander", "undine", "ierde" ], "by_mood": [ "arvore" ] }
   },
   {

--- a/data/mods/Xedra_Evolved/monsters/monster_spells.json
+++ b/data/mods/Xedra_Evolved/monsters/monster_spells.json
@@ -124,6 +124,7 @@
     "message": "",
     "teachable": false,
     "flags": [ "NO_PROJECTILE", "NO_HANDS", "NO_LEGS", "RANDOM_DURATION" ],
+    "extra_effects": [ { "id": "mon_shabriri_blind_spell_reduce_anger", "hit_self": true } ],
     "valid_targets": [ "ground", "hostile" ],
     "effect": "attack",
     "effect_str": "blind",
@@ -132,6 +133,24 @@
     "max_range": 20,
     "min_duration": 3000,
     "max_duration": 18000
+  },
+  {
+    "id": "mon_shabriri_blind_spell_reduce_anger",
+    "type": "SPELL",
+    "name": { "str": "Shabriri Blinding Spell Reduce Anger", "//~": "NO_I18N" },
+    "description": { "str": "After we blind a target we're less annoyed at them.", "//~": "NO_I18N" },
+    "message": "",
+    "teachable": false,
+    "flags": [ "NO_PROJECTILE", "NO_HANDS", "NO_LEGS" ],
+    "valid_targets": [ "self" ],
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_SHABRIRI_REDUCE_ANGER",
+    "shape": "blast"
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_SHABRIRI_REDUCE_ANGER",
+    "effect": [ { "math": [ "u_val('anger') -=10" ] }, { "math": [ "u_val('morale') -=5" ] } ]
   },
   {
     "id": "death_guilt",

--- a/data/mods/Xedra_Evolved/monsters/monster_spells.json
+++ b/data/mods/Xedra_Evolved/monsters/monster_spells.json
@@ -132,7 +132,7 @@
     "min_range": 20,
     "max_range": 20,
     "min_duration": 3000,
-    "max_duration": 18000
+    "max_duration": 30000
   },
   {
     "id": "mon_shabriri_blind_spell_reduce_anger",
@@ -150,7 +150,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_SHABRIRI_REDUCE_ANGER",
-    "effect": [ { "math": [ "u_val('anger') -=10" ] }, { "math": [ "u_val('morale') -=5" ] } ]
+    "effect": [ { "math": [ "u_val('anger') -=50" ] }, { "math": [ "u_val('morale') -=30" ] } ]
   },
   {
     "id": "death_guilt",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Xedra Evolved] Fix elemental fae joining the Butlerian Jihad"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

_**Thou Shalt Not Make a Machine In-**_

Ahem, excuse me.

anoobindisguise found the prototype robot and some shabririm engaged in a battle to the death, and frankly they shouldn't even acknowledge each other's existences. Also, shabririm should not just hang around and spam-blind you until you're blind forever.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Reduce the cooldown of the shabriri blinding power, but make it so puts a large penalty on their morale and aggression when they use it, so they're much more likely to run afterwards.

Also, increase the top end possible duration for the blinding.

Add some faction relations to elemental fae and `berserk_bot` faction. Homullus are friendly to them, arvore are `by_mood` so they'll still kill robots, all other elemental fae are neutral (and mirror this on the berserk_bot side)
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Put two shabririm and a protoype robot in a small room, _shalom bayit_ was preserved.

Pissed off a shabriri, it blinded me and then ran away not long after.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
