### PR TITLE
Move surroundings_menu_tab_enum to enums.h

### DIFF
--- a/src/enums.h
+++ b/src/enums.h
@@ -543,4 +543,16 @@ struct enum_traits<bp_type> {
     static constexpr bp_type last = bp_type::num_types;
 };
 
+enum class surroundings_menu_tab_enum : int {
+    items = 0,
+    monsters,
+    terfurn,
+    num_tabs
+};
+
+template<>
+struct enum_traits<surroundings_menu_tab_enum> {
+    static constexpr surroundings_menu_tab_enum last = surroundings_menu_tab_enum::num_tabs;
+};
+
 #endif // CATA_SRC_ENUMS_H

--- a/src/surroundings_menu.h
+++ b/src/surroundings_menu.h
@@ -14,6 +14,7 @@
 #include "cata_imgui.h"
 #include "color.h"
 #include "coordinates.h"
+#include "enums.h"
 #include "input_context.h"
 #include "map_entity_stack.h"
 #include "translations.h"
@@ -21,22 +22,9 @@
 class avatar;
 class Character;
 class Creature;
-template <typename T> struct enum_traits;
 class item;
 class map;
 struct map_data_common_t;
-
-enum class surroundings_menu_tab_enum : int {
-    items = 0,
-    monsters,
-    terfurn,
-    num_tabs
-};
-
-template<>
-struct enum_traits<surroundings_menu_tab_enum> {
-    static constexpr surroundings_menu_tab_enum last = surroundings_menu_tab_enum::num_tabs;
-};
 
 class tab_data
 {

--- a/src/uistate.h
+++ b/src/uistate.h
@@ -13,7 +13,6 @@
 #include "item_location.h"
 #include "json.h"
 #include "omdata.h"
-#include "surroundings_menu.h"
 #include "type_id.h"
 
 constexpr int DEFAULT_TILESET_ZOOM = 16;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

It's pretty dumb to include `surroundings_menu.h` in `uistate.h`, as it leads to a lot of unnecessary compiling.

#### Describe the solution

Move it and fix includes.

#### Describe alternatives you've considered



#### Testing

It still compiles.

#### Additional context

