### PR TITLE
Show time to hacksaw before committing to doing it

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -1291,7 +1291,7 @@ void hacksaw_activity_actor::start( player_activity &act, Character &/*who*/ )
     // Speed based on the SAW_M quality.  A hacksaw, at SAW_M 2, matches the duration in JSON data.
     // The reciprocating saw has SAW_M 3 and it cuts twice as fast as a hacksaw since it's an 800
     // watt power tool.  SAW_M 4 is thrice as fast as a hacksaw and so on.
-    act.moves_total = moves_before_quality / (qual - 1);
+    act.moves_total = moves_before_quality / ( qual - 1 );
     add_msg_debug( debugmode::DF_ACTIVITY, "%s moves_total: %d", act.id().str(), act.moves_total );
     act.moves_left = act.moves_total;
 }

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -1288,10 +1288,10 @@ void hacksaw_activity_actor::start( player_activity &act, Character &/*who*/ )
         return;
     }
 
-    //Speed of hacksaw action is the SAW_M quality over 2, 2 being the hacksaw level.
-    //3 makes the speed one-and-a-half times, and the total moves 66% of hacksaw. 4 is twice the speed, 50% the moves, etc, 5 is 2.5 times the speed, 40% the original time
-    //done because it's easy to code, and diminising returns on cutting speed make sense as the limiting factor becomes aligning the tool and controlling it instead of the actual cutting
-    act.moves_total = moves_before_quality / ( qual / 2 );
+    // Speed based on the SAW_M quality.  A hacksaw, at SAW_M 2, matches the duration in JSON data.
+    // The reciprocating saw has SAW_M 3 and it cuts twice as fast as a hacksaw since it's an 800
+    // watt power tool.  SAW_M 4 is thrice as fast as a hacksaw and so on.
+    act.moves_total = moves_before_quality / (qual - 1);
     add_msg_debug( debugmode::DF_ACTIVITY, "%s moves_total: %d", act.id().str(), act.moves_total );
     act.moves_left = act.moves_total;
 }

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -4741,10 +4741,23 @@ std::optional<int> iuse::hacksaw( Character *p, item *it, const tripoint_bub_ms 
         }
         return std::nullopt;
     }
+    // Assign activity to calculate total_moves via ::start _before_ asking for confirmation.
     if( p->pos_bub() == it_pnt ) {
         p->assign_activity( hacksaw_activity_actor( pnt, item_location{ *p, it } ) );
     } else {
         p->assign_activity( hacksaw_activity_actor( pnt, it->typeId(), it_pnt ) );
+    }
+
+    std::string query = string_format( _( "Cut up metal using your %1$s?" ), it->tname() );
+    query += "\n";
+    query += _( "Time to complete: " );
+    int required_moves = p->activity.moves_total;
+    time_duration required_time = time_duration::from_turns( required_moves / p->get_speed() );
+    const std::string time_string = colorize( to_string( required_time, true ), c_light_gray );
+    query += time_string;
+
+    if( !query_yn( query ) ) {
+        p->cancel_activity();
     }
 
     return std::nullopt;


### PR DESCRIPTION
#### Summary

Interface "Show time to hacksaw before committing to doing it"

#### Purpose of change

The cut up metal action takes a non-trivial amount of time. We should expose that to the player as we would for an extended crafting action so they can make informed decisions.

#### Describe the solution

1. After building the activity, show the player how much time it would take them and ask for confirmation.
2. Fix a bug in hacksaw activity causing a reciprocating saw to take the same amount of time as a hacksaw.

#### Describe alternatives you've considered

1. Tried to factor out the time calculations but there are so many weird data types. 😵‍💫
2. Calculating how much power a character is applying based on `bmr` and activity level and comparing that with the power draw of the reciprocating saw to determine the ratio of their efficiency.

#### Testing

<img width="291" height="58" alt="image" src="https://github.com/user-attachments/assets/8ee41ba7-ea41-4c27-9cf0-6a7e39d1bec6" /> 
<img width="300" height="55" alt="image" src="https://github.com/user-attachments/assets/d0ea9560-f346-44a7-afa1-b18493b61c8d" />

In curses, the text box is truncating the `o` in No and the `)` in `(Case Sensitive)`.

Answering `N` doesn't start the activity.  Answering `Y` saws as usual. ✅

Time before cut: 8:56:30 AM.  Predicted duration: 4:32
Time after cut: 9:01:03 AM.  Actual duration: 4:43 ✅ 

- [ ] Test resuming activity. Power saws often need to be reloaded. 

#### Additional context

The old formula was broken because `3 / 2 = 1`.

The reciprocating saw draws 800 W while a human is likely applying no more than 100 W or so.  I made it 2x as fast but it should probably be more like 8 times faster relative to a hacksaw.


- Show Lockpicking time https://github.com/CleverRaven/Cataclysm-DDA/pull/84895
- Show Hotwiring time https://github.com/CleverRaven/Cataclysm-DDA/pull/84869

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
