### PR TITLE
Chipped away at zone sorting issues

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -12242,6 +12242,7 @@ void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
     // Dropping off
     if( !dropoff_coords.empty() && !picked_up_stuff.empty() ) {
         auto dest_iter = dropoff_coords.begin();
+
         while( dest_iter != dropoff_coords.end() ) {
             const tripoint_abs_ms drop_dest = *dest_iter;
             // Sometimes we loop back to here while still picking stuff up (because we spent all our moves picking up)
@@ -12264,10 +12265,10 @@ void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
                     }
 
                     // FIXME HACK: teleports item onto ground
-                    you.mod_moves( -you.item_handling_cost( **iter ) );
                     std::vector<item_location> dropped_crap = put_into_vehicle_or_drop_ret_locs( you,
-                            item_drop_reason::deliberate, { **iter }, here.get_bub( drop_dest ) );
+                            item_drop_reason::deliberate, { **iter }, here.get_bub( drop_dest ), false );
                     if( !dropped_crap.empty() ) {
+                        you.mod_moves( -you.item_handling_cost( **iter ) );
                         if( const vehicle_cursor *veh_curs = iter->veh_cursor() ) {
                             vehicle &cart_with_items = veh_curs->veh;
                             cart_with_items.remove_item( cart_with_items.part( veh_curs->part ), iter->get_item() );
@@ -12421,8 +12422,88 @@ void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
         //this location is sorted
         stage = THINK;
         dropoff_coords.clear();
+
     } else if( !dropoff_coords.empty() && !you.has_destination() )  {
-        zone_sorting::route_to_destination( you, act, here.get_bub( dropoff_coords.front() ), stage );
+        bool match = false;
+        tripoint_abs_ms destination;
+
+        // Find a dropoff location that can take all the items picked up.
+        for( tripoint_abs_ms &dest : dropoff_coords ) {
+            std::vector<item_location> placed_items;
+
+            match = true;
+
+            for( item_location &item : picked_up_stuff ) {
+                std::vector<item_location> placed_item = put_into_vehicle_or_drop_ret_locs( you,
+                        item_drop_reason::deliberate, { *item }, here.get_bub( dest ), false );
+
+                if( placed_item.empty() ) {
+                    match = false;
+                    break;
+
+                } else {
+                    placed_items.emplace_back( placed_item.front() );
+                }
+            }
+
+            // Get rid of the placed items, as we really only wanted to know if they COULD be placed.
+            for( item_location &item : placed_items ) {
+                item.remove_item();
+            }
+
+            if( match ) {
+                destination = dest;
+                break;
+            }
+        }
+
+        if( !match ) {
+            // Couldn't find any destination that would take all items. Fallback to one that can accept
+            // the first one that has a usable destination.
+            // Note that we always have to be able to handle the situation where a destination is full
+            // when we get there due to things happening in the mean time (like other characters sorting
+            // stuff into that location as we move there), so we leave the handling of unsortable items
+            // in the inventory to that handling for now.
+            for( tripoint_abs_ms &dest : dropoff_coords ) {
+                std::vector<item_location> placed_items;
+
+                match = true;
+
+                for( item_location &item : picked_up_stuff ) {
+                    std::vector<item_location> placed_item = put_into_vehicle_or_drop_ret_locs( you,
+                            item_drop_reason::deliberate, { *item }, here.get_bub( dest ), false );
+
+                    if( placed_item.empty() ) {
+                        match = false;
+                        break;
+
+                    } else {
+                        placed_items.emplace_back( placed_item.front() );
+                        match = true;
+                        break;
+                    }
+                }
+
+                // Get rid of the placed items, as we really only wanted to know if they COULD be placed.
+                for( item_location &item : placed_items ) {
+                    item.remove_item();
+                }
+
+                if( match ) {
+                    destination = dest;
+                    break;
+                }
+            }
+        }
+
+        if( !match ) {
+            add_msg( m_bad, _( "None of the items picked up can be sorted because they won't fit anywhere." ) );
+            stage = LAST;
+            return;
+        }
+
+        zone_sorting::route_to_destination( you, act, here.get_bub( destination ), stage );
+
     } else if( !you.has_destination() ) {
         debugmsg( "Sort activity has items to sort but no valid destination, this is a bug" );
         // Completely kick us out of this activity, something's gone wrong and we don't know what's going on.

--- a/src/activity_handlers.h
+++ b/src/activity_handlers.h
@@ -176,13 +176,14 @@ void put_into_vehicle_or_drop( Character &you, item_drop_reason, const std::list
 void put_into_vehicle_or_drop( Character &you, item_drop_reason, const std::list<item> &items,
                                map *here, const tripoint_bub_ms &where, bool force_ground = false );
 std::vector<item_location> put_into_vehicle_or_drop_ret_locs( Character &you, item_drop_reason,
-        const std::list<item> &items, tripoint_bub_ms dest = tripoint_bub_ms::invalid );
+        const std::list<item> &items, tripoint_bub_ms dest = tripoint_bub_ms::invalid,
+        bool allow_overflow = true );
 std::vector<item_location> put_into_vehicle_or_drop_ret_locs( Character &you, item_drop_reason,
         const std::list<item> &items, map *here, const tripoint_bub_ms &where,
-        bool force_ground = false );
+        bool force_ground = false, bool allow_overflow = true );
 std::vector<item_location> drop_on_map( Character &you, item_drop_reason reason,
                                         const std::list<item> &items,
-                                        map *here, const tripoint_bub_ms &where );
+                                        map *here, const tripoint_bub_ms &where, bool allow_overflow = true );
 // used in unit tests to avoid triggering user input
 void repair_item_finish( player_activity *act, Character *you, bool no_menu );
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #84960, i.e. zone sorting dumping items to overflow into adjacent tiles.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Change code so items can be dropped only if there is room for the items at the destination tile (i.e. no overflow into other tiles). This change only addresses tile destinations. It's unknown whether there is an issue with vehicle destinations.
- Only deduct time for items that were actually placed at the destination. Not doing this check led to an infinite (player interruptible) loop, because the time to fail was enough to restart evaluation from scratch the next tick, so it obviously failed as well.
- Added evaluation of destination tiles to select tiles that could receive all items if possible, and then just go for the first one. This also included some handling to break the process when nothing could be placed.
- 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
This is a big mess, with lots of issues everywhere. I ended up with a reasonably small PR that deals with some issues, but there's a lot left to do.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
- Using the #84960 save as a starting point, the test setup was:
- Teleport to  a free area (no zones or enemies).
- Debug spawn 100 logs.
- Place an unsorted zone around the logs.
- Place a 2*2 wood zone a short distance away.
- Debug spawn a shopping cart a little bit from the items.
- Grab the shopping cart.
- Unwield the bayonet.
- Save as the starting point for the actual tests.
- Order sorting.
- Verify 80 logs are sorted.
- Note that the PC ends up with one carried log and 3 in the shopping cart when sorting ends. This is left for future improvements.
- Reload the save.
- Wield the bayonet.
- Order sorting.
- See that the game thinks the PC doesn't have any sorting capacity because the shopping cart is not taken into consideration. This is left for future improvements.
- Unwield the bayonet and drop the shopping cart.
- Order sorting.
- See that 80 logs are sorted and 20 are not.
- Note that the PC ends up carrying a log. This is not desired and left for future improvements.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Apart from the things mentioned above, i.e. vehicle destination, and in the testing section, there are other unknown issues regarding usages of the operations that now allows for suppression of overflow, as some of them probably shouldn't support overflow and have handling to deal with such situations. However, their behavior has been left unchanged.

There's probably also a need to prune the destination tiles to remove ones where nothing can be stored, rather than uselessly iterating over them repeatedly.

The code dropping items currently lies about dropping items because the output is produced before the attempt is made. This ought to be fixed.

This PR addresses some infinite looping, but it's unknown if it addresses the bug report case.

There's a bug report (by me) about sorting to the wrong locations. It should obviously be fixed.

There's really a need for good feedback when everything isn't sorted so you're told why items aren't sorted (no valid destination, insufficient sorter carrying capacity, full destinations, ...), rather than the lie that everything has been sorted when there's clearly items left to sort. That's not trivial given how the task is split up in steps with limited communication between them. You probably need a report at the end, because everything printed during the process gets drowned in other output about passing items and dropping items.

The whole project of sorting by actually moving is premature, in my opinion. In order for it to work properly with more than a single character, robust pathing that's capable of navigating past other character and select alternative destination tiles then the desired one is occupied is needed. Even before this it wasn't unusual to see one companion issue incessant complaints about another companion being in the way. With this they'll block each other in their paths until the PC detects the lock and cancels the sorting (and resorts to sort with a single character only, reducing the collision risk, but it's not exactly farfetched to expect a sorter to run into a crafter who happens to be in the chosen path to a stockpile the crafter needs for its crafting.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
