### PR TITLE
Make unloading liquids from an item container take time

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -5280,6 +5280,12 @@ void unload_activity_actor::unload( Character &who, item_location &target )
              } ) {
 
             for( item *contained : it.all_items_top( ptype, true ) ) {
+                if( contained->made_of( phase_id::LIQUID ) ) {
+                    item_location liquid_loc = item_location( target, contained );
+                    liquid_handler::handle_liquid( liquid_loc, &it, 1 );
+                    return;
+                }
+
                 int old_charges = contained->charges;
                 const bool consumed = who.add_or_drop_with_msg( *contained, true, &it, contained );
                 if( consumed || contained->charges != old_charges ) {

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -216,7 +216,8 @@ void activity_handlers::fill_liquid_do_turn( player_activity *act, Character *yo
             }
             case liquid_source_type::CONTAINER_ITEM: {
                 if( !act_ref.source_liquid || !*act_ref.source_liquid ) {
-                    throw std::runtime_error( "could not find source liquid for liquid transfer" );
+                    debugmsg( "could not find source liquid for liquid transfer" );
+                    act_ref.set_to_null();
                 }
                 item_location &src_loc = *act_ref.source_liquid;
                 liquid = *src_loc;
@@ -360,7 +361,8 @@ void activity_handlers::fill_liquid_do_turn( player_activity *act, Character *yo
                 break;
             case liquid_source_type::CONTAINER_ITEM: {
                 if( !act_ref.source_liquid || !*act_ref.source_liquid ) {
-                    throw std::runtime_error( "could not find source liquid for charge removal" );
+                    debugmsg( "could not find source liquid for charge removal" );
+                    act_ref.set_to_null();
                 }
                 item_location &src_loc = *act_ref.source_liquid;
                 src_loc->charges -= removed_charges;

--- a/src/enums.h
+++ b/src/enums.h
@@ -281,7 +281,8 @@ enum class liquid_source_type : int {
     INFINITE_MAP = 1,
     MAP_ITEM = 2,
     VEHICLE = 3,
-    MONSTER = 4
+    MONSTER = 4,
+    CONTAINER_ITEM = 5
 };
 
 enum class liquid_target_type : int {

--- a/src/handle_liquid.cpp
+++ b/src/handle_liquid.cpp
@@ -86,6 +86,14 @@ static void serialize_liquid_source( player_activity &act, const tripoint_bub_ms
     act.str_values.push_back( serialize( liquid ) );
 }
 
+static void serialize_liquid_source( player_activity &act, const item_location &liquid_loc )
+{
+    act.values.push_back( static_cast<int>( liquid_source_type::CONTAINER_ITEM ) );
+    act.values.push_back( 0 ); // dummy
+    act.coords.emplace_back(); // dummy
+    act.source_liquid = liquid_loc;
+}
+
 static void serialize_liquid_target( player_activity &act, const vpart_reference &vp )
 {
     map &here = get_map();
@@ -566,6 +574,10 @@ bool perform_liquid_transfer( item_location &liquid, liquid_dest_opt &target )
         } else if( liquid.where() == item_location::type::map ) {
             player_character.assign_activity( ACT_FILL_LIQUID );
             serialize_liquid_source( player_character.activity, liquid.pos_bub( here ), *liquid );
+            return true;
+        } else if( liquid.where() == item_location::type::container ) {
+            player_character.assign_activity( ACT_FILL_LIQUID );
+            serialize_liquid_source( player_character.activity, liquid );
             return true;
         } else {
             return false;

--- a/src/player_activity.h
+++ b/src/player_activity.h
@@ -60,6 +60,8 @@ class player_activity
         int position = 0;
         std::string name;
         std::vector<item_location> targets;
+        // For transfering liquids from a container item
+        std::optional<item_location> source_liquid;
         std::vector<int> values;
         std::vector<std::string> str_values;
         std::vector<tripoint_abs_ms> coords;

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -399,6 +399,7 @@ void player_activity::serialize( JsonOut &json ) const
         json.member( "coord_set", coord_set );
         json.member( "name", name );
         json.member( "targets", targets );
+        json.member( "source_liquid", source_liquid );
         json.member( "placement", placement );
         json.member( "relative_placement", relative_placement );
         json.member( "values", values );
@@ -468,6 +469,7 @@ void player_activity::deserialize( const JsonObject &data )
     data.read( "coord_set", coord_set );
     data.read( "name", name );
     data.read( "targets", targets );
+    data.read( "source_liquid", source_liquid );
     data.read( "placement", placement );
     data.read( "relative_placement", relative_placement );
     values = data.get_int_array( "values" );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Balance "[u]nloading liquids from item containers now takes time"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
It will bring it in line with other types of liquid transfers that are incremental and take time
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Extend liquid activity handler to cover for item containers
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Unloaded a lot of liquid to different targets like ground, vehicles, standing tanks, tried unloading gasoline into a petri dish, tried unloading a sealed soda can, it got unsealed, dumped a carried 200L barrel, the weight carried progressively reduced 

<img width="868" height="537" alt="Screenshot 2026-01-28 at 21 00 31" src="https://github.com/user-attachments/assets/294f7931-b310-4d84-9f81-36930f2c24b0" />

There are still some cases where the time to refill something is 1 second, i'm planning to address it in further PR's if this one gets merged
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
The rate of liquid transfer can be adjusted based on source and target types, so it might be a good idea to make dumping quicker to somewhat account for open containers like buckets 

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
