### PR TITLE
Fix surroundings menu layout bugs

### DIFF
--- a/src/surroundings_menu.cpp
+++ b/src/surroundings_menu.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cfloat>
 #include <functional>
+#include <imgui/imgui.h>
 #include <imgui/imgui_internal.h>
 #include <iterator>
 #include <list>
@@ -285,8 +286,7 @@ int item_tab_data::get_max_entity_width()
 {
     int max_width = 0;
     for( auto &it : item_list ) {
-        max_width = std::max( max_width,
-                              utf8_width( remove_color_tags( it->get_selected_entity()->display_name() ) ) );
+        max_width = std::max( max_width, utf8_width( it->get_selected_name(), true ) );
     }
     return max_width;
 }
@@ -675,17 +675,12 @@ surroundings_menu::surroundings_menu( avatar &you, map &m, std::optional<tripoin
     you( you ),
     path_end( path_end ),
     stored_view_offset( you.view_offset ),
-    info_height( std::min( 25, TERMY / 2 ) )
+    min_width( min_width )
 {
     item_data.init( you, m );
     monster_data.init( you );
     terfurn_data.init( you, m );
 
-    // todo: add distance width, calculate correct creature text width
-    int wanted_width = std::max( { item_data.get_max_entity_width(),
-                                   monster_data.get_max_entity_width(),
-                                   terfurn_data.get_max_entity_width() } );
-    width = clamp( wanted_width, min_width, TERMX / 3 );
     highlight_new = get_option<bool>( "HIGHLIGHT_UNREAD_ITEMS" );
     switch_tab = uistate.vmenu_tab;
     if( you.get_wielded_item() ) {
@@ -695,8 +690,19 @@ surroundings_menu::surroundings_menu( avatar &you, map &m, std::optional<tripoin
 
 cataimgui::bounds surroundings_menu::get_bounds()
 {
-    info_height = std::min( 25, TERMY / 2 );
-    return { static_cast<float>( str_width_to_pixels( TERMX - width ) ), 0.f, static_cast<float>( str_width_to_pixels( width ) ), static_cast<float>( str_height_to_pixels( TERMY ) ) };
+    // todo: calculate correct creature text width
+    int wanted_width = dist_width + std::max( { item_data.get_max_entity_width(),
+                       monster_data.get_max_entity_width(),
+                       terfurn_data.get_max_entity_width() } );
+    width = clamp( wanted_width, min_width, TERMX / 3 );
+    // hide info panel on small displays
+    info_height = TERMY > 30 ? std::min( 25, TERMY / 2 ) : 0;
+    return {
+        static_cast<float>( str_width_to_pixels( TERMX - width ) ),
+        0.f,
+        static_cast<float>( str_width_to_pixels( width ) ),
+        static_cast<float>( str_height_to_pixels( TERMY ) )
+    };
 }
 
 void surroundings_menu::draw_controls()
@@ -747,6 +753,16 @@ static void mark_items_read_rec( const item *itm )
     }
 }
 
+static float total_cell_padding( int num_cols )
+{
+    return ImGui::GetStyle().CellPadding.x * ( num_cols - 1 ) * 2;
+}
+
+static float total_menu_padding( bool has_info )
+{
+    return ImGui::GetStyle().ItemSpacing.y * ( has_info ? 2 : 1 );
+}
+
 void surroundings_menu::draw_item_tab()
 {
     ImGuiTabItemFlags_ flags = ImGuiTabItemFlags_None;
@@ -761,11 +777,13 @@ void surroundings_menu::draw_item_tab()
         selected_tab = surroundings_menu_tab_enum::items;
 
         // list of nearby items
-        float list_height = str_height_to_pixels( TERMY - info_height ) -
-                            get_hotkey_buttons_height( &item_data ) - magic_number_other_elements_height;
-        if( ImGui::BeginTable( "items", 2, ImGuiTableFlags_ScrollY, ImVec2( 0.0f, list_height ) ) ) {
-            float name_col_width = str_width_to_pixels( width - dist_width - 3 );
+        float list_height = ImGui::GetContentRegionAvail().y - str_height_to_pixels( info_height ) -
+                            get_hotkey_buttons_height( &item_data ) - total_menu_padding( info_height > 0 );
+        const int num_cols = 2;
+        if( ImGui::BeginTable( "items", num_cols, ImGuiTableFlags_ScrollY, ImVec2( 0.0f, list_height ) ) ) {
             float dir_col_width = str_width_to_pixels( dist_width );
+            float name_col_width = ImGui::GetContentRegionAvail().x - dir_col_width -
+                                   total_cell_padding( num_cols );
             ImGui::TableSetupColumn( "it_name",
                                      ImGuiTableColumnFlags_WidthFixed | ImGuiTableColumnFlags_NoResize, name_col_width );
             ImGui::TableSetupColumn( "it_distance",
@@ -857,28 +875,30 @@ void surroundings_menu::draw_item_tab()
 
         draw_hotkey_buttons( &item_data );
 
-        if( ImGui::BeginChild( "info", ImVec2( 0.0f, str_height_to_pixels( info_height ) ) ) ) {
-            if( item_data.selected_entry ) {
-                const item *selected_it = item_data.selected_entry->get_selected_entity();
-                // using table so we get a (pre-styled) header
-                if( ImGui::BeginTable( "iteminfo", 1, ImGuiTableFlags_None, ImVec2( 0.0f, 0.0f ) ) ) {
-                    ImGui::TableSetupColumn( remove_color_tags( selected_it->display_name() ).c_str() );
-                    ImGui::TableHeadersRow();
-                    ImGui::TableNextColumn();
-                    // embedded info for selected item
-                    std::vector<iteminfo> selected_info;
-                    std::vector<iteminfo> dummy_info;
-                    selected_it->info( true, selected_info );
-                    item_info_data dummy( "", "", selected_info, dummy_info );
-                    dummy.without_getch = true;
-                    dummy.without_border = true;
-                    cataimgui::set_scroll( info_scroll );
-                    display_item_info( dummy.get_item_display(), dummy.get_item_compare() );
-                    ImGui::EndTable();
+        if( info_height > 0 ) {
+            if( ImGui::BeginChild( "info", ImVec2( 0.0f, str_height_to_pixels( info_height ) ) ) ) {
+                if( item_data.selected_entry ) {
+                    const item *selected_it = item_data.selected_entry->get_selected_entity();
+                    // using table so we get a (pre-styled) header
+                    if( ImGui::BeginTable( "iteminfo", 1, ImGuiTableFlags_None, ImVec2( 0.0f, 0.0f ) ) ) {
+                        ImGui::TableSetupColumn( remove_color_tags( selected_it->display_name() ).c_str() );
+                        ImGui::TableHeadersRow();
+                        ImGui::TableNextColumn();
+                        // embedded info for selected item
+                        std::vector<iteminfo> selected_info;
+                        std::vector<iteminfo> dummy_info;
+                        selected_it->info( true, selected_info );
+                        item_info_data dummy( "", "", selected_info, dummy_info );
+                        dummy.without_getch = true;
+                        dummy.without_border = true;
+                        cataimgui::set_scroll( info_scroll );
+                        display_item_info( dummy.get_item_display(), dummy.get_item_compare() );
+                        ImGui::EndTable();
+                    }
                 }
             }
+            ImGui::EndChild();
         }
-        ImGui::EndChild();
         ImGui::EndTabItem();
     }
 }
@@ -898,24 +918,27 @@ void surroundings_menu::draw_monster_tab()
         selected_tab = surroundings_menu_tab_enum::monsters;
 
         // list of nearby monsters
-        float list_height = str_height_to_pixels( TERMY - info_height ) -
-                            get_hotkey_buttons_height( &monster_data ) - magic_number_other_elements_height;
-        if( ImGui::BeginTable( "monsters", 5, ImGuiTableFlags_ScrollY, ImVec2( 0.0f, list_height ) ) ) {
+        float list_height = ImGui::GetContentRegionAvail().y - str_height_to_pixels( info_height ) -
+                            get_hotkey_buttons_height( &monster_data ) - total_menu_padding( info_height > 0 );
+        const int num_cols = 5;
+        if( ImGui::BeginTable( "monsters", num_cols, ImGuiTableFlags_ScrollY, ImVec2( 0.0f,
+                               list_height ) ) ) {
+            float sees_col_width = str_width_to_pixels( 1 );
+            float health_col_width = str_width_to_pixels( 5 );
+            float att_col_width = str_width_to_pixels( 12 );
+            float dir_col_width = str_width_to_pixels( dist_width );
+            float name_col_width = ImGui::GetContentRegionAvail().x - sees_col_width - health_col_width -
+                                   att_col_width - dir_col_width - total_cell_padding( num_cols );
             ImGui::TableSetupColumn( "mon_sees",
-                                     ImGuiTableColumnFlags_WidthFixed | ImGuiTableColumnFlags_NoResize,
-                                     str_width_to_pixels( 1 ) );
+                                     ImGuiTableColumnFlags_WidthFixed | ImGuiTableColumnFlags_NoResize, sees_col_width );
             ImGui::TableSetupColumn( "mon_name",
-                                     ImGuiTableColumnFlags_WidthFixed | ImGuiTableColumnFlags_NoResize,
-                                     str_width_to_pixels( width - dist_width - 26 ) );
+                                     ImGuiTableColumnFlags_WidthFixed | ImGuiTableColumnFlags_NoResize, name_col_width );
             ImGui::TableSetupColumn( "mon_health",
-                                     ImGuiTableColumnFlags_WidthFixed | ImGuiTableColumnFlags_NoResize,
-                                     str_width_to_pixels( 5 ) );
+                                     ImGuiTableColumnFlags_WidthFixed | ImGuiTableColumnFlags_NoResize, health_col_width );
             ImGui::TableSetupColumn( "mon_attitude",
-                                     ImGuiTableColumnFlags_WidthFixed | ImGuiTableColumnFlags_NoResize,
-                                     str_width_to_pixels( 18 ) );
+                                     ImGuiTableColumnFlags_WidthFixed | ImGuiTableColumnFlags_NoResize, att_col_width );
             ImGui::TableSetupColumn( "mon_distance",
-                                     ImGuiTableColumnFlags_WidthFixed | ImGuiTableColumnFlags_NoResize,
-                                     str_width_to_pixels( dist_width ) );
+                                     ImGuiTableColumnFlags_WidthFixed | ImGuiTableColumnFlags_NoResize, dir_col_width );
             if( monster_data.filtered_list.empty() ) {
                 monster_data.selected_entry = nullptr;
             } else if( !monster_data.selected_entry ||
@@ -988,7 +1011,7 @@ void surroundings_menu::draw_monster_tab()
                     att_text = npc_attitude_name( mon->as_npc()->get_attitude() );
                     att_color = mon->symbol_color();
                 }
-                cataimgui::draw_colored_text( att_text, att_color );
+                cataimgui::TextColoredTrimmed( att_text, att_color );
 
                 ImGui::TableNextColumn();
                 cataimgui::draw_colored_text( it->get_selected_distance_string(), c_light_gray );
@@ -999,14 +1022,16 @@ void surroundings_menu::draw_monster_tab()
         draw_hotkey_buttons( &monster_data );
 
         // embedded info for selected monster
-        if( ImGui::BeginChild( "info", ImVec2( 0.0f, str_height_to_pixels( info_height ) ) ) ) {
-            if( monster_data.selected_entry ) {
-                draw_extended_description(
-                    monster_data.selected_entry->get_selected_entity()->extended_description(),
-                    str_width_to_pixels( width ), info_scroll );
+        if( info_height > 0 ) {
+            if( ImGui::BeginChild( "info", ImVec2( 0.0f, str_height_to_pixels( info_height ) ) ) ) {
+                if( monster_data.selected_entry ) {
+                    draw_extended_description(
+                        monster_data.selected_entry->get_selected_entity()->extended_description(),
+                        str_width_to_pixels( width ), info_scroll );
+                }
             }
+            ImGui::EndChild();
         }
-        ImGui::EndChild();
         ImGui::EndTabItem();
     }
 }
@@ -1025,15 +1050,18 @@ void surroundings_menu::draw_terfurn_tab()
     if( ImGui::BeginTabItem( title.c_str(), nullptr, flags ) ) {
         selected_tab = surroundings_menu_tab_enum::terfurn;
 
-        float list_height = str_height_to_pixels( TERMY - info_height ) -
-                            get_hotkey_buttons_height( &terfurn_data ) - magic_number_other_elements_height;
-        if( ImGui::BeginTable( "terfurn", 2, ImGuiTableFlags_ScrollY, ImVec2( 0.0f, list_height ) ) ) {
+        float list_height = ImGui::GetContentRegionAvail().y - str_height_to_pixels( info_height ) -
+                            get_hotkey_buttons_height( &terfurn_data ) - total_menu_padding( info_height > 0 );
+        const int num_cols = 2;
+        if( ImGui::BeginTable( "terfurn", num_cols, ImGuiTableFlags_ScrollY, ImVec2( 0.0f,
+                               list_height ) ) ) {
+            float dir_col_width = str_width_to_pixels( dist_width );
+            float name_col_width = ImGui::GetContentRegionAvail().x - dir_col_width -
+                                   total_cell_padding( num_cols );
             ImGui::TableSetupColumn( "tf_name",
-                                     ImGuiTableColumnFlags_WidthFixed | ImGuiTableColumnFlags_NoResize,
-                                     str_width_to_pixels( width - dist_width - 3 ) );
+                                     ImGuiTableColumnFlags_WidthFixed | ImGuiTableColumnFlags_NoResize, name_col_width );
             ImGui::TableSetupColumn( "tf_distance",
-                                     ImGuiTableColumnFlags_WidthFixed | ImGuiTableColumnFlags_NoResize,
-                                     str_width_to_pixels( dist_width ) );
+                                     ImGuiTableColumnFlags_WidthFixed | ImGuiTableColumnFlags_NoResize, dir_col_width );
             if( terfurn_data.filtered_list.empty() ) {
                 terfurn_data.selected_entry = nullptr;
             } else if( !terfurn_data.selected_entry ||
@@ -1074,14 +1102,16 @@ void surroundings_menu::draw_terfurn_tab()
         draw_hotkey_buttons( &terfurn_data );
 
         // embedded info for selected terrain/furniture
-        if( ImGui::BeginChild( "info", ImVec2( 0.0f, str_height_to_pixels( info_height ) ) ) ) {
-            if( terfurn_data.selected_entry ) {
-                draw_extended_description(
-                    terfurn_data.selected_entry->get_selected_entity()->extended_description(),
-                    str_width_to_pixels( width ), info_scroll );
+        if( info_height > 0 ) {
+            if( ImGui::BeginChild( "info", ImVec2( 0.0f, str_height_to_pixels( info_height ) ) ) ) {
+                if( terfurn_data.selected_entry ) {
+                    draw_extended_description(
+                        terfurn_data.selected_entry->get_selected_entity()->extended_description(),
+                        str_width_to_pixels( width ), info_scroll );
+                }
             }
+            ImGui::EndChild();
         }
-        ImGui::EndChild();
         ImGui::EndTabItem();
     }
 }
@@ -1366,16 +1396,14 @@ void surroundings_menu::change_selected_tab_sorting()
     data->apply_filter();
 }
 
-void surroundings_menu::draw_hotkey_buttons( const tab_data *tab )
+// todo: better solution for this
+std::vector<std::unordered_set<std::string>> surroundings_menu::get_shown_hotkeys(
+            const tab_data *tab )
 {
-    float pos = ImGui::GetStyle().WindowPadding.x;
-    float button_inner_padding = ImGui::GetStyle().FramePadding.x;
-    float posy = ImGui::GetCursorPosY();
-    float line_height = str_height_to_pixels( 1 ) + ImGui::GetStyle().FramePadding.y +
-                        ImGui::GetStyle().ItemSpacing.y;
+    std::vector<std::unordered_set<std::string>> ret;
     for( const std::unordered_set<std::string> &group : tab->hotkey_groups ) {
+        std::unordered_set<std::string> shown_group;
         for( const std::string &button : group ) {
-            // todo: don't just hardcode this
             if( button == "RESET_FILTER" && !tab->has_filter() ) {
                 continue;
             }
@@ -1400,7 +1428,25 @@ void surroundings_menu::draw_hotkey_buttons( const tab_data *tab )
                     }
                 }
             }
+            shown_group.emplace( button );
+        }
+        if( !shown_group.empty() ) {
+            ret.emplace_back( shown_group );
+        }
+    }
 
+    return ret;
+}
+
+void surroundings_menu::draw_hotkey_buttons( const tab_data *tab )
+{
+    float pos = ImGui::GetStyle().WindowPadding.x;
+    float button_inner_padding = ImGui::GetStyle().FramePadding.x;
+    float posy = ImGui::GetCursorPosY();
+    float line_height = str_height_to_pixels( 1 ) + ImGui::GetStyle().FramePadding.y +
+                        ImGui::GetStyle().ItemSpacing.y;
+    for( const std::unordered_set<std::string> &group : get_shown_hotkeys( tab ) ) {
+        for( const std::string &button : group ) {
             std::string buttontxt = tab->ctxt.get_button_text( button );
             float next_pos = get_text_width( buttontxt ) + button_inner_padding +
                              ImGui::GetStyle().ItemSpacing.x;
@@ -1427,9 +1473,9 @@ float surroundings_menu::get_hotkey_buttons_height( const tab_data *tab )
         return 0;
     }
 
-    int pos = 0;
-    int lines = 1;
-    for( const std::unordered_set<std::string> &group : tab->hotkey_groups ) {
+    int lines = 0;
+    for( const std::unordered_set<std::string> &group : get_shown_hotkeys( tab ) ) {
+        int pos = 0;
         for( const std::string &button : group ) {
             pos += ImGui::GetStyle().FramePadding.x;
 

--- a/src/surroundings_menu.h
+++ b/src/surroundings_menu.h
@@ -8,7 +8,6 @@
 #include <string>
 #include <unordered_set>
 #include <vector>
-#include <imgui/imgui.h>
 #include <stddef.h>
 
 #include "cata_imgui.h"
@@ -186,6 +185,7 @@ class surroundings_menu : public cataimgui::window
         void draw_examine_info();
         void draw_category_separator( const std::string &category, std::string &last_category,
                                       int target_col );
+        std::vector<std::unordered_set<std::string>> get_shown_hotkeys( const tab_data *tab );
         void draw_hotkey_buttons( const tab_data *tab );
         float get_hotkey_buttons_height( const tab_data *tab );
 
@@ -225,19 +225,18 @@ class surroundings_menu : public cataimgui::window
         avatar &you;
         std::optional<tripoint_bub_ms> &path_end;
         const tripoint_rel_ms stored_view_offset;
+        const int min_width;
 
         cataimgui::scroll info_scroll = cataimgui::scroll::none;
 
         int width;
         int info_height;
-        float magic_number_other_elements_height = ImGui::GetTextLineHeight() * 3 +
-                ImGui::GetStyle().FramePadding.y * 2;
 
         item_tab_data item_data;
         monster_tab_data monster_data;
         terfurn_tab_data terfurn_data;
 
-        const int dist_width = 7;
+        const int dist_width = 8; // width of the distance column, to display e.g. "15 DN_SE"
         const int page_scroll = 10;
 };
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fixes #84923
Fixes #84926

#### Describe the solution

Properly calculate menu sizes, table cell sizes, area needed by buttons.
Don't display embedded info panel on small window sizes.

#### Describe alternatives you've considered



#### Testing

Checked on various window sizes and with different font size settings. It's still not perfect if you see monsters on different z levels with a smaller than normal font size, but I'm not sure what I'm still missing here and don't want to hold it up any longer. It should be an incredibly rare case anyway and not too much cut off.

#### Additional context

On small window sizes you won't be able to see monster or terrain info anymore. This needs dedicated examine windows like item info, but that's a job for a future PR.
