### PR TITLE
[Xedra Evolved] Karma Arms rebalance

### DIFF
--- a/data/mods/Xedra_Evolved/body_parts.json
+++ b/data/mods/Xedra_Evolved/body_parts.json
@@ -16,7 +16,15 @@
     "hit_size": 13,
     "hit_difficulty": 0.95,
     "limb_type": "arm",
-    "limb_scores": [ [ "manip", 0.1, 0.2 ], [ "lift", 0.2 ], [ "balance", 0.15 ], [ "block", 1.0 ], [ "swim", 0.1 ], [ "crawl", 0.3 ] ],
+    "limb_scores": [
+      [ "grip", 0 ],
+      [ "manip", 0 ],
+      [ "lift", 0 ],
+      [ "reaction", 0.1 ],
+      [ "block", 1.0 ],
+      [ "swim", 0.1 ],
+      [ "crawl", 0.3 ]
+    ],
     "flags": [ "IGNORE_TEMP", "BIONIC_LIMB" ],
     "side": "right",
     "sub_parts": [ "karma_hand" ],

--- a/data/mods/Xedra_Evolved/spells/spell_eocs.json
+++ b/data/mods/Xedra_Evolved/spells/spell_eocs.json
@@ -177,6 +177,10 @@
       { "u_lose_effect": "infected", "target_part": "karma_arm_up_l" },
       { "u_lose_effect": "infected", "target_part": "karma_arm_lw_r" },
       { "u_lose_effect": "infected", "target_part": "karma_arm_lw_l" },
+      { "u_lose_effect": "bite", "target_part": "karma_arm_up_r" },
+      { "u_lose_effect": "bite", "target_part": "karma_arm_up_l" },
+      { "u_lose_effect": "bite", "target_part": "karma_arm_lw_r" },
+      { "u_lose_effect": "bite", "target_part": "karma_arm_lw_l" },
       { "u_lose_trait": "karma_arms" },
       { "u_message": "The cyan arms grow dim and finally disappear.", "type": "neutral" }
     ]

--- a/data/mods/Xedra_Evolved/spells/spell_eocs.json
+++ b/data/mods/Xedra_Evolved/spells/spell_eocs.json
@@ -165,6 +165,18 @@
       }
     ],
     "false_effect": [
+      { "math": [ "u_hp('karma_arm_up_r') += 150" ] },
+      { "math": [ "u_hp('karma_arm_up_l') += 150" ] },
+      { "math": [ "u_hp('karma_arm_lw_r') += 150" ] },
+      { "math": [ "u_hp('karma_arm_lw_l') += 150" ] },
+      { "u_lose_effect": "bleed", "target_part": "karma_arm_up_r" },
+      { "u_lose_effect": "bleed", "target_part": "karma_arm_up_l" },
+      { "u_lose_effect": "bleed", "target_part": "karma_arm_lw_r" },
+      { "u_lose_effect": "bleed", "target_part": "karma_arm_lw_l" },
+      { "u_lose_effect": "infected", "target_part": "karma_arm_up_r" },
+      { "u_lose_effect": "infected", "target_part": "karma_arm_up_l" },
+      { "u_lose_effect": "infected", "target_part": "karma_arm_lw_r" },
+      { "u_lose_effect": "infected", "target_part": "karma_arm_lw_l" },
       { "u_lose_trait": "karma_arms" },
       { "u_message": "The cyan arms grow dim and finally disappear.", "type": "neutral" }
     ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Xedra Evolved] Karma Arms rebalance"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Karma Arms are, as many people say repeatedly, busted. Due to the way limbs and limb scores work, they provide a massive offensive bonus when they're suposed to be primarily a defensive trait. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Set several limb scores to zero (meaning they provide no bonus over baseline). Karma Arms have grip, lift, and manip but not any higher than a normal arm. They have 10% better reaction and are much better at blocking. 

When you dismiss the arms, they're fully healed, stop bleeding, and lose their infections.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Blocked a bunch of stuff with arms, dismissed them when they were low health and infected, they came back just fine. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

They still reduce the stamina cost of attacks and I have no idea why (they do this even if they provide no limb scores at all)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
