### PR TITLE
Use constexpr structures in headers for units.

### DIFF
--- a/src/calendar.cpp
+++ b/src/calendar.cpp
@@ -789,7 +789,8 @@ bool x_in_y( const time_duration &a, const time_duration &b )
     return ::x_in_y( to_turns<int>( a ), to_turns<int>( b ) );
 }
 
-const std::vector<std::pair<std::string, time_duration>> time_duration::units = { {
+constexpr const std::array<std::pair<std::string_view, time_duration>, 15> time_duration::units
+= { {
         { "turns", 1_turns },
         { "turn", 1_turns },
         { "t", 1_turns },

--- a/src/calendar.h
+++ b/src/calendar.h
@@ -2,12 +2,13 @@
 #ifndef CATA_SRC_CALENDAR_H
 #define CATA_SRC_CALENDAR_H
 
+#include <array>
 #include <limits>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <type_traits>
 #include <utility>
-#include <vector>
 #include <climits>
 
 #include "units_fwd.h"
@@ -354,7 +355,7 @@ class time_duration
         /// Returns a random duration in the range [low, hi].
         friend time_duration rng( time_duration lo, time_duration hi );
 
-        static const std::vector<std::pair<std::string, time_duration>> units;
+        static const std::array<std::pair<std::string_view, time_duration>, 15> units;
 };
 
 /// @see x_in_y(int,int)

--- a/src/item_search.cpp
+++ b/src/item_search.cpp
@@ -33,9 +33,9 @@ static const itype_id itype_debug_item_search( "debug_item_search" );
 
 static std::pair<std::string, std::string> get_both( std::string_view a );
 
-template<typename Unit>
+template<typename Unit, size_t N>
 static std::function< bool( const item & )> can_contain_filter( std::string_view hint,
-        std::string_view filter, Unit max, std::vector<std::pair<std::string, Unit>> units,
+        std::string_view filter, Unit max, const std::array<std::pair<std::string_view, Unit>, N> &units,
         std::function<item( itype *, Unit u )> set_function )
 {
     // TODO: LAMBDA_NORETURN_CLANG21x1 can be replaced with [[noreturn]] once we switch to C++23 on all compilers

--- a/src/math_parser_diag.cpp
+++ b/src/math_parser_diag.cpp
@@ -1,6 +1,7 @@
 #include "math_parser_diag.h"
 
 #include <algorithm>
+#include <array>
 #include <cstddef>
 #include <functional>
 #include <list>
@@ -99,8 +100,9 @@ constexpr std::string_view _str_type_of()
     return "cookies";
 }
 
-template <typename T>
-T _read_from_string( std::string_view s, const std::vector<std::pair<std::string, T>> &units )
+template <typename T, size_t N>
+T _read_from_string( std::string_view s,
+                     const std::array<std::pair<std::string_view, T>, N> &units )
 {
     // TODO: LAMBDA_NORETURN_CLANG21x1 can be replaced with [[noreturn]] once we switch to C++23 on all compilers
     auto const error = [s]( char const * suffix, size_t /* offset */ ) LAMBDA_NORETURN_CLANG21x1 {
@@ -1153,8 +1155,9 @@ void spell_level_adjustment_ass( double val, dialogue &d, char scope,
 double _time_in_unit( double time, std::string_view unit )
 {
     if( !unit.empty() ) {
-        auto const iter = std::find_if( time_duration::units.cbegin(), time_duration::units.cend(),
-        [&unit]( std::pair<std::string, time_duration> const & u ) {
+        decltype( time_duration::units )::const_iterator iter = std::find_if( time_duration::units.cbegin(),
+                time_duration::units.cend(),
+        [&unit]( std::pair<std::string_view, time_duration> const & u ) {
             return u.first == unit;
         } );
 
@@ -1268,8 +1271,9 @@ double time_until_eoc_eval( const_dialogue const &d, char /* scope */,
     diag_value unit_val = kwargs.kwarg_or( "unit" );
 
     effect_on_condition_id eoc_id( params[0].str( d ) );
-    auto const &list = g->queued_global_effect_on_conditions.list;
-    auto const it = std::find_if( list.cbegin(), list.cend(), [&eoc_id]( queued_eoc const & eoc ) {
+    const std::list<queued_eoc> &list = g->queued_global_effect_on_conditions.list;
+    std::list<queued_eoc>::const_iterator it = std::find_if( list.cbegin(),
+    list.cend(), [&eoc_id]( queued_eoc const & eoc ) {
         return eoc.eoc == eoc_id;
     } );
 

--- a/src/recipe_dictionary.cpp
+++ b/src/recipe_dictionary.cpp
@@ -215,9 +215,9 @@ static std::unordered_set<bodypart_id> filtered_bodyparts;
 static std::unordered_set<sub_bodypart_id> filtered_sub_bodyparts;
 static std::unordered_set<layer_level> filtered_layers;
 
-template<typename Unit>
+template<typename Unit, size_t N>
 static Unit can_contain_filter( std::string_view hint, std::string_view txt, Unit max,
-                                std::vector<std::pair<std::string, Unit>> units )
+                                const std::array<std::pair<std::string_view, Unit>, N> &units )
 {
     // TODO: LAMBDA_NORETURN_CLANG21x1 can be replaced with [[noreturn]] once we switch to C++23 on all compilers
     auto const error = [hint, txt]( char const *, size_t /* offset */ ) LAMBDA_NORETURN_CLANG21x1 {

--- a/src/stomach.h
+++ b/src/stomach.h
@@ -2,12 +2,12 @@
 #ifndef CATA_SRC_STOMACH_H
 #define CATA_SRC_STOMACH_H
 
+#include <array>
 #include <cstdint>
 #include <map>
-#include <string>
+#include <string_view>
 #include <utility>
 #include <variant>
-#include <vector>
 
 #include "calendar.h"
 #include "type_id.h"
@@ -25,7 +25,7 @@ using mass = units::quantity<int, units::mass_in_microgram_tag>;
 constexpr mass microgram = units::quantity<int, units::mass_in_microgram_tag>( 1, {} );
 constexpr mass milligram = units::quantity<int, units::mass_in_microgram_tag>( 1000, {} );
 constexpr mass gram = units::quantity<int, units::mass_in_microgram_tag>( 1000000, {} );
-const std::vector<std::pair<std::string, mass>> mass_units = { {
+constexpr std::array<std::pair<std::string_view, mass>, 5> mass_units = { {
         { "ug", microgram },
         { "μg", microgram },
         { "mcg", microgram },

--- a/tests/sun_test.cpp
+++ b/tests/sun_test.cpp
@@ -9,6 +9,7 @@
 #include <string>
 #include <tuple>
 #include <unordered_set>
+#include <vector>
 
 #include "cata_catch.h"
 #include "cata_scope_helpers.h"


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Performance "Shrink binary by using constexpr arrays for units constants"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
A casual `bloaty` pass on the linux binary showed a lot of static initializer code duplicated in the object files for the units constants, like 62.5kb per variable. Fixing it is worthwhile just to avoid the initialization cost hit. Turns out it was way huger than that.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Use `std::array<std::pair<std::string_view, T>, N>` instead of `std::vector<std::string, T>>`
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Before:
```
akrieger@d-sov5b34umi:~/Cataclysm-DDA$ du -sh obj/tiles
426M    obj/tiles
akrieger@d-sov5b34umi:~/Cataclysm-DDA$ du -sh cataclysm-tiles
180M    cataclysm-tiles
akrieger@d-sov5b34umi:~/Cataclysm-DDA$ du -shb cataclysm-tiles
187735968       cataclysm-tiles
 ```
After:
```
akrieger@d-sov5b34umi:~/Cataclysm-DDA$ du -sh obj/tiles
383M    obj/tiles
akrieger@d-sov5b34umi:~/Cataclysm-DDA$ du -sh cataclysm-tiles
168M    cataclysm-tiles
akrieger@d-sov5b34umi:~/Cataclysm-DDA$ du -shb cataclysm-tiles
176009968       cataclysm-tiles
```
Most of the binary size savings are in debug info reduction
```
akrieger@d-sov5b34umi:~/Cataclysm-DDA$ diff before.txt after.txt
3,8c3,8
<   76.3%   136Mi   0.0%       0    [Unmapped]
<     43.5%  59.4Mi   NAN%       0    .debug_info
<     22.8%  31.1Mi   NAN%       0    .debug_line
<     11.9%  16.2Mi   NAN%       0    .debug_addr
<      8.0%  11.0Mi   NAN%       0    .strtab
<       74.5%  8.17Mi   NAN%       0    [43302 Others]
---
>   75.3%   126Mi   0.0%       0    [Unmapped]
>     42.5%  53.7Mi   NAN%       0    .debug_info
>     22.5%  28.4Mi   NAN%       0    .debug_line
>     11.8%  15.0Mi   NAN%       0    .debug_addr
>      8.7%  10.9Mi   NAN%       0    .strtab
>       74.5%  8.16Mi   NAN%       0    [43301 Others]
```

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
