### PR TITLE
Ice connects_to

### DIFF
--- a/data/json/connect_groups.json
+++ b/data/json/connect_groups.json
@@ -142,5 +142,9 @@
   {
     "type": "connect_group",
     "id": "BEACH_FORMATIONS"
+  },
+  {
+    "type": "connect_group",
+    "id": "ICE"
   }
 ]

--- a/data/json/furniture_and_terrain/terrain-ice.json
+++ b/data/json/furniture_and_terrain/terrain-ice.json
@@ -9,6 +9,8 @@
     "move_cost": 4,
     "trap": "tr_thin_ice",
     "examine_action": "thin_ice",
+    "connect_groups": "ICE",
+    "connects_to": "ICE",
     "bash": { "str_min": 3, "str_max": 6, "sound": "crack!", "ter_set": "t_water_sh" },
     "flags": [ "THIN_ICE", "TRANSPARENT", "FLAT", "PHASE_BACK", "SWIM_UNDER" ]
   },
@@ -21,6 +23,8 @@
     "color": "cyan",
     "move_cost": 2,
     "trap": "tr_thick_ice",
+    "connect_groups": "ICE",
+    "connects_to": "ICE",
     "bash": { "str_min": 80, "str_max": 180, "sound": "crack!", "ter_set": "t_water_sh" },
     "flags": [ "THICK_ICE", "TRANSPARENT", "FLAT", "PHASE_BACK", "SWIM_UNDER" ]
   },
@@ -34,6 +38,8 @@
     "move_cost": 4,
     "trap": "tr_thin_ice",
     "examine_action": "thin_ice",
+    "connect_groups": "ICE",
+    "connects_to": "ICE",
     "bash": { "str_min": 3, "str_max": 6, "sound": "crack!", "ter_set": "t_water_dp" },
     "flags": [ "THIN_ICE", "TRANSPARENT", "FLAT", "PHASE_BACK", "SWIM_UNDER" ]
   },
@@ -46,6 +52,8 @@
     "color": "cyan",
     "move_cost": 2,
     "trap": "tr_thick_ice",
+    "connect_groups": "ICE",
+    "connects_to": "ICE",
     "bash": { "str_min": 80, "str_max": 180, "sound": "crack!", "ter_set": "t_water_dp" },
     "flags": [ "THICK_ICE", "TRANSPARENT", "FLAT", "PHASE_BACK", "SWIM_UNDER" ]
   },


### PR DESCRIPTION


#### Summary
None

#### Purpose of change
Give ice connect_group and connects_to so the sprite can work
#### Describe the solution
adds ICE connect_group
Give ice terrains ICE connect_group and connects_to

#### Describe alternatives you've considered
No

#### Testing
Before
![Screenshot_20260128_234837](https://github.com/user-attachments/assets/8bf44d61-e2f6-4553-a8e9-f91982b25765)

After
![Screenshot_20260129_101141](https://github.com/user-attachments/assets/e56dcaf0-7912-4bd6-8e5b-e6411c321e62)

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
