### PR TITLE
Make ice traps invisible

### DIFF
--- a/data/json/traps.json
+++ b/data/json/traps.json
@@ -599,9 +599,10 @@
     "memorial_female": { "ctxt": "memorial_female", "str": "Fell through thin ice into water." },
     "flags": [ "ECHOLOCATION_DETECTABLE" ],
     "symbol": "/",
-    "visibility": 0,
+    "visibility": 99,
     "avoidance": 12,
     "difficulty": 99,
+    "always_invisible": true,
     "action": "thin_ice",
     "trigger_message_u": "The ice cracks beneath you!",
     "vehicle_data": { "chance": 80, "damage": 30, "remove_trap": true }
@@ -615,9 +616,10 @@
     "memorial_female": { "ctxt": "memorial_female", "str": "Stumbled on ice." },
     "flags": [ "ECHOLOCATION_DETECTABLE" ],
     "symbol": "/",
-    "visibility": 0,
+    "visibility": 99,
     "avoidance": 4,
     "difficulty": 99,
+    "always_invisible": true,
     "action": "thick_ice",
     "trigger_message_u": "You stumbled on the ice!"
   },


### PR DESCRIPTION

#### Summary
None
#### Purpose of change
Make the ice terrain traps properly invisible.
#### Describe the solution
Give it visibility 99 and always invisible true

#### Describe alternatives you've considered
No

#### Testing
Before
![Screenshot_20260129_101141](https://github.com/user-attachments/assets/723a6db5-abb3-4bce-9094-904168eb732c)

After
![Screenshot_20260129_123736](https://github.com/user-attachments/assets/0fa5d6a2-57f0-4443-8376-5276beca0936)



#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
