### PR TITLE
Fix LTO error

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -396,7 +396,8 @@ queued_eocs::queued_eocs( const queued_eocs &rhs )
     for( auto it = list.begin(), end = list.end(); it != end; ++it ) {
         queue.emplace( it );
     }
-};
+}
+
 queued_eocs::queued_eocs( queued_eocs &&rhs ) noexcept
 {
     queue.swap( rhs.queue );


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
```
Error: src/character.cpp:399:2: error: extra ‘;’ [-Werror=pedantic]
  399 | };
```
#### Describe the solution
Remove `;`
#### Testing
CI