### PR TITLE
Fix add_mod printf specifier

### DIFF
--- a/src/item_info.cpp
+++ b/src/item_info.cpp
@@ -1566,7 +1566,7 @@ void item::gunmod_info( std::vector<iteminfo> &info, const iteminfo_query *parts
             if( iternum != 0 ) {
                 mod_loc_str += "; ";
             }
-            mod_loc_str += string_format( "<bold>%s</bold> %s", elem.second, elem.first.name() );
+            mod_loc_str += string_format( "<bold>%d</bold> %s", elem.second, elem.first.name() );
             iternum++;
         }
         mod_loc_str += ".";


### PR DESCRIPTION
#### Summary
Bugfixes "Fix add_mod printf specifier"
#### Purpose of change
Fix #84961.
Fix #85000.
#### Describe the solution
Use int specifier for int variables.
#### Describe alternatives you've considered

#### Testing
No debug msg and crashes.
#### Additional context
