### PR TITLE
Fix multiple issues with limbs

### DIFF
--- a/data/core/sentinels.json
+++ b/data/core/sentinels.json
@@ -29,7 +29,7 @@
     "id": "sub_bp_null",
     "type": "sub_body_part",
     "parent": "bp_null",
-    "side": 0,
+    "side": "both",
     "opposite": "sub_bp_null",
     "name": { "str": "Null sub_body_part, if you see this please report it", "//~": "NO_I18N" }
   },

--- a/data/json/body_parts.json
+++ b/data/json/body_parts.json
@@ -887,7 +887,7 @@
     "id": "sub_limb_debug",
     "type": "sub_body_part",
     "parent": "bp_null",
-    "side": 0,
+    "side": "both",
     "opposite": "sub_limb_debug",
     "name": { "str": "debug limb should never be seen", "//~": "NO_I18N" }
   },
@@ -895,7 +895,7 @@
     "id": "sub_limb_debug_tail",
     "type": "sub_body_part",
     "parent": "debug_tail",
-    "side": 0,
+    "side": "both",
     "opposite": "sub_limb_debug_tail",
     "name": { "str": "debug limb for debug tail", "//~": "NO_I18N" }
   },
@@ -904,7 +904,7 @@
     "type": "sub_body_part",
     "max_coverage": 60,
     "parent": "torso",
-    "side": 0,
+    "side": "both",
     "opposite": "torso_lower",
     "name_multiple": "torso",
     "name": "upper torso"
@@ -915,7 +915,7 @@
     "parent": "torso",
     "secondary": true,
     "type": "sub_body_part",
-    "side": 0,
+    "side": "both",
     "opposite": "sub_limb_debug",
     "name": "neck",
     "locations_under": [ "torso_upper" ]
@@ -925,7 +925,7 @@
     "type": "sub_body_part",
     "max_coverage": 40,
     "parent": "torso",
-    "side": 0,
+    "side": "both",
     "opposite": "torso_upper",
     "name_multiple": "torso",
     "name": "lower torso"
@@ -936,7 +936,7 @@
     "max_coverage": 35,
     "parent": "torso",
     "secondary": true,
-    "side": 0,
+    "side": "both",
     "name": "front torso (hang)",
     "opposite": "torso_hanging_back",
     "name_multiple": "item hangs off you",
@@ -948,7 +948,7 @@
     "max_coverage": 45,
     "parent": "torso",
     "secondary": true,
-    "side": 0,
+    "side": "both",
     "name": "back torso (hang)",
     "opposite": "torso_hanging_front",
     "name_multiple": "item hangs off you",
@@ -959,7 +959,7 @@
     "type": "sub_body_part",
     "max_coverage": 100,
     "parent": "leg_l",
-    "side": 1,
+    "side": "left",
     "secondary": true,
     "opposite": "leg_draped_r",
     "name_multiple": "legs (draped)",
@@ -971,7 +971,7 @@
     "type": "sub_body_part",
     "max_coverage": 100,
     "parent": "leg_r",
-    "side": 2,
+    "side": "right",
     "secondary": true,
     "opposite": "leg_draped_l",
     "name_multiple": "legs (draped)",
@@ -984,7 +984,7 @@
     "max_coverage": 10,
     "parent": "torso",
     "secondary": true,
-    "side": 0,
+    "side": "both",
     "name": "waist",
     "opposite": "sub_limb_debug",
     "locations_under": [ "leg_hip_r", "leg_hip_l" ]
@@ -994,7 +994,7 @@
     "type": "sub_body_part",
     "max_coverage": 20,
     "parent": "arm_r",
-    "side": 2,
+    "side": "right",
     "opposite": "arm_shoulder_l",
     "name_multiple": "shoulders",
     "name": "right shoulder"
@@ -1004,7 +1004,7 @@
     "type": "sub_body_part",
     "max_coverage": 40,
     "parent": "arm_r",
-    "side": 2,
+    "side": "right",
     "opposite": "arm_upper_l",
     "name_multiple": "upper arms",
     "name": "right upper arm"
@@ -1014,7 +1014,7 @@
     "type": "sub_body_part",
     "max_coverage": 5,
     "parent": "arm_r",
-    "side": 2,
+    "side": "right",
     "opposite": "arm_elbow_l",
     "name_multiple": "elbows",
     "name": "right elbow"
@@ -1024,7 +1024,7 @@
     "type": "sub_body_part",
     "max_coverage": 35,
     "parent": "arm_r",
-    "side": 2,
+    "side": "right",
     "opposite": "arm_lower_l",
     "name_multiple": "lower arms",
     "name": "right forearm"
@@ -1034,7 +1034,7 @@
     "type": "sub_body_part",
     "max_coverage": 20,
     "parent": "arm_l",
-    "side": 1,
+    "side": "left",
     "opposite": "arm_shoulder_r",
     "name_multiple": "shoulders",
     "name": "left shoulder"
@@ -1044,7 +1044,7 @@
     "type": "sub_body_part",
     "max_coverage": 40,
     "parent": "arm_l",
-    "side": 1,
+    "side": "left",
     "opposite": "arm_upper_r",
     "name_multiple": "upper arms",
     "name": "left upper arm"
@@ -1054,7 +1054,7 @@
     "type": "sub_body_part",
     "max_coverage": 5,
     "parent": "arm_l",
-    "side": 1,
+    "side": "left",
     "opposite": "arm_elbow_r",
     "name_multiple": "elbows",
     "name": "left elbow"
@@ -1064,7 +1064,7 @@
     "type": "sub_body_part",
     "max_coverage": 35,
     "parent": "arm_l",
-    "side": 1,
+    "side": "left",
     "opposite": "arm_lower_r",
     "name_multiple": "lower arms",
     "name": "left forearm"
@@ -1074,7 +1074,7 @@
     "type": "sub_body_part",
     "max_coverage": 20,
     "parent": "leg_r",
-    "side": 2,
+    "side": "right",
     "opposite": "leg_hip_l",
     "name_multiple": "hips",
     "name": "right hip"
@@ -1084,7 +1084,7 @@
     "type": "sub_body_part",
     "max_coverage": 40,
     "parent": "leg_r",
-    "side": 2,
+    "side": "right",
     "opposite": "leg_upper_l",
     "name_multiple": "thighs",
     "name": "right thigh"
@@ -1094,7 +1094,7 @@
     "type": "sub_body_part",
     "max_coverage": 5,
     "parent": "leg_r",
-    "side": 2,
+    "side": "right",
     "opposite": "leg_knee_l",
     "name_multiple": "knees",
     "name": "right knee"
@@ -1104,7 +1104,7 @@
     "type": "sub_body_part",
     "max_coverage": 35,
     "parent": "leg_r",
-    "side": 2,
+    "side": "right",
     "opposite": "leg_lower_l",
     "name_multiple": "lower legs",
     "name": "right lower leg"
@@ -1114,7 +1114,7 @@
     "type": "sub_body_part",
     "max_coverage": 20,
     "parent": "leg_l",
-    "side": 1,
+    "side": "left",
     "opposite": "leg_hip_r",
     "name_multiple": "hips",
     "name": "left hip"
@@ -1124,7 +1124,7 @@
     "type": "sub_body_part",
     "max_coverage": 40,
     "parent": "leg_l",
-    "side": 1,
+    "side": "left",
     "opposite": "leg_upper_r",
     "name_multiple": "thighs",
     "name": "left thigh"
@@ -1134,7 +1134,7 @@
     "type": "sub_body_part",
     "max_coverage": 5,
     "parent": "leg_l",
-    "side": 1,
+    "side": "left",
     "opposite": "leg_knee_r",
     "name_multiple": "knees",
     "name": "left knee"
@@ -1144,7 +1144,7 @@
     "type": "sub_body_part",
     "max_coverage": 35,
     "parent": "leg_l",
-    "side": 1,
+    "side": "left",
     "opposite": "leg_lower_r",
     "name_multiple": "lower legs",
     "name": "left lower leg"
@@ -1154,7 +1154,7 @@
     "type": "sub_body_part",
     "max_coverage": 10,
     "parent": "hand_r",
-    "side": 2,
+    "side": "right",
     "opposite": "hand_wrist_l",
     "name_multiple": "wrists",
     "name": "right wrist"
@@ -1164,7 +1164,7 @@
     "type": "sub_body_part",
     "max_coverage": 20,
     "parent": "hand_r",
-    "side": 2,
+    "side": "right",
     "opposite": "hand_palm_l",
     "name_multiple": "palms",
     "name": "right palm"
@@ -1174,7 +1174,7 @@
     "type": "sub_body_part",
     "max_coverage": 20,
     "parent": "hand_r",
-    "side": 2,
+    "side": "right",
     "opposite": "hand_back_l",
     "name_multiple": "back of hands",
     "name": "right back of hand"
@@ -1184,7 +1184,7 @@
     "type": "sub_body_part",
     "max_coverage": 50,
     "parent": "hand_r",
-    "side": 2,
+    "side": "right",
     "opposite": "hand_fingers_l",
     "name_multiple": "fingers",
     "name": "right fingers"
@@ -1194,7 +1194,7 @@
     "type": "sub_body_part",
     "max_coverage": 10,
     "parent": "hand_l",
-    "side": 1,
+    "side": "left",
     "opposite": "hand_wrist_r",
     "name_multiple": "wrists",
     "name": "left wrist"
@@ -1204,7 +1204,7 @@
     "type": "sub_body_part",
     "max_coverage": 20,
     "parent": "hand_l",
-    "side": 1,
+    "side": "left",
     "opposite": "hand_palm_r",
     "name_multiple": "palms",
     "name": "left palm"
@@ -1214,7 +1214,7 @@
     "type": "sub_body_part",
     "max_coverage": 20,
     "parent": "hand_l",
-    "side": 1,
+    "side": "left",
     "opposite": "hand_back_r",
     "name_multiple": "back of hands",
     "name": "left back of hand"
@@ -1224,7 +1224,7 @@
     "type": "sub_body_part",
     "max_coverage": 50,
     "parent": "hand_l",
-    "side": 1,
+    "side": "left",
     "opposite": "hand_fingers_r",
     "name_multiple": "fingers",
     "name": "left fingers"
@@ -1234,7 +1234,7 @@
     "type": "sub_body_part",
     "max_coverage": 50,
     "parent": "eyes",
-    "side": 1,
+    "side": "left",
     "opposite": "eyes_right",
     "name_multiple": "eyes",
     "name": "left eye"
@@ -1244,7 +1244,7 @@
     "type": "sub_body_part",
     "max_coverage": 50,
     "parent": "eyes",
-    "side": 2,
+    "side": "right",
     "opposite": "eyes_left",
     "name_multiple": "eyes",
     "name": "right eye"
@@ -1255,7 +1255,7 @@
     "max_coverage": 15,
     "parent": "mouth",
     "opposite": "sub_limb_debug",
-    "side": 0,
+    "side": "both",
     "name": "lips"
   },
   {
@@ -1264,7 +1264,7 @@
     "max_coverage": 15,
     "parent": "mouth",
     "opposite": "sub_limb_debug",
-    "side": 0,
+    "side": "both",
     "name": "nose"
   },
   {
@@ -1273,7 +1273,7 @@
     "max_coverage": 30,
     "parent": "mouth",
     "opposite": "sub_limb_debug",
-    "side": 0,
+    "side": "both",
     "name": "cheeks"
   },
   {
@@ -1282,7 +1282,7 @@
     "max_coverage": 40,
     "parent": "mouth",
     "opposite": "sub_limb_debug",
-    "side": 0,
+    "side": "both",
     "name": "chin"
   },
   {
@@ -1290,7 +1290,7 @@
     "type": "sub_body_part",
     "max_coverage": 25,
     "parent": "foot_l",
-    "side": 1,
+    "side": "left",
     "opposite": "foot_sole_r",
     "name_multiple": "foot bottoms",
     "name": "left foot bottom"
@@ -1300,7 +1300,7 @@
     "type": "sub_body_part",
     "max_coverage": 25,
     "parent": "foot_l",
-    "side": 1,
+    "side": "left",
     "opposite": "foot_arch_r",
     "name_multiple": "foot arches",
     "name": "left foot arch"
@@ -1310,7 +1310,7 @@
     "type": "sub_body_part",
     "max_coverage": 10,
     "parent": "foot_l",
-    "side": 1,
+    "side": "left",
     "opposite": "foot_toes_r",
     "name_multiple": "toes",
     "name": "left toes"
@@ -1320,7 +1320,7 @@
     "type": "sub_body_part",
     "max_coverage": 20,
     "parent": "foot_l",
-    "side": 1,
+    "side": "left",
     "opposite": "foot_ankle_r",
     "name_multiple": "ankles",
     "name": "left ankle"
@@ -1330,7 +1330,7 @@
     "type": "sub_body_part",
     "max_coverage": 20,
     "parent": "foot_l",
-    "side": 1,
+    "side": "left",
     "opposite": "foot_heel_r",
     "name_multiple": "heels",
     "name": "left heel"
@@ -1340,7 +1340,7 @@
     "type": "sub_body_part",
     "max_coverage": 25,
     "parent": "foot_r",
-    "side": 2,
+    "side": "right",
     "opposite": "foot_sole_l",
     "name_multiple": "foot bottoms",
     "name": "right foot bottom"
@@ -1350,7 +1350,7 @@
     "type": "sub_body_part",
     "max_coverage": 25,
     "parent": "foot_r",
-    "side": 2,
+    "side": "right",
     "opposite": "foot_arch_l",
     "name_multiple": "foot arches",
     "name": "right foot arch"
@@ -1360,7 +1360,7 @@
     "type": "sub_body_part",
     "max_coverage": 10,
     "parent": "foot_r",
-    "side": 2,
+    "side": "right",
     "opposite": "foot_toes_l",
     "name_multiple": "toes",
     "name": "right toes"
@@ -1370,7 +1370,7 @@
     "type": "sub_body_part",
     "max_coverage": 20,
     "parent": "foot_r",
-    "side": 2,
+    "side": "right",
     "opposite": "foot_ankle_l",
     "name_multiple": "ankles",
     "name": "right ankle"
@@ -1380,7 +1380,7 @@
     "type": "sub_body_part",
     "max_coverage": 20,
     "parent": "foot_r",
-    "side": 2,
+    "side": "right",
     "opposite": "foot_heel_l",
     "name_multiple": "heels",
     "name": "right heel"
@@ -1391,7 +1391,7 @@
     "max_coverage": 15,
     "parent": "head",
     "opposite": "sub_limb_debug",
-    "side": 0,
+    "side": "both",
     "name": "forehead"
   },
   {
@@ -1400,7 +1400,7 @@
     "max_coverage": 25,
     "parent": "head",
     "opposite": "sub_limb_debug",
-    "side": 0,
+    "side": "both",
     "name": "crown"
   },
   {
@@ -1409,7 +1409,7 @@
     "max_coverage": 20,
     "parent": "head",
     "opposite": "sub_limb_debug",
-    "side": 0,
+    "side": "both",
     "name": "nape"
   },
   {
@@ -1418,7 +1418,7 @@
     "max_coverage": 20,
     "parent": "head",
     "opposite": "sub_limb_debug",
-    "side": 0,
+    "side": "both",
     "name": "throat"
   },
   {
@@ -1427,7 +1427,7 @@
     "max_coverage": 10,
     "parent": "head",
     "opposite": "head_ear_l",
-    "side": 2,
+    "side": "right",
     "name": "right ear",
     "name_multiple": "ears"
   },
@@ -1437,7 +1437,7 @@
     "max_coverage": 10,
     "parent": "head",
     "opposite": "head_ear_r",
-    "side": 1,
+    "side": "left",
     "name": "left ear",
     "name_multiple": "ears"
   }

--- a/data/json/mutations/limbs_body_parts.json
+++ b/data/json/mutations/limbs_body_parts.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "tail",
-    "//": "Used as a default for similar_bodyparts to work for armor.",
+    "//": "Used as a default for similar_bodypart to work for armor.",
     "type": "body_part",
     "name": "default tail",
     "name_multiple": "default tails",
@@ -20,8 +20,7 @@
     "hp_bar_ui_text": "TST TAIL",
     "base_hp": 20,
     "limb_scores": [ [ "balance", 0.0 ] ],
-    "sub_parts": [ "sub_limb_debug_tail" ],
-    "similar_bodyparts": [ "tail_long", "tail_fluffy", "tail_scorpion" ]
+    "sub_parts": [ "sub_limb_debug_tail" ]
   },
   {
     "id": "tail_long",
@@ -47,6 +46,7 @@
     "limb_scores": [ [ "balance", 0.05 ], [ "reaction", 0.1 ] ],
     "base_hp": 25,
     "health_limit": 5,
+    "similar_bodypart": "tail",
     "effects_on_hit": [
       {
         "id": "bleed",
@@ -106,6 +106,7 @@
     "limb_scores": [ [ "balance", 0.08 ], [ "reaction", 0.15 ] ],
     "base_hp": 25,
     "health_limit": 5,
+    "similar_bodypart": "tail",
     "effects_on_hit": [
       {
         "id": "bleed",
@@ -166,6 +167,7 @@
     "health_limit": 10,
     "techniques": [ "TAIL_SCORPION_STING", "TAIL_SCORPION_STING_NATURAL", "TAIL_SCORPION_STING_CRIT" ],
     "technique_encumbrance_limit": 5,
+    "similar_bodypart": "tail",
     "effects_on_hit": [
       {
         "id": "bleed",

--- a/data/json/mutations/limbs_sublimbs.json
+++ b/data/json/mutations/limbs_sublimbs.json
@@ -6,7 +6,7 @@
     "name_multiple": "tail bases",
     "max_coverage": 10,
     "parent": "tail_long",
-    "side": 0,
+    "side": "both",
     "opposite": "tail_long_tip"
   },
   {
@@ -16,7 +16,7 @@
     "name_multiple": "long tail centers",
     "max_coverage": 60,
     "parent": "tail_long",
-    "side": 0,
+    "side": "both",
     "opposite": "tail_long_center"
   },
   {
@@ -26,7 +26,7 @@
     "name_multiple": "long tail tips",
     "max_coverage": 30,
     "parent": "tail_long",
-    "side": 0,
+    "side": "both",
     "opposite": "tail_long_base"
   },
   {
@@ -36,7 +36,7 @@
     "name_multiple": "tail bases",
     "max_coverage": 10,
     "parent": "tail_fluffy",
-    "side": 0,
+    "side": "both",
     "opposite": "tail_fluffy_tip"
   },
   {
@@ -46,7 +46,7 @@
     "name_multiple": "fluffy tail centers",
     "max_coverage": 60,
     "parent": "tail_fluffy",
-    "side": 0,
+    "side": "both",
     "opposite": "tail_fluffy_center"
   },
   {
@@ -56,7 +56,7 @@
     "name_multiple": "fluffy tail tips",
     "max_coverage": 30,
     "parent": "tail_fluffy",
-    "side": 0,
+    "side": "both",
     "opposite": "tail_fluffy_base"
   },
   {

--- a/data/mods/Limb_WIP/mutations/mutation_limbs.json
+++ b/data/mods/Limb_WIP/mutations/mutation_limbs.json
@@ -1,96 +1,5 @@
 [
   {
-    "id": "head",
-    "type": "body_part",
-    "name": "head",
-    "copy-from": "head",
-    "limb_type": "head",
-    "limb_scores": [ [ "reaction", 0.3 ] ],
-    "is_vital": true,
-    "similar_bodyparts": [ "head_dragonfly" ]
-  },
-  {
-    "id": "eyes",
-    "type": "body_part",
-    "copy-from": "eyes",
-    "name": "eyes",
-    "limb_type": "sensor",
-    "limb_scores": [ [ "vision", 1.0 ], [ "night_vis", 1.0 ], [ "reaction", 0.7 ] ],
-    "similar_bodyparts": [ "eyes_bulging", "eyes_insect_1" ]
-  },
-  {
-    "type": "body_part",
-    "id": "arm_l",
-    "name": "left arm",
-    "copy-from": "arm_l",
-    "limb_type": "arm",
-    "limb_scores": [ [ "manip", 0.1, 0.2 ], [ "lift", 0.5 ], [ "balance", 0.15 ], [ "block", 1.0 ], [ "swim", 0.1 ], [ "crawl", 0.3 ] ],
-    "similar_bodyparts": [ "arm_bionic_basic_l" ]
-  },
-  {
-    "type": "body_part",
-    "id": "arm_r",
-    "copy-from": "arm_r",
-    "limb_type": "arm",
-    "limb_scores": [ [ "manip", 0.1, 0.2 ], [ "lift", 0.5 ], [ "balance", 0.15 ], [ "block", 1.0 ], [ "swim", 0.1 ], [ "crawl", 0.3 ] ],
-    "similar_bodyparts": [ "arm_bionic_basic_r" ]
-  },
-  {
-    "type": "body_part",
-    "id": "hand_l",
-    "copy-from": "hand_l",
-    "name": "left hand",
-    "limb_type": "hand",
-    "limb_scores": [ [ "grip", 0.5 ], [ "manip", 0.5, 1.0 ], [ "swim", 0.15 ] ],
-    "similar_bodyparts": [ "hand_bionic_basic_l" ]
-  },
-  {
-    "type": "body_part",
-    "id": "hand_r",
-    "copy-from": "hand_r",
-    "name": "right hand",
-    "limb_type": "hand",
-    "limb_scores": [ [ "grip", 0.5 ], [ "manip", 0.5, 1.0 ], [ "swim", 0.15 ] ],
-    "similar_bodyparts": [ "hand_bionic_basic_r" ]
-  },
-  {
-    "type": "body_part",
-    "id": "leg_l",
-    "copy-from": "leg_l",
-    "name": "left leg",
-    "limb_type": "leg",
-    "limb_scores": [ [ "manip", 0.1, 0.2 ], [ "move_speed", 0.5 ], [ "swim", 0.15 ], [ "block", 1 ], [ "crawl", 0.2 ] ],
-    "similar_bodyparts": [ "leg_bionic_basic_l" ]
-  },
-  {
-    "type": "body_part",
-    "id": "leg_r",
-    "copy-from": "leg_r",
-    "name": "right leg",
-    "limb_type": "leg",
-    "limb_scores": [ [ "manip", 0.1, 0.2 ], [ "move_speed", 0.5 ], [ "swim", 0.15 ], [ "block", 1 ], [ "crawl", 0.2 ] ],
-    "similar_bodyparts": [ "leg_bionic_basic_r" ]
-  },
-  {
-    "type": "body_part",
-    "id": "foot_l",
-    "copy-from": "foot_l",
-    "name": "left foot",
-    "limb_type": "foot",
-    "limb_scores": [ [ "manip", 0.1, 0.2 ], [ "footing", 0.5 ], [ "swim", 0.1 ] ],
-    "sub_parts": [ "foot_sole_l", "foot_arch_l", "foot_toes_l", "foot_ankle_l", "foot_heel_l" ],
-    "similar_bodyparts": [ "foot_bionic_basic_l" ]
-  },
-  {
-    "type": "body_part",
-    "id": "foot_r",
-    "copy-from": "foot_r",
-    "name": "right foot",
-    "limb_type": "foot",
-    "limb_scores": [ [ "manip", 0.1, 0.2 ], [ "footing", 0.5 ], [ "swim", 0.1 ] ],
-    "similar_bodyparts": [ "foot_bionic_basic_r" ]
-  },
-  {
     "type": "body_part",
     "id": "debug_torso",
     "limb_type": "torso",
@@ -128,7 +37,7 @@
     "sub_parts": [ "eyes_bulging_l", "eyes_bulging_r" ],
     "limb_type": "sensor",
     "limb_scores": [ [ "vision", 1.0 ], [ "night_vis", 1.0 ], [ "reaction", 0.7 ] ],
-    "similar_bodyparts": [  ],
+    "similar_bodypart": "eyes",
     "hit_size": 0.9,
     "hit_difficulty": 1.25
   },
@@ -145,8 +54,8 @@
     "limb_type": "sensor",
     "encumbrance_text": "Your vision is impaired!",
     "main_part": "head",
-    "opposite_part": "eyes_insect_1",
     "hit_size": 1.2,
+    "similar_bodypart": "eyes",
     "limb_scores": [ [ "vision", 0.65 ], [ "night_vis", 0.8 ], [ "reaction", 0.8 ] ],
     "armor": { "cut": 3 },
     "sub_parts": [ "eyes_compound_l", "eyes_compound_r" ],
@@ -202,6 +111,7 @@
     "encumbrance_threshold": 0,
     "encumbrance_limit": 75,
     "armor": { "cut": 3 },
+    "similar_bodypart": "head",
     "sub_parts": [
       "head_dragonfly_forehead",
       "head_dragonfly_crown",
@@ -302,7 +212,7 @@
     "ugliness": -2,
     "ugliness_mandatory": 1,
     "sub_parts": [ "arm_feathers_shoulder_l", "arm_feathers_upper_l", "arm_feathers_elbow_l", "arm_feathers_lower_l" ],
-    "similar_bodyparts": [  ]
+    "similar_bodypart": null
   },
   {
     "type": "body_part",
@@ -1438,6 +1348,7 @@
     "drench_capacity": 1000,
     "smash_message": "You elbow-smash the %s.",
     "no_power_effect": "no_power_arm_l",
+    "similar_bodypart": "arm_l",
     "effects_on_hit": [
       {
         "id": "staggered_character",
@@ -1498,6 +1409,7 @@
     "drench_capacity": 1000,
     "smash_message": "You elbow-smash the %s.",
     "no_power_effect": "no_power_arm_r",
+    "similar_bodypart": "arm_r",
     "effects_on_hit": [
       {
         "id": "staggered_character",
@@ -1552,6 +1464,7 @@
     "squeamish_penalty": 0,
     "base_hp": 150,
     "drench_capacity": 300,
+    "similar_bodypart": "hand_l",
     "smash_message": "You smash the %s with your fist.",
     "sub_parts": [ "hand_bionic_basic_wrist_l", "hand_bionic_basic_palm_l", "hand_bionic_basic_back_l", "hand_bionic_basic_fingers_l" ],
     "flags": [ "IGNORE_TEMP", "BIONIC_LIMB" ],
@@ -1584,6 +1497,7 @@
     "squeamish_penalty": 0,
     "base_hp": 150,
     "drench_capacity": 300,
+    "similar_bodypart": "hand_r",
     "smash_message": "You smash the %s with your fist.",
     "sub_parts": [ "hand_bionic_basic_wrist_r", "hand_bionic_basic_palm_r", "hand_bionic_basic_back_r", "hand_bionic_basic_fingers_r" ],
     "flags": [ "IGNORE_TEMP", "BIONIC_LIMB" ],
@@ -1612,6 +1526,7 @@
     "hit_difficulty": 0.9,
     "limb_type": "leg",
     "limb_scores": [ [ "manip", 0.1, 0.2 ], [ "move_speed", 0.6 ], [ "swim", 0.15 ], [ "block", 1 ], [ "crawl", 0.5 ] ],
+    "similar_bodypart": "leg_l",
     "side": "left",
     "hot_morale_mod": 0.0,
     "cold_morale_mod": 0.0,
@@ -1685,6 +1600,7 @@
     "hit_difficulty": 0.9,
     "limb_type": "leg",
     "limb_scores": [ [ "manip", 0.1, 0.2 ], [ "move_speed", 0.6 ], [ "swim", 0.15 ], [ "block", 1 ], [ "crawl", 0.5 ] ],
+    "similar_bodypart": "leg_r",
     "side": "right",
     "hot_morale_mod": 0.0,
     "cold_morale_mod": 0.0,
@@ -1771,6 +1687,7 @@
       "foot_bionic_basic_ankle_l",
       "foot_bionic_basic_heel_l"
     ],
+    "similar_bodypart": "foot_l",
     "flags": [ "LIMB_LOWER", "IGNORE_TEMP", "BIONIC_LIMB" ],
     "power_efficiency": 1000,
     "feels_discomfort": false,
@@ -1810,6 +1727,7 @@
       "foot_bionic_basic_ankle_r",
       "foot_bionic_basic_heel_r"
     ],
+    "similar_bodypart": "foot_r",
     "flags": [ "LIMB_LOWER", "IGNORE_TEMP", "BIONIC_LIMB" ],
     "power_efficiency": 1000,
     "feels_discomfort": false,

--- a/data/mods/Limb_WIP/mutations/sub_limbs.json
+++ b/data/mods/Limb_WIP/mutations/sub_limbs.json
@@ -1,345 +1,9 @@
 [
   {
-    "type": "sub_body_part",
-    "id": "arm_shoulder_l",
-    "copy-from": "arm_shoulder_l",
-    "name": "left shoulder",
-    "similar_bodyparts": [ "arm_bionic_basic_shoulder_l", "arm_feathers_shoulder_l", "arm_wing_bird_shoulder_l" ]
-  },
-  {
-    "type": "sub_body_part",
-    "id": "arm_shoulder_r",
-    "copy-from": "arm_shoulder_r",
-    "name": "right shoulder",
-    "similar_bodyparts": [ "arm_bionic_basic_shoulder_r", "arm_feathers_shoulder_r", "arm_wing_bird_shoulder_r" ]
-  },
-  {
-    "type": "sub_body_part",
-    "id": "arm_upper_l",
-    "copy-from": "arm_upper_l",
-    "name": "left upper arm",
-    "similar_bodyparts": [ "arm_bionic_basic_upper_l", "arm_feathers_upper_l" ]
-  },
-  {
-    "type": "sub_body_part",
-    "id": "arm_upper_r",
-    "copy-from": "arm_upper_r",
-    "name": "right upper arm",
-    "similar_bodyparts": [ "arm_bionic_basic_upper_r", "arm_feathers_upper_r" ]
-  },
-  {
-    "type": "sub_body_part",
-    "id": "arm_elbow_l",
-    "copy-from": "arm_elbow_l",
-    "name": "left elbow",
-    "similar_bodyparts": [ "arm_bionic_basic_elbow_l", "arm_feathers_elbow_l" ]
-  },
-  {
-    "type": "sub_body_part",
-    "id": "arm_elbow_r",
-    "copy-from": "arm_elbow_r",
-    "name": "right elbow",
-    "similar_bodyparts": [ "arm_bionic_basic_elbow_r", "arm_feathers_elbow_r" ]
-  },
-  {
-    "type": "sub_body_part",
-    "id": "arm_lower_l",
-    "copy-from": "arm_lower_l",
-    "name": "left forearm",
-    "similar_bodyparts": [ "arm_bionic_basic_lower_l" ]
-  },
-  {
-    "type": "sub_body_part",
-    "id": "arm_lower_r",
-    "copy-from": "arm_lower_r",
-    "name": "right forearm",
-    "similar_bodyparts": [ "arm_bionic_basic_lower_r" ]
-  },
-  {
-    "id": "eyes_left",
-    "type": "sub_body_part",
-    "max_coverage": 50,
-    "parent": "eyes",
-    "side": 1,
-    "opposite": "eyes_right",
-    "name_multiple": "eyes",
-    "name": "left eye",
-    "similar_bodyparts": [ "eyes_bulging_l", "eyes_compound_l", "eyes_dragonfly_mono_l" ]
-  },
-  {
-    "id": "eyes_right",
-    "type": "sub_body_part",
-    "max_coverage": 50,
-    "parent": "eyes",
-    "side": 2,
-    "opposite": "eyes_left",
-    "name_multiple": "eyes",
-    "name": "right eye",
-    "similar_bodyparts": [ "eyes_bulging_r", "eyes_compound_l", "eyes_dragonfly_mono_r" ]
-  },
-  {
-    "id": "head_forehead",
-    "type": "sub_body_part",
-    "max_coverage": 15,
-    "parent": "head",
-    "opposite": "sub_limb_debug",
-    "side": 0,
-    "name": "forehead",
-    "similar_bodyparts": [ "head_dragonfly_forehead" ]
-  },
-  {
-    "id": "head_crown",
-    "type": "sub_body_part",
-    "max_coverage": 25,
-    "parent": "head",
-    "opposite": "sub_limb_debug",
-    "side": 0,
-    "name": "crown",
-    "similar_bodyparts": [ "head_dragonfly_crown" ]
-  },
-  {
-    "id": "head_nape",
-    "type": "sub_body_part",
-    "max_coverage": 20,
-    "parent": "head",
-    "opposite": "sub_limb_debug",
-    "side": 0,
-    "name": "nape",
-    "similar_bodyparts": [ "head_dragonfly_nape" ]
-  },
-  {
-    "id": "head_throat",
-    "type": "sub_body_part",
-    "max_coverage": 20,
-    "parent": "head",
-    "opposite": "sub_limb_debug",
-    "side": 0,
-    "name": "throat",
-    "similar_bodyparts": [ "head_dragonfly_throat" ]
-  },
-  {
-    "id": "head_ear_r",
-    "type": "sub_body_part",
-    "max_coverage": 10,
-    "parent": "head",
-    "opposite": "head_ear_l",
-    "side": 2,
-    "name": "right ear",
-    "name_multiple": "ears",
-    "similar_bodyparts": [ "head_dragonfly_ear_r" ]
-  },
-  {
-    "id": "head_ear_l",
-    "type": "sub_body_part",
-    "max_coverage": 10,
-    "parent": "head",
-    "opposite": "head_ear_r",
-    "side": 1,
-    "name": "left ear",
-    "name_multiple": "ears",
-    "similar_bodyparts": [ "head_dragonfly_ear_l" ]
-  },
-  {
-    "type": "sub_body_part",
-    "id": "hand_wrist_l",
-    "copy-from": "hand_wrist_l",
-    "name": "left wrist",
-    "similar_bodyparts": [ "hand_bionic_basic_wrist_l" ]
-  },
-  {
-    "type": "sub_body_part",
-    "id": "hand_wrist_r",
-    "copy-from": "hand_wrist_r",
-    "name": "right wrist",
-    "similar_bodyparts": [ "hand_bionic_basic_wrist_r" ]
-  },
-  {
-    "type": "sub_body_part",
-    "id": "hand_palm_l",
-    "copy-from": "hand_palm_l",
-    "name": "left palm",
-    "similar_bodyparts": [ "hand_bionic_basic_palm_l" ]
-  },
-  {
-    "type": "sub_body_part",
-    "id": "hand_palm_r",
-    "copy-from": "hand_palm_r",
-    "name": "right palm",
-    "similar_bodyparts": [ "hand_bionic_basic_palm_r" ]
-  },
-  {
-    "type": "sub_body_part",
-    "id": "hand_back_l",
-    "copy-from": "hand_back_l",
-    "name": "left back of hand",
-    "similar_bodyparts": [ "hand_bionic_basic_back_l" ]
-  },
-  {
-    "type": "sub_body_part",
-    "id": "hand_back_r",
-    "copy-from": "hand_back_r",
-    "name": "right back of hand",
-    "similar_bodyparts": [ "hand_bionic_basic_back_r" ]
-  },
-  {
-    "type": "sub_body_part",
-    "id": "hand_fingers_l",
-    "copy-from": "hand_fingers_l",
-    "name": "left fingers",
-    "similar_bodyparts": [ "hand_bionic_basic_fingers_l", "arm_wing_bird_fingers_l" ]
-  },
-  {
-    "type": "sub_body_part",
-    "id": "hand_fingers_r",
-    "copy-from": "hand_fingers_r",
-    "name": "right fingers",
-    "similar_bodyparts": [ "hand_bionic_basic_fingers_r", "arm_wing_bird_fingers_r" ]
-  },
-  {
-    "type": "sub_body_part",
-    "id": "leg_hip_l",
-    "copy-from": "leg_hip_l",
-    "name": "left hip",
-    "similar_bodyparts": [ "leg_bionic_basic_hip_l" ]
-  },
-  {
-    "type": "sub_body_part",
-    "id": "leg_hip_r",
-    "copy-from": "leg_hip_r",
-    "name": "right hip",
-    "similar_bodyparts": [ "leg_bionic_basic_hip_r" ]
-  },
-  {
-    "type": "sub_body_part",
-    "id": "leg_upper_l",
-    "copy-from": "leg_upper_l",
-    "name": "left thigh",
-    "similar_bodyparts": [ "leg_bionic_basic_upper_l" ]
-  },
-  {
-    "type": "sub_body_part",
-    "id": "leg_upper_r",
-    "copy-from": "leg_upper_r",
-    "name": "right thigh",
-    "similar_bodyparts": [ "leg_bionic_basic_upper_r" ]
-  },
-  {
-    "type": "sub_body_part",
-    "id": "leg_knee_l",
-    "copy-from": "leg_knee_l",
-    "name": "left knee",
-    "similar_bodyparts": [ "leg_bionic_basic_knee_l" ]
-  },
-  {
-    "type": "sub_body_part",
-    "id": "leg_knee_r",
-    "copy-from": "leg_knee_r",
-    "name": "right knee",
-    "similar_bodyparts": [ "leg_bionic_basic_knee_r" ]
-  },
-  {
-    "type": "sub_body_part",
-    "id": "leg_lower_l",
-    "copy-from": "leg_lower_l",
-    "name": "left lower leg",
-    "similar_bodyparts": [ "leg_bionic_basic_lower_l" ]
-  },
-  {
-    "type": "sub_body_part",
-    "id": "leg_lower_r",
-    "copy-from": "leg_lower_r",
-    "name": "right lower leg",
-    "similar_bodyparts": [ "leg_bionic_basic_lower_r" ]
-  },
-  {
-    "type": "sub_body_part",
-    "id": "leg_draped_l",
-    "copy-from": "leg_draped_l",
-    "name": "left leg (draped)",
-    "similar_bodyparts": [ "leg_bionic_basic_draped_l" ]
-  },
-  {
-    "type": "sub_body_part",
-    "id": "leg_draped_r",
-    "copy-from": "leg_draped_r",
-    "name": "right leg (draped)",
-    "similar_bodyparts": [ "leg_bionic_basic_draped_r" ]
-  },
-  {
-    "type": "sub_body_part",
-    "id": "foot_sole_l",
-    "copy-from": "foot_sole_l",
-    "name": "left foot bottom",
-    "similar_bodyparts": [ "foot_bionic_basic_sole_l" ]
-  },
-  {
-    "type": "sub_body_part",
-    "id": "foot_sole_r",
-    "copy-from": "foot_sole_r",
-    "name": "right foot bottom",
-    "similar_bodyparts": [ "foot_bionic_basic_sole_r" ]
-  },
-  {
-    "type": "sub_body_part",
-    "id": "foot_arch_l",
-    "copy-from": "foot_arch_l",
-    "name": "left foot arch",
-    "similar_bodyparts": [ "foot_bionic_basic_arch_l" ]
-  },
-  {
-    "type": "sub_body_part",
-    "id": "foot_arch_r",
-    "copy-from": "foot_arch_r",
-    "name": "right foot arch",
-    "similar_bodyparts": [ "foot_bionic_basic_arch_r" ]
-  },
-  {
-    "type": "sub_body_part",
-    "id": "foot_ankle_l",
-    "copy-from": "foot_ankle_l",
-    "name": "left ankle",
-    "similar_bodyparts": [ "foot_bionic_basic_ankle_l" ]
-  },
-  {
-    "type": "sub_body_part",
-    "id": "foot_ankle_r",
-    "copy-from": "foot_ankle_r",
-    "name": "right ankle",
-    "similar_bodyparts": [ "foot_bionic_basic_ankle_r" ]
-  },
-  {
-    "type": "sub_body_part",
-    "id": "foot_toes_l",
-    "copy-from": "foot_toes_l",
-    "name": "left toes",
-    "similar_bodyparts": [ "foot_bionic_basic_toes_l" ]
-  },
-  {
-    "type": "sub_body_part",
-    "id": "foot_toes_r",
-    "copy-from": "foot_toes_r",
-    "name": "right toes",
-    "similar_bodyparts": [ "foot_bionic_basic_toes_r" ]
-  },
-  {
-    "type": "sub_body_part",
-    "id": "foot_heel_l",
-    "copy-from": "foot_heel_l",
-    "name": "left heel",
-    "similar_bodyparts": [ "foot_bionic_basic_heel_l" ]
-  },
-  {
-    "type": "sub_body_part",
-    "id": "foot_heel_r",
-    "copy-from": "foot_heel_r",
-    "name": "right heel",
-    "similar_bodyparts": [ "foot_bionic_basic_heel_r" ]
-  },
-  {
     "id": "sub_limb_debug_tail_1",
     "type": "sub_body_part",
     "parent": "debug_tail",
-    "side": 0,
+    "side": "both",
     "max_coverage": 100,
     "name": "first debug sublimb for debug tail"
   },
@@ -348,7 +12,7 @@
     "id": "sub_limb_debug_tail_2",
     "parent": "debug_tail",
     "max_coverage": 50,
-    "side": 0,
+    "side": "both",
     "name": "second debug sublimb for debug tail"
   },
   {
@@ -356,7 +20,8 @@
     "type": "sub_body_part",
     "max_coverage": 50,
     "parent": "eyes_bulging",
-    "side": 1,
+    "side": "left",
+    "similar_bodypart": "eyes_left",
     "opposite": "eyes_bulging_r",
     "name_multiple": "bulging eyes",
     "name": "left bulging eye"
@@ -366,7 +31,8 @@
     "type": "sub_body_part",
     "max_coverage": 50,
     "parent": "eyes_bulging",
-    "side": 2,
+    "side": "right",
+    "similar_bodypart": "eyes_right",
     "opposite": "eyes_bulging_l",
     "name_multiple": "bulging eyes",
     "name": "right bulging eye"
@@ -376,7 +42,8 @@
     "type": "sub_body_part",
     "max_coverage": 50,
     "parent": "eyes_insect_1",
-    "side": 1,
+    "side": "left",
+    "similar_bodypart": "eyes_left",
     "opposite": "eyes_compound_r",
     "name_multiple": "compound eyes",
     "name": "left compound eye"
@@ -386,7 +53,8 @@
     "type": "sub_body_part",
     "max_coverage": 50,
     "parent": "eyes_insect_1",
-    "side": 2,
+    "side": "right",
+    "similar_bodypart": "eyes_right",
     "opposite": "eyes_compound_l",
     "name_multiple": "compound eyes",
     "name": "right compound eye"
@@ -398,7 +66,8 @@
     "name_multiple": "gigantic compound eye (front)",
     "parent": "eyes_dragonfly",
     "max_coverage": 50,
-    "side": 1,
+    "side": "left",
+    "similar_bodypart": "eyes_left",
     "opposite": "eyes_dragonfly_mono_r"
   },
   {
@@ -408,7 +77,8 @@
     "name_multiple": "gigantic compound eye (front)",
     "parent": "eyes_dragonfly",
     "max_coverage": 50,
-    "side": 2,
+    "side": "right",
+    "similar_bodypart": "eyes_right",
     "opposite": "eyes_dragonfly_mono_l"
   },
   {
@@ -417,7 +87,8 @@
     "name": "gigantic compound eye (forehead)",
     "parent": "head_dragonfly",
     "max_coverage": 20,
-    "side": 0
+    "similar_bodypart": "head_forehead",
+    "side": "both"
   },
   {
     "id": "head_dragonfly_crown",
@@ -425,7 +96,8 @@
     "name": "gigantic compound eye (crown)",
     "parent": "head_dragonfly",
     "max_coverage": 20,
-    "side": 0
+    "similar_bodypart": "head_crown",
+    "side": "both"
   },
   {
     "id": "head_dragonfly_nape",
@@ -433,7 +105,8 @@
     "name": "nape",
     "parent": "head_dragonfly",
     "max_coverage": 20,
-    "side": 0
+    "similar_bodypart": "head_nape",
+    "side": "both"
   },
   {
     "id": "head_dragonfly_throat",
@@ -441,7 +114,8 @@
     "name": "throat",
     "parent": "head_dragonfly",
     "max_coverage": 20,
-    "side": 0
+    "similar_bodypart": "head_throat",
+    "side": "both"
   },
   {
     "id": "head_dragonfly_ear_l",
@@ -450,7 +124,8 @@
     "name_multiple": "ears",
     "parent": "head_dragonfly",
     "max_coverage": 10,
-    "side": 1,
+    "side": "left",
+    "similar_bodypart": "head_ear_l",
     "opposite": "head_dragonfly_ear_r"
   },
   {
@@ -460,7 +135,8 @@
     "name_multiple": "ears",
     "parent": "head_dragonfly",
     "max_coverage": 10,
-    "side": 2,
+    "side": "right",
+    "similar_bodypart": "head_ear_r",
     "opposite": "head_dragonfly_ear_l"
   },
   {
@@ -469,7 +145,8 @@
     "name": "left feathered shoulder",
     "name_multiple": "feathered shoulders",
     "parent": "arm_feathers_l",
-    "side": 1,
+    "side": "left",
+    "similar_bodypart": "arm_shoulder_l",
     "opposite": "arm_feathers_shoulder_r",
     "max_coverage": 15
   },
@@ -479,7 +156,8 @@
     "name": "right feathered shoulder",
     "name_multiple": "feathered shoulders",
     "parent": "arm_feathers_r",
-    "side": 2,
+    "side": "right",
+    "similar_bodypart": "arm_shoulder_r",
     "opposite": "arm_feathers_shoulder_l",
     "max_coverage": 15
   },
@@ -489,7 +167,8 @@
     "name": "left feathered upper arm",
     "name_multiple": "feathered upper arms",
     "parent": "arm_feathers_l",
-    "side": 1,
+    "side": "left",
+    "similar_bodypart": "arm_upper_l",
     "opposite": "arm_feathers_upper_r",
     "max_coverage": 30
   },
@@ -499,7 +178,8 @@
     "name": "right feathered upper arm",
     "name_multiple": "feathered upper arms",
     "parent": "arm_feathers_r",
-    "side": 2,
+    "side": "right",
+    "similar_bodypart": "arm_upper_r",
     "opposite": "arm_feathers_upper_l",
     "max_coverage": 30
   },
@@ -509,7 +189,8 @@
     "name": "left feathered elbow",
     "name_multiple": "feathered elbows",
     "parent": "arm_feathers_l",
-    "side": 1,
+    "side": "left",
+    "similar_bodypart": "arm_elbow_l",
     "opposite": "arm_feathers_elbow_r",
     "max_coverage": 5
   },
@@ -519,7 +200,8 @@
     "name": "right feathered elbow",
     "name_multiple": "feathered elbows",
     "parent": "arm_feathers_r",
-    "side": 2,
+    "side": "right",
+    "similar_bodypart": "arm_elbow_r",
     "opposite": "arm_feathers_elbow_l",
     "max_coverage": 5
   },
@@ -529,7 +211,7 @@
     "name": "lower left feathered arms",
     "name_multiple": "lower feathered arms",
     "parent": "arm_feathers_l",
-    "side": 1,
+    "side": "left",
     "opposite": "arm_feathers_lower_r",
     "max_coverage": 45
   },
@@ -539,7 +221,7 @@
     "name": "lower right feathered arms",
     "name_multiple": "lower feathered arms",
     "parent": "arm_feathers_r",
-    "side": 2,
+    "side": "right",
     "opposite": "arm_feathers_lower_l",
     "max_coverage": 45
   },
@@ -549,7 +231,8 @@
     "parent": "arm_wing_bird_l",
     "name": "left wing shoulder",
     "name_multiple": "wing shoulders",
-    "side": 1,
+    "side": "left",
+    "similar_bodypart": "arm_shoulder_l",
     "opposite": "arm_wing_bird_shoulder_r",
     "max_coverage": 15
   },
@@ -559,7 +242,8 @@
     "parent": "arm_wing_bird_r",
     "name": "right wing shoulder",
     "name_multiple": "wing shoulders",
-    "side": 2,
+    "side": "right",
+    "similar_bodypart": "arm_shoulder_r",
     "opposite": "arm_wing_bird_shoulder_l",
     "max_coverage": 15
   },
@@ -569,7 +253,7 @@
     "parent": "arm_wing_bird_l",
     "name": "left upper wing",
     "name_multiple": "upper wings",
-    "side": 1,
+    "side": "left",
     "opposite": "arm_wing_bird_upper_r",
     "max_coverage": 30
   },
@@ -579,7 +263,7 @@
     "parent": "arm_wing_bird_r",
     "name": "right upper wing",
     "name_multiple": "upper wings",
-    "side": 2,
+    "side": "right",
     "opposite": "arm_wing_bird_upper_l",
     "max_coverage": 30
   },
@@ -589,7 +273,7 @@
     "parent": "arm_wing_bird_l",
     "name": "left wing joint",
     "name_multiple": "wing joints",
-    "side": 1,
+    "side": "left",
     "opposite": "arm_wing_bird_elbow_r",
     "max_coverage": 5
   },
@@ -599,7 +283,7 @@
     "parent": "arm_wing_bird_r",
     "name": "right wing joint",
     "name_multiple": "wing joints",
-    "side": 2,
+    "side": "right",
     "opposite": "arm_wing_bird_elbow_l",
     "max_coverage": 5
   },
@@ -609,7 +293,7 @@
     "parent": "arm_wing_bird_l",
     "name": "lower left wings",
     "name_multiple": "lower wing",
-    "side": 1,
+    "side": "left",
     "opposite": "arm_wing_bird_lower_r",
     "max_coverage": 45
   },
@@ -619,7 +303,7 @@
     "parent": "arm_wing_bird_r",
     "name": "lower right wing",
     "name_multiple": "lower wings",
-    "side": 2,
+    "side": "right",
     "opposite": "arm_wing_bird_lower_l",
     "max_coverage": 45
   },
@@ -629,7 +313,8 @@
     "parent": "arm_wing_bird_l",
     "name": "left wing talons",
     "name_multiple": "wing talons",
-    "side": 1,
+    "side": "left",
+    "similar_bodypart": "hand_fingers_l",
     "opposite": "arm_wing_bird_fingers_r",
     "max_coverage": 5
   },
@@ -639,7 +324,8 @@
     "parent": "arm_wing_bird_r",
     "name": "right wing talons",
     "name_multiple": "wing talons",
-    "side": 2,
+    "side": "right",
+    "similar_bodypart": "hand_fingers_r",
     "opposite": "arm_wing_bird_fingers_l",
     "max_coverage": 5
   },
@@ -648,7 +334,8 @@
     "type": "sub_body_part",
     "max_coverage": 100,
     "parent": "leg_bionic_basic_l",
-    "side": 1,
+    "side": "left",
+    "similar_bodypart": "leg_draped_l",
     "secondary": true,
     "opposite": "leg_bionic_basic_draped_r",
     "name_multiple": "bionic legs (draped)",
@@ -660,7 +347,8 @@
     "type": "sub_body_part",
     "max_coverage": 100,
     "parent": "leg_bionic_basic_r",
-    "side": 2,
+    "side": "right",
+    "similar_bodypart": "leg_draped_r",
     "secondary": true,
     "opposite": "leg_bionic_basic_draped_l",
     "name_multiple": "bionic legs (draped)",
@@ -672,7 +360,8 @@
     "type": "sub_body_part",
     "max_coverage": 20,
     "parent": "arm_bionic_basic_r",
-    "side": 2,
+    "side": "right",
+    "similar_bodypart": "arm_shoulder_r",
     "opposite": "arm_bionic_basic_shoulder_l",
     "name_multiple": "bionic shoulders",
     "name": "right bionic shoulder"
@@ -682,7 +371,8 @@
     "type": "sub_body_part",
     "max_coverage": 40,
     "parent": "arm_bionic_basic_r",
-    "side": 2,
+    "side": "right",
+    "similar_bodypart": "arm_upper_r",
     "opposite": "arm_bionic_basic_upper_l",
     "name_multiple": "upper bionic arms",
     "name": "right upper bionic arm"
@@ -692,7 +382,8 @@
     "type": "sub_body_part",
     "max_coverage": 5,
     "parent": "arm_bionic_basic_r",
-    "side": 2,
+    "side": "right",
+    "similar_bodypart": "arm_elbow_r",
     "opposite": "arm_bionic_basic_elbow_l",
     "name_multiple": "bionic elbows",
     "name": "right bionic elbow"
@@ -702,7 +393,8 @@
     "type": "sub_body_part",
     "max_coverage": 35,
     "parent": "arm_bionic_basic_r",
-    "side": 2,
+    "side": "right",
+    "similar_bodypart": "arm_lower_r",
     "opposite": "arm_bionic_basic_lower_l",
     "name_multiple": "lower bionic arms",
     "name": "right bionic forearm"
@@ -712,7 +404,8 @@
     "type": "sub_body_part",
     "max_coverage": 20,
     "parent": "arm_bionic_basic_l",
-    "side": 1,
+    "side": "left",
+    "similar_bodypart": "arm_shoulder_l",
     "opposite": "arm_bionic_basic_shoulder_r",
     "name_multiple": "bionic shoulders",
     "name": "left bionic shoulder"
@@ -722,7 +415,8 @@
     "type": "sub_body_part",
     "max_coverage": 40,
     "parent": "arm_bionic_basic_l",
-    "side": 1,
+    "side": "left",
+    "similar_bodypart": "arm_upper_l",
     "opposite": "arm_bionic_basic_upper_r",
     "name_multiple": "upper bionic arms",
     "name": "left upper bionic arm"
@@ -732,7 +426,8 @@
     "type": "sub_body_part",
     "max_coverage": 5,
     "parent": "arm_bionic_basic_l",
-    "side": 1,
+    "side": "left",
+    "similar_bodypart": "arm_elbow_l",
     "opposite": "arm_bionic_basic_elbow_r",
     "name_multiple": "bionic elbows",
     "name": "left bionic elbow"
@@ -742,7 +437,8 @@
     "type": "sub_body_part",
     "max_coverage": 35,
     "parent": "arm_bionic_basic_l",
-    "side": 1,
+    "side": "left",
+    "similar_bodypart": "arm_lower_l",
     "opposite": "arm_bionic_basic_lower_r",
     "name_multiple": "lower bionic arms",
     "name": "left bionic forearm"
@@ -752,7 +448,8 @@
     "type": "sub_body_part",
     "max_coverage": 20,
     "parent": "leg_bionic_basic_r",
-    "side": 2,
+    "side": "right",
+    "similar_bodypart": "leg_hip_r",
     "opposite": "leg_bionic_basic_hip_l",
     "name_multiple": "bionic hips",
     "name": "right bionic hip"
@@ -762,7 +459,8 @@
     "type": "sub_body_part",
     "max_coverage": 40,
     "parent": "leg_bionic_basic_r",
-    "side": 2,
+    "side": "right",
+    "similar_bodypart": "leg_upper_r",
     "opposite": "leg_bionic_basic_upper_l",
     "name_multiple": "bionic thighs",
     "name": "right bionic thigh"
@@ -772,7 +470,8 @@
     "type": "sub_body_part",
     "max_coverage": 5,
     "parent": "leg_bionic_basic_r",
-    "side": 2,
+    "side": "right",
+    "similar_bodypart": "leg_knee_r",
     "opposite": "leg_bionic_basic_knee_l",
     "name_multiple": "bionic knees",
     "name": "right bionic knee"
@@ -782,7 +481,8 @@
     "type": "sub_body_part",
     "max_coverage": 35,
     "parent": "leg_bionic_basic_r",
-    "side": 2,
+    "side": "right",
+    "similar_bodypart": "leg_lower_r",
     "opposite": "leg_bionic_basic_lower_l",
     "name_multiple": "bionic lower legs",
     "name": "right bionic lower leg"
@@ -792,7 +492,8 @@
     "type": "sub_body_part",
     "max_coverage": 20,
     "parent": "leg_bionic_basic_l",
-    "side": 1,
+    "side": "left",
+    "similar_bodypart": "leg_hip_l",
     "opposite": "leg_bionic_basic_hip_r",
     "name_multiple": "bionic hips",
     "name": "left bionic hip"
@@ -802,7 +503,8 @@
     "type": "sub_body_part",
     "max_coverage": 40,
     "parent": "leg_bionic_basic_l",
-    "side": 1,
+    "side": "left",
+    "similar_bodypart": "leg_upper_l",
     "opposite": "leg_bionic_basic_upper_r",
     "name_multiple": "bionic thighs",
     "name": "left bionic thigh"
@@ -812,7 +514,8 @@
     "type": "sub_body_part",
     "max_coverage": 5,
     "parent": "leg_bionic_basic_l",
-    "side": 1,
+    "side": "left",
+    "similar_bodypart": "leg_knee_l",
     "opposite": "leg_bionic_basic_knee_r",
     "name_multiple": "bionic knees",
     "name": "left bionic knee"
@@ -822,7 +525,8 @@
     "type": "sub_body_part",
     "max_coverage": 35,
     "parent": "leg_bionic_basic_l",
-    "side": 1,
+    "side": "left",
+    "similar_bodypart": "leg_lower_l",
     "opposite": "leg_bionic_basic_lower_r",
     "name_multiple": "bionic lower legs",
     "name": "left bionic lower leg"
@@ -832,7 +536,8 @@
     "type": "sub_body_part",
     "max_coverage": 10,
     "parent": "hand_bionic_basic_r",
-    "side": 2,
+    "side": "right",
+    "similar_bodypart": "hand_wrist_r",
     "opposite": "hand_bionic_basic_wrist_l",
     "name_multiple": "bionic wrists",
     "name": "right bionic wrist"
@@ -842,7 +547,8 @@
     "type": "sub_body_part",
     "max_coverage": 20,
     "parent": "hand_bionic_basic_r",
-    "side": 2,
+    "side": "right",
+    "similar_bodypart": "hand_palm_r",
     "opposite": "hand_bionic_basic_palm_l",
     "name_multiple": "bionic palms",
     "name": "right bionic palm"
@@ -852,7 +558,8 @@
     "type": "sub_body_part",
     "max_coverage": 20,
     "parent": "hand_bionic_basic_r",
-    "side": 2,
+    "side": "right",
+    "similar_bodypart": "hand_back_r",
     "opposite": "hand_bionic_basic_back_l",
     "name_multiple": "back of bionic hands",
     "name": "right back of bionic hand"
@@ -862,7 +569,8 @@
     "type": "sub_body_part",
     "max_coverage": 50,
     "parent": "hand_bionic_basic_r",
-    "side": 2,
+    "side": "right",
+    "similar_bodypart": "hand_fingers_r",
     "opposite": "hand_bionic_basic_fingers_l",
     "name_multiple": "bionic fingers",
     "name": "right bionic fingers"
@@ -872,7 +580,8 @@
     "type": "sub_body_part",
     "max_coverage": 10,
     "parent": "hand_bionic_basic_l",
-    "side": 1,
+    "side": "left",
+    "similar_bodypart": "hand_wrist_l",
     "opposite": "hand_bionic_basic_wrist_r",
     "name_multiple": "bionic wrists",
     "name": "left bionic wrist"
@@ -882,7 +591,8 @@
     "type": "sub_body_part",
     "max_coverage": 20,
     "parent": "hand_bionic_basic_l",
-    "side": 1,
+    "side": "left",
+    "similar_bodypart": "hand_palm_l",
     "opposite": "hand_bionic_basic_palm_r",
     "name_multiple": "bionic palms",
     "name": "left bionic palm"
@@ -892,7 +602,8 @@
     "type": "sub_body_part",
     "max_coverage": 20,
     "parent": "hand_bionic_basic_l",
-    "side": 1,
+    "side": "left",
+    "similar_bodypart": "hand_back_l",
     "opposite": "hand_bionic_basic_back_r",
     "name_multiple": "back of bionic hands",
     "name": "left back of bionic hand"
@@ -902,7 +613,8 @@
     "type": "sub_body_part",
     "max_coverage": 50,
     "parent": "hand_bionic_basic_l",
-    "side": 1,
+    "side": "left",
+    "similar_bodypart": "hand_fingers_l",
     "opposite": "hand_bionic_basic_fingers_r",
     "name_multiple": "bionic fingers",
     "name": "left bionic fingers"
@@ -912,7 +624,8 @@
     "type": "sub_body_part",
     "max_coverage": 25,
     "parent": "foot_bionic_basic_l",
-    "side": 1,
+    "side": "left",
+    "similar_bodypart": "foot_sole_l",
     "opposite": "foot_bionic_basic_sole_r",
     "name_multiple": "bionic foot bottoms",
     "name": "left bionic foot bottom"
@@ -922,7 +635,8 @@
     "type": "sub_body_part",
     "max_coverage": 25,
     "parent": "foot_bionic_basic_l",
-    "side": 1,
+    "side": "left",
+    "similar_bodypart": "foot_arch_l",
     "opposite": "foot_bionic_basic_arch_r",
     "name_multiple": "bionic foot arches",
     "name": "left bionic foot arch"
@@ -932,7 +646,8 @@
     "type": "sub_body_part",
     "max_coverage": 10,
     "parent": "foot_bionic_basic_l",
-    "side": 1,
+    "side": "left",
+    "similar_bodypart": "foot_toes_l",
     "opposite": "foot_bionic_basic_toes_r",
     "name_multiple": "bionic toes",
     "name": "left bionic toes"
@@ -942,7 +657,8 @@
     "type": "sub_body_part",
     "max_coverage": 20,
     "parent": "foot_bionic_basic_l",
-    "side": 1,
+    "side": "left",
+    "similar_bodypart": "foot_ankle_l",
     "opposite": "foot_bionic_basic_ankle_r",
     "name_multiple": "bionic ankles",
     "name": "left bionic ankle"
@@ -952,7 +668,8 @@
     "type": "sub_body_part",
     "max_coverage": 20,
     "parent": "foot_bionic_basic_l",
-    "side": 1,
+    "side": "left",
+    "similar_bodypart": "foot_heel_l",
     "opposite": "foot_bionic_basic_heel_r",
     "name_multiple": "bionic heels",
     "name": "left bionic heel"
@@ -962,7 +679,8 @@
     "type": "sub_body_part",
     "max_coverage": 25,
     "parent": "foot_bionic_basic_r",
-    "side": 2,
+    "side": "right",
+    "similar_bodypart": "foot_sole_r",
     "opposite": "foot_bionic_basic_sole_l",
     "name_multiple": "bionic foot bottoms",
     "name": "right bionic foot bottom"
@@ -972,7 +690,8 @@
     "type": "sub_body_part",
     "max_coverage": 25,
     "parent": "foot_bionic_basic_r",
-    "side": 2,
+    "side": "right",
+    "similar_bodypart": "foot_arch_r",
     "opposite": "foot_arch_l",
     "name_multiple": "bionic foot arches",
     "name": "bionic right foot arch"
@@ -982,7 +701,8 @@
     "type": "sub_body_part",
     "max_coverage": 10,
     "parent": "foot_bionic_basic_r",
-    "side": 2,
+    "side": "right",
+    "similar_bodypart": "foot_toes_r",
     "opposite": "foot_bionic_basic_toes_l",
     "name_multiple": "bionic toes",
     "name": "bionic right toes"
@@ -992,7 +712,8 @@
     "type": "sub_body_part",
     "max_coverage": 20,
     "parent": "foot_bionic_basic_r",
-    "side": 2,
+    "side": "right",
+    "similar_bodypart": "foot_ankle_r",
     "opposite": "foot_bionic_basic_ankle_l",
     "name_multiple": "bionic ankles",
     "name": "bionic right ankle"
@@ -1002,7 +723,8 @@
     "type": "sub_body_part",
     "max_coverage": 20,
     "parent": "foot_bionic_basic_r",
-    "side": 2,
+    "side": "right",
+    "similar_bodypart": "foot_heel_r",
     "opposite": "foot_bionic_basic_heel_l",
     "name_multiple": "bionic heels",
     "name": "bionic right heel"
@@ -1012,7 +734,7 @@
     "type": "sub_body_part",
     "max_coverage": 80,
     "parent": "leg_bionic_treads",
-    "side": 0,
+    "side": "both",
     "opposite": "bionic_treads_treads",
     "name_multiple": "bionic",
     "name": "tank treads shell"
@@ -1022,7 +744,7 @@
     "type": "sub_body_part",
     "max_coverage": 20,
     "parent": "leg_bionic_treads",
-    "side": 0,
+    "side": "both",
     "opposite": "bionic_treads_body",
     "name_multiple": "bionic treads",
     "name": "tank treads tracks"

--- a/data/mods/TEST_DATA/bionics.json
+++ b/data/mods/TEST_DATA/bionics.json
@@ -206,7 +206,7 @@
     "type": "sub_body_part",
     "max_coverage": 100,
     "parent": "test_bionic_basic_leg_l",
-    "side": 1,
+    "side": "left",
     "opposite": "test_bionic_basic_leg_sub_r",
     "name_multiple": "bionic sublegs",
     "name": "left bionic subleg"
@@ -216,7 +216,7 @@
     "type": "sub_body_part",
     "max_coverage": 100,
     "parent": "test_bionic_basic_leg_r",
-    "side": 2,
+    "side": "right",
     "opposite": "test_bionic_basic_leg_sub_l",
     "name_multiple": "bionic sublegs",
     "name": "right bionic subleg"

--- a/data/mods/TEST_DATA/body_parts.json
+++ b/data/mods/TEST_DATA/body_parts.json
@@ -1,29 +1,9 @@
 [
   {
     "type": "body_part",
-    "id": "mouth",
-    "copy-from": "mouth",
-    "name": "mouth",
-    "similar_bodyparts": [ "test_corvid_beak" ],
-    "limb_type": "mouth",
-    "limb_scores": [ [ "breathing", 1.0 ], [ "manip", 0.05, 0.2 ], [ "consume_liquid", 1.0 ], [ "consume_solid", 1.0 ] ]
-  },
-  {
-    "type": "sub_body_part",
-    "id": "mouth_lips",
-    "copy-from": "mouth_lips",
-    "similar_bodyparts": [ "sub_limb_test_corvid_beak" ],
-    "opposite": "mouth_lips",
-    "side": 0,
-    "name": "lips",
-    "name_multiple": "lips"
-  },
-  {
-    "type": "body_part",
     "id": "test_arm_l",
     "name": "left arm",
     "copy-from": "arm_l",
-    "similar_bodyparts": [ "test_bird_wing_l" ],
     "opposite_part": "test_arm_r"
   },
   {
@@ -31,7 +11,6 @@
     "id": "test_arm_r",
     "name": "right arm",
     "copy-from": "arm_r",
-    "similar_bodyparts": [ "test_bird_wing_r" ],
     "opposite_part": "test_arm_l"
   },
   {
@@ -39,7 +18,7 @@
     "type": "sub_body_part",
     "max_coverage": 100,
     "parent": "foot_l",
-    "side": 0,
+    "side": "both",
     "opposite": "test_foot_r",
     "name_multiple": "feet",
     "name": "left foot"
@@ -52,7 +31,6 @@
     "side": 0,
     "opposite": "test_foot_l",
     "name_multiple": "feet",
-    "similar_bodyparts": [ "sub_limb_test_bird_foot_r", "sub_limb_test_bird_foot_l" ],
     "name": "right foot"
   },
   {
@@ -120,6 +98,7 @@
     "opposite_part": "test_corvid_beak",
     "hit_size": 0.5,
     "hit_difficulty": 1.15,
+    "similar_bodypart": "mouth",
     "limb_types": [ [ "mouth", 1.0 ], [ "hand", 0.1 ] ],
     "limb_scores": [ [ "breathing", 1.0 ], [ "manip", 0.05, 0.2 ], [ "consume_liquid", 0.5 ], [ "consume_solid", 2.0 ] ],
     "side": "both",
@@ -139,7 +118,8 @@
     "type": "sub_body_part",
     "max_coverage": 100,
     "parent": "test_corvid_beak",
-    "side": 0,
+    "side": "both",
+    "similar_bodypart": "mouth_lips",
     "opposite": "sub_limb_test_corvid_beak",
     "name_multiple": "corvid beaks",
     "name": "corvid beak"
@@ -157,6 +137,7 @@
     "encumbrance_threshold": 5,
     "hp_bar_ui_text": "L WING",
     "main_part": "test_bird_wing_l",
+    "similar_bodypart": "test_arm_l",
     "connected_to": "torso",
     "opposite_part": "test_bird_wing_r",
     "hit_size": 13,
@@ -186,7 +167,7 @@
     "type": "sub_body_part",
     "max_coverage": 100,
     "parent": "test_bird_wing_l",
-    "side": 1,
+    "side": "left",
     "opposite": "sub_test_wing_r",
     "name_multiple": "wings",
     "name": "left bird wing"
@@ -196,7 +177,7 @@
     "type": "sub_body_part",
     "max_coverage": 100,
     "parent": "test_bird_wing_r",
-    "side": 1,
+    "side": "left",
     "opposite": "sub_test_wing_l",
     "name_multiple": "wings",
     "name": "right bird wing"
@@ -214,6 +195,7 @@
     "encumbrance_text": "Melee combat is hampered.",
     "encumbrance_threshold": 5,
     "main_part": "test_bird_wing_r",
+    "similar_bodypart": "test_arm_r",
     "connected_to": "torso",
     "opposite_part": "test_bird_wing_l",
     "hit_size": 13,
@@ -272,8 +254,9 @@
     "type": "sub_body_part",
     "max_coverage": 100,
     "parent": "test_bird_foot_l",
-    "side": 0,
+    "side": "both",
     "opposite": "sub_limb_test_bird_foot_l",
+    "similar_bodypart": "test_foot_r",
     "name_multiple": "feet",
     "name": "left bird foot"
   },
@@ -311,8 +294,9 @@
     "type": "sub_body_part",
     "max_coverage": 100,
     "parent": "test_bird_foot_r",
-    "side": 0,
+    "side": "both",
     "opposite": "sub_limb_test_bird_foot_r",
+    "similar_bodypart": "test_foot_r",
     "name_multiple": "feet",
     "name": "right bird foot"
   },

--- a/data/mods/Xedra_Evolved/body_parts.json
+++ b/data/mods/Xedra_Evolved/body_parts.json
@@ -106,7 +106,7 @@
     "type": "sub_body_part",
     "max_coverage": 10,
     "parent": "bp_null",
-    "side": 1,
+    "side": "left",
     "opposite": "karma_hand",
     "name": "karma hand",
     "name_multiple": "karma hands"
@@ -127,6 +127,7 @@
     "limb_type": "sensor",
     "limb_scores": [ [ "vision", 2.0 ], [ "night_vis", 12 ], [ "reaction", 1.4 ] ],
     "side": "both",
+    "similar_bodypart": "eyes",
     "base_hp": 60,
     "drench_capacity": 0,
     "flags": [ "IGNORE_TEMP", "LIMB_UPPER", "BIONIC_LIMB", "CRAFT_IN_DARKNESS" ],
@@ -138,7 +139,7 @@
     "type": "sub_body_part",
     "max_coverage": 10,
     "parent": "bp_null",
-    "side": 2,
+    "side": "right",
     "opposite": "stalker_eye",
     "name": "stalker eye",
     "name_multiple": "stalker eyes"
@@ -159,6 +160,7 @@
     "limb_type": "sensor",
     "limb_scores": [ [ "vision", 1.0 ], [ "night_vis", 1.5 ], [ "reaction", 1 ] ],
     "side": "both",
+    "similar_bodypart": "eyes",
     "base_hp": 60,
     "drench_capacity": 0,
     "flags": [ "IGNORE_TEMP", "LIMB_UPPER" ],
@@ -181,7 +183,7 @@
     "type": "sub_body_part",
     "max_coverage": 10,
     "parent": "bp_null",
-    "side": 2,
+    "side": "right",
     "opposite": "gracken_eye",
     "name": "gracken eye",
     "name_multiple": "gracken eyes"
@@ -224,19 +226,10 @@
     "type": "sub_body_part",
     "max_coverage": 10,
     "parent": "bp_null",
-    "side": 1,
+    "side": "left",
     "opposite": "devil_tail_tip",
     "name": "devil's tail tip",
     "name_multiple": "devil's tail tips"
-  },
-  {
-    "id": "eyes",
-    "type": "body_part",
-    "copy-from": "eyes",
-    "name": "eyes",
-    "limb_type": "sensor",
-    "limb_scores": [ [ "vision", 1.0 ], [ "night_vis", 1.0 ], [ "reaction", 0.7 ] ],
-    "similar_bodyparts": [ "gracken_eyes", "stalker_eyes" ]
   },
   {
     "id": "assist_arm_r",
@@ -286,7 +279,7 @@
     "type": "sub_body_part",
     "max_coverage": 10,
     "parent": "bp_null",
-    "side": 1,
+    "side": "left",
     "opposite": "assist_hand",
     "name": "assistant's  hand",
     "name_multiple": "assistant's hands"

--- a/src/bodypart.h
+++ b/src/bodypart.h
@@ -6,6 +6,7 @@
 #include <climits>
 #include <cstddef>
 #include <map>
+#include <optional>
 #include <set>
 #include <string>
 #include <string_view>
@@ -307,7 +308,7 @@ struct body_part_type {
 
         // These limbs should be covered by armor covering this limb (1:1 coverage)
         // TODO: Coverage/Encumbrance multiplier
-        std::vector<bodypart_str_id> similar_bodyparts;
+        std::optional<bodypart_str_id> similar_bodypart;
 
         weighted_int_list<bp_wounds> potential_wounds;
 
@@ -372,6 +373,8 @@ struct body_part_type {
         // this version just pairs normal body parts
         static std::set<translation, localized_comparator> consolidate( std::vector<bodypart_id>
                 &covered );
+
+        std::vector<bodypart_str_id> get_all_combined_similar_bodyparts() const;
 };
 
 struct layer_details {

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -936,8 +936,8 @@ void Item_factory::finalize_post_armor( itype &obj )
         body_part_set similar_bp;
         if( data.covers.has_value() ) {
             for( const bodypart_str_id &bp : data.covers.value() ) {
-                for( const bodypart_str_id &similar : bp->similar_bodyparts ) {
-                    similar_bp.set( similar );
+                for( const bodypart_str_id &combined : bp->get_all_combined_similar_bodyparts() ) {
+                    similar_bp.set( combined );
                 }
             }
         }
@@ -964,8 +964,8 @@ void Item_factory::finalize_post_armor( itype &obj )
         std::set<sub_bodypart_str_id> similar_sbp;
         if( !data.sub_coverage.empty() ) {
             for( const sub_bodypart_str_id &sbp : data.sub_coverage ) {
-                for( const sub_bodypart_str_id &similar : sbp->similar_bodyparts ) {
-                    similar_sbp.emplace( similar );
+                for( const sub_bodypart_str_id &combined : sbp->get_all_combined_similar_sub_bodyparts() ) {
+                    similar_sbp.emplace( combined );
                 }
             }
         }

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -656,7 +656,7 @@ void finalize_martial_arts()
         // The vector needs both a limb and a contact area, so we can substitute safely
         std::vector<bodypart_str_id> similar_bp;
         for( const bodypart_str_id &bp : vector.limbs ) {
-            for( const bodypart_str_id &similar : bp->similar_bodyparts ) {
+            for( const bodypart_str_id &similar : bp->get_all_combined_similar_bodyparts() ) {
                 similar_bp.emplace_back( similar );
             }
         }
@@ -665,7 +665,7 @@ void finalize_martial_arts()
 
         std::vector<sub_bodypart_str_id> similar_sbp;
         for( const sub_bodypart_str_id &sbp : vector.contact_area ) {
-            for( const sub_bodypart_str_id &similar : sbp->similar_bodyparts ) {
+            for( const sub_bodypart_str_id &similar : sbp->get_all_combined_similar_sub_bodyparts() ) {
                 similar_sbp.emplace_back( similar );
             }
         }

--- a/src/subbodypart.h
+++ b/src/subbodypart.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_SUBBODYPART_H
 #define CATA_SRC_SUBBODYPART_H
 
+#include <optional>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -66,7 +67,7 @@ struct sub_body_part_type {
 
     // These subparts act like this limb for armor coverage
     // TODO: Coverage/Encumbrance multiplier
-    std::vector<sub_bodypart_str_id> similar_bodyparts;
+    std::optional<sub_bodypart_str_id> similar_bodypart;
     // Unarmed damage when this subpart is our contact area
     damage_instance unarmed_damage;
 
@@ -77,12 +78,14 @@ struct sub_body_part_type {
     // combine matching body part strings together for printing
     static std::vector<translation> consolidate( std::vector<sub_bodypart_id> &covered );
 
+    std::vector<sub_bodypart_str_id> get_all_combined_similar_sub_bodyparts() const;
+
     // Clears all bps
     static void reset();
     // Post-load finalization
     static void finalize_all();
 
-    static void finalize();
+    void finalize();
 };
 
 #endif // CATA_SRC_SUBBODYPART_H

--- a/tests/limb_test.cpp
+++ b/tests/limb_test.cpp
@@ -1,4 +1,5 @@
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -26,8 +27,6 @@
 #include "weather_gen.h"
 #include "weather_type.h"
 
-static const bodypart_str_id body_part_test_arm_l( "test_arm_l" );
-static const bodypart_str_id body_part_test_arm_r( "test_arm_r" );
 static const bodypart_str_id body_part_test_bird_foot_l( "test_bird_foot_l" );
 static const bodypart_str_id body_part_test_bird_foot_r( "test_bird_foot_r" );
 static const bodypart_str_id body_part_test_bird_wing_l( "test_bird_wing_l" );
@@ -284,9 +283,8 @@ TEST_CASE( "Limb_armor_coverage", "[character][limb][armor]" )
     create_bird_char( dude );
     REQUIRE( dude.has_part( body_part_test_bird_wing_l ) );
     REQUIRE( dude.has_part( body_part_test_bird_wing_r ) );
-
-    REQUIRE( body_part_test_arm_l->similar_bodyparts.size() == 1 );
-    REQUIRE( body_part_test_arm_r->similar_bodyparts.size() == 1 );
+    REQUIRE( body_part_test_bird_wing_l->similar_bodypart.has_value() );
+    REQUIRE( body_part_test_bird_wing_r->similar_bodypart.has_value() );
 
     // Explicitly-defined armor covers custom limbs
     CHECK( wing_covers.covers( body_part_test_bird_wing_l ) );


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
One thing that i wanted to fix for a long time, and few more that i just happened to be able to figure a fix
#### Describe the solution
- Previously `similar_bodyparts` was intended to be used on vanilla part (arm) to tell the game which limbs it should cover additionally (bionic arm). Now it works more sanely, you point new bodypart (bionic arm) to some existing bodypart (arm)
- For this, `similar_bodyparts` is not an array anymore, but a string (optional)
- Because of this, json overriding of main parts was removed, and `similar_bodyparts` were set for bodyparts directly
- There was a very annoying bug, where limbs and sublimbs required `opposite`, but didn't actually enforce it in any way, making many of our json not specify opposite bodypart, and for this throw error about invalid bodypart id "" (and then crash the game because imgui do not like our debugmsg). Now it is an optional part, that fall back to itself if not provided - same as it was intended in code and in json
- `"side"` is an enum, but for some reason people blindly copypasted it's numeric representation - `0` instead of `both`, `1` instead of `right` etc. Now it uses string, as intended
- There was a small bug in item armor consolidation screen, where it missed the name of a limb; it was because, A, head_dragonfly_forehead didn't have `name_multiple`, and B, because code incorrectly assumed it has to be multiple; since it is not a bodypart that you can have multiple of, A was not touched, and B was resolved instead
#### Testing
Compiled, checked armor screen, took some damage, all looks fine

UI in previous versions (cannot even load version after the imgui enrolling because of bug nr 4)
<img width="639" height="331" alt="image" src="https://github.com/user-attachments/assets/aebf726c-622e-4349-bb96-84f653b8fb8b" />

UI after fixes (but before i fixed bug nr 6)
<img width="639" height="331" alt="image" src="https://github.com/user-attachments/assets/9993823c-5a2a-4cee-bd31-621fdfa3fad8" />

UI with fixed bug nr 6
<img width="633" height="62" alt="image" src="https://github.com/user-attachments/assets/471e771a-6681-4a3a-b0ab-942c037f05ac" />

#### Additional context
It would be a fine addition to remove enum being loaded as int altogether