### PR TITLE
Allow resuming hacksaw cutting metal with different tools

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -1443,7 +1443,8 @@ int hacksaw_activity_actor::get_tool_quality() const
 }
 
 void hacksaw_activity_actor::set_resume_values_internal( const activity_actor &other,
-                                 const Character &/*who*/ ) {
+        const Character &/*who*/ )
+{
     // This method recalculates moves_left based on tool quality comparison but it doesn't have
     // access to update the moves_left on the corresponding player_activity.  You must set the
     // player_activity's moves_left separately after resuming the activity_actor.
@@ -1454,12 +1455,11 @@ void hacksaw_activity_actor::set_resume_values_internal( const activity_actor &o
     int qual = get_tool_quality();
 
     int new_moves_left = -1;
-    if( actor_qual > 0 )
-    {
+    if( actor_qual > 0 ) {
         new_moves_left = moves_left * qual / actor_qual;
     }
     debugmsg( string_format( "Actor quality: %d, quality: %d, moves_left: %d, new_moves_left: %d, actor moves left: %d.",
-                            actor_qual, qual, moves_left, new_moves_left, actor.moves_left ) );
+                             actor_qual, qual, moves_left, new_moves_left, actor.moves_left ) );
     moves_left = new_moves_left;
     tool = actor.tool;
 }

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -1455,8 +1455,8 @@ void hacksaw_activity_actor::set_resume_values_internal( const activity_actor &o
     int qual = get_tool_quality();
 
     int new_moves_left = -1;
-    if( actor_qual > 0 ) {
-        new_moves_left = moves_left * qual / actor_qual;
+    if( actor_qual > 1 ) {
+        new_moves_left = moves_left * ( qual - 1 ) / ( actor_qual - 1 );
     }
     add_msg_debug( debugmode::DF_ACTIVITY,
                    "Hacksaw resume.  Actor quality: %d, quality: %d, moves_left: %d, new_moves_left: %d.",

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -1459,8 +1459,8 @@ void hacksaw_activity_actor::set_resume_values_internal( const activity_actor &o
         new_moves_left = moves_left * qual / actor_qual;
     }
     add_msg_debug( debugmode::DF_ACTIVITY,
-        "Hacksaw resume.  Actor quality: %d, quality: %d, moves_left: %d, new_moves_left: %d.",
-        actor_qual, qual, moves_left, new_moves_left );
+                   "Hacksaw resume.  Actor quality: %d, quality: %d, moves_left: %d, new_moves_left: %d.",
+                   actor_qual, qual, moves_left, new_moves_left );
     moves_left = new_moves_left;
     tool = actor.tool;
 }

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -1458,8 +1458,9 @@ void hacksaw_activity_actor::set_resume_values_internal( const activity_actor &o
     if( actor_qual > 0 ) {
         new_moves_left = moves_left * qual / actor_qual;
     }
-    debugmsg( string_format( "Actor quality: %d, quality: %d, moves_left: %d, new_moves_left: %d, actor moves left: %d.",
-                             actor_qual, qual, moves_left, new_moves_left, actor.moves_left ) );
+    add_msg_debug( debugmode::DF_ACTIVITY,
+        "Hacksaw resume.  Actor quality: %d, quality: %d, moves_left: %d, new_moves_left: %d.",
+        actor_qual, qual, moves_left, new_moves_left );
     moves_left = new_moves_left;
     tool = actor.tool;
 }

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -1263,22 +1263,7 @@ void hacksaw_activity_actor::start( player_activity &act, Character &/*who*/ )
         return;
     }
 
-    int qual = 0;
-    if( type.has_value() ) {
-        item veh_tool = item( type.value(), calendar::turn );
-        for( const std::pair<const quality_id, int> &quality : type.value()->qualities ) {
-            if( quality.first == qual_SAW_M ) {
-                qual = quality.second;
-            }
-        }
-        for( const std::pair<const quality_id, int> &quality : type.value()->charged_qualities ) {
-            if( quality.first == qual_SAW_M ) {
-                qual = std::max( qual, quality.second );
-            }
-        }
-    } else {
-        qual = tool->get_quality( qual_SAW_M );
-    }
+    int qual = get_tool_quality();
     if( qual < 2 ) {
         if( !testing ) {
             debugmsg( "Item %s with 'HACKSAW' use action requires SAW_M quality of at least 2.",
@@ -1294,6 +1279,7 @@ void hacksaw_activity_actor::start( player_activity &act, Character &/*who*/ )
     act.moves_total = moves_before_quality / ( qual - 1 );
     add_msg_debug( debugmode::DF_ACTIVITY, "%s moves_total: %d", act.id().str(), act.moves_total );
     act.moves_left = act.moves_total;
+    moves_left = act.moves_left;
 }
 
 static void tool_out_of_charges( Character &who, const std::string &tool_name )
@@ -1307,8 +1293,9 @@ static void tool_out_of_charges( Character &who, const std::string &tool_name )
     who.cancel_activity();
 }
 
-void hacksaw_activity_actor::do_turn( player_activity &/*act*/, Character &who )
+void hacksaw_activity_actor::do_turn( player_activity &act, Character &who )
 {
+    moves_left = act.moves_left;
     map &here = get_map();
 
     std::string method = "HACKSAW";
@@ -1424,18 +1411,57 @@ void hacksaw_activity_actor::finish( player_activity &act, Character &who )
     act.set_to_null();
 }
 
-//TODO: Make hacksawing resumable with different tools with the same SAW_M quality.
-//Potentially make it possible to resume with different SAW_M quality and recalculate time to completion partway through.
-//This is really not a big deal, and will cost a few minutes of in game time and part of a medium battery charge at worst as someone accidentally cancels the activity_actor and has to start again
-//If a few minutes are life and death, sawing metal may not be the wise choice in the first place.
-bool hacksaw_activity_actor::can_resume_with_internal( const activity_actor &other,
-        const Character &/*who*/ ) const
+float hacksaw_activity_actor::exertion_level() const
 {
-    const hacksaw_activity_actor &actor = static_cast<const hacksaw_activity_actor &>
-                                          ( other );
-    return actor.target == target && ( ( veh_pos.has_value() &&
-                                         veh_pos.value() == actor.veh_pos.value_or( tripoint_bub_ms::max ) ) ||
-                                       actor.tool.operator == ( tool ) );
+    if( tool->ammo_required() ) {
+        return LIGHT_EXERCISE;
+    } else {
+        return get_type()->exertion_level();
+    }
+}
+
+int hacksaw_activity_actor::get_tool_quality() const
+{
+    int qual = 0;
+    if( type.has_value() ) {
+        item veh_tool = item( type.value(), calendar::turn );
+        for( const std::pair<const quality_id, int> &quality : type.value()->qualities ) {
+            if( quality.first == qual_SAW_M ) {
+                qual = quality.second;
+            }
+        }
+        for( const std::pair<const quality_id, int> &quality : type.value()->charged_qualities ) {
+            if( quality.first == qual_SAW_M ) {
+                qual = std::max( qual, quality.second );
+            }
+        }
+    } else {
+        qual = tool->get_quality( qual_SAW_M );
+    }
+
+    return qual;
+}
+
+void hacksaw_activity_actor::set_resume_values_internal( const activity_actor &other,
+                                 const Character &/*who*/ ) {
+    // This method recalculates moves_left based on tool quality comparison but it doesn't have
+    // access to update the moves_left on the corresponding player_activity.  You must set the
+    // player_activity's moves_left separately after resuming the activity_actor.
+
+    const hacksaw_activity_actor &actor = static_cast<const hacksaw_activity_actor &>( other );
+
+    int actor_qual = actor.get_tool_quality();
+    int qual = get_tool_quality();
+
+    int new_moves_left = -1;
+    if( actor_qual > 0 )
+    {
+        new_moves_left = moves_left * qual / actor_qual;
+    }
+    debugmsg( string_format( "Actor quality: %d, quality: %d, moves_left: %d, new_moves_left: %d, actor moves left: %d.",
+                            actor_qual, qual, moves_left, new_moves_left, actor.moves_left ) );
+    moves_left = new_moves_left;
+    tool = actor.tool;
 }
 
 void hacksaw_activity_actor::serialize( JsonOut &jsout ) const
@@ -1445,6 +1471,7 @@ void hacksaw_activity_actor::serialize( JsonOut &jsout ) const
     jsout.member( "tool", tool );
     jsout.member( "type", type );
     jsout.member( "veh_pos", veh_pos );
+    jsout.member( "moves_left", moves_left );
     jsout.end_object();
 }
 
@@ -1456,6 +1483,7 @@ std::unique_ptr<activity_actor> hacksaw_activity_actor::deserialize( JsonValue &
     data.read( "tool", actor.tool );
     data.read( "type", actor.type );
     data.read( "veh_pos", actor.veh_pos );
+    data.read( "moves_left", actor.moves_left );
     return actor.clone();
 }
 

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -435,6 +435,8 @@ class hacksaw_activity_actor : public activity_actor
         void start( player_activity &act, Character &who ) override;
         void do_turn( player_activity &/*act*/, Character &who ) override;
         void finish( player_activity &act, Character &who ) override;
+        float exertion_level() const override;
+        int get_tool_quality() const;
 
         std::unique_ptr<activity_actor> clone() const override {
             return std::make_unique<hacksaw_activity_actor>( *this );
@@ -443,6 +445,7 @@ class hacksaw_activity_actor : public activity_actor
         void serialize( JsonOut &jsout ) const override;
         static std::unique_ptr<activity_actor> deserialize( JsonValue &jsin );
 
+        int moves_left;
         // debugmsg causes a backtrace when fired during cata_test
         bool testing = false;  // NOLINT(cata-serialize)
     private:
@@ -450,8 +453,16 @@ class hacksaw_activity_actor : public activity_actor
         item_location tool;
         std::optional<itype_id> type;
         std::optional<tripoint_bub_ms> veh_pos;
+
         bool can_resume_with_internal( const activity_actor &other,
-                                       const Character &/*who*/ ) const override;
+                const Character &/*who*/ ) const override {
+            const hacksaw_activity_actor &actor = static_cast<const hacksaw_activity_actor &>
+                                                  ( other );
+            return actor.target == target;
+        }
+
+        void set_resume_values_internal( const activity_actor &other,
+                                         const Character &/*who*/ ) override;
 };
 
 class hacking_activity_actor : public activity_actor

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -455,7 +455,7 @@ class hacksaw_activity_actor : public activity_actor
         std::optional<tripoint_bub_ms> veh_pos;
 
         bool can_resume_with_internal( const activity_actor &other,
-                const Character &/*who*/ ) const override {
+                                       const Character &/*who*/ ) const override {
             const hacksaw_activity_actor &actor = static_cast<const hacksaw_activity_actor &>
                                                   ( other );
             return actor.target == target;

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -4754,9 +4754,18 @@ std::optional<int> iuse::hacksaw( Character *p, item *it, const tripoint_bub_ms 
     } else {
         query += string_format( _( "Resume cutting up metal using your %1$s?" ), it->tname() );
     }
+
+    // HACK: Update the player_activity moves_left based on progress stored in the activity_actor.
+    int activity_actor_moves_left = static_cast<const hacksaw_activity_actor &>(
+            *p->activity.actor ).moves_left;
+    p->activity.moves_left = activity_actor_moves_left;
+
     query += "\n";
     query += _( "Time to complete: " );
     int required_moves = p->activity.moves_left;
+
+    debugmsg( string_format( "iuse hacksaw required_moves: %d.", required_moves ) );
+
     const float weary_mult = p->exertion_adjusted_move_multiplier( p->activity.exertion_level() );
     time_duration required_time = time_duration::from_turns( required_moves * weary_mult / p->get_speed() );
     const std::string time_string = colorize( to_string( required_time, true ), c_light_gray );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -4748,7 +4748,7 @@ std::optional<int> iuse::hacksaw( Character *p, item *it, const tripoint_bub_ms 
         p->assign_activity( hacksaw_activity_actor( pnt, it->typeId(), it_pnt ) );
     }
 
-    std::string query = "";
+    std::string query;
     if( p->activity.moves_left == p->activity.moves_total ) {
         query += string_format( _( "Cut up metal using your %1$s?" ), it->tname() );
     } else {

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -4749,7 +4749,7 @@ std::optional<int> iuse::hacksaw( Character *p, item *it, const tripoint_bub_ms 
     }
 
     std::string query = "";
-    if ( p->activity.moves_left == p->activity.moves_total ) {
+    if( p->activity.moves_left == p->activity.moves_total ) {
         query += string_format( _( "Cut up metal using your %1$s?" ), it->tname() );
     } else {
         query += string_format( _( "Resume cutting up metal using your %1$s?" ), it->tname() );
@@ -4757,7 +4757,7 @@ std::optional<int> iuse::hacksaw( Character *p, item *it, const tripoint_bub_ms 
 
     // HACK: Update the player_activity moves_left based on progress stored in the activity_actor.
     int activity_actor_moves_left = static_cast<const hacksaw_activity_actor &>(
-            *p->activity.actor ).moves_left;
+                                        *p->activity.actor ).moves_left;
     p->activity.moves_left = activity_actor_moves_left;
 
     query += "\n";
@@ -4767,7 +4767,8 @@ std::optional<int> iuse::hacksaw( Character *p, item *it, const tripoint_bub_ms 
     debugmsg( string_format( "iuse hacksaw required_moves: %d.", required_moves ) );
 
     const float weary_mult = p->exertion_adjusted_move_multiplier( p->activity.exertion_level() );
-    time_duration required_time = time_duration::from_turns( required_moves * weary_mult / p->get_speed() );
+    time_duration required_time = time_duration::from_turns( required_moves * weary_mult /
+                                  p->get_speed() );
     const std::string time_string = colorize( to_string( required_time, true ), c_light_gray );
     query += time_string;
 
@@ -4778,9 +4779,9 @@ std::optional<int> iuse::hacksaw( Character *p, item *it, const tripoint_bub_ms 
             query += string_format( _( "This will require %d kJ." ), charges_needed );
         } else {
             query += string_format(
-                        _( "This will require %d %s." ),
-                        charges_needed, it->ammo_current()->nname( charges_needed )
-                    );
+                         _( "This will require %d %s." ),
+                         charges_needed, it->ammo_current()->nname( charges_needed )
+                     );
         }
     }
 

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -4786,6 +4786,7 @@ std::optional<int> iuse::hacksaw( Character *p, item *it, const tripoint_bub_ms 
 
     if( !query_yn( query ) ) {
         p->cancel_activity();
+        p->add_msg_if_player( m_info, _( "You decide not to cut up this metal." ) );
     }
 
     return std::nullopt;

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -4763,8 +4763,7 @@ std::optional<int> iuse::hacksaw( Character *p, item *it, const tripoint_bub_ms 
     query += "\n";
     query += _( "Time to complete: " );
     int required_moves = p->activity.moves_left;
-
-    debugmsg( string_format( "iuse hacksaw required_moves: %d.", required_moves ) );
+    add_msg_debug( debugmode::DF_ACTIVITY, "iuse hacksaw required_moves: %d.", required_moves );
 
     const float weary_mult = p->exertion_adjusted_move_multiplier( p->activity.exertion_level() );
     time_duration required_time = time_duration::from_turns( required_moves * weary_mult /

--- a/src/player_activity.h
+++ b/src/player_activity.h
@@ -34,13 +34,14 @@ class player_activity
 {
     private:
         activity_id type;
-        cata::clone_ptr<activity_actor> actor;
 
         std::set<distraction_type> ignored_distractions; // NOLINT(cata-serialize)
 
         bool ignoreQuery = false; // NOLINT(cata-serialize)
 
     public:
+        cata::clone_ptr<activity_actor> actor;
+
         /** Total number of moves (1/100th of a second) required to complete the activity */
         int moves_total = 0;
         /** The number of moves (1/100th of a second) remaining in this activity before it is complete. */


### PR DESCRIPTION
#### Summary

Interface "Allow resuming hacksaw cutting metal with different tools"

#### Purpose of change

Currently the cut metal action can only be resumed using a tool with the same quality as the one that initiated the process.  This is suboptimal because cutting metal with a reciprocating saw takes more than a small tool battery, so finishing up the cut with a hacksaw might be necessary.

#### Describe the solution

1. Store the `moves_required` remaining when saving a hacksaw activity.  Recalculate the `moves_required` and display them on subsequent sawing attempts.
2. Show how much energy is required when using a tool with `consumes_ammo` in addition to the time required.
3. If using a power tool, cutting metal is a light activity instead of a moderate (or whatever the json says hacksaw takes, if it changes).

#### Describe alternatives you've considered

1. Went down a crazy rabbit hole trying to change `set_resume_values_internal` to take a pointer to `player_activity` instead of a `const` pointer to `activity_actor` so that I could adjust the moves in the "correct" place.  It was beyond my meager C++ skills.

#### Testing

Starting vs metal bars with a hacksaw:
```
Cut up metal using your hacksaw?
Time to complete: 15 minutes (Case Sensitive
                                 [Y]es   [N]
```
☝️ note there is truncation in curses 😞

Starting vs metal bars with a reciprocating saw:
```
Cut up metal using your reciprocating saw?
Time to complete: 10 minutes
This will require 600 kJ. (Case Sensitive)
                              [Y]es   [N]o
```

After cutting with 259 kJ of energy:
```
Resume cutting up metal using your reciprocating saw?
Time to complete: 5 mins 40 secs
This will require 340 kJ. (Case Sensitive)
                                         [Y]es   [N]o
```
resuming with a hacksaw takes twice as long:
```
Resume cutting up metal using your hacksaw?
Time to complete: 11 mins 20 secs (Case Sensitive
                                      [Y]es   [N]
```

✅ the prorated times persist across save & load.

#### Additional context

1. Initial hacksaw time estimates added in https://github.com/CleverRaven/Cataclysm-DDA/pull/84968
2. Because the hacksaw timing is calculated by started the activity _then_ asking, you will see "You resume your task." in the message log when being asked whether to cut the metal.  If you cancel you get this:
```
You resume your task.
You decide not to cut up this metal.
```
4. I still think reciprocating saws should be faster than they currently are.
5. Using a power tool should be a time based activity and using a hand tool should remain a speed based activity.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
