### PR TITLE
Move ACT_MULTIPLE_FISH/FARM/READ/STUDY to activity_actors

### DIFF
--- a/data/json/player_activities.json
+++ b/data/json/player_activities.json
@@ -227,6 +227,7 @@
     "activity_level": "NO_EXERCISE",
     "verb": "fishing",
     "based_on": "neither",
+    "multi_activity": true,
     "auto_needs": true
   },
   {

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -196,6 +196,7 @@ static const activity_id ACT_MULTIPLE_FARM( "ACT_MULTIPLE_FARM" );
 static const activity_id ACT_MULTIPLE_FISH( "ACT_MULTIPLE_FISH" );
 static const activity_id ACT_MULTIPLE_MINE( "ACT_MULTIPLE_MINE" );
 static const activity_id ACT_MULTIPLE_MOP( "ACT_MULTIPLE_MOP" );
+static const activity_id ACT_MULTIPLE_READ( "ACT_MULTIPLE_READ" );
 static const activity_id ACT_MULTIPLE_STUDY( "ACT_MULTIPLE_STUDY" );
 static const activity_id ACT_OPEN_GATE( "ACT_OPEN_GATE" );
 static const activity_id ACT_OPERATION( "ACT_OPERATION" );
@@ -2581,6 +2582,25 @@ std::unique_ptr<activity_actor> read_activity_actor::deserialize( JsonValue &jsi
     data.read( "continuous", actor.continuous );
     data.read( "learner_id", actor.learner_id );
 
+    return actor.clone();
+}
+
+activity_reason_info multi_read_activity_actor::multi_activity_can_do(
+    Character &you, const tripoint_bub_ms &src_loc )
+{
+    return multi_activity_actor::read_can_do( ACT_MULTIPLE_READ, you,
+            src_loc );
+}
+bool multi_read_activity_actor::multi_activity_do( Character &you,
+        const activity_reason_info &act_info,
+        const tripoint_abs_ms &src, const tripoint_bub_ms &src_loc )
+{
+    return multi_activity_actor::read_do( you, act_info, src, src_loc );
+}
+
+std::unique_ptr<activity_actor> multi_read_activity_actor::deserialize( JsonValue & )
+{
+    multi_read_activity_actor actor;
     return actor.clone();
 }
 
@@ -12683,6 +12703,7 @@ deserialize_functions = {
     { ACT_MULTIPLE_FISH, &multi_fish_activity_actor::deserialize },
     { ACT_MULTIPLE_MINE, &multi_mine_activity_actor::deserialize },
     { ACT_MULTIPLE_MOP, &multi_mop_activity_actor::deserialize },
+    { ACT_MULTIPLE_READ, &multi_read_activity_actor::deserialize },
     { ACT_OPEN_GATE, &open_gate_activity_actor::deserialize },
     { ACT_OPERATION, &bionic_operation_activity_actor::deserialize },
     { ACT_OXYTORCH, &oxytorch_activity_actor::deserialize },

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -4640,6 +4640,30 @@ std::unique_ptr<activity_actor> fish_activity_actor::deserialize( JsonValue &jsi
     return actor.clone();
 }
 
+activity_reason_info multi_fish_activity_actor::multi_activity_can_do(
+    Character &you, const tripoint_bub_ms &src_loc )
+{
+    return multi_activity_actor::fish_can_do( ACT_VEHICLE_REPAIR, you,
+            src_loc );
+}
+std::optional<requirement_id> multi_fish_activity_actor::multi_activity_requirements(
+    Character &you, activity_reason_info &act_info, const tripoint_bub_ms &src_loc )
+{
+    return multi_activity_actor::fish_requirements( you, act_info, src_loc );
+}
+bool multi_fish_activity_actor::multi_activity_do( Character &you,
+        const activity_reason_info &act_info,
+        const tripoint_abs_ms &src, const tripoint_bub_ms &src_loc )
+{
+    return multi_activity_actor::fish_do( you, act_info, src, src_loc );
+}
+
+std::unique_ptr<activity_actor> multi_fish_activity_actor::deserialize( JsonValue & )
+{
+    multi_fish_activity_actor actor;
+    return actor.clone();
+}
+
 std::unordered_set<tripoint_abs_ms> multi_zone_activity_actor::multi_activity_locations(
     Character  &you )
 {
@@ -12630,6 +12654,7 @@ deserialize_functions = {
     { ACT_MOVE_LOOT, &zone_sort_activity_actor::deserialize },
     { ACT_MULTIPLE_CHOP_PLANKS, &multi_chop_planks_activity_actor::deserialize },
     { ACT_MULTIPLE_CHOP_TREES, &multi_chop_trees_activity_actor::deserialize },
+    { ACT_MULTIPLE_FISH, &multi_fish_activity_actor::deserialize },
     { ACT_MULTIPLE_MINE, &multi_mine_activity_actor::deserialize },
     { ACT_MULTIPLE_MOP, &multi_mop_activity_actor::deserialize },
     { ACT_OPEN_GATE, &open_gate_activity_actor::deserialize },

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -192,6 +192,7 @@ static const activity_id ACT_MOVE_ITEMS( "ACT_MOVE_ITEMS" );
 static const activity_id ACT_MOVE_LOOT( "ACT_MOVE_LOOT" );
 static const activity_id ACT_MULTIPLE_CHOP_PLANKS( "ACT_MULTIPLE_CHOP_PLANKS" );
 static const activity_id ACT_MULTIPLE_CHOP_TREES( "ACT_MULTIPLE_CHOP_TREES" );
+static const activity_id ACT_MULTIPLE_FARM( "ACT_MULTIPLE_FARM" );
 static const activity_id ACT_MULTIPLE_FISH( "ACT_MULTIPLE_FISH" );
 static const activity_id ACT_MULTIPLE_MINE( "ACT_MULTIPLE_MINE" );
 static const activity_id ACT_MULTIPLE_MOP( "ACT_MULTIPLE_MOP" );
@@ -4643,7 +4644,7 @@ std::unique_ptr<activity_actor> fish_activity_actor::deserialize( JsonValue &jsi
 activity_reason_info multi_fish_activity_actor::multi_activity_can_do(
     Character &you, const tripoint_bub_ms &src_loc )
 {
-    return multi_activity_actor::fish_can_do( ACT_VEHICLE_REPAIR, you,
+    return multi_activity_actor::fish_can_do( ACT_MULTIPLE_FISH, you,
             src_loc );
 }
 std::optional<requirement_id> multi_fish_activity_actor::multi_activity_requirements(
@@ -9151,6 +9152,30 @@ std::unique_ptr<activity_actor> churn_activity_actor::deserialize( JsonValue &js
     return actor.clone();
 }
 
+activity_reason_info multi_farm_activity_actor::multi_activity_can_do(
+    Character &you, const tripoint_bub_ms &src_loc )
+{
+    return multi_activity_actor::farm_can_do( ACT_MULTIPLE_FARM, you,
+            src_loc );
+}
+std::optional<requirement_id> multi_farm_activity_actor::multi_activity_requirements(
+    Character &you, activity_reason_info &act_info, const tripoint_bub_ms &src_loc )
+{
+    return multi_activity_actor::farm_requirements( you, act_info, src_loc );
+}
+bool multi_farm_activity_actor::multi_activity_do( Character &you,
+        const activity_reason_info &act_info,
+        const tripoint_abs_ms &src, const tripoint_bub_ms &src_loc )
+{
+    return multi_activity_actor::farm_do( you, act_info, src, src_loc );
+}
+
+std::unique_ptr<activity_actor> multi_farm_activity_actor::deserialize( JsonValue & )
+{
+    multi_farm_activity_actor actor;
+    return actor.clone();
+}
+
 void hand_crank_activity_actor::start( player_activity &act, Character & )
 {
     act.moves_total = to_moves<int>( initial_moves );
@@ -12654,6 +12679,7 @@ deserialize_functions = {
     { ACT_MOVE_LOOT, &zone_sort_activity_actor::deserialize },
     { ACT_MULTIPLE_CHOP_PLANKS, &multi_chop_planks_activity_actor::deserialize },
     { ACT_MULTIPLE_CHOP_TREES, &multi_chop_trees_activity_actor::deserialize },
+    { ACT_MULTIPLE_FARM, &multi_farm_activity_actor::deserialize },
     { ACT_MULTIPLE_FISH, &multi_fish_activity_actor::deserialize },
     { ACT_MULTIPLE_MINE, &multi_mine_activity_actor::deserialize },
     { ACT_MULTIPLE_MOP, &multi_mop_activity_actor::deserialize },

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -2585,6 +2585,12 @@ std::unique_ptr<activity_actor> read_activity_actor::deserialize( JsonValue &jsi
     return actor.clone();
 }
 
+std::unordered_set<tripoint_abs_ms> multi_read_activity_actor::multi_activity_locations(
+    Character &you )
+{
+    return multi_activity_actor::read_locations( you, get_type() );
+}
+
 activity_reason_info multi_read_activity_actor::multi_activity_can_do(
     Character &you, const tripoint_bub_ms &src_loc )
 {
@@ -2610,6 +2616,13 @@ activity_reason_info multi_study_activity_actor::multi_activity_can_do(
     return multi_activity_actor::study_can_do( ACT_MULTIPLE_STUDY, you,
             src_loc );
 }
+
+std::unordered_set<tripoint_abs_ms> multi_study_activity_actor::multi_activity_locations(
+    Character &you )
+{
+    return multi_activity_actor::study_locations( you, get_type() );
+}
+
 bool multi_study_activity_actor::multi_activity_do( Character &you,
         const activity_reason_info &act_info,
         const tripoint_abs_ms &src, const tripoint_bub_ms &src_loc )
@@ -4687,7 +4700,7 @@ activity_reason_info multi_fish_activity_actor::multi_activity_can_do(
             src_loc );
 }
 std::optional<requirement_id> multi_fish_activity_actor::multi_activity_requirements(
-    Character &you, activity_reason_info &act_info, const tripoint_bub_ms &src_loc )
+    Character &you, activity_reason_info &act_info, const tripoint_bub_ms &src_loc, const zone_data * )
 {
     return multi_activity_actor::fish_requirements( you, act_info, src_loc );
 }
@@ -4711,7 +4724,7 @@ std::unordered_set<tripoint_abs_ms> multi_zone_activity_actor::multi_activity_lo
 }
 
 std::optional<requirement_id> multi_zone_activity_actor::multi_activity_requirements(
-    Character &, activity_reason_info &, const tripoint_bub_ms & )
+    Character &, activity_reason_info &, const tripoint_bub_ms &, const zone_data * )
 {
     return std::nullopt;
 }
@@ -4913,7 +4926,7 @@ requirement_check_result multi_zone_activity_actor::check_requirements( Characte
 
         //begin requirements
         std::optional<requirement_id> activity_requirements = multi_activity_requirements( you, act_info,
-                src_loc );
+                src_loc, zone );
         //end requirements
 
         // requirement check was invalid, skip this location
@@ -9011,7 +9024,7 @@ activity_reason_info multi_chop_planks_activity_actor::multi_activity_can_do( Ch
 }
 std::optional<requirement_id> multi_chop_planks_activity_actor::multi_activity_requirements(
     Character &you,
-    activity_reason_info &act_info, const tripoint_bub_ms &src_loc )
+    activity_reason_info &act_info, const tripoint_bub_ms &src_loc, const zone_data * )
 {
     return multi_activity_actor::chop_planks_requirements( you, act_info, src_loc );
 }
@@ -9136,7 +9149,7 @@ activity_reason_info multi_chop_trees_activity_actor::multi_activity_can_do( Cha
 }
 std::optional<requirement_id> multi_chop_trees_activity_actor::multi_activity_requirements(
     Character &you,
-    activity_reason_info &act_info, const tripoint_bub_ms &src_loc )
+    activity_reason_info &act_info, const tripoint_bub_ms &src_loc, const zone_data * )
 {
     return multi_activity_actor::chop_trees_requirements( you, act_info, src_loc );
 }
@@ -9198,9 +9211,10 @@ activity_reason_info multi_farm_activity_actor::multi_activity_can_do(
             src_loc );
 }
 std::optional<requirement_id> multi_farm_activity_actor::multi_activity_requirements(
-    Character &you, activity_reason_info &act_info, const tripoint_bub_ms &src_loc )
+    Character &you, activity_reason_info &act_info, const tripoint_bub_ms &src_loc,
+    const zone_data *zone )
 {
-    return multi_activity_actor::farm_requirements( you, act_info, src_loc );
+    return multi_activity_actor::farm_requirements( you, act_info, src_loc, zone );
 }
 bool multi_farm_activity_actor::multi_activity_do( Character &you,
         const activity_reason_info &act_info,
@@ -9934,7 +9948,7 @@ activity_reason_info multi_mine_activity_actor::multi_activity_can_do( Character
 }
 std::optional<requirement_id> multi_mine_activity_actor::multi_activity_requirements(
     Character &you,
-    activity_reason_info &act_info, const tripoint_bub_ms &src_loc )
+    activity_reason_info &act_info, const tripoint_bub_ms &src_loc, const zone_data * )
 {
     return multi_activity_actor::mining_requirements( you, act_info, src_loc );
 }
@@ -10602,7 +10616,7 @@ activity_reason_info multi_vehicle_deconstruct_activity_actor::multi_activity_ca
 }
 std::optional<requirement_id> multi_vehicle_deconstruct_activity_actor::multi_activity_requirements(
     Character &you,
-    activity_reason_info &act_info, const tripoint_bub_ms &src_loc )
+    activity_reason_info &act_info, const tripoint_bub_ms &src_loc, const zone_data * )
 {
     return multi_activity_actor::vehicle_work_requirements( you, act_info, src_loc );
 }
@@ -10628,7 +10642,7 @@ activity_reason_info multi_vehicle_repair_activity_actor::multi_activity_can_do(
 }
 std::optional<requirement_id> multi_vehicle_repair_activity_actor::multi_activity_requirements(
     Character &you,
-    activity_reason_info &act_info, const tripoint_bub_ms &src_loc )
+    activity_reason_info &act_info, const tripoint_bub_ms &src_loc, const zone_data * )
 {
     return multi_activity_actor::vehicle_work_requirements( you, act_info, src_loc );
 }

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -2604,6 +2604,25 @@ std::unique_ptr<activity_actor> multi_read_activity_actor::deserialize( JsonValu
     return actor.clone();
 }
 
+activity_reason_info multi_study_activity_actor::multi_activity_can_do(
+    Character &you, const tripoint_bub_ms &src_loc )
+{
+    return multi_activity_actor::study_can_do( ACT_MULTIPLE_STUDY, you,
+            src_loc );
+}
+bool multi_study_activity_actor::multi_activity_do( Character &you,
+        const activity_reason_info &act_info,
+        const tripoint_abs_ms &src, const tripoint_bub_ms &src_loc )
+{
+    return multi_activity_actor::study_do( you, act_info, src, src_loc );
+}
+
+std::unique_ptr<activity_actor> multi_study_activity_actor::deserialize( JsonValue & )
+{
+    multi_study_activity_actor actor;
+    return actor.clone();
+}
+
 void study_spell_activity_actor::start( player_activity &act, Character &who )
 {
     if( learning ) {
@@ -12704,6 +12723,7 @@ deserialize_functions = {
     { ACT_MULTIPLE_MINE, &multi_mine_activity_actor::deserialize },
     { ACT_MULTIPLE_MOP, &multi_mop_activity_actor::deserialize },
     { ACT_MULTIPLE_READ, &multi_read_activity_actor::deserialize },
+    { ACT_MULTIPLE_STUDY, &multi_study_activity_actor::deserialize },
     { ACT_OPEN_GATE, &open_gate_activity_actor::deserialize },
     { ACT_OPERATION, &bionic_operation_activity_actor::deserialize },
     { ACT_OXYTORCH, &oxytorch_activity_actor::deserialize },

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -276,6 +276,26 @@ class multi_fish_activity_actor : public multi_zone_activity_actor
         static std::unique_ptr<activity_actor> deserialize( JsonValue & );
 };
 
+class multi_farm_activity_actor : public multi_zone_activity_actor
+{
+    public:
+        using multi_zone_activity_actor::multi_zone_activity_actor;
+        const activity_id &get_type() const override {
+            static const activity_id ACT_MULTIPLE_FARM( "ACT_MULTIPLE_FARM" );
+            return ACT_MULTIPLE_FARM;
+        }
+        activity_reason_info multi_activity_can_do( Character &you,
+                const tripoint_bub_ms &src_loc ) override;
+        std::optional<requirement_id> multi_activity_requirements( Character &you,
+                activity_reason_info &act_info, const tripoint_bub_ms &src_loc ) override;
+        bool multi_activity_do( Character &you, const activity_reason_info &act_info,
+                                const tripoint_abs_ms &src, const tripoint_bub_ms &src_loc ) override;
+        std::unique_ptr<activity_actor> clone() const override {
+            return std::make_unique<multi_farm_activity_actor>( *this );
+        }
+        static std::unique_ptr<activity_actor> deserialize( JsonValue & );
+};
+
 class aim_activity_actor : public activity_actor
 {
     private:

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -256,6 +256,26 @@ class multi_vehicle_repair_activity_actor : public multi_zone_activity_actor
         static std::unique_ptr<activity_actor> deserialize( JsonValue & );
 };
 
+class multi_fish_activity_actor : public multi_zone_activity_actor
+{
+    public:
+        using multi_zone_activity_actor::multi_zone_activity_actor;
+        const activity_id &get_type() const override {
+            static const activity_id ACT_MULTIPLE_FISH( "ACT_MULTIPLE_FISH" );
+            return ACT_MULTIPLE_FISH;
+        }
+        activity_reason_info multi_activity_can_do( Character &you,
+                const tripoint_bub_ms &src_loc ) override;
+        std::optional<requirement_id> multi_activity_requirements( Character &you,
+                activity_reason_info &act_info, const tripoint_bub_ms &src_loc ) override;
+        bool multi_activity_do( Character &you, const activity_reason_info &act_info,
+                                const tripoint_abs_ms &src, const tripoint_bub_ms &src_loc ) override;
+        std::unique_ptr<activity_actor> clone() const override {
+            return std::make_unique<multi_fish_activity_actor>( *this );
+        }
+        static std::unique_ptr<activity_actor> deserialize( JsonValue & );
+};
+
 class aim_activity_actor : public activity_actor
 {
     private:

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -296,6 +296,24 @@ class multi_farm_activity_actor : public multi_zone_activity_actor
         static std::unique_ptr<activity_actor> deserialize( JsonValue & );
 };
 
+class multi_read_activity_actor : public multi_zone_activity_actor
+{
+    public:
+        using multi_zone_activity_actor::multi_zone_activity_actor;
+        const activity_id &get_type() const override {
+            static const activity_id ACT_MULTIPLE_READ( "ACT_MULTIPLE_READ" );
+            return ACT_MULTIPLE_READ;
+        }
+        activity_reason_info multi_activity_can_do( Character &you,
+                const tripoint_bub_ms &src_loc ) override;
+        bool multi_activity_do( Character &you, const activity_reason_info &act_info,
+                                const tripoint_abs_ms &src, const tripoint_bub_ms &src_loc ) override;
+        std::unique_ptr<activity_actor> clone() const override {
+            return std::make_unique<multi_read_activity_actor>( *this );
+        }
+        static std::unique_ptr<activity_actor> deserialize( JsonValue & );
+};
+
 class aim_activity_actor : public activity_actor
 {
     private:

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -127,7 +127,7 @@ class multi_zone_activity_actor : public activity_actor
                 const tripoint_bub_ms &src_loc ) = 0;
         // specific requirements for the activity, used in `check_requirements`
         virtual std::optional<requirement_id> multi_activity_requirements( Character &,
-                activity_reason_info &, const tripoint_bub_ms & );
+                activity_reason_info &, const tripoint_bub_ms &, const zone_data *zone = nullptr );
         // main activity body, once zone locations and requirements are satisfied
         // @return whether activity was NOT successful
         virtual bool multi_activity_do( Character &you, const activity_reason_info &act_info,
@@ -149,7 +149,8 @@ class multi_mine_activity_actor : public multi_zone_activity_actor
         activity_reason_info multi_activity_can_do( Character &you,
                 const tripoint_bub_ms &src_loc ) override;
         std::optional<requirement_id> multi_activity_requirements( Character &you,
-                activity_reason_info &act_info, const tripoint_bub_ms &src_loc ) override;
+                activity_reason_info &act_info, const tripoint_bub_ms &src_loc,
+                const zone_data *zone = nullptr ) override;
         bool multi_activity_do( Character &you, const activity_reason_info &act_info,
                                 const tripoint_abs_ms &src, const tripoint_bub_ms &src_loc ) override;
         std::unique_ptr<activity_actor> clone() const override {
@@ -187,7 +188,8 @@ class multi_chop_planks_activity_actor : public multi_zone_activity_actor
         activity_reason_info multi_activity_can_do( Character &you,
                 const tripoint_bub_ms &src_loc ) override;
         std::optional<requirement_id> multi_activity_requirements( Character &you,
-                activity_reason_info &act_info, const tripoint_bub_ms &src_loc ) override;
+                activity_reason_info &act_info, const tripoint_bub_ms &src_loc,
+                const zone_data *zone = nullptr ) override;
         bool multi_activity_do( Character &you, const activity_reason_info &act_info,
                                 const tripoint_abs_ms &src, const tripoint_bub_ms &src_loc ) override;
         std::unique_ptr<activity_actor> clone() const override {
@@ -207,7 +209,8 @@ class multi_chop_trees_activity_actor : public multi_zone_activity_actor
         activity_reason_info multi_activity_can_do( Character &you,
                 const tripoint_bub_ms &src_loc ) override;
         std::optional<requirement_id> multi_activity_requirements( Character &you,
-                activity_reason_info &act_info, const tripoint_bub_ms &src_loc ) override;
+                activity_reason_info &act_info, const tripoint_bub_ms &src_loc,
+                const zone_data *zone = nullptr ) override;
         bool multi_activity_do( Character &you, const activity_reason_info &act_info,
                                 const tripoint_abs_ms &src, const tripoint_bub_ms &src_loc ) override;
         std::unique_ptr<activity_actor> clone() const override {
@@ -227,7 +230,8 @@ class multi_vehicle_deconstruct_activity_actor : public multi_zone_activity_acto
         activity_reason_info multi_activity_can_do( Character &you,
                 const tripoint_bub_ms &src_loc ) override;
         std::optional<requirement_id> multi_activity_requirements( Character &you,
-                activity_reason_info &act_info, const tripoint_bub_ms &src_loc ) override;
+                activity_reason_info &act_info, const tripoint_bub_ms &src_loc,
+                const zone_data *zone = nullptr ) override;
         bool multi_activity_do( Character &you, const activity_reason_info &act_info,
                                 const tripoint_abs_ms &src, const tripoint_bub_ms &src_loc ) override;
         std::unique_ptr<activity_actor> clone() const override {
@@ -247,7 +251,8 @@ class multi_vehicle_repair_activity_actor : public multi_zone_activity_actor
         activity_reason_info multi_activity_can_do( Character &you,
                 const tripoint_bub_ms &src_loc ) override;
         std::optional<requirement_id> multi_activity_requirements( Character &you,
-                activity_reason_info &act_info, const tripoint_bub_ms &src_loc ) override;
+                activity_reason_info &act_info, const tripoint_bub_ms &src_loc,
+                const zone_data *zone = nullptr ) override;
         bool multi_activity_do( Character &you, const activity_reason_info &act_info,
                                 const tripoint_abs_ms &src, const tripoint_bub_ms &src_loc ) override;
         std::unique_ptr<activity_actor> clone() const override {
@@ -267,7 +272,8 @@ class multi_fish_activity_actor : public multi_zone_activity_actor
         activity_reason_info multi_activity_can_do( Character &you,
                 const tripoint_bub_ms &src_loc ) override;
         std::optional<requirement_id> multi_activity_requirements( Character &you,
-                activity_reason_info &act_info, const tripoint_bub_ms &src_loc ) override;
+                activity_reason_info &act_info, const tripoint_bub_ms &src_loc,
+                const zone_data *zone = nullptr ) override;
         bool multi_activity_do( Character &you, const activity_reason_info &act_info,
                                 const tripoint_abs_ms &src, const tripoint_bub_ms &src_loc ) override;
         std::unique_ptr<activity_actor> clone() const override {
@@ -287,7 +293,8 @@ class multi_farm_activity_actor : public multi_zone_activity_actor
         activity_reason_info multi_activity_can_do( Character &you,
                 const tripoint_bub_ms &src_loc ) override;
         std::optional<requirement_id> multi_activity_requirements( Character &you,
-                activity_reason_info &act_info, const tripoint_bub_ms &src_loc ) override;
+                activity_reason_info &act_info, const tripoint_bub_ms &src_loc,
+                const zone_data *zone = nullptr ) override;
         bool multi_activity_do( Character &you, const activity_reason_info &act_info,
                                 const tripoint_abs_ms &src, const tripoint_bub_ms &src_loc ) override;
         std::unique_ptr<activity_actor> clone() const override {
@@ -304,10 +311,9 @@ class multi_read_activity_actor : public multi_zone_activity_actor
             static const activity_id ACT_MULTIPLE_READ( "ACT_MULTIPLE_READ" );
             return ACT_MULTIPLE_READ;
         }
+        std::unordered_set<tripoint_abs_ms> multi_activity_locations( Character &you ) override;
         activity_reason_info multi_activity_can_do( Character &you,
                 const tripoint_bub_ms &src_loc ) override;
-        std::optional<requirement_id> multi_activity_requirements( Character &you,
-                activity_reason_info &act_info, const tripoint_bub_ms &src_loc ) override;
         bool multi_activity_do( Character &you, const activity_reason_info &act_info,
                                 const tripoint_abs_ms &src, const tripoint_bub_ms &src_loc ) override;
         std::unique_ptr<activity_actor> clone() const override {
@@ -324,6 +330,7 @@ class multi_study_activity_actor : public multi_zone_activity_actor
             static const activity_id ACT_MULTIPLE_STUDY( "ACT_MULTIPLE_STUDY" );
             return ACT_MULTIPLE_STUDY;
         }
+        std::unordered_set<tripoint_abs_ms> multi_activity_locations( Character &you ) override;
         activity_reason_info multi_activity_can_do( Character &you,
                 const tripoint_bub_ms &src_loc ) override;
         bool multi_activity_do( Character &you, const activity_reason_info &act_info,

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -306,10 +306,30 @@ class multi_read_activity_actor : public multi_zone_activity_actor
         }
         activity_reason_info multi_activity_can_do( Character &you,
                 const tripoint_bub_ms &src_loc ) override;
+        std::optional<requirement_id> multi_activity_requirements( Character &you,
+                activity_reason_info &act_info, const tripoint_bub_ms &src_loc ) override;
         bool multi_activity_do( Character &you, const activity_reason_info &act_info,
                                 const tripoint_abs_ms &src, const tripoint_bub_ms &src_loc ) override;
         std::unique_ptr<activity_actor> clone() const override {
             return std::make_unique<multi_read_activity_actor>( *this );
+        }
+        static std::unique_ptr<activity_actor> deserialize( JsonValue & );
+};
+
+class multi_study_activity_actor : public multi_zone_activity_actor
+{
+    public:
+        using multi_zone_activity_actor::multi_zone_activity_actor;
+        const activity_id &get_type() const override {
+            static const activity_id ACT_MULTIPLE_STUDY( "ACT_MULTIPLE_STUDY" );
+            return ACT_MULTIPLE_STUDY;
+        }
+        activity_reason_info multi_activity_can_do( Character &you,
+                const tripoint_bub_ms &src_loc ) override;
+        bool multi_activity_do( Character &you, const activity_reason_info &act_info,
+                                const tripoint_abs_ms &src, const tripoint_bub_ms &src_loc ) override;
+        std::unique_ptr<activity_actor> clone() const override {
+            return std::make_unique<multi_study_activity_actor>( *this );
         }
         static std::unique_ptr<activity_actor> deserialize( JsonValue & );
 };

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -68,7 +68,6 @@ static const activity_id ACT_MULTIPLE_CONSTRUCTION( "ACT_MULTIPLE_CONSTRUCTION" 
 static const activity_id ACT_MULTIPLE_CRAFT( "ACT_MULTIPLE_CRAFT" );
 static const activity_id ACT_MULTIPLE_DIS( "ACT_MULTIPLE_DIS" );
 static const activity_id ACT_MULTIPLE_FARM( "ACT_MULTIPLE_FARM" );
-static const activity_id ACT_MULTIPLE_FISH( "ACT_MULTIPLE_FISH" );
 static const activity_id ACT_MULTIPLE_READ( "ACT_MULTIPLE_READ" );
 static const activity_id ACT_MULTIPLE_STUDY( "ACT_MULTIPLE_STUDY" );
 static const activity_id ACT_REPAIR_ITEM( "ACT_REPAIR_ITEM" );
@@ -108,7 +107,6 @@ const std::map< activity_id, std::function<void( player_activity *, Character * 
 activity_handlers::do_turn_functions = {
     { ACT_FILL_LIQUID, fill_liquid_do_turn },
     { ACT_START_FIRE, start_fire_do_turn },
-    { ACT_MULTIPLE_FISH, multiple_fish_do_turn },
     { ACT_MULTIPLE_CONSTRUCTION, multiple_construction_do_turn },
     { ACT_MULTIPLE_BUTCHER, multiple_butcher_do_turn },
     { ACT_MULTIPLE_FARM, multiple_farm_do_turn },

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -67,7 +67,6 @@ static const activity_id ACT_MULTIPLE_BUTCHER( "ACT_MULTIPLE_BUTCHER" );
 static const activity_id ACT_MULTIPLE_CONSTRUCTION( "ACT_MULTIPLE_CONSTRUCTION" );
 static const activity_id ACT_MULTIPLE_CRAFT( "ACT_MULTIPLE_CRAFT" );
 static const activity_id ACT_MULTIPLE_DIS( "ACT_MULTIPLE_DIS" );
-static const activity_id ACT_MULTIPLE_READ( "ACT_MULTIPLE_READ" );
 static const activity_id ACT_MULTIPLE_STUDY( "ACT_MULTIPLE_STUDY" );
 static const activity_id ACT_REPAIR_ITEM( "ACT_REPAIR_ITEM" );
 static const activity_id ACT_START_FIRE( "ACT_START_FIRE" );
@@ -110,7 +109,6 @@ activity_handlers::do_turn_functions = {
     { ACT_MULTIPLE_BUTCHER, multiple_butcher_do_turn },
     { ACT_MULTIPLE_CRAFT, multiple_craft_do_turn },
     { ACT_MULTIPLE_DIS, multiple_dis_do_turn },
-    { ACT_MULTIPLE_READ, multiple_read_do_turn },
     { ACT_MULTIPLE_STUDY, multiple_study_do_turn },
     { ACT_FETCH_REQUIRED, fetch_do_turn },
     { ACT_TIDY_UP, tidy_up_do_turn },

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -67,7 +67,6 @@ static const activity_id ACT_MULTIPLE_BUTCHER( "ACT_MULTIPLE_BUTCHER" );
 static const activity_id ACT_MULTIPLE_CONSTRUCTION( "ACT_MULTIPLE_CONSTRUCTION" );
 static const activity_id ACT_MULTIPLE_CRAFT( "ACT_MULTIPLE_CRAFT" );
 static const activity_id ACT_MULTIPLE_DIS( "ACT_MULTIPLE_DIS" );
-static const activity_id ACT_MULTIPLE_FARM( "ACT_MULTIPLE_FARM" );
 static const activity_id ACT_MULTIPLE_READ( "ACT_MULTIPLE_READ" );
 static const activity_id ACT_MULTIPLE_STUDY( "ACT_MULTIPLE_STUDY" );
 static const activity_id ACT_REPAIR_ITEM( "ACT_REPAIR_ITEM" );
@@ -109,7 +108,6 @@ activity_handlers::do_turn_functions = {
     { ACT_START_FIRE, start_fire_do_turn },
     { ACT_MULTIPLE_CONSTRUCTION, multiple_construction_do_turn },
     { ACT_MULTIPLE_BUTCHER, multiple_butcher_do_turn },
-    { ACT_MULTIPLE_FARM, multiple_farm_do_turn },
     { ACT_MULTIPLE_CRAFT, multiple_craft_do_turn },
     { ACT_MULTIPLE_DIS, multiple_dis_do_turn },
     { ACT_MULTIPLE_READ, multiple_read_do_turn },

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -67,7 +67,6 @@ static const activity_id ACT_MULTIPLE_BUTCHER( "ACT_MULTIPLE_BUTCHER" );
 static const activity_id ACT_MULTIPLE_CONSTRUCTION( "ACT_MULTIPLE_CONSTRUCTION" );
 static const activity_id ACT_MULTIPLE_CRAFT( "ACT_MULTIPLE_CRAFT" );
 static const activity_id ACT_MULTIPLE_DIS( "ACT_MULTIPLE_DIS" );
-static const activity_id ACT_MULTIPLE_STUDY( "ACT_MULTIPLE_STUDY" );
 static const activity_id ACT_REPAIR_ITEM( "ACT_REPAIR_ITEM" );
 static const activity_id ACT_START_FIRE( "ACT_START_FIRE" );
 static const activity_id ACT_TIDY_UP( "ACT_TIDY_UP" );
@@ -109,7 +108,6 @@ activity_handlers::do_turn_functions = {
     { ACT_MULTIPLE_BUTCHER, multiple_butcher_do_turn },
     { ACT_MULTIPLE_CRAFT, multiple_craft_do_turn },
     { ACT_MULTIPLE_DIS, multiple_dis_do_turn },
-    { ACT_MULTIPLE_STUDY, multiple_study_do_turn },
     { ACT_FETCH_REQUIRED, fetch_do_turn },
     { ACT_TIDY_UP, tidy_up_do_turn },
     { ACT_REPAIR_ITEM, repair_item_do_turn },

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -3571,7 +3571,7 @@ bool read_do( Character &you, const activity_reason_info &act_info,
             const time_duration time_taken = you.time_to_read( *books[0], you );
             item_location book = item_location( you, books[0] );
             item_location ereader;
-            you.backlog.emplace_front( ACT_MULTIPLE_READ );
+            you.backlog.emplace_front( multi_read_activity_actor() );
             you.assign_activity( read_activity_actor( time_taken, book, ereader, true ) );
             return false;
         }

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -3499,7 +3499,7 @@ bool farm_do( Character &you, const activity_reason_info &act_info,
                here.has_flag( ter_furn_flag::TFLAG_PLOWABLE, src_loc ) &&
                you.has_quality( qual_DIG, 1 ) && !here.has_furn( src_loc ) ) {
         you.assign_activity( churn_activity_actor( 18000, item_location() ) );
-        you.backlog.emplace_front( ACT_MULTIPLE_FARM );
+        you.backlog.emplace_front( multi_farm_activity_actor() );
         you.activity.placement = src;
         return false;
     } else if( reason == do_activity_reason::NEEDS_PLANTING ) {
@@ -3518,7 +3518,7 @@ bool farm_do( Character &you, const activity_reason_info &act_info,
                 continue;
             }
             iexamine::plant_seed( you, src_loc, itype_id( seed ) );
-            you.backlog.emplace_front( ACT_MULTIPLE_FARM );
+            you.backlog.emplace_front( multi_farm_activity_actor() );
             return false;
         }
     }

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -3679,7 +3679,7 @@ bool fish_do( Character &you, const activity_reason_info &act_info,
     const do_activity_reason &reason = act_info.reason;
 
     if( reason == do_activity_reason::NEEDS_FISHING && you.has_quality( qual_FISHING_ROD, 1 ) ) {
-        you.backlog.emplace_front( ACT_MULTIPLE_FISH );
+        you.backlog.emplace_front( multi_fish_activity_actor() );
         // we don't want to keep repeating the fishing activity, just piggybacking on this functions structure to find requirements.
         you.activity = player_activity();
         item_location best_rod_loc( you, &you.best_item_with_quality( qual_FISHING_ROD ) );

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -3591,7 +3591,7 @@ bool study_do( Character &you, const activity_reason_info &act_info,
             you.may_activity_occupancy_after_end_items_loc.push_back( book_loc );
             const time_duration time_taken = you.time_to_read( *book_loc, you );
             item_location ereader;
-            you.backlog.emplace_front( ACT_MULTIPLE_STUDY );
+            you.backlog.emplace_front( multi_study_activity_actor() );
             you.assign_activity( read_activity_actor( time_taken, book_loc, ereader, true ) );
             return false;
         }

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -115,7 +115,6 @@ static const activity_id ACT_FERTILIZE_PLOT( "ACT_FERTILIZE_PLOT" );
 static const activity_id ACT_MULTIPLE_BUTCHER( "ACT_MULTIPLE_BUTCHER" );
 static const activity_id ACT_MULTIPLE_CONSTRUCTION( "ACT_MULTIPLE_CONSTRUCTION" );
 static const activity_id ACT_MULTIPLE_DIS( "ACT_MULTIPLE_DIS" );
-static const activity_id ACT_MULTIPLE_FARM( "ACT_MULTIPLE_FARM" );
 static const activity_id ACT_MULTIPLE_STUDY( "ACT_MULTIPLE_STUDY" );
 
 static const bionic_id bio_remote( "bio_remote" );
@@ -1672,7 +1671,7 @@ static void loot()
             player_character.assign_activity( ACT_MULTIPLE_CONSTRUCTION );
             break;
         case MultiFarmPlots:
-            player_character.assign_activity( ACT_MULTIPLE_FARM );
+            player_character.assign_activity( multi_farm_activity_actor() );
             break;
         case Multichoptrees:
             player_character.assign_activity( multi_chop_trees_activity_actor() );

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -115,7 +115,6 @@ static const activity_id ACT_FERTILIZE_PLOT( "ACT_FERTILIZE_PLOT" );
 static const activity_id ACT_MULTIPLE_BUTCHER( "ACT_MULTIPLE_BUTCHER" );
 static const activity_id ACT_MULTIPLE_CONSTRUCTION( "ACT_MULTIPLE_CONSTRUCTION" );
 static const activity_id ACT_MULTIPLE_DIS( "ACT_MULTIPLE_DIS" );
-static const activity_id ACT_MULTIPLE_STUDY( "ACT_MULTIPLE_STUDY" );
 
 static const bionic_id bio_remote( "bio_remote" );
 
@@ -1698,7 +1697,7 @@ static void loot()
             player_character.assign_activity( multi_mop_activity_actor() );
             break;
         case MultiStudy:
-            player_character.assign_activity( ACT_MULTIPLE_STUDY );
+            player_character.assign_activity( multi_study_activity_actor() );
             break;
         default:
             debugmsg( "Unsupported flag" );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -117,6 +117,7 @@ static const activity_id ACT_FIRSTAID( "ACT_FIRSTAID" );
 static const activity_id ACT_MOVE_LOOT( "ACT_MOVE_LOOT" );
 static const activity_id ACT_MULTIPLE_CHOP_PLANKS( "ACT_MULTIPLE_CHOP_PLANKS" );
 static const activity_id ACT_MULTIPLE_CHOP_TREES( "ACT_MULTIPLE_CHOP_TREES" );
+static const activity_id ACT_MULTIPLE_FARM( "ACT_MULTIPLE_FARM" );
 static const activity_id ACT_MULTIPLE_FISH( "ACT_MULTIPLE_FISH" );
 static const activity_id ACT_OPERATION( "ACT_OPERATION" );
 static const activity_id ACT_SPELLCASTING( "ACT_SPELLCASTING" );
@@ -3412,6 +3413,9 @@ bool npc::find_job_to_perform()
             return true;
         } else if( elem == ACT_MULTIPLE_CHOP_PLANKS ) {
             assign_activity( multi_chop_planks_activity_actor() );
+            return true;
+        } else if( elem == ACT_MULTIPLE_FARM ) {
+            assign_activity( multi_farm_activity_actor() );
             return true;
         } else if( elem == ACT_MULTIPLE_FISH ) {
             assign_activity( multi_fish_activity_actor() );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -117,6 +117,7 @@ static const activity_id ACT_FIRSTAID( "ACT_FIRSTAID" );
 static const activity_id ACT_MOVE_LOOT( "ACT_MOVE_LOOT" );
 static const activity_id ACT_MULTIPLE_CHOP_PLANKS( "ACT_MULTIPLE_CHOP_PLANKS" );
 static const activity_id ACT_MULTIPLE_CHOP_TREES( "ACT_MULTIPLE_CHOP_TREES" );
+static const activity_id ACT_MULTIPLE_FISH( "ACT_MULTIPLE_FISH" );
 static const activity_id ACT_OPERATION( "ACT_OPERATION" );
 static const activity_id ACT_SPELLCASTING( "ACT_SPELLCASTING" );
 static const activity_id ACT_TIDY_UP( "ACT_TIDY_UP" );
@@ -3411,6 +3412,9 @@ bool npc::find_job_to_perform()
             return true;
         } else if( elem == ACT_MULTIPLE_CHOP_PLANKS ) {
             assign_activity( multi_chop_planks_activity_actor() );
+            return true;
+        } else if( elem == ACT_MULTIPLE_FISH ) {
+            assign_activity( multi_fish_activity_actor() );
             return true;
         } else if( elem == ACT_VEHICLE_DECONSTRUCTION ) {
             assign_activity( multi_vehicle_deconstruct_activity_actor() );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -119,6 +119,7 @@ static const activity_id ACT_MULTIPLE_CHOP_PLANKS( "ACT_MULTIPLE_CHOP_PLANKS" );
 static const activity_id ACT_MULTIPLE_CHOP_TREES( "ACT_MULTIPLE_CHOP_TREES" );
 static const activity_id ACT_MULTIPLE_FARM( "ACT_MULTIPLE_FARM" );
 static const activity_id ACT_MULTIPLE_FISH( "ACT_MULTIPLE_FISH" );
+static const activity_id ACT_MULTIPLE_READ( "ACT_MULTIPLE_READ" );
 static const activity_id ACT_OPERATION( "ACT_OPERATION" );
 static const activity_id ACT_SPELLCASTING( "ACT_SPELLCASTING" );
 static const activity_id ACT_TIDY_UP( "ACT_TIDY_UP" );
@@ -3419,6 +3420,9 @@ bool npc::find_job_to_perform()
             return true;
         } else if( elem == ACT_MULTIPLE_FISH ) {
             assign_activity( multi_fish_activity_actor() );
+            return true;
+        } else if( elem == ACT_MULTIPLE_READ ) {
+            assign_activity( multi_read_activity_actor() );
             return true;
         } else if( elem == ACT_VEHICLE_DECONSTRUCTION ) {
             assign_activity( multi_vehicle_deconstruct_activity_actor() );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -120,6 +120,7 @@ static const activity_id ACT_MULTIPLE_CHOP_TREES( "ACT_MULTIPLE_CHOP_TREES" );
 static const activity_id ACT_MULTIPLE_FARM( "ACT_MULTIPLE_FARM" );
 static const activity_id ACT_MULTIPLE_FISH( "ACT_MULTIPLE_FISH" );
 static const activity_id ACT_MULTIPLE_READ( "ACT_MULTIPLE_READ" );
+static const activity_id ACT_MULTIPLE_STUDY( "ACT_MULTIPLE_STUDY" );
 static const activity_id ACT_OPERATION( "ACT_OPERATION" );
 static const activity_id ACT_SPELLCASTING( "ACT_SPELLCASTING" );
 static const activity_id ACT_TIDY_UP( "ACT_TIDY_UP" );
@@ -3423,6 +3424,9 @@ bool npc::find_job_to_perform()
             return true;
         } else if( elem == ACT_MULTIPLE_READ ) {
             assign_activity( multi_read_activity_actor() );
+            return true;
+        } else if( elem == ACT_MULTIPLE_STUDY ) {
+            assign_activity( multi_study_activity_actor() );
             return true;
         } else if( elem == ACT_VEHICLE_DECONSTRUCTION ) {
             assign_activity( multi_vehicle_deconstruct_activity_actor() );

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -67,7 +67,6 @@ static const activity_id ACT_FIND_MOUNT( "ACT_FIND_MOUNT" );
 static const activity_id ACT_MULTIPLE_BUTCHER( "ACT_MULTIPLE_BUTCHER" );
 static const activity_id ACT_MULTIPLE_CONSTRUCTION( "ACT_MULTIPLE_CONSTRUCTION" );
 static const activity_id ACT_MULTIPLE_DIS( "ACT_MULTIPLE_DIS" );
-static const activity_id ACT_MULTIPLE_FARM( "ACT_MULTIPLE_FARM" );
 static const activity_id ACT_MULTIPLE_READ( "ACT_MULTIPLE_READ" );
 static const activity_id ACT_MULTIPLE_STUDY( "ACT_MULTIPLE_STUDY" );
 
@@ -325,7 +324,7 @@ void talk_function::do_chop_trees( npc &p )
 
 void talk_function::do_farming( npc &p )
 {
-    p.assign_activity( ACT_MULTIPLE_FARM );
+    p.assign_activity( multi_farm_activity_actor() );
 }
 
 void talk_function::do_fishing( npc &p )

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -68,7 +68,6 @@ static const activity_id ACT_MULTIPLE_BUTCHER( "ACT_MULTIPLE_BUTCHER" );
 static const activity_id ACT_MULTIPLE_CONSTRUCTION( "ACT_MULTIPLE_CONSTRUCTION" );
 static const activity_id ACT_MULTIPLE_DIS( "ACT_MULTIPLE_DIS" );
 static const activity_id ACT_MULTIPLE_FARM( "ACT_MULTIPLE_FARM" );
-static const activity_id ACT_MULTIPLE_FISH( "ACT_MULTIPLE_FISH" );
 static const activity_id ACT_MULTIPLE_READ( "ACT_MULTIPLE_READ" );
 static const activity_id ACT_MULTIPLE_STUDY( "ACT_MULTIPLE_STUDY" );
 
@@ -331,7 +330,7 @@ void talk_function::do_farming( npc &p )
 
 void talk_function::do_fishing( npc &p )
 {
-    p.assign_activity( ACT_MULTIPLE_FISH );
+    p.assign_activity( multi_fish_activity_actor() );
 }
 
 void talk_function::revert_activity( npc &p )

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -67,7 +67,6 @@ static const activity_id ACT_FIND_MOUNT( "ACT_FIND_MOUNT" );
 static const activity_id ACT_MULTIPLE_BUTCHER( "ACT_MULTIPLE_BUTCHER" );
 static const activity_id ACT_MULTIPLE_CONSTRUCTION( "ACT_MULTIPLE_CONSTRUCTION" );
 static const activity_id ACT_MULTIPLE_DIS( "ACT_MULTIPLE_DIS" );
-static const activity_id ACT_MULTIPLE_READ( "ACT_MULTIPLE_READ" );
 static const activity_id ACT_MULTIPLE_STUDY( "ACT_MULTIPLE_STUDY" );
 
 static const efftype_id effect_allow_sleep( "allow_sleep" );
@@ -266,7 +265,7 @@ void talk_function::do_eread( npc &p )
 
 void talk_function::do_read_repeatedly( npc &p )
 {
-    p.assign_activity( ACT_MULTIPLE_READ );
+    p.assign_activity( multi_read_activity_actor() );
 }
 
 void talk_function::do_study( npc &p )

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -67,7 +67,6 @@ static const activity_id ACT_FIND_MOUNT( "ACT_FIND_MOUNT" );
 static const activity_id ACT_MULTIPLE_BUTCHER( "ACT_MULTIPLE_BUTCHER" );
 static const activity_id ACT_MULTIPLE_CONSTRUCTION( "ACT_MULTIPLE_CONSTRUCTION" );
 static const activity_id ACT_MULTIPLE_DIS( "ACT_MULTIPLE_DIS" );
-static const activity_id ACT_MULTIPLE_STUDY( "ACT_MULTIPLE_STUDY" );
 
 static const efftype_id effect_allow_sleep( "allow_sleep" );
 static const efftype_id effect_asked_for_item( "asked_for_item" );
@@ -270,7 +269,7 @@ void talk_function::do_read_repeatedly( npc &p )
 
 void talk_function::do_study( npc &p )
 {
-    p.assign_activity( ACT_MULTIPLE_STUDY );
+    p.assign_activity( multi_study_activity_actor() );
 }
 
 void talk_function::dismount( npc &p )


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Infrastructure "Move ACT_MULTIPLE_FISH/FARM/READ/STUDY to activity_actors"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Update legacy activities.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

See title.

Added `"multi_activity": true` to ACT_MULTIPLE_FISH because it should be a multi-activity. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

ACT_MULTIPLE_STUDY
Confirmed the following for reading a first aid manual in a Study Zone:
- successful as avatar
- successful as NPC
- serialization without error through save/load during NPC
- loading save without error from a 1-23-26 experimental save (not in 0.H)

ACT_MULTIPLE_READ
Confirmed the following for ordering NPC to "read all books you have in order", in this case a Big Book of First Aid:
- N/A for avatar
- successful as NPC
- serialization without error through save/load during NPC
- loading save without error from a 0.H save

ACT_MULTIPLE_FARM
Confirmed the following for farming a 10-tile huckleberry Farm Plot Zone with a hoe:
- successful as avatar
- successful as NPC
- serialization without error through save/load during NPC
- loading save without error from a 0.H save (gracefully cancelled activity)

ACT_MULTIPLE_FISH
Confirmed the following for ordering NPC to fish in a Fishing Zone with a pro fishing rod:
- N/A for avatar
- successful as NPC (caught fish)
- serialization without error through save/load during NPC
- loading save without error from a 0.H save (gracefully cancelled activity)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Not a huge deal, but I do need to go back and add some multi-activity location overrides that I missed.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
