### PR TITLE
Improve vmenu sorting

### DIFF
--- a/src/enums.h
+++ b/src/enums.h
@@ -74,17 +74,20 @@ struct enum_traits<bionic_ui_sort_mode> {
     static constexpr bionic_ui_sort_mode last = bionic_ui_sort_mode::nsort;
 };
 
-enum class list_item_sort_mode : int {
-    DISTANCE,
-    NAME,
-    CATEGORY_DISTANCE,
-    CATEGORY_NAME,
+// default is sorting by distance
+enum class surroundings_menu_sort_flags : int {
+    DEFAULT       = 0,
+    NAME          = 1 << 0,
+    CATEGORY      = 1 << 1,
+    CATEGORY_NAME = NAME | CATEGORY, // this is currently needed to cycle through the option
     count
 };
 
 template<>
-struct enum_traits<list_item_sort_mode> {
-    static constexpr list_item_sort_mode last = list_item_sort_mode::count;
+struct enum_traits<surroundings_menu_sort_flags> {
+    static constexpr surroundings_menu_sort_flags first = surroundings_menu_sort_flags::DEFAULT;
+    static constexpr surroundings_menu_sort_flags last = surroundings_menu_sort_flags::count;
+    static constexpr bool is_flag_enum = true;
 };
 
 // When bool is not enough. NONE, SOME or ALL

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6413,23 +6413,6 @@ bool game::take_screenshot() const
 }
 #endif
 
-template<>
-std::string io::enum_to_string<list_item_sort_mode>( list_item_sort_mode data )
-{
-    switch( data ) {
-        case list_item_sort_mode::count:
-        case list_item_sort_mode::DISTANCE:
-            return "DISTANCE";
-        case list_item_sort_mode::NAME:
-            return "NAME";
-        case list_item_sort_mode::CATEGORY_DISTANCE:
-            return "CATEGORY_DISTANCE";
-        case list_item_sort_mode::CATEGORY_NAME:
-            return "CATEGORY_NAME";
-    }
-    cata_fatal( "Invalid list item sort mode" );
-}
-
 void game::list_surroundings()
 {
     temp_exit_fullscreen();

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -383,7 +383,9 @@ void uistatedata::serialize( JsonOut &json ) const
     json.member( "overmap_show_revealed_omts", overmap_show_revealed_omts );
     json.member( "overmap_show_forest_trails", overmap_show_forest_trails );
     json.member( "vmenu_tab", vmenu_tab );
-    json.member( "list_item_sort", list_item_sort );
+    json.member( "vmenu_item_sort", vmenu_item_sort );
+    json.member( "vmenu_monster_sort", vmenu_monster_sort );
+    json.member( "vmenu_terfurn_sort", vmenu_terfurn_sort );
     json.member( "read_items", read_items );
     json.member( "list_item_filter_active", list_item_filter_active );
     json.member( "list_item_downvote_active", list_item_downvote_active );
@@ -507,7 +509,9 @@ void uistatedata::deserialize( const JsonObject &jo )
     jo.read( "distraction_withdrawal", distraction_withdrawal );
     jo.read( "numpad_navigation", numpad_navigation );
     jo.read( "vmenu_tab", vmenu_tab );
-    jo.read( "list_item_sort", list_item_sort );
+    jo.read( "vmenu_item_sort", vmenu_item_sort );
+    jo.read( "vmenu_monster_sort", vmenu_monster_sort );
+    jo.read( "vmenu_terfurn_sort", vmenu_terfurn_sort );
     jo.read( "read_items", read_items );
     jo.read( "list_item_filter_active", list_item_filter_active );
     jo.read( "list_item_downvote_active", list_item_downvote_active );

--- a/src/map_entity_stack.h
+++ b/src/map_entity_stack.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "coordinates.h"
+#include "enums.h"
 #include "point.h"
 
 template<typename T>
@@ -55,7 +56,8 @@ class map_entity_stack
         // through all older entity groups for a match.
         void add_at_pos( const T *entity, const tripoint_rel_ms &pos, int count = 1 );
 
-        bool compare( const map_entity_stack<T> &rhs, bool use_category = false ) const;
+        bool compare( const map_entity_stack<T> &rhs,
+                      surroundings_menu_sort_flags sort_flags = surroundings_menu_sort_flags::DEFAULT ) const;
         std::string get_category() const;
 };
 

--- a/src/surroundings_menu.h
+++ b/src/surroundings_menu.h
@@ -34,7 +34,7 @@ class tab_data
         input_context ctxt;
         std::string title;
 
-        bool draw_categories = false;
+        surroundings_menu_sort_flags sort_flags = surroundings_menu_sort_flags::DEFAULT;
         // each group will start at a new line
         // currently roughly grouped by actions on an entry and actions on the list as a whole
         std::vector<std::unordered_set<std::string>> hotkey_groups;

--- a/src/uistate.h
+++ b/src/uistate.h
@@ -216,7 +216,14 @@ class uistatedata
         bool numpad_navigation = false;
 
         // V Menu Stuff
-        list_item_sort_mode list_item_sort = list_item_sort_mode::DISTANCE;
+        // enum serialization relies on string conversion,
+        // which doesn't make too much sense for flag enums
+        // so we store them as ints instead
+        // todo: turn into surroundings_menu_sort_flags
+        // when flag enums can be serialized as numbers
+        int vmenu_item_sort = 0;
+        int vmenu_monster_sort = 0;
+        int vmenu_terfurn_sort = 0;
         std::set<itype_id> read_items;
 
         // These five aren't serialized because deserialize can extract them


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

As noted in https://github.com/CleverRaven/Cataclysm-DDA/issues/84965#issuecomment-3806806594, sorting wasn't saved. Turned out I also forgot to port over additions to sorting that were implemented while I was working on the imgui migration, so those are implemented now, too.

#### Describe the solution

Sorting mode is saved for each tab separately. Serializing flag enums is a bit of a pain currently, so I'm just casting it to an `int` and save/load it as that.

Sorting mode cycles through:
1. distance (default)
2. name
3. distance with categories
4. name with categories

Since it cycles, the enum needs an entry for every possible combination. It's just one extra with the limited options we have currently, but this _will_ turn into an issue if it's extended.

#### Describe alternatives you've considered

Think of a better solution for selecting the sorting.

#### Testing

Tried all the sorting, save & load.

#### Additional context

