### PR TITLE
Move cata_path formatter specialization to .cpp

### DIFF
--- a/src/cata_path.h
+++ b/src/cata_path.h
@@ -166,9 +166,7 @@ class cata_path
 
 template <>
 struct fmt::formatter<cata_path> : formatter<std::string_view> {
-    auto format( const cata_path &path, fmt::format_context &ctx ) const {
-        return formatter<std::string_view>::format( path.generic_u8string(), ctx );
-    }
+    auto format( const cata_path &path, fmt::format_context &ctx ) const -> decltype( ctx.out() );
 };
 
 #endif // CATA_SRC_CATA_PATH_H

--- a/src/string_formatter.cpp
+++ b/src/string_formatter.cpp
@@ -39,3 +39,9 @@ std::string string_vprintf( fmt::string_view format, fmt::printf_args args )
         return err.what();
     }
 }
+
+auto fmt::formatter<cata_path>::format( const cata_path &path,
+                                        fmt::format_context &ctx ) const -> decltype( ctx.out() )
+{
+    return formatter<std::string_view>::format( path.generic_u8string(), ctx );
+}


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Another weenie build optimization. It's not important to have in the header that cata_path formats like a string_view. The vprintf/vformat calls are all virtualized and separated into a separate TU anyway.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Move the definition of the format function to string_formater.cpp.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Before (best of many):
```
**** Time summary:
Compilation (443 times):
  Parsing (frontend):         2413.1 s
  Codegen & opts (backend):   1069.3 s
...
**** Templates that took longest to instantiate:
 16375 ms: std::__detail::__variant::_Move_assign_base<false, std::monostate, d... (309 times, avg 52 ms)
  8390 ms: cata::heap<std::map<string_id<itype>, std::vector<item>>> (304 times, avg 27 ms)
  8051 ms: fmt::formatter<std::basic_string_view<char>>::format<fmt::context> (391 times, avg 20 ms)
  7908 ms: std::set<std::basic_string<char>>::insert (774 times, avg 10 ms)
  7393 ms: std::unordered_map<string_id<damage_type>, float>::operator[] (321 times, avg 23 ms)  
```
After (best of many):
```
**** Time summary:
Compilation (443 times):
  Parsing (frontend):         2400.5 s
  Codegen & opts (backend):   1062.4 s
...
**** Templates that took longest to instantiate:
 16471 ms: std::__detail::__variant::_Move_assign_base<false, std::monostate, d... (309 times, avg 53 ms)
  8330 ms: cata::heap<std::map<string_id<itype>, std::vector<item>>> (304 times, avg 27 ms)
  7750 ms: std::set<std::basic_string<char>>::insert (774 times, avg 10 ms)
  7451 ms: std::set<unsigned long, flexbuffers::Builder::KeyOffsetCompare>::ins... (430 times, avg 17 ms)
  7376 ms: std::unordered_map<string_id<damage_type>, float>::operator[] (321 times, avg 22 ms)
```
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
