### PR TITLE
refactor eoc_selector to be an object instead of bunch of arrays

### DIFF
--- a/data/json/effects_on_condition/example_eocs.json
+++ b/data/json/effects_on_condition/example_eocs.json
@@ -7,11 +7,36 @@
       { "set_string_var": "name_3", "target_var": { "context_val": "name" } },
       { "set_string_var": "option 3", "target_var": { "context_val": "description" }, "i18n": true },
       {
-        "run_eoc_selector": [ "EOC_selector_test_1", "EOC_selector_test_2", "EOC_selector_test_3", "EOC_selector_test_4" ],
-        "names": [ "name_1", "name_2", "<context_val:name>", "should_fail" ],
-        "keys": [ "a", "b", "c", "d" ],
-        "descriptions": [ "option 1", "option 2", "<context_val:description>", "should not be available" ],
-        "variables": [ { "val": 8 } ],
+        "run_eoc_selector": [
+          {
+            "eocs": [ "EOC_selector_test_1" ],
+            "name": "name_1",
+            "key": "a",
+            "description": "option 1",
+            "variables": [ { "val": 8 } ]
+          },
+          {
+            "eocs": [ "EOC_selector_test_2" ],
+            "name": "name_2",
+            "key": "b",
+            "description": "option 2",
+            "variables": [ { "val": 8 } ]
+          },
+          {
+            "eocs": [ "EOC_selector_test_3" ],
+            "name": "<context_val:name>",
+            "key": "c",
+            "description": "<context_val:description>",
+            "variables": [ { "val": 8 } ]
+          },
+          {
+            "eocs": [ "EOC_selector_test_4" ],
+            "name": "should_fail",
+            "key": "d",
+            "description": "should not be available",
+            "variables": [ { "val": 8 } ]
+          }
+        ],
         "title": "<context_val:title>",
         "allow_cancel": true
       }

--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -3077,15 +3077,21 @@ Open a menu, that allow to select one of multiple options
 
 | Syntax | Optionality | Value  | Info |
 | --- | --- | --- | --- |
-| "run_eoc_selector" | **mandatory** | array of strings or [variable objects](#variable-object) or inline EOCs| list of EoCs, that could be picked; conditions of the listed EoCs would be checked, and one that do not pass would be grayed out |
-| "names" | optional | array of strings or [variable objects](#variable-object) | name of the option, that would be shown on the list; amount of names should be equal amount of EoCs |
-| "descriptions" | optional | array of strings or [variable objects](#variable-object) | description of the options, that would be shown on the list; amount of descriptions should be equal amount of EoCs |
-| "keys" | optional | single character | a character, that would be used as a shortcut to pick each EoC; amount of keys should be equal amount of EoCs |
+| "run_eoc_selector" | **mandatory** | eoc_selector_data | Object, that contain all the data for each separate option; See description of each value below |
 | "title" | optional | string | Text, that would be shown as the name of the list; Default `Select an option.` |
 | "hide_failing" | optional | boolean | if true, the options, that fail their check, would be completely removed from the list, instead of being grayed out |
 | "allow_cancel" | optional | boolean | if true, you can quit the menu without selecting an option, no effect will occur |
 | "hilight_disabled" | optional | boolean | if true, the option, that fail their check, would still be navigateable, meaning you can highlight it and read it's description. If `allow_cancel` is true, picking it would be considered same as quitting |
-| "variables" | optional | pair of `"variable_name": "variable"` | variables, that would be passed to the EoCs; can be either a [variable object](#variable-object), or an [inline variable](#inline-variables); `expects_vars` condition can be used to ensure every variable exist before the EoC is run |
+
+Values of eoc_selector_data:
+| Syntax | Optionality | Value  | Info |
+| --- | --- | --- | --- |
+| "eocs" | **mandatory** | array of strings or [variable objects](#variable-object) or inline EOCs | list of EoCs, that will be run when this option is picked; conditions of the listed EoCs would be checked, and if at least one of eocs has it's condition failing, entire option will be grayed out |
+| "name" | **mandatory** | string or [variable objects](#variable-object) | name of the option, that would be shown on the list |
+| "description" | optional | string or [variable objects](#variable-object) | description of the options, that would be shown on the list |
+| "keys" | optional | string of single character | a character, that would be used as a shortcut to pick each EoC |
+| "variables" | optional | array of pairs of `"variable_name": "variable"` | variables, that would be passed to the EoCs; can be either a [variable object](#variable-object), or an [inline variable](#inline-variables); `expects_vars` condition can be used to ensure every variable exist before the EoC is run |
+
 ##### Valid talkers:
 
 | Avatar | NPC | Monster | Furniture | Item | Vehicle |
@@ -3095,18 +3101,35 @@ Open a menu, that allow to select one of multiple options
 ##### Examples
 you can pick one of four options from `Choose your destiny` list;
 ```jsonc
-{
-  "run_eoc_selector": [ "EOC_OPTION_1", "EOC_OPTION_2", "EOC_OPTION_3", "EOC_OPTION_4" ],
-  "names": [ "Option 1", "Option 2", "Option 3", "Option 4" ],
-  "keys": [ "a", "b", "1", "2" ],
-  "title": "Choose your destiny",
-  "descriptions": [
-    "Gives you something good",
-    "Gives you something bad",
-    "Gives you twice as good",
-    "Gives you twice as bad, but condition is not met, so you can't pick it up"
-  ]
-}
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_selector_showcase",
+    "effect": {
+      "run_eoc_selector": [
+        { "eocs": [ "EOC_OPTION_1" ], "name": "Option 1", "key": "a", "description": "Gives you something good" },
+        { "eocs": [ "EOC_OPTION_2" ], "name": "Option 2", "key": "b", "description": "Gives you something bad" },
+        {
+          "eocs": [ "EOC_OPTION_1", "EOC_OPTION_1" ],
+          "name": "<randomly_picked_name_of_option_3>",
+          "key": "1",
+          "description": "Gives you twice as good, <context_val:yay>"
+        },
+        {
+          "eocs": [ "EOC_OPTION_4" ],
+          "name": "Option 4",
+          "key": "2",
+          "description": "Gives you twice as bad, but condition is not met, so you can't pick it up"
+        },
+        {
+          "eocs": [ "EOC_OPTION_5" ],
+          "name": "Option 5",
+          "key": "c",
+          "variables": [ { "some_value_option_5_needs": 25, "some_another_value_option_5_needs": "foobar" } ],
+          "description": "Passes some variables to EOC_OPTION_5"
+        }
+      ],
+      "title": "Choose your destiny"
+    }
 ```
 
 ## Character effects

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -6384,71 +6384,44 @@ talk_effect_fun_t::func f_run_eocs( const JsonObject &jo, std::string_view membe
     };
 }
 
+struct eoc_selector_data {
+    std::vector<eoc_entry> eocs;
+    translation_or_var name;
+    std::optional<translation_or_var> description;
+    std::optional<char> key;
+    // variables that should be passed among the eocs
+    std::unordered_map<std::string, diag_value_or_var> context;
+};
+
 talk_effect_fun_t::func f_run_eoc_selector( const JsonObject &jo, std::string_view member,
         std::string_view src )
 {
 
-    std::vector<eoc_entry> eocs = load_eoc_vector_id_and_var( jo, member, src );
-    if( eocs.empty() ) {
-        jo.throw_error( "Invalid input for run_eocs" );
-    }
+    std::vector<eoc_selector_data> v_data;
 
-    std::vector<translation_or_var> eoc_names;
-    if( jo.has_array( "names" ) ) {
-        for( const JsonValue &jv : jo.get_array( "names" ) ) {
-            eoc_names.emplace_back( get_translation_or_var( jv, "names", true ) );
+    for( const JsonObject job : jo.get_array( member ) ) {
+        eoc_selector_data data;
+
+        data.eocs = load_eoc_vector_id_and_var( job, "eocs", src );
+        data.name = get_translation_or_var( job.get_member( "name" ), "name", true );
+        data.description = get_translation_or_var( job.get_member( "description" ), "description", true );
+
+        if( job.has_string( "key" ) ) {
+            const std::string val = job.get_string( "key" );
+            data.key = val[0];
         }
-    }
 
-    std::vector<translation_or_var> eoc_descriptions;
-    if( jo.has_array( "descriptions" ) ) {
-        for( const JsonValue &jv : jo.get_array( "descriptions" ) ) {
-            eoc_descriptions.emplace_back( get_translation_or_var( jv, "descriptions", true ) );
-        }
-    }
-
-    std::vector<char> eoc_keys;
-    if( jo.has_array( "keys" ) ) {
-        for( const JsonValue &jv : jo.get_array( "keys" ) ) {
-            std::string val = jv.get_string();
-            if( val.size() != 1 ) {
-                jo.throw_error( "Invalid input for run_eoc_selector, key strings must be exactly 1 character." );
-            } else {
-                eoc_keys.push_back( val[0] );
+        if( job.has_array( "variables" ) ) {
+            for( const JsonObject &variables : job.get_array( "variables" ) ) {
+                for( const JsonMember &jv : variables ) {
+                    diag_value_or_var vov;
+                    mandatory( variables, false, jv.name(), vov );
+                    data.context.emplace( jv.name(), vov );
+                }
             }
         }
-    }
 
-    if( !eoc_names.empty() && eoc_names.size() != eocs.size() ) {
-        jo.throw_error( "Invalid input for run_eoc_selector, size of eocs and names needs to be identical, or names need to be empty" );
-    }
-
-    if( !eoc_descriptions.empty() && eoc_descriptions.size() != eocs.size() ) {
-        jo.throw_error( "Invalid input for run_eoc_selector, size of eocs and descriptions needs to be identical, or descriptions need to be empty" );
-    }
-
-    if( !eoc_keys.empty() && eoc_keys.size() != eocs.size() ) {
-        jo.throw_error( "Invalid input for run_eoc_selector, size of eocs and keys needs to be identical, or keys need to be empty." );
-    }
-
-    std::vector<std::unordered_map<std::string, diag_value_or_var>> context;
-    if( jo.has_array( "variables" ) ) {
-        for( const JsonValue &member : jo.get_array( "variables" ) ) {
-            const JsonObject &variables = member.get_object();
-            std::unordered_map<std::string, diag_value_or_var> temp_context;
-            for( const JsonMember &jv : variables ) {
-                diag_value_or_var vov;
-                mandatory( variables, false, jv.name(), vov );
-                temp_context[jv.name()] = vov;
-            }
-            context.emplace_back( temp_context );
-        }
-    }
-
-    if( !context.empty() && context.size() != 1 && context.size() != eocs.size() ) {
-        jo.throw_error(
-            string_format( "Invalid input for run_eoc_selector, size of vars needs to be 0 (no vars), 1 (all have the same vars), or the same size as the eocs (each has their own vars). Current size is: %d",
-                           context.size() ) );
+        v_data.emplace_back( data );
     }
 
     bool hide_failing = jo.get_bool( "hide_failing", false );
@@ -6458,8 +6431,7 @@ talk_effect_fun_t::func f_run_eoc_selector( const JsonObject &jo, std::string_vi
     translation title = to_translation( "Select an option." );
     jo.read( "title", title );
 
-    return [eocs, context, title, eoc_names, eoc_keys, eoc_descriptions,
-          hide_failing, allow_cancel, hilight_disabled]( dialogue & d ) {
+    return [v_data, title, hide_failing, allow_cancel, hilight_disabled]( dialogue & d ) {
         uilist eoc_list;
 
         std::unique_ptr<talker> default_talker = get_talker_for( get_player_character() );
@@ -6469,21 +6441,28 @@ talk_effect_fun_t::func f_run_eoc_selector( const JsonObject &jo, std::string_vi
 
         eoc_list.text = title.translated();
         eoc_list.allow_cancel = allow_cancel;
-        eoc_list.desc_enabled = !eoc_descriptions.empty();
+        for( const eoc_selector_data &sd : v_data ) {
+            if( sd.description.has_value() ) {
+                eoc_list.desc_enabled = true;
+                break;
+            }
+        }
         eoc_list.hilight_disabled = hilight_disabled;
         parse_tags( eoc_list.text, alpha, beta, d );
 
-        for( size_t i = 0; i < eocs.size(); i++ ) {
+        int i = 0;
+        for( const eoc_selector_data &sd : v_data ) {
 
-            effect_on_condition_id eoc_id =
-                eocs[i].var ? effect_on_condition_id( eocs[i].var->evaluate( d ) ) : eocs[i].id;
-            // check and set condition
-            bool display = false;
-            if( eoc_id->has_condition ) {
-                // if it has a condition check that it is true
-                display = eoc_id->test_condition( d );
-            } else {
-                display = true;
+            // check if all eocs conditions of this instance return true
+            bool display = true;
+            for( const eoc_entry &eoc : sd.eocs ) {
+                effect_on_condition_id eoc_id = eoc.var ? effect_on_condition_id( eoc.var->evaluate( d ) ) : eoc.id;
+                if( eoc_id->has_condition ) {
+                    // if it has a condition check that it is true
+                    display = display && eoc_id->test_condition( d );
+                } else {
+                    display = display && true;
+                }
             }
 
             if( hide_failing && !display ) {
@@ -6496,23 +6475,22 @@ talk_effect_fun_t::func f_run_eoc_selector( const JsonObject &jo, std::string_vi
             };
             std::string name;
             std::string description;
-            if( eoc_names.empty() ) {
-                name = eoc_id.str();
-            } else {
-                name = eoc_names[i].evaluate( d ).translated();
-                parse_tags( name, alpha, beta, d );
-            }
-            if( !eoc_descriptions.empty() ) {
-                description = eoc_descriptions[i].evaluate( d ).translated();
+            name = sd.name.evaluate( d ).translated();
+            parse_tags( name, alpha, beta, d );
+
+            if( sd.description.has_value() ) {
+                description = sd.description.value().evaluate( d ).translated();
                 parse_tags( description, alpha, beta, d );
                 description = wrap60( description );
             }
 
-            if( eoc_keys.empty() ) {
-                eoc_list.entries.emplace_back( static_cast<int>( i ), display, std::nullopt, name, description );
+            if( sd.key.has_value() ) {
+                eoc_list.entries.emplace_back( i, display, sd.key.value(), name, description );
             } else {
-                eoc_list.entries.emplace_back( static_cast<int>( i ), display, eoc_keys[i], name, description );
+                eoc_list.entries.emplace_back( i, display, std::nullopt, name, description );
             }
+
+            ++i;
         }
 
         if( eoc_list.entries.empty() ) {
@@ -6522,26 +6500,25 @@ talk_effect_fun_t::func f_run_eoc_selector( const JsonObject &jo, std::string_vi
         }
 
         eoc_list.query();
+
+        // close if nothing is picked
         if( eoc_list.ret < 0 ) {
             return;
         }
 
-        // add context variables
         dialogue newDialog( d );
-        int contextIndex = 0;
-        if( context.size() > 1 ) {
-            contextIndex = eoc_list.ret;
-        }
-        if( !context.empty() ) {
-            for( const auto &val : context[contextIndex] ) {
-                newDialog.set_value( val.first, val.second.evaluate( d ) );
-            }
+
+        // populate new dialogue with context vars from picked object
+        for( const auto &[str, val] : v_data[eoc_list.ret].context ) {
+            newDialog.set_value( str, val.evaluate( d ) );
         }
 
-        effect_on_condition_id chosen_eoc_id =
-            eocs[eoc_list.ret].var ? effect_on_condition_id( eocs[eoc_list.ret].var->evaluate(
-                        d ) ) : eocs[eoc_list.ret].id;
-        chosen_eoc_id->activate( newDialog );
+        // activate all eocs
+        for( const eoc_entry &eoc : v_data[eoc_list.ret].eocs ) {
+            const effect_on_condition_id chosen_eoc_id = eoc.var ?
+                    effect_on_condition_id( eoc.var->evaluate( d ) ) : eoc.id;
+            chosen_eoc_id->activate( newDialog );
+        }
     };
 }
 


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
I recently found myself annoyed by how eoc selector works, in that first you need to list all the EoCs, then all the names, all the descriptions etc; Secondly, i was annoyed by `variables` being send to every single option instead of depending on eoc
#### Describe the solution
Refactor: make eoc_selector_data struct, that contain the information for each option in selector, insert everything into this struct, pass to lambda, then grab the data from struct instead of asking the contributor to make amount of eocs, names and descriptions equal
#### Testing
Updated EOC_selector_test to a new format, run it, works exactly as it worked before
The only thing left is to update every instance of selector to a new format, which is, eeh,
<img width="158" height="32" alt="image" src="https://github.com/user-attachments/assets/7b440165-b8af-4162-917e-12491d09ae04" />

complicated