### PR TITLE
Fix surroundings menu window position on more variations of font settings

### DIFF
--- a/src/surroundings_menu.cpp
+++ b/src/surroundings_menu.cpp
@@ -743,7 +743,7 @@ cataimgui::bounds surroundings_menu::get_bounds()
     // hide info panel on small displays
     info_height = TERMY > 30 ? std::min( 25, TERMY / 2 ) : 0;
     return {
-        static_cast<float>( str_width_to_pixels( TERMX - width ) ),
+        static_cast<float>( ImGui::GetMainViewport()->Size.x - str_width_to_pixels( width ) ),
         0.f,
         static_cast<float>( str_width_to_pixels( width ) ),
         static_cast<float>( str_height_to_pixels( TERMY ) )


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Actually fix #84923 for real this time.
Fix #85019

#### Describe the solution

Instead of calculating window width with `str_width_to_pixels`, get the Viewport width through Imgui.
There are various broken and/or inconsisten ways font settings are used by different parts of the game code, which causes `str_width_to_pixels` to be actually slightly broken for Imgui purposes and shouldn't be used for critical parts like window position.

#### Describe alternatives you've considered



#### Testing

Properly tested with the config from the issue this time. And various weird combinations of font width, height and size.

#### Additional context

