### PR TITLE
Fix no wind in reverberation dimension

### DIFF
--- a/data/json/items/tool/debug_tools.json
+++ b/data/json/items/tool/debug_tools.json
@@ -4,8 +4,8 @@
     "type": "ITEM",
     "subtypes": [ "TOOL" ],
     "category": "tools",
-    "name": { "str": "debug lux meter" },
-    "description": "This debug tool will tell you about light.",
+    "name": { "str": "debug lux meter", "//~": "NO_I18N" },
+    "description": { "str": "This debug tool will tell you about light.", "//~": "NO_I18N" },
     "weight": "1 g",
     "volume": "1 ml",
     "material": [ "plastic" ],
@@ -18,8 +18,8 @@
     "type": "ITEM",
     "subtypes": [ "TOOL" ],
     "category": "tools",
-    "name": { "str_sp": "debug item damager (simple)" },
-    "description": "Deals 1 full bar of damage to an item you wield.",
+    "name": { "str_sp": "debug item damager (simple)", "//~": "NO_I18N" },
+    "description": { "str": "Deals 1 full bar of damage to an item you wield.", "//~": "NO_I18N" },
     "weight": "1 g",
     "volume": "1 ml",
     "material": [ "plastic" ],
@@ -53,8 +53,8 @@
     "type": "ITEM",
     "subtypes": [ "TOOL" ],
     "category": "tools",
-    "name": { "str_sp": "debug item damager (advanced)" },
-    "description": "Deals damage to items you pick.",
+    "name": { "str_sp": "debug item damager (advanced)", "//~": "NO_I18N" },
+    "description": { "str": "Deals damage to items you pick.", "//~": "NO_I18N" },
     "weight": "1 g",
     "volume": "1 ml",
     "material": [ "plastic" ],
@@ -85,8 +85,8 @@
     "type": "ITEM",
     "subtypes": [ "TOOL" ],
     "category": "tools",
-    "name": { "str_sp": "debug explosion generator" },
-    "description": "Causes explosion at overmap you pick.",
+    "name": { "str_sp": "debug explosion generator", "//~": "NO_I18N" },
+    "description": { "str": "Causes explosion at overmap you pick.", "//~": "NO_I18N" },
     "weight": "1 g",
     "volume": "1 ml",
     "material": [ "plastic" ],
@@ -117,8 +117,8 @@
     "type": "ITEM",
     "subtypes": [ "TOOL" ],
     "category": "tools",
-    "name": { "str_sp": "debug fault applier" },
-    "description": "Applies the fault on item by id.",
+    "name": { "str_sp": "debug fault applier", "//~": "NO_I18N" },
+    "description": { "str": "Applies the fault on item by id.", "//~": "NO_I18N" },
     "weight": "1 g",
     "volume": "1 ml",
     "material": [ "plastic" ],
@@ -169,6 +169,63 @@
               ]
             }
           }
+        }
+      ]
+    }
+  },
+  {
+    "id": "debug_dimension_traveller",
+    "type": "ITEM",
+    "subtypes": [ "TOOL" ],
+    "category": "tools",
+    "name": { "str_sp": "debug dimension traveller", "//~": "NO_I18N" },
+    "description": {
+      "str": "Allows you to pick a dimension to teleport to.  Travellers are adviced to use Debug Phase Movement.  To teleport back to main dimension, just leave both empty.",
+      "//~": "NO_I18N"
+    },
+    "weight": "1 g",
+    "volume": "1 ml",
+    "material": [ "plastic" ],
+    "symbol": ";",
+    "color": "light_gray",
+    "use_action": {
+      "type": "effect_on_conditions",
+      "menu_text": { "str": "Change dimension", "//~": "NO_I18N" },
+      "effect_on_conditions": [ "EOC_dimension_swap_test" ]
+    }
+  },
+  {
+    "id": "debug_weather_check",
+    "type": "ITEM",
+    "subtypes": [ "TOOL" ],
+    "category": "tools",
+    "name": { "str_sp": "debug weather reporter", "//~": "NO_I18N" },
+    "description": { "str": "Reports current weather.", "//~": "NO_I18N" },
+    "weight": "1 g",
+    "volume": "1 ml",
+    "material": [ "plastic" ],
+    "symbol": ";",
+    "color": "light_gray",
+    "use_action": {
+      "type": "effect_on_conditions",
+      "menu_text": { "str": "Check weather", "//~": "NO_I18N" },
+      "effect_on_conditions": [
+        {
+          "id": "EOC_REPORT_WEATHER",
+          "effect": [
+            { "math": [ "_moon_phase = moon_phase()" ] },
+            { "math": [ "_temperature = celsius(weather('temperature'))" ] },
+            { "math": [ "_humidity = weather('humidity')" ] },
+            { "math": [ "_pressure = weather('pressure')" ] },
+            { "math": [ "_windpower = weather('windpower')" ] },
+            { "math": [ "_precipitation = weather('precipitation')" ] },
+            { "message": "moon_phase: <context_val:moon_phase>" },
+            { "message": "temperature: <context_val:temperature> °C" },
+            { "message": "humidity: <context_val:humidity> %" },
+            { "message": "pressure: <context_val:pressure> mbar" },
+            { "message": "windpower: <context_val:windpower> mph" },
+            { "message": "precipitation: <context_val:precipitation> mm/h" }
+          ]
         }
       ]
     }

--- a/data/json/region_settings/region_settings/dimensions/reverberations.json
+++ b/data/json/region_settings/region_settings/dimensions/reverberations.json
@@ -4,7 +4,7 @@
     "id": "reverberation_rainy_weather",
     "base_temperature": 4.5,
     "base_humidity": 70.0,
-    "base_pressure": 800.0,
+    "base_pressure": 1015.0,
     "base_wind": 2.0,
     "base_wind_distrib_peaks": 80,
     "base_wind_season_variation": 0,

--- a/doc/JSON/REGION_SETTINGS.md
+++ b/doc/JSON/REGION_SETTINGS.md
@@ -556,10 +556,10 @@ See above.
 | ------------------------------ | --------------------------------------------------------------------- |
 | `base_temperature`             | Base temperature for the region in degrees Celsius.                   |
 | `base_humidity`                | Base humidity for the region in relative humidity %                   |
-| `base_pressure`                | Base pressure for the region in millibars.                            |
+| `base_pressure`                | Base pressure for the region in millibars.  Increasing it decreases the wind strength |
 | `base_wind`                    | Base wind for the region in mph units. Roughly the yearly average.    |
 | `base_wind_distrib_peaks`      | How high the wind peaks can go. Higher values produce windier days.   |
-| `base_wind_season_variation`   | How the wind varies with season. Lower values produce more variation  |
+| `base_wind_season_variation`   | How the wind varies with season. Bigger values produce more variation |
 | `weather_black_list`           | Ids of weather types not allowed in this region.                      |
 | `weather_white_list`           | Ids of the only weather types allowed in this region.                 |
 

--- a/src/weather_gen.cpp
+++ b/src/weather_gen.cpp
@@ -194,9 +194,11 @@ w_point weather_generator::get_weather( const tripoint_abs_ms &location, const t
         15 * ( -seasonality + 2 );
 
     // Wind power
+    const double variation = base_wind_season_variation == 0 ? 0 :
+                             -cyf / base_wind_season_variation * rng( 1, 2 );
     W = std::max( 0, static_cast<int>( base_wind * rng( 1, 2 ) / std::pow( ( P + W ) / 1014.78, rng( 9,
-                                       base_wind_distrib_peaks ) ) +
-                                       -cyf / base_wind_season_variation * rng( 1, 2 ) ) );
+                                       base_wind_distrib_peaks ) ) + variation ) );
+
     // Initial static variable
     if( current_winddir == 1000 ) {
         current_winddir = get_wind_direction( season );


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fix #84255
The general issue was that zero base_wind_season_variation resulted in division by zero, that resulted in inf, that, when casted to int, resulted in -MAX_INT value of wind, that was clamped by std::max() to zero
#### Describe the solution
Applied Snup code snippet that separated base_wind_season_variation into separate variable, that just returned zero if base_wind_season_variation is zero, meaning it didn't affect the wind in any way if it was zero;
This fix also revealed that decreasing the base_pressure in reverberation dimensions resulted in gust of winds of (if my napkin math is correct) up to 600 million miles per hour. I switched the base_pressure of reverberations back to earthly values of 1015, ~~but i didn't receive an approval of author yet~~ permission secured
Also i added two debug items to simplify my work, and marked some strings NO_I18N
#### Testing
Took a measurements in radiosphere:
<img width="206" height="110" alt="image" src="https://github.com/user-attachments/assets/d8d12176-60ce-4255-b79a-1b86031d594f" />
