### PR TITLE
[Bombastic Perks] Kevlard perk

### DIFF
--- a/data/mods/BombasticPerks/perkdata/kevlard.json
+++ b/data/mods/BombasticPerks/perkdata/kevlard.json
@@ -1,49 +1,12 @@
 [
   {
     "type": "mutation",
-    "id": "perk_kevlard",
-    "name": { "str": "Kevlard" },
-    "points": 0,
-    "purifiable": false,
-    "valid": false,
-    "description": "Conventional wisdom says it's not healthy to be fat, but you're nothing if not unconventional.  Your natural padding acts as a ballistic vest, and the fatter you are, the more protection you'll get.  You must be at least Obese to recieve any benefit.",
-    "enchantments": [
-      {
-        "condition": {
-          "and": [
-            { "math": [ "u_calories('format': 'percent') >= 200" ] },
-            { "math": [ "u_calories('format': 'percent') < 300" ] }
-          ]
-        },
-		"mutations": [ "perk_kevlard_obese" ]
-      },
-      {
-        "condition": {
-          "and": [
-            { "math": [ "u_calories('format': 'percent') >= 300" ] },
-            { "math": [ "u_calories('format': 'percent') < 400" ] }
-          ]
-        },
-        "mutations": [ "perk_kevlard_veryobese" ]
-      },
-      {
-        "condition": {
-          "and": [
-            { "math": [ "u_calories('format': 'percent') >= 400" ] }
-          ]
-        },
-		"mutations": [ "perk_kevlard_morbidlyobese" ]
-      }
-    ]
-  },
-  {
-    "type": "mutation",
     "id": "perk_kevlard_obese",
     "name": { "str": "Kevlard I" },
     "points": 0,
     "purifiable": false,
     "valid": false,
-	"player_display": false,
+  	"player_display": false,
     "description": "You shouldn't see this; provides integrated armor while Obese for kevlard perk.",
     "integrated_armor": [ "integrated_kevlard_obese" ]
   },
@@ -54,8 +17,8 @@
     "points": 0,
     "purifiable": false,
     "valid": false,
-	"player_display": false,
-	"description": "You shouldn't see this; provides integrated armor while Very Obese for kevlard perk.",
+	  "player_display": false,
+	  "description": "You shouldn't see this; provides integrated armor while Very Obese for kevlard perk.",
     "integrated_armor": [ "integrated_kevlard_veryobese" ]
   },
   {
@@ -65,7 +28,7 @@
     "points": 0,
     "purifiable": false,
     "valid": false,
-	"player_display": false,
+	  "player_display": false,
     "description": "You shouldn't see this; provides integrated armor while Morbidly Obese for kevlard perk.",
     "integrated_armor": [ "integrated_kevlard_morbidlyobese" ]
   },

--- a/data/mods/BombasticPerks/perkdata/kevlard.json
+++ b/data/mods/BombasticPerks/perkdata/kevlard.json
@@ -51,7 +51,7 @@
       {
         "material": [
           { "type": "hflesh", "covered_by_mat": 100, "thickness": 2.5 },
-          { "type": "kevlar_layered", "covered_by_mat": 90, "thickness": 2.2, "ignore_sheet_thickness": true  }
+          { "type": "kevlar_layered", "covered_by_mat": 90, "thickness": 2.2, "ignore_sheet_thickness": true }
         ],
         "covers": [ "torso" ],
         "coverage": 95,

--- a/data/mods/BombasticPerks/perkdata/kevlard.json
+++ b/data/mods/BombasticPerks/perkdata/kevlard.json
@@ -6,7 +6,7 @@
     "points": 0,
     "purifiable": false,
     "valid": false,
-  	"player_display": false,
+    "player_display": false,
     "description": "You shouldn't see this; provides integrated armor while Obese for kevlard perk.",
     "integrated_armor": [ "integrated_kevlard_obese" ]
   },
@@ -17,8 +17,8 @@
     "points": 0,
     "purifiable": false,
     "valid": false,
-	  "player_display": false,
-	  "description": "You shouldn't see this; provides integrated armor while Very Obese for kevlard perk.",
+    "player_display": false,
+    "description": "You shouldn't see this; provides integrated armor while Very Obese for kevlard perk.",
     "integrated_armor": [ "integrated_kevlard_veryobese" ]
   },
   {
@@ -28,7 +28,7 @@
     "points": 0,
     "purifiable": false,
     "valid": false,
-	  "player_display": false,
+    "player_display": false,
     "description": "You shouldn't see this; provides integrated armor while Morbidly Obese for kevlard perk.",
     "integrated_armor": [ "integrated_kevlard_morbidlyobese" ]
   },

--- a/data/mods/BombasticPerks/perkdata/kevlard.json
+++ b/data/mods/BombasticPerks/perkdata/kevlard.json
@@ -1,11 +1,49 @@
 [
   {
     "type": "mutation",
+    "id": "perk_kevlard",
+    "name": { "str": "Kevlard" },
+    "points": 0,
+    "purifiable": false,
+    "valid": false,
+    "description": "Conventional wisdom says it's not healthy to be fat, but you're nothing if not unconventional.  Your natural padding acts as a ballistic vest, and the fatter you are, the more protection you'll get.  You must be at least Obese to recieve any benefit.",
+    "enchantments": [
+      {
+        "condition": {
+          "and": [
+            { "math": [ "u_calories('format': 'percent') >= 200" ] },
+            { "math": [ "u_calories('format': 'percent') < 300" ] }
+          ]
+        },
+		"mutations": [ "perk_kevlard_obese" ]
+      },
+      {
+        "condition": {
+          "and": [
+            { "math": [ "u_calories('format': 'percent') >= 300" ] },
+            { "math": [ "u_calories('format': 'percent') < 400" ] }
+          ]
+        },
+        "mutations": [ "perk_kevlard_veryobese" ]
+      },
+      {
+        "condition": {
+          "and": [
+            { "math": [ "u_calories('format': 'percent') >= 400" ] }
+          ]
+        },
+		"mutations": [ "perk_kevlard_morbidlyobese" ]
+      }
+    ]
+  },
+  {
+    "type": "mutation",
     "id": "perk_kevlard_obese",
     "name": { "str": "Kevlard I" },
     "points": 0,
     "purifiable": false,
     "valid": false,
+	"player_display": false,
     "description": "You shouldn't see this; provides integrated armor while Obese for kevlard perk.",
     "integrated_armor": [ "integrated_kevlard_obese" ]
   },
@@ -16,7 +54,8 @@
     "points": 0,
     "purifiable": false,
     "valid": false,
-    "description": "You shouldn't see this; provides integrated armor while Very Obese for kevlard perk.",
+	"player_display": false,
+	"description": "You shouldn't see this; provides integrated armor while Very Obese for kevlard perk.",
     "integrated_armor": [ "integrated_kevlard_veryobese" ]
   },
   {
@@ -26,6 +65,7 @@
     "points": 0,
     "purifiable": false,
     "valid": false,
+	"player_display": false,
     "description": "You shouldn't see this; provides integrated armor while Morbidly Obese for kevlard perk.",
     "integrated_armor": [ "integrated_kevlard_morbidlyobese" ]
   },

--- a/data/mods/BombasticPerks/perkdata/kevlard.json
+++ b/data/mods/BombasticPerks/perkdata/kevlard.json
@@ -1,0 +1,125 @@
+[
+  {
+    "type": "mutation",
+    "id": "perk_kevlard_obese",
+    "name": { "str": "Kevlard I" },
+    "points": 0,
+    "purifiable": false,
+    "valid": false,
+    "description": "You shouldn't see this; provides integrated armor while Obese for kevlard perk.",
+    "integrated_armor": [ "integrated_kevlard_obese" ]
+  },
+  {
+    "type": "mutation",
+    "id": "perk_kevlard_veryobese",
+    "name": { "str": "Kevlard II" },
+    "points": 0,
+    "purifiable": false,
+    "valid": false,
+    "description": "You shouldn't see this; provides integrated armor while Very Obese for kevlard perk.",
+    "integrated_armor": [ "integrated_kevlard_veryobese" ]
+  },
+  {
+    "type": "mutation",
+    "id": "perk_kevlard_morbidlyobese",
+    "name": { "str": "Kevlard III" },
+    "points": 0,
+    "purifiable": false,
+    "valid": false,
+    "description": "You shouldn't see this; provides integrated armor while Morbidly Obese for kevlard perk.",
+    "integrated_armor": [ "integrated_kevlard_morbidlyobese" ]
+  },
+  {
+    "id": "integrated_kevlard_obese",
+    "type": "ITEM",
+    "subtypes": [ "ARMOR" ],
+    "category": "armor",
+    "name": { "str_sp": "kevlard I" },
+    "description": "Your fat protects you from bullets, a little.  Maybe eat more.",
+    "weight": "0 kg",
+    "volume": "0 L",
+    "price": "0 cent",
+    "price_postapoc": "0 cent",
+    "material": [ "hflesh", "kevlar_layered" ],
+    "symbol": "x",
+    "color": "magenta",
+    "warmth": 0,
+    "environmental_protection": 0,
+    "//": "No encumbrance, obesity penalties already account for it",
+    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "PERSONAL", "SOFT", "ZERO_WEIGHT", "TRADER_AVOID" ],
+    "armor": [
+      {
+        "material": [
+          { "type": "hflesh", "covered_by_mat": 100, "thickness": 2.5 },
+          { "type": "kevlar_layered", "covered_by_mat": 90, "thickness": 2.2, "ignore_sheet_thickness": true  }
+        ],
+        "covers": [ "torso" ],
+        "coverage": 95,
+        "encumbrance": 0,
+        "breathability": "SECOND_SKIN"
+      }
+    ]
+  },
+  {
+    "id": "integrated_kevlard_veryobese",
+    "type": "ITEM",
+    "subtypes": [ "ARMOR" ],
+    "category": "armor",
+    "name": { "str_sp": "kevlard II" },
+    "description": "Your fat protects you from bullets, but there's still room for improvement.",
+    "weight": "0 kg",
+    "volume": "0 L",
+    "price": "0 cent",
+    "price_postapoc": "0 cent",
+    "material": [ "hflesh", "kevlar_layered" ],
+    "symbol": "x",
+    "color": "magenta",
+    "warmth": 0,
+    "environmental_protection": 0,
+    "//": "No encumbrance, obesity penalties already account for it",
+    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "PERSONAL", "SOFT", "ZERO_WEIGHT", "TRADER_AVOID" ],
+    "armor": [
+      {
+        "material": [
+          { "type": "hflesh", "covered_by_mat": 100, "thickness": 5.0 },
+          { "type": "kevlar_layered", "covered_by_mat": 95, "thickness": 3.3, "ignore_sheet_thickness": true }
+        ],
+        "covers": [ "torso" ],
+        "coverage": 95,
+        "encumbrance": 0,
+        "breathability": "SECOND_SKIN"
+      }
+    ]
+  },
+  {
+    "id": "integrated_kevlard_morbidlyobese",
+    "type": "ITEM",
+    "subtypes": [ "ARMOR" ],
+    "category": "armor",
+    "name": { "str_sp": "kevlard III" },
+    "description": "Your substantial fat deflects bullets with ease.",
+    "weight": "0 kg",
+    "volume": "0 L",
+    "price": "0 cent",
+    "price_postapoc": "0 cent",
+    "material": [ "hflesh", "kevlar_layered" ],
+    "symbol": "x",
+    "color": "magenta",
+    "warmth": 0,
+    "environmental_protection": 0,
+    "//": "No encumbrance, obesity penalties already account for it",
+    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "PERSONAL", "SOFT", "ZERO_WEIGHT", "TRADER_AVOID" ],
+    "armor": [
+      {
+        "material": [
+          { "type": "hflesh", "covered_by_mat": 100, "thickness": 7.5 },
+          { "type": "kevlar_layered", "covered_by_mat": 100, "thickness": 4.4, "ignore_sheet_thickness": true }
+        ],
+        "covers": [ "torso" ],
+        "coverage": 95,
+        "encumbrance": 0,
+        "breathability": "SECOND_SKIN"
+      }
+    ]
+  }
+]

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -1961,6 +1961,25 @@
         "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
       },
       {
+        "condition": { "not": { "u_has_trait": "perk_kevlard" } },
+        "text": "Gain [<trait_name:perk_kevlard>]",
+        "effect": [
+          { "set_string_var": "<trait_name:perk_kevlard>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:perk_kevlard>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "perk_kevlard", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Must at least be Obese",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "math": [ "u_calories('format': 'percent') >= 200" ] } }
+        ],
+        "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
+      },
+      {
         "condition": { "not": { "u_has_trait": "perk_boomstick_blast" } },
         "text": "Gain [<trait_name:perk_boomstick_blast>]",
         "effect": [

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -1125,10 +1125,7 @@
     "enchantments": [
       {
         "condition": {
-          "and": [
-            { "math": [ "u_calories('format': 'percent') >= 200" ] },
-            { "math": [ "u_calories('format': 'percent') < 300" ] }
-          ]
+          "and": [ { "math": [ "u_calories('format': 'percent') >= 200" ] }, { "math": [ "u_calories('format': 'percent') < 300" ] } ]
         },
 		"mutations": [ "perk_kevlard_obese" ]
       },

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -1116,6 +1116,43 @@
   },
   {
     "type": "mutation",
+    "id": "perk_kevlard",
+    "name": { "str": "Kevlard" },
+    "points": 0,
+    "purifiable": false,
+    "valid": false,
+    "description": "Conventional wisdom says it's not healthy to be fat, but you're nothing if not unconventional.  Your natural padding acts as a ballistic vest, and the fatter you are, the more protection you'll get.  You must be at least Obese to recieve any benefit.",
+    "enchantments": [
+      {
+        "condition": {
+          "and": [
+            { "math": [ "u_calories('format': 'percent') >= 120" ] },
+            { "math": [ "u_calories('format': 'percent') < 140" ] }
+          ]
+        },
+        "values": [ "mutations": [ "perk_kevlard_obese" ] ],
+      },
+      {
+        "condition": {
+          "and": [
+            { "math": [ "u_calories('format': 'percent') >= 140" ] },
+            { "math": [ "u_calories('format': 'percent') < 160" ] }
+          ]
+        },
+        "values": [ "mutations": [ "perk_kevlard_veryobese" ] ],
+      },
+      {
+        "condition": {
+          "and": [
+            { "math": [ "u_calories('format': 'percent') >= 160" ] }
+          ]
+        },
+        "values": [ "mutations": [ "perk_kevlard_morbidlyobese" ] ],
+      }
+    ]
+  },
+  {
+    "type": "mutation",
     "id": "perk_nocturnal",
     "name": { "str": "Nocturnal" },
     "points": 0,

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -1136,12 +1136,8 @@
         "mutations": [ "perk_kevlard_veryobese" ]
       },
       {
-        "condition": {
-          "and": [
-            { "math": [ "u_calories('format': 'percent') >= 400" ] }
-          ]
-        },
-		"mutations": [ "perk_kevlard_morbidlyobese" ]
+        "condition": { "and": [ { "math": [ "u_calories('format': 'percent') >= 400" ] } ] },
+        "mutations": [ "perk_kevlard_morbidlyobese" ]
       }
     ]
   },

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -1127,7 +1127,7 @@
         "condition": {
           "and": [ { "math": [ "u_calories('format': 'percent') >= 200" ] }, { "math": [ "u_calories('format': 'percent') < 300" ] } ]
         },
-		"mutations": [ "perk_kevlard_obese" ]
+        "mutations": [ "perk_kevlard_obese" ]
       },
       {
         "condition": {

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -1131,10 +1131,7 @@
       },
       {
         "condition": {
-          "and": [
-            { "math": [ "u_calories('format': 'percent') >= 300" ] },
-            { "math": [ "u_calories('format': 'percent') < 400" ] }
-          ]
+          "and": [ { "math": [ "u_calories('format': 'percent') >= 300" ] }, { "math": [ "u_calories('format': 'percent') < 400" ] } ]
         },
         "mutations": [ "perk_kevlard_veryobese" ]
       },

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -1126,28 +1126,28 @@
       {
         "condition": {
           "and": [
-            { "math": [ "u_calories('format': 'percent') >= 120" ] },
-            { "math": [ "u_calories('format': 'percent') < 140" ] }
+            { "math": [ "u_calories('format': 'percent') >= 200" ] },
+            { "math": [ "u_calories('format': 'percent') < 300" ] }
           ]
         },
-        "values": [ "mutations": [ "perk_kevlard_obese" ] ],
+		"mutations": [ "perk_kevlard_obese" ]
       },
       {
         "condition": {
           "and": [
-            { "math": [ "u_calories('format': 'percent') >= 140" ] },
-            { "math": [ "u_calories('format': 'percent') < 160" ] }
+            { "math": [ "u_calories('format': 'percent') >= 300" ] },
+            { "math": [ "u_calories('format': 'percent') < 400" ] }
           ]
         },
-        "values": [ "mutations": [ "perk_kevlard_veryobese" ] ],
+        "mutations": [ "perk_kevlard_veryobese" ]
       },
       {
         "condition": {
           "and": [
-            { "math": [ "u_calories('format': 'percent') >= 160" ] }
+            { "math": [ "u_calories('format': 'percent') >= 400" ] }
           ]
         },
-        "values": [ "mutations": [ "perk_kevlard_morbidlyobese" ] ],
+		"mutations": [ "perk_kevlard_morbidlyobese" ]
       }
     ]
   },

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -1121,7 +1121,7 @@
     "points": 0,
     "purifiable": false,
     "valid": false,
-    "description": "Conventional wisdom says it's not healthy to be fat, but you're nothing if not unconventional.  Your natural padding acts as a ballistic vest, and the fatter you are, the more protection you'll get.  You must be at least Obese to recieve any benefit.",
+    "description": "Conventional wisdom says it's not healthy to be fat, but you're nothing if not unconventional.  Your natural padding acts as a ballistic vest, and the fatter you are, the more protection you'll get.  You must be at least Obese to receive any benefit.",
     "enchantments": [
       {
         "condition": {

--- a/tools/spell_checker/dictionary.txt
+++ b/tools/spell_checker/dictionary.txt
@@ -3173,6 +3173,10 @@ Ketubot
 Kev
 Kevin
 Kevlar
+kevlard
+kevlard i
+kevlard ii
+kevlard iii
 keybind
 keybinding
 keybindings


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "New Bombastic Perk, obesity-based protection"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
"Fat person whose fat deflects bullets" is a classic and I wanted to make a perk to represent it.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
New playstyle perk, "Kevlard". Gives you an integrated ballistic vest, torso only, which upgrades in tier with how fat you are (Obese, Very Obese, Morbidly Obese). It only protects your torso, and doesn't cost any extra encumbrance beyond the penalties from being that overweight. At Obese, it's about half a ballistic vest's worth of protection, and at Morbidly Obese, it's a little bit better than a ballistic vest (though still isn't as good as ESAPI plates). Being super fat has big encumbrance penalties and it is a playstyle perk (so it costs 4 perks) so it should hopefully be pretty balanced.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Arms/legs protection.
The way I did the enchantment could maybe instead use an EOC that updates periodically, I don't know if there will be a performance cost with my method.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded in game. Confirmed you can only take the perk if already Obese or heavier. Saw perk scale as I debug-changed my stored calories.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
How the survivor feels after tanking an MP5 magdump with their blubber
![Roadhog_Overwatch](https://github.com/user-attachments/assets/847ef6ea-61bc-47fe-b8e2-393141400b77)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
