### PR TITLE
[Bombastic Perks] Change the way you get playstyle perks

### DIFF
--- a/data/mods/BombasticPerks/corefiles/core_eocs.json
+++ b/data/mods/BombasticPerks/corefiles/core_eocs.json
@@ -14,6 +14,14 @@
       { "math": [ "u_available_exp = u_val('exp') + u_bonus_exp - u_used_exp" ] },
       { "math": [ "u_exp_to_perk += u_exp_per_level" ] },
       { "math": [ "u_current_level += 1" ] },
+      { "math": [ "u_perks_toward_playstyle += 1" ] },
+      {
+        "if": { "math": [ "u_perks_toward_playstyle >= u_perks_toward_playstyle_setting" ] },
+        "then": [
+          { "math": [ "u_playstyle_perks_available += 1" ] },
+          { "math": [ "u_perks_toward_playstyle -= u_perks_toward_playstyle_setting" ] }
+        ]
+      },
       { "run_eocs": "EOC_level_up_notification" }
     ]
   },
@@ -66,8 +74,9 @@
       { "math": [ "u_available_exp = 0" ] },
       { "math": [ "u_current_level = 0" ] },
       { "math": [ "u_no_playstyle = 0" ] },
-      { "math": [ "u_playstyle_cost = 3" ] },
+      { "math": [ "u_perks_toward_playstyle_setting = 6" ] },
       { "math": [ "u_no_prerecs = 0" ] },
+      { "math": [ "u_upgraded_to_new_bombastic_version = 1" ] },
       { "u_add_trait": "perk_perk_menu" }
     ]
   },

--- a/data/mods/BombasticPerks/corefiles/core_eocs.json
+++ b/data/mods/BombasticPerks/corefiles/core_eocs.json
@@ -75,6 +75,7 @@
       { "math": [ "u_current_level = 0" ] },
       { "math": [ "u_no_playstyle = 0" ] },
       { "math": [ "u_perks_toward_playstyle_setting = 6" ] },
+      { "math": [ "u_playstyle_perks_available = 0" ] },
       { "math": [ "u_no_prerecs = 0" ] },
       { "math": [ "u_upgraded_to_new_bombastic_version = 1" ] },
       { "u_add_trait": "perk_perk_menu" }

--- a/data/mods/BombasticPerks/corefiles/welcomemenu.json
+++ b/data/mods/BombasticPerks/corefiles/welcomemenu.json
@@ -71,23 +71,29 @@
   {
     "type": "talk_topic",
     "id": "TALK_PERK_MENU_WELCOME_PLAYSTYLE",
-    "dynamic_line": "Normal perks are considered lifestyle perks and are small bonuses to help your character progress.  Playstyle perks on the other hand can vary wildly in power, in some cases aren't well balanced, and will define your character's playstyle.  Do you want to enable playstyle perks and if so, how many perk points should they cost?",
+    "dynamic_line": "Normal perks are considered lifestyle perks and are small bonuses to help your character progress.  Playstyle perks on the other hand can vary wildly in power, in some cases aren't well balanced, and will define your character's playstyle.  Do you want to enable playstyle perks and if so, how many lifestyle perks do you need before you can acquire one?",
     "responses": [
       {
-        "text": "Default (4 perk points)",
+        "text": "Default (6 lifestyle perks unlocks one playstyle perk)",
         "effect": [
-          { "math": [ "u_playstyle_cost = 3" ] },
+          { "math": [ "u_perks_toward_playstyle_setting = 6" ] },
           { "math": [ "u_no_playstyle = 0" ] },
-          { "u_add_var": "dialogue_perks_playstyle_note", "value": "I can select playstyle perks for 4 perk points." }
+          {
+            "u_add_var": "dialogue_perks_playstyle_note",
+            "value": "I will gain 1 playstyle perk option per 6 lifestyle perks."
+          }
         ],
         "topic": "TALK_PERK_MENU_WELCOME_CONFIRM"
       },
       {
         "text": "Enabled, Custom Cost",
         "effect": [
-          { "math": [ "u_playstyle_cost = num_input('Playstyle Perks Cost?', 4) - 1" ] },
+          { "math": [ "u_perks_toward_playstyle_setting = num_input('Lifestyle perks per playstyle perk?', 6)" ] },
           { "math": [ "u_no_playstyle = 0" ] },
-          { "u_add_var": "dialogue_perks_playstyle_note", "value": "I can select playstyle perks for a custom cost." }
+          {
+            "u_add_var": "dialogue_perks_playstyle_note",
+            "value": "I will gain 1 playstyle perk for a custom amount of lifestyle perks."
+          }
         ],
         "topic": "TALK_PERK_MENU_WELCOME_CONFIRM"
       },
@@ -113,6 +119,8 @@
           { "math": [ "u_num_perks = 0" ] },
           { "math": [ "u_available_exp = 0" ] },
           { "math": [ "u_current_level = 0" ] },
+          { "math": [ "u_playssty = 0" ] },
+          { "math": [ "u_upgraded_to_new_bombastic_version = 1" ] },
           { "u_add_trait": "perk_perk_menu" }
         ],
         "topic": "TALK_DONE"

--- a/data/mods/BombasticPerks/corefiles/welcomemenu.json
+++ b/data/mods/BombasticPerks/corefiles/welcomemenu.json
@@ -121,6 +121,7 @@
           { "math": [ "u_current_level = 0" ] },
           { "math": [ "u_playssty = 0" ] },
           { "math": [ "u_upgraded_to_new_bombastic_version = 1" ] },
+          { "math": [ "u_playstyle_perks_available = 0" ] },
           { "u_add_trait": "perk_perk_menu" }
         ],
         "topic": "TALK_DONE"

--- a/data/mods/BombasticPerks/obsolete.json
+++ b/data/mods/BombasticPerks/obsolete.json
@@ -2,6 +2,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_EXISTING_CHARACTER_UPDATE_BOMBASTIC_PERKS",
+    "//": "Remove after 0.J",
     "eoc_type": "EVENT",
     "required_event": "game_load",
     "condition": { "math": [ "u_upgraded_to_new_bombastic_version != 1" ] },

--- a/data/mods/BombasticPerks/obsolete.json
+++ b/data/mods/BombasticPerks/obsolete.json
@@ -1,0 +1,10 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_EXISTING_CHARACTER_UPDATE_BOMBASTIC_PERKS",
+    "eoc_type": "EVENT",
+    "required_event": "game_load",
+    "condition": { "math": [ "u_upgraded_to_new_bombastic_version != 1" ] },
+    "effect": [ { "math": [ "u_upgraded_to_new_bombastic_version = 1" ] }, { "math": [ "u_perks_toward_playstyle_setting = 6" ] } ]
+  }
+]

--- a/data/mods/BombasticPerks/obsolete.json
+++ b/data/mods/BombasticPerks/obsolete.json
@@ -5,6 +5,10 @@
     "eoc_type": "EVENT",
     "required_event": "game_load",
     "condition": { "math": [ "u_upgraded_to_new_bombastic_version != 1" ] },
-    "effect": [ { "math": [ "u_upgraded_to_new_bombastic_version = 1" ] }, { "math": [ "u_perks_toward_playstyle_setting = 6" ] } ]
+    "effect": [
+      { "math": [ "u_upgraded_to_new_bombastic_version = 1" ] },
+      { "math": [ "u_perks_toward_playstyle_setting = 6" ] },
+      { "math": [ "u_playstyle_perks_available = 0" ] }
+    ]
   }
 ]

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -2067,7 +2067,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_PERK_MENU_PLAYSTYLE_STORMWROUGHT",
-    "dynamic_line": "Stormwrought Playstyle Perks:\nLevel <u_val:current_level>.\n<u_val:num_perks> perk points to spend.\n<u_val:playstyle_perks_available> playstyle perks available\nCurrent EXP: <u_val:available_exp> \nEXP to next level: <u_val:exp_to_perk>.",
+    "dynamic_line": "Stormwrought Playstyle Perks:\nLevel <u_val:current_level>.\n<u_val:num_perks> perk points to spend.\n<u_val:playstyle_perks_available> playstyle perks available\nCurrent EXP: <u_val:available_exp>\nEXP to next level: <u_val:exp_to_perk>.",
     "responses": [
       {
         "condition": { "not": { "u_has_trait": "perk_portal_storm_mutator_bird" } },

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -2471,7 +2471,8 @@
         "failure_topic": "TALK_PERK_MENU_FAIL",
         "effect": [
           { "u_mutate_towards": { "context_val": "trait_id" }, "category": "ANY", "use_vitamins": false },
-          { "math": [ "u_num_perks--" ] }
+          { "math": [ "u_num_perks--" ] },
+          { "math": [ "u_perks_toward_playstyle++" ] }
         ]
       },
       {
@@ -2493,14 +2494,15 @@
         "condition": {
           "and": [
             { "or": [ { "math": [ "u_no_prerecs > 0" ] }, { "get_condition": "perk_condition" } ] },
-            { "math": [ "u_num_perks >= u_playstyle_cost + 1" ] }
+            { "math": [ "u_playstyle_perks_available >= 1" ] }
           ]
         },
         "failure_explanation": "Requirements Not Met",
         "failure_topic": "TALK_PERK_MENU_FAIL",
         "effect": [
           { "u_mutate_towards": { "context_val": "trait_id" }, "category": "ANY", "use_vitamins": false },
-          { "math": [ "u_num_perks -= u_playstyle_cost + 1" ] }
+          { "math": [ "u_num_perks--" ] },
+          { "math": [ "u_playstyle_perks_available--" ] }
         ]
       },
       {

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -2,7 +2,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_PERK_MENU_MAIN",
-    "dynamic_line": "Lifestyle Perks:\nLevel <u_val:current_level>.\n<u_val:num_perks> perk points to spend.\nCurrent EXP: <u_val:available_exp>.\nEXP to next level: <u_val:exp_to_perk>.",
+    "dynamic_line": "Lifestyle Perks:\nLevel <u_val:current_level>.\n<u_val:num_perks> perk points to spend.\n<u_val:playstyle_perks_available> playstyle perks available.\nCurrent EXP: <u_val:available_exp>.\nEXP to next level: <u_val:exp_to_perk>.",
     "responses": [
       {
         "condition": { "and": [ { "not": { "u_has_trait": "perk_STR_UP" } }, { "not": { "u_has_trait": "perk_STR_UP_2" } } ] },
@@ -1619,7 +1619,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_PERK_MENU_PLAYSTYLE",
-    "dynamic_line": "Playstyle Perks:\nLevel <u_val:current_level>.\n<u_val:num_perks> perk points to spend.\nCurrent EXP: <u_val:available_exp>.\nEXP to next level: <u_val:exp_to_perk>.",
+    "dynamic_line": "Playstyle Perks:\nLevel <u_val:current_level>.\n<u_val:num_perks> perk points to spend.\n<u_val:playstyle_perks_available> playstyle perks available.\nCurrent EXP: <u_val:available_exp>.\nEXP to next level: <u_val:exp_to_perk>.",
     "responses": [
       {
         "condition": { "not": { "u_has_trait": "perk_frakenstein" } },
@@ -2067,7 +2067,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_PERK_MENU_PLAYSTYLE_STORMWROUGHT",
-    "dynamic_line": "Stormwrought Playstyle Perks:\nLevel <u_val:current_level>.\n<u_val:num_perks> perk points to spend.\nCurrent EXP: <u_val:available_exp>.\nEXP to next level: <u_val:exp_to_perk>.",
+    "dynamic_line": "Stormwrought Playstyle Perks:\nLevel <u_val:current_level>.\n<u_val:num_perks> perk points to spend.\n<u_val:playstyle_perks_available> playstyle perks available\nCurrent EXP: <u_val:available_exp> \nEXP to next level: <u_val:exp_to_perk>.",
     "responses": [
       {
         "condition": { "not": { "u_has_trait": "perk_portal_storm_mutator_bird" } },
@@ -2276,7 +2276,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_PERK_MENU_METAMAGIC",
-    "dynamic_line": "Metamagic Perks:\nLevel <u_val:current_level>.\n<u_val:num_perks> perk points to spend.\nCurrent EXP: <u_val:available_exp>.\nEXP to next level: <u_val:exp_to_perk>.",
+    "dynamic_line": "Metamagic Perks:\nLevel <u_val:current_level>.\n<u_val:num_perks> perk points to spend.\n<u_val:playstyle_perks_available> playstyle perks available.\nCurrent EXP: <u_val:available_exp>.\nEXP to next level: <u_val:exp_to_perk>.",
     "responses": [
       {
         "condition": { "not": { "u_has_trait": "perk_metamagic_quicken" } },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Bombastic Perks] Change the way you get playstyle perks"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Most playstyle perks are, bluntly, not worth four perk points, even the powerful ones, not compared to simple workaday lifestyle perks like "5% chance for any attack to miss you." But they're fun, and most of them _are_ sweeping changes and you shouldn't be able to take them back to back (at least not by default). So, how about a new system?

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Change the way you gain playstyle perks. Now, they cost 1 perk point _but_ you only gain the option to take them after taking a number of lifestyle perks, default 6. Every 6 (or whatever) lifestyle perks unlocks the option for 1 playstyle perk. 

Playstyle perks still cost 1 perk point--you don't get them for free, you just get the option to buy them. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Used default settings, required 6 perks per playstyle perk.

Used custom settings, set it to 5 perks per playstyle perk. Gained 5 perks, gained the option to buy a playstyle perk. 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Next part--adding more prerequisites to perks so you don't always take the same ones on every character every time. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
