### PR TITLE
[Bombastic Perks] Add more prerequisites for perks

### DIFF
--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -15,11 +15,14 @@
           },
           { "set_string_var": "perk_STR_UP", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "No Requirements",
+            "set_string_var": "Must have perk level 8",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "not": { "u_has_trait": "perk_STR_UP_2" } } }
+          {
+            "set_condition": "perk_condition",
+            "condition": { "and": [ { "math": [ "u_current_level >= 8" ] }, { "not": { "u_has_trait": "perk_STR_UP_2" } } ] }
+          }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },
@@ -34,10 +37,13 @@
           },
           { "set_string_var": "perk_STR_UP_2", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Must have the <trait_name:perk_STR_UP> perk",
+            "set_string_var": "Must have the <trait_name:perk_STR_UP> perk and perk level 20",
             "target_var": { "context_val": "trait_requirement_description" }
           },
-          { "set_condition": "perk_condition", "condition": { "u_has_trait": "perk_STR_UP" } }
+          {
+            "set_condition": "perk_condition",
+            "condition": { "and": [ { "u_has_trait": "perk_STR_UP" }, { "math": [ "u_current_level >= 20" ] } ] }
+          }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },
@@ -52,11 +58,14 @@
           },
           { "set_string_var": "perk_DEX_UP", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "No Requirements",
+            "set_string_var": "Must have perk level 8",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "not": { "u_has_trait": "perk_DEX_UP_2" } } }
+          {
+            "set_condition": "perk_condition",
+            "condition": { "and": [ { "math": [ "u_current_level >= 8" ] }, { "not": { "u_has_trait": "perk_DEX_UP_2" } } ] }
+          }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },
@@ -71,10 +80,13 @@
           },
           { "set_string_var": "perk_DEX_UP_2", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Must have the <trait_name:perk_DEX_UP> perk",
+            "set_string_var": "Must have the <trait_name:perk_DEX_UP> perk and perk level 20",
             "target_var": { "context_val": "trait_requirement_description" }
           },
-          { "set_condition": "perk_condition", "condition": { "u_has_trait": "perk_DEX_UP" } }
+          {
+            "set_condition": "perk_condition",
+            "condition": { "and": [ { "u_has_trait": "perk_DEX_UP" }, { "math": [ "u_current_level >= 20" ] } ] }
+          }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },
@@ -89,11 +101,14 @@
           },
           { "set_string_var": "perk_INT_UP", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "No Requirements",
+            "set_string_var": "Must have perk level 8",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "not": { "u_has_trait": "perk_INT_UP_2" } } }
+          {
+            "set_condition": "perk_condition",
+            "condition": { "and": [ { "math": [ "u_current_level >= 8" ] }, { "not": { "u_has_trait": "perk_INT_UP_2" } } ] }
+          }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },
@@ -108,10 +123,13 @@
           },
           { "set_string_var": "perk_INT_UP_2", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Must have the <trait_name:perk_INT_UP> perk",
+            "set_string_var": "Must have the <trait_name:perk_INT_UP> perk and perk level 20",
             "target_var": { "context_val": "trait_requirement_description" }
           },
-          { "set_condition": "perk_condition", "condition": { "u_has_trait": "perk_INT_UP" } }
+          {
+            "set_condition": "perk_condition",
+            "condition": { "and": [ { "u_has_trait": "perk_INT_UP" }, { "math": [ "u_current_level >= 20" ] } ] }
+          }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },
@@ -126,11 +144,14 @@
           },
           { "set_string_var": "perk_PER_UP", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "No Requirements",
+            "set_string_var": "Must have perk level 8",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "not": { "u_has_trait": "perk_PER_UP_2" } } }
+          {
+            "set_condition": "perk_condition",
+            "condition": { "and": [ { "math": [ "u_current_level >= 8" ] }, { "not": { "u_has_trait": "perk_PER_UP_2" } } ] }
+          }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },
@@ -145,10 +166,13 @@
           },
           { "set_string_var": "perk_PER_UP_2", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Must have the <trait_name:perk_PER_UP> perk",
+            "set_string_var": "Must have the <trait_name:perk_PER_UP> perk and perk level 20",
             "target_var": { "context_val": "trait_requirement_description" }
           },
-          { "set_condition": "perk_condition", "condition": { "u_has_trait": "perk_PER_UP" } }
+          {
+            "set_condition": "perk_condition",
+            "condition": { "and": [ { "u_has_trait": "perk_PER_UP" }, { "math": [ "u_current_level >= 20" ] } ] }
+          }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },
@@ -163,13 +187,15 @@
           },
           { "set_string_var": "perk_sight_beyond_sight", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Requires perception 13",
+            "set_string_var": "Requires perception 13 or <trait_name:SPIRITUAL>",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
           {
             "set_condition": "perk_condition",
-            "condition": { "math": [ "u_val('perception_base') + u_val('perception_bonus') >= 13" ] }
+            "condition": {
+              "or": [ { "math": [ "u_val('perception_base') + u_val('perception_bonus') >= 13" ] }, { "u_has_trait": "SPIRITUAL" } ]
+            }
           }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
@@ -185,7 +211,7 @@
           },
           { "set_string_var": "perk_mighty_thews", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Requires strength 13",
+            "set_string_var": "Requires strength 13 and perk level 12",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
@@ -207,7 +233,7 @@
           },
           { "set_string_var": "perk_pantherish_grace", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Requires dexterity 13",
+            "set_string_var": "Requires dexterity 13 and perk level 12",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
@@ -229,7 +255,7 @@
           },
           { "set_string_var": "perk_eagle_eyes", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Requires perception 13",
+            "set_string_var": "Requires perception 13 and perk level 12",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
@@ -298,11 +324,14 @@
           },
           { "set_string_var": "perk_built_tough", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "No Requirements",
+            "set_string_var": "Must not have <trait_name:FLIMSY>, <trait_name:FLIMSY2>, <trait_name:FLIMSY3>, or <trait_name:GLASSJAW>.",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "math": [ "0 == 0" ] } }
+          {
+            "set_condition": "perk_condition",
+            "condition": { "not": { "u_has_any_trait": [ "FLIMSY", "FLIMSY2", "FLIMSY3", "GLASSJAW" ] } }
+          }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -217,7 +217,9 @@
           },
           {
             "set_condition": "perk_condition",
-            "condition": { "math": [ "u_val('strength_base') + u_val('strength_bonus') >= 13" ] }
+            "condition": {
+              "and": [ { "math": [ "u_val('strength_base') + u_val('strength_bonus') >= 13" ] }, { "math": [ "u_current_level >= 12" ] } ]
+            }
           }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
@@ -239,7 +241,9 @@
           },
           {
             "set_condition": "perk_condition",
-            "condition": { "math": [ "u_val('dexterity_base') + u_val('dexterity_bonus') >= 13" ] }
+            "condition": {
+              "and": [ { "math": [ "u_val('dexterity_base') + u_val('dexterity_bonus') >= 13" ] }, { "math": [ "u_current_level >= 12" ] } ]
+            }
           }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
@@ -261,7 +265,12 @@
           },
           {
             "set_condition": "perk_condition",
-            "condition": { "math": [ "u_val('perception_base') + u_val('perception_bonus') >= 13" ] }
+            "condition": {
+              "and": [
+                { "math": [ "u_val('perception_base') + u_val('perception_bonus') >= 13" ] },
+                { "math": [ "u_current_level >= 12" ] }
+              ]
+            }
           }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
@@ -346,11 +355,14 @@
           },
           { "set_string_var": "perk_thick_skin", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Must have <trait_name:perk_built_tough>.",
+            "set_string_var": "Must have <trait_name:perk_built_tough> and perk level 6.",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "u_has_trait": "perk_built_tough" } }
+          {
+            "set_condition": "perk_condition",
+            "condition": { "and": [ { "u_has_trait": "perk_built_tough" }, { "math": [ "u_current_level >= 6" ] } ] }
+          }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },
@@ -365,11 +377,11 @@
           },
           { "set_string_var": "perk_hauler", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "No Requirements",
+            "set_string_var": "Requires athletics 4",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "math": [ "0 == 0" ] } }
+          { "set_condition": "perk_condition", "condition": { "math": [ "u_skill('swimming') >= 4" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },
@@ -482,11 +494,19 @@
           },
           { "set_string_var": "perk_thick_skull", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "No Requirements",
+            "set_string_var": "Must not have <trait_name:GLASSJAW>. Requires unarmed 4 or melee 4",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "math": [ "0 == 0" ] } }
+          {
+            "set_condition": "perk_condition",
+            "condition": {
+              "and": [
+                { "not": { "u_has_trait": "GLASSJAW" } },
+                { "or": [ { "math": [ "u_skill('unarmed') >= 4" ] }, { "math": [ "u_skill('melee') >= 4" ] } ] }
+              ]
+            }
+          }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },
@@ -501,7 +521,7 @@
           },
           { "set_string_var": "perk_way_openpalm", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Must not have <trait_name:perk_way_closedfist>, <trait_name:perk_way_pinchedfingers>.  Requires unarmed 2 and cutting 1",
+            "set_string_var": "Must not have <trait_name:perk_way_closedfist>, <trait_name:perk_way_pinchedfingers>.  Requires unarmed 4 and cutting 4",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
@@ -510,7 +530,7 @@
             "condition": {
               "and": [
                 { "not": { "or": [ { "u_has_trait": "perk_way_closedfist" }, { "u_has_trait": "perk_way_pinchedfingers" } ] } },
-                { "and": [ { "math": [ "u_skill('unarmed') >= 2" ] }, { "math": [ "u_skill('cutting') >= 1" ] } ] }
+                { "and": [ { "math": [ "u_skill('unarmed') >= 4" ] }, { "math": [ "u_skill('cutting') >= 4" ] } ] }
               ]
             }
           },
@@ -533,7 +553,7 @@
           },
           { "set_string_var": "perk_way_closedfist", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Must not have <trait_name:perk_way_openpalm>, <trait_name:perk_way_pinchedfingers>.  Requires unarmed 2 and bashing 1",
+            "set_string_var": "Must not have <trait_name:perk_way_openpalm>, <trait_name:perk_way_pinchedfingers>.  Requires unarmed 4 and bashing 4",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
@@ -542,7 +562,7 @@
             "condition": {
               "and": [
                 { "not": { "or": [ { "u_has_trait": "perk_way_openpalm" }, { "u_has_trait": "perk_way_pinchedfingers" } ] } },
-                { "and": [ { "math": [ "u_skill('unarmed') >= 2" ] }, { "math": [ "u_skill('bashing') >= 1" ] } ] }
+                { "and": [ { "math": [ "u_skill('unarmed') >= 4" ] }, { "math": [ "u_skill('bashing') >= 4" ] } ] }
               ]
             }
           },
@@ -565,7 +585,7 @@
           },
           { "set_string_var": "perk_way_pinchedfingers", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Must not have <trait_name:perk_way_closedfist>, <trait_name:perk_way_openpalm>.  Requires unarmed 2 and piercing 1",
+            "set_string_var": "Must not have <trait_name:perk_way_closedfist>, <trait_name:perk_way_openpalm>.  Requires unarmed 4 and piercing 4",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
@@ -574,7 +594,7 @@
             "condition": {
               "and": [
                 { "not": { "or": [ { "u_has_trait": "perk_way_closedfist" }, { "u_has_trait": "perk_way_openpalm" } ] } },
-                { "and": [ { "math": [ "u_skill('unarmed') >= 2" ] }, { "math": [ "u_skill('stabbing') >= 1" ] } ] }
+                { "and": [ { "math": [ "u_skill('unarmed') >= 4" ] }, { "math": [ "u_skill('stabbing') >= 4" ] } ] }
               ]
             }
           },
@@ -621,7 +641,7 @@
           },
           { "set_string_var": "perk_surgical_strikes", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Must not have <trait_name:perk_bloody_mess>.  Melee or guns 2",
+            "set_string_var": "Must not have <trait_name:perk_bloody_mess>.  Melee or guns 5",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
@@ -630,7 +650,7 @@
             "condition": {
               "and": [
                 { "not": { "u_has_trait": "perk_bloody_mess" } },
-                { "or": [ { "math": [ "u_skill('melee') >= 2" ] }, { "math": [ "u_skill('gun') >= 2" ] } ] }
+                { "or": [ { "math": [ "u_skill('melee') >= 5" ] }, { "math": [ "u_skill('gun') >= 5" ] } ] }
               ]
             }
           },
@@ -653,11 +673,11 @@
           },
           { "set_string_var": "perk_animal_friend", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "No Requirements",
+            "set_string_var": "Requires survival 6",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "math": [ "0 == 0" ] } }
+          { "set_condition": "perk_condition", "condition": { "math": [ "u_skill('survival') >= 6" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },
@@ -672,11 +692,11 @@
           },
           { "set_string_var": "perk_quickdraw", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Requires handguns 2",
+            "set_string_var": "Requires handguns 3",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "math": [ "u_skill('pistol') >= 2" ] } }
+          { "set_condition": "perk_condition", "condition": { "math": [ "u_skill('pistol') >= 3" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },
@@ -775,11 +795,11 @@
           },
           { "set_string_var": "perk_big_eater", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "No Requirements",
+            "set_string_var": "Must not have <trait_name:LIGHTEATER>.",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "math": [ "0 == 0" ] } }
+          { "set_condition": "perk_condition", "condition": { "not": { "u_has_trait": "LIGHTEATER" } } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -814,11 +814,11 @@
           },
           { "set_string_var": "perk_tuck_and_roll", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "No Requirements",
+            "set_string_var": "Requires athletics 5",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "math": [ "0 == 0" ] } }
+          { "set_condition": "perk_condition", "condition": { "math": [ "u_skill('swimming') >= 5" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },
@@ -833,7 +833,7 @@
           },
           { "set_string_var": "perk_reduced_falling_damage", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Must have <trait_name:perk_tuck_and_roll>, the Parkour Expert proficiency, or dexterity 13.",
+            "set_string_var": "Must have <trait_name:perk_tuck_and_roll> and athletics 7, the Parkour Expert proficiency, or dexterity 13 and athletics 5.",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
@@ -841,9 +841,14 @@
             "set_condition": "perk_condition",
             "condition": {
               "or": [
-                { "u_has_trait": "perk_tuck_and_roll" },
+                { "and": [ { "u_has_trait": "perk_tuck_and_roll" }, { "math": [ "u_skill('swimming') >= 7" ] } ] },
                 { "u_has_proficiency": "prof_parkour" },
-                { "math": [ "u_val('dexterity_base') + u_val('dexterity_bonus') >= 13" ] }
+                {
+                  "and": [
+                    { "math": [ "u_val('dexterity_base') + u_val('dexterity_bonus') >= 13" ] },
+                    { "math": [ "u_skill('swimming') >= 5" ] }
+                  ]
+                }
               ]
             }
           }
@@ -923,11 +928,14 @@
           },
           { "set_string_var": "perk_static_stockpile", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Must have the <trait_name:perk_tingly> perk",
+            "set_string_var": "Must have the <trait_name:perk_tingly> perk and perk level 8",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "u_has_trait": "perk_tingly" } }
+          {
+            "set_condition": "perk_condition",
+            "condition": { "and": [ { "u_has_trait": "perk_tingly" }, { "math": [ "u_current_level >= 8" ] } ] }
+          }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },
@@ -942,14 +950,19 @@
           },
           { "set_string_var": "perk_slippery_escape", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Must have the <trait_name:perk_DEX_UP_2> perk or dexterity 12",
+            "set_string_var": "Must have the <trait_name:perk_DEX_UP_2> perk or dexterity 12 and perk level 12",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
           {
             "set_condition": "perk_condition",
             "condition": {
-              "or": [ { "math": [ "u_val('dexterity_base') + u_val('dexterity_bonus') >= 12" ] }, { "u_has_trait": "perk_DEX_UP_2" } ]
+              "and": [
+                {
+                  "or": [ { "math": [ "u_val('dexterity_base') + u_val('dexterity_bonus') >= 12" ] }, { "u_has_trait": "perk_DEX_UP_2" } ]
+                },
+                { "math": [ "u_current_level >= 12" ] }
+              ]
             }
           }
         ],
@@ -982,13 +995,20 @@
           },
           { "set_string_var": "perk_quick_recovery", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Requires dexterity 10",
+            "set_string_var": "Requires dexterity 10 or <trait_name:perk_jumpy> and perk level 6",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
           {
             "set_condition": "perk_condition",
-            "condition": { "math": [ "u_val('dexterity_base') + u_val('dexterity_bonus') >= 10" ] }
+            "condition": {
+              "and": [
+                { "math": [ "u_current_level >= 6" ] },
+                {
+                  "or": [ { "math": [ "u_val('dexterity_base') + u_val('dexterity_bonus') >= 10" ] }, { "u_has_trait": "perk_jumpy" } ]
+                }
+              ]
+            }
           }
         ],
         "topic": "TALK_PERK_MENU_SELECT"

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -2452,11 +2452,14 @@
           },
           { "set_string_var": "perk_metamagic_quicken", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Requires a spell known of level 12 or above",
+            "set_string_var": "Requires a spell known of level 12 or above and perk level 9",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "math": [ "u_spell_level('null') >= 12" ] } }
+          {
+            "set_condition": "perk_condition",
+            "condition": { "and": [ { "math": [ "u_spell_level('null') >= 12" ] }, { "math": [ "u_current_level >= 9" ] } ] }
+          }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },
@@ -2490,11 +2493,14 @@
           },
           { "set_string_var": "perk_metamagic_reach", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Requires a spell known of level 6 or above",
+            "set_string_var": "Requires a spell known of level 6 or above and perk level 6",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "math": [ "u_spell_level('null') >= 6" ] } }
+          {
+            "set_condition": "perk_condition",
+            "condition": { "and": [ { "math": [ "u_spell_level('null') >= 6" ] }, { "math": [ "u_current_level >= 6" ] } ] }
+          }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },
@@ -2597,11 +2603,14 @@
           },
           { "set_string_var": "perk_metamagic_intuitive", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Requires a spell known of level 14 or above",
+            "set_string_var": "Requires a spell known of level 14 or above and perk level 12",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "math": [ "u_spell_level('null') >= 14" ] } }
+          {
+            "set_condition": "perk_condition",
+            "condition": { "and": [ { "math": [ "u_spell_level('null') >= 14" ] }, { "math": [ "u_current_level >= 12" ] } ] }
+          }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -1122,11 +1122,14 @@
           },
           { "set_string_var": "perk_blood_drinking_heal", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Must have <trait_name:perk_blood_drinker>.",
+            "set_string_var": "Must have <trait_name:perk_blood_drinker> and perk level 9.",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "u_has_trait": "perk_blood_drinker" } }
+          {
+            "set_condition": "perk_condition",
+            "condition": { "and": [ { "u_has_trait": "perk_blood_drinker" }, { "math": [ "u_current_level >= 9" ] } ] }
+          }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },
@@ -1141,13 +1144,18 @@
           },
           { "set_string_var": "perk_long_shot", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Requires perception 10",
+            "set_string_var": "Requires perception 10 or the Spotting and Awareness proficiency",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
           {
             "set_condition": "perk_condition",
-            "condition": { "math": [ "u_val('perception_base') + u_val('perception_bonus') >= 10" ] }
+            "condition": {
+              "or": [
+                { "math": [ "u_val('perception_base') + u_val('perception_bonus') >= 10" ] },
+                { "u_has_proficiency": "prof_spotting" }
+              ]
+            }
           }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
@@ -1258,11 +1266,21 @@
           },
           { "set_string_var": "perk_crafty_hands", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "No Requirements",
+            "set_string_var": "Requires fabrication 4, food preparation 4, tailoring 4, or chemistry 4.",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "math": [ "0 == 0" ] } }
+          {
+            "set_condition": "perk_condition",
+            "condition": {
+              "or": [
+                { "math": [ "u_skill('chemistry') >= 4" ] },
+                { "math": [ "u_skill('cooking') >= 4" ] },
+                { "math": [ "u_skill('fabrication') >= 4" ] },
+                { "math": [ "u_skill('tailor') >= 4" ] }
+              ]
+            }
+          }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },
@@ -1277,11 +1295,11 @@
           },
           { "set_string_var": "perk_sleepy", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "No Requirements",
+            "set_string_var": "Must not have <trait_name:perk_nocturnal>.",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "math": [ "0 == 0" ] } }
+          { "set_condition": "perk_condition", "condition": { "not": { "u_has_trait": "perk_nocturnal" } } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },
@@ -1337,13 +1355,15 @@
           },
           { "set_string_var": "perk_duck_and_weave", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Requires dexterity 12",
+            "set_string_var": "Requires dexterity 12 or dodge 6",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
           {
             "set_condition": "perk_condition",
-            "condition": { "math": [ "u_val('dexterity_base') + u_val('dexterity_bonus') >= 12" ] }
+            "condition": {
+              "or": [ { "math": [ "u_val('dexterity_base') + u_val('dexterity_bonus') >= 12" ] }, { "math": [ "u_skill('dodge') >= 6" ] } ]
+            }
           }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
@@ -1907,11 +1927,14 @@
           },
           { "set_string_var": "perk_nocturnal", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Must not have <trait_name:perk_early_to_rise>.",
+            "set_string_var": "Must not have <trait_name:perk_early_to_rise> or <trait_name:perk_sleepy> perks.",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "not": { "u_has_trait": "perk_early_to_rise" } } }
+          {
+            "set_condition": "perk_condition",
+            "condition": { "not": { "u_has_any_trait": [ "perk_early_to_rise", "perk_sleepy" ] } }
+          }
         ],
         "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
       },
@@ -1926,11 +1949,11 @@
           },
           { "set_string_var": "perk_second_chance", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "No Requirements",
+            "set_string_var": "Requires perk level 12",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "math": [ "0 == 0" ] } }
+          { "set_condition": "perk_condition", "condition": { "math": [ "u_current_level >= 12" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
       },
@@ -1964,11 +1987,14 @@
           },
           { "set_string_var": "perk_ascetic_empowerment", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Must not have the <trait_name:GOURMAND> trait",
+            "set_string_var": "Must not have the <trait_name:GOURMAND> trait or the <trait_name:perk_big_eater> perk",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "not": { "u_has_trait": "GOURMAND" } } }
+          {
+            "set_condition": "perk_condition",
+            "condition": { "not": { "u_has_any_trait": [ "GOURMAND", "perk_big_eater" ] } }
+          }
         ],
         "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
       },
@@ -2002,11 +2028,11 @@
           },
           { "set_string_var": "perk_flawless_memory", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "No Requirements",
+            "set_string_var": "Must have <trait_name:GOODMEMORY>",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "math": [ "0 == 0" ] } }
+          { "set_condition": "perk_condition", "condition": { "u_has_trait": "GOODMEMORY" } }
         ],
         "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
       },
@@ -2021,11 +2047,11 @@
           },
           { "set_string_var": "perk_forge_blood", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "No Requirements",
+            "set_string_var": "Requires fabrication 5",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "math": [ "0 == 0" ] } }
+          { "set_condition": "perk_condition", "condition": { "math": [ "u_skill('fabrication') >= 6" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
       },
@@ -2040,7 +2066,7 @@
           },
           { "set_string_var": "perk_boomstick_blast", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Requires shotguns 6+",
+            "set_string_var": "Requires shotguns 6",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
@@ -2078,11 +2104,14 @@
           },
           { "set_string_var": "perk_secret_closet_teleporter_paths", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Must have <trait_name:perk_secret_closet_storage>",
+            "set_string_var": "Must have <trait_name:perk_secret_closet_storage> and perk level 16",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "u_has_trait": "perk_secret_closet_storage" } }
+          {
+            "set_condition": "perk_condition",
+            "condition": { "and": [ { "u_has_trait": "perk_secret_closet_storage" }, { "math": [ "u_current_level >= 16" ] } ] }
+          }
         ],
         "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
       },

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -795,7 +795,7 @@
           },
           { "set_string_var": "perk_big_eater", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Must not have <trait_name:LIGHTEATER>.",
+            "set_string_var": "Must not have <trait_name:LIGHTEATER>",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
@@ -1129,7 +1129,7 @@
           },
           { "set_string_var": "perk_blood_drinking_heal", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Must have <trait_name:perk_blood_drinker> and perk level 9.",
+            "set_string_var": "Must have <trait_name:perk_blood_drinker> and perk level 9",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -641,7 +641,7 @@
           },
           { "set_string_var": "perk_surgical_strikes", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Must not have <trait_name:perk_bloody_mess>.  Melee or guns 5",
+            "set_string_var": "Must not have <trait_name:perk_bloody_mess>.  Melee or marksmanship 5",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
@@ -1024,11 +1024,18 @@
           },
           { "set_string_var": "perk_hobbyist", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "No Requirements",
+            "set_string_var": "Requires 25 levels worth of crafting skills",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "math": [ "0 == 0" ] } }
+          {
+            "set_condition": "perk_condition",
+            "condition": {
+              "math": [
+                "(u_skill('chemistry') + u_skill('cooking') + u_skill('fabrication') + u_skill('tailor') + u_skill('electronics') + u_skill('survival') ) >= 25"
+              ]
+            }
+          }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },
@@ -1526,11 +1533,14 @@
           },
           { "set_string_var": "perk_belowthebelt", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Requires Melee 1",
+            "set_string_var": "Requires Melee 4 or Unarmed 4",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "math": [ "u_skill('melee') >= 1" ] } }
+          {
+            "set_condition": "perk_condition",
+            "condition": { "or": [ { "math": [ "u_skill('melee') >= 4" ] }, { "math": [ "u_skill('unarmed') >= 4" ] } ] }
+          }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },
@@ -1564,11 +1574,19 @@
           },
           { "set_string_var": "perk_dream_armor", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "No Requirements",
+            "set_string_var": "Must have the <trait_name:SLEEPY> trait or the <trait_name:perk_sleepy> perk.  Must not have <trait_name:WAKEFUL>, <trait_name:WAKEFUL2>, or <trait_name:WAKEFUL3> traits.",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "math": [ "0 == 0" ] } }
+          {
+            "set_condition": "perk_condition",
+            "condition": {
+              "and": [
+                { "u_has_any_trait": [ "SLEEPY", "perk_sleepy" ] },
+                { "not": { "u_has_any_trait": [ "WAKEFUL", "WAKEFUL2", "WAKEFUL3" ] } }
+              ]
+            }
+          }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },
@@ -1621,11 +1639,11 @@
           },
           { "set_string_var": "perk_poison_painkill", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "No Requirements",
+            "set_string_var": "Requires perk level 6",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "math": [ "0 == 0" ] } }
+          { "set_condition": "perk_condition", "condition": { "math": [ "u_current_level >= 6" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },
@@ -1659,11 +1677,11 @@
           },
           { "set_string_var": "perk_radio_infusion", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "No Requirements",
+            "set_string_var": "Requires applied science 4",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "math": [ "0 == 0" ] } }
+          { "set_condition": "perk_condition", "condition": { "math": [ "u_skill('chemistry') >= 4" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },
@@ -1721,13 +1739,13 @@
           },
           { "set_string_var": "perk_frakenstein", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Requires electronics 4, and health care 4",
+            "set_string_var": "Requires electronics 4, and health care 6",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
           {
             "set_condition": "perk_condition",
-            "condition": { "and": [ { "math": [ "u_skill('electronics') >= 4" ] }, { "math": [ "u_skill('firstaid') >= 4" ] } ] }
+            "condition": { "and": [ { "math": [ "u_skill('electronics') >= 4" ] }, { "math": [ "u_skill('firstaid') >= 6" ] } ] }
           }
         ],
         "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
@@ -1759,11 +1777,26 @@
           },
           { "set_string_var": "perk_olde_guns", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "No Requirements",
+            "set_string_var": "Requires marksmanship 3 and either pistol 5, shotguns 5, submachine guns 5, or rifles 5",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "math": [ "0 == 0" ] } }
+          {
+            "set_condition": "perk_condition",
+            "condition": {
+              "and": [
+                { "math": [ "u_skill('gun') >= 3" ] },
+                {
+                  "or": [
+                    { "math": [ "u_skill('pistol') >= 5" ] },
+                    { "math": [ "u_skill('rifle') >= 5" ] },
+                    { "math": [ "u_skill('shotgun') >= 5" ] },
+                    { "math": [ "u_skill('smg') >= 5" ] }
+                  ]
+                }
+              ]
+            }
+          }
         ],
         "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
       },
@@ -1778,11 +1811,11 @@
           },
           { "set_string_var": "revolvers_are_cool", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "No Requirements",
+            "set_string_var": "Requires handguns 6",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "math": [ "0 == 0" ] } }
+          { "set_condition": "perk_condition", "condition": { "math": [ "u_skill('pistol') >= 6" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
       },
@@ -1794,11 +1827,11 @@
           { "set_string_var": "<trait_description:22_is_cool>", "target_var": { "context_val": "trait_description" } },
           { "set_string_var": "22_is_cool", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "No Requirements",
+            "set_string_var": "Requires marksmanship 5",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "math": [ "0 == 0" ] } }
+          { "set_condition": "perk_condition", "condition": { "math": [ "u_skill('gun') >= 5" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
       },
@@ -1813,11 +1846,14 @@
           },
           { "set_string_var": "perk_empath", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "No Requirements",
+            "set_string_var": "Must not have <trait_name:PSYCHOPATH>.  Requires social 7",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "math": [ "0 == 0" ] } }
+          {
+            "set_condition": "perk_condition",
+            "condition": { "and": [ { "not": { "u_has_trait": "PSYCHOPATH" } }, { "math": [ "u_skill('speech') >= 7" ] } ] }
+          }
         ],
         "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
       },

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -950,7 +950,7 @@
           },
           { "set_string_var": "perk_slippery_escape", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Must have the <trait_name:perk_DEX_UP_2> perk or dexterity 12 and perk level 12",
+            "set_string_var": "Must have the <trait_name:perk_DEX_UP_2> perk or dexterity 12 and perk level 6",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
@@ -961,7 +961,7 @@
                 {
                   "or": [ { "math": [ "u_val('dexterity_base') + u_val('dexterity_bonus') >= 12" ] }, { "u_has_trait": "perk_DEX_UP_2" } ]
                 },
-                { "math": [ "u_current_level >= 12" ] }
+                { "math": [ "u_current_level >= 6" ] }
               ]
             }
           }
@@ -1024,7 +1024,7 @@
           },
           { "set_string_var": "perk_hobbyist", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Requires 25 levels worth of crafting skills",
+            "set_string_var": "Requires 12 levels worth of crafting skills",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
@@ -1032,7 +1032,7 @@
             "set_condition": "perk_condition",
             "condition": {
               "math": [
-                "(u_skill('chemistry') + u_skill('cooking') + u_skill('fabrication') + u_skill('tailor') + u_skill('electronics') + u_skill('survival') ) >= 25"
+                "(u_skill('chemistry') + u_skill('cooking') + u_skill('fabrication') + u_skill('tailor') + u_skill('electronics') + u_skill('survival') ) >= 12"
               ]
             }
           }
@@ -1273,7 +1273,7 @@
           },
           { "set_string_var": "perk_crafty_hands", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Requires fabrication 4, food preparation 4, tailoring 4, or chemistry 4.",
+            "set_string_var": "Requires fabrication 4, food preparation 4, tailoring 4, electronics 4, or chemistry 4.",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
@@ -1284,7 +1284,8 @@
                 { "math": [ "u_skill('chemistry') >= 4" ] },
                 { "math": [ "u_skill('cooking') >= 4" ] },
                 { "math": [ "u_skill('fabrication') >= 4" ] },
-                { "math": [ "u_skill('tailor') >= 4" ] }
+                { "math": [ "u_skill('tailor') >= 4" ] },
+                { "math": [ "u_skill('electronics') >= 4" ] }
               ]
             }
           }
@@ -1302,11 +1303,14 @@
           },
           { "set_string_var": "perk_sleepy", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Must not have <trait_name:perk_nocturnal>.",
+            "set_string_var": "Must not have <trait_name:perk_nocturnal> or <trait_name:INSOMNIA>.",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "not": { "u_has_trait": "perk_nocturnal" } } }
+          {
+            "set_condition": "perk_condition",
+            "condition": { "not": { "u_has_any_trait": [ "perk_nocturnal", "INSOMNIA" ] } }
+          }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },
@@ -1868,11 +1872,20 @@
           },
           { "set_string_var": "perk_chainsaw", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "No Requirements",
+            "set_string_var": "Requires strength 12 or <trait_name:perk_STR_UP_2> and cutting 5",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "math": [ "0 == 0" ] } }
+          {
+            "set_condition": "perk_condition",
+            "condition": {
+              "and": [
+                { "or": [ { "math": [ "u_val('strength_base') + u_val('strength_bonus') >= 12" ] } ] },
+                { "u_has_trait": "perk_STR_UP_2" },
+                { "math": [ "u_skill('cutting') >= 5" ] }
+              ]
+            }
+          }
         ],
         "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
       },
@@ -1887,11 +1900,14 @@
           },
           { "set_string_var": "perk_eating_window", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "No Requirements",
+            "set_string_var": "Must not have <trait_name:GOURMAND> or <trait_name:perk_big_eater>",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "math": [ "0 == 0" ] } }
+          {
+            "set_condition": "perk_condition",
+            "condition": { "not": { "u_has_any_trait": [ "GOURMAND", "perk_big_eater" ] } }
+          }
         ],
         "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
       },
@@ -1925,11 +1941,14 @@
           },
           { "set_string_var": "perk_rage_against_unnatural", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "No Requirements",
+            "set_string_var": "Must have melee 7 or unarmed 7",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "math": [ "0 == 0" ] } }
+          {
+            "set_condition": "perk_condition",
+            "condition": { "or": [ { "math": [ "u_skill('melee') >= 7" ] }, { "math": [ "u_skill('unarmed') >= 7" ] } ] }
+          }
         ],
         "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
       },
@@ -1944,11 +1963,11 @@
           },
           { "set_string_var": "perk_soup_healing", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "No Requirements",
+            "set_string_var": "Requires food handling 5",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "math": [ "0 == 0" ] } }
+          { "set_condition": "perk_condition", "condition": { "math": [ "u_skill('cooking') >= 5" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
       },
@@ -2023,13 +2042,13 @@
           },
           { "set_string_var": "perk_ascetic_empowerment", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Must not have the <trait_name:GOURMAND> trait or the <trait_name:perk_big_eater> perk",
+            "set_string_var": "Must not have the <trait_name:GOURMAND>, <trait_name:perk_big_eater> perk.  Must have the <trait_name:LIGHTEATER> trait",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
           {
             "set_condition": "perk_condition",
-            "condition": { "not": { "u_has_any_trait": [ "GOURMAND", "perk_big_eater" ] } }
+            "condition": { "and": [ { "u_has_trait": "LIGHTEATER" }, { "not": { "u_has_any_trait": [ "GOURMAND", "perk_big_eater" ] } } ] }
           }
         ],
         "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
@@ -2045,11 +2064,11 @@
           },
           { "set_string_var": "perk_speedballing", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "No Requirements",
+            "set_string_var": "Must have the <trait_name:ADDICTIVE> or <trait_name:STIMBOOST> traits.",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "math": [ "0 == 0" ] } }
+          { "set_condition": "perk_condition", "condition": { "u_has_any_trait": [ "ADDICTIVE", "STIMBOOST" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
       },
@@ -2184,11 +2203,21 @@
           },
           { "set_string_var": "perk_dexterous_speed", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "No Requirements",
+            "set_string_var": "Must have the <trait_name:perk_DEX_UP_2> perk or dexterity 10 and perk level 12",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "math": [ "0 == 0" ] } }
+          {
+            "set_condition": "perk_condition",
+            "condition": {
+              "and": [
+                {
+                  "or": [ { "u_has_trait": "perk_DEX_UP_2" }, { "math": [ "u_val('dexterity_base') + u_val('dexterity_bonus') >= 13" ] } ]
+                },
+                { "math": [ "u_current_level >= 12" ] }
+              ]
+            }
+          }
         ],
         "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
       },
@@ -2423,11 +2452,11 @@
           },
           { "set_string_var": "perk_metamagic_quicken", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Requires a spell known of level 2 or above",
+            "set_string_var": "Requires a spell known of level 12 or above",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "math": [ "u_spell_level('null') >= 2" ] } }
+          { "set_condition": "perk_condition", "condition": { "math": [ "u_spell_level('null') >= 12" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },
@@ -2442,11 +2471,11 @@
           },
           { "set_string_var": "perk_metamagic_widen", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Requires a spell known of level 2 or above",
+            "set_string_var": "Requires a spell known of level 6 or above",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "math": [ "u_spell_level('null') >= 2" ] } }
+          { "set_condition": "perk_condition", "condition": { "math": [ "u_spell_level('null') >= 6" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },
@@ -2461,11 +2490,11 @@
           },
           { "set_string_var": "perk_metamagic_reach", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Requires a spell known of level 2 or above",
+            "set_string_var": "Requires a spell known of level 6 or above",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "math": [ "u_spell_level('null') >= 2" ] } }
+          { "set_condition": "perk_condition", "condition": { "math": [ "u_spell_level('null') >= 6" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },
@@ -2486,11 +2515,11 @@
           },
           { "set_string_var": "perk_metamagic_silent", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Requires a spell known of level 2 or above",
+            "set_string_var": "Requires a spell known of level 4 or above",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "math": [ "u_spell_level('null') >= 2" ] } }
+          { "set_condition": "perk_condition", "condition": { "math": [ "u_spell_level('null') >= 4" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },
@@ -2511,11 +2540,11 @@
           },
           { "set_string_var": "perk_metamagic_still", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Requires a spell known of level 2 or above",
+            "set_string_var": "Requires a spell known of level 5 or above",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "math": [ "u_spell_level('null') >= 2" ] } }
+          { "set_condition": "perk_condition", "condition": { "math": [ "u_spell_level('null') >= 5" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },
@@ -2568,11 +2597,11 @@
           },
           { "set_string_var": "perk_metamagic_intuitive", "target_var": { "context_val": "trait_id" } },
           {
-            "set_string_var": "Requires a spell known of level 8 or above",
+            "set_string_var": "Requires a spell known of level 14 or above",
             "target_var": { "context_val": "trait_requirement_description" },
             "i18n": true
           },
-          { "set_condition": "perk_condition", "condition": { "math": [ "u_spell_level('null') >= 8" ] } }
+          { "set_condition": "perk_condition", "condition": { "math": [ "u_spell_level('null') >= 14" ] } }
         ],
         "topic": "TALK_PERK_MENU_SELECT"
       },

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -734,7 +734,7 @@
   {
     "type": "mutation",
     "id": "perk_popeye",
-    "name": { "str": "Of sailors and spinach" },
+    "name": { "str": "Of Sailors and Spinach" },
     "points": 0,
     "purifiable": false,
     "valid": false,

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -1224,7 +1224,7 @@
     "points": 0,
     "purifiable": false,
     "valid": false,
-    "description": "You hate the feeling of your blood leaking so much that it empowers you.  Deal more melee damage the more you are bleeding.",
+    "description": "You hate the feeling of your blood leaking so much that it empowers you.  You deal more melee damage the more you are bleeding.",
     "enchantments": [
       {
         "condition": "ALWAYS",
@@ -1259,7 +1259,7 @@
   {
     "type": "mutation",
     "id": "perk_poison_painkill",
-    "name": { "str": "Numb from the toxin" },
+    "name": { "str": "Numb from the Toxin" },
     "points": 0,
     "purifiable": false,
     "valid": false,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Bombastic Perks] Add more prerequisites for perks"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

A lot of perks had no prereqs, or prereqs so easy to meet they basically didn't exist (like unarmed 2 bashing 1). This is uninteresting mostly because it means you just take the same perks on every character.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Go through and add a _lot_ more prereqs, including using your perk level (i.e., how many perks you have) to gate some perks behind. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Tried to buy various perks, checked the requirements. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
