### PR TITLE
Fix zone sorting improperly aborting early when failing to move an item with no destination zone.

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -12620,6 +12620,11 @@ void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
             return;
         }
 
+        if( zt_id == zone_type_id::NULL_ID() ) {
+            // After unloading, this item isn't going anywhere else.
+            continue;
+        }
+
         // Picking up
 
         if( !picked_up_stuff.empty() ) {

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -916,8 +916,12 @@ bool has_items_to_sort( Character &you, const tripoint_abs_ms &src,
 
     for( std::pair<item *, bool> it_pair : items ) {
         item *it = it_pair.first;
-        const zone_type_id zone_type_id = mgr.get_near_zone_type_for_item( *it, abspos,
-                                          MAX_VIEW_DISTANCE, fac_id );
+        const zone_type_id dest_zone_type_id = mgr.get_near_zone_type_for_item( *it, abspos,
+                                               MAX_VIEW_DISTANCE, fac_id );
+
+        if( dest_zone_type_id == zone_type_id::NULL_ID() ) {
+            continue;
+        }
 
         if( !you.can_add( *it ) ) {
             *pickup_failure = true;
@@ -930,7 +934,7 @@ bool has_items_to_sort( Character &you, const tripoint_abs_ms &src,
         }
 
         const std::unordered_set<tripoint_abs_ms> dest_set =
-            mgr.get_near( zone_type_id, abspos, MAX_VIEW_DISTANCE, it, fac_id );
+            mgr.get_near( dest_zone_type_id, abspos, MAX_VIEW_DISTANCE, it, fac_id );
 
         //if we're unloading all or a corpse
         if( zone_unload_options.unload_all || ( zone_unload_options.unload_corpses && it->is_corpse() ) ) {

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -1425,7 +1425,7 @@ zone_type_id zone_manager::get_near_zone_type_for_item( const item &it,
         }
     }
 
-    return zone_type_id();
+    return zone_type_id::NULL_ID();
 }
 
 std::vector<zone_data> zone_manager::get_zones( const zone_type_id &type,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Fix another edge case with zone sorting"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I noticed my character was refusing to move food out of the garbage can into the cupboards and fridges. Although understandable IRL, this is a video game and if I've setup sort zones to do this, the character should do that.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
The issue was the first item my character could pick up had no valid destination zone (which makes sense, not all items can be sorted). This then fails a particular safety check which tests if the 'destination tiles' set is empty. However, it should be empty in this case! Instead, continue the loop early after possibly unloading containers if the destination zone type is null, and avoid this spurious check (which maybe can be removed now).
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
In the attached save, attempt to sort static zones. It will work and move food to the cupboards. I would have expected it to move perishables to the fridge, but tbh I don't understand the prioritization logic here.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
[3kumo5me-trimmed.tar.gz](https://github.com/user-attachments/files/24989443/3kumo5me-trimmed.tar.gz)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
