### PR TITLE
Make weather be able to apply passive effects

### DIFF
--- a/doc/JSON/JSON_INFO.md
+++ b/doc/JSON/JSON_INFO.md
@@ -4423,27 +4423,7 @@ Fields can exist on top of terrain/furniture, and support different intensity le
         "translucency": 2.0, // How much light the field blocks (higher numbers mean less light can penetrate through)
         "concentration": 1, // How concentrated this intensity of gas is. Generally the thin/hazy cloud intensity will be 1, the standard gas will be 2, and thick gas will be 4. The amount of time a gas mask filter will last will be divided by this value.
         "convection_temperature_mod": 12, // Heat given off by this level of intensity
-        "effects":  // List of effects applied to any creatures within the field as long as they aren't immune to the effect or the field itself
-        [
-          {
-            "effect_id": "webbed", // Effect ID
-            "min_duration": "1 minutes",
-            "max_duration": "5 minutes", // Effect duration randomized between min and max duration
-            "intensity": 1, // Intensity of the effect to apply
-            "body_part": "head", // Bodypart the effect gets applied to, default BP_NULL ("whole body")
-            "is_environmental": false, // If true the environmental effect roll is used to determine if the effect gets applied: <intensity>d3 > <target BP's armor/bionic env resist>d3
-            "immune_in_vehicle": // If true, *standing* inside a vehicle (like without walls or roof) protects from the effect
-            "immune_inside_vehicle": false, // If true being inside a vehicle protects from the effect
-            "immune_outside_vehicle": false, // If true being *outside* a vehicle protects from the effect,
-            "chance_in_vehicle": 2,
-            "chance_inside_vehicle": 2,
-            "chance_outside_vehicle": 2, // 1-in-<chance> chance of the effect being applied when traversing a field in a vehicle, inside a vehicle (as in, under a roof), and outside a vehicle
-            "message": "You're debilitated!", // Message to print when the effect is applied to the player
-            "message_npc": "<npcname> is debilitated!", // Message to print when the effect is applied to an NPC
-            "message_type": "bad", // Type of the above messages - good/bad/mixed/neutral
-            "immunity_data": {...} // See Immunity Data below
-          }
-        ]
+        "effects": [  ] // List of effects applied to any creatures within the field as long as they aren't immune to the effect or the field itself. See field_effect below for syntax
         "scent_neutralization": 3, // Reduce scents at the field's position by this value        
     ],
     "npc_complain": { "chance": 20, "issue": "weed_smoke", "duration": "10 minutes", "speech": "<weed_smoke>" }, // NPCs in this field will complain about being in it once per <duration> if a 1-in-<chance> roll succeeds, giving off a <speech> bark that supports snippets
@@ -4507,6 +4487,33 @@ Defines field emissions
   "qty": 100,             // amount of fields that would be emitted, in a circle, 1 means 1 field; 9 would be 3x3, 16 would be 4x4 square etc
   "chance": 50            // chance to emit one unit of field, from 1 to 100
 },
+```
+
+## field_effect
+Field effect defines what effect/effects will be applied on character or monsters, and what immunity protections can be used to defend against this effect.
+currnetly used as `"effects"` field in `field_type`, and as `passive_effects` in `weather_type`
+
+```jsonc
+[
+  {
+    "effect_id": "webbed", // Effect ID
+    "min_duration": "1 minutes",
+    "max_duration": "5 minutes", // Effect duration randomized between min and max duration
+    "intensity": 1, // Intensity of the effect to apply
+    "body_part": "head", // Bodypart the effect gets applied to, default BP_NULL ("whole body")
+    "is_environmental": false, // If true the environmental effect roll is used to determine if the effect gets applied: intensity amount of d3 vs bodypart environment resistance amount of d3 
+    "immune_in_vehicle": false, // If true, *standing* inside a vehicle (like without walls or roof) protects from the effect
+    "immune_inside_vehicle": false, // If true, being inside a vehicle protects from the effect
+    "immune_outside_vehicle": false, // If true, being *outside* a vehicle protects from the effect,
+    "chance_in_vehicle": 2,
+    "chance_inside_vehicle": 2,
+    "chance_outside_vehicle": 2, // 1-in-<chance> chance of the effect being applied when traversing a field in a vehicle, inside a vehicle (as in, under a roof), and outside a vehicle
+    "message": "You're debilitated!", // Message to print when the effect is applied to the player
+    "message_npc": "<npcname> is debilitated!", // Message to print when the effect is applied to an NPC
+    "message_type": "bad", // Type of the above messages - good/bad/mixed/neutral
+    "immunity_data": {...} // See Immunity Data below
+  }
+]
 ```
 
 ## Immunity data

--- a/doc/JSON/WEATHER_TYPE.md
+++ b/doc/JSON/WEATHER_TYPE.md
@@ -30,6 +30,7 @@ Each weather type is a type of weather that occurs, and what causes it. The only
 | `condition`          | A dialog condition to determine if this weather is happening.  See Dialogue conditions section of [NPCs](NPCs.md) A context variable of `weather_location` contains the location of the current tile checking its weather.  This can be used to have weather be based on location. |
 | `priority`           | An integer.  If the condition of multiple weather types are true the one with higher priority wins. |
 | `required_weathers`  | A string array of possible weathers, it is at this point in the loop. i.e. rain can only happen if the conditions for clouds light drizzle or drizzle are present.  Required weathers need to have lower load orders to be. |
+| `passive_effects`    | Passive effects, that will be applied on character when this weather occurs; for detailed syntax, see [field_effect](JSON_INFO.md#field_effect) |
 
 #### `weather_type` example
 
@@ -51,6 +52,26 @@ Each weather type is a type of weather that occurs, and what causes it. The only
     "rains": true,
     "required_weathers": [ "thunder" ],
     "priority": 80,
-    "condition": { "math": [ "weather('pressure') < 990" ] }
+    "condition": { "math": [ "weather('pressure') < 990" ] },
+    "passive_effects": [
+      {
+        "effect_id": "smoke_eyes",
+        "body_part": "eyes",
+        "intensity": 1,
+        "min_duration": "2 seconds",
+        "max_duration": "2 seconds",
+        "immunity_data": { "body_part_env_resistance": [ [ "sensor", 3 ] ] },
+        "immune_inside_vehicle": true
+      },
+      {
+        "effect_id": "smoke_lungs",
+        "body_part": "mouth",
+        "intensity": 1,
+        "min_duration": "2 seconds",
+        "max_duration": "2 seconds",
+        "immunity_data": { "body_part_env_resistance": [ [ "mouth", 3 ] ], "flags": [ "INHALED_TOXIN_IMMUNE" ] },
+        "immune_inside_vehicle": true
+      }
+    ]
   }
 ]

--- a/src/field_type.cpp
+++ b/src/field_type.cpp
@@ -177,6 +177,28 @@ const field_intensity_level &field_type::get_intensity_level( int level ) const
     return intensity_levels[level];
 }
 
+void field_effect::deserialize( const JsonObject &jo )
+{
+    mandatory( jo, false, "effect_id", id );
+    optional( jo, false, "min_duration", min_duration );
+    optional( jo, false, "max_duration", max_duration );
+    optional( jo, false, "intensity", intensity );
+    optional( jo, false, "body_part", bp, bodypart_str_id::NULL_ID() );
+    optional( jo, false, "is_environmental", is_environmental );
+    optional( jo, false, "immune_in_vehicle", immune_in_vehicle );
+    optional( jo, false, "immune_inside_vehicle", immune_inside_vehicle );
+    optional( jo, false, "immune_outside_vehicle", immune_outside_vehicle );
+    optional( jo, false, "chance_in_vehicle", chance_in_vehicle );
+    optional( jo, false, "chance_inside_vehicle", chance_inside_vehicle );
+    optional( jo, false, "chance_outside_vehicle", chance_outside_vehicle );
+    optional( jo, false, "message", message );
+    optional( jo, false, "message_npc", message_npc );
+    const auto game_message_type_reader = enum_flags_reader<game_message_type> { "game message types" };
+    optional( jo, false, "message_type", env_message_type, game_message_type_reader );
+    JsonObject jid = jo.get_object( "immunity_data" );
+    field_types::load_immunity( jid, immunity_data );
+}
+
 void field_type::load( const JsonObject &jo, std::string_view )
 {
     optional( jo, was_loaded, "legacy_enum_id", legacy_enum_id, -1 );
@@ -230,25 +252,7 @@ void field_type::load( const JsonObject &jo, std::string_view )
         if( jao.has_array( "effects" ) ) {
             for( const JsonObject joe : jao.get_array( "effects" ) ) {
                 field_effect fe;
-                mandatory( joe, was_loaded, "effect_id", fe.id );
-                optional( joe, was_loaded, "min_duration", fe.min_duration );
-                optional( joe, was_loaded, "max_duration", fe.max_duration );
-                optional( joe, was_loaded, "intensity", fe.intensity );
-                optional( joe, was_loaded, "body_part", fe.bp, bodypart_str_id::NULL_ID() );
-                optional( joe, was_loaded, "is_environmental", fe.is_environmental );
-                optional( joe, was_loaded, "immune_in_vehicle", fe.immune_in_vehicle );
-                optional( joe, was_loaded, "immune_inside_vehicle", fe.immune_inside_vehicle );
-                optional( joe, was_loaded, "immune_outside_vehicle", fe.immune_outside_vehicle );
-                optional( joe, was_loaded, "chance_in_vehicle", fe.chance_in_vehicle );
-                optional( joe, was_loaded, "chance_inside_vehicle", fe.chance_inside_vehicle );
-                optional( joe, was_loaded, "chance_outside_vehicle", fe.chance_outside_vehicle );
-                optional( joe, was_loaded, "message", fe.message );
-                optional( joe, was_loaded, "message_npc", fe.message_npc );
-                const auto game_message_type_reader = enum_flags_reader<game_message_type> { "game message types" };
-                optional( joe, was_loaded, "message_type", fe.env_message_type, game_message_type_reader );
-                JsonObject jid = joe.get_object( "immunity_data" );
-                field_types::load_immunity( jid, fe.immunity_data );
-
+                fe.deserialize( joe );
                 intensity_level.field_effects.emplace_back( fe );
             }
         } else {

--- a/src/field_type.h
+++ b/src/field_type.h
@@ -64,7 +64,7 @@ struct field_immunity_data {
 
 struct field_effect {
     efftype_id id;
-    std::vector<std::pair<efftype_id, mod_id>> src;
+    std::vector<std::pair<efftype_id, mod_id>> src; // NOLINT(cata-serialize)
     time_duration min_duration = 0_seconds;
     time_duration max_duration = 0_seconds;
     int intensity = 0;
@@ -93,6 +93,8 @@ struct field_effect {
         return effect( effect_source::empty(), &id.obj(), get_duration(), bp, false, intensity,
                        start_time );
     }
+
+    void deserialize( const JsonObject &jo );
 };
 
 struct field_intensity_level {

--- a/src/map.h
+++ b/src/map.h
@@ -1899,6 +1899,8 @@ class map
         * direction from 'p', leaving a stump behind at 'p'.
         */
         void cut_down_tree( tripoint_bub_ms p, point_rel_ms dir );
+
+        void maybe_apply_field_effect( const std::vector<field_effect> &vfe, Creature &critter ) const;
     protected:
         /**
          * Radiation-related plant (and fungus?) death.

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -470,6 +470,11 @@ void handle_weather_effects( const weather_type_id &w )
         }
     }
     glare( w );
+
+    for( Creature &c : g->all_creatures() ) {
+        here.maybe_apply_field_effect( w->passive_effect, c );
+    }
+
     get_weather().lightning_active = false;
 }
 

--- a/src/weather_type.cpp
+++ b/src/weather_type.cpp
@@ -121,6 +121,14 @@ void weather_type::load( const JsonObject &jo, std::string_view )
     if( duration_min > duration_max ) {
         jo.throw_error( "duration_min must be less than or equal to duration_max" );
     }
+
+    if( jo.has_array( "passive_effects" ) ) {
+        for( JsonObject job : jo.get_array( "passive_effects" ) ) {
+            field_effect fe;
+            fe.deserialize( job );
+            passive_effect.emplace_back( fe );
+        }
+    }
     optional( jo, was_loaded, "debug_cause_eoc", debug_cause_eoc );
     optional( jo, was_loaded, "debug_leave_eoc", debug_leave_eoc );
 

--- a/src/weather_type.h
+++ b/src/weather_type.h
@@ -13,6 +13,7 @@
 #include "calendar.h"
 #include "catacharset.h"
 #include "color.h"
+#include "field_type.h"
 #include "translation.h"
 #include "type_id.h"
 
@@ -119,6 +120,9 @@ struct weather_type {
         time_duration duration_max = 0_turns;
         std::optional<std::string> debug_cause_eoc;
         std::optional<std::string> debug_leave_eoc;
+        // what effects are applied to you when you visit this dimension
+        // and what protection you may use to counter it
+        std::vector<field_effect> passive_effect;
         void load( const JsonObject &jo, std::string_view src );
         void finalize();
         void check() const;


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
<img width="505" height="207" alt="image" src="https://github.com/user-attachments/assets/c482366d-0b8e-47b4-b6d1-1c1f8f111174" />

<img width="507" height="83" alt="image" src="https://github.com/user-attachments/assets/ae3b4eed-5734-4c19-b006-ec6f3aefc5cf" />

<img width="495" height="144" alt="image" src="https://github.com/user-attachments/assets/be97fee6-d344-4316-92f7-87aab36b320d" />

Except region setting do not have any reasonable framework to apply effect, nor it really should have
What should have such? 
Weather
#### Describe the solution
Add `passive_effects` field for weather, that reuses existing field_effect struct (used in, as you guess it, in fields) that allow to specify effect applied to player when this weather appears, and means to protect against it; Effect is applied to all creatures when such weather starts
Also a bit of code and docs shuffling to make a reusability simpler

#### Testing
<img width="504" height="443" alt="image" src="https://github.com/user-attachments/assets/153aa07f-0bb4-47e3-9c50-c30bf8b4c408" />

#### Additional context
As part of the same PR i wanted to make glare and wetness be applied to all creatures in bub (i didn't know it, but yes, only player character is affected by rain) but didn't figure if it's desired or not