### PR TITLE
Wind Seasonal Variation Sanification

### DIFF
--- a/data/json/region_settings/region_settings/dimensions/highland_dimension.json
+++ b/data/json/region_settings/region_settings/dimensions/highland_dimension.json
@@ -81,7 +81,7 @@
     "base_pressure": 995.0,
     "base_wind": 2.0,
     "base_wind_distrib_peaks": 80,
-    "base_wind_season_variation": 50,
+    "base_wind_season_variation": 0,
     "weather_white_list": [ "clear", "cloudy", "afs_whiteout", "light_drizzle", "rain", "mist", "fog" ]
   }
 ]

--- a/data/json/region_settings/region_settings/regional_map_settings.json
+++ b/data/json/region_settings/region_settings/regional_map_settings.json
@@ -1649,6 +1649,6 @@
     "base_pressure": 1015.0,
     "base_wind": 3.4,
     "base_wind_distrib_peaks": 80,
-    "base_wind_season_variation": 50
+    "base_wind_season_variation": 0
   }
 ]

--- a/data/json/region_settings/region_settings/test_regional_map_settings.json
+++ b/data/json/region_settings/region_settings/test_regional_map_settings.json
@@ -119,6 +119,6 @@
     "base_pressure": 1015.0,
     "base_wind": 90.0,
     "base_wind_distrib_peaks": 80,
-    "base_wind_season_variation": 50
+    "base_wind_season_variation": 0
   }
 ]

--- a/data/mods/Backrooms/region_settings/region_settings/regional_map_settings.json
+++ b/data/mods/Backrooms/region_settings/region_settings/regional_map_settings.json
@@ -8,7 +8,7 @@
     "base_pressure": 1015.0,
     "base_wind": 3.4,
     "base_wind_distrib_peaks": 80,
-    "base_wind_season_variation": 50,
+    "base_wind_season_variation": 0,
     "weather_black_list": [ "early_portal_storm", "portal_storm" ]
   },
   {

--- a/data/mods/TropiCataclysm/region_settings/tropical_regional_map_settings.json
+++ b/data/mods/TropiCataclysm/region_settings/tropical_regional_map_settings.json
@@ -30,7 +30,7 @@
     "base_pressure": 1010.0,
     "base_wind": 6.0,
     "base_wind_distrib_peaks": 30,
-    "base_wind_season_variation": 64,
+    "base_wind_season_variation": 0,
     "spring_temp_manual_mod": 5,
     "summer_temp_manual_mod": 0,
     "autumn_temp_manual_mod": 3,

--- a/data/mods/aftershock_exoplanet/region_settings/region_settings/region_settings.json
+++ b/data/mods/aftershock_exoplanet/region_settings/region_settings/region_settings.json
@@ -83,7 +83,7 @@
     "base_pressure": 1015.0,
     "base_wind": 9.0,
     "base_wind_distrib_peaks": 80,
-    "base_wind_season_variation": 50,
+    "base_wind_season_variation": 0,
     "weather_white_list": [ "clear", "sunny", "cloudy", "afs_whiteout", "afs_thunder", "afs_lightning", "afs_flurries", "afs_snowing" ]
   },
   {

--- a/data/mods/desert_region/region_settings/region_settings/desert_regional_map_settings.json
+++ b/data/mods/desert_region/region_settings/region_settings/desert_regional_map_settings.json
@@ -58,7 +58,7 @@
     "base_pressure": 1025.0,
     "base_wind": 5.7,
     "base_wind_distrib_peaks": 20,
-    "base_wind_season_variation": 40,
+    "base_wind_season_variation": 0,
     "summer_temp_manual_mod": 25,
     "spring_temp_manual_mod": 15,
     "autumn_temp_manual_mod": 15,

--- a/data/mods/rural_biome/region_settings/region_settings/rural_regional_map_settings.json
+++ b/data/mods/rural_biome/region_settings/region_settings/rural_regional_map_settings.json
@@ -234,7 +234,7 @@
     "base_pressure": 1015.0,
     "base_wind": 3.4,
     "base_wind_distrib_peaks": 80,
-    "base_wind_season_variation": 50
+    "base_wind_season_variation": 0
   },
   {
     "type": "map_extra_collection",

--- a/doc/JSON/REGION_SETTINGS.md
+++ b/doc/JSON/REGION_SETTINGS.md
@@ -559,7 +559,7 @@ See above.
 | `base_pressure`                | Base pressure for the region in millibars.  Increasing it decreases the wind strength |
 | `base_wind`                    | Base wind for the region in mph units. Roughly the yearly average.    |
 | `base_wind_distrib_peaks`      | How high the wind peaks can go. Higher values produce windier days.   |
-| `base_wind_season_variation`   | How the wind varies with season. Bigger values produce more variation |
+| `base_wind_season_variation`   | How the wind varies with season. Increases wind speed in the summer, decreases wind speed in the winter. Larger values amplify effects, negative values reverse effects.  |
 | `weather_black_list`           | Ids of weather types not allowed in this region.                      |
 | `weather_white_list`           | Ids of the only weather types allowed in this region.                 |
 

--- a/src/weather_gen.cpp
+++ b/src/weather_gen.cpp
@@ -195,7 +195,7 @@ w_point weather_generator::get_weather( const tripoint_abs_ms &location, const t
 
     // Wind power
     const double variation = base_wind_season_variation == 0 ? 0 :
-                             -cyf / base_wind_season_variation * rng( 1, 2 );
+                             cyf * base_wind_season_variation * rng_float( 0, 2 );
     W = std::max( 0, static_cast<int>( base_wind * rng( 1, 2 ) / std::pow( ( P + W ) / 1014.78, rng( 9,
                                        base_wind_distrib_peaks ) ) + variation ) );
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Adjusts region seasonal wind variation so it actually does something"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
More details described in resolved #85059. The way the base_wind_season_variation variable worked was unintuitive, and the most common setting for it (50+) caused it to do virtually nothing. Additionally, when manipulated into being somewhat functional it had the reverse effect of what was expected.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adjusts the variation formula under Wind Power so that base_wind_season_variation multiplies the value, rather that dividing it. Additionally, reverse the sign of the variable to reverse the phase of this effect. Documentation has been updated accordingly.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

- Make base_wind_season_variation accept non-integers, values between 0-1 increase the magnitude: Seems overcomplicated & unintuitive
- Don't reverse the sign: Admittedly this is pedantry, but changing it is more in line with what you would expect out of seasonal wind variance.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

 - Built & Ran after making changes.
 - Ran debug -> (i)nfo -> Test (W)eather with base_wind_season_variation at 0, showed peaks of 279 mph winds in January (typical for default climate)
 - Changed base_wind_season_variation value to 100000, saw peaks of 199432 mph winds in January. Average wind speeds rose accordingly.
 - Negative values of base_wind_season_variation reversed the effect as expected.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Additional context (images & data) are in issue #85059. I'll consolidate this process for future PRs.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
