### PR TITLE
Speed up autopickup

### DIFF
--- a/src/auto_pickup.cpp
+++ b/src/auto_pickup.cpp
@@ -253,9 +253,6 @@ static std::vector<item_location> get_autopickup_items( item_location &from )
 drop_locations auto_pickup::select_items(
     const std::vector<item_stack::iterator> &from, const tripoint_bub_ms &location )
 {
-    auto start = std::chrono::high_resolution_clock::now(); // debug timing
-    int items_checked = 0; // debug timing
-
     bool picking_up_itype_id;
     itype_id picking_up_last_itype_id;
     drop_locations result;
@@ -264,7 +261,6 @@ drop_locations auto_pickup::select_items(
     // iterate over all item stacks found in location
     for( const item_stack::iterator &stack : from ) {
         item *item_entry = &*stack;
-        items_checked++;
 
         if( item_entry->typeId() != picking_up_last_itype_id ) {
             picking_up_itype_id = false;
@@ -307,12 +303,6 @@ drop_locations auto_pickup::select_items(
                 result.emplace_back( std::make_pair( add_item, it_count ) );
             }
         }
-    }
-
-    if( items_checked > 0 ) { // debug timing
-        auto end = std::chrono::high_resolution_clock::now();
-        auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
-        debugmsg( "Run time: %d for %d items", duration.count(), items_checked );
     }
     return result;
 }

--- a/src/auto_pickup.cpp
+++ b/src/auto_pickup.cpp
@@ -253,12 +253,16 @@ static std::vector<item_location> get_autopickup_items( item_location &from )
 drop_locations auto_pickup::select_items(
     const std::vector<item_stack::iterator> &from, const tripoint_bub_ms &location )
 {
+    auto start = std::chrono::high_resolution_clock::now(); // debug timing
+    int items_checked = 0; // debug timing
+
     drop_locations result;
     const map_cursor map_location = map_cursor( location );
 
     // iterate over all item stacks found in location
     for( const item_stack::iterator &stack : from ) {
         item *item_entry = &*stack;
+        items_checked++;
         // do not auto pickup owned containers or items
         if( !get_option<bool>( "AUTO_PICKUP_OWNED" ) &&
             item_entry->is_owned_by( get_player_character() ) ) {
@@ -290,6 +294,12 @@ drop_locations auto_pickup::select_items(
                 result.emplace_back( std::make_pair( add_item, it_count ) );
             }
         }
+    }
+
+    if( items_checked > 0 ) { // debug timing
+        auto end = std::chrono::high_resolution_clock::now();
+        auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+        debugmsg( "Run time: %d for %d items", duration.count(), items_checked );
     }
     return result;
 }

--- a/src/auto_pickup.cpp
+++ b/src/auto_pickup.cpp
@@ -253,8 +253,8 @@ static std::vector<item_location> get_autopickup_items( item_location &from )
 drop_locations auto_pickup::select_items(
     const std::vector<item_stack::iterator> &from, const tripoint_bub_ms &location )
 {
-    bool picking_up_itype_id;
-    itype_id picking_up_last_itype_id;
+    bool picking_up_itype_id = true;
+    itype_id picking_up_last_itype_id = itype_id::NULL_ID();
     drop_locations result;
     const map_cursor map_location = map_cursor( location );
 


### PR DESCRIPTION
#### Summary
Performance "Speed up autopickup by skipping items that were already checked"

#### Purpose of change

Autopickup checks slow down the game when they encounter large stacks of items.

- https://github.com/CleverRaven/Cataclysm-DDA/issues/84569
- https://github.com/CleverRaven/Cataclysm-DDA/issues/38340

#### Describe the solution

Within a stack, skip over items that have the same itype after the first of that itype wasn't picked up.

#### Describe alternatives you've considered

1. Is there a faster way to check if items are identical than `typeId()`?

#### Testing

I sorted some evac shelter stuff into a pile then spawned a bunch of butchery refuse, chunks of chitin, and strands of endochitin.  I added 1 autopickup rule and enabled autopickup for owned items.  In some tests I put down a stack of 10 items that were picked up.  I walked over the pile 3 times did a save/load cycle between each test.

```
$ spark 12169 7865 7819 0 12286 7972 7876 0 0 0 6162 2085 2070 0 6246 2089 2043
▇▅▅▁█▅▅▁▁▁▄▂▂▁▄▂▂
☝️Before  ☝️After

▇█▁▁▄▄ 👈 first time seeing a pile
Be  Af

▇▇█▇▁▁▂▂▂▂  👈 subsequent checks for a pile
Be    Af
```

<details><summary>The numbers</summary>
<p>

##### Before
No items to pick up:
Run time: 12169 for 3232 items
Run time: 7865 for 3232 items
Run time: 7819 for 3232 items

Stack of 10 items to pick up:
Run time: 12286 for 3242 items
Run time: 7972 for 3242 items
Run time: 7876 for 3242 items

##### After
No items to pick up:
Run time: 6162 for 3232 items
Run time: 2085 for 3232 items
Run time: 2070 for 3232 items

Stack of 10 items to pick up:
Run time: 6246 for 3242 items
Run time: 2089 for 3242 items
Run time: 2043 for 3242 items

</p>
</details> 

#### Additional context

I added and reverted the code I used to time this in 36a4f831d75ed5cd72f3c8335085e44598a001d4 and 5ee719d98c499e4890a831ec194b576d66c66dc5 respectively.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
