### PR TITLE
[MoM] Added category tags to matrix crystals that were missing it

### DIFF
--- a/data/mods/MindOverMatter/items/matrix_crystals.json
+++ b/data/mods/MindOverMatter/items/matrix_crystals.json
@@ -242,6 +242,7 @@
   {
     "type": "ITEM",
     "subtypes": [ "ARTIFACT" ],
+    "category": "artifacts",
     "id": "matrix_crystal_pyrokinesis_artifact",
     "name": { "str_sp": "strange crystal, red" },
     "description": "A strange-looking, surprisingly-heavy crystal with a faintly-glowing red light in its depths.  Holding it, you feel hot.",
@@ -388,6 +389,7 @@
   {
     "type": "ITEM",
     "subtypes": [ "ARTIFACT" ],
+    "category": "artifacts",
     "id": "matrix_crystal_vitakinesis_artifact",
     "name": { "str_sp": "strange crystal, green" },
     "description": "A strange-looking, surprisingly-heavy crystal with a faintly-glowing green light in its depths.  Holding it, you feel healthier.",


### PR DESCRIPTION
#### Summary
Bugfixes "add missing category tags to matrix_crystals document"

#### Purpose of change

Added these tags so that items would sort consistently in inventory.

#### Describe the solution

Added a simple category tag to the two items that were missing it.

#### Describe alternatives you've considered

Doing nothing or letting someone else do something.  I'm not sure how else this could be addressed across the board _except_ by maybe using a copy-from tag like the non-artifact crystals use to assign these values.  That option would probably homogenize the approach a little bit but I'm not totally comfortable making sweeping changes to something that a) I don't fully understand, and b) is someone else's work.

#### Testing

I tested it and it works.

#### Additional context

Before:
<img width="736" height="184" alt="before" src="https://github.com/user-attachments/assets/0c1eea06-3fbd-4a84-8af6-16a0793cdadc" />

After:
<img width="763" height="184" alt="after" src="https://github.com/user-attachments/assets/0d13bd51-1eeb-45e5-a5f3-5b7b498724c5" />

