### PR TITLE
Add missing components to view priority from crafting menu

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -888,10 +888,7 @@
     "id": "PRIORITIZE_MISSING_COMPONENTS",
     "category": "CRAFTING",
     "name": "Add missing components to high priority in Item List",
-    "bindings": [
-      { "input_method": "keyboard_char", "key": "+" },
-      { "input_method": "keyboard_code", "key": "=", "mod": [ "shift" ] }
-    ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "+" }, { "input_method": "keyboard_code", "key": "=", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -885,6 +885,16 @@
   },
   {
     "type": "keybinding",
+    "id": "PRIORITIZE_MISSING_COMPONENTS",
+    "category": "CRAFTING",
+    "name": "Add missing components to high priority in Item List",
+    "bindings": [
+      { "input_method": "keyboard_char", "key": "+" },
+      { "input_method": "keyboard_code", "key": "=", "mod": [ "shift" ] }
+    ]
+  },
+  {
+    "type": "keybinding",
     "id": "LEVEL_UP",
     "name": "Go up",
     "bindings": [

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -2131,7 +2131,7 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
             ui.invalidate_ui();
 
             int new_filters_count = 0;
-            std::string added_filters = "";
+            std::string added_filters;
             const requirement_data &req = current[line]->simple_requirements();
             const inventory &crafting_inv = crafter->crafting_inventory();
             for( const std::vector<item_comp> &comp_list : req.get_components() ) {
@@ -2150,7 +2150,7 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
             }
 
             if( new_filters_count > 0 ) {
-                if( uistate.list_item_priority.size()
+                if( !uistate.list_item_priority.empty()
                     && !string_ends_with( uistate.list_item_priority, "," ) ) {
                     uistate.list_item_priority += ",";
                 }

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -644,6 +644,7 @@ static input_context make_crafting_context( bool highlight_unread_recipes )
     ctxt.register_action( "SCROLL_UP" );
     ctxt.register_action( "SCROLL_DOWN" );
     ctxt.register_action( "COMPARE" );
+    ctxt.register_action( "PRIORITIZE_MISSING_COMPONENTS" );
     if( highlight_unread_recipes ) {
         ctxt.register_action( "TOGGLE_RECIPE_UNREAD" );
         ctxt.register_action( "MARK_ALL_RECIPES_READ" );
@@ -1360,6 +1361,7 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
         add_action_desc( "TOGGLE_FAVORITE", pgettext( "crafting gui", "Favorite" ) );
         add_action_desc( "CYCLE_BATCH", pgettext( "crafting gui", "Batch" ) );
         add_action_desc( "CHOOSE_CRAFTER", pgettext( "crafting gui", "Choose crafter" ) );
+        add_action_desc( "PRIORITIZE_MISSING_COMPONENTS", pgettext( "crafting gui", "Prioritize" ) );
         add_action_desc( "HELP_KEYBINDINGS", pgettext( "crafting gui", "Keybindings" ) );
         keybinding_x = isWide ? 5 : 2;
         keybinding_tips = foldstring( enumerate_as_string( act_descs, enumeration_conjunction::none ),
@@ -2123,6 +2125,47 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
         } else if( action == "COMPARE" && selection_ok( current, line, false ) ) {
             const item recipe_result = get_recipe_result_item( *current[line], *crafter );
             compare_recipe_with_item( recipe_result, *crafter );
+        } else if( action == "PRIORITIZE_MISSING_COMPONENTS" && selection_ok( current, line, false ) ) {
+            uistate.read_recipes.insert( current[line]->ident() );
+            recalc_unread = highlight_unread_recipes;
+            ui.invalidate_ui();
+
+            int new_filters_count = 0;
+            std::string added_filters = "";
+            const requirement_data &req = current[line]->simple_requirements();
+            const inventory &crafting_inv = crafter->crafting_inventory();
+            for( const std::vector<item_comp> &comp_list : req.get_components() ) {
+                for( const item_comp &i_comp : comp_list ) {
+                    std::string nname = item::nname( i_comp.type, 1 );
+                    int filter_pos = uistate.list_item_priority.find( nname );
+                    bool enough_materials = req.check_enough_materials(
+                        i_comp, crafting_inv, current[line]->get_component_filter(), batch_size_out
+                    );
+                    if ( filter_pos == -1 && !enough_materials ) {
+                        new_filters_count++;
+                        added_filters += nname;
+                        added_filters += ",";
+                    }
+                }
+            }
+
+            if ( new_filters_count > 0 )
+            {
+                if ( uistate.list_item_priority.size()
+                        && !string_ends_with( uistate.list_item_priority, "," ) ) {
+                    uistate.list_item_priority += ",";
+                }
+                uistate.list_item_priority += added_filters;
+                uistate.list_item_priority_active = true;
+                std::vector<std::string> &hist = uistate.gethistory( "list_item_priority" );
+                if( hist.empty() || hist[hist.size() - 1] != uistate.list_item_priority ) {
+                    hist.push_back( uistate.list_item_priority );
+                }
+
+                popup( string_format( _( "Added %d components to the priority filter.\nAdded: %s\nNew Filter: %s" ), new_filters_count, added_filters, uistate.list_item_priority ) );
+            } else {
+                popup( string_format( _( "Did not find anything to add to the priority filter.\nFilter: %s" ), uistate.list_item_priority ) );
+            }
         } else if( action == "HELP_KEYBINDINGS" ) {
             // Regenerate keybinding tips
             ui.mark_resize();

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -2139,9 +2139,9 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
                     std::string nname = item::nname( i_comp.type, 1 );
                     int filter_pos = uistate.list_item_priority.find( nname );
                     bool enough_materials = req.check_enough_materials(
-                        i_comp, crafting_inv, current[line]->get_component_filter(), batch_size_out
-                    );
-                    if ( filter_pos == -1 && !enough_materials ) {
+                                                i_comp, crafting_inv, current[line]->get_component_filter(), batch_size_out
+                                            );
+                    if( filter_pos == -1 && !enough_materials ) {
                         new_filters_count++;
                         added_filters += nname;
                         added_filters += ",";
@@ -2149,10 +2149,9 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
                 }
             }
 
-            if ( new_filters_count > 0 )
-            {
-                if ( uistate.list_item_priority.size()
-                        && !string_ends_with( uistate.list_item_priority, "," ) ) {
+            if( new_filters_count > 0 ) {
+                if( uistate.list_item_priority.size()
+                    && !string_ends_with( uistate.list_item_priority, "," ) ) {
                     uistate.list_item_priority += ",";
                 }
                 uistate.list_item_priority += added_filters;
@@ -2162,9 +2161,11 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
                     hist.push_back( uistate.list_item_priority );
                 }
 
-                popup( string_format( _( "Added %d components to the priority filter.\nAdded: %s\nNew Filter: %s" ), new_filters_count, added_filters, uistate.list_item_priority ) );
+                popup( string_format( _( "Added %d components to the priority filter.\nAdded: %s\nNew Filter: %s" ),
+                                      new_filters_count, added_filters, uistate.list_item_priority ) );
             } else {
-                popup( string_format( _( "Did not find anything to add to the priority filter.\nFilter: %s" ), uistate.list_item_priority ) );
+                popup( string_format( _( "Did not find anything to add to the priority filter.\nFilter: %s" ),
+                                      uistate.list_item_priority ) );
             }
         } else if( action == "HELP_KEYBINDINGS" ) {
             // Regenerate keybinding tips

--- a/src/requirements.h
+++ b/src/requirements.h
@@ -347,6 +347,12 @@ struct requirement_data {
         bool can_make_with_inventory( const read_only_visitable &crafting_inv,
                                       const std::function<bool( const item & )> &filter, int batch = 1,
                                       craft_flags = craft_flags::none, bool restrict_volume = true ) const;
+        /**
+         * Returns true if there are enough item_comp in the crafting_inv for this recipe.
+         * @param filter should be recipe::get_component_filter() if used with a recipe, as above.
+         */
+        bool check_enough_materials( const item_comp &comp, const read_only_visitable &crafting_inv,
+                                     const std::function<bool( const item & )> &filter, int batch = 1 ) const;
 
         /** @param filter see @ref can_make_with_inventory */
         std::vector<std::string> get_folded_components_list( int width, nc_color col,
@@ -397,8 +403,6 @@ struct requirement_data {
         bool check_enough_materials( const read_only_visitable &crafting_inv,
                                      const std::function<bool( const item & )> &filter, int batch = 1,
                                      bool restrict_volume = true ) const;
-        bool check_enough_materials( const item_comp &comp, const read_only_visitable &crafting_inv,
-                                     const std::function<bool( const item & )> &filter, int batch = 1 ) const;
 
         template<typename T>
         static void check_consistency( const std::vector< std::vector<T> > &vec,


### PR DESCRIPTION
#### Summary

Interface "Add missing components to view priority from crafting menu"

#### Purpose of change

I like playing Sky Island but I do not like managing view priority for 50 some odd components I'm searching for to advance the warp crafting.

#### Describe the solution

Add an option to append all of the missing crafting components for the currently selected recipe in the crafting menu to the view priority list.

#### Describe alternatives you've considered

1. Option in the view list to highlight all components of all favorites recipes.
2. Keep a list on paper while playing the game.

#### Testing

1. Cleared priority list and set it to "duct tape".
2. Open craft menu and hover over adhesive bandage:
```
Components required:
> 1 medical gauze (have 6)
> 10 medical tape (have 6) OR 8 duct tape
```
3. Press `shift`+`=` to activate new key binding. It added medical tape:
```
Added 1 components to the priority filter.
Added: medical tape,
New Filter: duct tape,medical tape,
```
4. Press `shift`+`=` again. It doesn't add anything:
```
Did not find anything to add to the priority filter.
Filter: duct tape,medical tape,
```
5. Went to the priority list and used `ctrl`+`u` to clear the filter.
6. Opened crafting and added firecracker components to my list.
```
Components required:
> 10 thread
> 1 paper OR 6 rolling paper
> 50 black gunpowder OR 50 mixed smokeless
  gunpowder

Added 5 components to the priority filter.
Added: thread,paper,rolling paper,mixed smokeless gunpowder,black gunpowder
New Filter: thread,paper,rolling paper,mixed smokeless gunpowder,black
gunpowder,
```
7. Opened high priority list, pressed up to open history:
```
d: delete history
  duct tape
  duct tape,medical tape,
  thread,paper,rolling paper,mixed smokeless gunpowder,black gunpowder,
```
8. Saved, reloaded, verified current filter and history was persisted.
9. Added way too many items to the filter (whatever was on the food crafting list). The curses UI cannot handle displaying the filter at all (make sure to scroll right on this one):
```
retin,cooked mongrel,pickled meat,smoked meat,salted meat slice,dehydr............                                                    ked sausage,wasteland sausage,bratwurst,fried meat,cracklins
^^ This is in the high priority history window, truncated.            ^^ The ground behind the window                                 ^^ Filters overflows onto the item filter sidebar.
```
In tiles:
<img width="1728" height="597" alt="image" src="https://github.com/user-attachments/assets/87aeb8e6-924b-48ad-a4bb-12b0cf38eb81" />

#### Additional context

1. You can make extremely long filter lists with this feature.  They break the UI.
2. I think we'll need to change the item filter UI to be more like the diary multi-line input to allow super long lists of filters.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
