### PR TITLE
Support copy from in string extractor for overmap special

### DIFF
--- a/lang/string_extractor/parsers/overmap_special.py
+++ b/lang/string_extractor/parsers/overmap_special.py
@@ -10,4 +10,4 @@ def parse_overmap_special(json, origin):
 
         for om in overmaps:
             write_text(om.get("camp_name"), origin,
-                    comment="Name of NPC faction camp")
+                       comment="Name of NPC faction camp")

--- a/lang/string_extractor/parsers/overmap_special.py
+++ b/lang/string_extractor/parsers/overmap_special.py
@@ -3,10 +3,11 @@ from ..write_text import write_text
 
 def parse_overmap_special(json, origin):
 
-    overmaps = json["overmaps"]
+    overmaps = json.get("overmaps")
     if json.get("subtype") == "mutable":
-        overmaps = json["overmaps"].values()
+        overmaps = json.get("overmaps").values()
 
-    for om in overmaps:
-        write_text(om.get("camp_name"), origin,
-                   comment="Name of NPC faction camp")
+    if (overmaps):
+        for om in overmaps:
+            write_text(om.get("camp_name"), origin,
+                    comment="Name of NPC faction camp")

--- a/lang/string_extractor/parsers/overmap_special.py
+++ b/lang/string_extractor/parsers/overmap_special.py
@@ -4,10 +4,10 @@ from ..write_text import write_text
 def parse_overmap_special(json, origin):
 
     overmaps = json.get("overmaps")
-    if json.get("subtype") == "mutable":
-        overmaps = json.get("overmaps").values()
-
     if (overmaps):
+        if json.get("subtype") == "mutable":
+            overmaps = json.get("overmaps").values()
+
         for om in overmaps:
             write_text(om.get("camp_name"), origin,
                     comment="Name of NPC faction camp")


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Support copy from in string extractor for overmap special"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Change the logic for string extraction from overmap_special objects to support copy-from.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
The python script to extract strings from overmap_special objects assumes that the object always has the overmaps property. This changes the script to use get on the property and skip if the property doesn't exist
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Running the updated script locally on #85025 no longer errors as seen in the failed run [here](https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/21519867350/job/62007778844?pr=85025)
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
This is only for the string extractor, it does not fix the other problem, copy-from is not properly supported for overmap_specials as documented here #85024

Thinking about this, the other parsers could probably do with an audit for this same thing
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
