### PR TITLE
Fix surroundings menu freeze

### DIFF
--- a/src/text.cpp
+++ b/src/text.cpp
@@ -343,6 +343,11 @@ static std::string trim_substring( std::string_view text, float width )
 {
     std::string ellipsis = "\u2026";
     float ellipsis_width = ImGui::CalcTextSize( ellipsis.c_str() ).x;
+
+    if( width < ellipsis_width ) {
+        return ellipsis;
+    }
+
     // estimate number of visible characters by ellipsis width
     int visible_chars = width / ellipsis_width;
     float last_free = 0.f;
@@ -421,7 +426,7 @@ static std::string trim_by_width( std::string_view text, float width )
         if( str_width > width || ( str_width == width && i + 1 < color_segments.size() ) ) {
             // This segment won't fit OR
             // This segment just fits and there's another segment coming
-            // truncate_substring already appends the ellipsis
+            // trim_substring already appends the ellipsis
             temp_str = color_open_tag
                        .append( trim_substring( temp_str, temp_width - ( str_width - width ) ) )
                        .append( color_close_tag );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fixes #84965

#### Describe the solution

The text trimming algorithm would cause an infinite loop when the available width for a substring was smaller than the width of an ellipsis. So when we get that case, just trim the whole substring an return an ellipsis.
Also fixed a comment typo I noticed.

#### Describe alternatives you've considered

Improve the algorithm so it doesn't even call `trim_substring` in such a case.

#### Testing

Using the config from https://github.com/CleverRaven/Cataclysm-DDA/issues/84965#issuecomment-3837345268, just teleporting to a random city in any save and opening the surroundings menu would cause the freeze for me. With the fix it just opens the menu.

#### Additional context

