### PR TITLE
Add deprioritize components of a recipe to the crafting menu

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -899,10 +899,7 @@
     "id": "DEPRIORITIZE_COMPONENTS",
     "category": "CRAFTING",
     "name": "Remove components from high priority in Item List",
-    "bindings": [
-      { "input_method": "keyboard_any", "key": "-" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" }
-    ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "-" }, { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" } ]
   },
   {
     "type": "keybinding",

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -888,7 +888,21 @@
     "id": "PRIORITIZE_MISSING_COMPONENTS",
     "category": "CRAFTING",
     "name": "Add missing components to high priority in Item List",
-    "bindings": [ { "input_method": "keyboard_char", "key": "+" }, { "input_method": "keyboard_code", "key": "=", "mod": [ "shift" ] } ]
+    "bindings": [
+      { "input_method": "keyboard_char", "key": "+" },
+      { "input_method": "keyboard_code", "key": "=", "mod": [ "shift" ] },
+      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" }
+    ]
+  },
+  {
+    "type": "keybinding",
+    "id": "DEPRIORITIZE_COMPONENTS",
+    "category": "CRAFTING",
+    "name": "Remove components from high priority in Item List",
+    "bindings": [
+      { "input_method": "keyboard_any", "key": "-" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" }
+    ]
   },
   {
     "type": "keybinding",

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -645,6 +645,7 @@ static input_context make_crafting_context( bool highlight_unread_recipes )
     ctxt.register_action( "SCROLL_DOWN" );
     ctxt.register_action( "COMPARE" );
     ctxt.register_action( "PRIORITIZE_MISSING_COMPONENTS" );
+    ctxt.register_action( "DEPRIORITIZE_COMPONENTS" );
     if( highlight_unread_recipes ) {
         ctxt.register_action( "TOGGLE_RECIPE_UNREAD" );
         ctxt.register_action( "MARK_ALL_RECIPES_READ" );
@@ -1362,6 +1363,7 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
         add_action_desc( "CYCLE_BATCH", pgettext( "crafting gui", "Batch" ) );
         add_action_desc( "CHOOSE_CRAFTER", pgettext( "crafting gui", "Choose crafter" ) );
         add_action_desc( "PRIORITIZE_MISSING_COMPONENTS", pgettext( "crafting gui", "Prioritize" ) );
+        add_action_desc( "DEPRIORITIZE_COMPONENTS", pgettext( "crafting gui", "Deprioritize" ) );
         add_action_desc( "HELP_KEYBINDINGS", pgettext( "crafting gui", "Keybindings" ) );
         keybinding_x = isWide ? 5 : 2;
         keybinding_tips = foldstring( enumerate_as_string( act_descs, enumeration_conjunction::none ),
@@ -2165,6 +2167,52 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
                                       new_filters_count, added_filters, uistate.list_item_priority ) );
             } else {
                 popup( string_format( _( "Did not find anything to add to the priority filter.\nFilter: %s" ),
+                                      uistate.list_item_priority ) );
+            }
+        } else if( action == "DEPRIORITIZE_COMPONENTS" ) {
+            uistate.read_recipes.insert( current[line]->ident() );
+            recalc_unread = highlight_unread_recipes;
+            ui.invalidate_ui();
+
+            int removed_filters_count = 0;
+            std::string removed_filters;
+            const requirement_data &req = current[line]->simple_requirements();
+            for( const std::vector<item_comp> &comp_list : req.get_components() ) {
+                for( const item_comp &i_comp : comp_list ) {
+                    std::string nname = item::nname( i_comp.type, 1 );
+                    nname += ",";
+                    if( string_starts_with( uistate.list_item_priority, nname ) ) {
+                        removed_filters_count++;
+                        removed_filters += nname;
+                        uistate.list_item_priority.erase( 0, nname.length() );
+                    } else {
+                        std::string find_string = "," + nname;
+                        int filter_pos = uistate.list_item_priority.find( find_string );
+                        if( filter_pos > -1 ) {
+                            removed_filters_count++;
+                            removed_filters += nname;
+                            uistate.list_item_priority.replace( filter_pos, find_string.length(), "," );
+                        }
+                    }
+                }
+            }
+
+            if( !uistate.list_item_priority.empty() ) {
+                uistate.list_item_priority_active = true;
+
+                std::vector<std::string> &hist = uistate.gethistory( "list_item_priority" );
+                if( hist.empty() || hist[hist.size() - 1] != uistate.list_item_priority ) {
+                    hist.push_back( uistate.list_item_priority );
+                }
+            } else {
+                uistate.list_item_priority_active = false;
+            }
+
+            if( removed_filters_count > 0 ) {
+                popup( string_format( _( "Removed %d components from the priority filter.\nRemoved: %s\nNew Filter: %s" ),
+                                      removed_filters_count, removed_filters, uistate.list_item_priority ) );
+            } else {
+                popup( string_format( _( "Did not find anything to remove from the priority filter.\nFilter: %s" ),
                                       uistate.list_item_priority ) );
             }
         } else if( action == "HELP_KEYBINDINGS" ) {

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -133,6 +133,8 @@ static int related_menu_fill( uilist &rmenu,
                               const recipe_subset &available );
 static item get_recipe_result_item( const recipe &rec, Character &crafter );
 static void compare_recipe_with_item( const item &recipe_item, Character &crafter );
+static void prioritize_components( const recipe &recipe, Character &crafter );
+static void deprioritize_components( const recipe &recipe );
 
 static std::string get_cat_unprefixed( std::string_view prefixed_name )
 {
@@ -2132,90 +2134,13 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
             recalc_unread = highlight_unread_recipes;
             ui.invalidate_ui();
 
-            int new_filters_count = 0;
-            std::string added_filters;
-            const requirement_data &req = current[line]->simple_requirements();
-            const inventory &crafting_inv = crafter->crafting_inventory();
-            for( const std::vector<item_comp> &comp_list : req.get_components() ) {
-                for( const item_comp &i_comp : comp_list ) {
-                    std::string nname = item::nname( i_comp.type, 1 );
-                    int filter_pos = uistate.list_item_priority.find( nname );
-                    bool enough_materials = req.check_enough_materials(
-                                                i_comp, crafting_inv, current[line]->get_component_filter(), batch_size_out
-                                            );
-                    if( filter_pos == -1 && !enough_materials ) {
-                        new_filters_count++;
-                        added_filters += nname;
-                        added_filters += ",";
-                    }
-                }
-            }
-
-            if( new_filters_count > 0 ) {
-                if( !uistate.list_item_priority.empty()
-                    && !string_ends_with( uistate.list_item_priority, "," ) ) {
-                    uistate.list_item_priority += ",";
-                }
-                uistate.list_item_priority += added_filters;
-                uistate.list_item_priority_active = true;
-                std::vector<std::string> &hist = uistate.gethistory( "list_item_priority" );
-                if( hist.empty() || hist[hist.size() - 1] != uistate.list_item_priority ) {
-                    hist.push_back( uistate.list_item_priority );
-                }
-
-                popup( string_format( _( "Added %d components to the priority filter.\nAdded: %s\nNew Filter: %s" ),
-                                      new_filters_count, added_filters, uistate.list_item_priority ) );
-            } else {
-                popup( string_format( _( "Did not find anything to add to the priority filter.\nFilter: %s" ),
-                                      uistate.list_item_priority ) );
-            }
+            prioritize_components( *current[line], *crafter );
         } else if( action == "DEPRIORITIZE_COMPONENTS" ) {
             uistate.read_recipes.insert( current[line]->ident() );
             recalc_unread = highlight_unread_recipes;
             ui.invalidate_ui();
 
-            int removed_filters_count = 0;
-            std::string removed_filters;
-            const requirement_data &req = current[line]->simple_requirements();
-            for( const std::vector<item_comp> &comp_list : req.get_components() ) {
-                for( const item_comp &i_comp : comp_list ) {
-                    std::string nname = item::nname( i_comp.type, 1 );
-                    nname += ",";
-                    if( string_starts_with( uistate.list_item_priority, nname ) ) {
-                        removed_filters_count++;
-                        removed_filters += nname;
-                        uistate.list_item_priority.erase( 0, nname.length() );
-                    } else {
-                        std::string find_string = "," + nname;
-                        int filter_pos = uistate.list_item_priority.find( find_string );
-                        if( filter_pos > -1 ) {
-                            removed_filters_count++;
-                            removed_filters += nname;
-                            uistate.list_item_priority.replace( filter_pos, find_string.length(), "," );
-                        }
-                    }
-                }
-            }
-
-            if( !uistate.list_item_priority.empty() ) {
-                uistate.list_item_priority_active = true;
-
-                std::vector<std::string> &hist = uistate.gethistory( "list_item_priority" );
-                if( hist.empty() || hist[hist.size() - 1] != uistate.list_item_priority ) {
-                    hist.push_back( uistate.list_item_priority );
-                }
-            } else {
-                uistate.list_item_priority_active = false;
-            }
-
-            if( removed_filters_count > 0 ) {
-                popup( string_format(
-                           _( "Removed %d components from the priority filter.\nRemoved: %s\nNew Filter: %s" ),
-                           removed_filters_count, removed_filters, uistate.list_item_priority ) );
-            } else {
-                popup( string_format( _( "Did not find anything to remove from the priority filter.\nFilter: %s" ),
-                                      uistate.list_item_priority ) );
-            }
+            deprioritize_components( *current[line] );
         } else if( action == "HELP_KEYBINDINGS" ) {
             // Regenerate keybinding tips
             ui.mark_resize();
@@ -2437,6 +2362,93 @@ static void compare_recipe_with_item( const item &recipe_item, Character &crafte
         game_menus::inv::compare_item_menu menu( recipe_item, *to_compare );
         menu.show();
     } while( true );
+}
+
+static void prioritize_components( const recipe &recipe, Character &crafter )
+{
+    int new_filters_count = 0;
+    std::string added_filters;
+    const requirement_data &req = recipe.simple_requirements();
+    const inventory &crafting_inv = crafter.crafting_inventory();
+    for( const std::vector<item_comp> &comp_list : req.get_components() ) {
+        for( const item_comp &i_comp : comp_list ) {
+            std::string nname = item::nname( i_comp.type, 1 );
+            int filter_pos = uistate.list_item_priority.find( nname );
+            bool enough_materials = req.check_enough_materials(
+                    i_comp, crafting_inv, recipe.get_component_filter(), 1
+                    );
+            if( filter_pos == -1 && !enough_materials ) {
+                new_filters_count++;
+                added_filters += nname;
+                added_filters += ",";
+            }
+        }
+    }
+
+    if( new_filters_count > 0 ) {
+        if( !uistate.list_item_priority.empty()
+                && !string_ends_with( uistate.list_item_priority, "," ) ) {
+            uistate.list_item_priority += ",";
+        }
+        uistate.list_item_priority += added_filters;
+        uistate.list_item_priority_active = true;
+        std::vector<std::string> &hist = uistate.gethistory( "list_item_priority" );
+        if( hist.empty() || hist[hist.size() - 1] != uistate.list_item_priority ) {
+            hist.push_back( uistate.list_item_priority );
+        }
+
+        popup( string_format( _( "Added %d components to the priority filter.\nAdded: %s\nNew Filter: %s" ),
+                    new_filters_count, added_filters, uistate.list_item_priority ) );
+    } else {
+        popup( string_format( _( "Did not find anything to add to the priority filter.\n\nFilter: %s" ),
+                    uistate.list_item_priority ) );
+    }
+}
+
+static void deprioritize_components( const recipe &recipe )
+{
+    int removed_filters_count = 0;
+    std::string removed_filters;
+    const requirement_data &req = recipe.simple_requirements();
+    for( const std::vector<item_comp> &comp_list : req.get_components() ) {
+        for( const item_comp &i_comp : comp_list ) {
+            std::string nname = item::nname( i_comp.type, 1 );
+            nname += ",";
+            if( string_starts_with( uistate.list_item_priority, nname ) ) {
+                removed_filters_count++;
+                removed_filters += nname;
+                uistate.list_item_priority.erase( 0, nname.length() );
+            } else {
+                std::string find_string = "," + nname;
+                int filter_pos = uistate.list_item_priority.find( find_string );
+                if( filter_pos > -1 ) {
+                    removed_filters_count++;
+                    removed_filters += nname;
+                    uistate.list_item_priority.replace( filter_pos, find_string.length(), "," );
+                }
+            }
+        }
+    }
+
+    if( !uistate.list_item_priority.empty() ) {
+        uistate.list_item_priority_active = true;
+
+        std::vector<std::string> &hist = uistate.gethistory( "list_item_priority" );
+        if( hist.empty() || hist[hist.size() - 1] != uistate.list_item_priority ) {
+            hist.push_back( uistate.list_item_priority );
+        }
+    } else {
+        uistate.list_item_priority_active = false;
+    }
+
+    if( removed_filters_count > 0 ) {
+        popup( string_format(
+                   _( "Removed %d components from the priority filter.\nRemoved: %s\nNew Filter: %s" ),
+                   removed_filters_count, removed_filters, uistate.list_item_priority ) );
+    } else {
+        popup( string_format( _( "Did not find anything to remove from the priority filter.\nFilter: %s" ),
+                              uistate.list_item_priority ) );
+    }
 }
 
 static bool query_is_yes( std::string_view query )

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -2375,8 +2375,8 @@ static void prioritize_components( const recipe &recipe, Character &crafter )
             std::string nname = item::nname( i_comp.type, 1 );
             int filter_pos = uistate.list_item_priority.find( nname );
             bool enough_materials = req.check_enough_materials(
-                    i_comp, crafting_inv, recipe.get_component_filter(), 1
-                    );
+                                        i_comp, crafting_inv, recipe.get_component_filter(), 1
+                                    );
             if( filter_pos == -1 && !enough_materials ) {
                 new_filters_count++;
                 added_filters += nname;
@@ -2387,7 +2387,7 @@ static void prioritize_components( const recipe &recipe, Character &crafter )
 
     if( new_filters_count > 0 ) {
         if( !uistate.list_item_priority.empty()
-                && !string_ends_with( uistate.list_item_priority, "," ) ) {
+            && !string_ends_with( uistate.list_item_priority, "," ) ) {
             uistate.list_item_priority += ",";
         }
         uistate.list_item_priority += added_filters;
@@ -2398,10 +2398,10 @@ static void prioritize_components( const recipe &recipe, Character &crafter )
         }
 
         popup( string_format( _( "Added %d components to the priority filter.\nAdded: %s\nNew Filter: %s" ),
-                    new_filters_count, added_filters, uistate.list_item_priority ) );
+                              new_filters_count, added_filters, uistate.list_item_priority ) );
     } else {
         popup( string_format( _( "Did not find anything to add to the priority filter.\n\nFilter: %s" ),
-                    uistate.list_item_priority ) );
+                              uistate.list_item_priority ) );
     }
 }
 

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -2209,8 +2209,9 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
             }
 
             if( removed_filters_count > 0 ) {
-                popup( string_format( _( "Removed %d components from the priority filter.\nRemoved: %s\nNew Filter: %s" ),
-                                      removed_filters_count, removed_filters, uistate.list_item_priority ) );
+                popup( string_format(
+                           _( "Removed %d components from the priority filter.\nRemoved: %s\nNew Filter: %s" ),
+                           removed_filters_count, removed_filters, uistate.list_item_priority ) );
             } else {
                 popup( string_format( _( "Did not find anything to remove from the priority filter.\nFilter: %s" ),
                                       uistate.list_item_priority ) );


### PR DESCRIPTION
#### Summary

Interface "Add deprioritize components of a recipe to the crafting menu"

#### Purpose of change

Sometimes you no longer want to be on the lookout for particular recipe ingredients, and adding many crafting recipes to the priority list makes it hard to manage by hand.

#### Describe the solution

Add a new key (default `-` and friends) to remove all of the recipe components from the view priority list.

#### Describe alternatives you've considered

- It probably makes sense to add a key to the crafting menu to reset the view priority list completely.  Maybe `action == "TEXT.CLEAR"` to match the keybind in the priority editing UI.  Should I do that here, too?
- Spell check doesn't like "deprioritize".  Should I use a different word?  Use something much more verbose like "remove from priority" or something equally gross?

#### Testing

1. Hovered over adhesive bandages, added missing components with `+`, and removed them with `-`:
```
Removed 2 components from the priority filter.
Removed: duct tape,medical tape,
New Filter:
```
3. Confirmed no view filter was present in the `V`->`+` UI.
4. Added bandage stuff with `+`, removed adhesive bandages with `-`:
```
Removed 1 components from the priority filter.
Removed: duct tape,
New Filter: cotton patch,thyme oil,ethanol,denatured alcohol,methylated
spirits,
```
5. Confirmed filter history was updated in `V`->`+` UI.
6. Tested the special logic for the start of the filter by removing antiseptic soaked rag:
```
Removed 1 components from the priority filter.
Removed: cotton patch,
New Filter: thyme oil,ethanol,denatured alcohol,methylated spirits
```
7. Checked the `?` menu within the crafting UI:
```
…
Add missing components to high priority in Item List   +
Remove components from high priority in Item List      -
…
```
8. Added a recipe twice and got the "nothing to add" message:
```
Did not find anything to add to the priority filter.

Filter: emergency,cotton patch,thyme oil,ethanol,denatured alcohol,methylate
spirits,
```
Seems that the last column on the curses messages can be truncated, as in this example.

#### Additional context

- Adding missing crafting components is here https://github.com/CleverRaven/Cataclysm-DDA/pull/85069
- I also added the numpad plus keybinding to the add missing components action.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
