### PR TITLE
[XE] Tier 5 vampires don't feel cold temperatures.

### DIFF
--- a/data/mods/Xedra_Evolved/jmath.json
+++ b/data/mods/Xedra_Evolved/jmath.json
@@ -273,6 +273,14 @@
   },
   {
     "type": "jmath_function",
+    "id": "temperature_vw_cold_mod",
+    "//": "Copy of temperature_speed_mod(), but affects vampires no matter how cold-immune they are.",
+    "//2": "Temperature limit, after which the speed starts to change, in farenheit",
+    "num_args": 1,
+    "return": "min(fahrenheit(weather('temperature') - _0, 0)"
+  },
+  {
+    "type": "jmath_function",
     "id": "dhampir_total_weaknesses",
     "num_args": 0,
     "return": "u_has_trait('DHAMPIR_WEAKNESS_SUN_SENSITIVITY') + u_has_trait('DHAMPIR_WEAKNESS_SLOW_HEALING') + u_has_trait('DHAMPIR_WEAKNESS_ANIMAL_DISCORD') + u_has_trait('DHAMPIR_WEAKNESS_WATER_PAIN') + u_has_trait('DHAMPIR_WEAKNESS_CORPSELIKE_PALLOR') + u_has_trait('DHAMPIR_WEAKNESS_BLOODTHIRST') + u_has_trait('DHAMPIR_WEAKNESS_SLOWER_BLOOD_GAIN') + u_has_trait('DHAMPIR_WEAKNESS_OVERWHELMING_ARROGANCE') + u_has_trait('DHAMPIR_WEAKNESS_BURNED_BY_THE_SUN')"

--- a/data/mods/Xedra_Evolved/jmath.json
+++ b/data/mods/Xedra_Evolved/jmath.json
@@ -277,7 +277,7 @@
     "//": "Copy of temperature_speed_mod(), but affects vampires no matter how cold-immune they are.",
     "//2": "Temperature limit, after which the speed starts to change, in farenheit",
     "num_args": 2,
-    "return": "min(fahrenheit(weather('temperature') - _0, 0)"
+    "return": "min((fahrenheit(weather('temperature')) - _0) * 2, 0)"
   },
   {
     "type": "jmath_function",

--- a/data/mods/Xedra_Evolved/jmath.json
+++ b/data/mods/Xedra_Evolved/jmath.json
@@ -276,7 +276,7 @@
     "id": "temperature_vw_cold_mod",
     "//": "Copy of temperature_speed_mod(), but affects vampires no matter how cold-immune they are.",
     "//2": "Temperature limit, after which the speed starts to change, in farenheit",
-    "num_args": 1,
+    "num_args": 2,
     "return": "min(fahrenheit(weather('temperature') - _0, 0)"
   },
   {

--- a/data/mods/Xedra_Evolved/mutations/mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/mutations.json
@@ -1493,6 +1493,7 @@
     "enchantments": [
       {
         "values": [
+          { "value": "CLIMATE_CONTROL_HEAT", "add": 9999 },
           { "value": "STAMINA_REGEN_MOD", "add": 0.1 },
           { "value": "KCAL", "multiply": -100 },
           { "value": "VITAMIN_ABSORB_MOD", "multiply": -100 },

--- a/data/mods/Xedra_Evolved/mutations/mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/mutations.json
@@ -1753,21 +1753,11 @@
     "id": "VAMPIRE_WEAKNESS_COLD_BLOODED",
     "name": { "str": "Vampiric weakness: cold as a corpse" },
     "points": -1,
-    "description": "Ambient cold temperature makes you stiff and slow even under winter clothes.  You lose speed and stats based on how low the ambient temperature is.",
+    "description": "Ambient cold temperature makes you stiff and slow even under winter clothes.  The lower the ambient temperature, the lower your speed.",
     "starting_trait": false,
     "valid": false,
     "purifiable": false,
-    "enchantments": [
-      {
-        "values": [
-          { "value": "SPEED", "add": { "math": [ "temperature_vw_cold_mod(65, 1)" ] } },
-          { "value": "STRENGTH", "add": { "math": [ "temperature_vw_cold_mod(65, 0.1)" ] } },
-          { "value": "DEXTERITY", "add": { "math": [ "temperature_vw_cold_mod(65, 0.1)" ] } },
-          { "value": "INTELLIGENCE", "add": { "math": [ "temperature_vw_cold_mod(65, 0.1)" ] } },
-          { "value": "PERCEPTION", "add": { "math": [ "temperature_vw_cold_mod(65, 0.1)" ] } }
-        ]
-      }
-    ],
+    "enchantments": [ { "values": [ { "value": "SPEED", "add": { "math": [ "temperature_vw_cold_mod(65, 1)" ] } } ] } ],
     "flags": [ "NO_BODY_HEAT" ]
   },
   {

--- a/data/mods/Xedra_Evolved/mutations/mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/mutations.json
@@ -1753,15 +1753,18 @@
     "id": "VAMPIRE_WEAKNESS_COLD_BLOODED",
     "name": { "str": "Vampiric weakness: cold as a corpse" },
     "points": -1,
-    "description": "You now lack any body heat.  You feel colder at all times, and being cold will slow you down.",
+    "description": "Ambient cold temperature makes you stiff and slow even under winter clothes.  You lose speed and stats based on how low the ambient temperature is.",
     "starting_trait": false,
     "valid": false,
     "purifiable": false,
     "enchantments": [
       {
         "values": [
-          { "value": "CLIMATE_CONTROL_HEAT", "add": -20 },
-          { "value": "SPEED", "add": { "math": [ "temperature_speed_mod(65, 0.5)" ] } }
+          { "value": "SPEED", "add": { "math": [ "temperature_vw_cold_mod(65, 1)" ] } },
+          { "value": "STRENGTH", "add": { "math": [ "temperature_vw_cold_mod(65, 0.1)" ] } },
+          { "value": "DEXTERITY", "add": { "math": [ "temperature_vw_cold_mod(65, 0.1)" ] } },
+          { "value": "INTELLIGENCE", "add": { "math": [ "temperature_vw_cold_mod(65, 0.1)" ] } },
+          { "value": "PERCEPTION", "add": { "math": [ "temperature_vw_cold_mod(65, 0.1)" ] } }
         ]
       }
     ],


### PR DESCRIPTION
#### Summary
Mods "[XE] Tier 5 vampires don't feel cold temperatures."

#### Purpose of change

A discord discussion mentionned that T5s should be unaffected by cold temperatures

I'm fully in agreement. Currently Dhampirs have better cold resistance than T5 vampires do.

#### Describe the solution

Add a climate control enchant so they are unaffected by cold temperatures.

Rework the cold vulnerability weakness so it slows them the colder the ambient temperature is,

#### Describe alternatives you've considered

Make them fully cold immune. 

Make the weakness reduces all stats. his only resulted in all stats being locked at 0, so it'll only reduce

#### Testing

Not a T5: standing naked outside in winter causes frostbite.
A T5: doing that does nothing temperature-wise.

The cold vulnerability weakness rework severely reduces speed outside in winter. It is now intended as a more situational but harsher weakness. Cold nights, winter and cold labs will seriously slow you down.

#### Additional context

Other Dhampir abilities might get a vampire version, as Dhampirs appear to be vampires with less ups and less downs.