### PR TITLE
Add a .natvis file to improve visual studio debugging

### DIFF
--- a/CDDA.natvis
+++ b/CDDA.natvis
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+    <Type Name="Character">
+        <DisplayString>{name}</DisplayString>
+    </Type>
+    <Type Name="units::quantity&lt;*, units::volume_in_milliliter_tag&gt;">
+        <DisplayString>{value_} ml</DisplayString>
+    </Type>
+    <Type Name="units::quantity&lt;*, units::length_in_millimeter_tag&gt;">
+        <DisplayString>{value_ / 10} cm</DisplayString>
+    </Type>
+    <Type Name="units::quantity&lt;*, units::mass_in_milligram_tag&gt;">
+        <DisplayString>{value_ / 1000} g</DisplayString>
+    </Type>
+    <Type Name="item">
+        <DisplayString Condition="is_favorite">* {type->name}</DisplayString>
+        <DisplayString Condition="!is_favorite">{type->name}</DisplayString>
+    </Type>
+    <Type Name="item_pocket">
+        <DisplayString Condition="data->pocket_name.raw._Mypair._Myval2._Mysize != 0">{data->pocket_name} in {data->name}</DisplayString>
+        <DisplayString>{data->name}</DisplayString>
+    </Type>
+    <Type Name="item_location">
+        <DisplayString Condition="ptr._Ptr->what.impl._Rep->_Uses">{*ptr._Ptr}</DisplayString>
+        <DisplayString Condition="!ptr._Ptr->what.impl._Rep->_Uses">invalid item location</DisplayString>
+    </Type>
+    <Type Name="item_location::impl::item_in_container">
+        <DisplayString Condition="what.impl._Rep->_Uses">{*what.impl._Ptr} in {container}</DisplayString>
+        <DisplayString Condition="!what.impl._Rep->_Uses">invalid item location</DisplayString>
+    </Type>
+    <Type Name="item_location::impl::item_on_map">
+        <DisplayString Condition="what.impl._Rep->_Uses">{*what.impl._Ptr} at {cur}</DisplayString>
+        <DisplayString Condition="!what.impl._Rep->_Uses">invalid item location</DisplayString>
+    </Type>
+    <Type Name="item_location::impl::item_on_person">
+        <DisplayString Condition="what.impl._Rep->_Uses">{*what.impl._Ptr} on {*who}</DisplayString>
+        <DisplayString Condition="!what.impl._Rep->_Uses">invalid item location</DisplayString>
+    </Type>
+    <Type Name="item_location::impl::item_on_vehicle">
+        <DisplayString Condition="what.impl._Rep->_Uses">{*what.impl._Ptr} in vehicle {cur.veh.name}</DisplayString>
+        <DisplayString Condition="!what.impl._Rep->_Uses">invalid item location</DisplayString>
+    </Type>
+    <Type Name="translation">
+        <DisplayString>{raw}</DisplayString>
+    </Type>
+</AutoVisualizer>

--- a/msvc-full-features/Cataclysm-lib-vcpkg-static.vcxproj
+++ b/msvc-full-features/Cataclysm-lib-vcpkg-static.vcxproj
@@ -190,6 +190,9 @@
       <LinkLibraryDependencies>false</LinkLibraryDependencies>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Natvis Include="..\CDDA.natvis" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Viewing things like `item_location` and just `item` is hella annoying in the VS debugger because determining 'what' something is takes many clicks through members which are inconveniently located.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
VS supports what are called `.natvis` files which let one define a schema in XML (like most VS things are) which tells the debugger how to friendly-render certain types. Add implementations for the various `item_location::impl` classes, `item`, and some units, which together make the variables and watch windows much nicer on the eyes.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

(`inside` replaced with `in` in the actual natvis)
<img width="1342" height="468" alt="image" src="https://github.com/user-attachments/assets/39d0ae5e-0982-4366-8ec6-cc49d1656f88" />

<img width="1612" height="236" alt="image" src="https://github.com/user-attachments/assets/0dbba0e4-0ada-41ab-bb29-ca7a80523ee7" />


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
