### PR TITLE
Fix iwyu error in cata_variant

### DIFF
--- a/src/cata_variant.h
+++ b/src/cata_variant.h
@@ -19,6 +19,7 @@
 #include "to_string_id.h"
 #include "type_id.h"  // IWYU pragma: keep
 
+class cata_variant; // IWYU pragma: keep
 class JsonOut;
 class JsonValue;
 enum class mutagen_technique : int;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fixes IWYU error on latest master (https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/21578835386/job/62171819622)

#### Describe the solution

Do exactly what IWYU suggests and add a forward declaration of `class cata_variant;` to `cata_variant.h`

#### Describe alternatives you've considered

N/A

#### Testing

```
$ iwyu_tool.py src/cata_variant.cpp -p build/notiles/ --output-format clang --jobs 4 -- -Xiwyu --mapping_file=/home/username/github/Cataclysm-DDA/tools/iwyu/cata.imp -Xiwyu --cxx17ns -Xiwyu --comment_style=long -Xiwyu --max_line_length=1000 -Xiwyu --error=1 -Xiwyu --verbose=1
/home/username/github/Cataclysm-DDA/src/cata_variant.h:1:1: note: #includes/fwd-decls are correct
/home/username/github/Cataclysm-DDA/src/cata_variant.cpp:1:1: note: #includes/fwd-decls are correct
```

#### Additional context

The eror is wild.
It was introduced in https://github.com/CleverRaven/Cataclysm-DDA/pull/85063 which does not touch anything `cata_variant`-related at all.
Turns out the reason for the error is that now `event.h` is transitively included in `cata_variant.h`, and `event.h` has a `using data_type = std::map<std::string, cata_variant>;` line, which (and this is getting very sketch) somehow ends up invoking cata_variant's `type_for_impl` with `cata_variant` as `T` template argument. (I still don't understand how or why). And since `type_for_impl` is declared earlier in the file than `class cata_variant`, it complains about the lack of forward decl. So.. there..

I briefly considered shuffling the declarations around instead of adding a forward-decl, but that does not appear to be feasible.

I also added an extra `// IWYU pragma: keep` so that if `event.h` ends up being removed from the transitive includes, we won't need to be confused again about IWUY comlaining (except now about superfuous forward-decl rather than missing one).

