### PR TITLE
[XEDRA Evolved] Stabilize Timeline and Destabilizing Strikes mana drain scaling and levelling requirement resolution

### DIFF
--- a/data/mods/Xedra_Evolved/dialogue/chronomancer_insight_menu.json
+++ b/data/mods/Xedra_Evolved/dialogue/chronomancer_insight_menu.json
@@ -859,8 +859,8 @@
       {
         "condition": {
           "and": [
-            { "math": [ "u_spell_level('xedra_chronomancer_destabilizing_strikes') > 0" ] },
-            { "math": [ "u_spell_level('xedra_chronomancer_destabilizing_strikes') < xedra_chronomancer_level(1) " ] }
+            { "math": [ "u_spell_level('xedra_chronomancer_stabilize_timeline') > 0" ] },
+            { "math": [ "u_spell_level('xedra_chronomancer_stabilize_timeline') < xedra_chronomancer_level(1) " ] }
           ]
         },
         "text": "Level [<spell_name:xedra_chronomancer_stabilize_timeline>]",

--- a/data/mods/Xedra_Evolved/effects/effects.json
+++ b/data/mods/Xedra_Evolved/effects/effects.json
@@ -3630,7 +3630,7 @@
         "values": [
           {
             "value": "MAX_MANA",
-            "add": { "math": [ "-max( 1000 - ( 25 * u_spell_level('xedra_chronomancer_chronal_acceleration') ), 250 )" ] }
+            "add": { "math": [ "-max( 1000 - ( 25 * u_spell_level('xedra_chronomancer_destabilizing_strikes') ), 250 )" ] }
           }
         ]
       }
@@ -3652,7 +3652,7 @@
         "values": [
           {
             "value": "MAX_MANA",
-            "add": { "math": [ "-max( 500 - ( 12.5 * u_spell_level('xedra_chronomancer_chronal_acceleration') ), 125 )" ] }
+            "add": { "math": [ "-max( 500 - ( 12.5 * u_spell_level('xedra_chronomancer_stabilize_timeline') ), 125 )" ] }
           }
         ]
       }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Ensure Stabilize Timeline's requirement for levelling is based on its own existence, and ensure that Stabilize Timeline and Destabilizing Strikes drain mana based on their own level"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Stabilize Timeline's option to level exists based on whether you have Destabilizing Strikes when it should check for itself.  Stabilize Timeline and Destabilizing Strikes both base their mana drain on the level of Chronal Acceleration you had, when they should base their drain on their own respective levels.
Detailed further in #85062 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Changed the menu to check for Stabilize Timeline level when determining whether the menu option for levelling Stabilize Timeline would appear.

Changed the effects JSON to base mana drain for Stabilize Timeline and Destabilizing Strikes on their own levels, rather than the level of Chronal Acceleration.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Basing even more spell effects on Chronal Acceleration so you only need to level one god-spell to conquer the Cataclysm.  Other than that, just not sticking my nose in.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Obtained Stabilize Timeline, verified that it can be levelled without owning any other Chronomancer spells (besides Time Freeze and Normalize Time).  It can!

Obtained Destabilizing Strikes afterwards to see if it changes anything about that.  It does not!

Obtained and levelled Destabilizing Strikes and Stabilize Timeline, keeping them on to verify mana drain was correctly applied.  It is!

Obtained and levelled Chronal Acceleration to see if it affects Destabilizing Strikes or Stabilize Timeline's mana drain.  It does not!
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
HOW HARD CAN IT BE?!
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
