### PR TITLE
Remove carpet redundancy

### DIFF
--- a/data/json/furniture_and_terrain/terrain-floors-indoor.json
+++ b/data/json/furniture_and_terrain/terrain-floors-indoor.json
@@ -760,7 +760,7 @@
     "name": "red carpet",
     "description": "Soft red carpet.  Can support a roof.",
     "color": "red",
-    "deconstruct": { "items": [ { "item": "r_carpet", "count": 1 }, { "item": "nail", "charges": [ 2, 5 ] } ], "ter_set": "t_floor" }
+    "deconstruct": { "items": [ { "item": "r_carpet", "charges": 1 }, { "item": "nail", "charges": 5 } ], "ter_set": "t_floor" }
   },
   {
     "type": "terrain",

--- a/data/json/furniture_and_terrain/terrain-floors-indoor.json
+++ b/data/json/furniture_and_terrain/terrain-floors-indoor.json
@@ -955,7 +955,7 @@
   },
   {
     "type": "terrain",
-    "id": "t_carpet_base_strconcrete",
+    "abstract": "t_carpet_base_strconcrete",
     "copy-from": "t_carpet_base",
     "bash": {
       "sound": "SMASH!",
@@ -1118,7 +1118,7 @@
   },
   {
     "type": "terrain",
-    "id": "t_carpet_base_linoleum_gray",
+    "abstract": "t_carpet_base_linoleum_gray",
     "copy-from": "t_carpet_base",
     "bash": {
       "sound": "SMASH!",
@@ -1175,7 +1175,7 @@
   },
   {
     "type": "terrain",
-    "id": "t_carpet_base_linoleum_white",
+    "abstract": "t_carpet_base_linoleum_white",
     "copy-from": "t_carpet_base",
     "bash": {
       "sound": "SMASH!",

--- a/data/json/furniture_and_terrain/terrain-floors-indoor.json
+++ b/data/json/furniture_and_terrain/terrain-floors-indoor.json
@@ -729,15 +729,16 @@
   },
   {
     "type": "terrain",
-    "id": "t_carpet_base",
+    "abstract": "t_carpet_base",
     "name": "carpet",
     "description": "Base carpet!",
     "symbol": ".",
     "color": "red",
+    "connect_groups": [ "CARPET", "INDOORFLOOR" ],
+    "connects_to": "CARPET",
     "move_cost": 2,
     "comfort": 1,
     "roof": "t_flat_roof",
-    "connect_groups": "INDOORFLOOR",
     "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
     "bash": {
       "sound": "SMASH!",
@@ -750,23 +751,16 @@
         { "item": "cotton_patchwork", "count": [ 2, 4 ] },
         { "item": "nail", "charges": [ 1, 3 ] }
       ]
-    },
-    "deconstruct": { "items": [ { "item": "r_carpet", "count": 1 }, { "item": "nail", "charges": [ 2, 5 ] } ], "ter_set": "t_floor" }
+    }
   },
   {
     "type": "terrain",
     "id": "t_carpet_red",
     "copy-from": "t_carpet_base",
-    "name": "carpet",
-    "symbol": ".",
-    "color": "red",
-    "connect_groups": [ "CARPET", "INDOORFLOOR" ],
-    "connects_to": "CARPET",
-    "move_cost": 2,
-    "roof": "t_flat_roof",
+    "name": "red carpet",
     "description": "Soft red carpet.  Can support a roof.",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
-    "deconstruct": { "ter_set": "t_floor", "items": [ { "item": "r_carpet", "charges": 1 }, { "item": "nail", "charges": 5 } ] }
+    "color": "red",
+    "deconstruct": { "items": [ { "item": "r_carpet", "count": 1 }, { "item": "nail", "charges": [ 2, 5 ] } ], "ter_set": "t_floor" }
   },
   {
     "type": "terrain",
@@ -774,11 +768,7 @@
     "copy-from": "t_carpet_base",
     "name": "yellow carpet",
     "description": "Soft yellow carpet.  Can support a roof.",
-    "symbol": ".",
     "color": "yellow",
-    "move_cost": 2,
-    "connect_groups": "INDOORFLOOR",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
     "deconstruct": { "items": [ { "item": "y_carpet", "charges": 1 }, { "item": "nail", "charges": 5 } ], "ter_set": "t_floor" }
   },
   {
@@ -787,11 +777,7 @@
     "copy-from": "t_carpet_base",
     "name": "green carpet",
     "description": "Soft green carpet.  Can support a roof.",
-    "symbol": ".",
     "color": "green",
-    "move_cost": 2,
-    "connect_groups": "INDOORFLOOR",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
     "deconstruct": { "items": [ { "item": "g_carpet", "charges": 1 }, { "item": "nail", "charges": 5 } ], "ter_set": "t_floor" }
   },
   {
@@ -800,28 +786,16 @@
     "copy-from": "t_carpet_base",
     "name": "purple carpet",
     "description": "Soft purple carpet.  Can support a roof.",
-    "symbol": ".",
     "color": "magenta",
-    "move_cost": 2,
-    "connect_groups": "INDOORFLOOR",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
     "deconstruct": { "items": [ { "item": "p_carpet", "charges": 1 }, { "item": "nail", "charges": 5 } ], "ter_set": "t_floor" }
   },
   {
     "type": "terrain",
-    "id": "t_carpet_base_wood",
-    "name": "carpet",
-    "description": "Base carpet!",
-    "symbol": ".",
-    "color": "red",
-    "move_cost": 2,
-    "comfort": 1,
-    "roof": "t_flat_roof",
-    "connect_groups": "INDOORFLOOR",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
+    "abstract": "t_carpet_base_wood",
+    "copy-from": "t_carpet_base",
     "bash": {
       "sound": "SMASH!",
-      "ter_set": "t_floor",
+      "ter_set": "t_floor_noroof",
       "str_min": 5,
       "str_max": 15,
       "str_min_supported": 100,
@@ -830,81 +804,52 @@
         { "item": "cotton_patchwork", "count": [ 2, 4 ] },
         { "item": "nail", "charges": [ 1, 3 ] }
       ]
-    },
-    "deconstruct": {
-      "items": [ { "item": "r_carpet", "count": 1 }, { "item": "nail", "charges": [ 2, 5 ] } ],
-      "ter_set": "t_floor_noroof"
     }
   },
   {
     "type": "terrain",
     "id": "t_carpet_wood_red",
     "copy-from": "t_carpet_base_wood",
-    "name": "carpet",
-    "looks_like": "t_carpet_red",
-    "symbol": ".",
-    "color": "red",
-    "connect_groups": [ "CARPET", "INDOORFLOOR" ],
-    "connects_to": "CARPET",
-    "move_cost": 2,
-    "roof": "t_flat_roof",
+    "name": "red carpet",
     "description": "Soft red carpet on a wooden floor.  Can support a roof.",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
-    "deconstruct": { "ter_set": "t_floor", "items": [ { "item": "r_carpet", "charges": 1 }, { "item": "nail", "charges": 5 } ] }
+    "looks_like": "t_carpet_red",
+    "color": "red",
+    "deconstruct": { "ter_set": "t_floor_noroof", "items": [ { "item": "r_carpet", "charges": 1 }, { "item": "nail", "charges": 5 } ] }
   },
   {
     "type": "terrain",
     "id": "t_carpet_wood_yellow",
     "copy-from": "t_carpet_base_wood",
     "name": "yellow carpet",
-    "looks_like": "t_carpet_yellow",
     "description": "Soft yellow carpet on a wooden floor.  Can support a roof.",
-    "symbol": ".",
+    "looks_like": "t_carpet_yellow",
     "color": "yellow",
-    "move_cost": 2,
-    "connect_groups": "INDOORFLOOR",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
-    "deconstruct": { "items": [ { "item": "y_carpet", "charges": 1 }, { "item": "nail", "charges": 5 } ], "ter_set": "t_floor_noroof" }
+    "deconstruct": { "ter_set": "t_floor_noroof", "items": [ { "item": "y_carpet", "charges": 1 }, { "item": "nail", "charges": 5 } ] }
   },
   {
     "type": "terrain",
     "id": "t_carpet_wood_green",
     "copy-from": "t_carpet_base_wood",
     "name": "green carpet",
-    "looks_like": "t_carpet_green",
     "description": "Soft green carpet on a wooden floor.  Can support a roof.",
-    "symbol": ".",
+    "looks_like": "t_carpet_green",
     "color": "green",
-    "move_cost": 2,
-    "connect_groups": "INDOORFLOOR",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
-    "deconstruct": { "items": [ { "item": "g_carpet", "charges": 1 }, { "item": "nail", "charges": 5 } ], "ter_set": "t_floor_noroof" }
+    "deconstruct": { "ter_set": "t_floor_noroof", "items": [ { "item": "g_carpet", "charges": 1 }, { "item": "nail", "charges": 5 } ] }
   },
   {
     "type": "terrain",
     "id": "t_carpet_wood_purple",
     "copy-from": "t_carpet_base_wood",
     "name": "purple carpet",
-    "looks_like": "t_carpet_purple",
     "description": "Soft purple carpet on a wooden floor.  Can support a roof.",
-    "symbol": ".",
+    "looks_like": "t_carpet_purple",
     "color": "magenta",
-    "move_cost": 2,
-    "connect_groups": "INDOORFLOOR",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
-    "deconstruct": { "items": [ { "item": "p_carpet", "charges": 1 }, { "item": "nail", "charges": 5 } ], "ter_set": "t_floor_noroof" }
+    "deconstruct": { "ter_set": "t_floor_noroof", "items": [ { "item": "p_carpet", "charges": 1 }, { "item": "nail", "charges": 5 } ] }
   },
   {
     "type": "terrain",
-    "id": "t_carpet_base_concrete",
-    "name": "Carpet",
-    "symbol": ".",
-    "color": "red",
-    "move_cost": 2,
+    "abstract": "t_carpet_base_concrete",
     "copy-from": "t_carpet_base",
-    "description": "Base concrete carpet!",
-    "connect_groups": "INDOORFLOOR",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
     "bash": {
       "sound": "SMASH!",
       "ter_set": "t_thconc_floor",
@@ -912,21 +857,17 @@
       "str_max": 15,
       "str_min_supported": 100,
       "items": [ { "item": "sheet_cotton", "count": [ 1, 2 ] }, { "item": "cotton_patchwork", "count": [ 2, 4 ] } ]
-    },
-    "deconstruct": { "items": [ { "item": "r_carpet", "charges": 1 } ], "ter_set": "t_thconc_floor" }
+    }
   },
   {
     "type": "terrain",
     "id": "t_carpet_concrete_red",
     "copy-from": "t_carpet_base_concrete",
     "name": "industrial red carpet",
+    "description": "Firm, low-pile, high-durability carpet in a red color on a concrete floor.  Can support a roof.",
     "looks_like": "t_carpet_red",
-    "symbol": ".",
     "color": "red",
-    "move_cost": 2,
-    "connect_groups": "INDOORFLOOR",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
-    "description": "Firm, low-pile, high-durability carpet in a red color on a concrete floor.  Can support a roof."
+    "deconstruct": { "items": [ { "item": "r_carpet", "charges": 1 } ], "ter_set": "t_thconc_floor" }
   },
   {
     "type": "terrain",
@@ -934,12 +875,8 @@
     "copy-from": "t_carpet_base_concrete",
     "name": "industrial yellow carpet",
     "description": "Firm, low-pile, high-durability carpet in a yellow color on a concrete floor.  Can support a roof.",
-    "symbol": ".",
-    "color": "yellow",
-    "move_cost": 2,
     "looks_like": "t_carpet_yellow",
-    "connect_groups": "INDOORFLOOR",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
+    "color": "yellow",
     "deconstruct": { "items": [ { "item": "y_carpet", "charges": 1 } ], "ter_set": "t_thconc_floor" }
   },
   {
@@ -948,12 +885,8 @@
     "copy-from": "t_carpet_base_concrete",
     "name": "industrial green carpet",
     "description": "Firm, low-pile, high-durability carpet in a green color on a concrete floor.  Can support a roof.",
-    "symbol": ".",
-    "color": "green",
-    "move_cost": 2,
     "looks_like": "t_carpet_green",
-    "connect_groups": "INDOORFLOOR",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
+    "color": "green",
     "deconstruct": { "items": [ { "item": "g_carpet", "charges": 1 } ], "ter_set": "t_thconc_floor" }
   },
   {
@@ -962,24 +895,14 @@
     "copy-from": "t_carpet_base_concrete",
     "name": "industrial purple carpet",
     "description": "Firm, low-pile, high-durability carpet in a purple color on a concrete floor.  Can support a roof.",
-    "symbol": ".",
-    "color": "magenta",
-    "move_cost": 2,
     "looks_like": "t_carpet_purple",
-    "connect_groups": "INDOORFLOOR",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
+    "color": "magenta",
     "deconstruct": { "items": [ { "item": "p_carpet", "charges": 1 } ], "ter_set": "t_thconc_floor" }
   },
   {
     "type": "terrain",
-    "id": "t_carpet_base_metal",
-    "name": "carpet",
+    "abstract": "t_carpet_base_metal",
     "copy-from": "t_carpet_base",
-    "description": "Base metal carpet!",
-    "symbol": ".",
-    "color": "red",
-    "move_cost": 2,
-    "connect_groups": "INDOORFLOOR",
     "flags": [ "TRANSPARENT", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
     "bash": {
       "sound": "SMASH!",
@@ -988,21 +911,16 @@
       "str_max": 15,
       "str_min_supported": 100,
       "items": [ { "item": "sheet_cotton", "count": [ 1, 2 ] }, { "item": "cotton_patchwork", "count": [ 2, 4 ] } ]
-    },
-    "deconstruct": { "items": [ { "item": "r_carpet", "charges": 1 } ], "ter_set": "t_metal_floor" }
+    }
   },
   {
     "type": "terrain",
     "id": "t_carpet_metal_red",
     "copy-from": "t_carpet_base_metal",
     "name": "bunker red carpet",
-    "symbol": ".",
-    "color": "red",
-    "move_cost": 2,
-    "looks_like": "t_carpet_red",
     "description": "Firm, low-pile, totally non-flammable carpet in a red color, with an insulation layer beneath on a metal floor.  Can support a roof.",
-    "connect_groups": "INDOORFLOOR",
-    "flags": [ "TRANSPARENT", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
+    "looks_like": "t_carpet_red",
+    "color": "red",
     "deconstruct": { "items": [ { "item": "r_carpet", "charges": 1 } ], "ter_set": "t_metal_floor" }
   },
   {
@@ -1011,12 +929,8 @@
     "copy-from": "t_carpet_base_metal",
     "name": "bunker yellow carpet",
     "description": "Firm, low-pile, totally non-flammable carpet in a yellow color, with an insulation layer beneath on a metal floor.  Can support a roof.",
-    "symbol": ".",
-    "color": "yellow",
-    "move_cost": 2,
     "looks_like": "t_carpet_yellow",
-    "connect_groups": "INDOORFLOOR",
-    "flags": [ "TRANSPARENT", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
+    "color": "yellow",
     "deconstruct": { "items": [ { "item": "y_carpet", "charges": 1 } ], "ter_set": "t_metal_floor" }
   },
   {
@@ -1025,12 +939,8 @@
     "copy-from": "t_carpet_base_metal",
     "name": "bunker green carpet",
     "description": "Firm, low-pile, totally non-flammable carpet in a green color, with an insulation layer beneath on a metal floor.  Can support a roof.",
-    "symbol": ".",
-    "color": "green",
-    "move_cost": 2,
     "looks_like": "t_carpet_green",
-    "connect_groups": "INDOORFLOOR",
-    "flags": [ "TRANSPARENT", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
+    "color": "green",
     "deconstruct": { "items": [ { "item": "g_carpet", "charges": 1 } ], "ter_set": "t_metal_floor" }
   },
   {
@@ -1039,25 +949,14 @@
     "copy-from": "t_carpet_base_metal",
     "name": "bunker carpet purple",
     "description": "Firm, low-pile, totally non-flammable carpet in a purple color, with an insulation layer beneath on a metal floor.  Can support a roof.",
-    "symbol": ".",
-    "color": "magenta",
-    "move_cost": 2,
     "looks_like": "t_carpet_purple",
-    "connect_groups": "INDOORFLOOR",
-    "flags": [ "TRANSPARENT", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
+    "color": "magenta",
     "deconstruct": { "items": [ { "item": "p_carpet", "charges": 1 } ], "ter_set": "t_metal_floor" }
   },
   {
     "type": "terrain",
     "id": "t_carpet_base_strconcrete",
-    "name": "Carpet",
-    "symbol": ".",
-    "color": "red",
-    "move_cost": 2,
     "copy-from": "t_carpet_base",
-    "description": "Base concrete carpet!",
-    "connect_groups": "INDOORFLOOR",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
     "bash": {
       "sound": "SMASH!",
       "ter_set": "t_strconc_floor",
@@ -1065,21 +964,17 @@
       "str_max": 15,
       "str_min_supported": 100,
       "items": [ { "item": "sheet_cotton", "count": [ 1, 2 ] }, { "item": "cotton_patchwork", "count": [ 2, 4 ] } ]
-    },
-    "deconstruct": { "items": [ { "item": "r_carpet", "charges": 1 } ], "ter_set": "t_strconc_floor" }
+    }
   },
   {
     "type": "terrain",
     "id": "t_carpet_strconcrete_red",
     "copy-from": "t_carpet_base_strconcrete",
     "name": "industrial red carpet",
+    "description": "Firm, low-pile, high-durability carpet in a red color on a reinforced concrete floor.  Can support a roof.",
     "looks_like": "t_carpet_red",
-    "symbol": ".",
     "color": "red",
-    "move_cost": 2,
-    "connect_groups": "INDOORFLOOR",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
-    "description": "Firm, low-pile, high-durability carpet in a red color on a reinforced concrete floor.  Can support a roof."
+    "deconstruct": { "items": [ { "item": "r_carpet", "charges": 1 } ], "ter_set": "t_strconc_floor" }
   },
   {
     "type": "terrain",
@@ -1087,12 +982,8 @@
     "copy-from": "t_carpet_base_strconcrete",
     "name": "industrial yellow carpet",
     "description": "Firm, low-pile, high-durability carpet in a yellow color on a reinforced concrete floor.  Can support a roof.",
-    "symbol": ".",
-    "color": "yellow",
-    "move_cost": 2,
     "looks_like": "t_carpet_yellow",
-    "connect_groups": "INDOORFLOOR",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
+    "color": "yellow",
     "deconstruct": { "items": [ { "item": "y_carpet", "charges": 1 } ], "ter_set": "t_strconc_floor" }
   },
   {
@@ -1101,12 +992,8 @@
     "copy-from": "t_carpet_base_strconcrete",
     "name": "industrial green carpet",
     "description": "Firm, low-pile, high-durability carpet in a green color on a reinforced concrete floor.  Can support a roof.",
-    "symbol": ".",
-    "color": "green",
-    "move_cost": 2,
     "looks_like": "t_carpet_green",
-    "connect_groups": "INDOORFLOOR",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
+    "color": "green",
     "deconstruct": { "items": [ { "item": "g_carpet", "charges": 1 } ], "ter_set": "t_strconc_floor" }
   },
   {
@@ -1115,25 +1002,14 @@
     "copy-from": "t_carpet_base_strconcrete",
     "name": "industrial purple carpet",
     "description": "Firm, low-pile, high-durability carpet in a purple color on a reinforced concrete floor.  Can support a roof.",
-    "symbol": ".",
-    "color": "magenta",
-    "move_cost": 2,
     "looks_like": "t_carpet_purple",
-    "connect_groups": "INDOORFLOOR",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
+    "color": "magenta",
     "deconstruct": { "items": [ { "item": "p_carpet", "charges": 1 } ], "ter_set": "t_strconc_floor" }
   },
   {
     "type": "terrain",
-    "id": "t_carpet_base_rock",
-    "name": "Carpet",
-    "symbol": ".",
-    "color": "red",
-    "move_cost": 2,
+    "abstract": "t_carpet_base_rock",
     "copy-from": "t_carpet_base",
-    "description": "Base rock carpet!",
-    "connect_groups": "INDOORFLOOR",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
     "bash": {
       "sound": "SMASH!",
       "ter_set": "t_rock_floor",
@@ -1141,21 +1017,17 @@
       "str_max": 15,
       "str_min_supported": 100,
       "items": [ { "item": "sheet_cotton", "count": [ 1, 2 ] }, { "item": "cotton_patchwork", "count": [ 2, 4 ] } ]
-    },
-    "deconstruct": { "items": [ { "item": "r_carpet", "charges": 1 }, { "item": "nail", "charges": 5 } ], "ter_set": "t_rock_floor" }
+    }
   },
   {
     "type": "terrain",
     "id": "t_carpet_rock_red",
     "copy-from": "t_carpet_base_rock",
     "name": "red carpet",
+    "description": "Soft red carpet on a natural rock floor.  Can support a roof.",
     "looks_like": "t_carpet_red",
-    "symbol": ".",
     "color": "red",
-    "move_cost": 2,
-    "connect_groups": "INDOORFLOOR",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
-    "description": "Soft red carpet on a natural rock floor.  Can support a roof."
+    "deconstruct": { "items": [ { "item": "r_carpet", "charges": 1 }, { "item": "nail", "charges": 5 } ], "ter_set": "t_rock_floor" }
   },
   {
     "type": "terrain",
@@ -1163,12 +1035,8 @@
     "copy-from": "t_carpet_base_rock",
     "name": "yellow carpet",
     "description": "Soft yellow carpet on a natural rock floor.  Can support a roof.",
-    "symbol": ".",
-    "color": "yellow",
-    "move_cost": 2,
     "looks_like": "t_carpet_yellow",
-    "connect_groups": "INDOORFLOOR",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
+    "color": "yellow",
     "deconstruct": { "items": [ { "item": "y_carpet", "charges": 1 }, { "item": "nail", "charges": 5 } ], "ter_set": "t_rock_floor" }
   },
   {
@@ -1177,12 +1045,8 @@
     "copy-from": "t_carpet_base_rock",
     "name": "green carpet",
     "description": "Soft green carpet on a natural rock floor.  Can support a roof.",
-    "symbol": ".",
-    "color": "green",
-    "move_cost": 2,
     "looks_like": "t_carpet_green",
-    "connect_groups": "INDOORFLOOR",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
+    "color": "green",
     "deconstruct": { "items": [ { "item": "g_carpet", "charges": 1 }, { "item": "nail", "charges": 5 } ], "ter_set": "t_rock_floor" }
   },
   {
@@ -1191,25 +1055,14 @@
     "copy-from": "t_carpet_base_rock",
     "name": "purple carpet",
     "description": "Soft purple carpet on a natural rock floor.  Can support a roof.",
-    "symbol": ".",
-    "color": "magenta",
-    "move_cost": 2,
     "looks_like": "t_carpet_purple",
-    "connect_groups": "INDOORFLOOR",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
+    "color": "magenta",
     "deconstruct": { "items": [ { "item": "p_carpet", "charges": 1 }, { "item": "nail", "charges": 5 } ], "ter_set": "t_rock_floor" }
   },
   {
     "type": "terrain",
-    "id": "t_carpet_base_primitive",
-    "name": "Carpet",
-    "symbol": ".",
-    "color": "red",
-    "move_cost": 2,
+    "abstract": "t_carpet_base_primitive",
     "copy-from": "t_carpet_base",
-    "description": "Base primitive floor carpet!",
-    "connect_groups": "INDOORFLOOR",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
     "bash": {
       "sound": "SMASH!",
       "ter_set": "t_floor_primitive",
@@ -1221,21 +1074,17 @@
         { "item": "cotton_patchwork", "count": [ 2, 4 ] },
         { "item": "nail", "charges": [ 1, 3 ] }
       ]
-    },
-    "deconstruct": { "items": [ { "item": "r_carpet", "charges": 1 }, { "item": "nail", "charges": 5 } ], "ter_set": "t_floor_primitive" }
+    }
   },
   {
     "type": "terrain",
     "id": "t_carpet_primitive_red",
     "copy-from": "t_carpet_base_primitive",
     "name": "red carpet",
+    "description": "Soft red carpet on a timber floor.  Can support a roof.",
     "looks_like": "t_carpet_red",
-    "symbol": ".",
     "color": "red",
-    "move_cost": 2,
-    "connect_groups": "INDOORFLOOR",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
-    "description": "Soft red carpet on a timber floor.  Can support a roof."
+    "deconstruct": { "items": [ { "item": "r_carpet", "charges": 1 }, { "item": "nail", "charges": 5 } ], "ter_set": "t_floor_primitive" }
   },
   {
     "type": "terrain",
@@ -1243,12 +1092,8 @@
     "copy-from": "t_carpet_base_primitive",
     "name": "yellow carpet",
     "description": "Soft yellow carpet on a timber floor.  Can support a roof.",
-    "symbol": ".",
-    "color": "yellow",
-    "move_cost": 2,
     "looks_like": "t_carpet_yellow",
-    "connect_groups": "INDOORFLOOR",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
+    "color": "yellow",
     "deconstruct": { "items": [ { "item": "y_carpet", "charges": 1 }, { "item": "nail", "charges": 5 } ], "ter_set": "t_floor_primitive" }
   },
   {
@@ -1257,12 +1102,8 @@
     "copy-from": "t_carpet_base_primitive",
     "name": "green carpet",
     "description": "Soft green carpet on a timber floor.  Can support a roof.",
-    "symbol": ".",
-    "color": "green",
-    "move_cost": 2,
     "looks_like": "t_carpet_green",
-    "connect_groups": "INDOORFLOOR",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
+    "color": "green",
     "deconstruct": { "items": [ { "item": "g_carpet", "charges": 1 }, { "item": "nail", "charges": 5 } ], "ter_set": "t_floor_primitive" }
   },
   {
@@ -1271,25 +1112,14 @@
     "copy-from": "t_carpet_base_primitive",
     "name": "purple carpet",
     "description": "Soft purple carpet on a timber floor.  Can support a roof.",
-    "symbol": ".",
-    "color": "magenta",
-    "move_cost": 2,
     "looks_like": "t_carpet_purple",
-    "connect_groups": "INDOORFLOOR",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
+    "color": "magenta",
     "deconstruct": { "items": [ { "item": "p_carpet", "charges": 1 }, { "item": "nail", "charges": 5 } ], "ter_set": "t_floor_primitive" }
   },
   {
     "type": "terrain",
     "id": "t_carpet_base_linoleum_gray",
-    "name": "Carpet",
-    "symbol": ".",
-    "color": "red",
-    "move_cost": 2,
     "copy-from": "t_carpet_base",
-    "description": "Base gray linoleum floor carpet!",
-    "connect_groups": "INDOORFLOOR",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
     "bash": {
       "sound": "SMASH!",
       "ter_set": "t_linoleum_gray",
@@ -1301,21 +1131,17 @@
         { "item": "cotton_patchwork", "count": [ 2, 4 ] },
         { "item": "nail", "charges": [ 1, 3 ] }
       ]
-    },
-    "deconstruct": { "items": [ { "item": "r_carpet", "charges": 1 } ], "ter_set": "t_linoleum_gray" }
+    }
   },
   {
     "type": "terrain",
     "id": "t_carpet_linoleum_gray_red",
     "copy-from": "t_carpet_base_linoleum_gray",
     "name": "red carpet",
+    "description": "Soft red carpet on a gray linoleum floor.  Can support a roof.",
     "looks_like": "t_carpet_red",
-    "symbol": ".",
     "color": "red",
-    "move_cost": 2,
-    "connect_groups": "INDOORFLOOR",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
-    "description": "Soft red carpet on a gray linoleum floor.  Can support a roof."
+    "deconstruct": { "items": [ { "item": "r_carpet", "charges": 1 } ], "ter_set": "t_linoleum_gray" }
   },
   {
     "type": "terrain",
@@ -1323,12 +1149,8 @@
     "copy-from": "t_carpet_base_linoleum_gray",
     "name": "yellow carpet",
     "description": "Soft yellow carpet on a gray linoleum floor.  Can support a roof.",
-    "symbol": ".",
-    "color": "yellow",
-    "move_cost": 2,
     "looks_like": "t_carpet_yellow",
-    "connect_groups": "INDOORFLOOR",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
+    "color": "yellow",
     "deconstruct": { "items": [ { "item": "y_carpet", "charges": 1 } ], "ter_set": "t_linoleum_gray" }
   },
   {
@@ -1337,12 +1159,8 @@
     "copy-from": "t_carpet_base_linoleum_gray",
     "name": "green carpet",
     "description": "Soft green carpet on a gray linoleum floor.  Can support a roof.",
-    "symbol": ".",
-    "color": "green",
-    "move_cost": 2,
     "looks_like": "t_carpet_green",
-    "connect_groups": "INDOORFLOOR",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
+    "color": "green",
     "deconstruct": { "items": [ { "item": "g_carpet", "charges": 1 } ], "ter_set": "t_linoleum_gray" }
   },
   {
@@ -1351,25 +1169,14 @@
     "copy-from": "t_carpet_base_linoleum_gray",
     "name": "purple carpet",
     "description": "Soft purple carpet on a gray linoleum floor.  Can support a roof.",
-    "symbol": ".",
-    "color": "magenta",
-    "move_cost": 2,
     "looks_like": "t_carpet_purple",
-    "connect_groups": "INDOORFLOOR",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
+    "color": "magenta",
     "deconstruct": { "items": [ { "item": "p_carpet", "charges": 1 } ], "ter_set": "t_linoleum_gray" }
   },
   {
     "type": "terrain",
     "id": "t_carpet_base_linoleum_white",
-    "name": "Carpet",
-    "symbol": ".",
-    "color": "red",
-    "move_cost": 2,
     "copy-from": "t_carpet_base",
-    "description": "Base white linoleum floor carpet!",
-    "connect_groups": "INDOORFLOOR",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
     "bash": {
       "sound": "SMASH!",
       "ter_set": "t_linoleum_white",
@@ -1377,21 +1184,17 @@
       "str_max": 15,
       "str_min_supported": 100,
       "items": [ { "item": "sheet_cotton", "count": [ 1, 2 ] }, { "item": "cotton_patchwork", "count": [ 2, 4 ] } ]
-    },
-    "deconstruct": { "items": [ { "item": "r_carpet", "charges": 1 } ], "ter_set": "t_linoleum_white" }
+    }
   },
   {
     "type": "terrain",
     "id": "t_carpet_linoleum_white_red",
     "copy-from": "t_carpet_base_linoleum_white",
     "name": "red carpet",
+    "description": "Soft red carpet on a white linoleum floor.  Can support a roof.",
     "looks_like": "t_carpet_red",
-    "symbol": ".",
     "color": "red",
-    "move_cost": 2,
-    "connect_groups": "INDOORFLOOR",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
-    "description": "Soft red carpet on a white linoleum floor.  Can support a roof."
+    "deconstruct": { "items": [ { "item": "r_carpet", "charges": 1 } ], "ter_set": "t_linoleum_white" }
   },
   {
     "type": "terrain",
@@ -1399,12 +1202,8 @@
     "copy-from": "t_carpet_base_linoleum_white",
     "name": "yellow carpet",
     "description": "Soft yellow carpet on a white linoleum floor.  Can support a roof.",
-    "symbol": ".",
-    "color": "yellow",
-    "move_cost": 2,
     "looks_like": "t_carpet_yellow",
-    "connect_groups": "INDOORFLOOR",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
+    "color": "yellow",
     "deconstruct": { "items": [ { "item": "y_carpet", "charges": 1 } ], "ter_set": "t_linoleum_white" }
   },
   {
@@ -1413,12 +1212,8 @@
     "copy-from": "t_carpet_base_linoleum_white",
     "name": "green carpet",
     "description": "Soft green carpet on a white linoleum floor.  Can support a roof.",
-    "symbol": ".",
-    "color": "green",
-    "move_cost": 2,
     "looks_like": "t_carpet_green",
-    "connect_groups": "INDOORFLOOR",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
+    "color": "green",
     "deconstruct": { "items": [ { "item": "g_carpet", "charges": 1 } ], "ter_set": "t_linoleum_white" }
   },
   {
@@ -1427,12 +1222,8 @@
     "copy-from": "t_carpet_base_linoleum_white",
     "name": "purple carpet",
     "description": "Soft purple carpet on a white linoleum floor.  Can support a roof.",
-    "symbol": ".",
-    "color": "magenta",
-    "move_cost": 2,
     "looks_like": "t_carpet_purple",
-    "connect_groups": "INDOORFLOOR",
-    "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "RUG", "EASY_DECONSTRUCT" ],
+    "color": "magenta",
     "deconstruct": { "items": [ { "item": "p_carpet", "charges": 1 } ], "ter_set": "t_linoleum_white" }
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
A lot of unneeded redefinitions of fields in our carpet terrain definitions, why even use copy-from at this point. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

1. Make the base versions abstracts, they're not meant to spawn anywhere.
2. Remove every redundant definition.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
We have some carpet terrains that aren't used anywhere, maybe they're meant to be crafted but that looks a bit sus, I haven't looked too much into it.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loads, I've been to a couple of locations with carpets, looks fine. Admittedly I didn't go look for every type of carpet.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
