### PR TITLE
Make inv_search_cache operate on item_location

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -4432,16 +4432,16 @@ void atm_activity_actor::do_turn( player_activity &act, Character &who )
         // while the ATM activity is time-based, this option runs until invalid
         act.moves_left = calendar::INDEFINITELY_LONG;
         // get cash card
-        item *destination_cash_card;
-        const std::vector<item *> cash_cards = who.cache_get_items_with( "is_cash_card",
-                                               &item::is_cash_card );
+        item_location destination_cash_card;
+        const std::vector<item_location> cash_cards = who.cache_get_items_with( "is_cash_card",
+                &item::is_cash_card );
         if( cash_cards.empty() ) {
             popup( _( "You do not have a cash card." ) );
             act.set_to_null();
             return;
         }
-        destination_cash_card = *std::max_element( cash_cards.begin(), cash_cards.end(), []( const item * a,
-        const item * b ) {
+        destination_cash_card = *std::max_element( cash_cards.begin(),
+        cash_cards.end(), []( const item_location & a, const item_location & b ) {
             return a->ammo_remaining() < b->ammo_remaining();
         } );
 
@@ -4480,8 +4480,8 @@ void atm_activity_actor::do_turn( player_activity &act, Character &who )
         // while the ATM activity is time-based, this option runs until invalid
         act.moves_left = calendar::INDEFINITELY_LONG;
         // get first available cash card
-        item *destination_cash_card;
-        std::vector<item *> cash_cards_on_hand = who.cache_get_items_with( "is_cash_card",
+        item_location destination_cash_card;
+        std::vector<item_location> cash_cards_on_hand = who.cache_get_items_with( "is_cash_card",
                 &item::is_cash_card );
         // if there aren't any, then we're done
         if( cash_cards_on_hand.empty() ) {
@@ -4493,7 +4493,7 @@ void atm_activity_actor::do_turn( player_activity &act, Character &who )
 
         bool card_transferred = false;
         // find first available non-destination cash card with e-cash, re-run next turn
-        for( item *cash_card_withdraw : cash_cards_on_hand ) {
+        for( item_location &cash_card_withdraw : cash_cards_on_hand ) {
             if( cash_card_withdraw == destination_cash_card ||
                 cash_card_withdraw->ammo_remaining() <= 0 ||
                 cash_card_withdraw->typeId() != itype_cash_card ) {
@@ -4533,7 +4533,7 @@ void atm_activity_actor::finish( player_activity &act, Character &who )
         who.use_charges( itype_cash_card, cash_amount );
         who.cash += cash_amount;
     } else if( option_selected == withdraw_money ) {
-        std::vector<item *> cash_cards_on_hand = who.cache_get_items_with( "is_cash_card",
+        std::vector<item_location> cash_cards_on_hand = who.cache_get_items_with( "is_cash_card",
                 &item::is_cash_card );
         if( cash_cards_on_hand.empty() ) {
             //Just in case we run into an edge case
@@ -4545,13 +4545,14 @@ void atm_activity_actor::finish( player_activity &act, Character &who )
         int inserted = 0;
         int remaining = cash_amount;
 
-        std::sort( cash_cards_on_hand.begin(), cash_cards_on_hand.end(), []( item * one, item * two ) {
+        std::sort( cash_cards_on_hand.begin(), cash_cards_on_hand.end(), []( item_location one,
+        item_location  two ) {
             int balance_one = one->ammo_remaining();
             int balance_two = two->ammo_remaining();
             return balance_one > balance_two;
         } );
 
-        for( item * const &cc : cash_cards_on_hand ) {
+        for( item_location &cc : cash_cards_on_hand ) {
             if( inserted == cash_amount ) {
                 break;
             }

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -3513,8 +3513,8 @@ bool farm_do( Character &you, const activity_reason_info &act_info,
         for( const zone_data &zone : zones ) {
             const itype_id seed =
                 dynamic_cast<const plot_options &>( zone.get_options() ).get_seed();
-            std::vector<item *> seed_inv = you.cache_get_items_with( "is_seed", itype_id( seed ), {},
-                                           &item::is_seed );
+            std::vector<item_location> seed_inv = you.cache_get_items_with( "is_seed", itype_id( seed ), {},
+                                                  &item::is_seed );
             if( seed_inv.empty() ) {
                 // we don't have the required seed, even though we should at this point.
                 // move onto the next tile, and if need be that will prompt a fetch seeds activity.

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1096,7 +1096,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
             bio.powered = g->remoteveh() != nullptr || maybe_get_value( "remote_controlling" );
         }
     } else if( bio.info().is_remote_fueled ) {
-        std::vector<item *> cables = cache_get_items_with( flag_CABLE_SPOOL );
+        std::vector<item_location> cables = cache_get_items_with( flag_CABLE_SPOOL );
         bool has_cable = !cables.empty();
         bool free_cable = false;
         bool success = false;
@@ -1104,7 +1104,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
             add_msg_if_player( m_info,
                                _( "You need a jumper cable connected to a power source to drain power from it." ) );
         } else {
-            for( const item *cable : cables ) {
+            for( const item_location &cable : cables ) {
                 if( cable->has_no_links() ) {
                     free_cable = true;
                 } else if( cable->link_has_states( link_state::no_link, link_state::bio_cable ) ) {
@@ -3332,8 +3332,8 @@ std::vector<item *> Character::get_cable_ups()
 {
     std::vector<item *> stored_fuels;
 
-    int n = cache_get_items_with( flag_CABLE_SPOOL, []( const item & it ) {
-        return it.link_has_states( link_state::ups, link_state::bio_cable );
+    int n = cache_get_items_with( flag_CABLE_SPOOL, []( const item_location & it ) {
+        return it->link_has_states( link_state::ups, link_state::bio_cable );
     } ).size();
     if( n == 0 ) {
         return stored_fuels;
@@ -3364,8 +3364,8 @@ std::vector<item *> Character::get_cable_solar()
 {
     std::vector<item *> solar_sources;
 
-    int n = cache_get_items_with( flag_CABLE_SPOOL, []( const item & it ) {
-        return it.link_has_states( link_state::solarpack, link_state::bio_cable );
+    int n = cache_get_items_with( flag_CABLE_SPOOL, []( const item_location & it ) {
+        return it->link_has_states( link_state::solarpack, link_state::bio_cable );
     } ).size();
     if( n == 0 ) {
         return solar_sources;
@@ -3394,11 +3394,11 @@ std::vector<vehicle *> Character::get_cable_vehicle() const
 {
     std::vector<vehicle *> remote_vehicles;
 
-    std::vector<const item *> cables = cache_get_items_with( flag_CABLE_SPOOL,
-    []( const item & it ) {
-        return it.link_has_state( link_state::bio_cable ) &&
-               ( it.link_has_state( link_state::vehicle_battery ) ||
-                 it.link_has_state( link_state::vehicle_port ) );
+    const std::vector<item_location> cables = cache_get_items_with( flag_CABLE_SPOOL,
+    []( const item_location & it ) {
+        return it->link_has_state( link_state::bio_cable ) &&
+               ( it->link_has_state( link_state::vehicle_battery ) ||
+                 it->link_has_state( link_state::vehicle_port ) );
     } );
     int n = cables.size();
     if( n == 0 ) {
@@ -3407,7 +3407,7 @@ std::vector<vehicle *> Character::get_cable_vehicle() const
 
     map &here = get_map();
 
-    for( const item *cable : cables ) {
+    for( const item_location &cable : cables ) {
         if( cable->link().t_veh ) {
             remote_vehicles.emplace_back( cable->link().t_veh.get() );
         } else {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2230,8 +2230,8 @@ void Character::process_turn()
     // Didn't just pick something up
     last_item = itype_id::NULL_ID();
 
-    cache_visit_items_with( "is_relic", &item::is_relic, [this]( item & it ) {
-        it.process_relic( this, pos_bub() );
+    cache_visit_items_with( "is_relic", &item::is_relic, [this]( item_location & it ) {
+        it->process_relic( this, pos_bub() );
     } );
 
     suffer();
@@ -3753,8 +3753,8 @@ float Character::active_light() const
     float lumination = 0.0f;
 
     int maxlum = 0;
-    cache_visit_items_with( "is_emissive", &item::is_emissive, [&maxlum]( const item & it ) {
-        const int lumit = it.getlight_emit();
+    cache_visit_items_with( "is_emissive", &item::is_emissive, [&maxlum]( const item_location & it ) {
+        const int lumit = it->getlight_emit();
         if( maxlum < lumit ) {
             maxlum = lumit;
         }
@@ -4785,14 +4785,14 @@ void Character::recalculate_enchantment_cache()
 {
     enchantment_cache->clear();
 
-    cache_visit_items_with( "is_relic", &item::is_relic, [this]( const item & it ) {
-        for( const enchant_cache &ench : it.get_proc_enchantments() ) {
-            if( ench.is_active( *this, it ) ) {
+    cache_visit_items_with( "is_relic", &item::is_relic, [this]( const item_location & it ) {
+        for( const enchant_cache &ench : it->get_proc_enchantments() ) {
+            if( ench.is_active( *this, *it ) ) {
                 enchantment_cache->force_add( ench );
             }
         }
-        for( const enchantment &ench : it.get_defined_enchantments() ) {
-            if( ench.is_active( *this, it ) ) {
+        for( const enchantment &ench : it->get_defined_enchantments() ) {
+            if( ench.is_active( *this, *it ) ) {
                 enchantment_cache->force_add( ench, *this );
             }
         }
@@ -5517,13 +5517,13 @@ const
     std::pair<float, item> best_weapon = std::make_pair( 0.0f, item() );
 
     cache_visit_items_with( "best_damage_" + dmg_type.str(), &item::is_melee, [&best_weapon, this,
-                  dmg_type]( const item & it ) {
+                  dmg_type]( const item_location & it ) {
         damage_instance di;
-        roll_damage( dmg_type, false, di, true, it, attack_vector_id::NULL_ID(),
+        roll_damage( dmg_type, false, di, true, *it, attack_vector_id::NULL_ID(),
                      sub_bodypart_str_id::NULL_ID(), 1.f );
         for( damage_unit &du : di.damage_units ) {
             if( du.type == dmg_type && best_weapon.first < du.amount ) {
-                best_weapon = std::make_pair( du.amount, it );
+                best_weapon = std::make_pair( du.amount, *it );
             }
         }
     } );
@@ -5542,8 +5542,8 @@ units::energy Character::available_ups() const
     }
 
     bool has_bio_powered_ups = false;
-    cache_visit_items_with( flag_IS_UPS, [&has_bio_powered_ups]( const item & it ) {
-        if( it.has_flag( flag_USES_BIONIC_POWER ) && !has_bio_powered_ups ) {
+    cache_visit_items_with( flag_IS_UPS, [&has_bio_powered_ups]( const item_location & it ) {
+        if( it->has_flag( flag_USES_BIONIC_POWER ) && !has_bio_powered_ups ) {
             has_bio_powered_ups = true;
         }
     } );
@@ -5551,9 +5551,8 @@ units::energy Character::available_ups() const
         available_charges += get_power_level();
     }
 
-    cache_visit_items_with( flag_IS_UPS, [&available_charges]( const item & it ) {
-        available_charges += units::from_kilojoule( static_cast<std::int64_t>( it.ammo_remaining(
-                             ) ) );
+    cache_visit_items_with( flag_IS_UPS, [&available_charges]( const item_location & it ) {
+        available_charges += units::from_kilojoule( static_cast<std::int64_t>( it->ammo_remaining( ) ) );
     } );
 
     return available_charges;
@@ -5572,8 +5571,8 @@ units::energy Character::consume_ups( units::energy qty, const int radius )
 
     // UPS from bionic
     bool has_bio_powered_ups = false;
-    cache_visit_items_with( flag_IS_UPS, [&has_bio_powered_ups]( const item & it ) {
-        if( it.has_flag( flag_USES_BIONIC_POWER ) && !has_bio_powered_ups ) {
+    cache_visit_items_with( flag_IS_UPS, [&has_bio_powered_ups]( const item_location & it ) {
+        if( it->has_flag( flag_USES_BIONIC_POWER ) && !has_bio_powered_ups ) {
             has_bio_powered_ups = true;
         }
     } );
@@ -5585,12 +5584,12 @@ units::energy Character::consume_ups( units::energy qty, const int radius )
 
     // UPS from inventory
     if( qty != 0_kJ ) {
-        cache_visit_items_with( flag_IS_UPS, [&qty]( item & it ) {
-            if( it.is_tool() && it.type->tool->fuel_efficiency >= 0 ) {
-                qty -= it.energy_consume( qty, tripoint_bub_ms::zero, nullptr,
-                                          it.type->tool->fuel_efficiency );
+        cache_visit_items_with( flag_IS_UPS, [&qty]( item_location & it ) {
+            if( it->is_tool() && it->type->tool->fuel_efficiency >= 0 ) {
+                qty -= it->energy_consume( qty, tripoint_bub_ms::zero, nullptr,
+                                           it->type->tool->fuel_efficiency );
             } else {
-                qty -= it.energy_consume( qty, tripoint_bub_ms::zero, nullptr );
+                qty -= it->energy_consume( qty, tripoint_bub_ms::zero, nullptr );
             }
         } );
     }

--- a/src/character.h
+++ b/src/character.h
@@ -50,7 +50,6 @@
 #include "point.h"
 #include "ranged.h"
 #include "ret_val.h"
-#include "safe_reference.h"
 #include "sleep.h"
 #include "stomach.h"
 #include "string_formatter.h"
@@ -2204,7 +2203,7 @@ class Character : public Creature, public visitable
         /**
          * Returns the items that are ammo and have the matching ammo type.
          */
-        std::vector<const item *> get_ammo( const ammotype &at ) const;
+        std::vector<item_location> get_ammo( const ammotype &at ) const;
 
         /**
          * Searches for ammo or magazines that can be used to reload obj
@@ -2953,23 +2952,23 @@ class Character : public Creature, public visitable
          * @param do_func A lambda function to apply on all items that pass the filters.
          */
         void cache_visit_items_with( const itype_id &type,
-                                     const std::function<void( item & )> &do_func );
+                                     const std::function<void( item_location & )> &do_func );
         void cache_visit_items_with( const flag_id &type_flag,
-                                     const std::function<void( item & )> &do_func );
+                                     const std::function<void( item_location & )> &do_func );
         void cache_visit_items_with( const std::string &key, bool( item::*filter_func )() const,
-                                     const std::function<void( item & )> &do_func );
+                                     const std::function<void( item_location & )> &do_func );
         void cache_visit_items_with( const std::string &key, const itype_id &type,
                                      const flag_id &type_flag, bool( item::*filter_func )() const,
-                                     const std::function<void( item & )> &do_func );
+                                     const std::function<void( item_location & )> &do_func );
         void cache_visit_items_with( const itype_id &type,
-                                     const std::function<void( const item & )> &do_func ) const;
+                                     const std::function<void( const item_location & )> &do_func ) const;
         void cache_visit_items_with( const flag_id &type_flag,
-                                     const std::function<void( const item & )> &do_func ) const;
+                                     const std::function<void( const item_location & )> &do_func ) const;
         void cache_visit_items_with( const std::string &key, bool( item::*filter_func )() const,
-                                     const std::function<void( const item & )> &do_func ) const;
+                                     const std::function<void( const item_location & )> &do_func ) const;
         void cache_visit_items_with( const std::string &key, const itype_id &type,
                                      const flag_id &type_flag, bool( item::*filter_func )() const,
-                                     const std::function<void( const item & )> &do_func ) const;
+                                     const std::function<void( const item_location & )> &do_func ) const;
         /**
         * @brief Returns true if the character has an item with given flag and/or that passes the given boolean item function, using or creating caches from @ref inv_search_caches.
         * @brief If you want to iterate over the entire cache, `cache_visit_items_with` should be used instead, as it's more optimized for processing entire caches.
@@ -3008,26 +3007,26 @@ class Character : public Creature, public visitable
          * If it returns true, the item is added to the return vector. These results are not cached, unlike filter_func.
          * @return A vector of pointers to all items that pass the criteria.
          */
-        std::vector<item *> cache_get_items_with( const itype_id &type,
-                const std::function<bool( item & )> &do_and_check_func = return_true<item> );
-        std::vector<item *> cache_get_items_with( const flag_id &type_flag,
-                const std::function<bool( item & )> &do_and_check_func = return_true<item> );
-        std::vector<item *> cache_get_items_with( const std::string &key,
+        std::vector<item_location> cache_get_items_with( const itype_id &type,
+                const std::function<bool( item_location & )> &do_and_check_func = return_true<item_location> );
+        std::vector<item_location> cache_get_items_with( const flag_id &type_flag,
+                const std::function<bool( item_location & )> &do_and_check_func = return_true<item_location> );
+        std::vector<item_location> cache_get_items_with( const std::string &key,
                 bool( item::*filter_func )() const,
-                const std::function<bool( item & )> &do_and_check_func = return_true<item> );
-        std::vector<item *> cache_get_items_with( const std::string &key, const itype_id &type,
+                const std::function<bool( item_location & )> &do_and_check_func = return_true<item_location> );
+        std::vector<item_location> cache_get_items_with( const std::string &key, const itype_id &type,
                 const flag_id &type_flag, bool( item::*filter_func )() const,
-                const std::function<bool( item & )> &do_and_check_func = return_true<item> );
-        std::vector<const item *> cache_get_items_with( const itype_id &type,
-                const std::function<bool( const item & )> &check_func = return_true<item> ) const;
-        std::vector<const item *> cache_get_items_with( const flag_id &type_flag,
-                const std::function<bool( const item & )> &check_func = return_true<item> ) const;
-        std::vector<const item *> cache_get_items_with( const std::string &key,
+                const std::function<bool( item_location & )> &do_and_check_func = return_true<item_location> );
+        std::vector<item_location> cache_get_items_with( const itype_id &type,
+                const std::function<bool( const item_location & )> &check_func = return_true<item_location> ) const;
+        std::vector<item_location> cache_get_items_with( const flag_id &type_flag,
+                const std::function<bool( const item_location & )> &check_func = return_true<item_location> ) const;
+        std::vector<item_location> cache_get_items_with( const std::string &key,
                 bool( item::*filter_func )() const,
-                const std::function<bool( const item & )> &check_func = return_true<item> ) const;
-        std::vector<const item *> cache_get_items_with( const std::string &key, const itype_id &type,
+                const std::function<bool( const item_location & )> &check_func = return_true<item_location> ) const;
+        std::vector<item_location> cache_get_items_with( const std::string &key, const itype_id &type,
                 const flag_id &type_flag, bool( item::*filter_func )() const,
-                const std::function<bool( const item & )> &check_func = return_true<item> ) const;
+                const std::function<bool( const item_location & )> &check_func = return_true<item_location> ) const;
         /**
          * Add an item to existing @ref inv_search_caches that it meets the criteria for. Will NOT create any new caches.
          */
@@ -4260,7 +4259,7 @@ class Character : public Creature, public visitable
             itype_id type;
             flag_id type_flag;
             bool ( item::*filter_func )() const;
-            std::list<safe_reference<item>> items;
+            std::list<item_location> items;
         };
         mutable std::unordered_map<std::string, inv_search_cache> inv_search_caches;
     protected:

--- a/src/character_guns.cpp
+++ b/src/character_guns.cpp
@@ -104,10 +104,10 @@ void find_ammo_helper( T &src, const item &obj, bool empty, Output out, bool nes
     } );
 }
 
-std::vector<const item *> Character::get_ammo( const ammotype &at ) const
+std::vector<item_location> Character::get_ammo( const ammotype &at ) const
 {
-    return cache_get_items_with( "is_ammo", &item::is_ammo, [at]( const item & it ) {
-        return it.ammo_type() == at;
+    return cache_get_items_with( "is_ammo", &item::is_ammo, [at]( const item_location & it ) {
+        return it->ammo_type() == at;
     } );
 }
 

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -25,6 +25,7 @@
 #include "item.h"
 #include "item_category.h"
 #include "item_group.h"
+#include "item_location.h"
 #include "item_pocket.h"
 #include "item_search.h"
 #include "itype.h"
@@ -32,6 +33,7 @@
 #include "localized_comparator.h"
 #include "map.h"
 #include "map_iterator.h"
+#include "map_selector.h"
 #include "memory_fast.h"
 #include "output.h"
 #include "path_info.h"
@@ -310,7 +312,8 @@ unload_options::query_unload_result unload_options::query_unload()
 plot_options::query_seed_result plot_options::query_seed()
 {
     Character &player_character = get_player_character();
-    std::vector<item *> seed_inv = player_character.cache_get_items_with( "is_seed", &item::is_seed );
+    std::vector<item_location> seed_inv = player_character.cache_get_items_with( "is_seed",
+                                          &item::is_seed );
     zone_manager &mgr = zone_manager::get_manager();
     map &here = get_map();
     const std::unordered_set<tripoint_abs_ms> zone_src_set =
@@ -320,7 +323,7 @@ plot_options::query_seed_result plot_options::query_seed()
         tripoint_bub_ms elem_loc = here.get_bub( elem );
         for( item &it : here.i_at( elem_loc ) ) {
             if( it.is_seed() ) {
-                seed_inv.push_back( &it );
+                seed_inv.emplace_back( map_cursor( elem_loc ), &it );
             }
         }
     }

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -2566,10 +2566,10 @@ void iexamine::fungus( Character &you, const tripoint_bub_ms &examp )
 /**
  *  Make lists of unique seed types and names for the menu(no multiple hemp seeds etc)
  */
-std::vector<seed_tuple> iexamine::get_seed_entries( const std::vector<item *> &seed_inv )
+std::vector<seed_tuple> iexamine::get_seed_entries( const std::vector<item_location> &seed_inv )
 {
     std::map<itype_id, int> seed_map;
-    for( const item *seed : seed_inv ) {
+    for( const item_location &seed : seed_inv ) {
         seed_map[seed->typeId()] += ( seed->charges > 0 ? seed->charges : 1 );
     }
 
@@ -2637,7 +2637,7 @@ void iexamine::dirtmound( Character &you, const tripoint_bub_ms &examp )
         add_msg(m_info, _("It is too dark to plant anything now."));
         return;
     }*/
-    std::vector<item *> seed_inv = you.cache_get_items_with( "is_seed", &item::is_seed );
+    std::vector<item_location> seed_inv = you.cache_get_items_with( "is_seed", &item::is_seed );
     if( seed_inv.empty() ) {
         add_msg( m_info, _( "You have no seeds to plant." ) );
         return;
@@ -2912,7 +2912,7 @@ void iexamine::fertilize_plant( Character &you, const tripoint_bub_ms &tile,
 itype_id iexamine::choose_fertilizer( Character &you, const std::string &pname,
                                       bool ask_player )
 {
-    std::vector<item *> f_inv = you.cache_get_items_with( flag_FERTILIZER );
+    std::vector<item_location> f_inv = you.cache_get_items_with( flag_FERTILIZER );
     if( f_inv.empty() ) {
         add_msg( m_info, _( "You have no fertilizer for the %s." ), pname );
         return itype_id();
@@ -2920,7 +2920,7 @@ itype_id iexamine::choose_fertilizer( Character &you, const std::string &pname,
 
     std::vector<itype_id> f_types;
     std::vector<std::string> f_names;
-    for( const item * const &f : f_inv ) {
+    for( const item_location &f : f_inv ) {
         if( std::find( f_types.begin(), f_types.end(), f->typeId() ) == f_types.end() ) {
             f_types.push_back( f->typeId() );
             f_names.push_back( f->tname() );
@@ -3736,7 +3736,7 @@ void iexamine::fvat_empty( Character &you, const tripoint_bub_ms &examp )
         // Code shamelessly stolen from the crop planting function!
         std::vector<itype_id> b_types;
         std::vector<std::string> b_names;
-        for( const item *b : b_inv ) {
+        for( const item_location &b : b_inv ) {
             if( std::find( b_types.begin(), b_types.end(), b->typeId() ) == b_types.end() ) {
                 b_types.push_back( b->typeId() );
                 b_names.push_back( item::nname( b->typeId() ) );
@@ -3967,7 +3967,7 @@ void iexamine::compost_empty( Character &you, const tripoint_bub_ms &examp )
         // Code shamelessly stolen from the crop planting function!
         std::vector<itype_id> b_types;
         std::vector<std::string> b_names;
-        for( const item *b : b_inv ) {
+        for( const item_location &b : b_inv ) {
             if( std::find( b_types.begin(), b_types.end(), b->typeId() ) == b_types.end() ) {
                 b_types.push_back( b->typeId() );
                 b_names.push_back( item::nname( b->typeId() ) );
@@ -5222,8 +5222,8 @@ static int findBestGasDiscount( Character &you )
 {
     int discount = 0;
 
-    you.cache_visit_items_with( flag_GAS_DISCOUNT, [&discount]( const item & it ) {
-        discount = std::max( discount, getGasDiscountCardQuality( it ) );
+    you.cache_visit_items_with( flag_GAS_DISCOUNT, [&discount]( const item_location & it ) {
+        discount = std::max( discount, getGasDiscountCardQuality( *it ) );
     } );
 
     return discount;
@@ -5511,7 +5511,8 @@ void iexamine::pay_gas( Character &you, const tripoint_bub_ms &examp )
     }
 
     if( refund == choice ) {
-        std::vector<item *> cash_cards = you.cache_get_items_with( "is_cash_card", &item::is_cash_card );
+        std::vector<item_location> cash_cards = you.cache_get_items_with( "is_cash_card",
+                                                &item::is_cash_card );
         if( cash_cards.empty() ) {
             popup( _( "You do not have a cash card to refund money!" ) );
             return;
@@ -5529,10 +5530,10 @@ void iexamine::pay_gas( Character &you, const tripoint_bub_ms &examp )
 
         // getGasPricePerLiter( platinum_discount) min price to avoid exploit
         int amount_money = amount_fuel * getGasPricePerLiter( 3 ) / 1000.0f;
-        std::sort( cash_cards.begin(), cash_cards.end(), []( item * l, const item * r ) {
+        std::sort( cash_cards.begin(), cash_cards.end(), []( item_location & l, const item_location & r ) {
             return l->ammo_remaining( ) > r->ammo_remaining( );
         } );
-        for( item * const &cc : cash_cards ) {
+        for( item_location &cc : cash_cards ) {
             if( amount_money == 0 ) {
                 break;
             }

--- a/src/iexamine.h
+++ b/src/iexamine.h
@@ -17,6 +17,7 @@
 class Character;
 class JsonObject;
 class item;
+class item_location;
 class time_point;
 class vpart_reference;
 struct itype;
@@ -164,7 +165,7 @@ std::list<item> get_harvest_items( const itype &type, int plant_count,
                                    int seed_count, bool byproducts );
 
 // Planting functions
-std::vector<seed_tuple> get_seed_entries( const std::vector<item *> &seed_inv );
+std::vector<seed_tuple> get_seed_entries( const std::vector<item_location> &seed_inv );
 int query_seed( const std::vector<seed_tuple> &seed_entries );
 void plant_seed( Character &you, const tripoint_bub_ms &examp, const itype_id &seed_id );
 void clear_overgrown( Character &you, const tripoint_bub_ms &examp );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -472,8 +472,8 @@ void remove_radio_mod( item &it, Character &p )
 // Checks that the player can smoke
 std::optional<std::string> iuse::can_smoke( const Character &you )
 {
-    auto cigs = you.cache_get_items_with( flag_LITCIG, []( const item & it ) {
-        return it.active;
+    auto cigs = you.cache_get_items_with( flag_LITCIG, []( const item_location & it ) {
+        return it->active;
     } );
 
     if( !cigs.empty() ) {
@@ -2563,7 +2563,7 @@ std::optional<int> iuse::directional_antenna( Character *p, item *it, const trip
         map_stack items = get_map().i_at( p->pos_bub() );
         for( item &an_item : items ) {
             if( an_item.typeId() == itype_radio_on ) {
-                radios.push_back( &an_item );
+                radios.emplace_back( map_cursor( p->pos_bub() ), &an_item );
             }
         }
     }
@@ -4119,11 +4119,12 @@ std::optional<int> iuse::portable_game( Character *p, item *it, const tripoint_b
             }
             for( npc *n : friends_w_game ) {
                 // this vector may be empty, so a nullptr would be passed
-                std::vector<item *> nit = n->cache_get_items_with( it->typeId(), []( const item & i ) {
-                    return i.ammo_sufficient( nullptr );
+                std::vector<item_location> nit = n->cache_get_items_with( it->typeId(), [](
+                const item_location & i ) {
+                    return i->ammo_sufficient( nullptr );
                 } );
-                portable_game_activity_actor portable_game_act( 15_minutes, item_location( *n, nit.front() ),
-                        entertain_players, winner );
+                portable_game_activity_actor portable_game_act( 15_minutes, nit.front(), entertain_players,
+                        winner );
                 n->assign_activity( portable_game_act );
             }
         }

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -183,7 +183,7 @@ static const trap_str_id tr_firewood_source( "tr_firewood_source" );
 static const zone_type_id zone_type_SOURCE_FIREWOOD( "SOURCE_FIREWOOD" );
 
 template<typename T>
-static item_location form_loc_recursive( T &loc, item &it )
+item_location form_loc_recursive( T &loc, item &it )
 {
     item *parent = loc.find_parent( it );
     if( parent != nullptr ) {
@@ -192,6 +192,10 @@ static item_location form_loc_recursive( T &loc, item &it )
 
     return item_location( loc, &it );
 }
+
+//explict template instantiation
+template item_location form_loc_recursive<Character>( Character &loc, item &it );
+template item_location form_loc_recursive<npc>( npc &loc, item &it );
 
 static item_location form_loc( Character &you, map *here, const tripoint_bub_ms &p, item &it )
 {

--- a/src/iuse_actor.h
+++ b/src/iuse_actor.h
@@ -38,6 +38,10 @@ namespace sounds
 enum class sound_t : int;
 } // namespace sounds
 
+// this might not be the ideal place for this, but for now it'll do
+template<typename T>
+item_location form_loc_recursive( T &loc, item &it );
+
 /**
  * Transform an item into a specific type.
  * Optionally activate it.

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -1439,9 +1439,9 @@ std::vector<matec_id> character_martial_arts::get_all_techniques( const item_loc
         tecs.insert( tecs.end(), weapon_techs.begin(), weapon_techs.end() );
     }
     // If we have any items that also provide techniques
-    const std::vector<const item *> tech_providing_items = u.cache_get_items_with(
+    const std::vector<item_location> tech_providing_items = u.cache_get_items_with(
                 json_flag_PROVIDES_TECHNIQUES );
-    for( const item *it : tech_providing_items ) {
+    for( const item_location &it : tech_providing_items ) {
         const std::set<matec_id> &item_techs = it->get_techniques();
         tecs.insert( tecs.end(), item_techs.begin(), item_techs.end() );
     }

--- a/src/mission_companion.cpp
+++ b/src/mission_companion.cpp
@@ -43,6 +43,7 @@
 #include "inventory.h"
 #include "item.h"
 #include "item_group.h"
+#include "item_location.h"
 #include "itype.h"
 #include "json.h"
 #include "map.h"
@@ -1549,9 +1550,10 @@ npc_ptr talk_function::temp_npc( const string_id<npc_template> &type )
 void talk_function::field_plant( npc &p, const std::string &place )
 {
     Character &player_character = get_player_character();
-    std::vector<item *> seed_inv = player_character.cache_get_items_with( "is_seed", &item::is_seed,
-    []( const item & itm ) {
-        return itm.typeId() != itype_marloss_seed && itm.typeId() != itype_fungal_seeds;
+    std::vector<item_location> seed_inv = player_character.cache_get_items_with( "is_seed",
+                                          &item::is_seed,
+    []( const item_location & itm ) {
+        return itm->typeId() != itype_marloss_seed && itm->typeId() != itype_fungal_seeds;
     } );
     if( seed_inv.empty() ) {
         popup( _( "You have no seeds to plant." ) );
@@ -1563,7 +1565,7 @@ void talk_function::field_plant( npc &p, const std::string &place )
 
     std::vector<itype_id> seed_types;
     std::vector<std::string> seed_names;
-    for( item *&seed : seed_inv ) {
+    for( item_location &seed : seed_inv ) {
         if( std::find( seed_types.begin(), seed_types.end(), seed->typeId() ) == seed_types.end() ) {
             seed_types.push_back( seed->typeId() );
             seed_names.push_back( seed->tname() );

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -416,7 +416,7 @@ void add_leash( monster &z )
         return;
     }
     Character &player_character = get_player_character();
-    std::vector<item *> rope_inv = player_character.cache_get_items_with( json_flag_TIE_UP );
+    std::vector<item_location> rope_inv = player_character.cache_get_items_with( json_flag_TIE_UP );
     if( rope_inv.empty() ) {
         return;
     }
@@ -424,7 +424,7 @@ void add_leash( monster &z )
     uilist selection_menu;
     selection_menu.text = string_format( _( "Select an item to leash your %s with." ), z.get_name() );
     selection_menu.addentry( i++, true, MENU_AUTOASSIGN, _( "Cancel" ) );
-    for( const item *iter : rope_inv ) {
+    for( const item_location &iter : rope_inv ) {
         selection_menu.addentry( i++, true, MENU_AUTOASSIGN, _( "Use %s" ), iter->tname() );
     }
     selection_menu.selected = 1;
@@ -434,9 +434,9 @@ void add_leash( monster &z )
         index > static_cast<int>( rope_inv.size() ) ) {
         return;
     }
-    item *rope_item = rope_inv[index - 1];
+    item_location rope_item = rope_inv[index - 1];
     z.tied_item = cata::make_value<item>( *rope_item );
-    player_character.i_rem( rope_item );
+    rope_item.remove_item();
     z.add_effect( effect_leashed, 1_turns, true );
     add_msg( _( "You add a leash to your %s." ), z.get_name() );
 }
@@ -608,7 +608,7 @@ void insert_battery( monster &z )
         return;
     }
     Character &player_character = get_player_character();
-    std::vector<item *> bat_inv = player_character.cache_get_items_with( json_flag_MECH_BAT );
+    std::vector<item_location> bat_inv = player_character.cache_get_items_with( json_flag_MECH_BAT );
     if( bat_inv.empty() ) {
         return;
     }
@@ -617,7 +617,7 @@ void insert_battery( monster &z )
     selection_menu.text = string_format( _( "Select an battery to insert into your %s." ),
                                          z.get_name() );
     selection_menu.addentry( i++, true, MENU_AUTOASSIGN, _( "Cancel" ) );
-    for( const item *iter : bat_inv ) {
+    for( const item_location &iter : bat_inv ) {
         selection_menu.addentry( i++, true, MENU_AUTOASSIGN, _( "Use %s" ), iter->tname() );
     }
     selection_menu.selected = 1;
@@ -627,9 +627,9 @@ void insert_battery( monster &z )
         index > static_cast<int>( bat_inv.size() ) ) {
         return;
     }
-    item *bat_item = bat_inv[index - 1];
+    item_location &bat_item = bat_inv[index - 1];
     z.battery_item = cata::make_value<item>( *bat_item );
-    player_character.i_rem( bat_item );
+    bat_item.remove_item();
 }
 
 } // namespace

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1921,9 +1921,9 @@ void npc::decide_needs()
     needrank[need_weapon] = evaluate_weapon( weap );
     needrank[need_food] = 15 - get_hunger();
     needrank[need_drink] = 15 - get_thirst();
-    cache_visit_items_with( "is_food", &item::is_food, [&]( const item & it ) {
-        needrank[ need_food ] += nutrition_for( it ) / 4.0;
-        needrank[ need_drink ] += it.get_comestible()->quench / 4.0;
+    cache_visit_items_with( "is_food", &item::is_food, [&]( const item_location & it ) {
+        needrank[ need_food ] += nutrition_for( *it ) / 4.0;
+        needrank[ need_drink ] += it->get_comestible()->quench / 4.0;
     } );
     needs.clear();
     size_t j;

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2219,16 +2219,6 @@ static bool wants_to_reload_with( const item &weap, const item &ammo )
     return !ammo.is_magazine() || ammo.ammo_remaining( ) > weap.ammo_remaining( );
 }
 
-// todo: make visit_items use item_locations and remove this
-static item_location form_loc_recursive( Character *npc, item *node, item *parent )
-{
-    if( parent ) {
-        return item_location( form_loc_recursive( npc, parent, npc->find_parent( *parent ) ), node );
-    }
-
-    return item_location( *npc, node );
-}
-
 item_location npc::find_reloadable()
 {
     auto cached_value = cached_info.find( "reloadables" );
@@ -2242,12 +2232,12 @@ item_location npc::find_reloadable()
     // TODO: Cache items checked for reloading to avoid re-checking same items every turn
     // TODO: Make it understand smaller and bigger magazines
     item_location reloadable;
-    visit_items( [this, &reloadable]( item * node, item * parent ) {
+    visit_items( [this, &reloadable]( item * node, item * ) {
         if( !wants_to_reload( *this, *node ) ) {
             return VisitResponse::NEXT;
         }
 
-        item_location node_loc = form_loc_recursive( this, node, parent );
+        item_location node_loc = form_loc_recursive( *this, *node );
 
         const item_location it_loc = select_ammo( node_loc ).ammo;
         if( it_loc && wants_to_reload_with( *node, *it_loc ) ) {
@@ -4734,12 +4724,12 @@ bool npc::consume_food_from_camp()
 bool npc::consume_food()
 {
     float best_weight = 0.0f;
-    item *best_food = nullptr;
+    item_location best_food;
     bool consumed = false;
     int want_hunger = std::max( 0, get_hunger() );
     int want_quench = std::max( 0, get_thirst() );
 
-    const std::vector<item *> inv_food = cache_get_items_with( "is_food", &item::is_food );
+    const std::vector<item_location> inv_food = cache_get_items_with( "is_food", &item::is_food );
 
     if( inv_food.empty() ) {
         if( !needs_food() ) {
@@ -4748,7 +4738,7 @@ bool npc::consume_food()
             set_thirst( 0 );
         }
     } else {
-        for( item * const &food_item : inv_food ) {
+        for( const item_location &food_item : inv_food ) {
             float cur_weight = rate_food( *food_item, want_hunger, want_quench );
             // Note: will_eat is expensive, avoid calling it if possible
             if( cur_weight > best_weight && will_eat( *food_item ).success() ) {
@@ -4758,9 +4748,9 @@ bool npc::consume_food()
         }
 
         // consume doesn't return a meaningful answer, we need to compare moves
-        if( best_food != nullptr ) {
+        if( best_food ) {
             const time_duration &consume_time = get_consume_time( *best_food );
-            consumed = consume( item_location( *this, best_food ) ) != trinary::NONE;
+            consumed = consume( best_food ) != trinary::NONE;
             if( consumed ) {
                 // TODO: Message that "X begins eating Y?" Right now it appears to the player
                 //       that "Urist eats a carp roast" and then stands still doing nothing

--- a/src/talker_character.cpp
+++ b/src/talker_character.cpp
@@ -908,9 +908,9 @@ bool talker_character_const::has_item_with_flag( const flag_id &flag ) const
 int talker_character_const::item_rads( const flag_id &flag, aggregate_type agg_func ) const
 {
     std::vector<int> rad_vals;
-    me_chr_const->cache_visit_items_with( flag, [&]( const item & it ) {
-        if( me_chr_const->is_worn( it ) || me_chr_const->is_wielding( it ) ) {
-            rad_vals.emplace_back( it.irradiation );
+    me_chr_const->cache_visit_items_with( flag, [&]( const item_location & it ) {
+        if( me_chr_const->is_worn( *it ) || me_chr_const->is_wielding( *it ) ) {
+            rad_vals.emplace_back( it->irradiation );
         }
     } );
     return aggregate( rad_vals, agg_func );

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -900,7 +900,8 @@ void vehicle::honk_horn( map &here ) const
 void vehicle::reload_seeds( map *here, const tripoint_bub_ms &pos )
 {
     Character &player_character = get_player_character();
-    std::vector<item *> seed_inv = player_character.cache_get_items_with( "is_seed", &item::is_seed );
+    std::vector<item_location> seed_inv = player_character.cache_get_items_with( "is_seed",
+                                          &item::is_seed );
 
     auto seed_entries = iexamine::get_seed_entries( seed_inv );
     seed_entries.emplace( seed_entries.begin(), itype_id::NULL_ID(), _( "No seed" ), 0 );


### PR DESCRIPTION
#### Summary
Infrastructure "Make inv_search_cache operate on item_location"

#### Purpose of change

While trying and failing to reproduce #84965 with massive amounts of item spawns I found a different performance issue with determining item color, as it goes through all your inventory to find all available ammo and magazines to see if the item can be reloaded. This search through the inventory did not use the `inv_search_cache` introduced in #67835.

That cache doesn't use `item_location`, though, so to be able to use it there, I need to move it to `item_location` first.

#### Describe the solution

Step 1: Make `form_loc_recursive` in `iuse_actor.cpp` available. I left it in `iuse_actor.h` for now, since that is already included in all the places that want to use it. But a better location might have to be found in the future.

Step 2: Replace loads of `item *` and `item &` with `item_location`. Use `form_loc_recursive` to make the `item_location` to be placed in the cache. I'm honestly not sure how much of a burden that puts on making the cache, although that's probably what makes or breaks this PR.

#### Describe alternatives you've considered

This would be simple if `visitable` were based on `item_location`. But as far as I can tell that can't be easily moved over because we don't have an `item_location` for the `inventory` class and don't need one either.

#### Testing

Tested with avatar light sources. Spawned regular and heavy duty flashlights. Turned them on and off at night, light changed as expeced. Cache added and removed light sources as expected.

#### Additional context
