### PR TITLE
[Sky Island] Undamage the cars

### DIFF
--- a/data/mods/Sky_Island/modinfo.json
+++ b/data/mods/Sky_Island/modinfo.json
@@ -14,6 +14,20 @@
   },
   {
     "type": "EXTERNAL_OPTION",
+    "name": "OVERRIDE_VEHICLE_INIT_STATE",
+    "//": "If true, initial status and amount of fuel for all spawned vehicles will be overridden by values of VEHICLE_STATUS_AT_SPAWN and VEHICLE_FUEL_AT_SPAWN options.",
+    "stype": "bool",
+    "value": true
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "VEHICLE_STATUS_AT_SPAWN",
+    "//": "All vehicles spawn in this status.  -1 is lightly damaged (default), 0 is undamaged, 1 is disabled (destroyed tires or engine).  Values are read only if OVERRIDE_VEHICLE_INIT_STATE is set to true.",
+    "stype": "int",
+    "value": 0
+  },
+  {
+    "type": "EXTERNAL_OPTION",
     "name": "DEFAULT_REGION",
     "stype": "string_input",
     "value": "default_skyisland"


### PR DESCRIPTION


#### Summary
None

#### Purpose of change
Undamage the cars for sky island, mainly because i felt like the random damaged car get a bit nonsense at times and it's not like you can bring the car back to the sky island anyway.

#### Describe the solution
Adds OVERRIDE_VEHICLE_INIT_STATE and VEHICLE_STATUS_AT_SPAWN external options, set the latter to 0


#### Describe alternatives you've considered

Not doing it.

#### Testing
Checked the cars nearby, completely undamaged. Fuel amount still random.
![Screenshot_20260203_230535](https://github.com/user-attachments/assets/8c85c99e-ba2d-456a-a7aa-cfe68739a16b)


#### Additional context
Wonder how much it'd change the gameplay in basegame.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
