### PR TITLE
Convert Thick Tail to limb, add techniques

### DIFF
--- a/data/json/items/armor/integrated.json
+++ b/data/json/items/armor/integrated.json
@@ -1345,7 +1345,7 @@
           { "type": "hflesh", "covered_by_mat": 100, "thickness": 0.5 },
           { "type": "mut_scales", "covered_by_mat": 50, "thickness": 1.0 }
         ],
-        "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
+        "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r", "tail" ],
         "coverage": 100,
         "encumbrance": 0,
         "breathability": "GOOD"
@@ -1395,7 +1395,7 @@
           { "type": "flesh", "covered_by_mat": 100, "thickness": 1.0 },
           { "type": "mut_scales", "covered_by_mat": 90, "thickness": 2.0 }
         ],
-        "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
+        "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r", "tail" ],
         "coverage": 100,
         "encumbrance": 2,
         "breathability": "POOR"
@@ -1464,7 +1464,7 @@
           { "type": "flesh", "covered_by_mat": 100, "thickness": 1.5 },
           { "type": "mut_scales", "covered_by_mat": 95, "thickness": 2.5 }
         ],
-        "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
+        "covers": [ "torso", "arm_l", "arm_r", "leg_l", "leg_r", "tail" ],
         "coverage": 100,
         "encumbrance": 3
       },
@@ -1541,7 +1541,7 @@
           { "type": "mut_scales", "covered_by_mat": 91, "thickness": 6.0 },
           { "type": "mut_bone", "covered_by_mat": 82, "thickness": 4.0 }
         ],
-        "covers": [ "arm_l", "arm_r", "leg_l", "leg_r" ],
+        "covers": [ "arm_l", "arm_r", "leg_l", "leg_r", "tail" ],
         "coverage": 100,
         "encumbrance": 8,
         "layers": [ "NORMAL" ]

--- a/data/json/mutations/limbs_body_parts.json
+++ b/data/json/mutations/limbs_body_parts.json
@@ -203,5 +203,67 @@
     "smash_message": "You smash %s with your tail.",
     "smash_efficiency": 0.25,
     "armor": { "bash": 4, "cut": 3, "stab": 2 }
+  },
+  {
+    "id": "tail_thick",
+    "type": "body_part",
+    "name": "thick tail",
+    "accusative": { "ctxt": "bodypart_accusative", "str": "thick tail" },
+    "heading": "tail",
+    "heading_multiple": "tails, thick",
+    "encumbrance_text": "Balance is hampered.",
+    "encumbrance_limit": 25,
+    "hp_bar_ui_text": "Th TAIL",
+    "limb_type": "tail",
+    "main_part": "torso",
+    "opposite_part": "tail_thick",
+    "side": "both",
+    "hit_size": 8,
+    "hit_difficulty": 0.5,
+    "hot_morale_mod": 2,
+    "cold_morale_mod": 2,
+    "wet_morale": 0,
+    "fire_warmth_bonus": 150,
+    "squeamish_penalty": 3,
+    "limb_scores": [ [ "balance", 0.05 ], [ "reaction", 0.05 ] ],
+    "base_hp": 35,
+    "health_limit": 10,
+    "similar_bodypart": "tail",
+    "techniques": [ "TAIL_THICK_BASH", "TAIL_THICK_BASH_NATURAL", "TAIL_THICK_BASH_CRIT", "TAIL_THICK_BASH_CRIT_VS_STUMBLE" ],
+    "technique_encumbrance_limit": 5,
+    "effects_on_hit": [
+      {
+        "id": "bleed",
+        "dmg_type": "cut",
+        "dmg_threshold": 5,
+        "dmg_scale_increment": 2,
+        "duration": 60,
+        "duration_dmg_scaling": 30,
+        "max_duration": 960
+      },
+      {
+        "id": "bleed",
+        "dmg_type": "stab",
+        "dmg_threshold": 1,
+        "dmg_scale_increment": 1.5,
+        "duration": 60,
+        "duration_dmg_scaling": 60,
+        "max_duration": 1200
+      },
+      {
+        "id": "bleed",
+        "dmg_type": "bullet",
+        "dmg_threshold": 1,
+        "dmg_scale_increment": 1,
+        "duration": 60,
+        "duration_dmg_scaling": 60
+      }
+    ],
+    "drench_capacity": 700,
+    "bionic_slots": 0,
+    "is_limb": true,
+    "sub_parts": [ "tail_thick_base", "tail_thick_center", "tail_thick_tip" ],
+    "smash_message": "You thwap %s with your tail.",
+    "smash_efficiency": 0.45
   }
 ]

--- a/data/json/mutations/limbs_sublimbs.json
+++ b/data/json/mutations/limbs_sublimbs.json
@@ -60,6 +60,36 @@
     "opposite": "tail_fluffy_base"
   },
   {
+    "id": "tail_thick_base",
+    "type": "sub_body_part",
+    "name": "thick tail base",
+    "name_multiple": "thick tail bases",
+    "max_coverage": 10,
+    "parent": "tail_thick",
+    "side": "both",
+    "opposite": "tail_thick_tip"
+  },
+  {
+    "id": "tail_thick_center",
+    "type": "sub_body_part",
+    "name": "thick tail center",
+    "name_multiple": "thick tail centers",
+    "max_coverage": 60,
+    "parent": "tail_thick",
+    "side": "both",
+    "opposite": "tail_thick_center"
+  },
+  {
+    "id": "tail_thick_tip",
+    "type": "sub_body_part",
+    "name": "thick tail tip",
+    "name_multiple": "thick tail tips",
+    "max_coverage": 30,
+    "parent": "tail_thick",
+    "side": "both",
+    "opposite": "tail_thick_base"
+  },
+  {
     "id": "tail_scorpion_base",
     "type": "sub_body_part",
     "name": "scorpion tail base",

--- a/data/json/mutations/mutation_attack_vectors.json
+++ b/data/json/mutations/mutation_attack_vectors.json
@@ -7,5 +7,14 @@
     "strict_limb_definition": true,
     "encumbrance_limit": 2,
     "bp_hp_limit": 50
+  },
+  {
+    "type": "attack_vector",
+    "id": "vector_tail_thick",
+    "limbs": [ "tail_thick" ],
+    "contact_area": [ "tail_thick_center", "tail_thick_tip" ],
+    "strict_limb_definition": true,
+    "encumbrance_limit": 4,
+    "bp_hp_limit": 50
   }
 ]

--- a/data/json/mutations/mutation_techs.json
+++ b/data/json/mutations/mutation_techs.json
@@ -785,5 +785,95 @@
       { "stat": "movecost", "scaling-stat": "melee", "scale": -1.25 },
       { "stat": "movecost", "scaling-stat": "dex", "scale": -0.5 }
     ]
+  },
+  {
+    "//": "Scaling on these three is 75% of normal",
+    "type": "technique",
+    "id": "TAIL_THICK_BASH",
+    "name": "Thick Tail Bash",
+    "melee_allowed": true,
+    "messages": [ "You thwack %s with your tail", "<npcname> thwacks %s with their tail" ],
+    "unarmed_allowed": true,
+    "weighting": -3,
+    "reach_ok": false,
+    "attack_vectors": [ "vector_tail_thick" ],
+    "condition": {
+      "and": [
+        { "not": { "u_has_effect": "natural_stance" } },
+        { "and": [ { "not": { "npc_has_flag": "GRAB_FILTER" } }, { "not": { "u_has_effect": "GRAB" } } ] }
+      ]
+    },
+    "flat_bonuses": [
+      { "stat": "damage", "type": "bash", "scaling-stat": "str", "scale": 0.375 },
+      { "stat": "damage", "type": "bash", "scaling-stat": "unarmed", "scale": 0.75 },
+      { "stat": "arpen", "type": "bash", "scaling-stat": "unarmed", "scale": 0.6 },
+      { "stat": "movecost", "scaling-stat": "melee", "scale": -1.25 },
+      { "stat": "movecost", "scaling-stat": "dex", "scale": -0.5 }
+    ]
+  },
+  {
+    "type": "technique",
+    "id": "TAIL_THICK_BASH_NATURAL",
+    "name": "Thick Tail Bash",
+    "melee_allowed": true,
+    "messages": [ "You thwack %s with your tail", "<npcname> thwacks %s with their tail" ],
+    "unarmed_allowed": true,
+    "weighting": 0,
+    "reach_ok": false,
+    "attack_vectors": [ "vector_tail_thick" ],
+    "condition": {
+      "and": [
+        { "u_has_effect": "natural_stance" },
+        { "and": [ { "not": { "npc_has_flag": "GRAB_FILTER" } }, { "not": { "u_has_effect": "GRAB" } } ] }
+      ]
+    },
+    "flat_bonuses": [
+      { "stat": "damage", "type": "bash", "scaling-stat": "str", "scale": 0.375 },
+      { "stat": "damage", "type": "bash", "scaling-stat": "unarmed", "scale": 0.75 },
+      { "stat": "arpen", "type": "bash", "scaling-stat": "unarmed", "scale": 0.6 },
+      { "stat": "movecost", "scaling-stat": "melee", "scale": -1.25 },
+      { "stat": "movecost", "scaling-stat": "dex", "scale": -0.5 }
+    ]
+  },
+  {
+    "type": "technique",
+    "id": "TAIL_THICK_BASH_CRIT",
+    "name": "Thick Tail Bash Crit",
+    "melee_allowed": true,
+    "messages": [ "You slam %s with your tail", "<npcname> slams %s with their tail" ],
+    "unarmed_allowed": true,
+    "reach_ok": false,
+    "crit_tec": true,
+    "attack_vectors": [ "vector_tail_thick" ],
+    "condition": { "not": { "npc_has_flag": "STUMBLES" } },
+    "knockback_dist": 1,
+    "flat_bonuses": [
+      { "stat": "damage", "type": "bash", "scaling-stat": "str", "scale": 0.5625 },
+      { "stat": "damage", "type": "bash", "scaling-stat": "unarmed", "scale": 3.3 },
+      { "stat": "arpen", "type": "bash", "scaling-stat": "unarmed", "scale": 0.75 },
+      { "stat": "movecost", "scaling-stat": "melee", "scale": -1.25 },
+      { "stat": "movecost", "scaling-stat": "dex", "scale": -0.5 }
+    ]
+  },
+  {
+    "type": "technique",
+    "id": "TAIL_THICK_BASH_CRIT_VS_STUMBLE",
+    "name": "Thick Tail Bash Crit",
+    "melee_allowed": true,
+    "messages": [ "You slam %s with your tail and knock them down", "<npcname> slams %s with their tail and knock them down" ],
+    "unarmed_allowed": true,
+    "reach_ok": false,
+    "crit_tec": true,
+    "attack_vectors": [ "vector_tail_thick" ],
+    "condition": { "npc_has_flag": "STUMBLES" },
+    "knockback_dist": 1,
+    "down_dur": 2,
+    "flat_bonuses": [
+      { "stat": "damage", "type": "bash", "scaling-stat": "str", "scale": 0.5625 },
+      { "stat": "damage", "type": "bash", "scaling-stat": "unarmed", "scale": 3.3 },
+      { "stat": "arpen", "type": "bash", "scaling-stat": "unarmed", "scale": 0.75 },
+      { "stat": "movecost", "scaling-stat": "melee", "scale": -1.25 },
+      { "stat": "movecost", "scaling-stat": "dex", "scale": -0.5 }
+    ]
   }
 ]

--- a/data/json/mutations/mutations_limbs.json
+++ b/data/json/mutations/mutations_limbs.json
@@ -645,13 +645,7 @@
     "allow_soft_gear": true,
     "allowed_items": [ "ALLOWS_TAIL" ],
     "restricts_gear": [ "leg_hip_l", "leg_hip_r" ],
-    "attacks": {
-      "attack_text_u": "You whap %s with your tail!",
-      "attack_text_npc": "%1$s whaps %2$s with their tail!",
-      "chance": 20,
-      "base_damage": { "damage_type": "bash", "amount": 8 }
-    },
-    "enchantments": [ { "values": [ { "value": "DODGE_CHANCE", "add": 1 } ] } ]
+    "enchantments": [ { "condition": "ALWAYS", "modified_bodyparts": [ { "gain": "tail_thick" } ] } ]
   },
   {
     "type": "mutation",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Features "Convert Thick Tail to limb, add techniques"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Continued limbification of tails, this this with Thick Tail
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Convert Thick Tail to a limb, add techniques. The Thick Tail can knock monsters down if they have the STUMBLES flag on crits, otherwise it can just knock monsters back. Also, Thick Tail has 75% of normal mutation damage scaling. 

Club Tail (up next) will be able to knock anyone down on a crit (if they're your size or smaller) and have full damage scaling. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Thwaped some monsters with the tail. Zombies were knocked down, the debug monster was not. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
