### PR TITLE
Dermatik birth just plain kills you

### DIFF
--- a/data/json/effects_on_condition/effects_eocs.json
+++ b/data/json/effects_on_condition/effects_eocs.json
@@ -115,23 +115,13 @@
             "min_radius": 1,
             "max_radius": 4
           },
-          { "u_set_field": "fd_blood", "radius": 1, "intensity": 3 },
-          { "turn_cost": "6 seconds" },
-          { "math": [ "HOW_MUCH_WILL_THIS_SUCK = rng(21, 30)" ] },
-          { "math": [ "u_vitamin('blood') -= HOW_MUCH_WILL_THIS_SUCK * 100" ] },
-          { "math": [ "u_vitamin('redcells') -= HOW_MUCH_WILL_THIS_SUCK * 100" ] },
-          {
-            "u_add_effect": "bleed",
-            "target_part": { "global_val": "IMPREGNATED_BODYPART" },
-            "duration": { "math": [ "HOW_MUCH_WILL_THIS_SUCK * 60" ] }
-          },
-          { "math": [ "u_pain('type': 'perceived') += HOW_MUCH_WILL_THIS_SUCK * 2" ] },
-          { "math": [ "u_hp(IMPREGNATED_BODYPART) -= HOW_MUCH_WILL_THIS_SUCK * 2" ] }
+          { "u_set_field": "fd_blood", "radius": 1, "intensity": 3 }
         ],
         "else": { "math": [ "u_vitamin('mutant_toxin') += u_vitamin('dermatik_larva_size') / 3" ] }
       },
       { "u_lose_effect": "dermatik_visible" },
-      { "math": [ "u_vitamin('dermatik_larva_size') = 0" ] }
+      { "math": [ "u_vitamin('dermatik_larva_size') = 0" ] },
+      "u_die"
     ]
   },
   {

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -65,8 +65,6 @@ std::string enum_to_string<event_type>( event_type data )
         case event_type::crosses_mutation_threshold: return "crosses_mutation_threshold";
         case event_type::crosses_mycus_threshold: return "crosses_mycus_threshold";
         case event_type::cuts_tree: return "cuts_tree";
-        case event_type::dermatik_eggs_hatch: return "dermatik_eggs_hatch";
-        case event_type::dermatik_eggs_injected: return "dermatik_eggs_injected";
         case event_type::destroys_triffid_grove: return "destroys_triffid_grove";
         case event_type::dies_from_asthma_attack: return "dies_from_asthma_attack";
         case event_type::dies_from_drug_overdose: return "dies_from_drug_overdose";
@@ -145,7 +143,7 @@ DEFINE_EVENT_HELPER_FIELDS( event_spec_empty )
 DEFINE_EVENT_HELPER_FIELDS( event_spec_character )
 DEFINE_EVENT_HELPER_FIELDS( event_spec_character_item )
 
-static_assert( static_cast<int>( event_type::num_event_types ) == 107,
+static_assert( static_cast<int>( event_type::num_event_types ) == 105,
                "This static_assert is a reminder to add a definition below when you add a new "
                "event_type.  If your event_spec specialization inherits from another struct for "
                "its fields definition then you probably don't need a definition here." );

--- a/src/event.h
+++ b/src/event.h
@@ -73,8 +73,6 @@ enum class event_type : int {
     crosses_mutation_threshold,
     crosses_mycus_threshold,
     cuts_tree,
-    dermatik_eggs_hatch,
-    dermatik_eggs_injected,
     destroys_triffid_grove,
     dies_from_asthma_attack,
     dies_from_drug_overdose,
@@ -193,7 +191,7 @@ struct event_spec_character_item {
     };
 };
 
-static_assert( static_cast<int>( event_type::num_event_types ) == 107,
+static_assert( static_cast<int>( event_type::num_event_types ) == 105,
                "This static_assert is to remind you to add a specialization for your new "
                "event_type below" );
 
@@ -568,12 +566,6 @@ struct event_spec<event_type::crosses_mycus_threshold> : event_spec_character {}
 
 template<>
 struct event_spec<event_type::cuts_tree> : event_spec_character {};
-
-template<>
-struct event_spec<event_type::dermatik_eggs_hatch> : event_spec_character {};
-
-template<>
-struct event_spec<event_type::dermatik_eggs_injected> : event_spec_character {};
 
 template<>
 struct event_spec<event_type::destroys_triffid_grove> : event_spec_empty {};

--- a/src/memorial_logger.cpp
+++ b/src/memorial_logger.cpp
@@ -685,22 +685,6 @@ void memorial_logger::notify( const cata::event &e )
             }
             break;
         }
-        case event_type::dermatik_eggs_hatch: {
-            character_id ch = e.get<character_id>( "character" );
-            if( ch == avatar_id ) {
-                add( pgettext( "memorial_male", "Dermatik eggs hatched." ),
-                     pgettext( "memorial_female", "Dermatik eggs hatched." ) );
-            }
-            break;
-        }
-        case event_type::dermatik_eggs_injected: {
-            character_id ch = e.get<character_id>( "character" );
-            if( ch == avatar_id ) {
-                add( pgettext( "memorial_male", "Injected with dermatik eggs." ),
-                     pgettext( "memorial_female", "Injected with dermatik eggs." ) );
-            }
-            break;
-        }
         case event_type::destroys_triffid_grove: {
             add( pgettext( "memorial_male", "Destroyed a triffid grove." ),
                  pgettext( "memorial_female", "Destroyed a triffid grove." ) );

--- a/tests/memorial_test.cpp
+++ b/tests/memorial_test.cpp
@@ -150,12 +150,6 @@ TEST_CASE( "memorials", "[memorial]" )
     check_memorial<event_type::crosses_mycus_threshold>(
         m, b, "Became one with the Mycus.", ch );
 
-    check_memorial<event_type::dermatik_eggs_hatch>(
-        m, b, "Dermatik eggs hatched.", ch );
-
-    check_memorial<event_type::dermatik_eggs_injected>(
-        m, b, "Injected with dermatik eggs.", ch );
-
     check_memorial<event_type::destroys_triffid_grove>(
         m, b, "Destroyed a triffid grove." );
 


### PR DESCRIPTION
#### Summary
Balance "Dermatik birth just plain kills you"

#### Purpose of change
Surviving this is absolutely insane.

Besides the impossibility of that, it makes no sense. If the dermatiks birthed in things that *lived afterwards*, the living being would just squish their new children. There would be no dermatiks.

#### Describe the solution
It just plain kills you.

Also removed a bunch of orphaned events here. The dermatik events have not been in the game ever since they were moved to json.

#### Describe alternatives you've considered
It kills you, but you explode in gore instead of simply bleeding a bit.

#### Testing
Loads

#### Additional context
