### PR TITLE
[MoM] Reduce cost of some artifact abilities

### DIFF
--- a/data/mods/MindOverMatter/procgen/biokinetic_artifacts.json
+++ b/data/mods/MindOverMatter/procgen/biokinetic_artifacts.json
@@ -234,7 +234,7 @@
         "max_value": 4,
         "type": "DODGE_CHANCE",
         "increment": 1,
-        "power_per_increment": 1000,
+        "power_per_increment": 200,
         "ench_has": "HELD"
       },
       {
@@ -243,7 +243,7 @@
         "max_value": 1,
         "type": "BONUS_DODGE",
         "increment": 1,
-        "power_per_increment": 2000,
+        "power_per_increment": 350,
         "ench_has": "HELD"
       },
       {
@@ -252,7 +252,7 @@
         "max_value": 3000,
         "type": "MAX_STAMINA",
         "increment": 500,
-        "power_per_increment": 500,
+        "power_per_increment": 150,
         "ench_has": "WIELD"
       },
       {
@@ -463,7 +463,7 @@
         "type": "MAX_STAMINA",
         "increment": 250,
         "power_per_increment": 50,
-        "ench_has": "WIELD"
+        "ench_has": "HELD"
       },
       {
         "weight": 50,
@@ -498,7 +498,7 @@
         "max_value": 4,
         "type": "DODGE_CHANCE",
         "increment": 1,
-        "power_per_increment": 1000,
+        "power_per_increment": 200,
         "ench_has": "HELD"
       },
       {
@@ -507,7 +507,7 @@
         "max_value": 1,
         "type": "BONUS_DODGE",
         "increment": 1,
-        "power_per_increment": 2000,
+        "power_per_increment": 350,
         "ench_has": "HELD"
       },
       {
@@ -516,7 +516,7 @@
         "max_value": 3000,
         "type": "MAX_STAMINA",
         "increment": 500,
-        "power_per_increment": 500,
+        "power_per_increment": 150,
         "ench_has": "WIELD"
       },
       {

--- a/data/mods/MindOverMatter/procgen/clairsentient_artifacts.json
+++ b/data/mods/MindOverMatter/procgen/clairsentient_artifacts.json
@@ -122,7 +122,7 @@
         "max_value": 3,
         "type": "BONUS_DODGE",
         "increment": 1,
-        "power_per_increment": 750,
+        "power_per_increment": 250,
         "ench_has": "HELD"
       },
       {
@@ -131,7 +131,7 @@
         "max_value": 5,
         "type": "DODGE_CHANCE",
         "increment": 1,
-        "power_per_increment": 250,
+        "power_per_increment": 150,
         "ench_has": "HELD"
       },
       {
@@ -149,7 +149,7 @@
         "max_value": 3,
         "type": "MELEE_TO_HIT",
         "increment": 1,
-        "power_per_increment": 750,
+        "power_per_increment": 250,
         "ench_has": "HELD"
       },
       {
@@ -158,8 +158,8 @@
         "max_value": 6,
         "type": "MOTION_ALARM",
         "increment": 1,
-        "power_per_increment": 150,
-        "ench_has": "WIELD"
+        "power_per_increment": 50,
+        "ench_has": "HELD"
       },
       {
         "weight": 100,
@@ -167,8 +167,8 @@
         "max_value": 10,
         "type": "NIGHT_VIS",
         "increment": 1,
-        "power_per_increment": 150,
-        "ench_has": "WIELD"
+        "power_per_increment": 50,
+        "ench_has": "HELD"
       },
       {
         "weight": 50,
@@ -176,8 +176,8 @@
         "max_value": 4,
         "type": "OVERMAP_SIGHT",
         "increment": 1,
-        "power_per_increment": 500,
-        "ench_has": "WIELD"
+        "power_per_increment": 200,
+        "ench_has": "HELD"
       },
       {
         "weight": 50,
@@ -185,7 +185,7 @@
         "max_value": 6,
         "type": "RANGE",
         "increment": 1,
-        "power_per_increment": 400,
+        "power_per_increment": 350,
         "ench_has": "HELD"
       },
       {
@@ -194,7 +194,7 @@
         "max_value": 0.5,
         "type": "RANGE_DODGE",
         "increment": 0.05,
-        "power_per_increment": 750,
+        "power_per_increment": 450,
         "ench_has": "HELD"
       }
     ],
@@ -323,7 +323,7 @@
         "max_value": 3,
         "type": "BONUS_DODGE",
         "increment": 1,
-        "power_per_increment": 750,
+        "power_per_increment": 250,
         "ench_has": "HELD"
       },
       {
@@ -332,7 +332,7 @@
         "max_value": 5,
         "type": "DODGE_CHANCE",
         "increment": 1,
-        "power_per_increment": 250,
+        "power_per_increment": 150,
         "ench_has": "HELD"
       },
       {
@@ -350,7 +350,7 @@
         "max_value": 3,
         "type": "MELEE_TO_HIT",
         "increment": 1,
-        "power_per_increment": 750,
+        "power_per_increment": 250,
         "ench_has": "HELD"
       },
       {
@@ -359,7 +359,7 @@
         "max_value": 6,
         "type": "MOTION_ALARM",
         "increment": 1,
-        "power_per_increment": 150,
+        "power_per_increment": 50,
         "ench_has": "HELD"
       },
       {
@@ -368,7 +368,7 @@
         "max_value": 10,
         "type": "NIGHT_VIS",
         "increment": 1,
-        "power_per_increment": 150,
+        "power_per_increment": 50,
         "ench_has": "HELD"
       },
       {
@@ -377,7 +377,7 @@
         "max_value": 4,
         "type": "OVERMAP_SIGHT",
         "increment": 1,
-        "power_per_increment": 500,
+        "power_per_increment": 200,
         "ench_has": "HELD"
       },
       {
@@ -386,7 +386,7 @@
         "max_value": 6,
         "type": "RANGE",
         "increment": 1,
-        "power_per_increment": 400,
+        "power_per_increment": 350,
         "ench_has": "HELD"
       },
       {
@@ -395,7 +395,7 @@
         "max_value": 0.5,
         "type": "RANGE_DODGE",
         "increment": 0.05,
-        "power_per_increment": 750,
+        "power_per_increment": 450,
         "ench_has": "HELD"
       }
     ],

--- a/data/mods/MindOverMatter/procgen/electrokinetic_artifacts.json
+++ b/data/mods/MindOverMatter/procgen/electrokinetic_artifacts.json
@@ -132,7 +132,7 @@
         "max_value": 30,
         "type": "LUMINATION",
         "increment": 5,
-        "power_per_increment": 50,
+        "power_per_increment": 25,
         "ench_has": "WIELD"
       },
       {
@@ -279,7 +279,7 @@
         "max_value": 30,
         "type": "LUMINATION",
         "increment": 5,
-        "power_per_increment": 50,
+        "power_per_increment": 25,
         "ench_has": "WIELD"
       },
       {

--- a/data/mods/MindOverMatter/procgen/photokinetic_artifacts.json
+++ b/data/mods/MindOverMatter/procgen/photokinetic_artifacts.json
@@ -32,7 +32,7 @@
         "max_value": 4,
         "type": "DODGE_CHANCE",
         "increment": 1,
-        "power_per_increment": 1000,
+        "power_per_increment": 200,
         "ench_has": "HELD"
       },
       {
@@ -50,7 +50,7 @@
         "max_value": 2000,
         "type": "LUMINATION",
         "increment": 25,
-        "power_per_increment": 25,
+        "power_per_increment": 5,
         "ench_has": "WIELD"
       },
       {
@@ -59,7 +59,7 @@
         "max_value": 3,
         "type": "MELEE_TO_HIT",
         "increment": 1,
-        "power_per_increment": 500,
+        "power_per_increment": 250,
         "ench_has": "HELD"
       },
       {
@@ -68,7 +68,7 @@
         "max_value": 0.25,
         "type": "RANGE_DODGE",
         "increment": 0.02,
-        "power_per_increment": 750,
+        "power_per_increment": 450,
         "ench_has": "HELD"
       },
       {
@@ -111,7 +111,7 @@
         "max_value": 4,
         "type": "DODGE_CHANCE",
         "increment": 1,
-        "power_per_increment": 1000,
+        "power_per_increment": 200,
         "ench_has": "HELD"
       },
       {
@@ -129,7 +129,7 @@
         "max_value": 2000,
         "type": "LUMINATION",
         "increment": 25,
-        "power_per_increment": 25,
+        "power_per_increment": 5,
         "ench_has": "WIELD"
       },
       {
@@ -138,7 +138,7 @@
         "max_value": 3,
         "type": "MELEE_TO_HIT",
         "increment": 1,
-        "power_per_increment": 500,
+        "power_per_increment": 250,
         "ench_has": "HELD"
       },
       {
@@ -147,7 +147,7 @@
         "max_value": 0.25,
         "type": "RANGE_DODGE",
         "increment": 0.02,
-        "power_per_increment": 750,
+        "power_per_increment": 450,
         "ench_has": "HELD"
       },
       {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[MoM] Reduce cost of some artifact abilities"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

People were getting resonance-effect-causing artifacts with one (1) real power at not very high levels, and some of the abilities were very overcosted compared to others--one bonus dodge is very good but it's not worth +4 dex.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Reduce the cost of a some high-cost abilities.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

EVASION and RANGE_DODGE remain high cost because they're extremely good, being the only abilities in the game that let you avoid bullets 

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
