### PR TITLE
tweak the ziggurat exit, string dimension

### DIFF
--- a/data/json/effects_on_condition/nether_eocs/string_dimension.json
+++ b/data/json/effects_on_condition/nether_eocs/string_dimension.json
@@ -81,17 +81,7 @@
         "success_message": "Your surroundings warp and fold into the recesses of the world you know."
       },
       { "u_location_variable": { "context_val": "player_teleport_loc" }, "z_adjust": 0, "z_override": true },
-      { "u_teleport": { "context_val": "player_teleport_loc" } },
-      {
-        "if": { "math": [ "u_string_dimension_ziggurat_exit >= 1" ] },
-        "then": [
-          {
-            "u_message": "As you pulled the hypercube free, there was an immense explosion of light.  The object is gone and you're back in the world you know.",
-            "popup": true
-          },
-          { "clear_dimension": "string_dimension" }
-        ]
-      }
+      { "u_teleport": { "context_val": "player_teleport_loc" } }
     ],
     "false_effect": [
       {
@@ -120,8 +110,29 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_PORTAL_STRING_DIMENSION_ZIGGURAT_RETURN",
-    "condition": { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_PORTAL_PROOF" },
-    "effect": [ { "math": [ "u_string_dimension_ziggurat_exit += 1" ] }, { "run_eocs": "EOC_PORTAL_STRING_DIMENSION_RETURN" } ],
-    "false_effect": { "u_message": "An invisible, repulsive field keeps you from touching the hypercube.", "popup": true }
+    "effect": [
+      {
+        "if": { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_PORTAL_PROOF" },
+        "then": {
+          "u_message": "You touched the cube and there was an immense explosion of light.  The object is gone and you're back in the world you know.",
+          "popup": true
+        },
+        "else": [
+          {
+            "u_message": "You pull the hypercube free and space around you violently bends before snapping back in place!",
+            "popup": true
+          },
+          { "u_spawn_item": "string_dimension_hypercube", "count": 1 }
+        ]
+      },
+      { "u_transform_radius": 5, "ter_furn_transform": "string_dimension_ziggurat_transform" },
+      { "math": [ "u_string_dimension_ziggurat_exit += 1" ] },
+      { "run_eocs": "EOC_PORTAL_STRING_DIMENSION_RETURN" }
+    ]
+  },
+  {
+    "type": "ter_furn_transform",
+    "id": "string_dimension_ziggurat_transform",
+    "furniture": [ { "result": [ "f_string_dimension_housing_imploded" ], "valid_furniture": [ "f_string_dimension_housing" ] } ]
   }
 ]

--- a/data/json/furniture_and_terrain/furniture-alien.json
+++ b/data/json/furniture_and_terrain/furniture-alien.json
@@ -887,6 +887,18 @@
   },
   {
     "type": "furniture",
+    "id": "f_string_dimension_housing_imploded",
+    "name": "imploded clump of metal",
+    "description": "An extremely dense ball of imploded metal.",
+    "symbol": "#",
+    "color": "dark_gray",
+    "move_cost_mod": -1,
+    "required_str": -1,
+    "coverage": 100,
+    "flags": [ "NOITEM", "BLOCKSDOOR" ]
+  },
+  {
+    "type": "furniture",
     "id": "f_tall_vent_pipe",
     "looks_like": "f_vent_pipe",
     "name": "tall vent pipe",

--- a/data/json/items/relics/extradimensional_artifacts.json
+++ b/data/json/items/relics/extradimensional_artifacts.json
@@ -45,5 +45,19 @@
     "material": [ "plastic" ],
     "weight": "10 g",
     "volume": "20 ml"
+  },
+  {
+    "id": "string_dimension_hypercube",
+    "type": "ITEM",
+    "subtypes": [ "ARTIFACT" ],
+    "category": "artifacts",
+    "name": { "str": "transparent hypercube" },
+    "description": "A transparent cube within a cube.  It seems to be made of clear plastic or glass, but it feels quite solid, despite also seeming weightless.  It's full of stars.",
+    "material": [ "anomaly" ],
+    "symbol": "[",
+    "volume": "500 ml",
+    "weight": "0 g",
+    "flags": [ "ZERO_WEIGHT" ],
+    "passive_effects": [ { "has": "HELD", "condition": "ALWAYS", "values": [ { "value": "ARTIFACT_RESONANCE", "add": 2000 } ] } ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Tweak ziggurat exit from string dimension"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Trying to exit the string dimension via the ziggurat specials did nothing if dimensionally anchored, and when exit happened it reset the dimension, which would make the upcoming globally unique special (#85104) not globally unique anymore (since it could just respawn in a "fresh" dimension).

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Now, if you try to remove the hypercube from the box without dimensional anchor, it's like before - you're transported back to the default dimension. The string dimension is no longer cleared.

If you do it with anchor, the box implodes and you get the hypercube.  The cube doesn't do anything for now except give you dangerous levels of resonance (+2000).  It can do interesting things in the future.  I'm thinking perhaps another special it plays a role in.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Having the hypercube kill you, or explode, or do something else really crazy.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Went back and forth to string dimension, `e`xamining the box and removing the cube in various states.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
