### PR TITLE
Implement basic filters for monsters and terrain and furniture

### DIFF
--- a/src/item_search.cpp
+++ b/src/item_search.cpp
@@ -12,13 +12,16 @@
 #include "bodypart.h"
 #include "cata_compiler_support.h"
 #include "cata_utility.h"
+#include "creature.h"
 #include "enums.h"
 #include "flag.h"
 #include "item.h"
 #include "item_category.h"
 #include "item_factory.h"
 #include "itype.h"
+#include "mapdata.h"
 #include "material.h"
+#include "monster.h"
 #include "math_parser_type.h"
 #include "requirements.h"
 #include "ret_val.h"
@@ -220,4 +223,58 @@ std::pair<std::string, std::string> get_both( std::string_view a )
     size_t split_mark = a.find( ';' );
     return std::pair( std::string( a.substr( 0, split_mark ) ),
                       std::string( a.substr( split_mark + 1 ) ) );
+}
+
+std::function<bool( const Creature & )> creature_filter_from_string(
+    const std::string &filter )
+{
+    return filter_from_string<Creature>( filter, basic_creature_filter );
+}
+
+std::function<bool( const Creature & )> basic_creature_filter( std::string filter )
+{
+    size_t colon;
+    char flag = '\0';
+    if( ( colon = filter.find( ':' ) ) != std::string::npos ) {
+        if( colon >= 1 ) {
+            flag = filter[colon - 1];
+            filter = filter.substr( colon + 1 );
+        }
+    }
+
+    switch( flag ) {
+        default:
+            return [filter]( const Creature & a ) {
+                std::string name = a.disp_name();
+                if( a.is_monster() ) {
+                    name = a.as_monster()->name();
+                }
+                return lcmatch( remove_color_tags( name ), filter );
+            };
+    }
+}
+
+std::function<bool( const map_data_common_t & )> terfurn_filter_from_string(
+    const std::string &filter )
+{
+    return filter_from_string<map_data_common_t>( filter, basic_terfurn_filter );
+}
+
+std::function<bool( const map_data_common_t & )> basic_terfurn_filter( std::string filter )
+{
+    size_t colon;
+    char flag = '\0';
+    if( ( colon = filter.find( ':' ) ) != std::string::npos ) {
+        if( colon >= 1 ) {
+            flag = filter[colon - 1];
+            filter = filter.substr( colon + 1 );
+        }
+    }
+
+    switch( flag ) {
+        default:
+            return [filter]( const map_data_common_t &a ) {
+                return lcmatch( remove_color_tags( a.name() ), filter );
+            };
+    }
 }

--- a/src/item_search.h
+++ b/src/item_search.h
@@ -10,6 +10,10 @@
 
 #include "output.h"
 
+class Creature;
+class item;
+struct map_data_common_t;
+
 /**
  * Get a function that returns true if the value matches the query.
  */
@@ -84,8 +88,6 @@ std::function<bool( const T & )> filter_from_string( std::string filter,
     return basic_filter( filter );
 }
 
-class item;
-
 /**
  * Get a function that returns true if the item matches the query.
  */
@@ -95,5 +97,13 @@ std::function<bool( const item & )> item_filter_from_string( const std::string &
  * Get a function that returns true if the value matches the basic query (no commas or minuses).
  */
 std::function<bool( const item & )> basic_item_filter( std::string filter );
+
+std::function<bool( const Creature & )> creature_filter_from_string(
+    const std::string &filter );
+std::function<bool( const Creature & )> basic_creature_filter( std::string filter );
+
+std::function<bool( const map_data_common_t & )> terfurn_filter_from_string(
+    const std::string &filter );
+std::function<bool( const map_data_common_t & )> basic_terfurn_filter( std::string filter );
 
 #endif // CATA_SRC_ITEM_SEARCH_H

--- a/src/surroundings_menu.cpp
+++ b/src/surroundings_menu.cpp
@@ -465,15 +465,12 @@ void monster_tab_data::apply_filter()
     uistate.monster_filter = filter;
     uistate.vmenu_monster_sort = static_cast<int>( sort_flags );
 
-    // todo: filter_from_string<Creature>
-    // for now just matching creature name
-    // auto z = item_filter_from_string( filter );
+    auto filter_function = creature_filter_from_string( uistate.monster_filter );
 
     // first apply regular filter
-    std::copy_if( monster_list.begin(), monster_list.end(),
-    std::back_inserter( filtered_list ), []( const map_entity_stack<Creature> *a ) {
-        return lcmatch( remove_color_tags( a->get_selected_entity()->disp_name() ),
-                        uistate.monster_filter );
+    std::copy_if( monster_list.begin(), monster_list.end(), std::back_inserter( filtered_list ),
+    [filter_function]( const map_entity_stack<Creature> *monster_stack ) {
+        return filter_function( *monster_stack->get_selected_entity() );
     } );
 
     // then apply regular sorting
@@ -655,14 +652,12 @@ void terfurn_tab_data::apply_filter()
     uistate.terfurn_filter = filter;
     uistate.vmenu_terfurn_sort = static_cast<int>( sort_flags );
 
-    // todo: filter_from_string<map_data_common_t>
-    // for now just matching creature name
-    // auto z = item_filter_from_string( filter );
+    auto filter_function = terfurn_filter_from_string( uistate.terfurn_filter );
 
     // first apply regular filter
-    std::copy_if( terfurn_list.begin(), terfurn_list.end(),
-    std::back_inserter( filtered_list ), []( const map_entity_stack<map_data_common_t> *a ) {
-        return lcmatch( remove_color_tags( a->get_selected_entity()->name() ), uistate.terfurn_filter );
+    std::copy_if( terfurn_list.begin(), terfurn_list.end(), std::back_inserter( filtered_list ),
+    [filter_function]( const map_entity_stack<map_data_common_t> *terfurn_stack ) {
+        return filter_function( *terfurn_stack->get_selected_entity() );
     } );
 
     // then apply regular sorting


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fix #85114, it was on my list anyway.

#### Describe the solution

We have a generic filtering system that was only implemented for `item`. This adds very basic filter implementations for `Creature` and `map_data_common_t`. All it really does currently is allowing to use `,` to search for multiple things and `-` to exclude results for slightly more complex filter results. These filters are only used in the surroundings menu for now. Not sure what other places might benefit from them.

#### Describe alternatives you've considered

Rename `item_search.h/cpp`?

#### Testing

Filter the monster and terrain/furniture tabs in the surroundings menu with `,` and `-`.

#### Additional context


