### PR TITLE
[XE] Direct drinking from those wearing holy symbols burns the holy-burnt.

### DIFF
--- a/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/vampire_trait_eocs.json
@@ -264,6 +264,10 @@
           { "npc_assign_activity": "ACT_VAMPIRE_DRINKING_BLOOD", "duration": "3 seconds" },
           { "message": "You are drinking from an NPC.", "type": "debug" },
           {
+            "if": { "and": [ { "u_has_worn_with_flag": "WARDING_SYMBOL" }, { "npc_has_trait": "VAMPIRE_WEAKNESS_HOLY_BURN" } ] },
+            "then": [ { "npc_message": "The holy symbol they wear burns you!", "type": "bad" }, { "math": [ "n_pain() += rng(10,15)" ] } ]
+          },
+          {
             "if": { "or": [ { "math": [ "u_vitamin('blood') <= -40000" ] }, { "math": [ "u_vitamin('redcells') <= -40000" ] } ] },
             "then": "u_die"
           }
@@ -292,6 +296,12 @@
               {
                 "if": { "or": [ { "u_has_species": "CHANGELING" }, { "u_has_species": "HOMULLUS" }, { "u_has_trait": "FAE_CREATURE" } ] },
                 "then": [ { "math": [ "n_vampire_just_drank_fae_blood = 1" ] } ]
+              },
+              {
+                "if": {
+                  "and": [ "u_is_npc", { "u_has_worn_with_flag": "WARDING_SYMBOL" }, { "npc_has_trait": "VAMPIRE_WEAKNESS_HOLY_BURN" } ]
+                },
+                "then": [ { "npc_message": "The holy symbol they wear burns you!", "type": "bad" }, { "math": [ "n_pain() += rng(10,15)" ] } ]
               },
               { "run_eocs": "EOC_VAMPIRE_DRINK_FROM_HUMAN_IN_COMBAT", "alpha_talker": "npc", "time_in_future": 2 },
               { "u_add_effect": "effect_vampire_drunk_from_in_combat", "duration": "48 hours" },

--- a/data/mods/Xedra_Evolved/npc/vampire_askblood.json
+++ b/data/mods/Xedra_Evolved/npc/vampire_askblood.json
@@ -3,6 +3,8 @@
     "id": [ "TALK_FRIEND" ],
     "type": "talk_topic",
     "insert_before_standard_exits": true,
+    "//": "Drinking from willing targets doesn't check for worn holy symbols, as the follower is cooperating.",
+    "//2": "When asked, they remove the symbol, are drank from, then put on the symbol again without needing player input.",
     "responses": [
       {
         "text": "Can I drink some of your blood?  I really need some of it.",


### PR DESCRIPTION
#### Summary
Mods "[XE] Direct drinking from those wearing holy symbols burns the holy-burnt."

#### Purpose of change
More parts for the holy-burn weakness, as it is still among the least impactful of them.

#### Describe the solution

While having the holy-burn weakness, direct drinking from a NPC wearing any holy symbol will cause pain with each drink.

This doesn't apply when asking for blood, as they will put aside while you drink from them. (and the player could simply remove the symbol, ask for a drink, then put it back on)

#### Describe alternatives you've considered

Make holy symbols repel nearby vampires, requiring constant checks.

#### Testing

Direct drank from NPC: no pain
Direct drank from NPC while having weakness: no pain
Direct drank from NPC wearing symbol: no pain

Direct drank from NPC wearing symbol while having weakness: pain with each drink

Ask for drink from wearer while having weakness: no pain

#### Additional context

It could be given to some strigoi too, but there's no way to see which strigoi has what weakness, and they're probably blood-thirsty enough that the holy pain is lesser than the thirst pain.