### PR TITLE
Hide weight for NPCs generated in older versions

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -623,6 +623,12 @@ std::pair<std::string, nc_color> display::hunger_text_color( const Character &u 
 
 std::pair<std::string, nc_color> display::weight_text_color( const Character &u )
 {
+    // Remove after 0.J.
+    // NPCs with the default mod should always be spawned at healthy weight. But some older saves had NPCs generated without normal weight.
+    // Just in case, debug mode always shows the real value.
+    if( !u.needs_food() && !debug_mode ) {
+        return { _( translate_marker( "Normal" ) ), c_light_gray };
+    }
     const float bmi = u.get_bmi_fat();
     std::string weight_string;
     nc_color weight_color = c_light_gray;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Followup to #84542

Some previously generated NPCs still had weight outside the normal range.

This doesn't have any effect, but at least one player checked their status screen and was still confused.

#### Describe the solution
Always show their weight as normal.

Just in case, debug mode will bypass this.

This is basically just a little lubricant for older saves.

#### Describe alternatives you've considered

#### Testing


#### Additional context