### PR TITLE
Move ACT_MULTIPLE_BUILD, ACT_FETCH_REQUIRED, ACT_MULTIPLE_CONSTRUCTION to activity_actors

### DIFF
--- a/data/json/player_activities.json
+++ b/data/json/player_activities.json
@@ -51,6 +51,7 @@
     "based_on": "neither",
     "can_resume": false,
     "multi_activity": true,
+    "fetch_items_to_zone": false,
     "auto_needs": true
   },
   {
@@ -199,6 +200,7 @@
     "based_on": "neither",
     "can_resume": false,
     "multi_activity": true,
+    "fetch_items_to_zone": false,
     "auto_needs": true
   },
   {

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -192,6 +192,7 @@ static const activity_id ACT_MOVE_ITEMS( "ACT_MOVE_ITEMS" );
 static const activity_id ACT_MOVE_LOOT( "ACT_MOVE_LOOT" );
 static const activity_id ACT_MULTIPLE_CHOP_PLANKS( "ACT_MULTIPLE_CHOP_PLANKS" );
 static const activity_id ACT_MULTIPLE_CHOP_TREES( "ACT_MULTIPLE_CHOP_TREES" );
+static const activity_id ACT_MULTIPLE_CONSTRUCTION( "ACT_MULTIPLE_CONSTRUCTION" );
 static const activity_id ACT_MULTIPLE_CRAFT( "ACT_MULTIPLE_CRAFT" );
 static const activity_id ACT_MULTIPLE_DIS( "ACT_MULTIPLE_DIS" );
 static const activity_id ACT_MULTIPLE_FARM( "ACT_MULTIPLE_FARM" );
@@ -8113,6 +8114,33 @@ std::unique_ptr<activity_actor> build_construction_activity_actor::deserialize( 
     return actor.clone();
 }
 
+activity_reason_info multi_build_construction_activity_actor::multi_activity_can_do(
+    Character &you, const tripoint_bub_ms &src_loc )
+{
+    return multi_activity_actor::construction_can_do( ACT_MULTIPLE_CONSTRUCTION, you,
+            src_loc );
+}
+
+std::unordered_set<tripoint_abs_ms>
+multi_build_construction_activity_actor::multi_activity_locations(
+    Character &you )
+{
+    return multi_activity_actor::construction_locations( you, get_type() );
+}
+
+bool multi_build_construction_activity_actor::multi_activity_do( Character &you,
+        const activity_reason_info &act_info,
+        const tripoint_abs_ms &src, const tripoint_bub_ms &src_loc )
+{
+    return multi_activity_actor::construction_do( you, act_info, src, src_loc );
+}
+
+std::unique_ptr<activity_actor> multi_build_construction_activity_actor::deserialize( JsonValue & )
+{
+    multi_build_construction_activity_actor actor;
+    return actor.clone();
+}
+
 void reel_cable_activity_actor::start( player_activity &act, Character & )
 {
     act.moves_total = moves_total;
@@ -12927,6 +12955,7 @@ deserialize_functions = {
     { ACT_MOVE_LOOT, &zone_sort_activity_actor::deserialize },
     { ACT_MULTIPLE_CHOP_PLANKS, &multi_chop_planks_activity_actor::deserialize },
     { ACT_MULTIPLE_CHOP_TREES, &multi_chop_trees_activity_actor::deserialize },
+    { ACT_MULTIPLE_CONSTRUCTION, &multi_build_construction_activity_actor::deserialize },
     { ACT_MULTIPLE_CRAFT, &multi_craft_activity_actor::deserialize },
     { ACT_MULTIPLE_DIS, &multi_disassemble_activity_actor::deserialize },
     { ACT_MULTIPLE_FARM, &multi_farm_activity_actor::deserialize },

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -5009,6 +5009,32 @@ void multi_zone_activity_actor::serialize( JsonOut &jsout ) const
     jsout.end_object();
 }
 
+activity_reason_info fetch_required_activity_actor::multi_activity_can_do(
+    Character &you, const tripoint_bub_ms &src_loc )
+{
+    return multi_activity_actor::fetch_can_do( ACT_FETCH_REQUIRED, you,
+            src_loc );
+}
+
+std::unordered_set<tripoint_abs_ms> fetch_required_activity_actor::multi_activity_locations(
+    Character &you )
+{
+    return multi_activity_actor::fetch_locations( you, get_type() );
+}
+
+bool fetch_required_activity_actor::multi_activity_do( Character &you,
+        const activity_reason_info &act_info,
+        const tripoint_abs_ms &src, const tripoint_bub_ms &src_loc )
+{
+    return multi_activity_actor::fetch_do( you, act_info, src, src_loc );
+}
+
+std::unique_ptr<activity_actor> fetch_required_activity_actor::deserialize( JsonValue & )
+{
+    fetch_required_activity_actor actor;
+    return actor.clone();
+}
+
 std::unique_ptr<activity_actor> multi_mine_activity_actor::deserialize( JsonValue & )
 {
     multi_mine_activity_actor actor;
@@ -12945,6 +12971,7 @@ deserialize_functions = {
     { ACT_DROP, &drop_activity_actor::deserialize },
     { ACT_E_FILE, &efile_activity_actor::deserialize },
     { ACT_EBOOKSAVE, &ebooksave_activity_actor::deserialize },
+    { ACT_FETCH_REQUIRED, &fetch_required_activity_actor::deserialize },
     { ACT_FIELD_DRESS, &butchery_activity_actor::deserialize },
     { ACT_FIRSTAID, &firstaid_activity_actor::deserialize },
     { ACT_FISH, &fish_activity_actor::deserialize },

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -8148,6 +8148,13 @@ activity_reason_info multi_build_construction_activity_actor::multi_activity_can
             src_loc );
 }
 
+std::optional<requirement_id> multi_build_construction_activity_actor::multi_activity_requirements(
+    Character &you,
+    activity_reason_info &act_info, const tripoint_bub_ms &src_loc, const zone_data * )
+{
+    return multi_activity_actor::construction_requirements( you, act_info, src_loc );
+}
+
 std::unordered_set<tripoint_abs_ms>
 multi_build_construction_activity_actor::multi_activity_locations(
     Character &you )
@@ -12318,6 +12325,13 @@ activity_reason_info multi_butchery_activity_actor::multi_activity_can_do(
 {
     return multi_activity_actor::butcher_can_do( ACT_MULTIPLE_BUTCHER, you,
             src_loc );
+}
+
+std::optional<requirement_id> multi_butchery_activity_actor::multi_activity_requirements(
+    Character &you,
+    activity_reason_info &act_info, const tripoint_bub_ms &src_loc, const zone_data * )
+{
+    return multi_activity_actor::butcher_requirements( you, act_info, src_loc );
 }
 
 bool multi_butchery_activity_actor::multi_activity_do( Character &you,

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -4975,18 +4975,16 @@ requirement_check_result multi_zone_activity_actor::check_requirements( Characte
         bool tool_pickup = multi_activity_actor::activity_reason_picks_up_tools( reason );
         // is it even worth fetching anything if there isn't enough nearby?
         if( !multi_activity_actor::are_requirements_nearby( tool_pickup ? loot_zone_spots : combined_spots,
-                what_we_need, you,
-                act_id, tool_pickup, src_loc ) ) {
+                what_we_need, you, act_id, tool_pickup, src_loc ) ) {
+            const tripoint_bub_ms you_pos_bub = you.pos_bub();
             if( zone ) {
-                you.add_msg_player_or_npc( m_info,
-                                           _( "The required items are not available to complete the %s task at zone %s." ), act_id.c_str(),
-                                           zone->get_name(),
-                                           _( "The required items are not available to complete the %s task at zone %s." ), act_id.c_str(),
-                                           zone->get_name() );
+                add_msg_if_player_sees( you_pos_bub, m_info, string_format(
+                                            _( "The required items are not available to complete the %s task at zone %s." ),
+                                            act_id.c_str(), zone->get_name() ) );
             } else {
-                you.add_msg_player_or_npc( m_info,
-                                           _( "The required items are not available to complete the %s task." ), act_id.c_str(),
-                                           _( "The required items are not available to complete the %s task." ), act_id.c_str() );
+                add_msg_if_player_sees( you_pos_bub, m_info, string_format(
+                                            _( "The required items are not available to complete the %s task." ),
+                                            act_id.c_str() ) );
             }
             //TODO: this is hacky, move it
             if( reason == do_activity_reason::NEEDS_VEH_DECONST ||

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -15,6 +15,7 @@
 #include <queue>
 #include <set>
 #include <string>
+#include <tuple>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -5002,7 +5003,7 @@ requirement_check_result multi_zone_activity_actor::check_requirements( Characte
     return requirement_check_result::SKIP_LOCATION_NO_MATCH;
 }
 
-bool multi_zone_activity_actor::can_resume_with_internal( const activity_actor &other_act,
+bool multi_zone_activity_actor::can_resume_with_internal( const activity_actor &,
         const Character & ) const
 {
     return true;
@@ -5066,11 +5067,8 @@ activity_reason_info fetch_required_activity_actor::multi_activity_can_do(
 
 void fetch_required_activity_actor::set_npc_fetch_history( Character &you )
 {
-    if( !you.backlog.empty() ) {
-        player_activity &act_prev = you.backlog.front();
-        if( !fetch_requirements.is_empty() && you.as_npc() ) {
-            you.as_npc()->job.fetch_history[fetch_requirements.str()] = calendar::turn;
-        }
+    if( !fetch_requirements.is_empty() && you.as_npc() ) {
+        you.as_npc()->job.fetch_history[fetch_requirements.str()] = calendar::turn;
     }
 }
 
@@ -5105,7 +5103,7 @@ std::unordered_set<tripoint_abs_ms> fetch_required_activity_actor::multi_activit
 
 bool fetch_required_activity_actor::multi_activity_do( Character &you,
         const activity_reason_info &act_info,
-        const tripoint_abs_ms &src, const tripoint_bub_ms &src_loc )
+        const tripoint_abs_ms &, const tripoint_bub_ms &src_loc )
 {
     const do_activity_reason &reason = act_info.reason;
 

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -190,6 +190,7 @@ static const activity_id ACT_MILK( "ACT_MILK" );
 static const activity_id ACT_MOP( "ACT_MOP" );
 static const activity_id ACT_MOVE_ITEMS( "ACT_MOVE_ITEMS" );
 static const activity_id ACT_MOVE_LOOT( "ACT_MOVE_LOOT" );
+static const activity_id ACT_MULTIPLE_BUTCHER( "ACT_MULTIPLE_BUTCHER" );
 static const activity_id ACT_MULTIPLE_CHOP_PLANKS( "ACT_MULTIPLE_CHOP_PLANKS" );
 static const activity_id ACT_MULTIPLE_CHOP_TREES( "ACT_MULTIPLE_CHOP_TREES" );
 static const activity_id ACT_MULTIPLE_CONSTRUCTION( "ACT_MULTIPLE_CONSTRUCTION" );
@@ -12286,6 +12287,26 @@ std::unique_ptr<activity_actor> butchery_activity_actor::deserialize( JsonValue 
     return actor.clone();
 }
 
+activity_reason_info multi_butchery_activity_actor::multi_activity_can_do(
+    Character &you, const tripoint_bub_ms &src_loc )
+{
+    return multi_activity_actor::butcher_can_do( ACT_MULTIPLE_BUTCHER, you,
+            src_loc );
+}
+
+bool multi_butchery_activity_actor::multi_activity_do( Character &you,
+        const activity_reason_info &act_info,
+        const tripoint_abs_ms &src, const tripoint_bub_ms &src_loc )
+{
+    return multi_activity_actor::butcher_do( you, act_info, src, src_loc );
+}
+
+std::unique_ptr<activity_actor> multi_butchery_activity_actor::deserialize( JsonValue & )
+{
+    multi_butchery_activity_actor actor;
+    return actor.clone();
+}
+
 void wait_activity_actor::start( player_activity &act, Character & )
 {
     act.moves_total = to_moves<int>( initial_wait_time );
@@ -12953,6 +12974,7 @@ deserialize_functions = {
     { ACT_MOP, &mop_activity_actor::deserialize },
     { ACT_MOVE_ITEMS, &move_items_activity_actor::deserialize },
     { ACT_MOVE_LOOT, &zone_sort_activity_actor::deserialize },
+    { ACT_MULTIPLE_BUTCHER, &multi_butchery_activity_actor::deserialize },
     { ACT_MULTIPLE_CHOP_PLANKS, &multi_chop_planks_activity_actor::deserialize },
     { ACT_MULTIPLE_CHOP_TREES, &multi_chop_trees_activity_actor::deserialize },
     { ACT_MULTIPLE_CONSTRUCTION, &multi_build_construction_activity_actor::deserialize },

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -398,6 +398,9 @@ class multi_build_construction_activity_actor : public multi_zone_activity_actor
         std::unordered_set<tripoint_abs_ms> multi_activity_locations( Character &you ) override;
         activity_reason_info multi_activity_can_do( Character &you,
                 const tripoint_bub_ms &src_loc ) override;
+        std::optional<requirement_id> multi_activity_requirements( Character &you,
+                activity_reason_info &act_info, const tripoint_bub_ms &src_loc,
+                const zone_data *zone = nullptr ) override;
         bool multi_activity_do( Character &you, const activity_reason_info &act_info,
                                 const tripoint_abs_ms &src, const tripoint_bub_ms &src_loc ) override;
         std::unique_ptr<activity_actor> clone() const override {
@@ -416,6 +419,9 @@ class multi_butchery_activity_actor : public multi_zone_activity_actor
         }
         activity_reason_info multi_activity_can_do( Character &you,
                 const tripoint_bub_ms &src_loc ) override;
+        std::optional<requirement_id> multi_activity_requirements( Character &you,
+                activity_reason_info &act_info, const tripoint_bub_ms &src_loc,
+                const zone_data *zone = nullptr ) override;
         bool multi_activity_do( Character &you, const activity_reason_info &act_info,
                                 const tripoint_abs_ms &src, const tripoint_bub_ms &src_loc ) override;
         std::unique_ptr<activity_actor> clone() const override {

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -406,6 +406,24 @@ class multi_build_construction_activity_actor : public multi_zone_activity_actor
         static std::unique_ptr<activity_actor> deserialize( JsonValue & );
 };
 
+class multi_butchery_activity_actor : public multi_zone_activity_actor
+{
+    public:
+        using multi_zone_activity_actor::multi_zone_activity_actor;
+        const activity_id &get_type() const override {
+            static const activity_id ACT_MULTIPLE_BUTCHER( "ACT_MULTIPLE_BUTCHER" );
+            return ACT_MULTIPLE_BUTCHER;
+        }
+        activity_reason_info multi_activity_can_do( Character &you,
+                const tripoint_bub_ms &src_loc ) override;
+        bool multi_activity_do( Character &you, const activity_reason_info &act_info,
+                                const tripoint_abs_ms &src, const tripoint_bub_ms &src_loc ) override;
+        std::unique_ptr<activity_actor> clone() const override {
+            return std::make_unique<multi_butchery_activity_actor>( *this );
+        }
+        static std::unique_ptr<activity_actor> deserialize( JsonValue & );
+};
+
 class aim_activity_actor : public activity_actor
 {
     private:

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -387,6 +387,25 @@ class multi_disassemble_activity_actor : public multi_zone_activity_actor
         static std::unique_ptr<activity_actor> deserialize( JsonValue & );
 };
 
+class multi_build_construction_activity_actor : public multi_zone_activity_actor
+{
+    public:
+        using multi_zone_activity_actor::multi_zone_activity_actor;
+        const activity_id &get_type() const override {
+            static const activity_id ACT_MULTIPLE_CONSTRUCTION( "ACT_MULTIPLE_CONSTRUCTION" );
+            return ACT_MULTIPLE_CONSTRUCTION;
+        }
+        std::unordered_set<tripoint_abs_ms> multi_activity_locations( Character &you ) override;
+        activity_reason_info multi_activity_can_do( Character &you,
+                const tripoint_bub_ms &src_loc ) override;
+        bool multi_activity_do( Character &you, const activity_reason_info &act_info,
+                                const tripoint_abs_ms &src, const tripoint_bub_ms &src_loc ) override;
+        std::unique_ptr<activity_actor> clone() const override {
+            return std::make_unique<multi_build_construction_activity_actor>( *this );
+        }
+        static std::unique_ptr<activity_actor> deserialize( JsonValue & );
+};
+
 class aim_activity_actor : public activity_actor
 {
     private:

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -125,7 +125,7 @@ class multi_zone_activity_actor : public activity_actor
                 activity_reason_info &act_info, const tripoint_abs_ms &src, const tripoint_bub_ms &src_loc,
                 const std::unordered_set<tripoint_abs_ms> &src_set );
         // @return equal types
-        bool can_resume_with_internal( const activity_actor &other_act,
+        bool can_resume_with_internal( const activity_actor &,
                                        const Character & ) const override;
 
         // BEGIN interface block
@@ -457,9 +457,9 @@ class fetch_required_activity_actor : public multi_zone_activity_actor
 
         void set_npc_fetch_history( Character &you );
         std::vector<std::tuple<tripoint_bub_ms, itype_id, int>> requirements_map( Character &you,
-                const int distance = MAX_VIEW_DISTANCE );
+                int distance = MAX_VIEW_DISTANCE );
         bool fetch_activity( Character &you, const tripoint_bub_ms &src_loc,
-                             const activity_id &activity_to_restore, const int distance = MAX_VIEW_DISTANCE );
+                             const activity_id &activity_to_restore, int distance = MAX_VIEW_DISTANCE );
         // is the front of the activity backlog a multi-activity?
         bool fetch_activity_valid( const Character &you ) const;
 
@@ -467,14 +467,14 @@ class fetch_required_activity_actor : public multi_zone_activity_actor
         activity_reason_info multi_activity_can_do( Character &you,
                 const tripoint_bub_ms &src_loc ) override;
         bool multi_activity_do( Character &you, const activity_reason_info &act_info,
-                                const tripoint_abs_ms &src, const tripoint_bub_ms &src_loc ) override;
+                                const tripoint_abs_ms &, const tripoint_bub_ms &src_loc ) override;
         std::unique_ptr<activity_actor> clone() const override {
             return std::make_unique<fetch_required_activity_actor>( *this );
         }
         static std::unique_ptr<activity_actor> deserialize( JsonValue & );
     private:
         requirement_id fetch_requirements;
-        do_activity_reason act_reason;
+        do_activity_reason act_reason = do_activity_reason::UNKNOWN_ACTIVITY;
         // where should this item be placed
         tripoint_abs_ms fetched_item_destination;
         // what zone tile was the fetching multi-activity currently processing?

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -424,6 +424,27 @@ class multi_butchery_activity_actor : public multi_zone_activity_actor
         static std::unique_ptr<activity_actor> deserialize( JsonValue & );
 };
 
+// find items for a multi-activity
+// NOTE: ACT_FETCH_REQUIRED is not a multi-activity but still uses the framework
+class fetch_required_activity_actor : public multi_zone_activity_actor
+{
+    public:
+        using multi_zone_activity_actor::multi_zone_activity_actor;
+        const activity_id &get_type() const override {
+            static const activity_id ACT_MULTIPLE_CONSTRUCTION( "ACT_MULTIPLE_CONSTRUCTION" );
+            return ACT_MULTIPLE_CONSTRUCTION;
+        }
+        std::unordered_set<tripoint_abs_ms> multi_activity_locations( Character &you ) override;
+        activity_reason_info multi_activity_can_do( Character &you,
+                const tripoint_bub_ms &src_loc ) override;
+        bool multi_activity_do( Character &you, const activity_reason_info &act_info,
+                                const tripoint_abs_ms &src, const tripoint_bub_ms &src_loc ) override;
+        std::unique_ptr<activity_actor> clone() const override {
+            return std::make_unique<fetch_required_activity_actor>( *this );
+        }
+        static std::unique_ptr<activity_actor> deserialize( JsonValue & );
+};
+
 class aim_activity_actor : public activity_actor
 {
     private:

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -120,6 +120,13 @@ class multi_zone_activity_actor : public activity_actor
         requirement_check_result check_requirements( Character &you, activity_reason_info &act_info,
                 const tripoint_abs_ms &src, const tripoint_bub_ms &src_loc,
                 const std::unordered_set<tripoint_abs_ms> &src_set, bool check_only = false );
+        // assigns fetch activity to find provided requirements
+        requirement_check_result fetch_requirements( Character &you, requirement_id what_we_need,
+                activity_reason_info &act_info, const tripoint_abs_ms &src, const tripoint_bub_ms &src_loc,
+                const std::unordered_set<tripoint_abs_ms> &src_set );
+        // @return equal types
+        bool can_resume_with_internal( const activity_actor &other_act,
+                                       const Character & ) const override;
 
         // BEGIN interface block
         virtual std::unordered_set<tripoint_abs_ms> multi_activity_locations( Character &you );
@@ -430,16 +437,32 @@ class multi_butchery_activity_actor : public multi_zone_activity_actor
         static std::unique_ptr<activity_actor> deserialize( JsonValue & );
 };
 
-// find items for a multi-activity
+// find and retrieve items for the front multi-activity of the backlog
 // NOTE: ACT_FETCH_REQUIRED is not a multi-activity but still uses the framework
 class fetch_required_activity_actor : public multi_zone_activity_actor
 {
     public:
         using multi_zone_activity_actor::multi_zone_activity_actor;
+        explicit fetch_required_activity_actor( requirement_id fetch_requirements,
+                                                do_activity_reason act_reason, tripoint_abs_ms fetched_item_destination,
+                                                tripoint_abs_ms fetch_for_activity_position ) :
+            fetch_requirements( fetch_requirements ), act_reason( act_reason ),
+            fetched_item_destination( fetched_item_destination ),
+            fetch_for_activity_position( fetch_for_activity_position ) {
+        };
         const activity_id &get_type() const override {
-            static const activity_id ACT_MULTIPLE_CONSTRUCTION( "ACT_MULTIPLE_CONSTRUCTION" );
-            return ACT_MULTIPLE_CONSTRUCTION;
+            static const activity_id ACT_FETCH_REQUIRED( "ACT_FETCH_REQUIRED" );
+            return ACT_FETCH_REQUIRED;
         }
+
+        void set_npc_fetch_history( Character &you );
+        std::vector<std::tuple<tripoint_bub_ms, itype_id, int>> requirements_map( Character &you,
+                const int distance = MAX_VIEW_DISTANCE );
+        bool fetch_activity( Character &you, const tripoint_bub_ms &src_loc,
+                             const activity_id &activity_to_restore, const int distance = MAX_VIEW_DISTANCE );
+        // is the front of the activity backlog a multi-activity?
+        bool fetch_activity_valid( const Character &you ) const;
+
         std::unordered_set<tripoint_abs_ms> multi_activity_locations( Character &you ) override;
         activity_reason_info multi_activity_can_do( Character &you,
                 const tripoint_bub_ms &src_loc ) override;
@@ -449,6 +472,13 @@ class fetch_required_activity_actor : public multi_zone_activity_actor
             return std::make_unique<fetch_required_activity_actor>( *this );
         }
         static std::unique_ptr<activity_actor> deserialize( JsonValue & );
+    private:
+        requirement_id fetch_requirements;
+        do_activity_reason act_reason;
+        // where should this item be placed
+        tripoint_abs_ms fetched_item_destination;
+        // what zone tile was the fetching multi-activity currently processing?
+        tripoint_abs_ms fetch_for_activity_position;
 };
 
 class aim_activity_actor : public activity_actor

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -63,7 +63,6 @@ static const activity_id ACT_FERTILIZE_PLOT( "ACT_FERTILIZE_PLOT" );
 static const activity_id ACT_FETCH_REQUIRED( "ACT_FETCH_REQUIRED" );
 static const activity_id ACT_FILL_LIQUID( "ACT_FILL_LIQUID" );
 static const activity_id ACT_FIND_MOUNT( "ACT_FIND_MOUNT" );
-static const activity_id ACT_MULTIPLE_BUTCHER( "ACT_MULTIPLE_BUTCHER" );
 static const activity_id ACT_REPAIR_ITEM( "ACT_REPAIR_ITEM" );
 static const activity_id ACT_START_FIRE( "ACT_START_FIRE" );
 static const activity_id ACT_TIDY_UP( "ACT_TIDY_UP" );
@@ -101,7 +100,6 @@ const std::map< activity_id, std::function<void( player_activity *, Character * 
 activity_handlers::do_turn_functions = {
     { ACT_FILL_LIQUID, fill_liquid_do_turn },
     { ACT_START_FIRE, start_fire_do_turn },
-    { ACT_MULTIPLE_BUTCHER, multiple_butcher_do_turn },
     { ACT_FETCH_REQUIRED, fetch_do_turn },
     { ACT_TIDY_UP, tidy_up_do_turn },
     { ACT_REPAIR_ITEM, repair_item_do_turn },

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -64,7 +64,6 @@ static const activity_id ACT_FETCH_REQUIRED( "ACT_FETCH_REQUIRED" );
 static const activity_id ACT_FILL_LIQUID( "ACT_FILL_LIQUID" );
 static const activity_id ACT_FIND_MOUNT( "ACT_FIND_MOUNT" );
 static const activity_id ACT_MULTIPLE_BUTCHER( "ACT_MULTIPLE_BUTCHER" );
-static const activity_id ACT_MULTIPLE_CONSTRUCTION( "ACT_MULTIPLE_CONSTRUCTION" );
 static const activity_id ACT_REPAIR_ITEM( "ACT_REPAIR_ITEM" );
 static const activity_id ACT_START_FIRE( "ACT_START_FIRE" );
 static const activity_id ACT_TIDY_UP( "ACT_TIDY_UP" );
@@ -102,7 +101,6 @@ const std::map< activity_id, std::function<void( player_activity *, Character * 
 activity_handlers::do_turn_functions = {
     { ACT_FILL_LIQUID, fill_liquid_do_turn },
     { ACT_START_FIRE, start_fire_do_turn },
-    { ACT_MULTIPLE_CONSTRUCTION, multiple_construction_do_turn },
     { ACT_MULTIPLE_BUTCHER, multiple_butcher_do_turn },
     { ACT_FETCH_REQUIRED, fetch_do_turn },
     { ACT_TIDY_UP, tidy_up_do_turn },

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -60,7 +60,6 @@
 #include "weather.h"
 
 static const activity_id ACT_FERTILIZE_PLOT( "ACT_FERTILIZE_PLOT" );
-static const activity_id ACT_FETCH_REQUIRED( "ACT_FETCH_REQUIRED" );
 static const activity_id ACT_FILL_LIQUID( "ACT_FILL_LIQUID" );
 static const activity_id ACT_FIND_MOUNT( "ACT_FIND_MOUNT" );
 static const activity_id ACT_REPAIR_ITEM( "ACT_REPAIR_ITEM" );
@@ -100,7 +99,6 @@ const std::map< activity_id, std::function<void( player_activity *, Character * 
 activity_handlers::do_turn_functions = {
     { ACT_FILL_LIQUID, fill_liquid_do_turn },
     { ACT_START_FIRE, start_fire_do_turn },
-    { ACT_FETCH_REQUIRED, fetch_do_turn },
     { ACT_TIDY_UP, tidy_up_do_turn },
     { ACT_REPAIR_ITEM, repair_item_do_turn },
     { ACT_TRAVELLING, travel_do_turn },

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -3622,7 +3622,7 @@ bool construction_do( Character &you, const activity_reason_info &act_info,
 
     if( reason == do_activity_reason::CAN_DO_CONSTRUCTION ) {
         if( here.partial_con_at( src_loc ) ) {
-            you.backlog.emplace_front( ACT_MULTIPLE_CONSTRUCTION );
+            you.backlog.emplace_front( multi_build_construction_activity_actor() );
             you.assign_activity( build_construction_activity_actor( src ) );
             return false;
         }

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -2177,7 +2177,7 @@ requirement_check_result fetch_requirements( Character &you, requirement_id what
         return requirement_check_result::SKIP_LOCATION;
     }
     you.backlog.emplace_front( act_id );
-    you.assign_activity( ACT_FETCH_REQUIRED );
+    you.assign_activity( fetch_required_activity_actor() );
     player_activity &act_prev = you.backlog.front();
     act_prev.str_values.push_back( what_we_need.str() );
     act_prev.values.push_back( static_cast<int>( act_info.reason ) );

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -16,6 +16,7 @@
 #include <vector>
 
 #include "activity_actor_definitions.h"
+#include "activity_type.h"
 #include "avatar.h"
 #include "butchery.h"
 #include "calendar.h"
@@ -3626,7 +3627,7 @@ bool tidy_up_do( Character &you, const activity_reason_info &act_info,
 }
 
 bool fetch_do( Character &you, const activity_reason_info &act_info,
-               const tripoint_abs_ms &, const tripoint_bub_ms &src_loc )
+               const tripoint_abs_ms &, const tripoint_bub_ms & )
 {
     const do_activity_reason &reason = act_info.reason;
 

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -3555,7 +3555,7 @@ bool butcher_do( Character &you, const activity_reason_info &act_info,
     if( reason == do_activity_reason::NEEDS_BUTCHERING ||
         reason == do_activity_reason::NEEDS_BIG_BUTCHERING ) {
         if( butcher_corpse_activity( you, src_loc, reason ) ) {
-            you.backlog.emplace_front( ACT_MULTIPLE_BUTCHER );
+            you.backlog.emplace_front( multi_butchery_activity_actor() );
             return false;
         }
     }

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -242,7 +242,9 @@ struct act_item {
           consumed_moves( consumed_moves ) {}
 };
 
-static void check_npc_revert( Character &you )
+namespace multi_activity_actor
+{
+void check_npc_revert( Character &you )
 {
     if( you.is_npc() ) {
         npc *guy = dynamic_cast<npc *>( &you );
@@ -251,6 +253,7 @@ static void check_npc_revert( Character &you )
         }
     }
 }
+} //namespace multi_activity_actor
 
 // TODO: Deliberately unified with multidrop. Unify further.
 static bool same_type( const std::list<item> &items )
@@ -2177,7 +2180,7 @@ requirement_check_result fetch_requirements( Character &you, requirement_id what
         return requirement_check_result::SKIP_LOCATION;
     }
     you.backlog.emplace_front( act_id );
-    you.assign_activity( fetch_required_activity_actor() );
+    you.assign_activity( ACT_FETCH_REQUIRED );
     player_activity &act_prev = you.backlog.front();
     act_prev.str_values.push_back( what_we_need.str() );
     act_prev.values.push_back( static_cast<int>( act_info.reason ) );
@@ -2286,7 +2289,10 @@ requirement_id remove_met_requirements( requirement_id base_req_id, Character &y
     requirement_data::alter_tool_comp_vector reduced_tool_reqs_vector;
     requirement_data::alter_quali_req_vector reduced_quality_reqs_vector;
 
-    const inventory &inv = you.crafting_inventory();
+    // We cannot assume that required items on the ground when the multi-activity starts
+    // will *always* be in the multi-activity work area to meet requirements.
+    // Therefore, items on the ground aren't counted here for met requirements.
+    const inventory &inv = you.crafting_inventory( tripoint_bub_ms::zero, -1 );
 
     for( std::vector<tool_comp> &tools : tool_reqs_vector ) {
         bool found = false;
@@ -2532,29 +2538,23 @@ void add_basecamp_storage_to_loot_zone_list(
 }
 } //namespace multi_activity_actor
 
-static std::vector<std::tuple<tripoint_bub_ms, itype_id, int>> requirements_map( Character &you,
-        const int distance = MAX_VIEW_DISTANCE )
+std::vector<std::tuple<tripoint_bub_ms, itype_id, int>>
+        fetch_required_activity_actor::requirements_map( Character &you,
+                const int distance )
 {
     std::vector<std::tuple<tripoint_bub_ms, itype_id, int>> requirement_map;
-    if( you.backlog.empty() || you.backlog.front().str_values.empty() ) {
+    if( !fetch_activity_valid( you ) ) {
         return requirement_map;
     }
-    const requirement_data things_to_fetch = requirement_id( you.backlog.front().str_values[0] ).obj();
-    const activity_id activity_to_restore = you.backlog.front().id();
     // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
-    requirement_id things_to_fetch_id = things_to_fetch.id();
+    requirement_id things_to_fetch_id = fetch_requirements;
+    const requirement_data things_to_fetch = *fetch_requirements;
+    const activity_id activity_to_restore = you.backlog.front().id();
     std::vector<std::vector<item_comp>> req_comps = things_to_fetch.get_components();
     std::vector<std::vector<tool_comp>> tool_comps = things_to_fetch.get_tools();
     std::vector<std::vector<quality_requirement>> quality_comps = things_to_fetch.get_qualities();
     zone_manager &mgr = zone_manager::get_manager();
-    const bool pickup_task = you.backlog.front().id() == ACT_MULTIPLE_FARM ||
-                             you.backlog.front().id() == ACT_MULTIPLE_CHOP_PLANKS ||
-                             you.backlog.front().id() == ACT_MULTIPLE_BUTCHER ||
-                             you.backlog.front().id() == ACT_MULTIPLE_CHOP_TREES ||
-                             you.backlog.front().id() == ACT_VEHICLE_DECONSTRUCTION ||
-                             you.backlog.front().id() == ACT_VEHICLE_REPAIR ||
-                             you.backlog.front().id() == ACT_MULTIPLE_FISH ||
-                             you.backlog.front().id() == ACT_MULTIPLE_MINE;
+    const bool pickup_task = activity_to_restore->fetch_items_to_zone();
     // where it is, what it is, how much of it, and how much in total is required of that item.
     std::vector<std::tuple<tripoint_bub_ms, itype_id, int>> final_map;
     std::vector<tripoint_bub_ms> loot_spots;
@@ -2562,7 +2562,7 @@ static std::vector<std::tuple<tripoint_bub_ms, itype_id, int>> requirements_map(
     std::vector<tripoint_bub_ms> combined_spots;
     std::map<itype_id, int> total_map;
     map &here = get_map();
-    tripoint_bub_ms src_loc = here.get_bub( you.backlog.front().placement );
+    const tripoint_bub_ms &src_loc = here.get_bub( fetch_for_activity_position );
     for( const tripoint_bub_ms &elem : here.points_in_radius( src_loc,
             PICKUP_RANGE - 1 ) ) {
         already_there_spots.push_back( elem );
@@ -2918,29 +2918,35 @@ static bool tidy_activity( Character &you, const tripoint_bub_ms &src_loc,
     return true;
 }
 
-static bool fetch_activity(
+bool fetch_required_activity_actor::fetch_activity(
     Character &you, const tripoint_bub_ms &src_loc, const activity_id &activity_to_restore,
-    const int distance = MAX_VIEW_DISTANCE )
+    int distance )
 {
-    map &here = get_map();
-    if( !here.can_put_items_ter_furn( here.get_bub(
-                                          you.backlog.front().coords.back() ) ) ) {
+    if( !fetch_activity_valid( you ) ) {
         return false;
     }
-    const std::vector<std::tuple<tripoint_bub_ms, itype_id, int>> mental_map_2 =
+    const activity_id fetch_for_activity = you.backlog.front().id();
+    map &here = get_map();
+    if( !here.can_put_items_ter_furn( here.get_bub( fetched_item_destination ) ) ) {
+        return false;
+    }
+    const std::vector<std::tuple<tripoint_bub_ms, itype_id, int>> mental_item_map =
                 requirements_map( you, distance );
     int pickup_count = 1;
     map_stack items_there = here.i_at( src_loc );
     const units::volume volume_allowed = you.free_space();
     const units::mass weight_allowed = you.weight_capacity() - you.weight_carried();
+
+    // if the items are in vehicle cargo, move them to their position
     const std::optional<vpart_reference> ovp = here.veh_at( src_loc ).cargo();
     if( ovp ) {
         for( item &veh_elem : ovp->items() ) {
-            for( auto elem : mental_map_2 ) {
+            for( auto elem : mental_item_map ) {
                 if( std::get<0>( elem ) == src_loc && veh_elem.typeId() == std::get<1>( elem ) ) {
-                    if( !you.backlog.empty() && you.backlog.front().id() == ACT_MULTIPLE_CONSTRUCTION ) {
+                    if( fetch_for_activity == ACT_MULTIPLE_CONSTRUCTION ) {
+                        //TODO: this teleports the item, assign an item moving activity
                         move_item( you, veh_elem, veh_elem.count_by_charges() ? std::get<2>( elem ) : 1, src_loc,
-                                   here.get_bub( you.backlog.front().coords.back() ), ovp,
+                                   here.get_bub( fetched_item_destination ), ovp,
                                    activity_to_restore );
                         return true;
                     }
@@ -2950,26 +2956,19 @@ static bool fetch_activity(
     }
     for( auto item_iter = items_there.begin(); item_iter != items_there.end(); item_iter++ ) {
         item &it = *item_iter;
-        for( auto elem : mental_map_2 ) {
+        for( auto elem : mental_item_map ) {
             if( std::get<0>( elem ) == src_loc && it.typeId() == std::get<1>( elem ) ) {
-                // construction/crafting tasks want the required item moved near the work spot.
-                if( !you.backlog.empty() && ( you.backlog.front().id() == ACT_MULTIPLE_CONSTRUCTION ||
-                                              you.backlog.front().id() == ACT_MULTIPLE_DIS ) ) {
+                // some tasks (construction/crafting) want the required item moved near the work spot.
+                if( !fetch_for_activity->fetch_items_to_zone() ) {
+                    //TODO: this teleports the item, assign an item moving activity
                     move_item( you, it, it.count_by_charges() ? std::get<2>( elem ) : 1, src_loc,
-                               here.get_bub( you.backlog.front().coords.back() ), ovp,
-                               activity_to_restore );
+                               here.get_bub( fetched_item_destination ), ovp, activity_to_restore );
 
                     return true;
-                    // other tasks want the tool picked up
-                } else if( !you.backlog.empty() && ( you.backlog.front().id() == ACT_MULTIPLE_FARM ||
-                                                     you.backlog.front().id() == ACT_MULTIPLE_CHOP_PLANKS ||
-                                                     you.backlog.front().id() == ACT_VEHICLE_DECONSTRUCTION ||
-                                                     you.backlog.front().id() == ACT_VEHICLE_REPAIR ||
-                                                     you.backlog.front().id() == ACT_MULTIPLE_BUTCHER ||
-                                                     you.backlog.front().id() == ACT_MULTIPLE_CHOP_TREES ||
-                                                     you.backlog.front().id() == ACT_MULTIPLE_FISH ||
-                                                     you.backlog.front().id() == ACT_MULTIPLE_MINE ||
-                                                     you.backlog.front().id() == ACT_MULTIPLE_MOP ) ) {
+                    // other tasks want the item picked up
+                } else {
+                    // TODO: most of this `else` block should be handled by exactly one function call
+
                     if( it.volume() > volume_allowed || it.weight() > weight_allowed ) {
                         add_msg_if_player_sees( you, _( "%1s failed to fetch tools." ), you.name );
                         continue;
@@ -3004,7 +3003,7 @@ static bool fetch_activity(
             }
         }
     }
-    // if we got here, then the fetch failed for reasons that weren't predicted before setting it.
+    // if we got here, then the fetch failed for reasons that weren't predicted before assigning it.
     // nothing was moved or picked up, and nothing can be moved or picked up
     // so call the whole thing off to stop it looping back to this point ad nauseum.
     you.set_moves( 0 );
@@ -3430,26 +3429,6 @@ std::unordered_set<tripoint_abs_ms> craft_locations( Character &you, const activ
     return src_set;
 }
 
-std::unordered_set<tripoint_abs_ms> fetch_locations( Character &you, const activity_id & )
-{
-
-    map &here = get_map();
-    std::unordered_set<tripoint_abs_ms> src_set;
-
-    // get the right zones for the items in the requirements.
-    // we previously checked if the items are nearby before we set the fetch task
-    // but we will check again later, to be sure nothings changed.
-    std::vector<std::tuple<tripoint_bub_ms, itype_id, int>> mental_map =
-                requirements_map( you, MAX_VIEW_DISTANCE );
-    for( const auto &elem : mental_map ) {
-        const tripoint_bub_ms &elem_point = std::get<0>( elem );
-        src_set.insert( here.get_abs( elem_point ) );
-    }
-    multi_activity_actor::prune_dangerous_field_locations( src_set );
-
-    return src_set;
-}
-
 std::unordered_set<tripoint_abs_ms> fish_locations( Character &you, const activity_id &act_id )
 {
 
@@ -3652,14 +3631,14 @@ bool fetch_do( Character &you, const activity_reason_info &act_info,
     const do_activity_reason &reason = act_info.reason;
 
     if( reason == do_activity_reason::CAN_DO_FETCH ) {
-        if( fetch_activity( you, src_loc, ACT_FETCH_REQUIRED, MAX_VIEW_DISTANCE ) ) {
-            if( !you.is_npc() ) {
-                // Npcs will automatically start the next thing in the backlog, players need to be manually prompted
-                // Because some player activities are necessarily not marked as auto-resume.
-                activity_handlers::resume_for_multi_activities( you );
-            }
-            return false;
+        //if( fetch_activity( you, src_loc, ACT_FETCH_REQUIRED, MAX_VIEW_DISTANCE ) ) {
+        if( !you.is_npc() ) {
+            // Npcs will automatically start the next thing in the backlog, players need to be manually prompted
+            // Because some player activities are necessarily not marked as auto-resume.
+            activity_handlers::resume_for_multi_activities( you );
         }
+        return false;
+        //}
     }
     return true;
 }
@@ -3949,7 +3928,7 @@ static std::unordered_set<tripoint_abs_ms> generic_multi_activity_locations(
     } else if( act_id == ACT_MULTIPLE_CRAFT ) {
         src_set = multi_activity_actor::craft_locations( you, act_id );
     } else if( act_id == ACT_FETCH_REQUIRED ) {
-        src_set = multi_activity_actor::fetch_locations( you, act_id );
+        //src_set = multi_activity_actor::fetch_locations( you, act_id );
     } else if( act_id == ACT_MULTIPLE_MOP ) {
         src_set = multi_activity_actor::mop_locations( you, act_id );
     } else if( act_id == ACT_MULTIPLE_CONSTRUCTION ) {

--- a/src/activity_item_handling.h
+++ b/src/activity_item_handling.h
@@ -253,7 +253,7 @@ bool construction_do( Character &you, const activity_reason_info &act_info,
 bool farm_do( Character &you, const activity_reason_info &act_info,
               const tripoint_abs_ms &src, const tripoint_bub_ms &src_loc );
 bool fetch_do( Character &you, const activity_reason_info &act_info,
-               const tripoint_abs_ms &, const tripoint_bub_ms &src_loc );
+               const tripoint_abs_ms &, const tripoint_bub_ms & );
 bool craft_do( Character &you, const activity_reason_info &act_info,
                const tripoint_abs_ms &, const tripoint_bub_ms & );
 bool disassemble_do( Character &you, const activity_reason_info &act_info,

--- a/src/activity_item_handling.h
+++ b/src/activity_item_handling.h
@@ -134,6 +134,7 @@ bool activity_reason_continue( do_activity_reason reason );
 bool activity_reason_quit( do_activity_reason reason );
 // the activity (reason) requires picking up tools
 bool activity_reason_picks_up_tools( do_activity_reason reason );
+void check_npc_revert( Character &you );
 // assigns fetch activity to find requirements
 requirement_check_result fetch_requirements( Character &you, requirement_id what_we_need,
         const activity_id &act_id,
@@ -183,7 +184,6 @@ std::unordered_set<tripoint_abs_ms> tidy_up_locations( Character &you, const act
 std::unordered_set<tripoint_abs_ms> read_locations( Character &you, const activity_id &act_id );
 std::unordered_set<tripoint_abs_ms> study_locations( Character &you, const activity_id &act_id );
 std::unordered_set<tripoint_abs_ms> craft_locations( Character &you, const activity_id &act_id );
-std::unordered_set<tripoint_abs_ms> fetch_locations( Character &you, const activity_id & );
 std::unordered_set<tripoint_abs_ms> fish_locations( Character &you, const activity_id &act_id );
 std::unordered_set<tripoint_abs_ms> mop_locations( Character &you, const activity_id &act_id );
 void prune_same_tile_locations( Character &you, std::unordered_set<tripoint_abs_ms> &src_set );

--- a/src/activity_type.cpp
+++ b/src/activity_type.cpp
@@ -93,6 +93,7 @@ void activity_type::load( const JsonObject &jo )
     optional( jo, was_loaded, "interruptable_with_kb", interruptable_with_kb_, true );
     optional( jo, was_loaded, "can_resume", can_resume_, true );
     optional( jo, was_loaded, "multi_activity", multi_activity_, false );
+    optional( jo, was_loaded, "fetch_items_to_zone", fetch_items_to_zone_, true );
     optional( jo, was_loaded, "refuel_fires", refuel_fires, false );
     optional( jo, was_loaded, "auto_needs", auto_needs, false );
     optional( jo, was_loaded, "completion_eoc", completion_EOC );

--- a/src/activity_type.h
+++ b/src/activity_type.h
@@ -46,6 +46,7 @@ class activity_type
         based_on_type based_on_ = based_on_type::SPEED;
         bool can_resume_ = true;
         bool multi_activity_ = false;
+        bool fetch_items_to_zone_ = true;
         bool refuel_fires = false;
         bool auto_needs = false;
         float activity_level = NO_EXERCISE;
@@ -81,6 +82,9 @@ class activity_type
         }
         bool multi_activity() const {
             return multi_activity_;
+        }
+        bool fetch_items_to_zone() const {
+            return fetch_items_to_zone_;
         }
         /**
          * If true, player will refuel one adjacent fire if there is firewood spot adjacent.

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -5215,6 +5215,9 @@ void Character::assign_activity( const player_activity &act )
     } else {
         if( activity ) {
             backlog.push_front( activity );
+            if( backlog.size() > 100 ) {
+                debugmsg( "activity backlog exceeded 100, likely an infinite loop" );
+            }
         }
 
         activity = act;

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1547,7 +1547,7 @@ void build_construction_activity_actor::complete_construction( player_activity &
     if( you.is_avatar() && !you.backlog.empty() &&
         you.backlog.front().id() == ACT_MULTIPLE_CONSTRUCTION ) {
         you.backlog.clear();
-        you.assign_activity( ACT_MULTIPLE_CONSTRUCTION );
+        you.assign_activity( multi_build_construction_activity_actor() );
     }
 }
 

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -112,7 +112,6 @@ enum class direction : unsigned int;
 #endif
 
 static const activity_id ACT_FERTILIZE_PLOT( "ACT_FERTILIZE_PLOT" );
-static const activity_id ACT_MULTIPLE_BUTCHER( "ACT_MULTIPLE_BUTCHER" );
 
 static const bionic_id bio_remote( "bio_remote" );
 
@@ -1686,7 +1685,7 @@ static void loot()
             player_character.assign_activity( multi_vehicle_repair_activity_actor() );
             break;
         case MultiButchery:
-            player_character.assign_activity( ACT_MULTIPLE_BUTCHER );
+            player_character.assign_activity( multi_butchery_activity_actor() );
             break;
         case MultiMining:
             player_character.assign_activity( multi_mine_activity_actor() );

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -113,7 +113,6 @@ enum class direction : unsigned int;
 
 static const activity_id ACT_FERTILIZE_PLOT( "ACT_FERTILIZE_PLOT" );
 static const activity_id ACT_MULTIPLE_BUTCHER( "ACT_MULTIPLE_BUTCHER" );
-static const activity_id ACT_MULTIPLE_CONSTRUCTION( "ACT_MULTIPLE_CONSTRUCTION" );
 
 static const bionic_id bio_remote( "bio_remote" );
 
@@ -1669,7 +1668,7 @@ static void loot()
             player_character.assign_activity( ACT_FERTILIZE_PLOT );
             break;
         case ConstructPlots:
-            player_character.assign_activity( ACT_MULTIPLE_CONSTRUCTION );
+            player_character.assign_activity( multi_build_construction_activity_actor() );
             break;
         case MultiFarmPlots:
             player_character.assign_activity( multi_farm_activity_actor() );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -3445,7 +3445,7 @@ bool npc::find_job_to_perform()
             assign_activity( multi_disassemble_activity_actor() );
             return true;
         } else if( elem == ACT_MULTIPLE_CONSTRUCTION ) {
-            assign_activity( multi_disassemble_activity_actor() );
+            assign_activity( multi_build_construction_activity_actor() );
             return true;
         } else if( elem == ACT_MULTIPLE_BUTCHER ) {
             assign_activity( multi_butchery_activity_actor() );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -115,6 +115,7 @@ enum class side : int;
 static const activity_id ACT_CRAFT( "ACT_CRAFT" );
 static const activity_id ACT_FIRSTAID( "ACT_FIRSTAID" );
 static const activity_id ACT_MOVE_LOOT( "ACT_MOVE_LOOT" );
+static const activity_id ACT_MULTIPLE_BUTCHER( "ACT_MULTIPLE_BUTCHER" );
 static const activity_id ACT_MULTIPLE_CHOP_PLANKS( "ACT_MULTIPLE_CHOP_PLANKS" );
 static const activity_id ACT_MULTIPLE_CHOP_TREES( "ACT_MULTIPLE_CHOP_TREES" );
 static const activity_id ACT_MULTIPLE_CONSTRUCTION( "ACT_MULTIPLE_CONSTRUCTION" );
@@ -3445,6 +3446,9 @@ bool npc::find_job_to_perform()
             return true;
         } else if( elem == ACT_MULTIPLE_CONSTRUCTION ) {
             assign_activity( multi_disassemble_activity_actor() );
+            return true;
+        } else if( elem == ACT_MULTIPLE_BUTCHER ) {
+            assign_activity( multi_butchery_activity_actor() );
             return true;
         } else if( generic_multi_activity_handler( scan_act, *this->as_character(), true ) ) {
             assign_activity( elem );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -117,6 +117,7 @@ static const activity_id ACT_FIRSTAID( "ACT_FIRSTAID" );
 static const activity_id ACT_MOVE_LOOT( "ACT_MOVE_LOOT" );
 static const activity_id ACT_MULTIPLE_CHOP_PLANKS( "ACT_MULTIPLE_CHOP_PLANKS" );
 static const activity_id ACT_MULTIPLE_CHOP_TREES( "ACT_MULTIPLE_CHOP_TREES" );
+static const activity_id ACT_MULTIPLE_CONSTRUCTION( "ACT_MULTIPLE_CONSTRUCTION" );
 static const activity_id ACT_MULTIPLE_CRAFT( "ACT_MULTIPLE_CRAFT" );
 static const activity_id ACT_MULTIPLE_DIS( "ACT_MULTIPLE_DIS" );
 static const activity_id ACT_MULTIPLE_FARM( "ACT_MULTIPLE_FARM" );
@@ -3440,6 +3441,9 @@ bool npc::find_job_to_perform()
             assign_activity( multi_craft_activity_actor() );
             return true;
         } else if( elem == ACT_MULTIPLE_DIS ) {
+            assign_activity( multi_disassemble_activity_actor() );
+            return true;
+        } else if( elem == ACT_MULTIPLE_CONSTRUCTION ) {
             assign_activity( multi_disassemble_activity_actor() );
             return true;
         } else if( generic_multi_activity_handler( scan_act, *this->as_character(), true ) ) {

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -64,7 +64,6 @@
 #include "viewer.h"
 
 static const activity_id ACT_FIND_MOUNT( "ACT_FIND_MOUNT" );
-static const activity_id ACT_MULTIPLE_BUTCHER( "ACT_MULTIPLE_BUTCHER" );
 
 static const efftype_id effect_allow_sleep( "allow_sleep" );
 static const efftype_id effect_asked_for_item( "asked_for_item" );
@@ -295,7 +294,7 @@ void talk_function::find_mount( npc &p )
 
 void talk_function::do_butcher( npc &p )
 {
-    p.assign_activity( ACT_MULTIPLE_BUTCHER );
+    p.assign_activity( multi_butchery_activity_actor() );
 }
 
 void talk_function::do_chop_plank( npc &p )

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -65,7 +65,6 @@
 
 static const activity_id ACT_FIND_MOUNT( "ACT_FIND_MOUNT" );
 static const activity_id ACT_MULTIPLE_BUTCHER( "ACT_MULTIPLE_BUTCHER" );
-static const activity_id ACT_MULTIPLE_CONSTRUCTION( "ACT_MULTIPLE_CONSTRUCTION" );
 
 static const efftype_id effect_allow_sleep( "allow_sleep" );
 static const efftype_id effect_asked_for_item( "asked_for_item" );
@@ -238,7 +237,7 @@ void talk_function::sort_loot( npc &p )
 
 void talk_function::do_construction( npc &p )
 {
-    p.assign_activity( ACT_MULTIPLE_CONSTRUCTION );
+    p.assign_activity( multi_build_construction_activity_actor() );
 }
 
 void talk_function::do_mining( npc &p )

--- a/tests/act_build_test.cpp
+++ b/tests/act_build_test.cpp
@@ -82,7 +82,11 @@ void run_activities( Character &u, int max_moves )
 
     u.assign_activity( multi_build_construction_activity_actor() );
     int turns = 0;
-    while( ( !u.activity.is_null() || u.is_auto_moving() ) && turns < max_moves ) {
+    while( ( !u.activity.is_null() || u.is_auto_moving() ) ) {
+        if( turns == max_moves ) {
+            FAIL( "turn count exceeded, infinite loop possible" );
+            return;
+        }
         u.set_moves( u.get_speed() );
         if( u.is_auto_moving() ) {
             u.setpos( here, here.get_bub( *u.destination_point ) );
@@ -166,6 +170,7 @@ void run_test_case( Character &u )
 
     u.wear_item( item( itype_test_backpack ), false, false );
     u.wear_item( item( itype_wearable_test_lamp ), false, true );
+    //TODO: this test assumes that tools are on-person, but it should also test without tools on-person
     u.i_add( item( itype_test_multitool ) );
     u.i_add( item( itype_hammer ) );
     u.i_add( item( itype_bow_saw ) );

--- a/tests/act_build_test.cpp
+++ b/tests/act_build_test.cpp
@@ -79,7 +79,7 @@ void run_activities( Character &u, int max_moves )
 {
     map &here = get_map();
 
-    u.assign_activity( ACT_MULTIPLE_CONSTRUCTION );
+    u.assign_activity( multi_build_construction_activity_actor() );
     int turns = 0;
     while( ( !u.activity.is_null() || u.is_auto_moving() ) && turns < max_moves ) {
         u.set_moves( u.get_speed() );

--- a/tests/act_build_test.cpp
+++ b/tests/act_build_test.cpp
@@ -82,7 +82,7 @@ void run_activities( Character &u, int max_moves )
 
     u.assign_activity( multi_build_construction_activity_actor() );
     int turns = 0;
-    while( ( !u.activity.is_null() || u.is_auto_moving() ) ) {
+    while( !u.activity.is_null() || u.is_auto_moving() ) {
         if( turns == max_moves ) {
             FAIL( "turn count exceeded, infinite loop possible" );
             return;

--- a/tests/act_build_test.cpp
+++ b/tests/act_build_test.cpp
@@ -9,6 +9,7 @@
 #include <utility>
 #include <vector>
 
+#include "activity_actor_definitions.h"
 #include "activity_handlers.h"
 #include "avatar.h"
 #include "build_reqs.h"


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Infrastructure "move ACT_MULTIPLE_BUTCHER, ACT_FETCH_REQUIRED, ACT_MULTIPLE_CONSTRUCTION to activity_actors"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Update legacy activities.

- Fixes #84289
- Fixes an unreported error caused by #83768, where it was assumed that tools on the ground for a multi-activity could be removed for that activity's requirements even though an activity can be far away from the unmoved ground tools. Tools on the ground haven't been fetchable for over two months and nobody reported it?

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

1. 3ee43ddf24d74f9642c228746320e9d116e27f1c, 84987dd8686f66e3ab442004374851e2bf3fad76, 11b47fe88db6d4eb5fb4173ccd0720a8190002da are the bog-standard updates for multi-activities I've been doing lately, nothing special with those. 9ef5afdce944f916858f61261c2b9ba178005d1d is some functions I missed doing those.
2. fab651af31ddb6170f96f436ad11e4c7da1e6fcc is a safety check for the activity backlog being pushed to infinitely.
3. ba01a27f846c50544fad893a36882731dddf27d7 moves some necessary fetch-related `multi_activity_actor` namespace functions to `multi_zone_activity_actor`, and also fixes some consequences of multi-activities no longer calling static functions.
4. 06db84a31162d17d83ed1b8c8d0d279592ff5be8 moves some large `or` blocks into a JSON field.
5. e9d426c4cc81356d46c4f4988731544b12748eaf fixes 84289

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Also adds a TODO for making test case `act_multiple_construction` check for moving tools, because it always assumes that tools are in the player's inventory and missed the unreported error mentioned above.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

ACT_MULTIPLE_BUTCHER
Tested the following for butchering three chicken corpses in a Loot: Corpses Zone with a machete:
- successful as avatar (does not continue butchering after finishing one corpse, not a new issue)
- successful as npc
- serialization without error through save/load during NPC activity
- successfully loading activity from 0.H save (cancels gracefully)

ACT_MULTIPLE_CONSTRUCTION
Tested the following for a "Build Door" Zone:
- successful as avatar
- successful as npc
- serialization without error through save/load during NPC activity
- successfully loading activity from 0.H save (cancels gracefully, partial construction could be finished)
- multiple-stage constrution with fetches (replicated from `multiple-step construction activity with fetch required` act_build_test.cpp, which also passes locally)

ACT_FETCH_REQUIRED
Tested with ACT_MULTIPLE_CONSTRUCTION as above:
- successful as avatar
- successful as npc
- serialization without error through save/load during NPC activity
- successfully loading activity from 0.H save (cancels gracefully)
- also tested ACT_VEHICLE_DECONSTRUCTION with near zone, successfully fetched halfway into activity

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Fixed 84289 message:
<img width="876" height="51" alt="image" src="https://github.com/user-attachments/assets/a72e6faa-ce3e-4a72-9909-2a5652a28011" />

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
