### PR TITLE
Improve surroundings menu performance

### DIFF
--- a/src/map_entity_stack.cpp
+++ b/src/map_entity_stack.cpp
@@ -170,6 +170,39 @@ int map_entity_stack<T>::get_selected_index() const
 }
 
 template<typename T>
+nc_color map_entity_stack<T>::get_selected_color()
+{
+    if( entities.empty() || selected_index < 0 ||
+        selected_index >= static_cast<int>( entities.size() ) ) {
+        return c_light_gray;
+    }
+
+    if( !entities[selected_index].cached_color ) {
+        make_color_cache();
+    }
+
+    return *entities[selected_index].cached_color;
+}
+
+template<>
+void map_entity_stack<item>::make_color_cache()
+{
+    entities[selected_index].cached_color = get_selected_entity()->color_in_inventory();
+}
+
+template<>
+void map_entity_stack<Creature>::make_color_cache()
+{
+    entities[selected_index].cached_color = get_selected_entity()->basic_symbol_color();
+}
+
+template<>
+void map_entity_stack<map_data_common_t>::make_color_cache()
+{
+    entities[selected_index].cached_color = get_selected_entity()->color();
+}
+
+template<typename T>
 map_entity_stack<T>::map_entity_stack() : totalcount( 0 )
 {
     entities.emplace_back();

--- a/src/map_entity_stack.h
+++ b/src/map_entity_stack.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <vector>
 
+#include "color.h"
 #include "coordinates.h"
 #include "enums.h"
 #include "point.h"
@@ -22,6 +23,7 @@ class map_entity_stack
                 const T *entity;
                 std::optional<std::string> cached_name;
                 std::optional<std::string> cached_distance_string;
+                std::optional<nc_color> cached_color;
 
                 //only expected to be used for things like lists and vectors
                 entity_group() : count( 0 ), entity( nullptr ) {};
@@ -32,6 +34,7 @@ class map_entity_stack
         int selected_index = 0;
         void make_name_cache();
         void make_distance_string_cache();
+        void make_color_cache();
     public:
         std::vector<entity_group> entities;
         int totalcount;
@@ -42,6 +45,7 @@ class map_entity_stack
         std::string get_selected_name();
         std::string get_selected_distance_string();
         int get_selected_index() const;
+        nc_color get_selected_color();
 
         void select_next();
         void select_prev();

--- a/src/surroundings_menu.cpp
+++ b/src/surroundings_menu.cpp
@@ -884,7 +884,7 @@ void surroundings_menu::draw_item_tab()
                     }
                     ImGui::SameLine( 0, 0 );
                     ImGui::PopID();
-                    nc_color color = prio_plus ? c_yellow : prio_minus ? c_red : itm->color_in_inventory();
+                    nc_color color = prio_plus ? c_yellow : prio_minus ? c_red : it->get_selected_color();
                     std::string newness_str;
                     nc_color newness_color;
                     if( highlight_new ) {
@@ -1027,7 +1027,7 @@ void surroundings_menu::draw_monster_tab()
                 cataimgui::draw_colored_text( sees ? "!" : " ", c_yellow );
 
                 ImGui::TableNextColumn();
-                nc_color mon_color = mon->basic_symbol_color();
+                nc_color mon_color = it->get_selected_color();
                 cataimgui::TextColoredTrimmed( it->get_selected_name(), mon_color );
 
                 ImGui::TableNextColumn();
@@ -1144,8 +1144,7 @@ void surroundings_menu::draw_terfurn_tab()
                 }
                 ImGui::SameLine( 0, 0 );
                 ImGui::PopID();
-                const map_data_common_t *terfurn = it->get_selected_entity();
-                nc_color color = terfurn->color();
+                nc_color color = it->get_selected_color();
                 cataimgui::TextColoredTrimmed( it->get_selected_name(), color );
 
                 ImGui::TableNextColumn();


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Improve performance of the surroundings menu under somewhat extreme conditions. Should have some gains in other places as well, but only under the same extreme conditions. The conditions being an ungodly amount of different kinds of ammo and magazines in the player inventory and a large number of guns on surrounding tiles.

#### Describe the solution

Cache the result of `item::color_in_inventory`, because it can be a surprisingly expensive call.
Use the `inv_search_cache` in `Character::find_ammo` that searches the entirety of the inventory for all items that can reload the given item to make repeated calls of `item::color_in_inventory` cheaper.

#### Describe alternatives you've considered

Pretend the issue doesn't exist because surely nobody would carry around such a ridiculous amount of stuff.

#### Testing

Compared the attached save on master and this branch. It's not a save you should load for fun. Opening the surroundings menu on the master branch will take seconds, then every frame while navigating it will also take a long time.
On this branch, it's still a bit slow to open (still a ridiculous save), but much faster. And once it's loaded, there's no more hanging.
Also did a small spot check to see if the colors are still correct and didn't notice any difference, but it's still possible there's an oversight hiding in moving the search logic over to the cache.

#### Additional context

Save:
[Debug-trimmed.tar.gz](https://github.com/user-attachments/files/25113403/Debug-trimmed.tar.gz)

Color comparison - left new, right old:
<img width="883" height="295" alt="grafik" src="https://github.com/user-attachments/assets/a917d5e2-0104-490c-a3e2-dce0c8b9c27b" />
