### PR TITLE
Climate Change: Adjust Regional Temperatures to be Boston Appropriate

### DIFF
--- a/data/json/region_settings/region_settings/regional_map_settings.json
+++ b/data/json/region_settings/region_settings/regional_map_settings.json
@@ -1644,7 +1644,7 @@
   {
     "type": "weather_generator",
     "id": "default",
-    "base_temperature": 6.5,
+    "base_temperature": 11.1,
     "base_humidity": 70.0,
     "base_pressure": 1015.0,
     "base_wind": 3.4,

--- a/src/weather_gen.cpp
+++ b/src/weather_gen.cpp
@@ -146,7 +146,7 @@ static units::temperature weather_temperature_from_common_data( const weather_ge
         seasonality * seasonality_magnitude_K );
 
     const double T = baseline + raw_noise_4d( x, y, z, modSEED ) *
-                     (1 + (1 + -seasonality) * seasonal_noise_magnitude / 2) * noise_magnitude_K;
+                     ( 1 + ( 1 + -seasonality ) * seasonal_noise_magnitude / 2 ) * noise_magnitude_K;
 
     return units::from_celsius( T );
 }

--- a/src/weather_gen.cpp
+++ b/src/weather_gen.cpp
@@ -37,7 +37,7 @@ constexpr double daily_seasonal_range_K = 2.0;
 // Increases daily temperature variation by this much at the coldest time of the year, decreases it this much at the warmest time of the year, In kelvins.
 constexpr double seasonality_magnitude_K = 12;
 // Greatest absolute change from the year's average temperature, in kelvins
-// Mean normal monthly temperatures over the year is 30.47-73.86F (-0.85-23.25C)  
+// Mean normal monthly temperatures over the year is 30.47-73.86F (-0.85-23.25C)
 // Annual recorded minimum to maximum temperatures range from ~10-90F (-17.78-37.78C), lows of 0F & highs of 100F happen every few years. Any and all noise should stay bound within this range.
 constexpr double noise_magnitude_K = 6;
 // Greatest absolute change from a day's average through noise, in kelvins
@@ -142,10 +142,11 @@ static units::temperature weather_temperature_from_common_data( const weather_ge
     const double baseline(
         wg.base_temperature +
         seasonal_temp_mod[season] +
-        dayv * (daily_magnitude_K + daily_seasonal_range_K * (-seasonality + 1) / 2) + 
+        dayv * ( daily_magnitude_K + daily_seasonal_range_K * ( -seasonality + 1 ) / 2 ) +
         seasonality * seasonality_magnitude_K );
 
-    const double T = baseline + raw_noise_4d( x, y, z, modSEED ) * (1 + (1 + -seasonality) * seasonal_noise_magnitude / 2) * noise_magnitude_K;
+    const double T = baseline + raw_noise_4d( x, y, z, modSEED ) *
+                     (1 + (1 + -seasonality) * seasonal_noise_magnitude / 2) * noise_magnitude_K;
 
     return units::from_celsius( T );
 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Balance "Adjusts default game temperatures to be more in line with Boston, MA"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

The default climate prior to changes was usually too cold, especially in the winter where the average temperatures dipped below 20F for the entire season. The changes made should push the temperature curve to be more in line with temperature data from Boston, most prominently in the winter but still affecting temperatures year-round.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Regional map settings have been adjusted from 6.5C to 11.1C (annual average). I've also allowed daily temperature range and day-to-day temperature noise to be affected by seasonality, with their respective variables. Changes to weather_gen.cpp have been made so that monthly averages range from 30F-74F Jan-July, with daily highs of ~44F-82F and daily lows of ~12F-62F throughout the year with some room for extremes from 8F-92F. Theoretical maximums & minimums are 1.4F-93.3F with the right RNG.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

We could change the default region to Quebec, since the current temperature range we have matches the city pretty well.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

1. Make tweaks to weather_gen.cpp
2. Build & Launch
3. New game through Play Now (Default Scenario)
4. debug menu > (i)nfo > test (W)eather
5. Quit w/o saving (guarantees new seed on next test)
6. Consider graphs
7. Repeat ad nauseum


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Sorry. Screwed something up with the last PR, should be alright now.

Generally, most of the fiddling came how much noise would affect day to day temperature ranges. Too little and you miss out on the extremes unless you throw averages out of whack. Too much and you're regularly seeing temperatures that only happen irl once every 5-6 years, again unless you throw averages out of whack. For now, this is the best compromise I could come up with, but in the future I would like to overhaul how the noise maps interact with weather generation, primarily by adding layers across different time scales.

The charts below take the hourly data from each year/month and provide mean values for each. The graphs provide daily mean, minimum, and maximum values for in game temperatures, and also provide mean, minimum, and/or maximum values of temperatures in the 10th and 90th percentile. The range between these should (theoretically) contain 81% of all temperature values
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
##### Boston, MA NOAA Normal '91-'20
<img width="209" height="379" alt="Weather Analysis - Temperature - Boston - Chart" src="https://github.com/user-attachments/assets/5d827090-2f31-4e60-98d2-258dba434848" />
<img width="2226" height="598" alt="Weather Analysis - Temperature - Boston - Graph" src="https://github.com/user-attachments/assets/9b9c4940-9dc3-4981-8825-a40710287e5d" />

##### In-game Test Weather report (default climate)
<img width="210" height="377" alt="Weather Analysis - Temperature - In-game (default) - Chart" src="https://github.com/user-attachments/assets/41804a38-82b4-4f4f-896a-bb9470a2a1c0" />
<img width="2227" height="599" alt="Weather Analysis - Temperature - In-game (default) - Graph" src="https://github.com/user-attachments/assets/c31e443f-b39a-416d-9f1d-4d878a368bc1" />

##### In-game Test Weather report (this branch's climate)
<img width="205" height="379" alt="Weather Analysis - Temperature - In-game (adjusted) - Chart" src="https://github.com/user-attachments/assets/fb61a733-63a5-48f7-a839-6173e8c00311" />
<img width="2227" height="598" alt="Weather Analysis - Temperature - In-game (adjusted) - Graph" src="https://github.com/user-attachments/assets/adae8a15-f101-4a2a-bc73-892531983540" />


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
