### PR TITLE
Unification of need_charges_msg

### DIFF
--- a/data/json/items/armor/cloaks.json
+++ b/data/json/items/armor/cloaks.json
@@ -1960,7 +1960,7 @@
       "msg": "Your optical cloak flickers as it becomes transparent.",
       "target": "optical_cloak_on",
       "need_charges": 20,
-      "need_charges_msg": "You don't have enough UPS charges to turn on the %s"
+      "need_charges_msg": "You don't have enough UPS charges."
     },
     "flags": [ "USE_UPS", "OVERSIZE", "HOOD", "BELTED", "SOFT", "NO_REPAIR", "RAINPROOF" ],
     "armor": [

--- a/data/json/items/armor/combat_exoskeleton.json
+++ b/data/json/items/armor/combat_exoskeleton.json
@@ -166,7 +166,7 @@
       "msg": "You turn the exoskeleton on.\n>>Initiating boot sequence…\n//Loading DoubleOS v1.38…\n//Loading calibration profile…\n//Activating atmospheric filtration…\n//Activating liquid cooling…\n//Activating sound dampeners…\n>>Boot successful.",
       "target": "combat_exoskeleton_heavy_on",
       "need_charges": 1,
-      "need_charges_msg": "The exoskeleton batteries are empty."
+      "need_charges_msg": "The batteries are dead."
     },
     "tool_ammo": "battery",
     "passive_effects": [ { "id": "combat_exoskeleton_heavy_active" } ]
@@ -273,7 +273,7 @@
       "msg": "You turn the exoskeleton on.\n>>Initiating boot sequence…\n//Loading DoubleOS v2.86…\n//Loading calibration profile…\n//Activating atmospheric filtration…\n//Activating liquid cooling…\n//Activating sound dampeners…\n>>Boot successful.",
       "target": "combat_exoskeleton_medium_on",
       "need_charges": 1,
-      "need_charges_msg": "The exoskeleton batteries are empty."
+      "need_charges_msg": "The batteries are dead."
     },
     "tool_ammo": "battery",
     "passive_effects": [ { "id": "combat_exoskeleton_medium_active" } ]
@@ -380,7 +380,7 @@
       "msg": "You turn the exoskeleton on.\n>>Initiating boot sequence…\n//Loading DoubleOS v3.51…\n//Loading calibration profile…\n//Activating atmospheric filtration…\n//Activating liquid cooling…\n//Activating sound dampeners…\n>>Boot successful.",
       "target": "combat_exoskeleton_light_on",
       "need_charges": 1,
-      "need_charges_msg": "The exoskeleton batteries are empty."
+      "need_charges_msg": "The batteries are dead."
     },
     "tool_ammo": "battery",
     "passive_effects": [ { "id": "combat_exoskeleton_light_active" } ]

--- a/data/json/items/armor/head_attachments.json
+++ b/data/json/items/armor/head_attachments.json
@@ -237,7 +237,7 @@
       "msg": "You activate your %s.",
       "target": "military_nvg_on",
       "need_charges": 1,
-      "need_charges_msg": "The %s's batteries are dead."
+      "need_charges_msg": "The batteries are dead."
     },
     "material_thickness": 1,
     "pocket_data": [
@@ -297,7 +297,7 @@
       "msg": "You activate your %s.",
       "target": "advanced_gpnvg_on",
       "need_charges": 1,
-      "need_charges_msg": "The %s's batteries are dead."
+      "need_charges_msg": "The batteries are dead."
     },
     "material_thickness": 1,
     "pocket_data": [
@@ -365,7 +365,7 @@
       "msg": "You activate your %s.",
       "target": "enhanced_nvg_on",
       "need_charges": 1,
-      "need_charges_msg": "The %s's batteries are dead."
+      "need_charges_msg": "The batteries are dead."
     },
     "material_thickness": 1,
     "pocket_data": [

--- a/data/json/items/armor/robofac_armor.json
+++ b/data/json/items/armor/robofac_armor.json
@@ -324,7 +324,7 @@
       "msg": "You lower the visor and flick the control dial to light amplification mode.",
       "target": "robofac_head_rig_nv",
       "need_charges": 1,
-      "need_charges_msg": "The visor's batteries are dead."
+      "need_charges_msg": "The batteries are dead."
     },
     "pocket_data": [
       {

--- a/data/json/items/gunmod/rail.json
+++ b/data/json/items/gunmod/rail.json
@@ -80,7 +80,7 @@
       "msg": "You turn the army flashlight-laser module flashlight on.",
       "target": "mipim_on",
       "need_charges": 1,
-      "need_charges_msg": "The mounted flashlight's batteries are dead."
+      "need_charges_msg": "The batteries are dead."
     },
     "pocket_data": [
       {

--- a/data/json/items/gunmod/underbarrel.json
+++ b/data/json/items/gunmod/underbarrel.json
@@ -616,7 +616,7 @@
       "msg": "You turn the mounted flashlight on.",
       "target": "mounted_flashlight_on",
       "need_charges": 1,
-      "need_charges_msg": "The mounted flashlight's batteries are dead."
+      "need_charges_msg": "The batteries are dead."
     },
     "pocket_data": [
       {

--- a/data/json/items/melee/bludgeons.json
+++ b/data/json/items/melee/bludgeons.json
@@ -449,7 +449,7 @@
       "msg": "You turn the wizard cane on.",
       "target": "wizard_cane_cheap_on",
       "need_charges": 1,
-      "need_charges_msg": "The wizard cane's batteries are dead."
+      "need_charges_msg": "The batteries are dead."
     },
     "pocket_data": [
       {
@@ -502,7 +502,7 @@
       "msg": "You turn the wizard cane on.",
       "target": "wizard_cane_on",
       "need_charges": 1,
-      "need_charges_msg": "The wizard cane's batteries are dead."
+      "need_charges_msg": "The batteries are dead."
     },
     "pocket_data": [
       {
@@ -1902,11 +1902,10 @@
     "use_action": [
       "TAZER",
       {
+        "ammo_scale": 0,
         "target": "shocktonfa_off",
         "msg": "You turn off the light.",
         "menu_text": "Turn off light",
-        "need_charges": 1,
-        "need_charges_msg": "The batteries are dead.",
         "type": "transform"
       }
     ],

--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -163,9 +163,10 @@
     "use_action": [
       {
         "target": "cell_phone_flashlight",
+        "menu_text": "Light up the screen",
         "msg": "You light up the screen.",
         "need_charges": 1,
-        "need_charges_msg": "The cellphone's batteries need more charge.",
+        "need_charges_msg": "The batteries are dead.",
         "type": "transform"
       },
       { "type": "link_up", "cable_length": 3, "charge_rate": "20 W" }
@@ -254,11 +255,11 @@
       "EBOOKSAVE",
       {
         "type": "transform",
-        "menu_text": "Turn on the screen",
-        "msg": "You power up the screen.",
+        "menu_text": "Light up the screen",
+        "msg": "You light up the screen.",
         "target": "eink_tablet_pc_on",
         "need_charges": 1,
-        "need_charges_msg": "The tablet batteries are dead."
+        "need_charges_msg": "The batteries are dead."
       },
       { "type": "link_up", "cable_length": 4, "charge_rate": "10 W" }
     ],
@@ -610,7 +611,7 @@
         "msg": "You light up the screen.",
         "menu_text": "Light up the screen",
         "need_charges": 1,
-        "need_charges_msg": "The laptop's batteries need more charge.",
+        "need_charges_msg": "The batteries are dead.",
         "type": "transform"
       },
       { "type": "link_up", "cable_length": 5, "charge_rate": "140 W" }
@@ -642,8 +643,8 @@
       {
         "ammo_scale": 0,
         "target": "laptop",
-        "msg": "You stop lighting up the screen.",
-        "menu_text": "Turn off",
+        "msg": "You turn off the screen.",
+        "menu_text": "Turn off the screen",
         "type": "transform"
       },
       { "type": "link_up", "cable_length": 5, "charge_rate": "140 W" }
@@ -766,7 +767,7 @@
       "type": "transform",
       "msg": "You turn the EMF detector on.",
       "target": "emf_detector_on",
-      "need_charges_msg": "It's dead."
+      "need_charges_msg": "The batteries are dead."
     },
     "flags": [ "WATER_BREAK", "ELECTRONIC" ],
     "faults": [ { "fault_group": "electronic_general" } ],
@@ -856,7 +857,7 @@
         "msg": "You activate the flashlight app.",
         "menu_text": "Turn on flashlight",
         "need_charges": 1,
-        "need_charges_msg": "The smartphone's charge is too low.",
+        "need_charges_msg": "The batteries are dead.",
         "type": "transform"
       },
       { "type": "link_up", "cable_length": 3, "charge_rate": "20 W" }
@@ -932,7 +933,7 @@
         "msg": "You activate the flashlight app.",
         "menu_text": "Turn on flashlight",
         "need_charges": 1,
-        "need_charges_msg": "The smartphone's charge is too low.",
+        "need_charges_msg": "The batteries are dead.",
         "type": "transform"
       },
       { "type": "link_up", "cable_length": 3, "charge_rate": "20 W" },
@@ -1066,7 +1067,7 @@
       "target": "UPS_ON",
       "msg": "You turn the charger on.",
       "need_charges": 1,
-      "need_charges_msg": "The charger's battery is empty.",
+      "need_charges_msg": "The batteries are dead.",
       "type": "transform"
     },
     "melee_damage": { "bash": 8 },

--- a/data/json/items/tool/lighting.json
+++ b/data/json/items/tool/lighting.json
@@ -61,7 +61,7 @@
         "target": "electric_lantern_on",
         "msg": "You turn the lamp on.",
         "need_charges": 1,
-        "need_charges_msg": "The lantern has no batteries."
+        "need_charges_msg": "The batteries are dead."
       },
       { "type": "link_up", "cable_length": 2, "charge_rate": "20 W" }
     ],
@@ -113,7 +113,7 @@
       "msg": "You turn the flashlight on.",
       "target": "flashlight_on",
       "need_charges": 1,
-      "need_charges_msg": "The flashlight's batteries are dead.",
+      "need_charges_msg": "The batteries are dead.",
       "damage_failure_msg": "You press the button on your %s, but nothing happens."
     },
     "pocket_data": [
@@ -175,7 +175,7 @@
       "msg": "You turn the flashlight on.",
       "target": "diving_flashlight_small_on",
       "need_charges": 1,
-      "need_charges_msg": "The flashlight's batteries are dead."
+      "need_charges_msg": "The batteries are dead."
     },
     "pocket_data": [
       {
@@ -229,7 +229,7 @@
       "msg": "You turn the flashlight on.",
       "target": "diving_flashlight_small_hipower_on",
       "need_charges": 1,
-      "need_charges_msg": "The flashlight's batteries are dead."
+      "need_charges_msg": "The batteries are dead."
     },
     "pocket_data": [
       {
@@ -284,7 +284,7 @@
         "msg": "You turn the flashlight on.",
         "target": "diving_flashlight_variable_on_hi",
         "need_charges": 1,
-        "need_charges_msg": "The flashlight's batteries are dead."
+        "need_charges_msg": "The batteries are dead."
       },
       {
         "type": "link_up",
@@ -596,7 +596,7 @@
         "msg": "You turn the heavy-duty flashlight on.",
         "target": "heavy_flashlight_on",
         "need_charges": 1,
-        "need_charges_msg": "The heavy-duty flashlight's battery is dead."
+        "need_charges_msg": "The batteries are dead."
       },
       { "type": "link_up", "cable_length": 3, "charge_rate": "20 W" }
     ],
@@ -833,7 +833,7 @@
       "target": "reading_light_on",
       "msg": "You switch on the reading light.",
       "need_charges": 1,
-      "need_charges_msg": "The reading light winks out.",
+      "need_charges_msg": "The batteries are dead.",
       "type": "transform"
     },
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 13 } } ],
@@ -879,7 +879,7 @@
         "target": "smart_lamp_on",
         "msg": "You turn the smart lamp on.",
         "need_charges": 1,
-        "need_charges_msg": "The smart lamp batteries are dead.",
+        "need_charges_msg": "The batteries are dead.",
         "type": "transform"
       },
       { "type": "link_up", "cable_length": 3, "charge_rate": "6 W" }

--- a/data/json/items/tool/misc.json
+++ b/data/json/items/tool/misc.json
@@ -392,8 +392,7 @@
         "target": "large_space_heater_on",
         "msg": "You turn on the heater.",
         "need_charges": 1,
-        "need_charges_msg": "The heater needs more charge.",
-        "menu_text": "Turn on",
+        "need_charges_msg": "The batteries are dead.",
         "type": "transform"
       },
       { "type": "link_up", "cable_length": 2, "charge_rate": "1 kW" }
@@ -603,8 +602,7 @@
         "target": "small_space_heater_on",
         "msg": "You turn on the heater.",
         "need_charges": 1,
-        "need_charges_msg": "The heater needs more charge.",
-        "menu_text": "Turn on",
+        "need_charges_msg": "The batteries are dead.",
         "type": "transform"
       },
       { "type": "link_up", "cable_length": 2, "charge_rate": "500 W" }

--- a/data/json/items/tool/radio_tools.json
+++ b/data/json/items/tool/radio_tools.json
@@ -127,7 +127,7 @@
         "menu_text": "Turn on",
         "msg": "You turn the radio on.",
         "need_charges": 1,
-        "need_charges_msg": "It's dead."
+        "need_charges_msg": "The batteries are dead."
       }
     ],
     "pocket_data": [

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -766,7 +766,7 @@
       "msg": "You activate your %s.",
       "target": "thermal_socks_on",
       "need_charges": 1,
-      "need_charges_msg": "The %s's batteries are dead."
+      "need_charges_msg": "The batteries are dead."
     },
     "warmth": 10,
     "material_thickness": 0.3,
@@ -821,7 +821,7 @@
       "msg": "You activate your %s.",
       "target": "thermal_suit_on",
       "need_charges": 1,
-      "need_charges_msg": "The %s's batteries are dead."
+      "need_charges_msg": "The batteries are dead."
     },
     "warmth": 10,
     "material_thickness": 0.1,
@@ -876,7 +876,7 @@
       "msg": "You activate your %s.",
       "target": "thermal_gloves_on",
       "need_charges": 1,
-      "need_charges_msg": "The %s's batteries are dead."
+      "need_charges_msg": "The batteries are dead."
     },
     "warmth": 10,
     "material_thickness": 0.3,
@@ -931,7 +931,7 @@
       "msg": "You activate your %s.",
       "target": "thermal_mask_on",
       "need_charges": 1,
-      "need_charges_msg": "The %s's batteries are dead."
+      "need_charges_msg": "The batteries are dead."
     },
     "warmth": 10,
     "material_thickness": 0.3,
@@ -1011,7 +1011,7 @@
       "msg": "You turn the headlamp on.",
       "target": "wearable_light_on",
       "need_charges": 1,
-      "need_charges_msg": "The headlamp batteries are dead."
+      "need_charges_msg": "The batteries are dead."
     },
     "material_thickness": 1,
     "pocket_data": [
@@ -1126,7 +1126,7 @@
       "msg": "You turn the headlamp on.",
       "target": "wearable_big_light_on",
       "need_charges": 1,
-      "need_charges_msg": "The headlamp batteries are dead."
+      "need_charges_msg": "The batteries are dead."
     },
     "material_thickness": 1,
     "pocket_data": [
@@ -1469,7 +1469,7 @@
       "target": "rm13_armor_on",
       "need_worn": true,
       "need_charges": 1,
-      "need_charges_msg": "The RM13 combat armor's battery is dead."
+      "need_charges_msg": "The batteries are dead."
     },
     "warmth": 30,
     "environmental_protection": 10,
@@ -1892,7 +1892,7 @@
       "msg": "You activate your %s.",
       "target": "rebreather_on",
       "need_charges": 1,
-      "need_charges_msg": "The %s's filter is used up."
+      "need_charges_msg": "The filter is used up."
     },
     "warmth": 10,
     "environmental_protection": 3,
@@ -1944,7 +1944,7 @@
       "msg": "You activate your %s.",
       "target": "rebreather_xl_on",
       "need_charges": 1,
-      "need_charges_msg": "The %s's filter is used up."
+      "need_charges_msg": "The filter is used up."
     },
     "warmth": 10,
     "environmental_protection": 3,
@@ -2002,7 +2002,7 @@
       "msg": "You activate your %s.",
       "target": "rebreather_xs_on",
       "need_charges": 1,
-      "need_charges_msg": "The %s's filter is used up."
+      "need_charges_msg": "The filter is used up."
     },
     "covers": [ "mouth" ],
     "warmth": 10,
@@ -2560,7 +2560,7 @@
       "msg": "You activate your %s.",
       "target": "goggles_nv_on",
       "need_charges": 1,
-      "need_charges_msg": "The %s's batteries are dead."
+      "need_charges_msg": "The batteries are dead."
     },
     "warmth": 10,
     "environmental_protection": 3,
@@ -2923,7 +2923,7 @@
       "msg": "You activate your %s and the fan starts to audibly whoosh.",
       "target": "basic_papr_belt_on",
       "need_charges": 1,
-      "need_charges_msg": "The %s's batteries are dead."
+      "need_charges_msg": "The batteries are dead."
     },
     "tool_ammo": [ "battery" ],
     "flags": [ "BELTED", "OVERSIZE", "ELECTRONIC", "WATER_BREAK_ACTIVE" ],
@@ -3019,7 +3019,7 @@
       "msg": "You activate your %s and the fan starts to audibly whoosh.",
       "target": "military_papr_blower_on",
       "need_charges": 1,
-      "need_charges_msg": "The %s's batteries are dead."
+      "need_charges_msg": "The batteries are dead."
     },
     "tool_ammo": [ "battery" ],
     "flags": [ "BELTED", "OVERSIZE", "ELECTRONIC" ],
@@ -3115,7 +3115,7 @@
       "msg": "You activate your %s and the fan starts to audibly whoosh.",
       "target": "molle_papr_blower_on",
       "need_charges": 1,
-      "need_charges_msg": "The %s's batteries are dead."
+      "need_charges_msg": "The batteries are dead."
     },
     "tool_ammo": [ "battery" ],
     "flags": [ "WATER_FRIENDLY", "BELTED", "OVERSIZE", "ELECTRONIC" ],
@@ -3219,7 +3219,7 @@
       "msg": "You activate your %s.",
       "target": "goggles_ir_on",
       "need_charges": 1,
-      "need_charges_msg": "The %s's batteries are dead."
+      "need_charges_msg": "The batteries are dead."
     },
     "warmth": 10,
     "environmental_protection": 3,
@@ -3322,7 +3322,7 @@
       "msg": "You activate your %s.",
       "target": "mask_h20survivor_on",
       "need_charges": 1,
-      "need_charges_msg": "The %s's filter is used up."
+      "need_charges_msg": "The filter is used up."
     },
     "warmth": 15,
     "environmental_protection": 4,
@@ -3386,7 +3386,7 @@
       "msg": "You activate your %s.",
       "target": "mask_h20survivorxl_on",
       "need_charges": 1,
-      "need_charges_msg": "The %s's filter is used up."
+      "need_charges_msg": "The filter is used up."
     }
   },
   {
@@ -3403,7 +3403,7 @@
       "msg": "You activate your %s.",
       "target": "mask_h20survivorxs_on",
       "need_charges": 1,
-      "need_charges_msg": "The %s's filter is used up."
+      "need_charges_msg": "The filter is used up."
     },
     "flags": [ "VARSIZE", "STURDY", "WATER_FRIENDLY", "SWIM_GOGGLES", "UNDERSIZE", "PREFIX_XS" ]
   },
@@ -3605,7 +3605,7 @@
       "msg": "You activate your %s.",
       "target": "thermal_outfit_on",
       "need_charges": 1,
-      "need_charges_msg": "The %s's batteries are dead."
+      "need_charges_msg": "The batteries are dead."
     },
     "warmth": 10,
     "material_thickness": 0.1,
@@ -3879,7 +3879,7 @@
       "msg": "You turn the earmuffs on.",
       "target": "powered_earmuffs_on",
       "need_charges": 1,
-      "need_charges_msg": "The earmuff's batteries are dead."
+      "need_charges_msg": "The batteries are dead."
     },
     "warmth": 5,
     "material_thickness": 2,
@@ -3955,7 +3955,7 @@
       "msg": "You turn the earplugs on.",
       "target": "powered_earplugs_on",
       "need_charges": 1,
-      "need_charges_msg": "The earplugs' batteries are dead."
+      "need_charges_msg": "The batteries are dead."
     },
     "material_thickness": 1,
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 10 } } ],
@@ -4363,7 +4363,7 @@
         "msg": "You turn the blanket's heating elements on.",
         "target": "electric_blanket_on",
         "need_charges": 1,
-        "need_charges_msg": "The blanket's batteries are dead."
+        "need_charges_msg": "The batteries are dead."
       },
       { "type": "link_up", "cable_length": 3, "charge_rate": "110 W" }
     ],
@@ -4429,7 +4429,7 @@
       "target": "foodperson_mask_on",
       "need_worn": true,
       "need_charges": 1,
-      "need_charges_msg": "The mask's batteries are dead."
+      "need_charges_msg": "The batteries are dead."
     },
     "flags": [ "OUTER", "SUN_GLASSES" ],
     "pocket_data": [
@@ -4553,7 +4553,7 @@
       "msg": "You turn the flight helmet on.",
       "target": "flight_helmet_on",
       "need_charges": 1,
-      "need_charges_msg": "The helmet's batteries are dead."
+      "need_charges_msg": "The batteries are dead."
     },
     "pocket_data": [
       {
@@ -4774,7 +4774,7 @@
         "msg": "You activate your AR system.\nAnduril IVASos v1.2: ONLINE.\nVisual systems:      ONLINE.\nRadio systems:       ONLINE.\nTargeting HUD:       ONLINE.\nGPS:                  ERROR.",
         "target": "military_vis_aug_system_on",
         "need_charges": 1,
-        "need_charges_msg": "The %s's batteries are dead."
+        "need_charges_msg": "The batteries are dead."
       },
       "CAMERA",
       "EBOOKSAVE",

--- a/data/mods/MindOverMatter/items/armor/head.json
+++ b/data/mods/MindOverMatter/items/armor/head.json
@@ -60,7 +60,7 @@
       "msg": "You activate your %s.",
       "target": "psionic_mindsight_glasses_on",
       "need_charges": 1,
-      "need_charges_msg": "The %s's batteries are dead."
+      "need_charges_msg": "The batteries are dead."
     },
     "pocket_data": [
       {

--- a/data/mods/MindOverMatter/items/tools/lighting.json
+++ b/data/mods/MindOverMatter/items/tools/lighting.json
@@ -21,7 +21,7 @@
       "msg": "You turn the flashlight on.",
       "target": "pyrokinetic_flashlight_on",
       "need_charges": 1,
-      "need_charges_msg": "The flashlight's batteries are dead."
+      "need_charges_msg": "The batteries are dead."
     },
     "pocket_data": [
       {
@@ -69,7 +69,7 @@
       "type": "transform",
       "target": "pyrokinetic_lamp_on",
       "need_charges": 1,
-      "need_charges_msg": "The lamp's batteries are dead.",
+      "need_charges_msg": "The batteries are dead.",
       "msg": "You open the lamp's cover.",
       "menu_text": "Open cover"
     },

--- a/data/mods/MindOverMatter/items/tools/travel.json
+++ b/data/mods/MindOverMatter/items/tools/travel.json
@@ -41,7 +41,7 @@
       "target": "psionic_transporter_remote_on",
       "msg": "You turn the transporter remote on and the screen begins displaying coordinates.",
       "need_charges": 1,
-      "need_charges_msg": "The transporter remote's batteries need more charge.",
+      "need_charges_msg": "The batteries are dead.",
       "type": "transform"
     },
     "flags": [ "WATER_BREAK", "ELECTRONIC" ],

--- a/data/mods/Xedra_Evolved/items/electronics.json
+++ b/data/mods/Xedra_Evolved/items/electronics.json
@@ -21,7 +21,7 @@
         "msg": "You light up the screen.",
         "menu_text": "Light up the screen",
         "need_charges": 1,
-        "need_charges_msg": "The laptop's batteries need more charge.",
+        "need_charges_msg": "The batteries are dead.",
         "type": "transform"
       },
       {
@@ -62,7 +62,7 @@
       {
         "ammo_scale": 0,
         "target": "laptop_xedra",
-        "msg": "You stop lighting up the screen.",
+        "msg": "You turn off the screen.",
         "menu_text": "Turn off",
         "type": "transform"
       },

--- a/data/mods/Xedra_Evolved/items/inventor/armor.json
+++ b/data/mods/Xedra_Evolved/items/inventor/armor.json
@@ -41,7 +41,15 @@
         "default_magazine": "medium_battery_cell"
       }
     ],
-    "use_action": [ { "target": "helmet_inventor_on", "need_charges": 1, "msg": "The helmet turns on.", "type": "transform" } ],
+    "use_action": [
+      {
+        "target": "helmet_inventor_on",
+        "msg": "You turn on the %s.",
+        "need_charges": 1,
+        "need_charges_msg": "The batteries are dead.",
+        "type": "transform"
+      }
+    ],
     "techniques": [ "WBLOCK_1" ],
     "flags": [ "MORPHIC", "WATERPROOF", "STURDY", "PADDED", "TRADER_AVOID", "PSYSHIELD_PARTIAL", "MUNDANE", "INVENTOR_CRAFTED" ],
     "tool_ammo": [ "battery" ],
@@ -313,6 +321,7 @@
         "target": "aura_force_on",
         "need_charges": 1,
         "msg": "The torus start to emit an invisible waves.",
+        "need_charges_msg": "The batteries are dead.",
         "type": "transform"
       }
     ],
@@ -367,7 +376,7 @@
         "msg": "Turn on.",
         "menu_text": "Turn on a battle mode",
         "need_charges": 1,
-        "need_charges_msg": "The halo's charge is too low.",
+        "need_charges_msg": "The batteries are dead.",
         "type": "transform"
       }
     ],
@@ -578,7 +587,7 @@
         "msg": "Turn on.",
         "menu_text": "Turn on the overture",
         "need_charges": 1,
-        "need_charges_msg": "The halo's charge is too low.",
+        "need_charges_msg": "The batteries are dead.",
         "type": "transform"
       }
     ],
@@ -652,7 +661,7 @@
         "msg": "Turn on.",
         "menu_text": "Turn on the mask",
         "need_charges": 1,
-        "need_charges_msg": "The mask's charge is too low.",
+        "need_charges_msg": "The batteries are dead.",
         "type": "transform"
       }
     ],
@@ -717,6 +726,7 @@
       {
         "target": "crafting_assistant_on",
         "need_charges": 1,
+        "need_charges_msg": "The batteries are dead.",
         "msg": "The assistant deploys its new arms, ready to help with crafting.",
         "type": "transform"
       }

--- a/data/mods/Xedra_Evolved/items/inventor/melee.json
+++ b/data/mods/Xedra_Evolved/items/inventor/melee.json
@@ -43,7 +43,7 @@
       "msg": "You turn on the chainsaw spear.",
       "type": "transform",
       "need_charges": 1,
-      "need_charges_msg": "The chainsaw spear battery is dead."
+      "need_charges_msg": "The batteries are dead."
     },
     "techniques": [ "SWEEP", "IMPALE", "SPIN" ],
     "flags": [
@@ -147,7 +147,7 @@
       "msg": "You turn on your \"Neon Angle\".",
       "type": "transform",
       "need_charges": 1,
-      "need_charges_msg": "The \"Neon Angle\" battery is dead."
+      "need_charges_msg": "The batteries are dead."
     },
     "techniques": [ "WBLOCK_1", "BRUTAL", "SWEEP", "PLASMA_AXE_WIDE" ],
     "flags": [ "DURABLE_MELEE", "NONCONDUCTIVE", "SHEATH_AXE", "MUNDANE", "INVENTOR_CRAFTED" ],

--- a/data/mods/aftershock_exoplanet/items/armor/exosuit/exosuit_underlayers.json
+++ b/data/mods/aftershock_exoplanet/items/armor/exosuit/exosuit_underlayers.json
@@ -20,7 +20,7 @@
       "msg": "You activate your %s.",
       "target": "afs_exo_standard_underlayer_on",
       "need_charges": 1,
-      "need_charges_msg": "The %s's batteries are dead."
+      "need_charges_msg": "The batteries are dead."
     },
     "armor": [
       {
@@ -98,7 +98,7 @@
       "msg": "You activate your %s.",
       "target": "afs_exo_combat_underlayer_on",
       "need_charges": 1,
-      "need_charges_msg": "The %s's batteries are dead."
+      "need_charges_msg": "The batteries are dead."
     },
     "armor": [
       {
@@ -176,7 +176,7 @@
       "msg": "You activate your %s.",
       "target": "afs_exo_eva_underlayer_on",
       "need_charges": 1,
-      "need_charges_msg": "The %s's batteries are dead."
+      "need_charges_msg": "The batteries are dead."
     },
     "armor": [
       {
@@ -256,7 +256,7 @@
       "msg": "You activate your %s.",
       "target": "afs_exo_hazard_underlayer_on",
       "need_charges": 1,
-      "need_charges_msg": "The %s's batteries are dead."
+      "need_charges_msg": "The batteries are dead."
     },
     "armor": [
       {

--- a/data/mods/aftershock_exoplanet/items/armor/headsets.json
+++ b/data/mods/aftershock_exoplanet/items/armor/headsets.json
@@ -30,7 +30,7 @@
         "msg": "You lower the visor and flick the control dial to active.",
         "type": "transform",
         "need_charges": 1,
-        "need_charges_msg": "The visor's batteries are dead."
+        "need_charges_msg": "The batteries are dead."
       }
     ],
     "material_thickness": 1,

--- a/data/mods/aftershock_exoplanet/items/armor/winter_suits.json
+++ b/data/mods/aftershock_exoplanet/items/armor/winter_suits.json
@@ -18,7 +18,7 @@
       "msg": "You activate your %s.",
       "target": "afs_magellan_suit_on",
       "need_charges": 1,
-      "need_charges_msg": "The %s's batteries are dead."
+      "need_charges_msg": "The batteries are dead."
     },
     "armor": [
       {
@@ -109,7 +109,7 @@
       "msg": "You activate your %s.",
       "target": "afs_frontier_cryo_on",
       "need_charges": 1,
-      "need_charges_msg": "The %s's batteries are dead."
+      "need_charges_msg": "The batteries are dead."
     },
     "armor": [
       {
@@ -197,7 +197,7 @@
       "msg": "You activate your %s.",
       "target": "afs_combat_cryo_on",
       "need_charges": 1,
-      "need_charges_msg": "The %s's batteries are dead."
+      "need_charges_msg": "The batteries are dead."
     },
     "armor": [
       {
@@ -267,7 +267,7 @@
       "msg": "You activate your %s.",
       "target": "afs_combat_cryo_on_xl",
       "need_charges": 1,
-      "need_charges_msg": "The %s's batteries are dead."
+      "need_charges_msg": "The batteries are dead."
     },
     "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
@@ -317,7 +317,7 @@
       "msg": "You activate your %s.",
       "target": "afs_cryopod_bodyglove_on",
       "need_charges": 5,
-      "need_charges_msg": "The %s's batteries are dead."
+      "need_charges_msg": "The batteries are dead."
     },
     "warmth": 20,
     "environmental_protection": 10,

--- a/data/mods/aftershock_exoplanet/items/tools.json
+++ b/data/mods/aftershock_exoplanet/items/tools.json
@@ -540,7 +540,7 @@
         "msg": "You light up the screen.",
         "menu_text": "Light up the screen",
         "need_charges": 1,
-        "need_charges_msg": "The laptop's batteries need more charge.",
+        "need_charges_msg": "The batteries are dead.",
         "type": "transform"
       }
     ],
@@ -602,7 +602,7 @@
         "msg": "The holosuite comes to life around you.",
         "menu_text": "power on holosuite",
         "need_charges": 1,
-        "need_charges_msg": "The laptop's batteries need more charge.",
+        "need_charges_msg": "The batteries are dead.",
         "type": "transform"
       }
     ],

--- a/data/mods/aftershock_exoplanet/items/weapons.json
+++ b/data/mods/aftershock_exoplanet/items/weapons.json
@@ -23,7 +23,7 @@
       "target": "afs_energy_saber_on",
       "msg": "You activate the claw, and its bludgeoning surface slowly flattens into an edge as it begins to glow red-hot",
       "need_charges": 1,
-      "need_charges_msg": "The claw is out of charge."
+      "need_charges_msg": "The batteries are dead."
     },
     "flags": [ "BELT_CLIP", "DURABLE_MELEE" ],
     "pocket_data": [

--- a/data/mods/classic_zombies/items/computers.json
+++ b/data/mods/classic_zombies/items/computers.json
@@ -23,7 +23,7 @@
         "msg": "You light up the screen.",
         "menu_text": "Light up the screen",
         "need_charges": 1,
-        "need_charges_msg": "The laptop's batteries need more charge.",
+        "need_charges_msg": "The batteries are dead.",
         "type": "transform"
       },
       { "type": "link_up", "cable_length": 5, "charge_rate": "140 W" }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
1. `(off)'s`
<img width="451" height="40" alt="off1" src="https://github.com/user-attachments/assets/08bcad8f-3ce2-4cc1-915e-c40388c1b81d" />

2. The game have many different messages for depleted batteries (`need_charges_msg`). The main issue is that these messages are too long and only appear in the `a`ctivation menu, where screen space is limited.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Replace all messages like `The %s's batteries are dead` with `The batteries are dead`. This wording is independent of the item's name, shorter, and more readable.

Minor related fixes:
Added the missing `ammo_scale` to `shocktonfa`, which prevented its flashlight from turning off when the battery died. Removed the unnecessary `need_charges` requirement, as turning the tonfa off does not require charge.
Laptops use the same messages for lighting up the screen.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Maybe a different message wording? It will display for both a depleted and a missing battery.
Maybe use the singular form `The battery is dead`.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
<img width="965" height="225" alt="off2" src="https://github.com/user-attachments/assets/ed06a11e-1698-440d-bea3-e3a7b2e9f89c" />

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
