### PR TITLE
[ Xedra Evolved ] Cut stab resistant clothes for vampire hunters

### DIFF
--- a/data/mods/Xedra_Evolved/items/armor/armor.json
+++ b/data/mods/Xedra_Evolved/items/armor/armor.json
@@ -1638,5 +1638,107 @@
     "environmental_protection": 1,
     "flags": [ "VARSIZE", "POCKETS", "COLLAR", "ALARMCLOCK", "OUTER" ],
     "passive_effects": [ { "id": "ench_sevenoclock_coat" } ]
+  },
+  {
+    "id": "trenchcoat_aramid",
+    "type": "ITEM",
+    "subtypes": [ "ARMOR" ],
+    "name": { "str": "trenchcoat, aramid" },
+    "description": "A trenchoat made of aramid fibers to provide level 1 stab/cut protection up to 24 joules.  Lots of pockets and low profile.",
+    "weight": "1750 g",
+    "volume": "7250 ml",
+    "price": "979 USD",
+    "price_postapoc": "7 USD 50 cent",
+    "material": [ "kevlar" ],
+    "symbol": "[",
+    "looks_like": "trenchcoat",
+    "color": "brown",
+    "armor": [
+      { "covers": [ "torso" ], "specifically_covers": [ "torso_lower" ], "coverage": 100, "encumbrance": [ 9, 19 ] },
+      { "covers": [ "torso" ], "specifically_covers": [ "torso_upper" ], "coverage": 95, "encumbrance": [ 0, 0 ] },
+      { "covers": [ "arm_l", "arm_r" ], "coverage": 100, "encumbrance": [ 9, 9 ] },
+      {
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_hip_l", "leg_hip_r" ],
+        "coverage": 90,
+        "encumbrance": [ 4, 5 ]
+      },
+      {
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_upper_l", "leg_upper_r" ],
+        "coverage": 80,
+        "encumbrance": [ 0, 0 ]
+      }
+    ],
+    "pocket_data": [
+      { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "4 kg", "moves": 80 },
+      { "pocket_type": "CONTAINER", "max_contains_volume": "1500 ml", "max_contains_weight": "4 kg", "moves": 80 },
+      { "pocket_type": "CONTAINER", "max_contains_volume": "1 L", "max_contains_weight": "2 kg", "moves": 80 },
+      { "pocket_type": "CONTAINER", "max_contains_volume": "1 L", "max_contains_weight": "2 kg", "moves": 80 },
+      { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1 kg", "moves": 120 },
+      { "pocket_type": "CONTAINER", "max_contains_volume": "500 ml", "max_contains_weight": "1 kg", "moves": 120 }
+    ],
+    "warmth": 50,
+    "material_thickness": 3,
+    "environmental_protection": 1,
+    "flags": [ "VARSIZE", "POCKETS", "OUTER" ]
+  },
+  {
+    "id": "blazer_aramid",
+    "type": "ITEM",
+    "subtypes": [ "ARMOR" ],
+    "name": { "str": "blazer, aramid" },
+    "description": "A professional-looking wool blazer.  It's made of aramid fibers to provide Level 1 cut/stab resistance up to 24 joules.",
+    "weight": "680 g",
+    "volume": "3500 ml",
+    "price": "120 USD",
+    "price_postapoc": "50 cent",
+    "material": [ "kevlar" ],
+    "symbol": "[",
+    "looks_like": "jacket_light",
+    "color": "dark_gray",
+    "armor": [
+      { "covers": [ "torso" ], "coverage": 85, "encumbrance": [ 16, 20 ] },
+      { "covers": [ "arm_l", "arm_r" ], "coverage": 85, "encumbrance": [ 16, 16 ] }
+    ],
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "750 ml",
+        "max_contains_weight": "3 kg",
+        "max_item_length": "11 cm",
+        "moves": 80
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "750 ml",
+        "max_contains_weight": "3 kg",
+        "max_item_length": "11 cm",
+        "moves": 80
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "350 ml",
+        "max_contains_weight": "2 kg",
+        "max_item_length": "9 cm",
+        "moves": 100
+      }
+    ],
+    "warmth": 25,
+    "material_thickness": 1.5,
+    "valid_mods": [ "steel_padded" ],
+    "flags": [ "VARSIZE", "OUTER" ],
+    "variant_type": "generic",
+    "variants": [
+      { "id": "generic", "//": "inherit name and description from item" },
+      {
+        "id": "bostonchan",
+        "name": { "str": "Boston-Chan blazer" },
+        "append": true,
+        "description": "This one is bright blue and styled to cosplay Boston-Chan.",
+        "color": "blue",
+        "weight": 0
+      }
+    ]
   }
 ]

--- a/data/mods/Xedra_Evolved/player/professions.json
+++ b/data/mods/Xedra_Evolved/player/professions.json
@@ -1154,6 +1154,7 @@
         "entries": [
           { "item": "jeans" },
           { "item": "longshirt" },
+          { "item": "trenchcoat_aramid" },
           { "item": "socks" },
           { "item": "sneakers" },
           { "item": "sheath", "contents-item": "knife_combat_marine" },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Adds some custom gear for vampire hunter caches.  Caches to come later.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adds two level 1 stab/cut resistant pieces of clothing.  I was able to find some explanations of cut stab resistance then converted that to our existing damage.  
24 joules is equal to roughly 10-12 cut or stab damage in DDA.  I came to this conclusion by finding stats that 24 joules of stabbing is the 85th percentile of stabs and cuts delivered.  So I made an all 8's character, gave them a hunting knife and had them stab crawling zombies for quite a bit.   The damage ranged from 10-13 mostly.   So level 1 stab/cut armor would block almost all of those hits entirely.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Applying this theory of 24 joules being an 8 strength character swinging a knife to all dda melee weapons in a grand refactor. 
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Its all testing baby!
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
