### PR TITLE
[Xedra Evolved]  Grackens helps each other out

### DIFF
--- a/data/mods/Xedra_Evolved/monsters/monster.json
+++ b/data/mods/Xedra_Evolved/monsters/monster.json
@@ -575,7 +575,7 @@
     "type": "MONSTER",
     "copy-from": "mon_gracke",
     "name": { "str": "gracken" },
-    "anger_triggers": [ "HURT" ],
+    "anger_triggers": [ "HURT", "FRIEND_ATTACKED", "FRIEND_DIED" ],
     "aggro_character": false,
     "melee_training_cap": 5,
     "extend": { "species": "GRACKEN" }


### PR DESCRIPTION


#### Summary
None

#### Purpose of change
Being stranded in a dimension vastly different from their home surely would make them help each other in this trying times.
#### Describe the solution
Gives gracken `"FRIEND_ATTACKED", "FRIEND_DIED"` in their anger_trigger.

#### Describe alternatives you've considered

Selfish gracken? 

#### Testing
Spawns in a couple dozen gracken, then spawn in a zombie. see that all the gracken go after the zed

I attacked them, then proceeds to get attacked by a buncha grackens.
#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
