### PR TITLE
Obsolete ACT_TIDY_UP

### DIFF
--- a/data/json/obsoletion_and_migration_0.J/player_activities.json
+++ b/data/json/obsoletion_and_migration_0.J/player_activities.json
@@ -52,5 +52,12 @@
     "verb": "teaching",
     "based_on": "speed",
     "can_resume": false
+  },
+  {
+    "id": "ACT_TIDY_UP",
+    "type": "activity_type",
+    "activity_level": "MODERATE_EXERCISE",
+    "verb": "tidying up",
+    "based_on": "time"
   }
 ]

--- a/data/json/player_activities.json
+++ b/data/json/player_activities.json
@@ -100,13 +100,6 @@
     "based_on": "speed"
   },
   {
-    "id": "ACT_TIDY_UP",
-    "type": "activity_type",
-    "activity_level": "MODERATE_EXERCISE",
-    "verb": "tidying up",
-    "based_on": "neither"
-  },
-  {
     "id": "ACT_VEHICLE_DECONSTRUCTION",
     "type": "activity_type",
     "activity_level": "BRISK_EXERCISE",

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -228,7 +228,6 @@ static const activity_id ACT_STASH( "ACT_STASH" );
 static const activity_id ACT_STUDY_SPELL( "ACT_STUDY_SPELL" );
 static const activity_id ACT_TENT_DECONSTRUCT( "ACT_TENT_DECONSTRUCT" );
 static const activity_id ACT_TENT_PLACE( "ACT_TENT_PLACE" );
-static const activity_id ACT_TIDY_UP( "ACT_TIDY_UP" );
 static const activity_id ACT_TOOLMOD_ADD( "ACT_TOOLMOD_ADD" );
 static const activity_id ACT_TRAIN( "ACT_TRAIN" );
 static const activity_id ACT_TREE_COMMUNION( "ACT_TREE_COMMUNION" );
@@ -4700,7 +4699,6 @@ void fish_activity_actor::finish( player_activity &act, Character &who )
     who.add_msg_if_player( m_info, _( "You finish fishing" ) );
     if( !who.backlog.empty() && who.backlog.front().id() == ACT_MULTIPLE_FISH ) {
         who.backlog.clear();
-        who.assign_activity( ACT_TIDY_UP );
     }
 }
 

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -64,7 +64,6 @@ static const activity_id ACT_FILL_LIQUID( "ACT_FILL_LIQUID" );
 static const activity_id ACT_FIND_MOUNT( "ACT_FIND_MOUNT" );
 static const activity_id ACT_REPAIR_ITEM( "ACT_REPAIR_ITEM" );
 static const activity_id ACT_START_FIRE( "ACT_START_FIRE" );
-static const activity_id ACT_TIDY_UP( "ACT_TIDY_UP" );
 static const activity_id ACT_TRAVELLING( "ACT_TRAVELLING" );
 
 static const ammotype ammo_battery( "battery" );
@@ -99,7 +98,6 @@ const std::map< activity_id, std::function<void( player_activity *, Character * 
 activity_handlers::do_turn_functions = {
     { ACT_FILL_LIQUID, fill_liquid_do_turn },
     { ACT_START_FIRE, start_fire_do_turn },
-    { ACT_TIDY_UP, tidy_up_do_turn },
     { ACT_REPAIR_ITEM, repair_item_do_turn },
     { ACT_TRAVELLING, travel_do_turn },
     { ACT_FIND_MOUNT, find_mount_do_turn },

--- a/src/activity_item_handling.h
+++ b/src/activity_item_handling.h
@@ -10,7 +10,6 @@
 #include "game.h"
 #include "item.h"
 #include "map.h"
-#include "map_scale_constants.h"
 #include "requirements.h"
 #include "type_id.h"
 
@@ -180,7 +179,6 @@ std::optional<requirement_id> disassemble_requirements( Character &,
 std::unordered_set<tripoint_abs_ms> generic_locations( Character &you, const activity_id &act_id );
 std::unordered_set<tripoint_abs_ms> construction_locations( Character &you,
         const activity_id &act_id );
-std::unordered_set<tripoint_abs_ms> tidy_up_locations( Character &you, const activity_id & );
 std::unordered_set<tripoint_abs_ms> read_locations( Character &you, const activity_id &act_id );
 std::unordered_set<tripoint_abs_ms> study_locations( Character &you, const activity_id &act_id );
 std::unordered_set<tripoint_abs_ms> craft_locations( Character &you, const activity_id &act_id );
@@ -217,8 +215,6 @@ activity_reason_info study_can_do( const activity_id &, Character &you,
                                    const tripoint_bub_ms &src_loc );
 activity_reason_info chop_planks_can_do( const activity_id &, Character &you,
         const tripoint_bub_ms &src_loc );
-activity_reason_info tidy_up_can_do( const activity_id &, Character &you,
-                                     const tripoint_bub_ms &src_loc, int distance = MAX_VIEW_DISTANCE );
 activity_reason_info construction_can_do( const activity_id &, Character &you,
         const tripoint_bub_ms &src_loc );
 activity_reason_info farm_can_do( const activity_id &, Character &you,
@@ -246,8 +242,6 @@ bool study_do( Character &you, const activity_reason_info &act_info,
                const tripoint_abs_ms &src, const tripoint_bub_ms & );
 bool chop_planks_do( Character &you, const activity_reason_info &act_info,
                      const tripoint_abs_ms &, const tripoint_bub_ms &src_loc );
-bool tidy_up_do( Character &you, const activity_reason_info &act_info,
-                 const tripoint_abs_ms &, const tripoint_bub_ms &src_loc );
 bool construction_do( Character &you, const activity_reason_info &act_info,
                       const tripoint_abs_ms &src, const tripoint_bub_ms &src_loc );
 bool farm_do( Character &you, const activity_reason_info &act_info,

--- a/src/npc.h
+++ b/src/npc.h
@@ -149,7 +149,6 @@ class job_data
             { activity_id( "ACT_MULTIPLE_CHOP_PLANKS" ), 0 },
             { activity_id( "ACT_MULTIPLE_FISH" ), 0 },
             { activity_id( "ACT_MOVE_LOOT" ), 0 },
-            { activity_id( "ACT_TIDY_UP" ), 0 },
             { activity_id( "ACT_MULTIPLE_DIS" ), 0}
         };
     public:

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -127,7 +127,6 @@ static const activity_id ACT_MULTIPLE_READ( "ACT_MULTIPLE_READ" );
 static const activity_id ACT_MULTIPLE_STUDY( "ACT_MULTIPLE_STUDY" );
 static const activity_id ACT_OPERATION( "ACT_OPERATION" );
 static const activity_id ACT_SPELLCASTING( "ACT_SPELLCASTING" );
-static const activity_id ACT_TIDY_UP( "ACT_TIDY_UP" );
 static const activity_id ACT_VEHICLE_DECONSTRUCTION( "ACT_VEHICLE_DECONSTRUCTION" );
 static const activity_id ACT_VEHICLE_REPAIR( "ACT_VEHICLE_REPAIR" );
 
@@ -4139,8 +4138,7 @@ bool npc::can_do_pulp()
 bool npc::do_player_activity()
 {
     int old_moves = moves;
-    if( moves > 200 && activity && ( activity.is_multi_type() ||
-                                     activity.id() == ACT_TIDY_UP ) ) {
+    if( moves > 200 && activity && activity.is_multi_type() ) {
         // a huge backlog of a multi-activity type can forever loop
         // instead; just scan the map ONCE for a task to do, and if it returns false
         // then stop scanning, abandon the activity, and kill the backlog of moves.

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -425,7 +425,8 @@ void player_activity::deserialize( const JsonObject &data )
         "ACT_CONSUME_DRINK_MENU", // Remove after 0.J
         "ACT_CONSUME_MEDS_MENU", // Remove after 0.J
         "ACT_ARMOR_LAYERS", // Remove after 0.J
-        "ACT_TRAIN_TEACHER" // Remove after 0.J
+        "ACT_TRAIN_TEACHER", // Remove after 0.J
+        "ACT_TIDY_UP" // Remove after 0.J
     };
     if( !data.read( "type", tmptype ) ) {
         // Then it's a legacy save.


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Infrastructure "obsolete ACT_TIDY_UP"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

ACT_TIDY_UP was an attempt to automate moving products of a finished multi-activity to an Unsorted Loot zone. It's an okay idea, and as far as I can tell, it works for its single implementation: fishing, wherein an NPC will probably catch one fish and move it.

The problem: one multi-activity using ACT_TIDY_UP isn't enough to constitute rewriting it entirely.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Instead of trying to migrate ACT_TIDY_UP, just remove it. Nobody's going to miss it, and it's going to be easier to start from scratch.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

- NPC finished finishing activity in Fishing zone, did not move fish to Unsorted Loot zone
- Loaded NPC doing ACT_TIDY_UP from a 0.H save, no errors and legacy activity cancelled

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
