### PR TITLE
Crab pincer limb provides tool qualities, remove integrated armor

### DIFF
--- a/data/json/items/armor/integrated.json
+++ b/data/json/items/armor/integrated.json
@@ -693,7 +693,20 @@
     "armor": [
       {
         "material": [ { "type": "leather_arthropod", "covered_by_mat": 100, "thickness": 2.5 } ],
-        "covers": [ "hand_l", "hand_r", "foot_l", "foot_r", "leg_l", "leg_r", "arm_l", "arm_r", "torso", "head", "tail" ],
+        "covers": [
+          "hand_l",
+          "hand_r",
+          "crustacean_pincer_r",
+          "foot_l",
+          "foot_r",
+          "leg_l",
+          "leg_r",
+          "arm_l",
+          "arm_r",
+          "torso",
+          "head",
+          "tail"
+        ],
         "coverage": 100,
         "encumbrance": 2
       },
@@ -776,7 +789,7 @@
       },
       {
         "material": [ { "type": "chitin", "covered_by_mat": 100, "thickness": 2.2 } ],
-        "covers": [ "hand_l", "hand_r" ],
+        "covers": [ "hand_l", "hand_r", "crustacean_pincer_r" ],
         "coverage": 85,
         "encumbrance": 3
       },
@@ -857,7 +870,7 @@
       },
       {
         "material": [ { "type": "leather_arthropod", "covered_by_mat": 100, "thickness": 1.1 } ],
-        "covers": [ "hand_l", "hand_r" ],
+        "covers": [ "hand_l", "hand_r", "crustacean_pincer_r" ],
         "coverage": 85,
         "encumbrance": 2
       },
@@ -1094,6 +1107,11 @@
         "encumbrance": 9
       },
       {
+        "material": [ { "type": "sclerotin", "covered_by_mat": 100, "thickness": 6.4 } ],
+        "covers": [ "crustacean_pincer_r" ],
+        "coverage": 80
+      },
+      {
         "material": [ { "type": "sclerotin", "covered_by_mat": 100, "thickness": 5.3 } ],
         "covers": [ "leg_l", "leg_r" ],
         "specifically_covers": [ "leg_upper_l", "leg_lower_l", "leg_upper_r", "leg_lower_r" ],
@@ -1178,34 +1196,6 @@
         "covers": [ "foot_l", "foot_r" ],
         "coverage": 90,
         "encumbrance": 6
-      }
-    ]
-  },
-  {
-    "//": "We need to keep this because limbs can't have material-based armor coverage or provide tool qualities currently.",
-    "//2": "No encumbrance because the pincer has awful manip limb scores to represent being a bad hand",
-    "id": "integrated_giant_pincer",
-    "type": "ITEM",
-    "subtypes": [ "ARMOR" ],
-    "category": "armor",
-    "name": { "str_sp": "sclerotin right pincer" },
-    "description": "A powerful tool for snatching fish or breaking open shells.",
-    "weight": "900 g",
-    "volume": "1 L",
-    "price": "0 cent",
-    "price_postapoc": "0 cent",
-    "material": [ "sclerotin" ],
-    "symbol": ",",
-    "color": "brown",
-    "warmth": 10,
-    "qualities": [ [ "CUT", 1 ], [ "BUTCHER", -4 ], [ "PRY", 1 ], [ "HAMMER", 1 ] ],
-    "techniques": [ "BRUTAL", "WBLOCK_2" ],
-    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "OUTER", "PADDED", "ALLOWS_TALONS" ],
-    "armor": [
-      {
-        "material": [ { "type": "sclerotin", "covered_by_mat": 100, "thickness": 6.4 } ],
-        "covers": [ "crustacean_pincer_r" ],
-        "coverage": 80
       }
     ]
   },

--- a/data/json/mutations/limbs_body_parts.json
+++ b/data/json/mutations/limbs_body_parts.json
@@ -18,6 +18,11 @@
     "base_hp": 90,
     "limb_scores": [ [ "grip", 0 ], [ "manip", 0.1, 0.5 ], [ "swim", 0 ] ],
     "bionic_slots": 0,
+    "qualities": [
+      { "quality": "BUTCHER", "level": -4, "disable_percent": 0.5 },
+      { "quality": "PRY", "level": 1, "disable_percent": 0.5 },
+      { "quality": "HAMMER", "level": 1, "disable_percent": 0.5 }
+    ],
     "smash_message": "You smash the %s with your pincer.",
     "smash_efficiency": 2,
     "sub_parts": [ "crustacean_pincer_wrist_r", "crustacean_pincer_claws_r" ],

--- a/data/json/mutations/mutations_limbs.json
+++ b/data/json/mutations/mutations_limbs.json
@@ -372,8 +372,7 @@
     "visibility": 10,
     "ugliness": 9,
     "restricts_gear": [ "hand_r" ],
-    "enchantments": [ { "condition": "ALWAYS", "modified_bodyparts": [ { "lose": "hand_r" }, { "gain": "crustacean_pincer_r" } ] } ],
-    "integrated_armor": [ "integrated_giant_pincer" ]
+    "enchantments": [ { "condition": "ALWAYS", "modified_bodyparts": [ { "lose": "hand_r" }, { "gain": "crustacean_pincer_r" } ] } ]
   },
   {
     "type": "mutation",

--- a/data/json/obsoletion_and_migration_0.I/obsolete_integrated.json
+++ b/data/json/obsoletion_and_migration_0.I/obsolete_integrated.json
@@ -1,0 +1,29 @@
+[
+  {
+    "//": "remover after 0.J",
+    "id": "integrated_giant_pincer",
+    "type": "ITEM",
+    "subtypes": [ "ARMOR" ],
+    "category": "armor",
+    "name": { "str_sp": "sclerotin right pincer" },
+    "description": "A powerful tool for snatching fish or breaking open shells.",
+    "weight": "900 g",
+    "volume": "1 L",
+    "price": "0 cent",
+    "price_postapoc": "0 cent",
+    "material": [ "sclerotin" ],
+    "symbol": ",",
+    "color": "brown",
+    "warmth": 10,
+    "qualities": [ [ "CUT", 1 ], [ "BUTCHER", -4 ], [ "PRY", 1 ], [ "HAMMER", 1 ] ],
+    "techniques": [ "BRUTAL", "WBLOCK_2" ],
+    "flags": [ "INTEGRATED", "ALLOWS_NATURAL_ATTACKS", "UNBREAKABLE", "OUTER", "PADDED", "ALLOWS_TALONS" ],
+    "armor": [
+      {
+        "material": [ { "type": "sclerotin", "covered_by_mat": 100, "thickness": 6.4 } ],
+        "covers": [ "crustacean_pincer_r" ],
+        "coverage": 80
+      }
+    ]
+  }
+]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Now that #85167 is here, we don't need to keep the integrated armor around to provide the tool qualities anymore. 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Remove the integrated pincer completely. Add the tool quality directly to the limb (except cut--talking to people on the Discord, a crab claw isn't really like a knife, which is what CUT represents). 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Spawned a crab, checked that the pincer was covered by the carapace (yes), checked that it provided the HAMMER quality (it does).
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
