### PR TITLE
Fix grid charging

### DIFF
--- a/src/item_gun_tool_ammo.cpp
+++ b/src/item_gun_tool_ammo.cpp
@@ -2927,7 +2927,7 @@ int item::charge_linked_batteries( vehicle &linked_veh, int turns_elapsed )
     }
 
     if( power_in ) {
-        int available_charges = linked_veh.battery_power_level( ).first;
+        int available_charges = linked_veh.connected_battery_power_level( here ).first;
         int wanted_charges = ammo_capacity( itype_battery->ammo->type ) - ammo_remaining( );
 
         // Nothing to charge or nothing to charge with
@@ -2937,8 +2937,8 @@ int item::charge_linked_batteries( vehicle &linked_veh, int turns_elapsed )
 
         if( short_time_passed ) {
             // Single charge - subtract one from source, roll against efficiency to add one to destination
-            linked_veh.discharge_battery( here, 1, true );
-            if( rng_float( 0.0, 1.0 ) <= link().efficiency ) {
+            int deficit = linked_veh.discharge_battery( here, 1, true );
+            if( deficit == 0 && rng_float( 0.0, 1.0 ) <= link().efficiency ) {
                 ammo_set( itype_battery, ammo_remaining( ) + 1 );
             }
         } else {
@@ -2948,16 +2948,17 @@ int item::charge_linked_batteries( vehicle &linked_veh, int turns_elapsed )
             int possible_transfer = turns_elapsed * 1.0f / link().charge_interval;
             int required_charges = wanted_charges / link().efficiency;
             int spent_charges = std::min( { possible_transfer, available_charges, required_charges } );
+            int deficit = linked_veh.discharge_battery( here, spent_charges, true );
+            int actual_spent = spent_charges - deficit;
             // Avoid rounding error on full charge
-            int received_charges = spent_charges == required_charges
+            int received_charges = actual_spent >= required_charges
                                    ? wanted_charges
-                                   : spent_charges * link().efficiency;
+                                   : static_cast<int>( actual_spent * link().efficiency );
 
-            linked_veh.discharge_battery( here, spent_charges, true );
             ammo_set( itype_battery, ammo_remaining( ) + received_charges );
         }
     } else {
-        const auto [bat_remaining, bat_capacity] = linked_veh.battery_power_level( );
+        const auto [bat_remaining, bat_capacity] = linked_veh.connected_battery_power_level( here );
         int available_charges = ammo_remaining( );
         int wanted_charges = bat_capacity - bat_remaining;
 
@@ -2970,7 +2971,11 @@ int item::charge_linked_batteries( vehicle &linked_veh, int turns_elapsed )
             // Single charge - subtract one from source, roll against efficiency to add one to destination
             ammo_set( itype_battery, ammo_remaining( ) - 1 );
             if( rng_float( 0.0, 1.0 ) <= link().efficiency ) {
-                linked_veh.charge_battery( here, 1, true );
+                int surplus = linked_veh.charge_battery( here, 1, true );
+                if( surplus != 0 ) {
+                    // Battery couldn't accept the charge, refund it
+                    ammo_set( itype_battery, ammo_remaining( ) + 1 );
+                }
             }
         } else {
             // Multiple charges - get minimum from available charges, possible transfer in given time and
@@ -2982,10 +2987,18 @@ int item::charge_linked_batteries( vehicle &linked_veh, int turns_elapsed )
             // Avoid rounding error on full charge
             int received_charges = spent_charges == required_charges
                                    ? wanted_charges
-                                   : spent_charges * link().efficiency;
+                                   : static_cast<int>( spent_charges * link().efficiency );
 
-            ammo_set( itype_battery, ammo_remaining( ) - spent_charges );
-            linked_veh.charge_battery( here, received_charges, true );
+            int surplus = linked_veh.charge_battery( here, received_charges, true );
+            int actual_received = received_charges - surplus;
+            // Only deduct from source what was actually accepted (accounting for efficiency)
+            int actual_spent = actual_received == wanted_charges
+                               ? required_charges
+                               : static_cast<int>( actual_received / link().efficiency );
+            // Ensure we don't spend more than planned
+            actual_spent = std::min( actual_spent, spent_charges );
+
+            ammo_set( itype_battery, ammo_remaining( ) - actual_spent );
         }
     }
     return link().charge_rate;

--- a/src/item_gun_tool_ammo.cpp
+++ b/src/item_gun_tool_ammo.cpp
@@ -2917,18 +2917,18 @@ int item::charge_linked_batteries( vehicle &linked_veh, int turns_elapsed )
     }
 
     // Normally efficiency is the chance to get a charge every charge_interval, but if we're catching up from
-    // time spent ouside the reality bubble it should be applied as a percentage of the total instead.
+    // time spent outside the reality bubble it should be applied as a percentage of the total instead.
     bool short_time_passed = turns_elapsed <= link().charge_interval;
 
     if( turns_elapsed < 1 || ( short_time_passed &&
                                !calendar::once_every( time_duration::from_turns( link().charge_interval ) ) ) ) {
-        // To early to get any charge
+        // Too early to get any charge
         return link().charge_rate;
     }
 
     if( power_in ) {
         int available_charges = linked_veh.connected_battery_power_level( here ).first;
-        int wanted_charges = ammo_capacity( itype_battery->ammo->type ) - ammo_remaining( );
+        int wanted_charges = ammo_capacity( ammo_battery ) - ammo_remaining( );
 
         // Nothing to charge or nothing to charge with
         if( wanted_charges == 0 || available_charges == 0 ) {
@@ -2945,8 +2945,9 @@ int item::charge_linked_batteries( vehicle &linked_veh, int turns_elapsed )
             // Multiple charges - get minimum from available charges, possible transfer in given time and
             // amount of charges destination needs to charge itself to full with given efficiency.
             // Subtract that value from the source and after reduction by efficiency add it to the destination.
-            int possible_transfer = turns_elapsed * 1.0f / link().charge_interval;
-            int required_charges = wanted_charges / link().efficiency;
+            int possible_transfer =
+                static_cast<int>( turns_elapsed * 1.0f / link().charge_interval );
+            int required_charges = static_cast<int>( wanted_charges / link().efficiency );
             int spent_charges = std::min( { possible_transfer, available_charges, required_charges } );
             int deficit = linked_veh.discharge_battery( here, spent_charges, true );
             int actual_spent = spent_charges - deficit;
@@ -2981,8 +2982,9 @@ int item::charge_linked_batteries( vehicle &linked_veh, int turns_elapsed )
             // Multiple charges - get minimum from available charges, possible transfer in given time and
             // amount of charges destination needs to charge itself to full with given efficiency.
             // Subtract that value from the source and after reduction by efficiency add it to the destination.
-            int possible_transfer = turns_elapsed * 1.0f / link().charge_interval;
-            int required_charges = wanted_charges / link().efficiency;
+            int possible_transfer =
+                static_cast<int>( turns_elapsed * 1.0f / link().charge_interval );
+            int required_charges = static_cast<int>( wanted_charges / link().efficiency );
             int spent_charges = std::min( { possible_transfer, available_charges, required_charges } );
             // Avoid rounding error on full charge
             int received_charges = spent_charges == required_charges


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary

Bugfixes "Items not charging from grid-connected appliances (wall wiring)"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->


  Fixes #85133

  PR #84364 changed connected_battery_power_level() to battery_power_level(), which broke charging for items connected to grid appliances like wall wiring. Wall outlets have no local batteries, so battery_power_level() returns 0 and the function returns early without ever attempting the grid-aware discharge_battery()/charge_battery().

  That same PR also stopped checking the return values from discharge_battery() and charge_battery(), which can result in phantom charges when operations partially fail (e.g. cable losses push the request over available power).



#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

  - Use connected_battery_power_level(here) instead of battery_power_level() for availability checks, so power is found across the grid.
  - Check the return value (deficit) from discharge_battery() and only credit the item with what was actually discharged.
  - Check the return value (surplus) from charge_battery() and only deduct from the source what was actually accepted.
  - Minor cleanup: fix typos, use ammo_battery consistently, add explicit static_cast<int> on float-to-int conversions.


#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

  Could fix only the connected_battery_power_level call without touching return value handling, but that would leave the phantom charge issue reported in #85133 comments unaddressed.


#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

  1. Placed a car battery as an appliance, connected wall wiring, connected a partially discharged smartphone to the wall wiring. Walked away from reality bubble, waited, returned - phone was charged and battery lost a proportional amount.
  2. Same setup but connected the phone directly to the battery appliance - still worked as before.
  3. Connected a phone to a nearly empty car battery. Verified the phone doesn't gain more charge than the battery can provide.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->

N/A