### PR TITLE
Fix pets jumping into fire 

### DIFF
--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -2383,7 +2383,7 @@ void monster::stumble()
         const tripoint_bub_ms dest = random_entry_removed( valid_stumbles );
         if( can_move_to( dest ) &&
             // Don't stumble into dangerous tiles if monster has AVOID_DANGER flag
-            // Makes it do that your pets don't stumble into traps and fireplaces 
+            // Makes it do that your pets don't stumble into traps and fireplaces
             know_danger_at( &here, dest ) &&
             //Stop zombies and other non-breathing monsters wandering INTO water
             //(Unless they can swim/are aquatic)

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1016,7 +1016,7 @@ void monster::move()
             ( get_dest() == player_character.pos_abs() &&
               pos_abs().z() == player_character.pos_abs().z() ) ) {
             moves = 0;
-            stumble();
+            stumble_voluntary();
             return;
         }
     } else if( ( current_attitude == MATT_IGNORE && patrol_route.empty() ) ||
@@ -1024,7 +1024,7 @@ void monster::move()
                    ( has_flag( mon_flag_KEEP_DISTANCE ) && !( current_attitude == MATT_FLEE ) ) )
                  && rl_dist( pos_abs(), get_dest() ) <= type->tracking_distance ) ) {
         moves = 0;
-        stumble();
+        stumble_voluntary();
         return;
     }
 
@@ -1320,7 +1320,7 @@ void monster::move()
         }
     } else {
         moves = 0;
-        stumble();
+        stumble_voluntary();
         path.clear();
     }
     if( has_effect( effect_led_by_leash ) ) {
@@ -2347,11 +2347,30 @@ bool monster::push_to( const tripoint_bub_ms &p, const int boost, const size_t d
 }
 
 /**
- * Wander in a random direction, but with some caveats.
+ * Wander in a random direction, without stepping into water (if not a swimmer)
+ * or into dangerious tiles (if has AVOID_DANGER flag)
  */
-void monster::stumble()
+void monster::stumble_voluntary()
 {
     add_msg_debug( debugmode::DF_MONMOVE, "%s starting monmove::stumble", name() );
+    stumble_base( true );
+}
+
+/**
+ * Forced stumble in a random direction
+ */
+void monster::stumble_involuntary()
+{
+    add_msg_debug( debugmode::DF_MONMOVE, "%s starting monmove::stumble_involuntary", name() );
+    stumble_base( false );
+}
+
+
+/**
+ * Stumble in a random direction
+ */
+void monster::stumble_base( const bool is_voluntary )
+{
     // Only move every 10 turns.
     if( !one_in( 10 ) ) {
         return;
@@ -2373,61 +2392,35 @@ void monster::stumble()
             }
         }
     }
-    const tripoint_bub_ms below( pos_bub() + tripoint::below );
-    if( here.valid_move( pos_bub(), below, false, true ) ) {
-        valid_stumbles.push_back( below );
-    }
 
-    creature_tracker &creatures = get_creature_tracker();
-    while( !valid_stumbles.empty() && !is_dead() ) {
-        const tripoint_bub_ms dest = random_entry_removed( valid_stumbles );
-        if( can_move_to( dest ) &&
-            // Don't wander into dangerous tiles if monster has AVOID_DANGER flag
-            know_danger_at( &here, dest ) &&
-            //Stop zombies and other non-breathing monsters wandering INTO water
-            //(Unless they can swim/are aquatic)
-            //But let them wander OUT of water if they are there.
-            !( avoid_water &&
-               here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, dest ) &&
-               !here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, pos_bub() ) ) &&
-            ( creatures.creature_at( dest, is_hallucination() ) == nullptr ) ) {
-            if( move_to( dest, true, false ) ) {
-                break;
-            }
-        }
-    }
-}
-
-/**
- * Forced stumble in a random direction
- */
-void monster::stumble_involuntary()
-{
-    add_msg_debug( debugmode::DF_MONMOVE, "%s starting monmove::stumble_involuntary", name() );
-    // Only move every 10 turns.
-    if( !one_in( 10 ) ) {
-        return;
-    }
-
-    map &here = get_map();
-    std::vector<tripoint_bub_ms> valid_stumbles;
-    valid_stumbles.reserve( 11 );
-    for( const tripoint_bub_ms &dest : here.points_in_radius( pos_bub(), 1 ) ) {
-        if( dest != pos_bub() ) {
-            if( here.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, dest ) ) {
-                valid_stumbles.emplace_back( dest + tripoint::below );
-            } else  if( here.has_flag( ter_furn_flag::TFLAG_RAMP_UP, dest ) ) {
-                valid_stumbles.emplace_back( dest + tripoint::above );
-            } else {
-                valid_stumbles.push_back( dest );
-            }
+    // When forced to stumble, monsters can't stumble-walk downstairs
+    if( is_voluntary ) {
+        const tripoint_bub_ms below( pos_bub() + tripoint::below );
+        if( here.valid_move( pos_bub(), below, false, true ) ) {
+            valid_stumbles.push_back( below );
         }
     }
 
     creature_tracker &creatures = get_creature_tracker();
     while( !valid_stumbles.empty() && !is_dead() ) {
         const tripoint_bub_ms dest = random_entry_removed( valid_stumbles );
+
+        // Stop zombies and other non-breathing monsters wandering INTO water
+        // (Unless they can swim/are aquatic)
+        // But let them wander OUT of water if they are there.
+        const bool avoiding_stepping_into_water = avoid_water &&
+                here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, dest ) &&
+                !here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, pos_bub() );
+
+
+        // If the stumble is voluntary (just moving around), don't step into water or known danger tiles
+        // If monster is made to stumble, they might walk into them even if they wouldn't normally
+        const bool safe_for_voluntary_step = !is_voluntary || ( !avoiding_stepping_into_water &&
+                                             know_danger_at( &here, dest ) );
+
+
         if( can_move_to( dest ) &&
+            safe_for_voluntary_step &&
             ( creatures.creature_at( dest, is_hallucination() ) == nullptr ) ) {
             if( move_to( dest, true, false ) ) {
                 break;

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -2382,6 +2382,9 @@ void monster::stumble()
     while( !valid_stumbles.empty() && !is_dead() ) {
         const tripoint_bub_ms dest = random_entry_removed( valid_stumbles );
         if( can_move_to( dest ) &&
+            // Don't stumble into dangerous tiles if monster has AVOID_DANGER flag
+            // Makes it do that your pets don't stumble into traps and fireplaces 
+            know_danger_at( &here, dest ) &&
             //Stop zombies and other non-breathing monsters wandering INTO water
             //(Unless they can swim/are aquatic)
             //But let them wander OUT of water if they are there.

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -2423,10 +2423,6 @@ void monster::stumble_involuntary()
             }
         }
     }
-    const tripoint_bub_ms below( pos_bub() + tripoint::below );
-    if( here.valid_move( pos_bub(), below, false, true ) ) {
-        valid_stumbles.push_back( below );
-    }
 
     creature_tracker &creatures = get_creature_tracker();
     while( !valid_stumbles.empty() && !is_dead() ) {

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -2347,7 +2347,7 @@ bool monster::push_to( const tripoint_bub_ms &p, const int boost, const size_t d
 }
 
 /**
- * Stumble in a random direction, but with some caveats.
+ * Wander in a random direction, but with some caveats.
  */
 void monster::stumble()
 {
@@ -2382,8 +2382,7 @@ void monster::stumble()
     while( !valid_stumbles.empty() && !is_dead() ) {
         const tripoint_bub_ms dest = random_entry_removed( valid_stumbles );
         if( can_move_to( dest ) &&
-            // Don't stumble into dangerous tiles if monster has AVOID_DANGER flag
-            // Makes it so that your pets don't stumble into traps and fireplaces
+            // Don't wander into dangerous tiles if monster has AVOID_DANGER flag
             know_danger_at( &here, dest ) &&
             //Stop zombies and other non-breathing monsters wandering INTO water
             //(Unless they can swim/are aquatic)

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -2383,7 +2383,7 @@ void monster::stumble()
         const tripoint_bub_ms dest = random_entry_removed( valid_stumbles );
         if( can_move_to( dest ) &&
             // Don't stumble into dangerous tiles if monster has AVOID_DANGER flag
-            // Makes it do that your pets don't stumble into traps and fireplaces
+            // Makes it so that your pets don't stumble into traps and fireplaces
             know_danger_at( &here, dest ) &&
             //Stop zombies and other non-breathing monsters wandering INTO water
             //(Unless they can swim/are aquatic)

--- a/src/monster.h
+++ b/src/monster.h
@@ -344,6 +344,7 @@ class monster : public Creature
         std::map<damage_type_id, int> group_bash_skill( const tripoint_bub_ms &target );
 
         void stumble();
+        void stumble_involuntary();
         void knock_back_to( const tripoint_bub_ms &to ) override;
 
         // Combat

--- a/src/monster.h
+++ b/src/monster.h
@@ -343,7 +343,8 @@ class monster : public Creature
          * bash the designated target.  **/
         std::map<damage_type_id, int> group_bash_skill( const tripoint_bub_ms &target );
 
-        void stumble();
+        void stumble_base( bool is_voluntary );
+        void stumble_voluntary();
         void stumble_involuntary();
         void knock_back_to( const tripoint_bub_ms &to ) override;
 

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -513,7 +513,7 @@ bool trapfunc::tripwire( const tripoint_bub_ms &p, Creature *c, item * )
             player_character.mod_moves( -z->get_speed() * 1.5 );
             g->update_map( player_character );
         } else {
-            z->stumble();
+            z->stumble_involuntary();
         }
         if( rng( 0, 10 ) > z->get_dodge() ) {
             z->deal_damage( nullptr, bodypart_id( "torso" ), damage_instance( damage_pure, rng( 1,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Your pets won't walk into fire and traps anymore"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
This was a pet rat, it jumped into the fireplace and died. F
<img width="190" height="135" alt="image" src="https://github.com/user-attachments/assets/ff676c1d-23d2-4c44-b564-35f72d5718c3" />

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
~~Very few things have both STUMBLE and AVOID_DANGER flags. namely cockroaches, so~~ i enabled stumble() to check for avoid danger before stumbling. this fixes the bug because pets manually call the stumble function when they're around you
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Making dogs fireproof? 
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Spawned 5 dogs, before they'd jump into lit fireplaces occasionally, now i can' wait for a few hours and they don't 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
