### PR TITLE
make zombies occasionally follow new sounds

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -4031,8 +4031,9 @@ void monster::hear_sound( const tripoint_bub_ms &source, const int vol, const in
     if( !tmp_provocative ) {
         return;
     }
-    // already following a more interesting sound
-    if( provocative_sound && wandf > 0 ) {
+    // already following a more interesting sound,
+    // so 50% will try to stick to it, and 50% will move in direction of a new sound
+    if( provocative_sound && wandf > 0 && rng( 0, 1 ) ) {
         return;
     }
 


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fix #85164
#### Describe the solution
Instead of ignoring all new sounds and stick to the old one, give them 50% chance to stick to old sound, and 50% chance to go to a new sound
#### Describe alternatives you've considered
i am a bit afraid that with enough sounds emitted, it will result in this bit of code being effectively bypassed, so maybe it should be less than 50%?
#### Testing
As you can see, zombies do not stick to the same group, but instead made 3 relatively distinct 
<img width="228" height="117" alt="image" src="https://github.com/user-attachments/assets/d6cb600b-39fd-4711-91b6-edea08dcdb11" />