### PR TITLE
Avoid unnecessary expensive map memory manipulation in tests

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -6611,6 +6611,21 @@ partial_con *map::partial_con_at( const tripoint_bub_ms &p )
 
 void map::partial_con_remove( const tripoint_bub_ms &p )
 {
+    partial_con_remove_impl( p );
+    memory_cache_dec_set_dirty( p, true );
+    avatar &player_character = get_avatar();
+    if( player_character.sees( *this, p ) ) {
+        player_character.memorize_clear_decoration( get_abs( p ), "tr_" );
+    }
+}
+
+void map::partial_con_remove_no_vision_for_testing( const tripoint_bub_ms &p )
+{
+    partial_con_remove_impl( p );
+}
+
+void map::partial_con_remove_impl( const tripoint_bub_ms &p )
+{
     if( !inbounds( p ) ) {
         return;
     }
@@ -6621,11 +6636,6 @@ void map::partial_con_remove( const tripoint_bub_ms &p )
         return;
     }
     current_submap->partial_constructions.erase( tripoint_sm_ms( l, p.z() ) );
-    memory_cache_dec_set_dirty( p, true );
-    avatar &player_character = get_avatar();
-    if( player_character.sees( *this, p ) ) {
-        player_character.memorize_clear_decoration( get_abs( p ), "tr_" );
-    }
 }
 
 void map::partial_con_set( const tripoint_bub_ms &p, const partial_con &con )

--- a/src/map.h
+++ b/src/map.h
@@ -1433,9 +1433,14 @@ class map
         // Partial construction functions
         void partial_con_set( const tripoint_bub_ms &p, const partial_con &con );
         void partial_con_remove( const tripoint_bub_ms &p );
+        void partial_con_remove_no_vision_for_testing( const tripoint_bub_ms &p );
         partial_con *partial_con_at( const tripoint_bub_ms &p );
         // Traps
         void trap_set( const tripoint_bub_ms &p, const trap_id &type );
+
+    private:
+        void partial_con_remove_impl( const tripoint_bub_ms &p );
+    public:
 
         const trap &tr_at( const tripoint_abs_ms &p ) const;
         const trap &tr_at( const tripoint_bub_ms &p ) const;

--- a/tests/item_pocket_test.cpp
+++ b/tests/item_pocket_test.cpp
@@ -1978,7 +1978,7 @@ static void test_pickup_autoinsert_sub_sub( bool autopickup, bool wear, bool sof
 
     map &m = get_map();
     Character &u = get_player_character();
-    clear_map();
+    clear_map_without_vision();
     clear_character( u, true );
     item_location cont1( map_cursor( u.pos_abs() ), &m.add_item_or_charges( u.pos_bub(),
                          cont_nest_rigid ) );

--- a/tests/map_helpers.h
+++ b/tests/map_helpers.h
@@ -13,6 +13,7 @@ class submap;
 class time_point;
 
 void wipe_map_terrain( map *target = nullptr );
+void wipe_map_terrain_with_vision( map *target = nullptr, bool with_vision = true );
 void clear_creatures();
 void clear_npcs();
 void clear_fields( int zlevel );
@@ -20,6 +21,8 @@ void clear_items( int zlevel );
 void clear_zones();
 void clear_basecamps();
 void clear_map( int zmin = -2, int zmax = 0 );
+void clear_map_without_vision( int zmin = -2, int zmax = 0 );
+void clear_map_with_vision( int zmin = -2, int zmax = 0, bool with_vision = true );
 void clear_radiation();
 void clear_map_and_put_player_underground();
 monster &spawn_test_monster( const std::string &monster_type, const tripoint_bub_ms &start,

--- a/tests/mongroup_test.cpp
+++ b/tests/mongroup_test.cpp
@@ -298,7 +298,7 @@ static void test_multi_spawn( const mtype_id &old_mon, int range, int min, int m
     calendar::start_of_game = calendar::turn_zero;
 
     for( int i = 0; i < upgrade_attempts; i++ ) {
-        clear_map();
+        clear_map_without_vision();
         map &m = get_map();
         calendar::turn = start;
         const tripoint_bub_ms ground_zero = get_player_character().pos_bub() - tripoint( 5, 5, 0 );

--- a/tests/vehicle_turrets_test.cpp
+++ b/tests/vehicle_turrets_test.cpp
@@ -51,7 +51,7 @@ static void clear_faults_from_vp( vehicle_part &vp )
 // Install, reload and fire every possible vehicle turret.
 TEST_CASE( "vehicle_turret", "[vehicle][gun][magazine]" )
 {
-    clear_map();
+    clear_map_without_vision();
     clear_avatar();
     map &here = get_map();
     Character &player_character = get_player_character();


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Performance "Speed up tests with faster map teardown"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
While profiling various alternative allocators, I noticed a hotspot in Character::sees in the test suite. Not unreasonable for tests, depending on what they're testing, but it was unusual to see it in happening in `clear_map()`. Why do we care about what the character sees while cleaning the map? It was a side effect of erasing constructions which was intended to update character map memory. The tests triggering this the most were tests which don't involve the character. Therefore, a godawful waste of time to the tune of 25% of the total test runtime.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add equivalent map clear functions which optionally don't touch character memory and call those from the appropriate tests.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Ran it locally on my machine and full test run went from 25+ minutes to ~20 minutes. I would screenshot but the IDE profiler interface was going nuts and glitching out. I guess it also couldn't believe it.

Here is what was happening before:
<img width="1848" height="772" alt="image" src="https://github.com/user-attachments/assets/912a243a-8656-425a-83f0-a4ed3d370602" />

<img width="1854" height="1814" alt="image" src="https://github.com/user-attachments/assets/3619f0b0-5aeb-4ed8-b16a-faa18d5d3773" />

Edit: mongroup tests are like 4x faster
<img width="1231" height="348" alt="image" src="https://github.com/user-attachments/assets/2bbc1235-4cbc-4f2b-bba7-19178db008a5" />


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
