### PR TITLE
Obsolete ACT_FERTILIZE_PLOT, replace with fertilize_plant_activity_actor

### DIFF
--- a/data/json/obsoletion_and_migration_0.J/player_activities.json
+++ b/data/json/obsoletion_and_migration_0.J/player_activities.json
@@ -59,5 +59,14 @@
     "activity_level": "MODERATE_EXERCISE",
     "verb": "tidying up",
     "based_on": "time"
+  },
+  {
+    "id": "ACT_FERTILIZE_PLOT",
+    "type": "activity_type",
+    "activity_level": "MODERATE_EXERCISE",
+    "verb": "fertilizing plots",
+    "based_on": "time",
+    "can_resume": false,
+    "auto_needs": true
   }
 ]

--- a/data/json/player_activities.json
+++ b/data/json/player_activities.json
@@ -811,6 +811,13 @@
     "based_on": "time"
   },
   {
+    "id": "ACT_FERTILIZE_PLANT",
+    "type": "activity_type",
+    "activity_level": "MODERATE_EXERCISE",
+    "verb": "fertilizing plants",
+    "based_on": "time"
+  },
+  {
     "id": "ACT_SHAVE",
     "type": "activity_type",
     "activity_level": "NO_EXERCISE",

--- a/data/json/player_activities.json
+++ b/data/json/player_activities.json
@@ -538,15 +538,6 @@
     "auto_needs": true
   },
   {
-    "id": "ACT_FERTILIZE_PLOT",
-    "type": "activity_type",
-    "activity_level": "MODERATE_EXERCISE",
-    "verb": "fertilizing plots",
-    "based_on": "neither",
-    "can_resume": false,
-    "auto_needs": true
-  },
-  {
     "id": "ACT_START_FIRE",
     "type": "activity_type",
     "activity_level": "NO_EXERCISE",

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -9578,7 +9578,7 @@ std::optional<itype_id> multi_farm_activity_actor::query_fertilizer( Character &
 
 }
 
-ret_val<void> multi_farm_activity_actor::can_fertilize( Character &you,
+ret_val<void> multi_farm_activity_actor::can_fertilize( Character &,
         const tripoint_bub_ms &tile )
 {
     map &here = get_map();

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -3377,6 +3377,36 @@ class churn_activity_actor : public activity_actor
         item_location tool;
 };
 
+class fertilize_plant_activity_actor : public activity_actor
+{
+    public:
+        fertilize_plant_activity_actor( time_duration initial_moves, const tripoint_bub_ms &plant_position,
+                                        itype_id fertilizer ) :
+            initial_moves( initial_moves ), plant_position( plant_position ), fertilizer( fertilizer ) { }
+
+        const activity_id &get_type() const override {
+            static const activity_id ACT_FERTILIZE_PLANT( "ACT_FERTILIZE_PLANT" );
+            return ACT_FERTILIZE_PLANT;
+        }
+
+        void start( player_activity &act, Character &who ) override;
+        void do_turn( player_activity &, Character & ) override {}
+        void finish( player_activity &act, Character &who ) override;
+
+        std::unique_ptr<activity_actor> clone() const override {
+            return std::make_unique<fertilize_plant_activity_actor>( *this );
+        }
+
+        void serialize( JsonOut &jsout ) const override;
+        static std::unique_ptr<activity_actor> deserialize( JsonValue &jsin );
+
+    private:
+        fertilize_plant_activity_actor() = default;
+        time_duration initial_moves; // NOLINT(cata-serialize)
+        tripoint_bub_ms plant_position;
+        itype_id fertilizer;
+};
+
 class hand_crank_activity_actor : public activity_actor
 {
     public:

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -307,6 +307,9 @@ class multi_farm_activity_actor : public multi_zone_activity_actor
                 const zone_data *zone = nullptr ) override;
         bool multi_activity_do( Character &you, const activity_reason_info &act_info,
                                 const tripoint_abs_ms &src, const tripoint_bub_ms &src_loc ) override;
+        static std::optional<itype_id> query_fertilizer( Character &you );
+        static ret_val<void> can_fertilize( Character &you, const tripoint_bub_ms &tile );
+
         std::unique_ptr<activity_actor> clone() const override {
             return std::make_unique<multi_farm_activity_actor>( *this );
         }

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -9,15 +9,12 @@
 #include <stdexcept>
 #include <string>
 #include <type_traits>
-#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 
-#include "activity_actor.h"
 #include "calendar.h"
 #include "cata_utility.h"
 #include "character.h"
-#include "clzones.h"
 #include "coordinates.h"
 #include "creature.h"
 #include "creature_tracker.h"
@@ -59,7 +56,6 @@
 #include "vpart_position.h"
 #include "weather.h"
 
-static const activity_id ACT_FERTILIZE_PLOT( "ACT_FERTILIZE_PLOT" );
 static const activity_id ACT_FILL_LIQUID( "ACT_FILL_LIQUID" );
 static const activity_id ACT_FIND_MOUNT( "ACT_FIND_MOUNT" );
 static const activity_id ACT_REPAIR_ITEM( "ACT_REPAIR_ITEM" );
@@ -90,8 +86,6 @@ static const itype_id itype_pseudo_magazine_mod( "pseudo_magazine_mod" );
 
 static const skill_id skill_survival( "survival" );
 
-static const zone_type_id zone_type_FARM_PLOT( "FARM_PLOT" );
-
 using namespace activity_handlers;
 
 const std::map< activity_id, std::function<void( player_activity *, Character * )> >
@@ -108,19 +102,6 @@ activity_handlers::finish_functions = {
     { ACT_START_FIRE, start_fire_finish },
     { ACT_REPAIR_ITEM, repair_item_finish }
 };
-
-static void assign_multi_activity( Character &you, const player_activity &act )
-{
-    const bool requires_actor = activity_actors::deserialize_functions.find( act.id() ) !=
-                                activity_actors::deserialize_functions.end();
-    if( requires_actor ) {
-        // the activity uses `activity_actor` and requires `player_activity::actor` to be set
-        you.assign_activity( player_activity( act ) );
-    } else {
-        // the activity uses the older type of player_activity where `player_activity::actor` is not used
-        you.assign_activity( act.id() );
-    }
-}
 
 bool activity_handlers::resume_for_multi_activities( Character &you )
 {

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -127,7 +127,7 @@ bool activity_handlers::resume_for_multi_activities( Character &you )
     if( !you.backlog.empty() ) {
         player_activity &back_act = you.backlog.front();
         if( back_act.is_multi_type() ) {
-            assign_multi_activity( you, back_act );
+            you.assign_activity( back_act );
             you.backlog.pop_front();
             return true;
         }

--- a/src/activity_handlers.h
+++ b/src/activity_handlers.h
@@ -66,6 +66,7 @@ enum class do_activity_reason : int {
     NEEDS_HARVESTING,       //* For farming - tile is harvestable now.
     NEEDS_PLANTING,         //* For farming - tile can be planted
     NEEDS_TILLING,          //* For farming - tile can be tilled
+    NEEDS_FERTILIZING,          //* For farming - tile can be fertilized
     BLOCKING_TILE,          // Something has made it's way onto the tile, so the activity cannot proceed
     NEEDS_BOOK_TO_LEARN,    //* There is book to learn
     NEEDS_CHOPPING,         //* There is wood there to be chopped
@@ -194,7 +195,6 @@ bool resume_for_multi_activities( Character &you );
 
 /** activity_do_turn functions: */
 void chop_trees_do_turn( player_activity *act, Character *you );
-void fertilize_plot_do_turn( player_activity *act, Character *you );
 void fetch_do_turn( player_activity *act, Character *you );
 void fill_liquid_do_turn( player_activity *act, Character *you );
 void find_mount_do_turn( player_activity *act, Character *you );

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -412,8 +412,7 @@ static std::vector<item_location> try_to_put_into_vehicle( Character &c, item_dr
     return result;
 }
 
-static itype_id get_first_fertilizer_itype( Character &you, const tripoint_abs_ms &src,
-        const tripoint_bub_ms &src_loc )
+static itype_id get_first_fertilizer_itype( Character &you, const tripoint_abs_ms &src )
 {
     const zone_manager &mgr = zone_manager::get_manager();
     std::vector<zone_data> zones = mgr.get_zones( zone_type_FARM_PLOT, src, _fac_id( you ) );
@@ -1970,7 +1969,7 @@ activity_reason_info farm_can_do( const activity_id &, Character &you,
         // there's a plant that isn't overgrown or harvestable, apply fertilizer if possible
         else if( here.has_flag_furn( ter_furn_flag::TFLAG_PLANT, src_loc ) &&
                  multi_farm_activity_actor::can_fertilize( you, src_loc ).success() &&
-                 !get_first_fertilizer_itype( you, here.get_abs( src_loc ), src_loc ).is_null() ) {
+                 !get_first_fertilizer_itype( you, here.get_abs( src_loc ) ).is_null() ) {
             return activity_reason_info::ok( do_activity_reason::NEEDS_FERTILIZING );
         } else if( here.has_flag( ter_furn_flag::TFLAG_PLOWABLE, src_loc ) && !here.has_furn( src_loc ) ) {
             if( you.has_quality( qual_DIG, 1 ) ) {
@@ -3389,7 +3388,7 @@ bool farm_do( Character &you, const activity_reason_info &act_info,
             return false;
         }
     } else if( reason == do_activity_reason::NEEDS_FERTILIZING ) {
-        itype_id used_fertilizer = get_first_fertilizer_itype( you, src, src_loc );
+        itype_id used_fertilizer = get_first_fertilizer_itype( you, src );
         if( !used_fertilizer.is_null() ) {
             iexamine::fertilize_plant( you, src_loc, used_fertilizer );
             you.backlog.emplace_front( multi_farm_activity_actor() );

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -3710,7 +3710,7 @@ std::optional<bool> route( Character &you, player_activity &act, const tripoint_
         if( !check_only ) {
             if( you.get_moves() <= 0 ) {
                 // Restart activity and break from cycle.
-                you.assign_activity( act_id );
+                you.assign_activity( act );
                 return true;
             }
             // set the destination and restart activity after player arrives there

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <tuple>
 
+#include "activity_actor_definitions.h"
 #include "avatar.h"
 #include "calendar.h"
 #include "cata_path.h"
@@ -365,6 +366,19 @@ plot_options::query_seed_result plot_options::query_seed()
     }
 }
 
+bool plot_options::query_fertilizer()
+{
+    std::optional<itype_id> selected_fertilizer =
+        multi_farm_activity_actor::query_fertilizer( get_player_character() );
+    itype_id previous_fertilizer = fertilizer;
+    if( !selected_fertilizer ) {
+        fertilizer = itype_id();
+    } else {
+        fertilizer = *selected_fertilizer;
+    }
+    return previous_fertilizer != fertilizer;
+}
+
 bool blueprint_options::query_at_creation()
 {
     return query_con() != canceled;
@@ -407,7 +421,9 @@ bool loot_options::query()
 
 bool plot_options::query()
 {
-    return query_seed() == changed;
+    plot_options::query_seed_result query_seed_result = query_seed();
+    bool query_fertilizer_result = query_fertilizer();
+    return query_seed_result == changed || query_fertilizer_result;
 }
 
 bool unload_options::query()

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -566,12 +566,14 @@ void plot_options::serialize( JsonOut &json ) const
 {
     json.member( "mark", mark );
     json.member( "seed", seed );
+    json.member( "fertilizer", fertilizer );
 }
 
 void plot_options::deserialize( const JsonObject &jo_zone )
 {
     jo_zone.read( "mark", mark );
     jo_zone.read( "seed", seed );
+    jo_zone.read( "fertilizer", fertilizer );
 }
 
 void unload_options::serialize( JsonOut &json ) const

--- a/src/clzones.h
+++ b/src/clzones.h
@@ -135,6 +135,7 @@ class plot_options : public zone_options, public mark_option
     private:
         itype_id mark;
         itype_id seed;
+        itype_id fertilizer;
 
         enum query_seed_result {
             canceled,
@@ -143,6 +144,7 @@ class plot_options : public zone_options, public mark_option
         };
 
         query_seed_result query_seed();
+        bool query_fertilizer();
 
     public:
         std::string get_mark() const override {
@@ -150,6 +152,9 @@ class plot_options : public zone_options, public mark_option
         }
         itype_id get_seed() const {
             return seed;
+        }
+        itype_id get_fertilizer() const {
+            return fertilizer;
         }
 
         bool has_options() const override {

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -111,8 +111,6 @@ enum class direction : unsigned int;
 #include "sdltiles.h"
 #endif
 
-static const activity_id ACT_FERTILIZE_PLOT( "ACT_FERTILIZE_PLOT" );
-
 static const bionic_id bio_remote( "bio_remote" );
 
 static const damage_type_id damage_cut( "cut" );
@@ -1496,7 +1494,6 @@ static void loot()
     Character &player_character = get_player_character();
     int flags = 0;
     zone_manager &mgr = zone_manager::get_manager();
-    const bool has_fertilizer = player_character.cache_has_item_with( flag_FERTILIZER );
 
     // reset any potentially disabled zones from a past activity
     mgr.reset_disabled();

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1479,7 +1479,6 @@ static void loot()
         SortLoot = 2,
         SortLootStatic = 4,
         SortLootPersonal = 8,
-        FertilizePlots = 16,
         ConstructPlots = 64,
         MultiFarmPlots = 128,
         Multichoptrees = 256,
@@ -1517,7 +1516,6 @@ static void loot()
     flags |= g->check_near_zone( zone_type_UNLOAD_ALL, player_character.pos_bub() ) ||
              g->check_near_zone( zone_type_STRIP_CORPSES, player_character.pos_bub() ) ? UnloadLoot : 0;
     if( g->check_near_zone( zone_type_FARM_PLOT, player_character.pos_bub() ) ) {
-        flags |= FertilizePlots;
         flags |= MultiFarmPlots;
     }
     flags |= g->check_near_zone( zone_type_CONSTRUCTION_BLUEPRINT,
@@ -1567,13 +1565,6 @@ static void loot()
         menu.addentry_desc( UnloadLoot, true, 'U', _( "Unload nearby containers" ),
                             wrap60( _( "Unloads any corpses or containers that are in their respective zones." ) ) );
     }
-
-    if( flags & FertilizePlots ) {
-        menu.addentry_desc( FertilizePlots, has_fertilizer, 'f',
-                            !has_fertilizer ? _( "Fertilize plots… you don't have any fertilizer" ) : _( "Fertilize plots" ),
-                            wrap60( _( "Fertilize any nearby Farm: Plot zones." ) ) );
-    }
-
     if( flags & ConstructPlots ) {
         menu.addentry_desc( ConstructPlots, true, 'c', _( "Construct plots" ),
                             wrap60( _( "Work on any nearby Blueprint: construction zones." ) ) );
@@ -1662,9 +1653,6 @@ static void loot()
             break;
         case UnloadLoot:
             player_character.assign_activity( unload_loot_activity_actor() );
-            break;
-        case FertilizePlots:
-            player_character.assign_activity( ACT_FERTILIZE_PLOT );
             break;
         case ConstructPlots:
             player_character.assign_activity( multi_build_construction_activity_actor() );

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -178,7 +178,6 @@ static const itype_id itype_dahlia_root( "dahlia_root" );
 static const itype_id itype_disassembly( "disassembly" );
 static const itype_id itype_fake_milling_item( "fake_milling_item" );
 static const itype_id itype_fake_smoke_plume( "fake_smoke_plume" );
-static const itype_id itype_fertilizer( "fertilizer" );
 static const itype_id itype_fire( "fire" );
 static const itype_id itype_foodperson_mask( "foodperson_mask" );
 static const itype_id itype_foodperson_mask_on( "foodperson_mask_on" );

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -2866,44 +2866,7 @@ void iexamine::fertilize_plant( Character &you, const tripoint_bub_ms &tile,
         return;
     }
 
-    std::list<item> planted;
-    if( fertilizer->count_by_charges() ) {
-        planted = you.use_charges( fertilizer, 1 );
-    } else {
-        planted = you.use_amount( fertilizer, 1 );
-    }
-
-    // Reduce the amount of time it takes until the next stage of the plant by
-    // 20% of a seasons length. (default 2.8 days).
-    const time_duration fertilizerEpoch = calendar::season_length() * 0.2;
-
-    map &here = get_map();
-    // Can't use item_stack::only_item() since there might be fertilizer
-    map_stack items = here.i_at( tile );
-    const map_stack::iterator seed = std::find_if( items.begin(), items.end(), []( const item & it ) {
-        return it.is_seed();
-    } );
-    if( seed == items.end() ) {
-        debugmsg( "Missing seed for plant at %s", tile.to_string() );
-        here.i_clear( tile );
-        here.furn_set( tile, furn_str_id::NULL_ID() );
-        return;
-    }
-
-    // TODO: item should probably clamp the value on its own
-    seed->set_birthday( seed->birthday() - fertilizerEpoch );
-    // The plant furniture has the NOITEM token which prevents adding items on that square,
-    // spawned items are moved to an adjacent field instead, but the fertilizer token
-    // must be on the square of the plant, therefore this hack:
-    const furn_id &old_furn = here.furn( tile );
-    here.furn_set( tile, furn_str_id::NULL_ID() );
-    here.spawn_item( tile, itype_fertilizer, 1, 1, calendar::turn );
-    here.furn_set( tile, old_furn );
-    you.mod_moves( -to_moves<int>( 10_seconds ) );
-
-    //~ %1$s: plant name, %2$s: fertilizer name
-    add_msg( m_info, _( "You fertilize the %1$s with the %2$s." ), seed->get_plant_name(),
-             planted.front().tname() );
+    you.assign_activity( fertilize_plant_activity_actor( 10_seconds, tile, fertilizer ) );
 }
 
 itype_id iexamine::choose_fertilizer( Character &you, const std::string &pname,

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -426,7 +426,8 @@ void player_activity::deserialize( const JsonObject &data )
         "ACT_CONSUME_MEDS_MENU", // Remove after 0.J
         "ACT_ARMOR_LAYERS", // Remove after 0.J
         "ACT_TRAIN_TEACHER", // Remove after 0.J
-        "ACT_TIDY_UP" // Remove after 0.J
+        "ACT_TIDY_UP", // Remove after 0.J
+        "ACT_FERTILIZE_PLOT" // Remove after 0.J
     };
     if( !data.read( "type", tmptype ) ) {
         // Then it's a legacy save.


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Infrastructure "Obsolete ACT_FERTILIZE_PLOT, replace with fertilize_plant_activity_actor"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Update legacy activities. ACT_FERTILIZE_PLOT for some reason used an entirely separate implementation of the multi-activity system.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

See title. 

Integrates fertilizing into `multi_farm_activity_actor`, where fertilizer is selected as a zone option for a Farm Plot zone. Therefore, doing O-menu "Farm Plots" will auto-fertilize if you have the selected fertilizer in your inventory. The fertilizer is not a `requirement`, so it can't be auto-fetched.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

The fertilizer selection UI is extremely bare-bones and should be improved.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

- Farmed a Farm Plot with huckleberry seeds, selected liquid fertilizer with zone options menu, and fully planted/fertilized the plot successfully.
- Did the above with an NPC
- Saved/loaded during NPC activity, no errors
- Farmed a Farm Plot with no seeds successfully, no fertilizer used
- Farmed both the huckleberry plot and the no seeds plot in the same multi-activity successfully
- iexamine fertilizing a single plant still works 
- e893821455eadb84d4e9985deca7ebf67a300524 fixes a bug where a legacy activity was being assigned by multi-activity routing when out of moves

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

The multi-activity backlog is not being cleared properly, I have fixed it and will PR it once this is merged.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
