### PR TITLE
track the used components

### DIFF
--- a/src/basecamp.cpp
+++ b/src/basecamp.cpp
@@ -1060,8 +1060,11 @@ void basecamp_action_components::consume_components()
         src.emplace_back( target_map.get_bub( p ) );
     }
     for( const comp_selection<item_comp> &sel : item_selections_ ) {
-        std::list<item> empty_consumed = player_character.consume_items( target_map, sel, batch_size_,
-                                         is_crafting_component, src );
+        std::list<item> consumed = player_character.consume_items( target_map, sel, batch_size_,
+                                   is_crafting_component, src );
+        for( item &comp : consumed ) {
+            consumed_components_.add( comp );
+        }
     }
     // this may consume pseudo-resources from fake items
     for( const comp_selection<tool_comp> &sel : tool_selections_ ) {

--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -20,6 +20,7 @@
 #include "craft_command.h"
 #include "game_constants.h"
 #include "inventory.h"
+#include "item_components.h"
 #include "item_location.h"
 #include "map.h"
 #include "mapgendata.h"
@@ -531,6 +532,9 @@ class basecamp_action_components
         // Returns true iff all necessary components were successfully chosen
         bool choose_components();
         void consume_components();
+        item_components &consumed_components() {
+            return consumed_components_;
+        }
     private:
         const recipe &making_;
         const mapgen_arguments &args_;
@@ -538,6 +542,7 @@ class basecamp_action_components
         basecamp &base_;
         std::vector<comp_selection<item_comp>> item_selections_;
         std::vector<comp_selection<tool_comp>> tool_selections_;
+        item_components consumed_components_;
 };
 
 #endif // CATA_SRC_BASECAMP_H

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -3406,7 +3406,8 @@ void basecamp::start_crafting( const mission_id &miss_id )
                                   0_hours, guy_to_send );
     if( comp != nullptr ) {
         components.consume_components();
-        for( const item &results : making->create_results( num_to_make ) ) {
+        item_components used = components.consumed_components();
+        for( const item &results : making->create_results( num_to_make, &used ) ) {
             comp->companion_mission_inv.add_item( results );
         }
         for( const item &byproducts : making->create_byproducts( num_to_make ) ) {

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -50,6 +50,7 @@
 #include "inventory.h"
 #include "inventory_ui.h"
 #include "item.h"
+#include "item_components.h"
 #include "item_group.h"
 #include "item_location.h"
 #include "item_pocket.h"


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Camp crafted food vitamins, toxins fixed"

#### Purpose of change
Closes #85078
Camp crafting food like pemmican from smoked mutant meat produces a result with no toxins, even though player crafting the same recipe correctly carries them over.

#### Describe the solution
Camp crafting's consume_components() calls consume_items() which returns the consumed items, but the result was being discarded (stored in a variable literally named empty_consumed). Then create_results() was called without any component data, so the result item was spawned with only default nutritional values.
The fix captures those consumed items into an item_components collection and passes it to create_results(), which already accepts that parameter and handles vitamin inheritance through set_new_comps().

#### Describe alternatives you've considered
Could have built the item_components from recipe requirements instead of capturing actual consumed items, but that's less accurate when ingredient alternatives exist. Capturing the real items mirrors player crafting and is simpler.

#### Testing
Camp-crafted pemmican from mutant tallow, result now shows toxins in "other contents", matching player-crafted pemmican.

#### Additional context

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
