### PR TITLE
Fix #85156: Replace rifle case for Deep Cold Marksman

### DIFF
--- a/data/mods/Magiclysm/professions.json
+++ b/data/mods/Magiclysm/professions.json
@@ -964,7 +964,7 @@
           { "item": "helmet_army" },
           { "item": "hatchet" },
           { "item": "balclava", "variant": "black" },
-          { "item": "rifle_case_soft" },
+          { "item": "rifle_case_xl_soft_leather" },
           { "item": "mess_kit" },
           { "item": "emer_blanket", "custom-flags": [ "no_auto_equip" ] },
           { "item": "tank_top", "variant": "tank_top_camo" },


### PR DESCRIPTION
Changed rifle_case_soft to rifle_case_xl_soft_leather to fit Mosin-Nagant with suppressor (142cm total length).

#### Summary
Bugfixes "Deep Cold Marksman profession now starts with correct rifle case size"

#### Purpose of change
Fixes #85156

The Deep Cold Marksman profession starts with a Mosin-Nagant rifle that has a suppressor attached. The combined length (142cm) exceeds the capacity of the provided rifle_case_soft (133cm max), making it impossible to store the starting weapon in the starting case.

#### Describe the solution
Changed the starting equipment from `rifle_case_soft` (max 133cm) to `rifle_case_xl_soft_leather` (max 146cm), which can accommodate the Mosin-Nagant with suppressor.

Calculation:
- Mosin-Nagant base: 1232mm
- Suppressor integral length: 188mm
- Total: 1420mm (142cm)
- XL leather case capacity: 146cm ✓

#### Describe alternatives you've considered
- Could remove the suppressor from starting equipment, but that would change the profession's intended loadout
- Could use rifle_case_soft_2 (double case), but it has the same 133cm limitation
- The XL leather case is the most appropriate solution as it's designed for longer rifles

#### Testing
- Verified the math: Mosin (1232mm) + suppressor (188mm) = 1420mm (142cm)
- Confirmed rifle_case_xl_soft_leather has max_item_length of 146cm
- Checked that the item ID exists in data/json/items/armor/storage.json

#### Additional context
This is a simple one-line JSON change in the Magiclysm mod's profession file.
