### PR TITLE
Add barrel threading gunmod to restore muzzle slots on pistols

### DIFF
--- a/data/json/itemgroups/Weapons_Mods_Ammo/nested_guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/nested_guns.json
@@ -1022,7 +1022,7 @@
     "subtype": "collection",
     "ammo": 100,
     "entries": [
-      { "item": "usp_45", "variant": "mk23", "contents-group": "mk23_mods", "charges": [ 0, 12 ] },
+      { "item": "usp_45_tactical", "variant": "mk23", "contents-group": "mk23_mods", "charges": [ 0, 12 ] },
       { "item": "usp45mag" },
       { "item": "usp45mag", "prob": 50 },
       { "group": "on_hand_45" }

--- a/data/json/items/gun/22.json
+++ b/data/json/items/gun/22.json
@@ -277,6 +277,7 @@
     "dispersion": 400,
     "valid_mod_locations": [
       [ "barrel", 1 ],
+      [ "barrel threading", 1 ],
       [ "brass catcher", 1 ],
       [ "mechanism", 2 ],
       [ "rail mount", 1 ],

--- a/data/json/items/gun/45.json
+++ b/data/json/items/gun/45.json
@@ -355,7 +355,14 @@
     "weight": "1050 g",
     "volume": "540 ml",
     "price": "1 kUSD 150 USD",
-    "valid_mod_locations": [ [ "barrel", 1 ], [ "barrel threading", 1 ], [ "mechanism", 2 ], [ "rail", 1 ], [ "sights mount", 1 ], [ "stock mount", 1 ] ],
+    "valid_mod_locations": [
+      [ "barrel", 1 ],
+      [ "barrel threading", 1 ],
+      [ "mechanism", 2 ],
+      [ "rail", 1 ],
+      [ "sights mount", 1 ],
+      [ "stock mount", 1 ]
+    ],
     "built_in_mods": [ "match_trigger", "barrel_threading" ]
   },
   {

--- a/data/json/items/gun/45.json
+++ b/data/json/items/gun/45.json
@@ -331,6 +331,34 @@
     "pocket_data": [ { "magazine_well": "250 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "usp45mag" ] } ]
   },
   {
+    "id": "usp_45_tactical",
+    "copy-from": "usp_45",
+    "type": "ITEM",
+    "subtypes": [ "GUN" ],
+    "name": { "str": "USP Tactical pistol" },
+    "description": "A semi-automatic pistol chambered in .45 ACP with a factory-threaded extended barrel for mounting muzzle devices.  Accepts USP magazines.",
+    "variant_type": "gun",
+    "variants": [
+      {
+        "id": "usp_45_tactical",
+        "name": { "str": "USP .45 Tactical pistol" },
+        "description": "The USP Tactical is a variant of the popular USP .45 featuring an extended threaded barrel and adjustable target trigger.  Designed with special operations forces in mind, it can accept suppressors and other muzzle devices directly."
+      },
+      {
+        "id": "mk23",
+        "name": { "str": "MK 23 MOD 0 pistol" },
+        "description": "Jokingly referred to as \"The World's Only Crew-Served Pistol\", this massive pistol was designed as a primary weapon for select \"special operators\".  Its cumbersome nature, the introduction of the derivative HK USP series, and the logistics of getting .45 ACP ammunition in theater doomed this behemoth to US SOCOM armories.  Like the USP, the MK 23 is a remarkably reliable gun; someone could probably take out a nuclear-equipped walking tank with this in their holster."
+      }
+    ],
+    "barrel_length": "136 mm",
+    "longest_side": "270 mm",
+    "weight": "1050 g",
+    "volume": "540 ml",
+    "price": "1 kUSD 150 USD",
+    "valid_mod_locations": [ [ "barrel", 1 ], [ "barrel threading", 1 ], [ "mechanism", 2 ], [ "rail", 1 ], [ "sights mount", 1 ], [ "stock mount", 1 ] ],
+    "built_in_mods": [ "match_trigger", "barrel_threading" ]
+  },
+  {
     "id": "walther_ppq_45",
     "copy-from": "gun_base_45_semi_pistol",
     "looks_like": "glock_17",

--- a/data/json/items/gunmod/barrel.json
+++ b/data/json/items/gunmod/barrel.json
@@ -33,6 +33,28 @@
     "flags": [ "IRREMOVABLE" ]
   },
   {
+    "id": "barrel_threading",
+    "type": "ITEM",
+    "subtypes": [ "GUNMOD" ],
+    "name": { "str": "barrel threading" },
+    "description": "Precision-cut threads on the muzzle end of a barrel, allowing attachment of muzzle devices such as suppressors and compensators.  Threading a barrel is a permanent modification that requires careful machining to ensure proper alignment.",
+    "weight": "100 g",
+    "integral_weight": "0 g",
+    "volume": "50 ml",
+    "integral_volume": "0 ml",
+    "price": "200 USD",
+    "price_postapoc": "5 USD",
+    "install_time": "30 m",
+    "material": [ "steel" ],
+    "symbol": ":",
+    "color": "light_gray",
+    "location": "barrel threading",
+    "mod_targets": [ "pistol" ],
+    "min_skills": [ [ "weapon", 3 ] ],
+    "add_mod": [ [ "muzzle", 1 ] ],
+    "flags": [ "INSTALL_DIFFICULT", "IRREMOVABLE" ]
+  },
+  {
     "id": "barrel_small",
     "type": "ITEM",
     "subtypes": [ "GUNMOD" ],

--- a/data/json/recipes/nested.json
+++ b/data/json/recipes/nested.json
@@ -4509,6 +4509,7 @@
     "description": "Recipes related to making mounts for attachments on older or makeshift guns.",
     "skill_used": "fabrication",
     "nested_category_data": [
+      "barrel_threading",
       "rail_mount",
       "rail_bayonet_lug",
       "sights_mount",

--- a/data/json/recipes/weapon/mods.json
+++ b/data/json/recipes/weapon/mods.json
@@ -1276,5 +1276,22 @@
     "tools": [ [ [ "forge", 150 ], [ "oxy_torch", 150 ] ], [ [ "metalworking_tongs_any", 1, "LIST" ] ] ],
     "byproducts": [ [ "scrap_aluminum", 3 ] ],
     "components": [ [ [ "material_aluminium_ingot", 1 ] ] ]
+  },
+  {
+    "result": "barrel_threading",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "fabrication",
+    "difficulty": 5,
+    "skills_required": [ [ "gun", 3 ] ],
+    "time": "1 h",
+    "book_learn": [ [ "mag_guns", 5 ], [ "mag_pistol", 5 ], [ "manual_gun", 5 ], [ "manual_pistol", 5 ] ],
+    "proficiencies": [ { "proficiency": "prof_machining_basic" } ],
+    "qualities": [ { "id": "FILE", "level": 2 } ],
+    "tools": [ [ [ "fake_lathe", 40 ] ] ],
+    "//": "Scrap is used for a thread protector cap to shield the newly-cut threads when no muzzle device is attached.",
+    "components": [ [ [ "scrap", 1 ] ] ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Barrel threading gunmod and USP Tactical for pistol muzzle devices"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

Fixes #80771
Fixes #85074

Pistols have no muzzle slot, so suppressors and compensators cannot be attached.  The MK 23 variant of the USP .45 spawns with a suppressor (via `mk23_mods`) that cannot be installed.  PR #80781 attempted a fix but was rejected for implying barrel swaps and lacking per-gun eligibility.


#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

A new `barrel_threading` gunmod following the mount pattern (`IRREMOVABLE` + `INSTALL_DIFFICULT` + `add_mod` for muzzle), with a dedicated `"barrel threading"` slot that guns must explicitly opt into.

Only guns whose barrel extends past the slide (threadable without a barrel swap) get the slot:
  - Ruger Mark IV - exposed bull barrel, Ruger sells factory-threaded models
  - USP .45 Tactical / MK 23 - new `usp_45_tactical` gun item with factory threading via `built_in_mods` and trhe `mk23` variant remains on `usp_45` for backward compatibility with existing saves.

The crafting recipe requires a lathe (`fake_lathe`) and `prof_machining_basic`, since threading is precision machining that cannot be done with hand tools.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

The rejected PR #80781 added a `"barrel"` slot replacement.  The v1 of this PR added threading to 26 pistols, but review pointedd that most semi-auto pistols have slides fully covering the barrel amnd threading those requires a barrel swap, not just cutting threads.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

TBD


#### Additional context

N/A

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
