### PR TITLE
Rewrite all tests to clear map without touching character map memory, for performance.

### DIFF
--- a/tests/act_build_test.cpp
+++ b/tests/act_build_test.cpp
@@ -162,7 +162,7 @@ construction setup_testcase( Character &u, std::string const &constr,
 void run_test_case( Character &u )
 {
     calendar::turn = calendar::turn_zero + 9_hours + 30_minutes;
-    clear_map();
+    clear_map_without_vision();
     scoped_weather_override weather_clear( WEATHER_CLEAR );
     clear_avatar();
     map &here = get_map();

--- a/tests/active_item_test.cpp
+++ b/tests/active_item_test.cpp
@@ -34,7 +34,7 @@ static const vproto_id vehicle_prototype_test_shopping_cart( "test_shopping_cart
 TEST_CASE( "active_items_processed_regularly", "[active_item]" )
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
     avatar &player_character = get_avatar();
     map &here = get_map();
     // An arbitrary active item that ticks every turn.

--- a/tests/activity_scheduling_helper.cpp
+++ b/tests/activity_scheduling_helper.cpp
@@ -90,7 +90,7 @@ weariness_events do_activity( tasklist tasks, bool do_clear_avatar )
     if( do_clear_avatar ) {
         clear_avatar();
     }
-    clear_map();
+    clear_map_without_vision();
 
     avatar &guy = get_avatar();
     // Ensure we have enough light to see

--- a/tests/advanced_inventory_test.cpp
+++ b/tests/advanced_inventory_test.cpp
@@ -122,7 +122,7 @@ TEST_CASE( "AIM_basic_move_items", "[items][advanced_inv]" )
 
     avatar &u = get_avatar();
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
     advanced_inventory advinv;
 
     advinv.init();

--- a/tests/behavior_test.cpp
+++ b/tests/behavior_test.cpp
@@ -171,7 +171,7 @@ TEST_CASE( "behavior_tree", "[behavior]" )
 // Make assertions about loaded behaviors.
 TEST_CASE( "check_npc_behavior_tree", "[npc][behavior]" )
 {
-    clear_map();
+    clear_map_without_vision();
     calendar::turn = calendar::start_of_cataclysm;
     behavior::tree npc_needs;
     npc_needs.add( &behavior_node_t_npc_needs.obj() );
@@ -235,7 +235,7 @@ TEST_CASE( "check_npc_behavior_tree", "[npc][behavior]" )
 TEST_CASE( "check_monster_behavior_tree_locust", "[monster][behavior]" )
 {
     const tripoint_bub_ms monster_location( 5, 5, 0 );
-    clear_map();
+    clear_map_without_vision();
     map &here = get_map();
     monster &test_monster = spawn_test_monster( "mon_locust", monster_location );
 
@@ -275,7 +275,7 @@ TEST_CASE( "check_monster_behavior_tree_locust", "[monster][behavior]" )
 TEST_CASE( "check_monster_behavior_tree_shoggoth", "[monster][behavior]" )
 {
     const tripoint_bub_ms monster_location( 5, 5, 0 );
-    clear_map();
+    clear_map_without_vision();
     map &here = get_map();
     monster &test_monster = spawn_test_monster( "mon_shoggoth", monster_location );
 
@@ -329,7 +329,7 @@ TEST_CASE( "check_monster_behavior_tree_shoggoth", "[monster][behavior]" )
 TEST_CASE( "check_monster_behavior_tree_theoretical_corpse_eater", "[monster][behavior]" )
 {
     const tripoint_bub_ms monster_location( 5, 5, 0 );
-    clear_map();
+    clear_map_without_vision();
     map &here = get_map();
     monster &test_monster = spawn_test_monster( "mon_shoggoth_flesh_only", monster_location );
 
@@ -388,7 +388,7 @@ TEST_CASE( "check_monster_behavior_tree_theoretical_absorb", "[monster][behavior
 {
     // tests a monster with the ABSORB_ITEMS ability but NOT the SPLIT ability
     const tripoint_bub_ms monster_location( 5, 5, 0 );
-    clear_map();
+    clear_map_without_vision();
     map &here = get_map();
     monster &test_monster = spawn_test_monster( "mon_shoggoth_absorb_only", monster_location );
 

--- a/tests/cardio_test.cpp
+++ b/tests/cardio_test.cpp
@@ -154,7 +154,7 @@ TEST_CASE( "base_cardio", "[cardio][base]" )
     verify_default_cardio_options();
     Character &they = get_player_character();
 
-    clear_map();
+    clear_map_without_vision();
     clear_avatar();
 
     // Ensure no initial effects that would affect cardio
@@ -196,7 +196,7 @@ TEST_CASE( "cardio_is_and_is_not_affected_by_certain_traits", "[cardio][traits]"
     verify_default_cardio_options();
     Character &they = get_player_character();
 
-    clear_map();
+    clear_map_without_vision();
     clear_avatar();
 
     // Ensure no initial effects that would affect cardio

--- a/tests/char_sight_test.cpp
+++ b/tests/char_sight_test.cpp
@@ -66,7 +66,7 @@ TEST_CASE( "light_and_fine_detail_vision_mod", "[character][sight][light][vision
     map &here = get_map();
 
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
     g->reset_light_level();
     scoped_weather_override weather_clear( WEATHER_CLEAR );
 
@@ -131,7 +131,7 @@ TEST_CASE( "npc_light_and_fine_detail_vision_mod", "[character][npc][sight][ligh
     n.set_body();
 
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
     tripoint const u_shift = GENERATE( tripoint::zero, tripoint::above );
     CAPTURE( u_shift );
     // Allow player to float for purpose of purely testing this and not factoring in terrain potentially blocking vision etc
@@ -181,7 +181,7 @@ TEST_CASE( "character_sight_limits", "[character][sight][vision]" )
     map &here = get_map();
 
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
     g->reset_light_level();
     scoped_weather_override weather_clear( WEATHER_CLEAR );
 
@@ -277,7 +277,7 @@ TEST_CASE( "ursine_vision", "[character][ursine][vision]" )
     map &here = get_map();
 
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
     g->reset_light_level();
     scoped_weather_override weather_clear( WEATHER_CLEAR );
 

--- a/tests/char_suffer_test.cpp
+++ b/tests/char_suffer_test.cpp
@@ -111,7 +111,7 @@ static int test_suffer_pain_felt( Character &dummy, const time_duration &dur )
 //
 TEST_CASE( "suffering_from_albinism", "[char][suffer][albino]" )
 {
-    clear_map();
+    clear_map_without_vision();
     clear_avatar();
     set_time_to_day();
     scoped_weather_override clear_weather( WEATHER_CLEAR );
@@ -216,7 +216,7 @@ TEST_CASE( "suffering_from_albinism", "[char][suffer][albino]" )
 //
 TEST_CASE( "suffering_from_sunburn", "[char][suffer][sunburn]" )
 {
-    clear_map();
+    clear_map_without_vision();
     clear_avatar();
     set_time_to_day();
     scoped_weather_override clear_weather( WEATHER_CLEAR );
@@ -381,7 +381,7 @@ TEST_CASE( "suffering_from_sunburn", "[char][suffer][sunburn]" )
 
 TEST_CASE( "suffering_from_asphyxiation", "[char][suffer][oxygen][grab]" )
 {
-    clear_map();
+    clear_map_without_vision();
     clear_avatar();
     Character &dummy = get_player_character();
     dummy.set_underwater( false );

--- a/tests/clzones_test.cpp
+++ b/tests/clzones_test.cpp
@@ -83,7 +83,7 @@ TEST_CASE( "zone_unloading_ammo_belts", "[zones][items][ammo_belt][activities][u
     CAPTURE( in_vehicle );
 
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
 
     tripoint_abs_ms const start = here.get_abs( tripoint_bub_ms::zero + tripoint::east );
     dummy.set_pos_abs_only( start );
@@ -129,7 +129,7 @@ TEST_CASE( "zone_unloading_ammo_belts", "[zones][items][ammo_belt][activities][u
 // shelf life and whether the container prevents rotting.
 TEST_CASE( "zone_sorting_comestibles_", "[zones][items][food][activities]" )
 {
-    clear_map();
+    clear_map_without_vision();
     zone_manager &zm = zone_manager::get_manager();
 
     const tripoint_abs_ms origin_pos;

--- a/tests/connect_rotate_test.cpp
+++ b/tests/connect_rotate_test.cpp
@@ -34,7 +34,7 @@ class cata_tiles_test_helper
 TEST_CASE( "walls_should_be_unconnected_without_nearby_walls", "[multitile][connects]" )
 {
     map &here = get_map();
-    clear_map();
+    clear_map_without_vision();
     clear_avatar();
 
     std::bitset<NUM_TERCONN> none;
@@ -64,7 +64,7 @@ TEST_CASE( "walls_should_be_unconnected_without_nearby_walls", "[multitile][conn
 TEST_CASE( "walls_should_connect_to_walls_as_end_pieces", "[multitile][connects]" )
 {
     map &here = get_map();
-    clear_map();
+    clear_map_without_vision();
     clear_avatar();
 
     std::bitset<NUM_TERCONN> none;
@@ -133,7 +133,7 @@ TEST_CASE( "walls_should_connect_to_walls_as_end_pieces", "[multitile][connects]
 TEST_CASE( "walls_should_connect_to_walls_as_corners", "[multitile][connects]" )
 {
     map &here = get_map();
-    clear_map();
+    clear_map_without_vision();
     clear_avatar();
 
     std::bitset<NUM_TERCONN> none;
@@ -202,7 +202,7 @@ TEST_CASE( "walls_should_connect_to_walls_as_corners", "[multitile][connects]" )
 TEST_CASE( "walls_should_connect_to_walls_as_edges", "[multitile][connects]" )
 {
     map &here = get_map();
-    clear_map();
+    clear_map_without_vision();
     clear_avatar();
 
     std::bitset<NUM_TERCONN> none;
@@ -245,7 +245,7 @@ TEST_CASE( "walls_should_connect_to_walls_as_edges", "[multitile][connects]" )
 TEST_CASE( "walls_should_connect_to_walls_as_t-connections_and_fully", "[multitile][connects]" )
 {
     map &here = get_map();
-    clear_map();
+    clear_map_without_vision();
     clear_avatar();
 
     std::bitset<NUM_TERCONN> none;
@@ -329,7 +329,7 @@ TEST_CASE( "walls_should_connect_to_walls_as_t-connections_and_fully", "[multiti
 TEST_CASE( "windows_should_connect_to_walls_and_rotate_to_indoor_floor", "[multitile][rotates]" )
 {
     map &here = get_map();
-    clear_map();
+    clear_map_without_vision();
     clear_avatar();
 
     std::bitset<NUM_TERCONN> floor;
@@ -453,7 +453,7 @@ TEST_CASE( "windows_should_connect_to_walls_and_rotate_to_indoor_floor", "[multi
 TEST_CASE( "unconnected_windows_rotate_to_indoor_floor", "[multitile][rotates]" )
 {
     map &here = get_map();
-    clear_map();
+    clear_map_without_vision();
     clear_avatar();
 
     std::bitset<NUM_TERCONN> none;

--- a/tests/coverage_test.cpp
+++ b/tests/coverage_test.cpp
@@ -156,7 +156,7 @@ static float get_avg_melee_dmg( item cloth, bool infect_risk = false )
 static float get_avg_bullet_dmg( const itype_id &clothing_id )
 {
     map &here = get_map();
-    clear_map();
+    clear_map_without_vision();
     std::unique_ptr<standard_npc> badguy = std::make_unique<standard_npc>( "TestBaddie",
                                            badguy_pos, std::vector<itype_id>(), 0, 8, 8, 8, 8 );
     std::unique_ptr<standard_npc> dude = std::make_unique<standard_npc>( "TestCharacter",

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -504,7 +504,7 @@ static void prep_craft( const recipe_id &rid, const std::vector<item> &tools,
 {
     map &here = get_map();
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
 
     const tripoint_bub_ms test_origin( 60, 60, 0 );
     Character &player_character = get_player_character();
@@ -850,7 +850,7 @@ TEST_CASE( "UPS_modded_tools", "[crafting][ups]" )
     bool const ups_on_ground = GENERATE( true, false );
     CAPTURE( ups_on_ground );
     avatar dummy;
-    clear_map();
+    clear_map_without_vision();
     clear_character( dummy );
     tripoint_bub_ms const test_loc = dummy.pos_bub();
     dummy.worn.wear_item( dummy, item( itype_backpack ), false, false );
@@ -1424,7 +1424,7 @@ TEST_CASE( "book_proficiency_mitigation", "[crafting][proficiency]" )
 {
     GIVEN( "a recipe with required proficiencies" ) {
         clear_avatar();
-        clear_map();
+        clear_map_without_vision();
         const recipe &test_recipe = *recipe_leather_belt;
 
         grant_skills_to_character( get_player_character(), test_recipe, 0 );
@@ -1454,7 +1454,7 @@ TEST_CASE( "partial_proficiency_mitigation", "[crafting][proficiency]" )
 {
     GIVEN( "a recipe with required proficiencies" ) {
         clear_avatar();
-        clear_map();
+        clear_map_without_vision();
         Character &tester = get_player_character();
         const recipe &test_recipe = *recipe_leather_belt;
 
@@ -1954,7 +1954,7 @@ TEST_CASE( "Unloading_non-empty_components", "[crafting]" )
 TEST_CASE( "Warn_when_using_favorited_component", "[crafting]" )
 {
     map &m = get_map();
-    clear_map();
+    clear_map_without_vision();
     item pocketknife( itype_pockknife );
 
     GIVEN( "crafting 1 makeshift funnel" ) {
@@ -2371,7 +2371,7 @@ TEST_CASE( "variant_crafting_recipes", "[crafting][slow]" )
 
 TEST_CASE( "pseudo_tools_in_crafting_inventory", "[crafting][tools]" )
 {
-    clear_map();
+    clear_map_without_vision();
     map &here = get_map();
 
     clear_vehicles();
@@ -2473,6 +2473,6 @@ TEST_CASE( "pseudo_tools_in_crafting_inventory", "[crafting][tools]" )
                 }
             }
         }
-        clear_map();
+        clear_map_without_vision();
     }
 }

--- a/tests/creature_in_field_test.cpp
+++ b/tests/creature_in_field_test.cpp
@@ -14,7 +14,7 @@ static const vproto_id vehicle_prototype_handjack( "handjack" );
 TEST_CASE( "creature_in_field", "[monster],[field]" )
 {
     static const tripoint_bub_ms target_location{ 5, 5, 0 };
-    clear_map();
+    clear_map_without_vision();
     map &here = get_map();
     GIVEN( "An acid field" ) {
         here.add_field( target_location, field_type_id( "fd_acid" ) );

--- a/tests/degradation_test.cpp
+++ b/tests/degradation_test.cpp
@@ -112,7 +112,7 @@ TEST_CASE( "only_degrade_items_with_defined_degradation", "[item][degradation]" 
 
 TEST_CASE( "Degradation_on_spawned_items", "[item][degradation]" )
 {
-    clear_map();
+    clear_map_without_vision();
 
     SECTION( "Non-spawned items have no degradation" ) {
         item norm( itype_test_baseball );
@@ -275,7 +275,7 @@ static void setup_repair( item &fix, player_activity &act, Character &u )
 TEST_CASE( "Repairing_degraded_items", "[item][degradation]" )
 {
     // Setup map
-    clear_map();
+    clear_map_without_vision();
     set_time_to_day();
     REQUIRE( static_cast<int>( get_map().light_at( spawn_pos ) ) > 2 );
 
@@ -460,7 +460,7 @@ TEST_CASE( "Gun_repair_with_degradation", "[item][degradation]" )
         item gun( itype_test_glock_degrade );
         clear_character( u );
         u.set_skill_level( skill_mechanics, 10 );
-        clear_map();
+        clear_map_without_vision();
         set_time_to_day();
 
         WHEN( "0 damage / 0 degradation" ) {
@@ -670,7 +670,7 @@ static item_location put_in_container( item_location &container, const itype_id 
 TEST_CASE( "refit_item_inside_spillable_container", "[item][repair][container]" )
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
     set_time_to_day();
     REQUIRE( static_cast<int>( get_map().light_at( spawn_pos ) ) > 2 );
 

--- a/tests/effect_test.cpp
+++ b/tests/effect_test.cpp
@@ -646,7 +646,7 @@ TEST_CASE( "bleed_effect_attribution", "[effect][bleed][monster]" )
     static const tripoint_bub_ms target_location{ 5, 0, 0 };
     clear_npcs();
     clear_vehicles();
-    clear_map();
+    clear_map_without_vision();
     clear_avatar();
     Character &player = get_player_character();
     const damage_instance cut_damage = damage_instance( damage_cut, 50, 50 );
@@ -763,7 +763,7 @@ TEST_CASE( "Vitamin_Effects", "[effect][vitamins]" )
 static void test_deadliness( const effect &applied, const int expected_dead, const int margin )
 {
     creature_tracker &creatures = get_creature_tracker();
-    clear_map();
+    clear_map_without_vision();
     std::vector<monster *> mons;
 
     // Place a hundred debug monsters, our subjects

--- a/tests/enchantments_test.cpp
+++ b/tests/enchantments_test.cpp
@@ -90,7 +90,7 @@ static void test_generic_ench( avatar &p, enchant_test enc_test )
 
     // place a zombie next to the avatar
     const tripoint_bub_ms spot( 61, 60, 0 );
-    clear_map();
+    clear_map_without_vision();
     monster &zombie = spawn_test_monster( "mon_zombie", spot );
 
     p.on_hit( &get_map(),  & zombie, bodypart_id( "torso" ), 0.0, nullptr );
@@ -158,7 +158,7 @@ TEST_CASE( "mutation_enchantments", "[enchantments][mutations]" )
 
 TEST_CASE( "Enchantments_change_stats", "[magic][enchantments]" )
 {
-    clear_map();
+    clear_map_without_vision();
     Character &guy = get_player_character();
     clear_avatar();
     INFO( "Default character with 8 8 8 8 stats" );
@@ -199,7 +199,7 @@ TEST_CASE( "Enchantments_change_stats", "[magic][enchantments]" )
 
 TEST_CASE( "Enchantment_SPEED_test", "[magic][enchantments]" )
 {
-    clear_map();
+    clear_map_without_vision();
     Character &guy = get_player_character();
     clear_avatar();
 
@@ -257,7 +257,7 @@ static int test_melee_attack_attack_speed( Character &guy, Creature &mon )
 
 TEST_CASE( "Enchantment_ATTACK_SPEED_test", "[magic][enchantments]" )
 {
-    clear_map();
+    clear_map_without_vision();
     Character &guy = get_player_character();
     clear_avatar();
     g->place_critter_at( pseudo_debug_mon, tripoint_bub_ms::zero + tripoint::south );
@@ -316,7 +316,7 @@ static int test_melee_attack_attack_stamina( Character &guy, Creature &mon )
 
 TEST_CASE( "Enchantment_MELEE_STAMINA_CONSUMPTION_test", "[magic][enchantments]" )
 {
-    clear_map();
+    clear_map_without_vision();
     Character &guy = get_player_character();
     clear_avatar();
     g->place_critter_at( pseudo_debug_mon, tripoint_bub_ms::zero + tripoint::south );
@@ -385,7 +385,7 @@ static double test_melee_attack_hit_rate( Character &guy, Creature &mon )
 
 TEST_CASE( "Enchantment_MELEE_TO_HIT_test", "[magic][enchantments]" )
 {
-    clear_map();
+    clear_map_without_vision();
     Character &guy = get_player_character();
     clear_avatar();
     g->place_critter_at( pseudo_debug_mon, tripoint_bub_ms::zero + tripoint::south );
@@ -409,7 +409,7 @@ TEST_CASE( "Enchantment_MELEE_TO_HIT_test", "[magic][enchantments]" )
 
 TEST_CASE( "Enchantment_BONUS_DODGE_test", "[magic][enchantments]" )
 {
-    clear_map();
+    clear_map_without_vision();
     Character &guy = get_player_character();
     clear_avatar();
 
@@ -437,7 +437,7 @@ TEST_CASE( "Enchantment_BONUS_DODGE_test", "[magic][enchantments]" )
 
 TEST_CASE( "Enchantment_PAIN_PENALTY_MOD_test", "[magic][enchantments]" )
 {
-    clear_map();
+    clear_map_without_vision();
     Character &guy = get_player_character();
     clear_avatar();
     INFO( "Character has 50 pain, not affected by enchantments" );

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -254,7 +254,7 @@ void check_ter_in_line( tripoint_abs_ms const &first, tripoint_abs_ms const &sec
 TEST_CASE( "EOC_teleport", "[eoc]" )
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
     tripoint_abs_ms before = get_avatar().pos_abs();
     dialogue newDialog( get_talker_for( get_avatar() ), nullptr );
     effect_on_condition_EOC_teleport_test->activate( newDialog );
@@ -266,7 +266,7 @@ TEST_CASE( "EOC_teleport", "[eoc]" )
 TEST_CASE( "EOC_beta_elevate", "[eoc]" )
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
     npc &n = spawn_npc( get_avatar().pos_bub().xy() + point::south, "thug" );
 
     REQUIRE( n.hp_percentage() > 0 );
@@ -357,7 +357,7 @@ TEST_CASE( "EOC_transform_radius", "[eoc][timed_event]" )
     constexpr int eoc_range = 5;
     constexpr time_duration delay = 30_seconds;
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
     tripoint_abs_ms const start = get_avatar().pos_abs();
     dialogue newDialog( get_talker_for( get_avatar() ), nullptr );
     check_ter_in_radius( start, eoc_range, ter_t_grass );
@@ -379,7 +379,7 @@ TEST_CASE( "EOC_transform_line", "[eoc][timed_event]" )
 {
     map &here = get_map();
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
     shared_ptr_fast<npc> guy = make_shared_fast<npc>();
     overmap_buffer.insert_npc( guy );
     npc &npc = *guy;
@@ -402,7 +402,7 @@ TEST_CASE( "EOC_transform_line", "[eoc][timed_event]" )
 TEST_CASE( "EOC_activity_finish", "[eoc][timed_event]" )
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
     get_avatar().assign_activity( ACT_ADD_VARIABLE_COMPLETE, 10 );
 
     complete_activity( get_avatar() );
@@ -413,7 +413,7 @@ TEST_CASE( "EOC_activity_finish", "[eoc][timed_event]" )
 TEST_CASE( "EOC_combat_mutator_test", "[eoc]" )
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
     item weapon( itype_test_knife_combat );
     get_avatar().set_wielded_item( weapon );
     npc &n = spawn_npc( get_avatar().pos_bub().xy() + point::south, "thug" );
@@ -434,7 +434,7 @@ TEST_CASE( "EOC_combat_mutator_test", "[eoc]" )
 TEST_CASE( "EOC_alive_test", "[eoc]" )
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
 
     dialogue d( get_talker_for( get_avatar() ), std::make_unique<talker>() );
     global_variables &globvars = get_globals();
@@ -448,7 +448,7 @@ TEST_CASE( "EOC_alive_test", "[eoc]" )
 TEST_CASE( "EOC_attack_test", "[eoc]" )
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
     npc &n = spawn_npc( get_avatar().pos_bub().xy() + point::south, "thug" );
 
     dialogue newDialog( get_talker_for( get_avatar() ), get_talker_for( n ) );
@@ -458,7 +458,7 @@ TEST_CASE( "EOC_attack_test", "[eoc]" )
 TEST_CASE( "EOC_context_test", "[eoc][math_parser]" )
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
 
     dialogue d( get_talker_for( get_avatar() ), std::make_unique<talker>() );
     global_variables &globvars = get_globals();
@@ -480,7 +480,7 @@ TEST_CASE( "EOC_context_test", "[eoc][math_parser]" )
 TEST_CASE( "EOC_option_test", "[eoc][math_parser]" )
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
 
     dialogue d( get_talker_for( get_avatar() ), std::make_unique<talker>() );
     global_variables &globvars = get_globals();
@@ -499,7 +499,7 @@ TEST_CASE( "EOC_option_test", "[eoc][math_parser]" )
 TEST_CASE( "EOC_mutator_test", "[eoc][math_parser]" )
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
 
     dialogue d( get_talker_for( get_avatar() ), std::make_unique<talker>() );
     global_variables &globvars = get_globals();
@@ -515,7 +515,7 @@ TEST_CASE( "EOC_mutator_test", "[eoc][math_parser]" )
 TEST_CASE( "EOC_math_addiction", "[eoc][math_parser]" )
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
     avatar &a = get_avatar();
 
     item test_whiskey( itype_test_whiskey_caffenated );
@@ -538,7 +538,7 @@ TEST_CASE( "EOC_math_addiction", "[eoc][math_parser]" )
 TEST_CASE( "EOC_math_armor", "[eoc][math_parser]" )
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
     avatar &a = get_avatar();
     a.worn.wear_item( a, item( itype_test_eoc_armor_suit ), false, true, true );
 
@@ -558,7 +558,7 @@ TEST_CASE( "EOC_math_armor", "[eoc][math_parser]" )
 TEST_CASE( "EOC_math_field", "[eoc][math_parser]" )
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
 
     dialogue d( get_talker_for( get_avatar() ), std::make_unique<talker>() );
     global_variables &globvars = get_globals();
@@ -577,7 +577,7 @@ TEST_CASE( "EOC_math_field", "[eoc][math_parser]" )
 TEST_CASE( "EOC_math_item", "[eoc][math_parser]" )
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
 
     dialogue d( get_talker_for( get_avatar() ), std::make_unique<talker>() );
     global_variables &globvars = get_globals();
@@ -593,7 +593,7 @@ TEST_CASE( "EOC_math_item", "[eoc][math_parser]" )
 TEST_CASE( "EOC_math_proficiency", "[eoc][math_parser]" )
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
 
     dialogue d( get_talker_for( get_avatar() ), std::make_unique<talker>() );
     global_variables &globvars = get_globals();
@@ -621,7 +621,7 @@ TEST_CASE( "EOC_math_proficiency", "[eoc][math_parser]" )
 TEST_CASE( "EOC_math_spell", "[eoc][math_parser]" )
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
 
     dialogue d( get_talker_for( get_avatar() ), std::make_unique<talker>() );
     global_variables &globvars = get_globals();
@@ -647,7 +647,7 @@ TEST_CASE( "EOC_math_spell", "[eoc][math_parser]" )
 TEST_CASE( "EOC_mutation_test", "[eoc][mutations]" )
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
 
     dialogue d( get_talker_for( get_avatar() ), std::make_unique<talker>() );
     global_variables &globvars = get_globals();
@@ -684,7 +684,7 @@ TEST_CASE( "EOC_mutation_test", "[eoc][mutations]" )
 TEST_CASE( "EOC_purifiability", "[eoc][mutations]" )
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
     avatar &me = get_avatar();
 
     // Gain both traits
@@ -711,7 +711,7 @@ TEST_CASE( "EOC_purifiability", "[eoc][mutations]" )
 TEST_CASE( "EOC_monsters_nearby", "[eoc][math_parser]" )
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
     avatar &a = get_avatar();
     global_variables &globvars = get_globals();
     globvars.clear_global_values();
@@ -749,7 +749,7 @@ TEST_CASE( "EOC_monsters_nearby", "[eoc][math_parser]" )
 TEST_CASE( "EOC_activity_ongoing", "[eoc][timed_event]" )
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
     get_avatar().assign_activity( ACT_ADD_VARIABLE_DURING, 300 );
 
     complete_activity( get_avatar() );
@@ -761,7 +761,7 @@ TEST_CASE( "EOC_activity_ongoing", "[eoc][timed_event]" )
 TEST_CASE( "EOC_stored_condition_test", "[eoc]" )
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
 
     dialogue d( get_talker_for( get_avatar() ), std::make_unique<talker>() );
     global_variables &globvars = get_globals();
@@ -903,7 +903,7 @@ TEST_CASE( "EOC_meta_test", "[eoc]" )
 TEST_CASE( "EOC_increment_var_var", "[eoc]" )
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
 
     dialogue d( get_talker_for( get_avatar() ), std::make_unique<talker>() );
     global_variables &globvars = get_globals();
@@ -922,7 +922,7 @@ TEST_CASE( "EOC_increment_var_var", "[eoc]" )
 TEST_CASE( "EOC_string_var_var", "[eoc]" )
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
     standard_npc dude;
     dialogue d( get_talker_for( get_avatar() ), get_talker_for( &dude ) );
     global_variables &globvars = get_globals();
@@ -943,7 +943,7 @@ TEST_CASE( "EOC_string_var_var", "[eoc]" )
 TEST_CASE( "EOC_run_with_test", "[eoc]" )
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
 
     dialogue d( get_talker_for( get_avatar() ), std::make_unique<talker>() );
     global_variables &globvars = get_globals();
@@ -967,7 +967,7 @@ TEST_CASE( "EOC_run_with_test", "[eoc]" )
 TEST_CASE( "EOC_run_until_test", "[eoc]" )
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
 
     dialogue d( get_talker_for( get_avatar() ), std::make_unique<talker>() );
     global_variables &globvars = get_globals();
@@ -982,7 +982,7 @@ TEST_CASE( "EOC_run_until_test", "[eoc]" )
 TEST_CASE( "EOC_run_with_test_expects", "[eoc]" )
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
 
     dialogue d( get_talker_for( get_avatar() ), std::make_unique<talker>() );
     global_variables &globvars = get_globals();
@@ -1010,7 +1010,7 @@ TEST_CASE( "EOC_run_with_test_expects", "[eoc]" )
 TEST_CASE( "EOC_run_with_test_queue", "[eoc]" )
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
 
     dialogue d( get_talker_for( get_avatar() ), std::make_unique<talker>() );
     global_variables &globvars = get_globals();
@@ -1038,7 +1038,7 @@ TEST_CASE( "EOC_run_with_test_queue", "[eoc]" )
 TEST_CASE( "EOC_run_inv_test", "[eoc]" )
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
 
     tripoint_abs_ms pos_before = get_avatar().pos_abs();
     tripoint_abs_ms pos_after = pos_before + tripoint::south_east;
@@ -1188,7 +1188,7 @@ TEST_CASE( "math_weapon_damage", "[eoc]" )
 TEST_CASE( "EOC_event_test", "[eoc]" )
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
 
     dialogue d( get_talker_for( get_avatar() ), std::make_unique<talker>() );
     global_variables &globvars = get_globals();
@@ -1250,7 +1250,7 @@ TEST_CASE( "EOC_combat_event_test", "[eoc]" )
     globvars.clear_global_values();
     clear_avatar();
     clear_npcs();
-    clear_map();
+    clear_map_without_vision();
 
     // character_melee_attacks_character
     npc &npc_dst_melee = spawn_npc( get_avatar().pos_bub().xy() + point::south, "thug" );
@@ -1266,7 +1266,7 @@ TEST_CASE( "EOC_combat_event_test", "[eoc]" )
     CHECK( globvars.get_global_value( "victim_name" ) == npc_dst_melee.get_name() );
 
     // character_melee_attacks_monster
-    clear_map();
+    clear_map_without_vision();
     monster &mon_dst_melee = spawn_test_monster( "mon_zombie",
                              get_avatar().pos_bub() + tripoint::east );
     get_avatar().melee_attack( mon_dst_melee, false );
@@ -1280,7 +1280,7 @@ TEST_CASE( "EOC_combat_event_test", "[eoc]" )
 
     // character_ranged_attacks_character
     const tripoint_bub_ms target_pos = get_avatar().pos_bub() + point::east;
-    clear_map();
+    clear_map_without_vision();
     npc &npc_dst_ranged = spawn_npc( target_pos.xy(), "thug" );
     for( loop = 0; loop < 1000; loop++ ) {
         arm_shooter( get_avatar(), itype_shotgun_s );
@@ -1299,7 +1299,7 @@ TEST_CASE( "EOC_combat_event_test", "[eoc]" )
     CHECK( globvars.get_global_value( "victim_name" ) == npc_dst_ranged.get_name() );
 
     // character_ranged_attacks_monster
-    clear_map();
+    clear_map_without_vision();
     monster &mon_dst_ranged = spawn_test_monster( "mon_zombie", target_pos );
     for( loop = 0; loop < 1000; loop++ ) {
         arm_shooter( get_avatar(), itype_shotgun_s );
@@ -1318,7 +1318,7 @@ TEST_CASE( "EOC_combat_event_test", "[eoc]" )
     CHECK( globvars.get_global_value( "victim_type" ) == "mon_zombie" );
 
     // character_kills_monster
-    clear_map();
+    clear_map_without_vision();
     monster &victim = spawn_test_monster( "mon_zombie", target_pos );
     victim.die( &here, &get_avatar() );
 
@@ -1330,7 +1330,7 @@ TEST_CASE( "EOC_combat_event_test", "[eoc]" )
 TEST_CASE( "EOC_spell_exp", "[eoc]" )
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
 
     dialogue d( get_talker_for( get_avatar() ), std::make_unique<talker>() );
     global_variables &globvars = get_globals();
@@ -1370,7 +1370,7 @@ TEST_CASE( "EOC_map_test", "[eoc]" )
     global_variables &globvars = get_globals();
     globvars.clear_global_values();
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
 
     map &m = get_map();
     const tripoint_abs_ms start = get_avatar().pos_abs();
@@ -1395,7 +1395,7 @@ TEST_CASE( "EOC_martial_art_test", "[eoc]" )
     global_variables &globvars = get_globals();
     globvars.clear_global_values();
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
 
     dialogue d( get_talker_for( get_avatar() ), std::make_unique<talker>() );
 
@@ -1420,7 +1420,7 @@ TEST_CASE( "EOC_martial_art_test", "[eoc]" )
 TEST_CASE( "EOC_string_test", "[eoc]" )
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
 
     dialogue d( get_talker_for( get_avatar() ), std::make_unique<talker>() );
     global_variables &globvars = get_globals();
@@ -1442,7 +1442,7 @@ TEST_CASE( "EOC_string_test", "[eoc]" )
 TEST_CASE( "EOC_compare_string_test", "[eoc]" )
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
 
     dialogue d( get_talker_for( get_avatar() ), std::make_unique<talker>() );
     global_variables &globvars = get_globals();
@@ -1480,7 +1480,7 @@ TEST_CASE( "EOC_compare_string_test", "[eoc]" )
 TEST_CASE( "EOC_run_eocs", "[eoc]" )
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
 
     dialogue d( get_talker_for( get_avatar() ), std::make_unique<talker>() );
     global_variables &globvars = get_globals();
@@ -1518,7 +1518,7 @@ TEST_CASE( "EOC_run_eocs", "[eoc]" )
     globvars.clear_global_values();
     avatar &u = get_avatar();
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
     clear_npcs();
     npc &guy = spawn_npc( u.pos_bub().xy() + point::east, "thug" );
     tripoint_abs_ms mon_loc = u.pos_abs() + tripoint::west;

--- a/tests/faction_camp_test.cpp
+++ b/tests/faction_camp_test.cpp
@@ -36,7 +36,7 @@ static const zone_type_id zone_type_CAMP_STORAGE( "CAMP_STORAGE" );
 TEST_CASE( "camp_calorie_counting", "[camp]" )
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
     map &m = get_map();
     const tripoint_abs_ms zone_loc = m.get_abs( tripoint_bub_ms{ 5, 5, 0 } );
     REQUIRE( m.inbounds( zone_loc ) );

--- a/tests/field_test.cpp
+++ b/tests/field_test.cpp
@@ -51,7 +51,7 @@ static int count_fields( const field_type_str_id &field_type )
 // or dynamically update their own lifetimes.
 TEST_CASE( "acid_field_expiry_on_map", "[field]" )
 {
-    clear_map();
+    clear_map_without_vision();
     map &m = get_map();
     // place a smoke field
     for( const tripoint_bub_ms &cursor : m.points_on_zlevel() ) {
@@ -111,7 +111,7 @@ static void fire_duration( const std::string &terrain_type, const time_duration 
     CAPTURE( to_string( minimum ) );
     CAPTURE( to_string( maximum ) );
 
-    clear_map();
+    clear_map_without_vision();
     const tripoint_bub_ms fire_loc{ 33, 33, 0 };
     map &m = get_map();
     m.ter_set( fire_loc, ter_id( terrain_type ) );
@@ -164,12 +164,12 @@ static int fields_test_turns()
 static void fields_test_setup()
 {
     fields_test_time_before() = calendar::turn;
-    clear_map();
+    clear_map_without_vision();
 }
 static void fields_test_cleanup()
 {
     calendar::turn = fields_test_time_before();
-    clear_map();
+    clear_map_without_vision();
 }
 
 TEST_CASE( "fd_acid_falls_down", "[field]" )

--- a/tests/firstaid_test.cpp
+++ b/tests/firstaid_test.cpp
@@ -51,7 +51,7 @@ TEST_CASE( "avatar_does_healing", "[activity][firstaid][avatar]" )
 {
     avatar &dummy = get_avatar();
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
     const bodypart_id right_arm( "arm_r" );
     npc &dunsel = spawn_npc( point_bub_ms( point::east ), "test_talker" );
     set_time( calendar::turn_zero + 12_hours );
@@ -106,7 +106,7 @@ TEST_CASE( "npc_does_healing", "[activity][firstaid][npc]" )
 {
     avatar &dummy = get_avatar();
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
     const bodypart_id right_arm( "arm_r" );
     npc &dunsel = spawn_npc( point_bub_ms( point::east ), "test_talker" );
     set_time( calendar::turn_zero + 12_hours );

--- a/tests/gates_test.cpp
+++ b/tests/gates_test.cpp
@@ -22,7 +22,7 @@ static const ter_str_id ter_t_window_no_curtains_open( "t_window_no_curtains_ope
 TEST_CASE( "doors_should_be_able_to_open_and_close", "[gates]" )
 {
     map &here = get_map();
-    clear_map();
+    clear_map_without_vision();
 
     tripoint_bub_ms pos = get_avatar().pos_bub() + point::east;
 
@@ -54,7 +54,7 @@ TEST_CASE( "doors_should_be_able_to_open_and_close", "[gates]" )
 TEST_CASE( "windows_should_be_able_to_open_and_close", "[gates]" )
 {
     map &here = get_map();
-    clear_map();
+    clear_map_without_vision();
 
     tripoint_bub_ms pos = get_avatar().pos_bub() + point::east;
 
@@ -82,7 +82,7 @@ TEST_CASE( "windows_should_be_able_to_open_and_close", "[gates]" )
 TEST_CASE( "doors_and_windows_should_make_whoosh_sound", "[gates]" )
 {
     map &here = get_map();
-    clear_map();
+    clear_map_without_vision();
     clear_avatar();
     sounds::reset_sounds();
 
@@ -152,7 +152,7 @@ TEST_CASE( "character_should_lose_moves_when_opening_or_closing_doors_or_windows
     map &here = get_map();
 
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
 
     tripoint_bub_ms pos = get_avatar().pos_bub() + point::east;
 

--- a/tests/iexamine_test.cpp
+++ b/tests/iexamine_test.cpp
@@ -21,7 +21,7 @@ TEST_CASE( "mapdata_examine" )
 
 TEST_CASE( "examine_bush" )
 {
-    clear_map();
+    clear_map_without_vision();
     map &m = get_map();
     const tripoint_bub_ms &pine_loc = tripoint_bub_ms::zero;
     const tripoint_bub_ms &elderberry_loc = pine_loc + tripoint::east;

--- a/tests/invlet_test.cpp
+++ b/tests/invlet_test.cpp
@@ -758,7 +758,7 @@ TEST_CASE( "Inventory_letter_test", "[.invlet]" )
     map &here = get_map();
     avatar &dummy = get_avatar();
     const tripoint_bub_ms spot( 60, 60, 0 );
-    clear_map();
+    clear_map_without_vision();
     dummy.setpos( here, spot );
     here.ter_set( spot, ter_id( "t_dirt" ) );
     here.furn_set( spot, furn_id( "f_null" ) );

--- a/tests/item_autopickup_test.cpp
+++ b/tests/item_autopickup_test.cpp
@@ -196,7 +196,7 @@ static void expect_to_find( const item &in, const std::list<const unique_item *>
 static void clear_everything()
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
 
     auto_pickup::player_settings &rules = get_auto_pickup();
     rules.clear_character_rules();

--- a/tests/item_contents_test.cpp
+++ b/tests/item_contents_test.cpp
@@ -32,7 +32,7 @@ TEST_CASE( "item_contents" )
 {
     map &here = get_map();
 
-    clear_map();
+    clear_map_without_vision();
     item tool_belt( itype_test_tool_belt );
 
     const units::volume tool_belt_vol = tool_belt.volume();
@@ -102,7 +102,7 @@ TEST_CASE( "item_contents" )
 
 TEST_CASE( "overflow_on_combine", "[item]" )
 {
-    clear_map();
+    clear_map_without_vision();
     tripoint_bub_ms origin{ 60, 60, 0 };
     item purse( itype_purse );
     item log( itype_log );
@@ -119,7 +119,7 @@ TEST_CASE( "overflow_on_combine", "[item]" )
 
 TEST_CASE( "overflow_test", "[item]" )
 {
-    clear_map();
+    clear_map_without_vision();
     tripoint_bub_ms origin{ 60, 60, 0 };
     item purse( itype_purse );
     item log( itype_log );
@@ -133,7 +133,7 @@ TEST_CASE( "overflow_test_into_parent_item", "[item]" )
 {
     map &here = get_map();
 
-    clear_map();
+    clear_map_without_vision();
     tripoint_bub_ms origin{ 60, 60, 0 };
     item jar( itype_jar_glass_sealed );
     item pickle( itype_pickle );

--- a/tests/item_location_test.cpp
+++ b/tests/item_location_test.cpp
@@ -24,7 +24,7 @@ static const itype_id itype_tshirt( "tshirt" );
 
 TEST_CASE( "item_location_can_maintain_reference_despite_item_removal", "[item][item_location]" )
 {
-    clear_map();
+    clear_map_without_vision();
     map &m = get_map();
     tripoint_bub_ms pos( 60, 60, 0 );
     m.i_clear( pos );
@@ -61,7 +61,7 @@ TEST_CASE( "item_location_can_maintain_reference_despite_item_removal", "[item][
 
 TEST_CASE( "item_location_doesnt_return_stale_map_item", "[item][item_location]" )
 {
-    clear_map();
+    clear_map_without_vision();
     map &m = get_map();
     tripoint_bub_ms pos( 60, 60, 0 );
     m.i_clear( pos );

--- a/tests/item_pickup_test.cpp
+++ b/tests/item_pickup_test.cpp
@@ -37,7 +37,7 @@ TEST_CASE( "putting_items_into_inventory_with_put_in_or_i_add", "[pickup][invent
     avatar &they = get_avatar();
     map &here = get_map();
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
 
     // Spawn items on the map at this location
     const tripoint_bub_ms ground = they.pos_bub();
@@ -150,7 +150,7 @@ TEST_CASE( "pickup_m4_with_a_rope_in_a_hiking_backpack", "[pickup][container]" )
     avatar &they = get_avatar();
     map &here = get_map();
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
 
     // Spawn items on the map at this location
     const tripoint_bub_ms ground = they.pos_bub();

--- a/tests/item_pocket_test.cpp
+++ b/tests/item_pocket_test.cpp
@@ -2400,7 +2400,7 @@ TEST_CASE( "picking_up_items_respects_pocket_autoinsert_settings", "[pocket][ite
 
 TEST_CASE( "multipocket_liquid_transfer_test", "[pocket][item][liquid]" )
 {
-    clear_map();
+    clear_map_without_vision();
     clear_avatar();
     map &m = get_map();
     Character &u = get_player_character();
@@ -2777,7 +2777,7 @@ TEST_CASE( "item_cannot_contain_contents_it_already_has", "[item][pocket]" )
 
     const tripoint_bub_ms ipos = get_player_character().pos_bub();
     map &m = get_map();
-    clear_map();
+    clear_map_without_vision();
 
     item_location backpack_loc( map_cursor( tripoint_bub_ms( ipos ) ), &m.add_item( ipos, backpack ) );
     item_location bottle_loc( backpack_loc, &backpack_loc->only_item() );
@@ -2848,7 +2848,7 @@ TEST_CASE( "bag_with_restrictions_and_nested_bag_does_not_fit_too_large_items", 
 TEST_CASE( "pocket_leak" )
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
     avatar &u = get_avatar();
     map &here = get_map();
     item backpack( itype_test_backpack );
@@ -2918,7 +2918,7 @@ TEST_CASE( "auto_whitelist", "[item][pocket][item_spawn]" )
     map &here = get_map();
 
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
     tripoint_abs_omt const this_omt =
         project_to<coords::omt>( get_avatar().pos_abs() );
     tripoint_bub_ms const this_bub = get_map().get_bub( project_to<coords::ms>( this_omt ) );
@@ -3033,7 +3033,7 @@ TEST_CASE( "pocket_mods", "[pocket][toolmod][gunmod]" )
 TEST_CASE( "unload_from_spillable_container", "[item][pocket]" )
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
     avatar &u = get_avatar();
     map &here = get_map();
     item pill( itype_tums ); // "antacid pill"

--- a/tests/item_spawn_test.cpp
+++ b/tests/item_spawn_test.cpp
@@ -61,7 +61,7 @@ TEST_CASE( "correct_amounts_of_an_item_spawn_inside_a_container", "[item_spawn]"
                             items = cs_data.recipe->create_results();
                             break;
                         case spawn_type::vehicle: {
-                            clear_map();
+                            clear_map_without_vision();
                             map &here = get_map();
                             const tripoint_bub_ms vehpos( 0, 0, here.get_abs_sub().z() );
                             vehicle *veh = here.add_vehicle( cs_data.vehicle, vehpos, 0_degrees, 0, 0 );
@@ -85,7 +85,7 @@ TEST_CASE( "correct_amounts_of_an_item_spawn_inside_a_container", "[item_spawn]"
                             break;
                         }
                         case spawn_type::map: {
-                            clear_map();
+                            clear_map_without_vision();
                             map &here = get_map();
                             here.spawn_item( tripoint_bub_ms::zero, cs_data.item, 1, cs_data.charges );
                             for( item &it : here.i_at( tripoint_bub_ms::zero ) ) {

--- a/tests/iuse_actor_test.cpp
+++ b/tests/iuse_actor_test.cpp
@@ -95,7 +95,7 @@ TEST_CASE( "manhack", "[iuse_actor][manhack]" )
 {
     clear_avatar();
     Character &player_character = get_avatar();
-    clear_map();
+    clear_map_without_vision();
 
     g->clear_zombies();
     item_location test_item = player_character.i_add( item( itype_bot_manhack, calendar::turn_zero,

--- a/tests/limb_test.cpp
+++ b/tests/limb_test.cpp
@@ -184,7 +184,7 @@ TEST_CASE( "Healing/mending_bonuses", "[character][limb]" )
 
 TEST_CASE( "drying_rate", "[character][limb]" )
 {
-    clear_map();
+    clear_map_without_vision();
     map &here = get_map();
     standard_npc dude( "Test NPC" );
     clear_character( dude, true );

--- a/tests/magic_spell_effect_test.cpp
+++ b/tests/magic_spell_effect_test.cpp
@@ -91,7 +91,7 @@ TEST_CASE( "remove_field_fd_fatigue", "[magic]" )
     // Test relies on lighting conditions, so ensure we control the level of
     // daylight.
     set_time( calendar::turn_zero );
-    clear_map();
+    clear_map_without_vision();
 
     map &m = get_map();
     spell sp( spell_AO_CLOSE_TEAR );
@@ -195,7 +195,7 @@ TEST_CASE( "remove_field_fd_fatigue", "[magic]" )
 
     // remove 3 fields again but without lighting this time
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
     Messages::clear_messages();
 
     player_initial_pos = dummy.pos_abs();

--- a/tests/magic_spell_test.cpp
+++ b/tests/magic_spell_test.cpp
@@ -691,7 +691,7 @@ TEST_CASE( "spell_effect_-_target_attack", "[magic][spell][effect][target_attack
 {
     // World setup
     map &here = get_map();
-    clear_map();
+    clear_map_without_vision();
 
     // Locations for avatar and monster
     const tripoint_bub_ms dummy_loc = { 60, 60, 0 };
@@ -748,7 +748,7 @@ TEST_CASE( "spell_effect_-_summon", "[magic][spell][effect][summon]" )
 {
     map &here = get_map();
 
-    clear_map();
+    clear_map_without_vision();
 
     // Avatar/spellcaster and summoned mummy locations
     const tripoint_bub_ms dummy_loc = { 60, 60, 0 };
@@ -820,7 +820,7 @@ TEST_CASE( "spell_effect_-_recover_energy", "[magic][spell][effect][recover_ener
     // Yer a wizard, ya dummy
     avatar &dummy = get_avatar();
     clear_character( dummy );
-    clear_map();
+    clear_map_without_vision();
 
     SECTION( "recover stamina" ) {
         spell_id montage_id( "test_spell_montage" );

--- a/tests/map_bash_test.cpp
+++ b/tests/map_bash_test.cpp
@@ -122,7 +122,7 @@ static void test_bash_set( const bash_test_set &set )
 
 TEST_CASE( "map_bash_chances", "[map][bash]" )
 {
-    clear_map();
+    clear_map_without_vision();
 
     for( const bash_test_set &set : test_data::bash_tests ) {
         test_bash_set( set );
@@ -135,7 +135,7 @@ static void test_bash_fields( const std::function<void( map &, const tripoint_bu
                               bool hit_field, field_type_str_id hit, int hit_intensity,
                               bool destroy_field, field_type_str_id destroy, int destroy_intensity )
 {
-    clear_map();
+    clear_map_without_vision();
     map &here = get_map();
 
     const tripoint_bub_ms pt_1( 30, 30, 0 );
@@ -334,7 +334,7 @@ TEST_CASE( "map_bash_create_fields", "[map][bash]" )
 
 TEST_CASE( "map_bash_ephemeral_persistence", "[map][bash]" )
 {
-    clear_map();
+    clear_map_without_vision();
     map &here = get_map();
 
     const tripoint_bub_ms test_pt( 40, 40, 0 );
@@ -456,7 +456,7 @@ static void shoot_at_terrain( std::function<void()> &setup, npc &shooter,
 
 TEST_CASE( "shooting_at_terrain", "[rng][map][bash][ranged]" )
 {
-    clear_map();
+    clear_map_without_vision();
 
     // Make a shooter
     standard_npc shooter( "Shooter", { 30, 30, 0 } );

--- a/tests/map_helpers.cpp
+++ b/tests/map_helpers.cpp
@@ -157,7 +157,6 @@ void clear_map_without_vision( int zmin, int zmax )
 
 void clear_map_with_vision( int zmin, int zmax, bool with_vision )
 {
-
     map &here = get_map();
     if( const tripoint_abs_sm &abs_sub = here.get_abs_sub(); abs_sub.z() != 0 ) {
         // Reset z level to 0

--- a/tests/map_path_test.cpp
+++ b/tests/map_path_test.cpp
@@ -82,7 +82,7 @@ static map &setup_map_without_obstacles()
 {
     const ter_id t_floor( "t_floor" );
     map &here = get_map();
-    clear_map();
+    clear_map_without_vision();
     const tripoint_bub_ms topleft = tripoint_bub_ms::zero;
     const tripoint_bub_ms bottomright { 20, 20, 0 };
     for( const tripoint_bub_ms &p : here.points_in_rectangle( topleft, bottomright ) ) {
@@ -184,7 +184,7 @@ TEST_CASE( "find_clear_path_with_adjacent_obstacles", "[map]" )
             expect_path( { nw, w_nw }, here.find_clear_path( p_center, w_nw ) );
         }
     }
-    clear_map();
+    clear_map_without_vision();
 }
 
 
@@ -289,7 +289,7 @@ TEST_CASE( "find_clear_path_5tiles_with_obstacles", "[map]" )
             CHECK( here.sees( target, source, -1 ) );
         }
     }
-    clear_map();
+    clear_map_without_vision();
 }
 
 
@@ -332,7 +332,7 @@ TEST_CASE( "map_route_player_without_obstacles", "[map][pathfinding]" )
             }
         }
     }
-    clear_map();
+    clear_map_without_vision();
 }
 
 TEST_CASE( "map_route_player_around_obstacles", "[map][pathfinding]" )
@@ -427,7 +427,7 @@ TEST_CASE( "map_route_player_around_obstacles", "[map][pathfinding]" )
             }
         }
     }
-    clear_map();
+    clear_map_without_vision();
 }
 
 TEST_CASE( "map_route_player_into_danger", "[map][pathfinding]" )
@@ -473,7 +473,7 @@ TEST_CASE( "map_route_player_into_danger", "[map][pathfinding]" )
             }
         }
     }
-    clear_map();
+    clear_map_without_vision();
 }
 
 TEST_CASE( "map_route_player_up_down_stairs", "[map][pathfinding]" )
@@ -531,7 +531,7 @@ TEST_CASE( "map_route_player_up_down_stairs", "[map][pathfinding]" )
             }
         }
     }
-    clear_map();
+    clear_map_without_vision();
 }
 
 TEST_CASE( "map_route_player_into_unreachable_tiles", "[map][pathfinding]" )
@@ -585,7 +585,7 @@ TEST_CASE( "map_route_player_into_unreachable_tiles", "[map][pathfinding]" )
             }
         }
     }
-    clear_map();
+    clear_map_without_vision();
 }
 
 TEST_CASE( "map_route_mon_around_danger", "[map][pathfinding]" )
@@ -645,5 +645,5 @@ TEST_CASE( "map_route_mon_around_danger", "[map][pathfinding]" )
             }
         }
     }
-    clear_map();
+    clear_map_without_vision();
 }

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -87,7 +87,7 @@ TEST_CASE( "map_coordinate_conversion_functions" )
 
 TEST_CASE( "destroy_grabbed_furniture" )
 {
-    clear_map();
+    clear_map_without_vision();
     avatar &player_character = get_avatar();
     GIVEN( "Furniture grabbed by the player" ) {
         const tripoint_bub_ms test_origin( 60, 60, 0 );
@@ -113,7 +113,7 @@ TEST_CASE( "map_bounds_checking" )
     // vehicles are stored in the global MAPBUFFER which all maps refer to.  To
     // work around the problem we clear the map of vehicles, but this is an
     // inelegant solution.
-    clear_map();
+    clear_map_without_vision();
     map m;
     tripoint_abs_sm point_away_from_real_map( get_map().get_abs_sub() + point( MAPSIZE_X, 0 ) );
     m.load( point_away_from_real_map, false );
@@ -139,7 +139,7 @@ TEST_CASE( "tinymap_bounds_checking" )
     // vehicles are stored in the global MAPBUFFER which all maps refer to.  To
     // work around the problem we clear the map of vehicles, but this is an
     // inelegant solution.
-    clear_map();
+    clear_map_without_vision();
     tinymap m;
     tripoint_abs_sm point_away_from_real_map( get_map().get_abs_sub() + point( MAPSIZE_X, 0 ) );
     m.load( project_to<coords::omt>( point_away_from_real_map + point::east ),
@@ -291,7 +291,7 @@ TEST_CASE( "milk_rotting", "[active_item][map]" )
 TEST_CASE( "active_monster_drops", "[active_item][map]" )
 {
     map &here = get_map();
-    clear_map();
+    clear_map_without_vision();
     get_avatar().setpos( here, tripoint_bub_ms::zero );
     tripoint_bub_ms start_loc = get_avatar().pos_bub( here ) + tripoint::east;
     restore_on_out_of_scope restore_temp(

--- a/tests/mapgen_place_vehicles_test.cpp
+++ b/tests/mapgen_place_vehicles_test.cpp
@@ -33,7 +33,7 @@ void nested_test( map &m, tripoint_abs_omt const &loc )
 TEST_CASE( "mapgen_place_vehicles" )
 {
     map &here = get_map();
-    clear_map();
+    clear_map_without_vision();
     clear_avatar();
     REQUIRE( here.get_vehicles().empty() );
     tripoint_abs_omt const this_test_omt = project_to<coords::omt>( get_avatar().pos_abs() );

--- a/tests/mapgen_remove_npcs_test.cpp
+++ b/tests/mapgen_remove_npcs_test.cpp
@@ -71,7 +71,7 @@ TEST_CASE( "mapgen_remove_npcs" )
 {
     GIVEN( "in bounds of main map" ) {
         map &here = get_map();
-        clear_map();
+        clear_map_without_vision();
         clear_avatar();
         tripoint_bub_ms const start_loc( HALF_MAPSIZE_X + SEEX - 2, HALF_MAPSIZE_Y + SEEY - 1, 0 );
         get_avatar().setpos( here, start_loc );

--- a/tests/mapgen_remove_vehicles_test.cpp
+++ b/tests/mapgen_remove_vehicles_test.cpp
@@ -98,7 +98,7 @@ TEST_CASE( "mapgen_remove_vehicles" )
     // this position should prevent pointless mapgen
     tripoint_bub_ms const start_loc( HALF_MAPSIZE_X + SEEX - 2, HALF_MAPSIZE_Y + SEEY - 1, 0 );
     get_avatar().setpos( here, start_loc );
-    clear_map();
+    clear_map_without_vision();
     REQUIRE( here.get_vehicles().empty() );
 
     vehicle *const veh =

--- a/tests/martial_art_test.cpp
+++ b/tests/martial_art_test.cpp
@@ -105,7 +105,7 @@ TEST_CASE( "Martial_art_required_weapon_categories", "[martial_arts]" )
 
 TEST_CASE( "Attack_vector_test", "[martial_arts][limb]" )
 {
-    clear_map();
+    clear_map_without_vision();
     standard_npc dude( "TestCharacter", dude_pos, {}, 0, 8, 8, 8, 8 );
     clear_character( dude );
     dude.martial_arts_data->add_martialart( test_style_ma1 );
@@ -167,7 +167,7 @@ TEST_CASE( "Attack_vector_test", "[martial_arts][limb]" )
 
 TEST_CASE( "Martial_art_technique_conditionals", "[martial_arts]" )
 {
-    clear_map();
+    clear_map_without_vision();
     standard_npc dude( "TestCharacter", dude_pos, {}, 0, 8, 8, 8, 8 );
     const tripoint_bub_ms target_1_pos = dude_pos + tripoint::east;
     const tripoint_bub_ms target_2_pos = dude_pos + tripoint::north;

--- a/tests/melee_dodge_hit_test.cpp
+++ b/tests/melee_dodge_hit_test.cpp
@@ -85,7 +85,7 @@ static float dodge_wearing_item( avatar &dummy, item &clothing )
 
 TEST_CASE( "monster_get_hit_base", "[monster][melee][hit]" )
 {
-    clear_map();
+    clear_map_without_vision();
 
     SECTION( "monster get_hit_base is equal to melee skill level" ) {
         monster zed( mon_zombie );
@@ -95,7 +95,7 @@ TEST_CASE( "monster_get_hit_base", "[monster][melee][hit]" )
 
 TEST_CASE( "Character_get_hit_base", "[character][melee][hit][dex]" )
 {
-    clear_map();
+    clear_map_without_vision();
 
     avatar &dummy = get_avatar();
     clear_character( dummy );
@@ -114,7 +114,7 @@ TEST_CASE( "Character_get_hit_base", "[character][melee][hit][dex]" )
 
 TEST_CASE( "monster_get_dodge_base", "[monster][melee][dodge]" )
 {
-    clear_map();
+    clear_map_without_vision();
 
     SECTION( "monster get_dodge_base is equal to dodge skill level" ) {
         monster smoker( mon_zombie_smoker );
@@ -124,7 +124,7 @@ TEST_CASE( "monster_get_dodge_base", "[monster][melee][dodge]" )
 
 TEST_CASE( "Character_get_dodge_base", "[character][melee][dodge][dex][skill]" )
 {
-    clear_map();
+    clear_map_without_vision();
 
     avatar &dummy = get_avatar();
     clear_character( dummy );
@@ -185,7 +185,7 @@ TEST_CASE( "Character_get_dodge_base", "[character][melee][dodge][dex][skill]" )
 
 TEST_CASE( "monster_get_dodge_with_effects", "[monster][melee][dodge][effect]" )
 {
-    clear_map();
+    clear_map_without_vision();
 
     monster zombie( mon_zombie_smoker );
 
@@ -216,7 +216,7 @@ TEST_CASE( "monster_get_dodge_with_effects", "[monster][melee][dodge][effect]" )
 
 TEST_CASE( "player_get_dodge", "[player][melee][dodge]" )
 {
-    clear_map();
+    clear_map_without_vision();
 
     avatar &dummy = get_avatar();
     clear_character( dummy );
@@ -239,7 +239,7 @@ TEST_CASE( "player_get_dodge", "[player][melee][dodge]" )
 
 TEST_CASE( "player_get_dodge_with_effects", "[player][melee][dodge][effect]" )
 {
-    clear_map();
+    clear_map_without_vision();
 
     avatar &dummy = get_avatar();
     clear_character( dummy );

--- a/tests/melee_test.cpp
+++ b/tests/melee_test.cpp
@@ -453,7 +453,7 @@ static void check_damage_from_test_fire( const std::vector<itype_id> &armor_item
 
 TEST_CASE( "Damage_type_effectiveness_vs_monster_resistance", "[melee][damage][eoc]" )
 {
-    clear_map();
+    clear_map_without_vision();
 
     SECTION( "Attacking a monster with no resistance to test_fire" ) {
         check_damage_from_test_fire( "mon_test_zombie", 0, false, 16.f );
@@ -489,7 +489,7 @@ TEST_CASE( "Damage_type_effectiveness_vs_monster_resistance", "[melee][damage][e
 
 TEST_CASE( "Damage_type_EOCs", "[damage][eoc]" )
 {
-    clear_map();
+    clear_map_without_vision();
 
     SECTION( "Attacking a monster" ) {
         check_eocs_from_test_fire( "mon_test_zombie_only_fire" );

--- a/tests/modify_morale_test.cpp
+++ b/tests/modify_morale_test.cpp
@@ -127,7 +127,7 @@ TEST_CASE( "food_enjoyability", "[food][modify_morale][fun]" )
 
 TEST_CASE( "dining_with_table_and_chair", "[food][modify_morale][table][chair]" )
 {
-    clear_map();
+    clear_map_without_vision();
     map &here = get_map();
     avatar dummy;
     dummy.set_body();

--- a/tests/monster_attack_test.cpp
+++ b/tests/monster_attack_test.cpp
@@ -117,7 +117,7 @@ static void monster_attack_zlevel( const std::string &title, const tripoint &off
                                    const std::string &monster_ter, const std::string &target_ter,
                                    const bool ledge, const bool expected_vertical, const bool expected_adjacent )
 {
-    clear_map();
+    clear_map_without_vision();
     map &here = get_map();
 
     SECTION( title ) {
@@ -147,7 +147,7 @@ static void monster_attack_zlevel( const std::string &title, const tripoint &off
 
 TEST_CASE( "monster_attack", "[vision][reachability]" )
 {
-    clear_map();
+    clear_map_without_vision();
     restore_on_out_of_scope restore_calendar_turn( calendar::turn );
     calendar::turn = daylight_time( calendar::turn ) + 2_hours;
     scoped_weather_override weather_clear( WEATHER_CLEAR );
@@ -156,7 +156,7 @@ TEST_CASE( "monster_attack", "[vision][reachability]" )
         for( const tripoint &offset : eight_horizontal_neighbors ) {
             test_monster_attack( offset, true, true );
         }
-        clear_map();
+        clear_map_without_vision();
         // Too far away cannot.
         test_monster_attack( { 2, 2, 0 }, false, true );
         test_monster_attack( { 2, 1, 0 }, false, true );
@@ -194,7 +194,7 @@ TEST_CASE( "monster_attack", "[vision][reachability]" )
 TEST_CASE( "monster_throwing_sanity_test", "[throwing],[balance]" )
 {
     std::array<float, 6> expected_average_damage_at_range = { 0, 0, 8.5, 6.5, 5, 3.25 };
-    clear_map();
+    clear_map_without_vision();
     map &here = get_map();
     restore_on_out_of_scope restore_calendar_turn( calendar::turn );
     calendar::turn = sunrise( calendar::turn );
@@ -257,7 +257,7 @@ TEST_CASE( "monster_throwing_sanity_test", "[throwing],[balance]" )
 TEST_CASE( "Mattack_dialog_condition_test", "[mattack]" )
 {
     map &here = get_map();
-    clear_map();
+    clear_map_without_vision();
     clear_creatures();
     const tripoint_bub_ms target_location = attacker_location + tripoint::east;
     Character &you = get_player_character();
@@ -305,7 +305,7 @@ TEST_CASE( "Targeted_grab_removal_test", "[mattack][grab]" )
     const tripoint_bub_ms target_location = attacker_location + tripoint::east;
     const tripoint_bub_ms attacker_location_e = target_location + tripoint::east;
 
-    clear_map();
+    clear_map_without_vision();
     clear_creatures();
     Character &you = get_player_character();
     clear_avatar();
@@ -344,7 +344,7 @@ TEST_CASE( "Ranged_pull_tests", "[mattack][grab]" )
 
     // Set up further from the target
     const tripoint_bub_ms target_location = attacker_location + tripoint{ 4, 0, 0 };
-    clear_map();
+    clear_map_without_vision();
     restore_on_out_of_scope restore_calendar_turn( calendar::turn );
     calendar::turn = daylight_time( calendar::turn ) + 2_hours;
     scoped_weather_override weather_clear( WEATHER_CLEAR );
@@ -418,7 +418,7 @@ TEST_CASE( "Grab_drag_tests", "[mattack][grab][drag]" )
 {
     map &here = get_map();
     const tripoint_bub_ms target_location = attacker_location + tripoint::east;
-    clear_map();
+    clear_map_without_vision();
     clear_creatures();
     Character &you = get_player_character();
     clear_avatar();
@@ -461,7 +461,7 @@ TEST_CASE( "Unified_grab_break_test", "[mattack][grab]" )
     bool lategame = false;
     int expected_success;
 
-    clear_map();
+    clear_map_without_vision();
     clear_creatures();
     Character &you = get_player_character();
     clear_avatar();

--- a/tests/monster_test.cpp
+++ b/tests/monster_test.cpp
@@ -127,7 +127,7 @@ static std::ostream &operator<<( std::ostream &os, const std::vector<track> &vec
 static int can_catch_player( const std::string &monster_type, const tripoint &direction_of_flight )
 {
     map &here = get_map();
-    clear_map();
+    clear_map_without_vision();
     REQUIRE( g->num_creatures() == 1 ); // the player
     Character &test_player = get_player_character();
     // Strip off any potentially encumbering clothing.
@@ -185,11 +185,11 @@ static int can_catch_player( const std::string &monster_type, const tripoint &di
                                } );
             if( rl_dist( test_monster.pos_bub(), test_player.pos_bub() ) == 1 ) {
                 INFO( tracker );
-                clear_map();
+                clear_map_without_vision();
                 return turn;
             } else if( rl_dist( test_monster.pos_bub(), test_player.pos_bub() ) > 20 ) {
                 INFO( tracker );
-                clear_map();
+                clear_map_without_vision();
                 return -turn;
             }
         }
@@ -656,7 +656,7 @@ TEST_CASE( "limit_mod_size_bonus", "[monster]" )
 
 TEST_CASE( "monsters_spawn_eggs", "[monster][reproduction]" )
 {
-    clear_map();
+    clear_map_without_vision();
     map &here = get_map();
     g->place_player( { 66, 66, 0 } );
     tripoint_bub_ms loc = get_avatar().pos_bub() + tripoint::east;
@@ -679,7 +679,7 @@ TEST_CASE( "monsters_spawn_eggs", "[monster][reproduction]" )
 
 TEST_CASE( "monsters_spawn_egg_itemgroups", "[monster][reproduction]" )
 {
-    clear_map();
+    clear_map_without_vision();
     map &here = get_map();
     g->place_player( { 66, 66, 0 } );
     tripoint_bub_ms loc = get_avatar().pos_bub() + tripoint::east;
@@ -702,7 +702,7 @@ TEST_CASE( "monsters_spawn_egg_itemgroups", "[monster][reproduction]" )
 
 TEST_CASE( "monsters_spawn_babies", "[monster][reproduction]" )
 {
-    clear_map();
+    clear_map_without_vision();
     creature_tracker &creatures = get_creature_tracker();
     g->place_player( { 66, 66, 0 } );
     tripoint_bub_ms loc = get_avatar().pos_bub() + tripoint::east;
@@ -726,7 +726,7 @@ TEST_CASE( "monsters_spawn_babies", "[monster][reproduction]" )
 
 TEST_CASE( "monsters_spawn_baby_groups", "[monster][reproduction]" )
 {
-    clear_map();
+    clear_map_without_vision();
     creature_tracker &creatures = get_creature_tracker();
     g->place_player( { 66, 66, 0 } );
     tripoint_bub_ms loc = get_avatar().pos_bub() + tripoint::east;
@@ -885,7 +885,7 @@ TEST_CASE( "monster_can_navigate_from_overmap_to_reality_bubble_following_sound"
 
 TEST_CASE( "monster_moved_to_overmap_after_map_shift", "[monster][hordes]" )
 {
-    clear_map();
+    clear_map_without_vision();
     map &here = get_map();
     // Place character in the central submap of map.
     tripoint_bub_ms player_start_pos{ 11 * 6, 11 * 6, 0 };
@@ -1118,7 +1118,7 @@ TEST_CASE( "monsters_appear_on_map_as_expected", "[monster][map][hordes]" )
 
 TEST_CASE( "obstacles_placed_on_map_are_present_in_overmap", "[map][hordes]" )
 {
-    clear_map();
+    clear_map_without_vision();
     map &here = get_map();
     tripoint_bub_ms player_start_pos{ 11 * 6, 11 * 6, 0 };
     Character &test_player = get_player_character();
@@ -1181,7 +1181,7 @@ TEST_CASE( "obstacles_placed_on_map_are_present_in_overmap", "[map][hordes]" )
 
 TEST_CASE( "dormant_zombie_places_corpse_and_trap", "[monster][map]" )
 {
-    clear_map();
+    clear_map_without_vision();
     map &here = get_map();
     tripoint_bub_ms player_start_pos{ 11 * 6, 11 * 6, 0 };
     Character &test_player = get_player_character();

--- a/tests/move_cost_test.cpp
+++ b/tests/move_cost_test.cpp
@@ -78,7 +78,7 @@ TEST_CASE( "footwear_may_affect_movement_cost", "[move_cost][shoes]" )
     avatar &ava = get_avatar();
     map &here = get_map();
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
 
     // Ensure expected base modifiers
     REQUIRE( ava.get_modifier( character_modifier_limb_run_cost_mod ) == 1 );
@@ -231,7 +231,7 @@ TEST_CASE( "Crawl_score_effects_on_movement_cost", "[move_cost]" )
     GIVEN( "Character is uninjured and unencumbered" ) {
         avatar &u = get_avatar();
         clear_avatar();
-        clear_map();
+        clear_map_without_vision();
         u.wear_item( item( itype_sneakers ) );
         u.set_moves( 0 );
 

--- a/tests/npc_behavior_rules_test.cpp
+++ b/tests/npc_behavior_rules_test.cpp
@@ -40,7 +40,7 @@ static shared_ptr_fast<npc> setup_generic_rules_test( ally_rule rule_to_test,
         update_mapgen_id update_mapgen_id_to_apply )
 {
     map &here = get_map();
-    clear_map();
+    clear_map_without_vision();
     clear_vehicles();
     clear_avatar();
     Character &player = get_player_character();

--- a/tests/npc_talk_test.cpp
+++ b/tests/npc_talk_test.cpp
@@ -150,7 +150,7 @@ static npc &prep_test( dialogue &d, bool shopkeep = false )
     map &here = get_map();
     clear_avatar();
     clear_vehicles();
-    clear_map();
+    clear_map_without_vision();
     avatar &player_character = get_avatar();
     player_character.set_value( "test_var", "It's avatar" );
     player_character.name = "Alpha Avatar";

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -368,7 +368,7 @@ TEST_CASE( "npc-board-player-vehicle" )
         GIVEN( given.first ) {
             npc_boarding_test_data &data = given.second;
             g->place_player( data.player_pos );
-            clear_map();
+            clear_map_without_vision();
             map &here = get_map();
             Character &pc = get_player_character();
 
@@ -456,7 +456,7 @@ TEST_CASE( "npc-movement" )
 
     g->place_player( { 60, 60, 0 } );
 
-    clear_map();
+    clear_map_without_vision();
 
     creature_tracker &creatures = get_creature_tracker();
     Character &player_character = get_player_character();
@@ -575,7 +575,7 @@ TEST_CASE( "npc_can_target_player" )
 {
     g->faction_manager_ptr->create_if_needed();
 
-    clear_map();
+    clear_map_without_vision();
     clear_avatar();
     set_time_to_day();
 
@@ -603,7 +603,7 @@ TEST_CASE( "npc_uses_guns", "[npc_ai]" )
 {
     g->faction_manager_ptr->create_if_needed();
 
-    clear_map();
+    clear_map_without_vision();
     clear_avatar();
     set_time_to_day();
 
@@ -643,7 +643,7 @@ TEST_CASE( "npc_prefers_guns", "[npc_ai]" )
 {
     g->faction_manager_ptr->create_if_needed();
 
-    clear_map();
+    clear_map_without_vision();
     clear_avatar();
     set_time_to_day();
 

--- a/tests/player_activities_test.cpp
+++ b/tests/player_activities_test.cpp
@@ -212,7 +212,7 @@ TEST_CASE( "safecracking", "[activity][safecracking]" )
     SECTION( "safecracking tools test" ) {
         map &here = get_map();
         clear_avatar();
-        clear_map();
+        clear_map_without_vision();
 
         tripoint_bub_ms safe;
         dummy.setpos( here, safe + tripoint::east );
@@ -315,7 +315,7 @@ TEST_CASE( "safecracking", "[activity][safecracking]" )
         };
 
         clear_avatar();
-        clear_map();
+        clear_map_without_vision();
 
         tripoint_bub_ms safe;
         dummy.setpos( here, safe + tripoint::east );
@@ -355,7 +355,7 @@ TEST_CASE( "shearing", "[activity][shearing][animals]" )
 {
     avatar &dummy = get_avatar();
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
 
     auto test_monster = [&dummy]( bool mon_shearable ) -> monster & {
         monster *mon;
@@ -377,7 +377,7 @@ TEST_CASE( "shearing", "[activity][shearing][animals]" )
 
         GIVEN( "player without shearing quality" ) {
             clear_avatar();
-            clear_map();
+            clear_map_without_vision();
             monster &mon = test_monster( true );
 
             REQUIRE( dummy.max_quality( qual_SHEAR ) <= 0 );
@@ -391,7 +391,7 @@ TEST_CASE( "shearing", "[activity][shearing][animals]" )
 
         GIVEN( "a tool with shearing quality one" ) {
             clear_avatar();
-            clear_map();
+            clear_map_without_vision();
             monster &mon = test_monster( true );
 
             dummy.i_add( item( itype_test_shears ) );
@@ -408,7 +408,7 @@ TEST_CASE( "shearing", "[activity][shearing][animals]" )
 
         GIVEN( "an electric tool with shearing quality three" ) {
             clear_avatar();
-            clear_map();
+            clear_map_without_vision();
             monster &mon = test_monster( true );
 
             item battery( itype_test_battery_disposable );
@@ -436,7 +436,7 @@ TEST_CASE( "shearing", "[activity][shearing][animals]" )
 
         GIVEN( "a non shearable animal" ) {
             clear_avatar();
-            clear_map();
+            clear_map_without_vision();
             monster &mon = test_monster( false );
 
             dummy.i_add( item( itype_test_shears ) );
@@ -456,7 +456,7 @@ TEST_CASE( "shearing", "[activity][shearing][animals]" )
             map &here = get_map();
 
             clear_avatar();
-            clear_map();
+            clear_map_without_vision();
             monster &mon = test_monster( true );
 
             item battery( itype_test_battery_disposable );
@@ -507,7 +507,7 @@ TEST_CASE( "shearing", "[activity][shearing][animals]" )
         GIVEN( "a shearable monster" ) {
 
             clear_avatar();
-            clear_map();
+            clear_map_without_vision();
             monster &mon = test_monster( true );
 
             dummy.i_add( item( itype_test_shears ) );
@@ -559,7 +559,7 @@ TEST_CASE( "shearing", "[activity][shearing][animals]" )
 
         GIVEN( "an previously tied shearable monster" ) {
             clear_avatar();
-            clear_map();
+            clear_map_without_vision();
             monster &mon = test_monster( true );
 
             dummy.i_add( item( itype_test_shears ) );
@@ -580,7 +580,7 @@ TEST_CASE( "shearing", "[activity][shearing][animals]" )
 
         GIVEN( "a previously untied shearable monster" ) {
             clear_avatar();
-            clear_map();
+            clear_map_without_vision();
             monster &mon = test_monster( true );
 
             dummy.i_add( item( itype_test_shears ) );
@@ -623,7 +623,7 @@ TEST_CASE( "boltcut", "[activity][boltcut]" )
 
     SECTION( "boltcut start checks" ) {
         GIVEN( "a tripoint with nothing" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             mp.ter_set( tripoint_bub_ms::zero, ter_str_id::NULL_ID() );
@@ -638,7 +638,7 @@ TEST_CASE( "boltcut", "[activity][boltcut]" )
         }
 
         GIVEN( "a tripoint with invalid terrain" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             mp.ter_set( tripoint_bub_ms::zero, ter_t_dirt );
@@ -653,7 +653,7 @@ TEST_CASE( "boltcut", "[activity][boltcut]" )
         }
 
         GIVEN( "a tripoint with valid terrain" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             mp.ter_set( tripoint_bub_ms::zero, ter_test_t_boltcut1 );
@@ -668,7 +668,7 @@ TEST_CASE( "boltcut", "[activity][boltcut]" )
         }
 
         GIVEN( "a tripoint with valid furniture" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             mp.furn_set( tripoint_bub_ms::zero, furn_test_f_boltcut1 );
@@ -683,7 +683,7 @@ TEST_CASE( "boltcut", "[activity][boltcut]" )
         }
 
         GIVEN( "a tripoint with valid terrain" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             mp.ter_set( tripoint_bub_ms::zero, ter_test_t_boltcut1 );
@@ -702,7 +702,7 @@ TEST_CASE( "boltcut", "[activity][boltcut]" )
         }
 
         GIVEN( "a tripoint with valid furniture" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             mp.furn_set( tripoint_bub_ms::zero, furn_test_f_boltcut1 );
@@ -723,7 +723,7 @@ TEST_CASE( "boltcut", "[activity][boltcut]" )
 
     SECTION( "boltcut turn checks" ) {
         GIVEN( "player is in mid activity" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             mp.furn_set( tripoint_bub_ms::zero, furn_test_f_boltcut3 );
@@ -764,7 +764,7 @@ TEST_CASE( "boltcut", "[activity][boltcut]" )
 
     SECTION( "boltcut finish checks" ) {
         GIVEN( "a tripoint with valid terrain" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             mp.ter_set( tripoint_bub_ms::zero, ter_test_t_boltcut1 );
@@ -783,7 +783,7 @@ TEST_CASE( "boltcut", "[activity][boltcut]" )
         }
 
         GIVEN( "a tripoint with valid furniture" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             mp.furn_set( tripoint_bub_ms::zero, furn_test_f_boltcut1 );
@@ -802,7 +802,7 @@ TEST_CASE( "boltcut", "[activity][boltcut]" )
         }
 
         GIVEN( "a tripoint with valid furniture" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             mp.furn_set( tripoint_bub_ms::zero, furn_test_f_boltcut2 );
@@ -821,7 +821,7 @@ TEST_CASE( "boltcut", "[activity][boltcut]" )
         }
 
         GIVEN( "a tripoint with a valid furniture with byproducts" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             mp.ter_set( tripoint_bub_ms::zero, ter_test_t_boltcut2 );
@@ -887,7 +887,7 @@ TEST_CASE( "hacksaw", "[activity][hacksaw]" )
 
     SECTION( "hacksaw start checks" ) {
         GIVEN( "a tripoint with nothing" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             mp.ter_set( tripoint_bub_ms::zero, ter_str_id::NULL_ID() );
@@ -902,7 +902,7 @@ TEST_CASE( "hacksaw", "[activity][hacksaw]" )
         }
 
         GIVEN( "a tripoint with invalid terrain" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             mp.ter_set( tripoint_bub_ms::zero, ter_t_dirt );
@@ -917,7 +917,7 @@ TEST_CASE( "hacksaw", "[activity][hacksaw]" )
         }
 
         GIVEN( "a tripoint with valid terrain" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             mp.ter_set( tripoint_bub_ms::zero, ter_test_t_hacksaw1 );
@@ -932,7 +932,7 @@ TEST_CASE( "hacksaw", "[activity][hacksaw]" )
         }
 
         GIVEN( "a tripoint with valid furniture" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             mp.furn_set( tripoint_bub_ms::zero, furn_test_f_hacksaw1 );
@@ -947,7 +947,7 @@ TEST_CASE( "hacksaw", "[activity][hacksaw]" )
         }
 
         GIVEN( "a tripoint with valid terrain" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             mp.ter_set( tripoint_bub_ms::zero, ter_test_t_hacksaw1 );
@@ -966,7 +966,7 @@ TEST_CASE( "hacksaw", "[activity][hacksaw]" )
         }
 
         GIVEN( "a tripoint with valid furniture" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             mp.furn_set( tripoint_bub_ms::zero, furn_test_f_hacksaw1 );
@@ -987,7 +987,7 @@ TEST_CASE( "hacksaw", "[activity][hacksaw]" )
 
     SECTION( "hacksaw turn checks" ) {
         GIVEN( "player is in mid activity" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             mp.furn_set( tripoint_bub_ms::zero, furn_test_f_hacksaw3 );
@@ -1029,7 +1029,7 @@ TEST_CASE( "hacksaw", "[activity][hacksaw]" )
 
     SECTION( "hacksaw finish checks" ) {
         GIVEN( "a tripoint with valid terrain" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             mp.ter_set( tripoint_bub_ms::zero, ter_test_t_hacksaw1 );
@@ -1048,7 +1048,7 @@ TEST_CASE( "hacksaw", "[activity][hacksaw]" )
         }
 
         GIVEN( "a tripoint with valid furniture" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             mp.furn_set( tripoint_bub_ms::zero, furn_test_f_hacksaw1 );
@@ -1067,7 +1067,7 @@ TEST_CASE( "hacksaw", "[activity][hacksaw]" )
         }
 
         GIVEN( "a tripoint with valid furniture" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             mp.furn_set( tripoint_bub_ms::zero, furn_test_f_hacksaw2 );
@@ -1086,7 +1086,7 @@ TEST_CASE( "hacksaw", "[activity][hacksaw]" )
         }
 
         GIVEN( "a tripoint with a valid furniture with byproducts" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             mp.ter_set( tripoint_bub_ms::zero, ter_test_t_hacksaw2 );
@@ -1153,7 +1153,7 @@ TEST_CASE( "oxytorch", "[activity][oxytorch]" )
 
     SECTION( "oxytorch start checks" ) {
         GIVEN( "a tripoint with nothing" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             mp.ter_set( tripoint_bub_ms::zero, ter_str_id::NULL_ID() );
@@ -1168,7 +1168,7 @@ TEST_CASE( "oxytorch", "[activity][oxytorch]" )
         }
 
         GIVEN( "a tripoint with invalid terrain" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             mp.ter_set( tripoint_bub_ms::zero, ter_t_dirt );
@@ -1183,7 +1183,7 @@ TEST_CASE( "oxytorch", "[activity][oxytorch]" )
         }
 
         GIVEN( "a tripoint with valid terrain" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             mp.ter_set( tripoint_bub_ms::zero, ter_test_t_oxytorch1 );
@@ -1198,7 +1198,7 @@ TEST_CASE( "oxytorch", "[activity][oxytorch]" )
         }
 
         GIVEN( "a tripoint with valid furniture" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             mp.furn_set( tripoint_bub_ms::zero, furn_test_f_oxytorch1 );
@@ -1213,7 +1213,7 @@ TEST_CASE( "oxytorch", "[activity][oxytorch]" )
         }
 
         GIVEN( "a tripoint with valid terrain" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             mp.ter_set( tripoint_bub_ms::zero, ter_test_t_oxytorch1 );
@@ -1232,7 +1232,7 @@ TEST_CASE( "oxytorch", "[activity][oxytorch]" )
         }
 
         GIVEN( "a tripoint with valid furniture" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             mp.furn_set( tripoint_bub_ms::zero, furn_test_f_oxytorch1 );
@@ -1253,7 +1253,7 @@ TEST_CASE( "oxytorch", "[activity][oxytorch]" )
 
     SECTION( "oxytorch turn checks" ) {
         GIVEN( "player is in mid activity" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             mp.furn_set( tripoint_bub_ms::zero, furn_test_f_oxytorch3 );
@@ -1284,7 +1284,7 @@ TEST_CASE( "oxytorch", "[activity][oxytorch]" )
 
     SECTION( "oxytorch finish checks" ) {
         GIVEN( "a tripoint with valid terrain" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             mp.ter_set( tripoint_bub_ms::zero, ter_test_t_oxytorch1 );
@@ -1303,7 +1303,7 @@ TEST_CASE( "oxytorch", "[activity][oxytorch]" )
         }
 
         GIVEN( "a tripoint with valid furniture" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             mp.furn_set( tripoint_bub_ms::zero, furn_test_f_oxytorch1 );
@@ -1322,7 +1322,7 @@ TEST_CASE( "oxytorch", "[activity][oxytorch]" )
         }
 
         GIVEN( "a tripoint with valid furniture" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             mp.furn_set( tripoint_bub_ms::zero, furn_test_f_oxytorch2 );
@@ -1341,7 +1341,7 @@ TEST_CASE( "oxytorch", "[activity][oxytorch]" )
         }
 
         GIVEN( "a tripoint with a valid furniture with byproducts" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             mp.ter_set( tripoint_bub_ms::zero, ter_test_t_oxytorch2 );
@@ -1417,7 +1417,7 @@ TEST_CASE( "prying", "[activity][prying]" )
 
     SECTION( "prying time tests" ) {
         GIVEN( "a furniture with prying_nails and duration set to 17 seconds " ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             item_location prying_tool = setup_dummy( true );
@@ -1432,7 +1432,7 @@ TEST_CASE( "prying", "[activity][prying]" )
         }
 
         GIVEN( "a terrain without prying_nails" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             item_location prying_tool = setup_dummy( true );
@@ -1450,7 +1450,7 @@ TEST_CASE( "prying", "[activity][prying]" )
 
     SECTION( "prying start checks" ) {
         GIVEN( "a tripoint with nothing" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             mp.ter_set( tripoint_bub_ms::zero, ter_str_id::NULL_ID() );
@@ -1465,7 +1465,7 @@ TEST_CASE( "prying", "[activity][prying]" )
         }
 
         GIVEN( "a tripoint with invalid terrain" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             mp.ter_set( tripoint_bub_ms::zero, ter_t_dirt );
@@ -1480,7 +1480,7 @@ TEST_CASE( "prying", "[activity][prying]" )
         }
 
         GIVEN( "a tripoint with valid terrain" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             mp.ter_set( tripoint_bub_ms::zero, ter_test_t_prying1 );
@@ -1495,7 +1495,7 @@ TEST_CASE( "prying", "[activity][prying]" )
         }
 
         GIVEN( "a tripoint with valid furniture" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             mp.furn_set( tripoint_bub_ms::zero, furn_test_f_prying1 );
@@ -1510,7 +1510,7 @@ TEST_CASE( "prying", "[activity][prying]" )
         }
 
         GIVEN( "a tripoint with valid terrain" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             mp.ter_set( tripoint_bub_ms::zero, ter_test_t_prying1 );
@@ -1529,7 +1529,7 @@ TEST_CASE( "prying", "[activity][prying]" )
         }
 
         GIVEN( "a tripoint with valid furniture" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             mp.furn_set( tripoint_bub_ms::zero, furn_test_f_prying1 );
@@ -1550,7 +1550,7 @@ TEST_CASE( "prying", "[activity][prying]" )
 
     SECTION( "prying finish checks with prying_nails" ) {
         GIVEN( "a tripoint with valid terrain" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             mp.ter_set( tripoint_bub_ms::zero, ter_test_t_prying1 );
@@ -1569,7 +1569,7 @@ TEST_CASE( "prying", "[activity][prying]" )
         }
 
         GIVEN( "a tripoint with valid furniture" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             mp.furn_set( tripoint_bub_ms::zero, furn_test_f_prying1 );
@@ -1590,7 +1590,7 @@ TEST_CASE( "prying", "[activity][prying]" )
 
     SECTION( "prying finish checks without prying_nails" ) {
         GIVEN( "a tripoint with valid impossible to pry open terrain" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             mp.ter_set( tripoint_bub_ms::zero, ter_test_t_prying2 );
@@ -1609,7 +1609,7 @@ TEST_CASE( "prying", "[activity][prying]" )
         }
 
         GIVEN( "a tripoint with valid terrain with a tool that always opens it" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             mp.ter_set( tripoint_bub_ms::zero, ter_test_t_prying2 );
@@ -1628,7 +1628,7 @@ TEST_CASE( "prying", "[activity][prying]" )
         }
 
         GIVEN( "a tripoint with valid terrain that will break" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             const tripoint_bub_ms terrain_pos = dummy.pos_bub() + tripoint::north;
@@ -1664,7 +1664,7 @@ TEST_CASE( "prying", "[activity][prying]" )
         }
 
         GIVEN( "a tripoint with a valid terrain with byproducts" ) {
-            clear_map();
+            clear_map_without_vision();
             clear_avatar();
 
             mp.ter_set( tripoint_bub_ms::zero, ter_test_t_prying1 );
@@ -1730,7 +1730,7 @@ TEST_CASE( "edevice", "[activity][edevice]" )
 {
     avatar dummy;
     dummy.set_skill_level( skill_computer, 1 );
-    clear_map();
+    clear_map_without_vision();
     std::vector<item_location> edevice_locs;
     std::vector<item_location> efile_locs;
     std::vector<item_location> copiable_efile_locs;
@@ -2005,7 +2005,7 @@ static const std::vector<std::function<player_activity()>> test_activities {
 static void cleanup( avatar &dummy )
 {
     dummy.inv->clear();
-    clear_map();
+    clear_map_without_vision();
 
     REQUIRE( dummy.activity.get_distractions().empty() );
     REQUIRE( !dummy.activity.is_distraction_ignored( distraction_type::hostile_spotted_near ) );
@@ -2028,7 +2028,7 @@ static void update_cache( map &m )
 TEST_CASE( "activity_interruption_by_distractions", "[activity][interruption]" )
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
     set_time_to_day();
     scoped_weather_override clear_weather( WEATHER_CLEAR );
     avatar &dummy = get_avatar();

--- a/tests/projectile_test.cpp
+++ b/tests/projectile_test.cpp
@@ -52,7 +52,7 @@ static tripoint_bub_ms projectile_end_point( const std::vector<tripoint_bub_ms> 
 
 TEST_CASE( "projectiles_through_obstacles", "[projectile]" )
 {
-    clear_map();
+    clear_map_without_vision();
     map &here = get_map();
     creature_tracker &creatures = get_creature_tracker();
 
@@ -95,7 +95,7 @@ static npc &liquid_projectiles_setup( Character &player )
 {
     clear_avatar();
     clear_npcs();
-    clear_map();
+    clear_map_without_vision();
 
     arm_shooter( player, itype_boomer_head );
     const tripoint_bub_ms next_to = player.adjacent_tile();

--- a/tests/pulping_test.cpp
+++ b/tests/pulping_test.cpp
@@ -22,7 +22,7 @@ static const itype_id itype_debug_backpack( "debug_backpack" );
 
 TEST_CASE( "monster_pulping_test" )
 {
-    clear_map();
+    clear_map_without_vision();
     Character &you = get_player_character();
     for( const pulp_test_data &test : test_data::pulp_test ) {
         clear_character( you );

--- a/tests/ranged_balance_test.cpp
+++ b/tests/ranged_balance_test.cpp
@@ -290,7 +290,7 @@ static constexpr tripoint_bub_ms shooter_pos( 60, 60, 0 );
 // The gun used for the test is the easiest for players to find.
 TEST_CASE( "unskilled_shooter_accuracy", "[ranged] [balance] [slow]" )
 {
-    clear_map();
+    clear_map_without_vision();
     standard_npc shooter( "Shooter", shooter_pos, {}, 0, 8, 8, 8, 7 );
     shooter.set_body();
     shooter.worn.wear_item( shooter, item( itype_backpack ), false, false );
@@ -332,7 +332,7 @@ TEST_CASE( "unskilled_shooter_accuracy", "[ranged] [balance] [slow]" )
 // To simulate players who already have sufficient proficiency and equipment
 TEST_CASE( "competent_shooter_accuracy", "[ranged] [balance]" )
 {
-    clear_map();
+    clear_map_without_vision();
     standard_npc shooter( "Shooter", shooter_pos, {}, 5, 10, 10, 10, 10 );
     shooter.set_body();
     equip_shooter( shooter, { itype_cloak_wool, itype_footrags_wool, itype_gloves_wraps_fur, itype_glasses_safety, itype_balclava } );
@@ -378,7 +378,7 @@ TEST_CASE( "competent_shooter_accuracy", "[ranged] [balance]" )
 // To simulate hero
 TEST_CASE( "expert_shooter_accuracy", "[ranged] [balance]" )
 {
-    clear_map();
+    clear_map_without_vision();
     standard_npc shooter( "Shooter", shooter_pos, {}, 10, 20, 20, 20, 20 );
     shooter.set_body();
     equip_shooter( shooter, { } );
@@ -497,7 +497,7 @@ static void shoot_monster( const itype_id &gun_type, const std::vector<itype_id>
                            const std::function<bool ( const standard_npc &, const monster & )> &other_checks = nullptr )
 {
     map &here = get_map();
-    clear_map();
+    clear_map_without_vision();
     statistics<int> damage;
     constexpr tripoint_bub_ms shooter_pos{ 60, 60, 0 };
     const tripoint_bub_ms monster_pos = shooter_pos + ( point::east * range );
@@ -537,7 +537,7 @@ static void shoot_monster( const itype_id &gun_type, const std::vector<itype_id>
 
 TEST_CASE( "shot_features", "[gun]" "[slow]" )
 {
-    clear_map();
+    clear_map_without_vision();
     // BIRDSHOT
     // Unarmored target
     // Minor damage at range.
@@ -656,7 +656,7 @@ TEST_CASE( "shot_features_with_choke", "[gun]" "[slow]" )
 
 TEST_CASE( "shot_custom_damage_type", "[gun]" "[slow]" )
 {
-    clear_map();
+    clear_map_without_vision();
     auto check_eocs = []( const standard_npc & src, const monster & tgt ) {
         return src.get_value( "general_dmg_type_test_test_fire" ) == "source" &&
                tgt.get_value( "general_dmg_type_test_test_fire" ) == "target";

--- a/tests/reading_test.cpp
+++ b/tests/reading_test.cpp
@@ -314,7 +314,7 @@ TEST_CASE( "estimated_reading_time_for_a_book", "[reading][book][time]" )
 TEST_CASE( "reasons_for_not_being_able_to_read", "[reading][reasons]" )
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
     Character &dummy = get_avatar();
     dummy.set_body();
     dummy.worn.wear_item( dummy, item( itype_backpack ), false, false );

--- a/tests/reload_time_test.cpp
+++ b/tests/reload_time_test.cpp
@@ -39,7 +39,7 @@ static void check_reload_time( const itype_id &weapon, const itype_id &ammo,
 
     const tripoint_bub_ms test_origin( 60, 60, 0 );
     const tripoint_bub_ms spot( 61, 60, 0 );
-    clear_map();
+    clear_map_without_vision();
     avatar &shooter = get_avatar();
     g->place_critter_at( pseudo_debug_mon, spot );
     shooter.setpos( here, test_origin );

--- a/tests/reloading_test.cpp
+++ b/tests/reloading_test.cpp
@@ -1134,7 +1134,7 @@ TEST_CASE( "reload_liquid_container", "[reload],[liquid]" )
 {
     Character &dummy = get_avatar();
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
     item backpack( itype_bigback );
     dummy.wear_item( backpack );
     item canteen( itype_2lcanteen );

--- a/tests/throwing_test.cpp
+++ b/tests/throwing_test.cpp
@@ -174,7 +174,7 @@ static constexpr throw_test_pstats hi_skill_athlete_stats = { MAX_SKILL, 12, 12,
 TEST_CASE( "basic_throwing_sanity_tests", "[throwing],[balance]" )
 {
     avatar &p = get_avatar();
-    clear_map();
+    clear_map_without_vision();
 
     SECTION( "test_player_vs_zombie_rock_basestats" ) {
         test_throwing_player_versus( p, "mon_zombie", itype_rock, 1, lo_skill_base_stats, { 0.78, 0.10 }, { 5, 3 } );
@@ -219,7 +219,7 @@ TEST_CASE( "basic_throwing_sanity_tests", "[throwing],[balance]" )
 TEST_CASE( "throwing_skill_impact_test", "[throwing],[balance]" )
 {
     avatar &p = get_avatar();
-    clear_map();
+    clear_map_without_vision();
 
     // we already cover low stats in the sanity tests and we only cover a few
     // ranges here because what we're really trying to capture is the effect
@@ -307,7 +307,7 @@ static void test_player_kills_monster(
 TEST_CASE( "player_kills_zombie_before_reach", "[throwing],[balance][scenario]" )
 {
     avatar &p = get_avatar();
-    clear_map();
+    clear_map_without_vision();
 
     SECTION( "test_player_kills_zombie_with_rock_basestats" ) {
         test_player_kills_monster( p, "mon_zombie", itype_rock, 15, 1, lo_skill_base_stats, 500 );

--- a/tests/uncraft_test.cpp
+++ b/tests/uncraft_test.cpp
@@ -37,7 +37,7 @@ static Character &setup_uncraft_character()
 {
     Character &they = get_player_character();
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
     set_time( midday );
     // Backpack for storage, and multi-tool for qualities
     they.worn.wear_item( they, item( itype_debug_backpack ), false, false );
@@ -66,7 +66,7 @@ static std::map<itype_id, int> repeat_uncraft( Character &they, const itype_id &
         it_dis_loc = they.create_in_progress_disassembly( it );
 
         // Clear away bits
-        clear_map();
+        clear_map_without_vision();
         // Get lit
         set_time( midday );
         // Disassemble it

--- a/tests/unload_naked_test.cpp
+++ b/tests/unload_naked_test.cpp
@@ -22,7 +22,7 @@ static const itype_id itype_sw629( "sw629" );
 TEST_CASE( "unload_revolver_naked_one_bullet", "[unload][nonmagzine]" )
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
 
     Character &dummy = get_player_character();
     avatar &player_character = get_avatar();
@@ -57,7 +57,7 @@ TEST_CASE( "unload_revolver_naked_one_bullet", "[unload][nonmagzine]" )
 TEST_CASE( "unload_revolver_naked_fully_loaded", "[unload][nonmagzine]" )
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
 
     Character &dummy = get_player_character();
     avatar &player_character = get_avatar();

--- a/tests/unseal_and_spill_test.cpp
+++ b/tests/unseal_and_spill_test.cpp
@@ -296,7 +296,7 @@ void match( item_location loc, const final_result &result )
 void test_scenario::run()
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
 
     const container_location cur_container_loc = value.get<container_location>();
     const scenario cur_scenario = value.get<scenario>();

--- a/tests/vehicle_export_test.cpp
+++ b/tests/vehicle_export_test.cpp
@@ -29,7 +29,7 @@ static bool operator==( const vehicle_item_spawn &l, const vehicle_item_spawn &r
 
 TEST_CASE( "export_vehicle_test" )
 {
-    clear_map();
+    clear_map_without_vision();
     map &here = get_map();
     // Spawn the vehicle with fuel.
     vehicle *veh_ptr = get_map().add_vehicle( vehicle_prototype_veh_export_test, tripoint_bub_ms::zero,

--- a/tests/vehicle_fake_part_test.cpp
+++ b/tests/vehicle_fake_part_test.cpp
@@ -28,9 +28,9 @@ static const vproto_id vehicle_prototype_schoolbus( "schoolbus" );
 static const vproto_id vehicle_prototype_suv( "suv" );
 static const vproto_id vehicle_prototype_test_van( "test_van" );
 
-static void really_clear_map()
+static void really_clear_map_without_vision()
 {
-    clear_map();
+    clear_map_without_vision();
     build_test_map( ter_id( "t_pavement" ) );
 }
 
@@ -80,7 +80,7 @@ TEST_CASE( "ensure_fake_parts_enable_on_place", "[vehicle] [vehicle_fake]" )
             for( int sub_angle = 0; sub_angle < std::round( 90_degrees / vehicles::steer_increment );
                  sub_angle += 1 )  {
                 const units::angle angle = quadrant * 90_degrees + sub_angle * vehicles::steer_increment;
-                really_clear_map();
+                really_clear_map_without_vision();
                 map &here = get_map();
 
                 vehicle *veh = here.add_vehicle( vehicle_prototype_test_van, test_origin, angle, 100, 0 );
@@ -110,7 +110,7 @@ TEST_CASE( "ensure_fake_parts_enable_on_turn", "[vehicle] [vehicle_fake]" )
     std::vector<int> active_fakes_by_angle = { 0, 3, 8, 15, 6, 1 };
 
     GIVEN( "A vehicle with a known number of parts" ) {
-        really_clear_map();
+        really_clear_map_without_vision();
         map &here = get_map();
         const tripoint_bub_ms test_origin( 30, 30, 0 );
         vehicle *veh = here.add_vehicle( vehicle_prototype_test_van, test_origin, 0_degrees, 100, 0 );
@@ -168,7 +168,7 @@ TEST_CASE( "ensure_fake_parts_enable_on_turn", "[vehicle] [vehicle_fake]" )
 TEST_CASE( "ensure_vehicle_weight_is_constant", "[vehicle] [vehicle_fake]" )
 {
     clear_avatar();
-    really_clear_map();
+    really_clear_map_without_vision();
     const tripoint_bub_ms test_origin( 30, 30, 0 );
     map &here = get_map();
     vehicle *veh = here.add_vehicle( vehicle_prototype_suv, test_origin, 0_degrees, 0, 0 );
@@ -196,7 +196,7 @@ TEST_CASE( "ensure_vehicle_weight_is_constant", "[vehicle] [vehicle_fake]" )
 TEST_CASE( "vehicle_collision_applies_damage_to_fake_parent", "[vehicle] [vehicle_fake]" )
 {
     clear_avatar();
-    really_clear_map();
+    really_clear_map_without_vision();
     map &here = get_map();
     GIVEN( "A moving vehicle traveling at a 45 degree angle to the X axis" ) {
         const tripoint_bub_ms test_origin( 30, 30, 0 );
@@ -255,7 +255,7 @@ TEST_CASE( "vehicle_collision_applies_damage_to_fake_parent", "[vehicle] [vehicl
 TEST_CASE( "vehicle_to_vehicle_collision", "[vehicle] [vehicle_fake]" )
 {
     clear_avatar();
-    really_clear_map();
+    really_clear_map_without_vision();
     map &here = get_map();
     GIVEN( "A moving vehicle traveling at a 30 degree angle to the X axis" ) {
         const tripoint_bub_ms test_origin( 30, 30, 0 );
@@ -312,7 +312,7 @@ TEST_CASE( "vehicle_to_vehicle_collision", "[vehicle] [vehicle_fake]" )
 TEST_CASE( "ensure_vehicle_with_no_obstacles_has_no_fake_parts", "[vehicle] [vehicle_fake]" )
 {
     clear_avatar();
-    really_clear_map();
+    really_clear_map_without_vision();
     map &here = get_map();
     GIVEN( "A vehicle with no parts that block movement" ) {
         const tripoint_bub_ms test_origin( 30, 30, 0 );
@@ -329,7 +329,7 @@ TEST_CASE( "ensure_vehicle_with_no_obstacles_has_no_fake_parts", "[vehicle] [veh
 TEST_CASE( "vehicle_with_fake_obstacle_parts_block_movement", "[vehicle][vehicle_fake]" )
 {
     clear_avatar();
-    really_clear_map();
+    really_clear_map_without_vision();
     map &here = get_map();
     Character &you = get_player_character();
     const tripoint_bub_ms test_origin( 30, 30, 0 );
@@ -352,7 +352,7 @@ TEST_CASE( "vehicle_with_fake_obstacle_parts_block_movement", "[vehicle][vehicle
 
 TEST_CASE( "fake_parts_are_opaque", "[vehicle][vehicle_fake]" )
 {
-    really_clear_map();
+    really_clear_map_without_vision();
     Character &you = get_player_character();
     clear_avatar();
     const tripoint_bub_ms test_origin = you.pos_bub() + point( 6, 2 );
@@ -369,7 +369,7 @@ TEST_CASE( "fake_parts_are_opaque", "[vehicle][vehicle_fake]" )
 
 TEST_CASE( "open_and_close_fake_doors", "[vehicle][vehicle_fake]" )
 {
-    really_clear_map();
+    really_clear_map_without_vision();
     Character &you = get_player_character();
     clear_avatar();
     const tripoint_bub_ms test_origin = you.pos_bub() + point( 3, 0 );

--- a/tests/vehicle_interact_test.cpp
+++ b/tests/vehicle_interact_test.cpp
@@ -46,7 +46,7 @@ static void test_repair( const std::vector<item> &tools, bool plug_in_tools, boo
 {
     map &here = get_map();
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
 
     const tripoint_bub_ms test_origin( 60, 60, 0 );
     Character &player_character = get_player_character();

--- a/tests/vehicle_part_test.cpp
+++ b/tests/vehicle_part_test.cpp
@@ -126,7 +126,7 @@ static void test_craft_via_rig( const std::vector<item> &items, int give_battery
 {
     map &here = get_map();
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
     clear_vehicles();
     set_time_to_day();
 
@@ -205,7 +205,7 @@ static void test_craft_via_rig( const std::vector<item> &items, int give_battery
 TEST_CASE( "faucet_offers_cold_water", "[vehicle][vehicle_parts]" )
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
     clear_vehicles();
     set_time( midday );
     map &here = get_map();

--- a/tests/vehicle_power_test.cpp
+++ b/tests/vehicle_power_test.cpp
@@ -283,7 +283,7 @@ TEST_CASE( "Daily_solar_power", "[vehicle][power]" )
 
 TEST_CASE( "maximum_reverse_velocity", "[vehicle][power][reverse]" )
 {
-    clear_map();
+    clear_map_without_vision();
     reset_player();
     build_test_map( ter_id( "t_pavement" ) );
     clear_vehicles();

--- a/tests/vehicle_ramp_test.cpp
+++ b/tests/vehicle_ramp_test.cpp
@@ -33,7 +33,7 @@ static void clear_game_and_set_ramp( const int transit_x, bool use_ramp, bool up
 {
     // Set to turn 0 to prevent solars from producing power
     calendar::turn = calendar::turn_zero;
-    clear_map();
+    clear_map_without_vision();
     clear_vehicles();
 
     Character &player_character = get_player_character();

--- a/tests/vehicle_split_test.cpp
+++ b/tests/vehicle_split_test.cpp
@@ -111,7 +111,7 @@ TEST_CASE( "crater_crash", "[vehicle]" )
 
 TEST_CASE( "split_vehicle_during_mapgen", "[vehicle]" )
 {
-    clear_map();
+    clear_map_without_vision();
     map &here = get_map();
     clear_vehicles();
     REQUIRE( here.get_vehicles().empty() );

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -72,7 +72,7 @@ static const vproto_id vehicle_prototype_wheelchair( "wheelchair" );
 
 TEST_CASE( "detaching_vehicle_unboards_passengers", "[vehicle]" )
 {
-    clear_map();
+    clear_map_without_vision();
     const tripoint_bub_ms test_origin( 60, 60, 0 );
     const tripoint_bub_ms vehicle_origin = test_origin;
     map &here = get_map();
@@ -114,7 +114,7 @@ TEST_CASE( "destroy_grabbed_vehicle_section", "[vehicle]" )
 TEST_CASE( "add_item_to_broken_vehicle_part", "[vehicle]" )
 {
     map &here = get_map();
-    clear_map();
+    clear_map_without_vision();
     const tripoint_bub_ms test_origin( 60, 60, 0 );
     const tripoint_bub_ms vehicle_origin = test_origin;
     vehicle *veh_ptr = here.add_vehicle( vehicle_prototype_bicycle, vehicle_origin, 0_degrees,
@@ -137,7 +137,7 @@ TEST_CASE( "add_item_to_broken_vehicle_part", "[vehicle]" )
 
 TEST_CASE( "starting_bicycle_damaged_pedal", "[vehicle]" )
 {
-    clear_map();
+    clear_map_without_vision();
     const tripoint_bub_ms test_origin( 60, 60, 0 );
     const tripoint_bub_ms vehicle_origin = test_origin;
     map &here = get_map();
@@ -210,7 +210,7 @@ static void unfold_and_check( const vehicle_preset &veh_preset, const damage_pre
     Character &u = get_player_character();
 
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
     clear_vehicles( &m );
 
     u.worn.wear_item( u, item( itype_debug_backpack ), false, false );
@@ -350,7 +350,7 @@ static void check_folded_item_to_parts_damage_transfer( const folded_item_damage
     // only the part damage is pseudo-random spread, while total damage should
     // round trip well in integers
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
 
     map &m = get_map();
     Character &u = get_player_character();
@@ -473,7 +473,7 @@ static void connect_power_line( const tripoint_bub_ms &src_pos, const tripoint_b
 
 TEST_CASE( "power_cable_stretch_disconnect" )
 {
-    clear_map();
+    clear_map_without_vision();
     clear_avatar();
     map &m = get_map();
     Character &player_character = get_player_character();
@@ -611,7 +611,7 @@ static void rack_check( const rack_preset &preset )
     Character &u = get_player_character();
 
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
     clear_vehicles( &m );
 
     std::vector<vehicle *> vehs;
@@ -773,7 +773,7 @@ TEST_CASE( "Racking_and_unracking_tests", "[vehicle][bikerack]" )
 static int test_autopilot_moving( const vproto_id &veh_id, const vpart_id &extra_part )
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
     map &here = get_map();
     Character &player_character = get_player_character();
     // Move player somewhere safe
@@ -825,7 +825,7 @@ TEST_CASE( "autopilot_tests", "[vehicle][autopilot]" )
 TEST_CASE( "vehicle_enchantments", "[vehicle][enchantments]" )
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
     map &here = get_map();
     Character &player_character = get_player_character();
     // Move player somewhere safe
@@ -861,7 +861,7 @@ TEST_CASE( "vehicle_enchantments", "[vehicle][enchantments]" )
 TEST_CASE( "vehicle_effects", "[vehicle][effects]" )
 {
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
     map &here = get_map();
     Character &player_character = get_player_character();
     // Move player somewhere safe
@@ -938,7 +938,7 @@ static void run_squish_test( const std::map<itype_id, double> &to_squish,
 
 TEST_CASE( "vehicle_wheels_damaged_by_running_over_items", "[vehicle]" )
 {
-    clear_map();
+    clear_map_without_vision();
     map &here = get_map();
     const tripoint_bub_ms test_point( 60, 60, 0 );
     REQUIRE( !here.veh_at( test_point ) );

--- a/tests/vision_test.cpp
+++ b/tests/vision_test.cpp
@@ -162,7 +162,8 @@ struct vision_test_case {
         player_character.clear_bionics();
         player_character.clear_mutations(); // remove mutations that potentially affect vision
         player_character.clear_moncams();
-        clear_map( -2, OVERMAP_HEIGHT );
+        clear_map_without_vision( -2,
+                                  OVERMAP_HEIGHT ); // without_vision just skips updating map memory which we don't test here.
         g->reset_light_level();
         scoped_weather_override weather_clear( WEATHER_CLEAR );
 

--- a/tests/visitable_remove_test.cpp
+++ b/tests/visitable_remove_test.cpp
@@ -62,7 +62,7 @@ TEST_CASE( "visitable_remove", "[visitable]" )
     Character &p = get_player_character();
     p.worn.wear_item( p, item( itype_backpack ), false, false );
     p.wear_item( item( itype_backpack ) ); // so we don't drop anything
-    clear_map();
+    clear_map_without_vision();
     map &here = get_map();
 
     // check if all tiles within radius are loaded within current submap and passable

--- a/tests/visitable_zone_test.cpp
+++ b/tests/visitable_zone_test.cpp
@@ -82,7 +82,7 @@ static constexpr tripoint_rel_ms cave_offset{ building_width, building_width, 0 
 TEST_CASE( "visitable_zone_surface_test" )
 {
     map &here = get_map();
-    clear_map();
+    clear_map_without_vision();
 
     std::string mon_type = "mon_zombie";
     std::vector<monster *> monsters;

--- a/tests/widget_test.cpp
+++ b/tests/widget_test.cpp
@@ -964,7 +964,7 @@ TEST_CASE( "widgets_showing_Sun_and_Moon_position", "[widget]" )
     widget sundial_w = widget_test_sundial_text.obj();
 
     avatar &ava = get_avatar();
-    clear_map();
+    clear_map_without_vision();
     clear_avatar();
     const tripoint_abs_ms orig_pos = ava.pos_abs();
 
@@ -1673,7 +1673,7 @@ TEST_CASE( "moon_and_lighting_widgets", "[widget]" )
 
     avatar &ava = get_avatar();
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
 
     set_time( calendar::turn_zero );
     CHECK( w_light.layout( ava ) == "LIGHTING: <color_c_black_white>very dark</color>" );
@@ -1717,7 +1717,7 @@ TEST_CASE( "compass_widget", "[widget][compass]" )
     const tripoint_bub_ms north = ava.pos_bub() + tripoint( 0, -15, 0 );
 
     SECTION( "No monsters" ) {
-        clear_map();
+        clear_map_without_vision();
         set_time( calendar::turn_zero + 12_hours );
         g->mon_info_update();
         CHECK( c5s_N.layout( ava, sidebar_width ) ==
@@ -1732,7 +1732,7 @@ TEST_CASE( "compass_widget", "[widget][compass]" )
     }
 
     SECTION( "1 monster NE" ) {
-        clear_map();
+        clear_map_without_vision();
         set_time( calendar::turn_zero + 12_hours );
         monster &mon1 = spawn_test_monster( "mon_test_CBM", northeast );
         g->mon_info_update();
@@ -1754,7 +1754,7 @@ TEST_CASE( "compass_widget", "[widget][compass]" )
     }
 
     SECTION( "1 monster N" ) {
-        clear_map();
+        clear_map_without_vision();
         set_time( calendar::turn_zero + 12_hours );
         monster &mon1 = spawn_test_monster( "mon_test_CBM", north );
         g->mon_info_update();
@@ -1776,7 +1776,7 @@ TEST_CASE( "compass_widget", "[widget][compass]" )
     }
 
     SECTION( "3 same monsters N" ) {
-        clear_map();
+        clear_map_without_vision();
         set_time( calendar::turn_zero + 12_hours );
         monster &mon1 = spawn_test_monster( "mon_test_CBM", north );
         //NOLINTNEXTLINE(cata-use-named-point-constants)
@@ -1803,7 +1803,7 @@ TEST_CASE( "compass_widget", "[widget][compass]" )
     }
 
     SECTION( "3 different monsters N" ) {
-        clear_map();
+        clear_map_without_vision();
         set_time( calendar::turn_zero + 12_hours );
         monster &mon1 = spawn_test_monster( "mon_test_CBM", north );
         //NOLINTNEXTLINE(cata-use-named-point-constants)
@@ -2007,7 +2007,7 @@ TEST_CASE( "multi-line_overmap_text_widget", "[widget][overmap]" )
     // Use mission target to invalidate the om cache
     msn.set_target( ava.pos_abs_omt() + tripoint( 5, 0, 0 ) );
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
     ava.on_mission_assignment( msn );
 
     // Mission marker is a red asterisk when it's along the border
@@ -2136,7 +2136,7 @@ TEST_CASE( "Dynamic_height_for_multiline_widgets", "[widget]" )
     const tripoint_bub_ms north = ava.pos_bub() + tripoint( 0, -15, 0 );
 
     SECTION( "No monsters (0 lines, bumped to 1 line when drawing)" ) {
-        clear_map();
+        clear_map_without_vision();
         set_time( calendar::turn_zero + 12_hours );
         g->mon_info_update();
         CHECK( c5s_legend3.layout( ava, sidebar_width ).empty() );
@@ -2144,7 +2144,7 @@ TEST_CASE( "Dynamic_height_for_multiline_widgets", "[widget]" )
     }
 
     SECTION( "1 monster N (1 line)" ) {
-        clear_map();
+        clear_map_without_vision();
         set_time( calendar::turn_zero + 12_hours );
         monster &mon1 = spawn_test_monster( "mon_test_CBM", north );
         g->mon_info_update();
@@ -2157,7 +2157,7 @@ TEST_CASE( "Dynamic_height_for_multiline_widgets", "[widget]" )
     }
 
     SECTION( "2 different monsters N (2 lines)" ) {
-        clear_map();
+        clear_map_without_vision();
         set_time( calendar::turn_zero + 12_hours );
         monster &mon1 = spawn_test_monster( "mon_test_CBM", north );
         //NOLINTNEXTLINE(cata-use-named-point-constants)
@@ -2174,7 +2174,7 @@ TEST_CASE( "Dynamic_height_for_multiline_widgets", "[widget]" )
     }
 
     SECTION( "3 different monsters N (3 lines)" ) {
-        clear_map();
+        clear_map_without_vision();
         set_time( calendar::turn_zero + 12_hours );
         monster &mon1 = spawn_test_monster( "mon_test_CBM", north );
         //NOLINTNEXTLINE(cata-use-named-point-constants)
@@ -2701,7 +2701,7 @@ TEST_CASE( "widget_rows_in_columns", "[widget]" )
 {
     avatar &ava = get_avatar();
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
     // Setup overmap
     fill_overmap_area( ava, oter_id( "field" ) );
     ava.reset_all_missions();
@@ -2863,7 +2863,7 @@ TEST_CASE( "W_NO_PADDING_widget_flag", "[widget]" )
 {
     avatar &ava = get_avatar();
     clear_avatar();
-    clear_map();
+    clear_map_without_vision();
     ava.reset_all_missions();
     ava.set_focus( 100 );
     ava.movecounter = 0;

--- a/tests/wield_test.cpp
+++ b/tests/wield_test.cpp
@@ -72,7 +72,7 @@ static void wield_check_from_ground( avatar &guy, const itype_id &item_name,
 
 TEST_CASE( "Wield_test", "[wield]" )
 {
-    clear_map();
+    clear_map_without_vision();
     item knife_hunting( itype_knife_hunting );
     item knife_combat( itype_knife_combat );
     item sheath( itype_sheath );
@@ -366,7 +366,7 @@ TEST_CASE( "Wield_test", "[wield]" )
 
 TEST_CASE( "Wield_time_test", "[wield]" )
 {
-    clear_map();
+    clear_map_without_vision();
 
     SECTION( "A knife in a sheath in cargo pants in a plastic bag in a backpack" ) {
         item backpack( itype_backpack );

--- a/tests/zones_custom_test.cpp
+++ b/tests/zones_custom_test.cpp
@@ -28,7 +28,7 @@ using pset = std::unordered_set<tripoint_abs_ms>;
 TEST_CASE( "zones_custom", "[zones]" )
 {
     WHEN( "overlapping custom zones" ) {
-        clear_map();
+        clear_map_without_vision();
         map &m = get_map();
         tripoint_abs_ms const zone_loc = m.get_abs( tripoint_bub_ms{ 5, 5, 0 } );
         tripoint_abs_ms const zone_hammer_end = zone_loc + tripoint::north;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Performance "Even faster tests with less map memory manipulation"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Turns out all the tests pass even if you don't clear map memory ever.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Rewrite all `clear_map()` calls to `clear_map_without_memory()`. Audit the remaining places which pass explicit z levels to clear and rewrite them manually to the same.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
CI. Whole test suite is even faster still now.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
