### PR TITLE
Clothing damage from unarmed attacks considers sturdiness

### DIFF
--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -287,7 +287,7 @@ bool Character::handle_melee_wear( item_location shield, float wear_multiplier )
     }
 
     // If the item is an armor that covers many body parts, it also takes less damage (ex. sturdy work coveralls)
-    damage_chance *= std::max( 1,  *shield.get_covered_body_parts().count() );
+    damage_chance *= std::max( 1,  &shield.get_covered_body_parts().count() );
 
     if( damage_chance > 0 && !one_in( damage_chance ) ) {
         return false;

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -287,7 +287,7 @@ bool Character::handle_melee_wear( item_location shield, float wear_multiplier )
     }
 
     // If the item is an armor that covers many body parts, it also takes less damage (ex. sturdy work coveralls)
-    damage_chance *= std::max( 1,  shield.get_covered_body_parts().count() );
+    damage_chance *= std::max( 1,  *shield.get_covered_body_parts().count() );
 
     if( damage_chance > 0 && !one_in( damage_chance ) ) {
         return false;

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -281,8 +281,14 @@ bool Character::handle_melee_wear( item_location shield, float wear_multiplier )
                                             ( wear_multiplier * enchant_multiplier ) ) );
     // DURABLE_MELEE items are made to hit stuff and they do it well, so they're considered to be a lot tougher
     // than other weapons made of the same materials.
-    if( shield->has_flag( flag_DURABLE_MELEE ) ) {
+    // Sturdy armor (such as a pair of steel gauntlets) are considered durable too.
+    if( shield->has_flag( flag_DURABLE_MELEE ) || shield->has_flag( flag_STURDY ) ) {
         damage_chance *= 4;
+    }
+
+    // If the item is an armor that covers many body parts, it also takes less damage (ex. sturdy work coveralls)
+    if( shield->get_covered_body_parts() ) {
+        damage_chance *= std::max( 1, shield->get_covered_body_parts()->count() );
     }
 
     if( damage_chance > 0 && !one_in( damage_chance ) ) {

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -287,7 +287,7 @@ bool Character::handle_melee_wear( item_location shield, float wear_multiplier )
     }
 
     // If the item is an armor that covers many body parts, it also takes less damage (ex. sturdy work coveralls)
-    damage_chance *= std::max( 1,  shield->get_item()->get_covered_body_parts() != nullptr );
+    damage_chance *= std::max( 1,  shield.get_covered_body_parts().count() );
 
     if( damage_chance > 0 && !one_in( damage_chance ) ) {
         return false;

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -287,8 +287,8 @@ bool Character::handle_melee_wear( item_location shield, float wear_multiplier )
     }
 
     // If the item is an armor that covers many body parts, it also takes less damage (ex. sturdy work coveralls)
-    if( shield->get_covered_body_parts() ) {
-        damage_chance *= std::max( 1, shield->get_covered_body_parts()->count() );
+    if( shield->get_covered_body_parts() != NULL ) {
+        damage_chance *= std::max( 1, shield->get_covered_body_parts().count() );
     }
 
     if( damage_chance > 0 && !one_in( damage_chance ) ) {

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -287,9 +287,7 @@ bool Character::handle_melee_wear( item_location shield, float wear_multiplier )
     }
 
     // If the item is an armor that covers many body parts, it also takes less damage (ex. sturdy work coveralls)
-    if( shield->get_covered_body_parts() != NULL ) {
-        damage_chance *= std::max( 1, shield->get_covered_body_parts().count() );
-    }
+    damage_chance *= std::max( 1,  shield->get_item()->get_covered_body_parts() != nullptr );
 
     if( damage_chance > 0 && !one_in( damage_chance ) ) {
         return false;

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -286,9 +286,6 @@ bool Character::handle_melee_wear( item_location shield, float wear_multiplier )
         damage_chance *= 4;
     }
 
-    // If the item is an armor that covers many body parts, it also takes less damage (ex. sturdy work coveralls)
-    damage_chance *= std::max( 1,  &shield.get_covered_body_parts().count() );
-
     if( damage_chance > 0 && !one_in( damage_chance ) ) {
         return false;
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Balance "Clothing is subject to more considerations when sustaining damage from unarmed attacks"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Clothing was damaged way too fast by unarmed, in part because the damage system treats the clothing like you are wielding it as a bludgeon, and not considering various aspects of the clothing that would reduce such damage.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
1. Treat "STURDY" as "DURABLE_MELEE". There really isn't any case where something that is designed to absorb a lot of damage from being attacked, also wouldn't in turn be less fragile when being used to deal damage.
2. Consider the coverage of armor when sustaining damage. When armor is attacked, its damage chance is reduced according to the number of body parts it covers (so a tank top takes damage about 5x more often than a jumpsuit when struck, because the jumpsuit will be hit almost 5x as often). Apply the same logic to armor being used offensively. Kneeing an enemy with your jumpsuit should not damage the integrity of the entire jumpsuit, but due to the hardcoded limitations of armor, the way around this is to make it happen far less often.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
#### Describe alternatives you've considered
Reduce the base damage that armor is damaged regardless of factors too. IDK. The system feels fine when you are just using a pair of brass knuckles, so the baseline is probably OK.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
