### PR TITLE
Fix multi-activity backlog not clearing

### DIFF
--- a/data/json/player_activities.json
+++ b/data/json/player_activities.json
@@ -49,7 +49,6 @@
     "activity_level": "NO_EXERCISE",
     "verb": "constructing",
     "based_on": "neither",
-    "can_resume": false,
     "multi_activity": true,
     "fetch_items_to_zone": false,
     "auto_needs": true
@@ -60,7 +59,6 @@
     "activity_level": "EXTRA_EXERCISE",
     "verb": "mining",
     "based_on": "neither",
-    "can_resume": false,
     "multi_activity": true
   },
   {
@@ -69,7 +67,6 @@
     "activity_level": "NO_EXERCISE",
     "verb": "mopping",
     "based_on": "neither",
-    "can_resume": false,
     "multi_activity": true
   },
   {
@@ -88,7 +85,6 @@
     "activity_level": "NO_EXERCISE",
     "verb": "studying",
     "based_on": "neither",
-    "can_resume": false,
     "multi_activity": true,
     "auto_needs": true
   },
@@ -105,7 +101,6 @@
     "activity_level": "BRISK_EXERCISE",
     "verb": "deconstructing a vehicle",
     "based_on": "neither",
-    "can_resume": false,
     "multi_activity": true
   },
   {
@@ -132,7 +127,6 @@
     "activity_level": "MODERATE_EXERCISE",
     "verb": "repairing a vehicle",
     "based_on": "neither",
-    "can_resume": false,
     "multi_activity": true
   },
   {
@@ -171,7 +165,6 @@
     "activity_level": "EXTRA_EXERCISE",
     "verb": "chopping logs",
     "based_on": "neither",
-    "can_resume": false,
     "multi_activity": true,
     "auto_needs": true
   },
@@ -191,7 +184,6 @@
     "activity_level": "MODERATE_EXERCISE",
     "verb": "disassembling things",
     "based_on": "neither",
-    "can_resume": false,
     "multi_activity": true,
     "fetch_items_to_zone": false,
     "auto_needs": true
@@ -202,7 +194,6 @@
     "activity_level": "MODERATE_EXERCISE",
     "verb": "butchering",
     "based_on": "neither",
-    "can_resume": false,
     "multi_activity": true,
     "auto_needs": true
   },
@@ -212,7 +203,6 @@
     "activity_level": "EXTRA_EXERCISE",
     "verb": "chopping trees",
     "based_on": "neither",
-    "can_resume": false,
     "multi_activity": true,
     "auto_needs": true
   },
@@ -524,8 +514,7 @@
     "type": "activity_type",
     "activity_level": "MODERATE_EXERCISE",
     "verb": "fetching components",
-    "based_on": "neither",
-    "can_resume": false
+    "based_on": "neither"
   },
   {
     "id": "ACT_MULTIPLE_FARM",
@@ -533,7 +522,6 @@
     "activity_level": "BRISK_EXERCISE",
     "verb": "farming",
     "based_on": "neither",
-    "can_resume": false,
     "multi_activity": true,
     "auto_needs": true
   },

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -109,7 +109,6 @@ bool activity_handlers::resume_for_multi_activities( Character &you )
         player_activity &back_act = you.backlog.front();
         if( back_act.is_multi_type() ) {
             you.assign_activity( back_act );
-            you.backlog.pop_front();
             return true;
         }
     }

--- a/tests/act_build_test.cpp
+++ b/tests/act_build_test.cpp
@@ -127,6 +127,8 @@ construction get_construction( std::string const &name )
 construction setup_testcase( Character &u, std::string const &constr,
                              tripoint_bub_ms const &build_loc, tripoint_bub_ms const &loot_loc )
 {
+    u.backlog.clear();
+    u.cancel_activity();
     construction build = get_construction( constr );
 
     zone_manager &zmgr = zone_manager::get_manager();


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Fix multi-activity backlog not clearing"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fix a bug I found while making #85193: multi-activities aren't resuming correctly, so new copies are getting pushed to the activity backlog, eventually triggering the debugmsg I added for the backlog being too large.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Remove "can_resume": false for most multi-activities. Multi-activities forward to other activity_actors and should be resumable.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Tested successfully while making 85193, but also did some mining and reading multi-activities to double-check.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
