### PR TITLE
Add the Smashing for Wimps perk.

### DIFF
--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -1723,6 +1723,25 @@
         "topic": "TALK_PERK_MENU_SELECT"
       },
       {
+        "condition": { "not": { "u_has_trait": "perk_smash_boost" } },
+        "text": "Gain [<trait_name:perk_smash_boost>]",
+        "effect": [
+          { "set_string_var": "<trait_name:perk_smash_boost>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:perk_smash_boost>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "perk_smash_boost", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Requires melee 3",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "math": [ "u_skill('melee') >= 3" ] } }
+        ],
+        "topic": "TALK_PERK_MENU_SELECT"
+      },
+      {
         "condition": { "not": { "u_has_trait": "perk_dice_addition_damage" } },
         "text": "Gain [<trait_name:perk_dice_addition_damage>]",
         "effect": [

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -1354,6 +1354,16 @@
   },
   {
     "type": "mutation",
+    "id": "perk_smash_boost",
+    "name": { "str": "Thing-Breaker" },
+    "points": 0,
+    "purifiable": false,
+    "valid": false,
+    "description": "Years of venting your rage on inanimate objects taught you how to hit them to maximize damage.  You are more likely to successfully smash things, and your upper range of smashable things is higher.  This knowledge doesn't apply against anything that moves.",
+    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "SMASH_BONUS", "add": 10 } ] } ]
+  },
+  {
+    "type": "mutation",
     "id": "perk_speedballing",
     "name": { "str": "Speedballing" },
     "points": 0,

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -1355,12 +1355,17 @@
   {
     "type": "mutation",
     "id": "perk_smash_boost",
-    "name": { "str": "Thing-Breaker" },
+    "name": { "str": "Smashing for Wimps" },
     "points": 0,
     "purifiable": false,
     "valid": false,
-    "description": "Years of venting your rage on inanimate objects taught you how to hit them to maximize damage.  You are more likely to successfully smash things, and your upper range of smashable things is higher.  This knowledge doesn't apply against anything that moves.",
-    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "SMASH_BONUS", "add": 10 } ] } ]
+    "description": "Strong you might not be, but you can still break things down by hitting them the right way.  You get a bonus to youe smashing ability that increases the weaker you are.",
+    "enchantments": [
+      {
+        "condition": "ALWAYS",
+        "values": [ { "value": "SMASH_BONUS", "add": { "math": [ "16 - clamp(u_val('strength'), 0, 16)" ] } } ]
+      }
+    ]
   },
   {
     "type": "mutation",

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -1359,7 +1359,7 @@
     "points": 0,
     "purifiable": false,
     "valid": false,
-    "description": "Strong you might not be, but you can still break things down by hitting them the right way.  You get a bonus to youe smashing ability that increases the weaker you are.",
+    "description": "Strong you might not be, but you can still break things down by hitting them the right way.  You get a bonus to your smashing ability that increases the weaker you are.",
     "enchantments": [
       {
         "condition": "ALWAYS",


### PR DESCRIPTION
#### Summary
Mods "Add the Smashing for Wimps perk."

#### Purpose of change

More uses for the new SMASH_BONUS enchantment.

#### Describe the solution

Add a perk that boosts smashing effectiveness through that enchantment. It is locked behund having a melee skill of three or more and is more effective the weaker you are, letting you smash more things without needing high strength.

#### Describe alternatives you've considered

Adding a flat smashing boost. That's too similar to percussive entry, so I reworked the perk into a boost for low-STR characters.

#### Testing

Game loaded.
Perk is buyable with 3 melee or more and not without on default settings.
Buying perk works as intended.

#### Additional context

As always, I'm open to suggestions for the perk's name.