### PR TITLE
Re-add event type to prevent bricking VERY old saves

### DIFF
--- a/src/event.cpp
+++ b/src/event.cpp
@@ -65,6 +65,8 @@ std::string enum_to_string<event_type>( event_type data )
         case event_type::crosses_mutation_threshold: return "crosses_mutation_threshold";
         case event_type::crosses_mycus_threshold: return "crosses_mycus_threshold";
         case event_type::cuts_tree: return "cuts_tree";
+        case event_type::dermatik_eggs_hatch: return "dermatik_eggs_hatch";
+        case event_type::dermatik_eggs_injected: return "dermatik_eggs_injected";
         case event_type::destroys_triffid_grove: return "destroys_triffid_grove";
         case event_type::dies_from_asthma_attack: return "dies_from_asthma_attack";
         case event_type::dies_from_drug_overdose: return "dies_from_drug_overdose";
@@ -144,7 +146,7 @@ DEFINE_EVENT_HELPER_FIELDS( event_spec_empty )
 DEFINE_EVENT_HELPER_FIELDS( event_spec_character )
 DEFINE_EVENT_HELPER_FIELDS( event_spec_character_item )
 
-static_assert( static_cast<int>( event_type::num_event_types ) == 106,
+static_assert( static_cast<int>( event_type::num_event_types ) == 108,
                "This static_assert is a reminder to add a definition below when you add a new "
                "event_type.  If your event_spec specialization inherits from another struct for "
                "its fields definition then you probably don't need a definition here." );

--- a/src/event.h
+++ b/src/event.h
@@ -73,6 +73,8 @@ enum class event_type : int {
     crosses_mutation_threshold,
     crosses_mycus_threshold,
     cuts_tree,
+    dermatik_eggs_hatch,
+    dermatik_eggs_injected,
     destroys_triffid_grove,
     dies_from_asthma_attack,
     dies_from_drug_overdose,
@@ -192,7 +194,10 @@ struct event_spec_character_item {
     };
 };
 
-static_assert( static_cast<int>( event_type::num_event_types ) == 106,
+// NOTE: Events are saved to the character file for later memorializing them. It's currently unsafe to ever remove any of these.
+// Removal will cause any save file with one of the saved events to be unable to load.
+// FIXME.
+static_assert( static_cast<int>( event_type::num_event_types ) == 108,
                "This static_assert is to remind you to add a specialization for your new "
                "event_type below" );
 
@@ -567,6 +572,12 @@ struct event_spec<event_type::crosses_mycus_threshold> : event_spec_character {}
 
 template<>
 struct event_spec<event_type::cuts_tree> : event_spec_character {};
+
+template<>
+struct event_spec<event_type::dermatik_eggs_hatch> : event_spec_character {};
+
+template<>
+struct event_spec<event_type::dermatik_eggs_injected> : event_spec_character {};
 
 template<>
 struct event_spec<event_type::destroys_triffid_grove> : event_spec_empty {};

--- a/src/memorial_logger.cpp
+++ b/src/memorial_logger.cpp
@@ -685,6 +685,22 @@ void memorial_logger::notify( const cata::event &e )
             }
             break;
         }
+        case event_type::dermatik_eggs_hatch: {
+            character_id ch = e.get<character_id>( "character" );
+            if( ch == avatar_id ) {
+                add( pgettext( "memorial_male", "Dermatik eggs hatched." ),
+                     pgettext( "memorial_female", "Dermatik eggs hatched." ) );
+            }
+            break;
+        }
+        case event_type::dermatik_eggs_injected: {
+            character_id ch = e.get<character_id>( "character" );
+            if( ch == avatar_id ) {
+                add( pgettext( "memorial_male", "Injected with dermatik eggs." ),
+                     pgettext( "memorial_female", "Injected with dermatik eggs." ) );
+            }
+            break;
+        }
         case event_type::destroys_triffid_grove: {
             add( pgettext( "memorial_male", "Destroyed a triffid grove." ),
                  pgettext( "memorial_female", "Destroyed a triffid grove." ) );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Hm...

<img width="1583" height="258" alt="image" src="https://github.com/user-attachments/assets/6580ce08-f4dc-401a-acb3-f96d0028f888" />

So it turns out that it is not safe to remove event types, ever. That was unexpected.

Although the event in question hasn't been accessible since [Aug 28, 2024](https://github.com/CleverRaven/Cataclysm-DDA/pull/75284), as you can see from the image some people are playing very old saves where the event HAS been recorded.

So if we can help it, we'd like to prevent bricking them.

This is a very low-effort 0-maintenance fix so it's absolutely worth doing. Plus it gives me an opportunity to add a comment.

#### Describe the solution
Re-add the bare minimum to let the save load.

Also add that comment, warning future contributors about accidentally bricking more modern saves.

#### Describe alternatives you've considered
Figure out some means of migrating event types

#### Testing
Hoping @Standing-Storm can test, they have the full save

#### Additional context

