### PR TITLE
Fix typos

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -2949,7 +2949,6 @@
     "id": "PHASE_BACK",
     "type": "json_flag",
     "//": "Terrain / Furniture flag",
-    "name": "Phase back",
-    "info": "This terrain will phase back to its original terrain when no longer modified."
+    "//2": "This terrain will phase back to its original terrain when no longer modified."
   }
 ]

--- a/data/json/furniture_and_terrain/terrain-ice.json
+++ b/data/json/furniture_and_terrain/terrain-ice.json
@@ -60,8 +60,11 @@
   {
     "type": "terrain",
     "id": "t_pseudo_phase",
-    "name": "pseudo phase",
-    "description": "Placeholder terrain representing the original tile for PHASE_BACK behavior.  Should not be seen in-game.",
+    "name": { "str": "pseudo phase", "//~": "NO_I18N" },
+    "description": {
+      "str": "Placeholder terrain representing the original tile for PHASE_BACK behavior.  Should not be seen in-game.",
+      "//~": "NO_I18N"
+    },
     "symbol": ".",
     "color": "light_gray",
     "move_cost": 2,

--- a/data/json/items/corpses/nether.json
+++ b/data/json/items/corpses/nether.json
@@ -48,7 +48,7 @@
     "type": "ITEM",
     "id": "broken_flailer_radiosphere",
     "name": { "str": "torn flailer" },
-    "description": "torn up cloth facsimile of a bird, you could tear it up even further for materials.",
+    "description": "A torn up cloth facsimile of a bird, you could tear it up even further for materials.",
     "symbol": "v",
     "color": "light_gray",
     "category": "corpses",

--- a/data/json/items/tool/science.json
+++ b/data/json/items/tool/science.json
@@ -659,8 +659,11 @@
     "id": "mws_weather_sensor_array",
     "type": "ITEM",
     "subtypes": [ "TOOL" ],
-    "name": { "str": "ambient weather sensor array" },
-    "description": "Represents the hardware and software for displaying the weather.  You should not see this item in game.",
+    "name": { "str": "ambient weather sensor array", "//~": "NO_I18N" },
+    "description": {
+      "str": "Represents the hardware and software for displaying the weather.  You should not see this item in game.",
+      "//~": "NO_I18N"
+    },
     "weight": "4000 g",
     "volume": "80000 ml",
     "longest_side": "55 cm",
@@ -679,8 +682,11 @@
     "id": "mws_advanced_weather_sensor_array",
     "type": "ITEM",
     "subtypes": [ "TOOL" ],
-    "name": { "str": "ambient weather sensor array" },
-    "description": "Represents the hardware and software for displaying the weather in a HEW system.  You should not see this item in game.",
+    "name": { "str": "ambient weather sensor array", "//~": "NO_I18N" },
+    "description": {
+      "str": "Represents the hardware and software for displaying the weather in a HEW system.  You should not see this item in game.",
+      "//~": "NO_I18N"
+    },
     "weight": "4000 g",
     "volume": "80000 ml",
     "longest_side": "55 cm",
@@ -699,8 +705,11 @@
     "id": "mws_HE_sensor_array",
     "type": "ITEM",
     "subtypes": [ "TOOL" ],
-    "name": { "str": "ambient HE sensor array" },
-    "description": "Represents the hardware and software to scan for nethery stuff.  You should not see this item in game.",
+    "name": { "str": "ambient HE sensor array", "//~": "NO_I18N" },
+    "description": {
+      "str": "Represents the hardware and software to scan for nethery stuff.  You should not see this item in game.",
+      "//~": "NO_I18N"
+    },
     "weight": "4000 g",
     "volume": "80000 ml",
     "longest_side": "55 cm",

--- a/data/json/monsters/mammal.json
+++ b/data/json/monsters/mammal.json
@@ -2,7 +2,7 @@
   {
     "id": "mon_human",
     "type": "MONSTER",
-    "name": { "str": "human", "//~": "NO_I18N" },
+    "name": { "str": "human" },
     "description": { "str": "Placeholder for human corpses.  If you see this, it's a bug.", "//~": "NO_I18N" },
     "bodytype": "human",
     "copy-from": "mon_zombie",
@@ -16,7 +16,7 @@
   {
     "id": "mon_human_scorched",
     "type": "MONSTER",
-    "name": { "str": "charred human", "//~": "NO_I18N" },
+    "name": { "str": "charred human" },
     "description": { "str": "Placeholder for charred human corpses.  If you see this, it's a bug.", "//~": "NO_I18N" },
     "bodytype": "human",
     "copy-from": "mon_zombie_scorched",
@@ -30,7 +30,7 @@
   {
     "id": "mon_child",
     "type": "MONSTER",
-    "name": { "str": "child", "str_pl": "children", "//~": "NO_I18N" },
+    "name": { "str": "child", "str_pl": "children" },
     "description": { "str": "Placeholder for children corpses.  If you see this, it's a bug.", "//~": "NO_I18N" },
     "bodytype": "human",
     "copy-from": "mon_zombie_child",

--- a/data/json/snippets/anomalous_mp3.json
+++ b/data/json/snippets/anomalous_mp3.json
@@ -13,9 +13,9 @@
     "type": "snippet",
     "category": "<mp3_reverberation_locator_almost_there>",
     "text": [
-      "Its song is indescribably beautiful..",
-      "Its song is painting the world in vibrant colors..",
-      "Its song is begging you to get closer.."
+      "Its song is indescribably beautiful.",
+      "Its song is painting the world in vibrant colors.",
+      "Its song is begging you to get closer."
     ]
   },
   {

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -5135,7 +5135,7 @@ std::optional<int> iuse::stimpack( Character *p, item *it, const tripoint_bub_ms
 
     } else if( !it->activation_success() ) {
         p->add_msg_if_player( m_bad,
-                              _( "nothing happens when you try to inject yourself with your %s. Try again." ), it->tname() );
+                              _( "You try to inject yourself with the %s, but nothing happens." ), it->tname() );
         return std::nullopt;
 
     } else {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
1. A technical flag was visible when inspecting ice.
2. Names from `mon_human`, `mon_child`, and similar were inherited by corpse names in some locations, meaning they were visible in-game.
3. Several typos.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
1. Move the flag description to a comment.
2. Remove NO_I18N from the names.
3. Fix the typos.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
The `PHASE_BACK` flag is no longer visible when inspecting ice.
<img width="432" height="210" alt="fix-typo1" src="https://github.com/user-attachments/assets/e9636cfa-76d7-420f-905d-fe836af358b4" />

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
