### PR TITLE
Fix multicooker crash when cooking recipes with no ingredients

### DIFF
--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -764,6 +764,11 @@ static void set_new_comps( item &newit, int amount, item_components *used, bool 
 std::vector<item> recipe::create_result( bool set_components, bool is_food,
         item_components *used ) const
 {
+    // Defensive check: prevent segfault if recipe has no ingredients
+    if( requirements_.is_empty() ) {
+        return {}; // return empty vector instead of crashing
+    }
+    
     item newit( result_, calendar::turn, item::default_charges_tag{} );
 
     if( !variant().empty() ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Category "Brief description"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

This pull request fixes bug #84491. The multicooker would crash (segfault) when trying to cook recipes that have no ingredients. This ensures that the game does not crash when attempting to craft empty recipes.

Steps to reproduce the original bug:

Load a save with a multicooker.

Select a recipe that has no ingredients.

Activate the multicooker and try to cook.

Previously, the game would immediately crash.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

Added a defensive check at the top of recipe::create_result() in src/recipe.cpp:

if( requirements_.is_empty() ) {
    return {};
}


This returns an empty vector when a recipe has no ingredients, preventing the function from dereferencing empty data and causing a segfault. All other recipes remain unaffected.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Could have added checks elsewhere before calling create_result(), but adding the check directly in the function ensures safety at the source and avoids duplication.

Other approaches would be more invasive and risk breaking existing crafting mechanics.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

Verified the change prevents crashes when attempting to cook recipes with no ingredients.

Checked that crafting normal recipes still works as expected.

Ran basic gameplay to ensure no other functions were affected by this change.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

This fix is a minimal, safe change and does not alter gameplay for recipes with ingredients.


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
