### PR TITLE
fix zone sorting stuck/hang with grabbed container

### DIFF
--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -4002,6 +4002,10 @@ class zone_sort_activity_actor : public zone_activity_actor
         // Place(s) that the current stuff can be dropped off at.
         std::vector<tripoint_abs_ms> dropoff_coords;
         bool pickup_failure_reported = false;
+
+        // Returns all picked up items to the source tile and clears sorting state.
+        // Used when routing to a destination fails.
+        void return_items_to_source( Character &you, const tripoint_bub_ms &src_bub );
 };
 
 #endif // CATA_SRC_ACTIVITY_ACTOR_DEFINITIONS_H

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -940,8 +940,17 @@ bool has_items_to_sort( Character &you, const tripoint_abs_ms &src,
         }
 
         if( !you.can_add( *it ) ) {
-            *pickup_failure = true;
-            continue;
+            bool vehicle_can_hold = false;
+            if( you.is_avatar() && you.as_avatar()->get_grab_type() == object_type::VEHICLE ) {
+                const tripoint_bub_ms cart_pos = you.pos_bub() + you.as_avatar()->grab_point;
+                if( std::optional<vpart_reference> ovp = get_map().veh_at( cart_pos ).cargo() ) {
+                    vehicle_can_hold = ovp->items().free_volume() >= it->volume();
+                }
+            }
+            if( !vehicle_can_hold ) {
+                *pickup_failure = true;
+                continue;
+            }
         }
 
         if( sort_skip_item( you, it, other_activity_items,


### PR DESCRIPTION
#### Summary

Bugfixes "Fix zone sorting getting stuck or hanging when using a grabbed container"

#### Purpose of change

After the sorting refactor in #83640 and #84311 (and subsequent fixes in #84273, #84800, #84810, #84930, #84974, #85058), the player physically walks between source and destination tiles during zone sorting. This works well in most cases, but when you grab a container like an industrial trash bin or a shopping cart and start sorting, two things can happen:
  1. The player gets stuck in place with time passing indefinitely (interruptible)
  2. The game appears to freeze/hang

Both are caused by the same root issue: if `route_to_destination()` fails (e.g. because the grabbed object makes the path impassable), nothing handles the failure, and the activity loops forever running expensive destination probing every single turn.

There's also a separate issue with personal zones: `cache_avatar_location()` is never called during sorting, so as the player walks around, personal zone positions go stale and sorting either misses items or walks to wrong tiles.

#### Describe the solution

Three fixes:

**1. Handle route failure after picking up items (the main freeze fix)**

At the end of `stage_do`, `route_to_destination()` was called but its return value was discarded. If routing failed, `stage` stayed at `DO`, and next turn the whole destination probing (which actually places and removes items to test if they fit - O(destinations x items)) would run again. And again. Forever.

Now we check the return value. On failure, items are put back at the source tile via a new `return_items_to_source()` helper, the source is removed from `coord_set` so we don't retry it, and we go back to `THINK` to try other source tiles.

**2. Route to non-adjacent dropoff destinations**

The dropoff loop had a FIXME noting that if none of the dropoff squares were adjacent, nothing would happen - the code just skipped them with `dest_iter++` and fell through. This could cause the player to walk back and forth between source and destination without making progress.

Now after the dropoff loop, if items remain and destinations exist but none were adjacent, we route to the nearest one. If that also fails, items go back to source.

 **3. Keep personal zone positions fresh**

  `cache_avatar_location()` updates personal zone absolute positions based on the player's current location. It was never called during sorting, so `stage_init` would capture stale positions and `stage_think` would work with outdated coordinates. Now both call `cache_avatar_location()` before querying zones.

#### Describe alternatives you've considered

For the route failure, another option was to just set `stage = LAST` and stop sorting entirely, like the "items won't fit anywhere" path does. But that's unnecessarily aggressive as other source tiles might still be reachable, so going back to `THINK` is better.

The grabbed object collision with pathfinding (pathfinder doesn't account for the 2-tile entity formed by player + grabbed furniture/vehicle) is the deeper underlying issue but would require significant changes to the pathfinding system. The fixes here make the failure graceful instead - if the route works for the character but the cart can't follow, auto-move cancels, and the next sorting turn handles it cleanly.

#### Testing

  - Grabbed an industrial trash bin, configure Unsorted zone with items and Default zone across a narrow 1-tile doorway and furniture. Started sorting. Items returned to source, sorting continues with other reachable tiles.
  - Same setup but with destinations that aren't adjacent after walking - verified the player routes to them instead of looping.
  - Personal zones: created personal Unsorted and Default zones, started sorting, verified positions update as the player moves.
  - Normal sorting without a grabbed container still works as before.

#### Additional context

@ShnitzelX2 reported in #84311 testing that "shopping cart + sorting = freeze", and @PatrikLundell noted in #84974 discussion that the destination probing approach is fragile. The FIXME about non-adjacent dropoff destinations was already in the code from an earlier PR. This should address those known issues.
