### PR TITLE
Allow mutations to be powered by Stamina, apply it to Insect Wings

### DIFF
--- a/data/json/effects_on_condition/mutation_eocs/mutation_effect_eocs.json
+++ b/data/json/effects_on_condition/mutation_eocs/mutation_effect_eocs.json
@@ -658,16 +658,6 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_insect_wings_shutoff",
-    "recurrence": [ "1 seconds", "1 seconds" ],
-    "condition": { "and": [ { "math": [ "u_val('stamina') < 3000" ] }, { "u_has_trait": "WINGS_INSECT_active" } ] },
-    "effect": [
-      { "u_activate_trait": "WINGS_INSECT_active" },
-      { "u_message": "You don't have the stamina to keep buzzing.", "type": "bad" }
-    ]
-  },
-  {
-    "type": "effect_on_condition",
     "id": "EOC_social1_bonus",
     "recurrence": [ "10 minutes", "30 minutes" ],
     "//": "Alcohol and sedatives prevent the bad effects of these EOCs.  Antidepressants prevent (but don't remove) both the good and bad effects, keeping you at a baseline state.",

--- a/data/json/enchantments.json
+++ b/data/json/enchantments.json
@@ -299,14 +299,6 @@
     "values": [ { "value": "FOOTSTEP_NOISE", "multiply": -0.67 } ]
   },
   {
-    "id": "ench_wings_insect_active",
-    "type": "enchantment",
-    "name": { "str": "Insect Wings (Buzzing)" },
-    "description": "Your rapidly buzzing wings propel you with extra speed.",
-    "condition": "ALWAYS",
-    "values": [ { "value": "REGEN_STAMINA", "add": -110 }, { "value": "MOVE_COST", "multiply": -0.25 } ]
-  },
-  {
     "id": "ench_quadruped_movement_full",
     "//": "For quadrupeds with all four of their animal limbs.  We should avoid giving this to every animal mutant, as it helps keep lines distinct.",
     "type": "enchantment",

--- a/data/json/mutations/mutations_limbs.json
+++ b/data/json/mutations/mutations_limbs.json
@@ -580,23 +580,34 @@
     "prereqs": [ "WINGS_STUB" ],
     "points": 1,
     "active": true,
+    "activated_is_setup": true,
+    "activation_msg": "You begin buzzing your wings.",
     "vitamin_cost": 220,
     "visibility": 4,
     "ugliness": 4,
     "flags": [ "WINGS_1" ],
+    "cost": 115,
+    "stamina": true,
+    "time": "1 s",
     "restricts_gear": [ "torso" ],
-    "transform": { "target": "WINGS_INSECT_active", "msg_transform": "You begin buzzing your wings.", "active": true, "moves": 20 }
+    "active_flags": [ "ONE_STORY_FALL", "MUSCLE_VEH_BOOST" ],
+    "//": "We apply WINGS_INSECT_active as a mutation because there are sound penalties with custom messages hard-coded to its id.",
+    "enchantments": [
+      {
+        "condition": "ACTIVE",
+        "values": [ { "value": "MOVE_COST", "multiply": -0.25 } ],
+        "mutations": [ "WINGS_INSECT_active" ]
+      }
+    ]
   },
   {
     "type": "mutation",
     "id": "WINGS_INSECT_active",
-    "copy-from": "WINGS_INSECT",
     "name": { "str": "Insect Wings (Buzzing)" },
     "description": "You're fluttering your wings as fast as you can.  This doesn't generate enough lift to move you, but it does increase your movement speed.  If you're not burdened, you can fall short distances without harm.",
     "valid": false,
-    "flags": [ "WINGS_1", "MUSCLE_VEH_BOOST" ],
-    "transform": { "target": "WINGS_INSECT", "msg_transform": "Your wings go still.", "active": false, "moves": 0 },
-    "enchantments": [ "ench_wings_insect_active" ]
+    "points": 0,
+    "player_display": false
   },
   {
     "type": "mutation",

--- a/data/json/obsoletion_and_migration_0.J/eocs.json
+++ b/data/json/obsoletion_and_migration_0.J/eocs.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_insect_wings_shutoff",
+    "effect": [  ]
+  }
+]

--- a/doc/JSON/MUTATIONS.md
+++ b/doc/JSON/MUTATIONS.md
@@ -212,6 +212,7 @@ Specific mutations are extremely versatile. A mutation only needs to have a few 
   "thirst": true,                             // If true, activated mutation increases thirst by cost (default: false).
   "sleepiness": true,                            // If true, activated mutation increases sleepiness by cost (default: false).
   "mana": true,                               // If true, activated mutation consumes `cost` mana. (default: false).
+  "stamina": true,                               // If true, activated mutation consumes `cost` stamina. (default: false).
   "active_flags": [ "BLIND" ],                // activation of the mutation apply this flag on your character
   "allowed_items": [ "ALLOWS_TAIL" ],         // you can wear items with this flag with this mutation, bypassing restricts_gear restriction
   "integrated_armor": [ "integrated_fur" ],   // this item is worn on your character forever, until you get rid of this mutation

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -419,8 +419,9 @@ bool Character::can_power_mutation( const trait_id &mut ) const
     bool thirst = mut->thirst && get_thirst() >= 260;
     bool sleepiness = mut->sleepiness && get_sleepiness() >= sleepiness_levels::EXHAUSTED;
     bool mana = mut->mana && magic->available_mana() <= mut->cost;
+    bool stamina = mut->stamina && get_stamina() <= mut->cost;
 
-    return !hunger && !sleepiness && !thirst && !mana;
+    return !hunger && !sleepiness && !thirst && !mana && !stamina;
 }
 
 void Character::mutation_reflex_trigger( const trait_id &mut )
@@ -863,6 +864,9 @@ void Character::activate_cached_mutation( const trait_id &mut )
         }
         if( mdata.mana ) {
             magic->mod_mana( *this, -cost );
+        }
+        if( mdata.stamina ) {
+            mod_stamina( -cost );
         }
         tdata.powered = true;
         recalc_sight_limits();

--- a/src/mutation.h
+++ b/src/mutation.h
@@ -207,11 +207,12 @@ struct mutation_branch {
         bool destroys_gear = false;
         // Allow soft (fabric) gear on restricted body parts
         bool allow_soft_gear  = false;
-        // IF any of the four are true, it drains that as the "cost"
+        // If any of the five are true, it drains that as the "cost"
         bool sleepiness       = false;
         bool hunger        = false;
         bool thirst        = false;
         bool mana       = false;
+        bool stamina       = false;
         // How many points it costs in character creation
         int points     = 0;
         // How many mutagen vitamins are consumed to gain this trait

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -318,6 +318,7 @@ void mutation_branch::load( const JsonObject &jo, std::string_view src )
     optional( jo, was_loaded, "thirst", thirst, false );
     optional( jo, was_loaded, "sleepiness", sleepiness, false );
     optional( jo, was_loaded, "mana", mana, false );
+    optional( jo, was_loaded, "stamina", stamina, false );
     optional( jo, was_loaded, "valid", valid, true );
     optional( jo, was_loaded, "purifiable", purifiable, true );
 

--- a/src/mutation_ui.cpp
+++ b/src/mutation_ui.cpp
@@ -316,7 +316,7 @@ void avatar::power_mutations()
                 }
                 if( md.thirst ) {
                     if( number_of_resource > 0 ) {
-                        //~ Resources consumed by a mutation: "kcal & thirst & sleepiness & mana"
+                        //~ Resources consumed by a mutation: "kcal & thirst & sleepiness & mana & stamina"
                         resource_unit += _( " &" );
                     }
                     resource_unit += _( " thirst" );
@@ -324,10 +324,17 @@ void avatar::power_mutations()
                 }
                 if( md.sleepiness ) {
                     if( number_of_resource > 0 ) {
-                        //~ Resources consumed by a mutation: "kcal & thirst & sleepiness & mana"
+                        //~ Resources consumed by a mutation: "kcal & thirst & sleepiness & mana & stamina"
                         resource_unit += _( " &" );
                     }
                     resource_unit += _( " sleepiness" );
+                }
+                if( md.stamina ) {
+                    if( number_of_resource > 0 ) {
+                        //~ Resources consumed by a mutation: "kcal & thirst & sleepiness & mana & stamina"
+                        resource_unit += _( " &" );
+                    }
+                    resource_unit += _( " stamina" );
                 }
                 if( md.mana ) {
                     resource_unit += _( " mana" );
@@ -447,7 +454,8 @@ void avatar::power_mutations()
                             } else if( ( !mut_data.hunger || get_kcal_percent() >= 0.8f ) &&
                                        ( !mut_data.thirst || get_thirst() <= 400 ) &&
                                        ( !mut_data.sleepiness || get_sleepiness() <= 400 ) &&
-                                       ( !mut_data.mana || magic->available_mana() >= mut_data.cost ) ) {
+                                       ( !mut_data.mana || magic->available_mana() >= mut_data.cost ) && 
+                                       ( !mut_data.stamina || get_stamina() >= mut_data.cost  ) && ) {
                                 add_msg_if_player( m_neutral,
                                                    string_format( mut_data.activation_msg.translated(), mutation_name( mut_data.id ) ) );
                                 // Reset menu in advance

--- a/src/mutation_ui.cpp
+++ b/src/mutation_ui.cpp
@@ -455,7 +455,7 @@ void avatar::power_mutations()
                                        ( !mut_data.thirst || get_thirst() <= 400 ) &&
                                        ( !mut_data.sleepiness || get_sleepiness() <= 400 ) &&
                                        ( !mut_data.mana || magic->available_mana() >= mut_data.cost ) && 
-                                       ( !mut_data.stamina || get_stamina() >= mut_data.cost  ) && ) {
+                                       ( !mut_data.stamina || get_stamina() >= mut_data.cost  ) ) {
                                 add_msg_if_player( m_neutral,
                                                    string_format( mut_data.activation_msg.translated(), mutation_name( mut_data.id ) ) );
                                 // Reset menu in advance

--- a/src/mutation_ui.cpp
+++ b/src/mutation_ui.cpp
@@ -454,8 +454,8 @@ void avatar::power_mutations()
                             } else if( ( !mut_data.hunger || get_kcal_percent() >= 0.8f ) &&
                                        ( !mut_data.thirst || get_thirst() <= 400 ) &&
                                        ( !mut_data.sleepiness || get_sleepiness() <= 400 ) &&
-                                       ( !mut_data.mana || magic->available_mana() >= mut_data.cost ) && 
-                                       ( !mut_data.stamina || get_stamina() >= mut_data.cost  ) ) {
+                                       ( !mut_data.mana || magic->available_mana() >= mut_data.cost ) &&
+                                       ( !mut_data.stamina || get_stamina() >= mut_data.cost ) ) {
                                 add_msg_if_player( m_neutral,
                                                    string_format( mut_data.activation_msg.translated(), mutation_name( mut_data.id ) ) );
                                 // Reset menu in advance

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -300,7 +300,7 @@ void suffer::mutation_power( Character &you, const trait_id &mut_id )
             }
         }
 
-         if( mut_id->stamina ) {
+        if( mut_id->stamina ) {
             // no enough stamina
             if( you.get_stamina() < mut_id->cost ) {
                 you.add_msg_if_player( m_warning,

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -300,6 +300,18 @@ void suffer::mutation_power( Character &you, const trait_id &mut_id )
             }
         }
 
+         if( mut_id->stamina ) {
+            // no enough stamina
+            if( you.get_stamina() < mut_id->cost ) {
+                you.add_msg_if_player( m_warning,
+                                       _( "You don't have enough stamina to keep your %s going." ),
+                                       you.mutation_name( mut_id ) );
+                you.deactivate_mutation( mut_id );
+            } else {
+                you.magic->mod_stamina( -mut_id->cost );
+            }
+        }
+
         // if you haven't deactivated then run the EOC
         for( const effect_on_condition_id &eoc : mut_id->processed_eocs ) {
             dialogue d( get_talker_for( you ), nullptr );

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -308,7 +308,7 @@ void suffer::mutation_power( Character &you, const trait_id &mut_id )
                                        you.mutation_name( mut_id ) );
                 you.deactivate_mutation( mut_id );
             } else {
-                you.magic->mod_stamina( -mut_id->cost );
+                you.mod_stamina( -mut_id->cost );
             }
         }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Features "Allow mutations to be powered by Stamina, apply it to Insect Wings"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Insect Wings already kind of does this with an enchantment but it'd be nice to have it displayed in the UI. 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the option to power mutations with stamina, the same way you can use thirst, kcal, sleepiness, or mana. The process is the same--set `"stamina": true`, set the `time` and the `cost`, and then it shows up in the UI.

Apply this to the Insect Wings mutation. As such, set it to be `"activated_is_setup": true` so it'll show as green in the UI when on. Replace the non-working `WINGS_1` flag with the `ONE_STORY_FALL` flag (which does what `WINGS_1` used to do) for now, until limbification of wings. Remove the transform aspect. Obsolete the every-second EoC set up to turn wings off when your Stamina gets low. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
<img width="469" height="72" alt="Untitled" src="https://github.com/user-attachments/assets/158d63d6-eebe-4a43-865c-c78bf1e97370" />

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

At the moment you can deplete your stamina all the way down to minimum. I'm not sure if a 500 or 1000 minimum would be better

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
