### PR TITLE
Expose dimension names to EOC

### DIFF
--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -3770,6 +3770,26 @@ Save the condition  `season is not winter, and it is a daytime` into `random_enc
 ```
 
 
+#### `dimension_name`
+Store string from set_string_var in the [variable](#variable-object) object target_var 
+
+| Syntax | Optionality | Value  | Info |
+| --- | --- | --- | --- |
+| "dimension_name" | **mandatory** | [variable object](#variable-object) | variable, that accept the value; usually `context_val` |
+
+##### Valid talkers:
+
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------ | --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
+
+##### Examples
+Saves the current dimension into `dimension_name` variable and display it in a message:
+```jsonc
+{ "dimension_name": { "u_val": "dim_name" } }, { "u_message": "Dimension Name: '<u_val:dim_name>'" },
+```
+
+
 #### `u_location_variable`, `npc_location_variable`
 Search a specific coordinates of map around `u_`, `npc_` or `target_params` and save them in [variable](#variable-object)
 

--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -3771,7 +3771,7 @@ Save the condition  `season is not winter, and it is a daytime` into `random_enc
 
 
 #### `dimension_name`
-Store string from set_string_var in the [variable](#variable-object) object target_var 
+Store string from dimension_name in the [variable](#variable-object) object. The default dimension is currently an empty string.
 
 | Syntax | Optionality | Value  | Info |
 | --- | --- | --- | --- |

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -4434,6 +4434,18 @@ talk_effect_fun_t::func f_location_variable( const JsonObject &jo, std::string_v
     };
 }
 
+talk_effect_fun_t::func f_dimension_name( const JsonObject &jo, std::string_view member,
+        std::string_view )
+{
+    var_info var = read_var_info( jo.get_object( member ) );
+    var_type type = var.type;
+    std::string var_name = var.name;
+
+    return [var_name, type]( dialogue & d ) {
+        write_var_value( type, var_name, &d, g->get_dimension_prefix() );
+    };
+}
+
 talk_effect_fun_t::func f_location_variable_adjust( const JsonObject &jo,
         std::string_view member, std::string_view )
 {
@@ -8095,6 +8107,7 @@ parsers = {
     { "u_learn_martial_art", "npc_learn_martial_art", jarg::member, &talk_effect_fun::f_learn_martial_art },
     { "u_forget_martial_art", "npc_forget_martial_art", jarg::member, &talk_effect_fun::f_forget_martial_art },
     { "u_location_variable", "npc_location_variable", jarg::object, &talk_effect_fun::f_location_variable },
+    { "dimension_name", jarg::object, &talk_effect_fun::f_dimension_name },
     { "u_transform_radius", "npc_transform_radius", jarg::member | jarg::array, &talk_effect_fun::f_transform_radius },
     { "u_explosion", "npc_explosion", jarg::member, &talk_effect_fun::f_explosion },
     { "u_query_tile", "npc_query_tile", jarg::member, &talk_effect_fun::f_query_tile },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Features "Expose dimension names to EOC"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Exposes the dimension name to EOCs allowing them to be saved and reused for dimension shifting
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add a talk function that stuffs the dimension name into the provided variable.
The default dimension is an empty string as of this PR
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Using a ternary to return something like `default` for the default dimension similar to what I did for showing the dimension name in the debug mode sidebar but other EOC functions already use the empty string for default and it would be better served changing the underlying code to have a name for the default dimension instead of this band-aid
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
<img width="889" height="259" alt="image" src="https://github.com/user-attachments/assets/c26adb4f-cba2-4370-a407-119994d8532b" />

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
