### PR TITLE
Add simple wooden rack and construction recipe

### DIFF
--- a/data/json/construction/furniture_storage.json
+++ b/data/json/construction/furniture_storage.json
@@ -211,6 +211,22 @@
   },
   {
     "type": "construction",
+    "id": "constr_rack_primitive",
+    "group": "build_wooden_rack_primitive",
+    "category": "FURN",
+    "required_skills": [ [ "fabrication", 4 ] ],
+    "time": "240 m",
+    "qualities": [ [ { "id": "CHISEL", "level": 1 } ], [ { "id": "SAW_W", "level": 1 } ] ],
+    "components": [
+      [ [ "2x4", 6 ] ],
+      [ [ "wood_sheet", 2 ], [ "wood_panel", 4 ] ],
+      [ [ "cordage_36_leather", 4 ], [ "string_36", 4 ], [ "cordage_36", 4 ] ]
+    ],
+    "pre_special": "check_empty",
+    "post_terrain": "f_rack_primitive"
+  },
+  {
+    "type": "construction",
     "id": "constr_safe",
     "group": "build_safe",
     "category": "FURN",

--- a/data/json/construction/furniture_storage.json
+++ b/data/json/construction/furniture_storage.json
@@ -220,7 +220,7 @@
     "components": [
       [ [ "2x4", 6 ] ],
       [ [ "wood_sheet", 2 ], [ "wood_panel", 4 ] ],
-      [ [ "cordage_36_leather", 4 ], [ "string_36", 4 ], [ "cordage_36", 4 ] ]
+      [ [ "cordage_36_leather", 8 ], [ "string_36", 8 ], [ "cordage_36", 8 ] ]
     ],
     "pre_special": "check_empty",
     "post_terrain": "f_rack_primitive"

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -921,6 +921,11 @@
   },
   {
     "type": "construction_group",
+    "id": "build_wooden_rack_primitive",
+    "name": "Build Primitive Wooden Rack"
+  },
+  {
+    "type": "construction_group",
     "id": "build_wooden_railing",
     "name": "Build Wooden Railing"
   },

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -922,7 +922,7 @@
   {
     "type": "construction_group",
     "id": "build_wooden_rack_primitive",
-    "name": "Build Primitive Wooden Rack"
+    "name": "Build Simple Wooden Rack"
   },
   {
     "type": "construction_group",

--- a/data/json/furniture_and_terrain/furniture-storage.json
+++ b/data/json/furniture_and_terrain/furniture-storage.json
@@ -657,6 +657,35 @@
   },
   {
     "type": "furniture",
+    "id": "f_rack_primitive",
+    "name": "simple wooden rack",
+    "symbol": "{",
+    "description": "Wooden planks joined together and tied with cords to form a set of shelves.",
+    "color": "brown",
+    "move_cost_mod": -1,
+    "coverage": 70,
+    "required_str": 6,
+    "looks_like": "f_rack_wood",
+    "flags": [ "FLAMMABLE", "PLACE_ITEM", "ORGANIC", "BLOCKSDOOR", "TRANSPARENT" ],
+    "rotates_to": "INDOORFLOOR",
+    "deconstruct": {
+      "items": [
+        { "item": "2x4", "count": 12 },
+        { "item": "wood_panel", "count": [ 1, 2 ] },
+        { "item": "rope_makeshift_6", "count": [ 1, 2 ] }
+      ]
+    },
+    "max_volume": "750 L",
+    "bash": {
+      "str_min": 6,
+      "str_max": 40,
+      "sound": "smash!",
+      "sound_fail": "whump.",
+      "items": [ { "item": "2x4", "count": [ 1, 4 ] }, { "item": "splinter", "count": 12 } ]
+    }
+  },
+  {
+    "type": "furniture",
     "id": "f_rack_coat",
     "name": "coat rack",
     "description": "A tall wooden pole with a set of hooks used to store outdoor jackets and hats to allow easy access.",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Been looking at videos of people building shelves without nails or screws. It's not incredibly difficult, there's just not much reason to do it most of the time when you can use screws and power tools. But you could. 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add a construction recipe for a simple wooden rack that doesn't require nails. It holds less than a regular wooden rack and takes higher skill and _much_ longer to build. 

I originally thought of Innawood for this but there's no reason it couldn't be basegame.

(It cannot be locked behind a book in vanilla because you can't limit who knows construction recipes) 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Went in the game, built a simple rack
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
