### PR TITLE
Fix pat earpiece/helmet rigidity conflict

### DIFF
--- a/data/json/items/tool/radio_tools.json
+++ b/data/json/items/tool/radio_tools.json
@@ -191,7 +191,7 @@
     "type": "ITEM",
     "subtypes": [ "TOOL", "ARMOR" ],
     "name": { "str": "transponder earpiece (off)", "str_pl": "transponder earpieces (off)" },
-    "description": "A small radio transponder attached to an over-the-ear earpiece.  It has two small cables for connecting to AR headsets.  If you have a compatible headset and it is switched on, Pat can keep track of you and communicate via radio.  Active it to switch it on.",
+    "description": "An earpiece with an inline transponder and two small cables custom-fit for AR headsets.  If you have a compatible headset and it is switched on, Pat can keep track of you and communicate via radio.  Active it to switch it on.",
     "weight": "10 g",
     "volume": "10 ml",
     "price": "20 USD",
@@ -201,7 +201,7 @@
     "armor": [ { "coverage": 10, "covers": "head", "specifically_covers": [ "head_ear_l" ] } ],
     "symbol": ";",
     "color": "green",
-    "flags": [ "ELECTRONIC", "OVERSIZE", "POWERARMOR_COMPATIBLE", "SKINTIGHT", "TRADER_AVOID", "PADDED" ],
+    "flags": [ "ELECTRONIC", "OVERSIZE", "POWERARMOR_COMPATIBLE", "SKINTIGHT", "TRADER_AVOID", "SOFT" ],
     "use_action": {
       "type": "transform",
       "menu_text": "Switch on the transponder.",
@@ -217,7 +217,7 @@
     "type": "ITEM",
     "subtypes": [ "TOOL", "ARMOR" ],
     "name": { "str": "transponder earpiece (on)", "str_pl": "transponder earpieces (on)" },
-    "description": "A small radio transponder attached to an over-the-ear earpiece.  It has two small cables for connecting to AR headsets.  If you have a compatible headset and it is switched on, Pat can keep track of you and communicate via radio.  It is currently active.  Active it to switch it off.",
+    "description": "An earpiece with an inline transponder and two small cables custom-fit for AR headsets.  It has two small cables for connecting to AR headsets.  If you have a compatible headset and it is switched on, Pat can keep track of you and communicate via radio.  It is currently active.  Active it to switch it off.",
     "extend": { "flags": [ "SPAWN_ACTIVE" ] },
     "use_action": {
       "type": "transform",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Can comfortably wear Pat's earpiece and a helmet"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

#85214 pointed out that the rigidity of Pat's earpiece made it difficult to wear with helmets, which was opposite to the design goal.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Switched `PADDED` flag to `SOFT`.  Also slightly modified description to make the electronics inline and not over the ear.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

n/a

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Donned the earpiece and Hub 01 VAH.  No conflicts.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Fixes #85214 

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
