### PR TITLE
Closetland keeps track of departed dimension + sky island

### DIFF
--- a/data/mods/BombasticPerks/perkdata/closetland.json
+++ b/data/mods/BombasticPerks/perkdata/closetland.json
@@ -34,6 +34,7 @@
     "//": "Searching for individual furniture IDs isn't great, but there's no obvious flag to check for.",
     "condition": { "not": { "u_has_effect": "effect_bombastic_escaped_closetland" } },
     "effect": [
+      { "dimension_name": { "global_val": "closetland_last_dimension" } },
       { "math": [ "u_closetland_perk_nearby_walls = 0" ] },
       { "math": [ "u_closetland_perk_nearby_doors = 0" ] },
       {
@@ -77,19 +78,31 @@
           "and": [ { "math": [ "u_closetland_perk_nearby_walls == 7" ] }, { "math": [ "u_closetland_perk_nearby_doors == 1" ] } ]
         },
         "then": [
-          { "u_location_variable": { "u_val": "closetland_departure_point" }, "min_radius": 0, "max_radius": 0 },
-          { "u_add_effect": "blind", "duration": 0 },
-          { "u_add_effect": "effect_perk_closetland_temp_levitation", "duration": 0 },
           {
-            "u_travel_to_dimension": "dimension_perk_closetland",
-            "npc_travel_radius": 0,
-            "region_type": "dimension_perk_closetland_settings"
-          },
-          { "u_add_effect": "effect_perk_closetland_sleepiness", "duration": "PERMANENT" },
-          {
-            "if": { "not": { "math": [ "has_var(u_closetland_arrival_point)" ] } },
-            "then": { "run_eocs": "EOC_BOMBASTIC_PERKS_CLOSET_STORAGE_TRAVEL_TO_CLOSETLAND_INITIAL_ARRIVAL" },
-            "else": [ { "u_teleport": { "u_val": "closetland_arrival_point" } }, { "u_lose_effect": "blind" } ]
+            "if": { "compare_string": [ { "global_val": "closetland_last_dimension" }, "", "dimension_sky_island_mission", "highlands" ] },
+            "then": [
+              { "u_location_variable": { "u_val": "closetland_departure_point" }, "min_radius": 0, "max_radius": 0 },
+              { "u_add_effect": "blind", "duration": 0 },
+              { "u_add_effect": "effect_perk_closetland_temp_levitation", "duration": 0 },
+              {
+                "u_travel_to_dimension": "dimension_perk_closetland",
+                "npc_travel_radius": 0,
+                "region_type": "dimension_perk_closetland_settings"
+              },
+              { "u_add_effect": "effect_perk_closetland_sleepiness", "duration": "PERMANENT" },
+              {
+                "if": { "not": { "math": [ "has_var(u_closetland_arrival_point)" ] } },
+                "then": { "run_eocs": "EOC_BOMBASTIC_PERKS_CLOSET_STORAGE_TRAVEL_TO_CLOSETLAND_INITIAL_ARRIVAL" },
+                "else": [ { "u_teleport": { "u_val": "closetland_arrival_point" } }, { "u_lose_effect": "blind" } ]
+              }
+            ],
+            "else": [
+              { "u_message": "Try as you might, you can't seem to find the way to the secret realm." },
+              {
+                "run_eocs": "EOC_BOMBASTIC_PERKS_CLOSET_STORAGE_TRAVEL_TO_CLOSETLAND_DEACTIVATE_FUTURE",
+                "time_in_future": 0
+              }
+            ]
           }
         ],
         "else": [
@@ -162,7 +175,7 @@
         "ter_furn_transform": "perk_closetland_regenerate_light_if_broken",
         "target_var": { "u_val": "closetland_arrival_point" }
       },
-      { "u_travel_to_dimension": "default" },
+      { "u_travel_to_dimension": { "global_val": "closetland_last_dimension" } },
       { "u_teleport": { "u_val": "closetland_departure_point" } },
       { "u_lose_effect": "blind" },
       { "u_lose_effect": "effect_perk_closetland_sleepiness" }

--- a/data/mods/BombasticPerks/perkdata/closetland.json
+++ b/data/mods/BombasticPerks/perkdata/closetland.json
@@ -141,7 +141,9 @@
         "u_location_variable": { "u_val": "closetland_arrival_point" },
         "terrain": "t_closetland_floor_olight",
         "target_min_radius": 0,
-        "target_max_radius": 24
+        "target_max_radius": 24,
+        "z_override": true,
+        "z_adjust": 0
       },
       { "u_teleport": { "u_val": "closetland_arrival_point" } },
       { "u_lose_effect": "blind" }

--- a/data/mods/BombasticPerks/perkdata/closetland.json
+++ b/data/mods/BombasticPerks/perkdata/closetland.json
@@ -94,6 +94,21 @@
                 "if": { "not": { "math": [ "has_var(u_closetland_arrival_point)" ] } },
                 "then": { "run_eocs": "EOC_BOMBASTIC_PERKS_CLOSET_STORAGE_TRAVEL_TO_CLOSETLAND_INITIAL_ARRIVAL" },
                 "else": [ { "u_teleport": { "u_val": "closetland_arrival_point" } }, { "u_lose_effect": "blind" } ]
+              },
+              {
+                "if": {
+                  "and": [
+                    { "mod_is_loaded": "skyisland" },
+                    { "not": { "math": [ "has_var(u_closetland_has_been_told_about_skyisland_risk)" ] } }
+                  ]
+                },
+                "then": [
+                  {
+                    "u_message": "The walls of the closet seem to vibrate to your heartbeat, you feel certain that failing a raid will cause the walls here to briefly vanish, ejecting everything here into nothingness.",
+                    "popup": true
+                  },
+                  { "math": [ "u_closetland_has_been_told_about_skyisland_risk = true" ] }
+                ]
               }
             ],
             "else": [

--- a/data/mods/BombasticPerks/perkdata/closetland_paths.json
+++ b/data/mods/BombasticPerks/perkdata/closetland_paths.json
@@ -4,6 +4,7 @@
     "id": "EOC_BOMBASTIC_PERKS_CLOSET_STORAGE_DIFFERENT_PATHS_OF_CLOSETLAND",
     "condition": { "not": { "current_dimension": "dimension_perk_closetland" } },
     "effect": [
+      { "dimension_name": { "context_val": "closetland_paths_last_dimension" } },
       { "math": [ "u_closetland_perk_nearby_walls = 0" ] },
       { "math": [ "u_closetland_perk_nearby_doors = 0" ] },
       {
@@ -46,7 +47,13 @@
         "if": {
           "and": [ { "math": [ "u_closetland_perk_nearby_walls == 7" ] }, { "math": [ "u_closetland_perk_nearby_doors == 1" ] } ]
         },
-        "then": [ { "run_eocs": "EOC_BOMBASTIC_PERKS_CLOSET_STORAGE_DIFFERENT_PATHS_OF_CLOSETLAND_MEMORIZE" } ],
+        "then": [
+          {
+            "if": { "compare_string": [ { "context_val": "closetland_paths_last_dimension" }, "" ] },
+            "then": [ { "run_eocs": "EOC_BOMBASTIC_PERKS_CLOSET_STORAGE_DIFFERENT_PATHS_OF_CLOSETLAND_MEMORIZE" } ],
+            "else": [ { "u_message": "You can't memorize this closet, for some reason." } ]
+          }
+        ],
         "else": [ { "u_message": "You're not in a closet, and there's no path here to remember." } ]
       }
     ],
@@ -83,7 +90,8 @@
         "string_input": { "title": "Input a destination name:", "description": "Destination Name:", "width": 35 },
         "target_var": { "u_val": "perk_closetland_paths_destination_name_1" }
       },
-      { "u_location_variable": { "u_val": "perk_closetland_paths_destination_1" }, "min_radius": 0, "max_radius": 0 }
+      { "u_location_variable": { "u_val": "perk_closetland_paths_destination_1" }, "min_radius": 0, "max_radius": 0 },
+      { "dimension_name": { "u_val": "perk_closetland_paths_destination_dimension_1" } }
     ]
   },
   {
@@ -95,7 +103,8 @@
         "string_input": { "title": "Input a destination name:", "description": "Destination Name:", "width": 35 },
         "target_var": { "u_val": "perk_closetland_paths_destination_name_2" }
       },
-      { "u_location_variable": { "u_val": "perk_closetland_paths_destination_2" }, "min_radius": 0, "max_radius": 0 }
+      { "u_location_variable": { "u_val": "perk_closetland_paths_destination_2" }, "min_radius": 0, "max_radius": 0 },
+      { "dimension_name": { "u_val": "perk_closetland_paths_destination_dimension_2" } }
     ]
   },
   {
@@ -107,7 +116,8 @@
         "string_input": { "title": "Input a destination name:", "description": "Destination Name:", "width": 35 },
         "target_var": { "u_val": "perk_closetland_paths_destination_name_3" }
       },
-      { "u_location_variable": { "u_val": "perk_closetland_paths_destination_3" }, "min_radius": 0, "max_radius": 0 }
+      { "u_location_variable": { "u_val": "perk_closetland_paths_destination_3" }, "min_radius": 0, "max_radius": 0 },
+      { "dimension_name": { "u_val": "perk_closetland_paths_destination_dimension_3" } }
     ]
   },
   {
@@ -138,7 +148,7 @@
     "condition": { "math": [ "has_var(u_perk_closetland_paths_destination_1)" ] },
     "effect": [
       { "u_add_effect": "blind", "duration": 0 },
-      { "u_travel_to_dimension": "default" },
+      { "u_travel_to_dimension": { "u_val": "perk_closetland_paths_destination_dimension_1" } },
       { "u_teleport": { "u_val": "perk_closetland_paths_destination_1" } },
       { "u_lose_effect": "blind" },
       { "u_lose_effect": "effect_perk_closetland_sleepiness" },
@@ -151,7 +161,7 @@
     "condition": { "math": [ "has_var(u_perk_closetland_paths_destination_2)" ] },
     "effect": [
       { "u_add_effect": "blind", "duration": 0 },
-      { "u_travel_to_dimension": "default" },
+      { "u_travel_to_dimension": { "u_val": "perk_closetland_paths_destination_dimension_2" } },
       { "u_teleport": { "u_val": "perk_closetland_paths_destination_2" } },
       { "u_lose_effect": "blind" },
       { "u_lose_effect": "effect_perk_closetland_sleepiness" },
@@ -164,7 +174,7 @@
     "condition": { "math": [ "has_var(u_perk_closetland_paths_destination_3)" ] },
     "effect": [
       { "u_add_effect": "blind", "duration": 0 },
-      { "u_travel_to_dimension": "default" },
+      { "u_travel_to_dimension": { "u_val": "perk_closetland_paths_destination_dimension_3" } },
       { "u_teleport": { "u_val": "perk_closetland_paths_destination_3" } },
       { "u_lose_effect": "blind" },
       { "u_lose_effect": "effect_perk_closetland_sleepiness" },

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -2220,7 +2220,7 @@
         "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
       },
       {
-        "condition": { "not": { "u_has_trait": "perk_secret_closet_teleporter_paths" } },
+        "condition": { "not": { "or": [ { "u_has_trait": "perk_secret_closet_teleporter_paths" }, { "mod_is_loaded": "skyisland" } ] } },
         "text": "Gain [<trait_name:perk_secret_closet_teleporter_paths>]",
         "effect": [
           { "set_string_var": "<trait_name:perk_secret_closet_teleporter_paths>", "target_var": { "context_val": "trait_name" } },

--- a/data/mods/Sky_Island/EOCs.json
+++ b/data/mods/Sky_Island/EOCs.json
@@ -196,6 +196,7 @@
         ]
       },
       { "clear_dimension": "dimension_sky_island_mission" },
+      { "if": { "mod_is_loaded": "bombastic_perks" }, "then": { "clear_dimension": "dimension_perk_closetland" } },
       { "math": [ "timeawayfromhome = 0 - bonuspulses" ] }
     ]
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Closetland perk tracks the dimension you entered it from, also better integration with sky island "

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Encountered issues while using the perk in my sky island run.
Changes made to closetland perk if using sky island are due to the perk being really unbalanced, allowing the player to basically bypass having to reach the exit in time if they just stash all their stuff in the closetland.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Upon entering closetland, the dimension from which you entered is tracked. You're returned to that dimension when you exit closetland.
Closetland Paths now also save what dimension the paths were saved in, but for now I restricted Paths perk to the default dimension. Also Paths perk can't be acquired if you have Sky Island mod enabled.
For Sky Island + Closetland interaction, the closetland dimension gets wiped if you lose a sky island raid. To prevent people from using the dimension to bypass losing their stuff on death.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Disabling closetland perk in sky island
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Everything seems to work fine, though i'm sure i probably missed some obscure interactions
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
thanks to the author of #85235 for implementing the required EOC func to make this work.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
