### PR TITLE
Even more input popup migration

### DIFF
--- a/data/json/effects_on_condition/example_eocs.json
+++ b/data/json/effects_on_condition/example_eocs.json
@@ -527,20 +527,12 @@
     "effect": [
       {
         "set_string_var": "default",
-        "string_input": {
-          "title": { "str": "teleport to dimension named:" },
-          "description": { "str": "empty for main dimension" },
-          "width": 30
-        },
+        "string_input": { "title": { "str": "teleport to dimension named:" }, "description": { "str": "empty for main dimension" } },
         "target_var": { "u_val": "destination_dimension" }
       },
       {
         "set_string_var": "default",
-        "string_input": {
-          "title": { "str": "region type for the dimension?" },
-          "description": { "str": "empty for default region." },
-          "width": 30
-        },
+        "string_input": { "title": { "str": "region type for the dimension?" }, "description": { "str": "empty for default region." } },
         "target_var": { "u_val": "region_type" }
       },
       {
@@ -563,11 +555,7 @@
     "effect": [
       {
         "set_string_var": "",
-        "string_input": {
-          "title": { "str": "clear the dimension named:" },
-          "description": { "str": "the main dimension can't be cleared." },
-          "width": 30
-        },
+        "string_input": { "title": { "str": "clear the dimension named:" }, "description": { "str": "the main dimension can't be cleared." } },
         "target_var": { "u_val": "target_dimension" }
       },
       { "clear_dimension": { "u_val": "target_dimension" } },

--- a/data/json/items/tool/debug_tools.json
+++ b/data/json/items/tool/debug_tools.json
@@ -137,7 +137,7 @@
               "effect": [
                 {
                   "set_string_var": "",
-                  "string_input": { "title": "", "description": "fault_id or fault_type_id", "identifier": "debug_apply_fault", "width": 30 },
+                  "string_input": { "title": "", "description": "fault_id or fault_type_id", "identifier": "debug_apply_fault" },
                   "target_var": { "context_val": "str" }
                 },
                 {

--- a/data/mods/BombasticPerks/perkdata/closetland_paths.json
+++ b/data/mods/BombasticPerks/perkdata/closetland_paths.json
@@ -80,7 +80,7 @@
     "effect": [
       {
         "set_string_var": "Destination 1",
-        "string_input": { "title": "Input a destination name:", "description": "Destination Name:", "width": 35 },
+        "string_input": { "title": "Input a destination name:", "description": "Destination Name:" },
         "target_var": { "u_val": "perk_closetland_paths_destination_name_1" }
       },
       { "u_location_variable": { "u_val": "perk_closetland_paths_destination_1" }, "min_radius": 0, "max_radius": 0 }
@@ -92,7 +92,7 @@
     "effect": [
       {
         "set_string_var": "Destination 1",
-        "string_input": { "title": "Input a destination name:", "description": "Destination Name:", "width": 35 },
+        "string_input": { "title": "Input a destination name:", "description": "Destination Name:" },
         "target_var": { "u_val": "perk_closetland_paths_destination_name_2" }
       },
       { "u_location_variable": { "u_val": "perk_closetland_paths_destination_2" }, "min_radius": 0, "max_radius": 0 }
@@ -104,7 +104,7 @@
     "effect": [
       {
         "set_string_var": "Destination 1",
-        "string_input": { "title": "Input a destination name:", "description": "Destination Name:", "width": 35 },
+        "string_input": { "title": "Input a destination name:", "description": "Destination Name:" },
         "target_var": { "u_val": "perk_closetland_paths_destination_name_3" }
       },
       { "u_location_variable": { "u_val": "perk_closetland_paths_destination_3" }, "min_radius": 0, "max_radius": 0 }

--- a/data/mods/MindOverMatter/powers/teleportation_eoc.json
+++ b/data/mods/MindOverMatter/powers/teleportation_eoc.json
@@ -515,7 +515,7 @@
     "effect": [
       {
         "set_string_var": "Destination 1",
-        "string_input": { "title": "Input a destination name:", "description": "Destination Name:", "width": 35 },
+        "string_input": { "title": "Input a destination name:", "description": "Destination Name:" },
         "target_var": { "u_val": "gateway_destination_name_1" }
       },
       { "u_location_variable": { "u_val": "gateway_destination_1" }, "min_radius": 0, "max_radius": 0 },
@@ -579,7 +579,7 @@
     "effect": [
       {
         "set_string_var": "Destination 2",
-        "string_input": { "title": "Input a destination name:", "description": "Destination Name:", "width": 35 },
+        "string_input": { "title": "Input a destination name:", "description": "Destination Name:" },
         "target_var": { "u_val": "gateway_destination_name_2" }
       },
       { "u_location_variable": { "u_val": "gateway_destination_2" }, "min_radius": 0, "max_radius": 0 },
@@ -639,7 +639,7 @@
     "effect": [
       {
         "set_string_var": "Destination 3",
-        "string_input": { "title": "Input a destination name:", "description": "Destination Name:", "width": 35 },
+        "string_input": { "title": "Input a destination name:", "description": "Destination Name:" },
         "target_var": { "u_val": "gateway_destination_name_3" }
       },
       { "u_location_variable": { "u_val": "gateway_destination_3" }, "min_radius": 0, "max_radius": 0 },
@@ -699,7 +699,7 @@
     "effect": [
       {
         "set_string_var": "Destination 4",
-        "string_input": { "title": "Input a destination name:", "description": "Destination Name:", "width": 35 },
+        "string_input": { "title": "Input a destination name:", "description": "Destination Name:" },
         "target_var": { "u_val": "gateway_destination_name_4" }
       },
       { "u_location_variable": { "u_val": "gateway_destination_4" }, "min_radius": 0, "max_radius": 0 },
@@ -759,7 +759,7 @@
     "effect": [
       {
         "set_string_var": "Destination 5",
-        "string_input": { "title": "Input a destination name:", "description": "Destination Name:", "width": 35 },
+        "string_input": { "title": "Input a destination name:", "description": "Destination Name:" },
         "target_var": { "u_val": "gateway_destination_name_5" }
       },
       { "u_location_variable": { "u_val": "gateway_destination_5" }, "min_radius": 0, "max_radius": 0 },
@@ -819,7 +819,7 @@
     "effect": [
       {
         "set_string_var": "Destination 6",
-        "string_input": { "title": "Input a destination name:", "description": "Destination Name:", "width": 35 },
+        "string_input": { "title": "Input a destination name:", "description": "Destination Name:" },
         "target_var": { "u_val": "gateway_destination_name_6" }
       },
       { "u_location_variable": { "u_val": "gateway_destination_6" }, "min_radius": 0, "max_radius": 0 },
@@ -879,7 +879,7 @@
     "effect": [
       {
         "set_string_var": "Destination 7",
-        "string_input": { "title": "Input a destination name:", "description": "Destination Name:", "width": 35 },
+        "string_input": { "title": "Input a destination name:", "description": "Destination Name:" },
         "target_var": { "u_val": "gateway_destination_name_7" }
       },
       { "u_location_variable": { "u_val": "gateway_destination_7" }, "min_radius": 0, "max_radius": 0 },
@@ -939,7 +939,7 @@
     "effect": [
       {
         "set_string_var": "Destination 8",
-        "string_input": { "title": "Input a destination name:", "description": "Destination Name:", "width": 35 },
+        "string_input": { "title": "Input a destination name:", "description": "Destination Name:" },
         "target_var": { "u_val": "gateway_destination_name_8" }
       },
       { "u_location_variable": { "u_val": "gateway_destination_8" }, "min_radius": 0, "max_radius": 0 },
@@ -999,7 +999,7 @@
     "effect": [
       {
         "set_string_var": "Destination 9",
-        "string_input": { "title": "Input a destination name:", "description": "Destination Name:", "width": 35 },
+        "string_input": { "title": "Input a destination name:", "description": "Destination Name:" },
         "target_var": { "u_val": "gateway_destination_name_9" }
       },
       { "u_location_variable": { "u_val": "gateway_destination_9" }, "min_radius": 0, "max_radius": 0 },
@@ -1059,7 +1059,7 @@
     "effect": [
       {
         "set_string_var": "Destination 10",
-        "string_input": { "title": "Input a destination name:", "description": "Destination Name:", "width": 35 },
+        "string_input": { "title": "Input a destination name:", "description": "Destination Name:" },
         "target_var": { "u_val": "gateway_destination_name_10" }
       },
       { "u_location_variable": { "u_val": "gateway_destination_10" }, "min_radius": 0, "max_radius": 0 },

--- a/src/magic_teleporter_list.cpp
+++ b/src/magic_teleporter_list.cpp
@@ -18,6 +18,7 @@
 #include "flexbuffer_json.h"
 #include "game.h"
 #include "imgui/imgui.h"
+#include "input_popup.h"
 #include "json.h"
 #include "map.h"
 #include "map_iterator.h"
@@ -26,7 +27,6 @@
 #include "output.h"
 #include "panels.h"
 #include "point.h"
-#include "string_input_popup.h"
 #include "translations.h"
 #include "type_id.h"
 #include "uilist.h"
@@ -35,15 +35,10 @@ static const efftype_id effect_ignore_fall_damage( "ignore_fall_damage" );
 
 static bool popup_string( std::string &result, std::string &title )
 {
-    string_input_popup popup;
-    popup.title( title );
-    popup.text( "" ).only_digits( false );
-    popup.query();
-    if( popup.canceled() ) {
-        return false;
-    }
-    result = popup.text();
-    return true;
+    string_input_popup_imgui popup( -1 );
+    popup.set_label( title );
+    result = popup.query();
+    return !popup.cancelled();
 }
 
 bool teleporter_list::activate_teleporter( const tripoint_abs_omt &omt_pt, const tripoint_bub_ms & )

--- a/src/math_parser_diag.cpp
+++ b/src/math_parser_diag.cpp
@@ -31,6 +31,7 @@
 #include "faction.h"
 #include "field.h"
 #include "game.h"
+#include "input_popup.h"
 #include "item.h"
 #include "item_location.h"
 #include "magic.h"
@@ -47,7 +48,6 @@
 #include "point.h"
 #include "proficiency.h"
 #include "stomach.h"
-#include "string_input_popup.h"
 #include "talker.h"
 #include "translations.h"
 #include "type_id.h"
@@ -606,14 +606,13 @@ double item_rad_eval( const_dialogue const &d, char scope, std::vector<diag_valu
 double num_input_eval( const_dialogue const &d, char /*scope*/,
                        std::vector<diag_value> const &params, diag_kwargs const & /* kwargs */ )
 {
-    string_input_popup popup;
     double dv = params[1].dbl( d );
     int popup_val = dv;
-    popup.title( _( "Input a value:" ) )
-    .width( 20 )
-    .description( params[0].str( d ) )
-    .edit( popup_val );
-    if( popup.canceled() ) {
+    number_input_popup<int> popup( 55, popup_val );
+    popup.set_label( _( "Input a value:" ) );
+    popup.set_description( params[0].str( d ) );
+    popup_val = popup.query();
+    if( popup.cancelled() ) {
         return dv;
     }
     return static_cast<double>( popup_val );

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -21,6 +21,7 @@
 #include "game.h"
 #include "game_inventory.h"
 #include "handle_liquid.h"
+#include "input_popup.h"
 #include "item.h"
 #include "item_location.h"
 #include "itype.h"
@@ -36,7 +37,6 @@
 #include "point.h"
 #include "rng.h"
 #include "string_formatter.h"
-#include "string_input_popup.h"
 #include "talker.h"  // IWYU pragma: keep
 #include "translations.h"
 #include "type_id.h"
@@ -192,11 +192,10 @@ void push( monster &z )
 
 void rename_pet( monster &z )
 {
-    std::string unique_name = string_input_popup()
-                              .title( _( "Enter new pet name:" ) )
-                              .width( 20 )
-                              .query_string();
-    if( !unique_name.empty() ) {
+    string_input_popup_imgui pet_popup( 55, z.unique_name );
+    pet_popup.set_label( _( "Enter new pet name:" ) );
+    std::string unique_name = pet_popup.query();
+    if( !pet_popup.cancelled() ) {
         z.unique_name = unique_name;
     }
 }

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -73,6 +73,7 @@
 #include "input.h"
 #include "input_context.h"
 #include "input_enums.h"
+#include "input_popup.h"
 #include "inventory.h"
 #include "inventory_ui.h"
 #include "item.h"
@@ -1224,28 +1225,22 @@ void game::chat( const std::optional<tripoint_bub_ms> &p )
             break;
         case NPC_CHAT_SENTENCE: {
             std::string popupdesc = _( "Enter a sentence to yell" );
-            string_input_popup popup;
-            popup.title( _( "Yell a sentence" ) )
-            .width( 64 )
-            .description( popupdesc )
-            .identifier( "sentence" )
-            .max_length( 128 )
-            .query();
-            yell_msg = popup.text();
+            string_input_popup_imgui popup( 80 );
+            popup.set_label( _( "Yell a sentence" ) );
+            popup.set_description( popupdesc );
+            popup.set_identifier( "sentence" );
+            yell_msg = popup.query();
             is_order = false;
             break;
         }
         case NPC_CHAT_EMOTE: {
             std::string popupdesc =
                 _( "What do you want to emote?  (This will have no in-game effect!)" );
-            string_input_popup popup;
-            popup.title( _( "Emote" ) )
-            .width( 64 )
-            .description( popupdesc )
-            .identifier( "sentence" )
-            .max_length( 128 )
-            .query();
-            emote_msg = popup.text();
+            string_input_popup_imgui popup( 80 );
+            popup.set_label( _( "Emote" ) );
+            popup.set_description( popupdesc );
+            popup.set_identifier( "sentence" );
+            emote_msg = popup.query();
             is_order = false;
             break;
         }
@@ -5830,19 +5825,20 @@ talk_effect_fun_t::func f_set_string_var( const JsonObject &jo, std::string_view
             i18n ? i18n_vals[index].evaluate( d ).translated() : str_vals[index].evaluate( d );
 
         if( input_params.has_value() ) {
-            string_input_popup popup;
-            popup
-            .title( input_params.value().title ? input_params.value().title->evaluate( d ).translated() : "" )
-            .description( input_params.value().description ? input_params.value().description->evaluate(
-                              d ).translated() : "" )
-            .width( input_params.value().width )
-            .identifier( input_params.value().identifier ? input_params.value().identifier->evaluate(
-                             d ) : "" );
-
+            std::string label = input_params.value().title ? input_params.value().title->evaluate(
+                                    d ).translated() : "";
             std::string str_temp = input_params.value().default_text ?
                                    input_params.value().default_text->evaluate( d ).translated() : "";
-            popup.edit( str_temp );
-            if( !popup.canceled() ) {
+            string_input_popup_imgui popup( input_params.value().width + label.size(), str_temp );
+            popup.set_label( input_params.value().title ? input_params.value().title->evaluate(
+                                 d ).translated() : "" );
+            popup.set_description( input_params.value().description ?
+                                   input_params.value().description->evaluate( d ).translated() : "" );
+            popup.set_identifier( input_params.value().identifier ? input_params.value().identifier->evaluate(
+                                      d ) : "" );
+
+            str_temp = popup.query();
+            if( !popup.cancelled() ) {
                 str = str_temp;
             }
         }

--- a/src/string_input_popup.cpp
+++ b/src/string_input_popup.cpp
@@ -701,7 +701,6 @@ string_input_params string_input_params::parse_string_input_params( const JsonOb
     optional( jo, false, "title", p.title );
     optional( jo, false, "description", p.description );
     optional( jo, false, "default_text", p.default_text );
-    optional( jo, false, "width", p.width, 20 );
     optional( jo, false, "identifier", p.identifier );
     return p;
 }

--- a/src/string_input_popup.h
+++ b/src/string_input_popup.h
@@ -304,8 +304,10 @@ struct string_input_params {
     std::optional<translation_or_var> title;
     std::optional<translation_or_var> description;
     std::optional<translation_or_var> default_text;
-    int width{};
     std::optional<str_or_var> identifier;
+    // actual width is this plus title width, 40 is just a number that works
+    int width = 40;
+
     static string_input_params parse_string_input_params( const JsonObject &jo );
 };
 #endif // CATA_SRC_STRING_INPUT_POPUP_H


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Migrate even more input popups.

#### Describe the solution

Migrated popups:
- teleporter naming
- math function num_input
- pet naming
- character creation filter inputs, character name, template name
- yelling and emoting
- set_string_var string_input

For the last one I removed the custom width. Mostly because the imgui input works differently to the old one in that regard.

#### Describe alternatives you've considered



#### Testing

Tested all the migrated inputs. Only tested one single instance for the EOC popups, but if one works, the rest should, too.

#### Additional context

