### PR TITLE
fix zone sorting with grabbed container: grab-aware pathfinding

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -12890,14 +12890,30 @@ void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
 
         // For first item: build dropoff_coords with route probing before pickup.
         // Always rebuild - previous item may have failed pickup and left stale coords.
+        // Sort by Chebyshev distance first so nearby destinations are probed
+        // first (populates route cache for later route_to_destination calls).
         if( picked_up_stuff.empty() ) {
             dropoff_coords.clear();
+            std::vector<std::pair<int, tripoint_abs_ms>> dest_candidates;
+            dest_candidates.reserve( dest_set.size() );
             for( const tripoint_abs_ms &possible_dest : dest_set ) {
                 const tripoint_bub_ms dest_bub = here.get_bub( possible_dest );
                 if( !here.inbounds( dest_bub ) || here.is_open_air( dest_bub ) ) {
                     continue;
                 }
-                // Probe actual routeability - same A* as route_to_destination.
+                dest_candidates.emplace_back( square_dist( abspos, possible_dest ), possible_dest );
+            }
+            std::sort( dest_candidates.begin(), dest_candidates.end(),
+            []( const std::pair<int, tripoint_abs_ms> &a, const std::pair<int, tripoint_abs_ms> &b ) {
+                return a.first < b.first;
+            } );
+            for( const auto &[cheb, possible_dest] : dest_candidates ) {
+                if( cheb <= 1 ) {
+                    // Adjacent - always reachable, skip A* probe
+                    dropoff_coords.emplace_back( possible_dest );
+                    continue;
+                }
+                const tripoint_bub_ms dest_bub = here.get_bub( possible_dest );
                 const int dist = zone_sorting::route_length( you, dest_bub );
                 if( dist == INT_MAX ) {
                     continue;
@@ -12953,11 +12969,25 @@ void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
 
         if( dropoff_coords.empty() ) {
             // Defensive fallback - 4a normally handles this. Probe fresh.
+            // Sort by Chebyshev so nearby destinations are probed first.
+            std::vector<std::pair<int, tripoint_abs_ms>> fallback_dests;
             for( const tripoint_abs_ms &possible_dest : dest_set ) {
                 const tripoint_bub_ms dest_bub = here.get_bub( possible_dest );
                 if( !here.inbounds( dest_bub ) || here.is_open_air( dest_bub ) ) {
                     continue;
                 }
+                fallback_dests.emplace_back( square_dist( abspos, possible_dest ), possible_dest );
+            }
+            std::sort( fallback_dests.begin(), fallback_dests.end(),
+            []( const std::pair<int, tripoint_abs_ms> &a, const std::pair<int, tripoint_abs_ms> &b ) {
+                return a.first < b.first;
+            } );
+            for( const auto &[cheb, possible_dest] : fallback_dests ) {
+                if( cheb <= 1 ) {
+                    dropoff_coords.emplace_back( possible_dest );
+                    continue;
+                }
+                const tripoint_bub_ms dest_bub = here.get_bub( possible_dest );
                 const int dist = zone_sorting::route_length( you, dest_bub );
                 if( dist == INT_MAX ) {
                     continue;

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <array>
+#include <climits>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
@@ -12,6 +13,7 @@
 #include <list>
 #include <map>
 #include <optional>
+#include <ostream>
 #include <queue>
 #include <set>
 #include <string>
@@ -12418,6 +12420,11 @@ void zone_activity_actor::do_turn( player_activity &act, Character &you )
         stage_init( act, you );
     }
     if( stage == THINK ) {
+        add_msg_debug( debugmode::DF_ACTIVITY,
+                       "zone_sort do_turn: THINK pos=(%d,%d) has_dest=%d coords=%zu",
+                       you.pos_bub().x(), you.pos_bub().y(),
+                       you.has_destination() ? 1 : 0,
+                       coord_set.size() );
         if( !stage_think( act, you ) ) {
             return;
         }
@@ -12476,8 +12483,10 @@ void zone_sort_activity_actor::do_turn( player_activity &act, Character &you )
 
 void zone_sort_activity_actor::stage_init( player_activity &, Character &you )
 {
-    const zone_manager &mgr = zone_manager::get_manager();
+    zone_manager &mgr = zone_manager::get_manager();
+    mgr.cache_avatar_location();
     coord_set.clear();
+    unreachable_dests.clear();
     for( const tripoint_abs_ms &p :
          mgr.get_near( zone_type_LOOT_UNSORTED, you.pos_abs(), MAX_VIEW_DISTANCE, nullptr,
                        you.get_faction_id() ) ) {
@@ -12489,16 +12498,85 @@ void zone_sort_activity_actor::stage_init( player_activity &, Character &you )
 bool zone_sort_activity_actor::stage_think( player_activity &act, Character &you )
 {
     const map &here = get_map();
+    zone_manager &mgr = zone_manager::get_manager();
+    mgr.cache_avatar_location();
 
     num_processed = 0;
+    // Clear stale state from previous source. Fresh destinations are computed
+    // in stage_do when items are picked up from the new source.
+    dropoff_coords.clear();
+    picked_up_stuff.clear();
 
-    // copy remaining zone positions, sort by closest distance
-    std::unordered_set<tripoint_abs_ms> src_set;
-    src_set.reserve( coord_set.size() );
+    // Sort sources by A* route distance. Pre-sort by Chebyshev (lower bound),
+    // compute A* lazily, stop when chebyshev > best_route + 1.
+    // Tiles past the cutoff are appended in Chebyshev order as fallback.
+    std::vector<std::pair<int, tripoint_abs_ms>> candidates;
+    candidates.reserve( coord_set.size() );
     for( const tripoint_abs_ms &p : coord_set ) {
-        src_set.emplace( p );
+        if( unreachable_dests.count( p ) ) {
+            continue;
+        }
+        candidates.emplace_back( square_dist( you.pos_abs(), p ), p );
     }
-    const auto &src_sorted = get_sorted_tiles_by_distance( you.pos_abs(), src_set );
+    std::sort( candidates.begin(), candidates.end(),
+    []( const std::pair<int, tripoint_abs_ms> &a, const std::pair<int, tripoint_abs_ms> &b ) {
+        return a.first < b.first;
+    } );
+
+    std::vector<std::pair<int, tripoint_abs_ms>> computed;
+    computed.reserve( candidates.size() );
+    std::vector<tripoint_abs_ms> oob_tiles; // out-of-bounds, handled by iteration loop
+    int best_route = INT_MAX;
+    size_t cutoff = candidates.size();
+
+    for( size_t i = 0; i < candidates.size(); i++ ) {
+        const int cheb = candidates[i].first;
+        if( best_route != INT_MAX && cheb > best_route + 1 ) {
+            cutoff = i;
+            break;
+        }
+        const tripoint_bub_ms p_bub = here.get_bub( candidates[i].second );
+        if( !here.inbounds( p_bub ) ) {
+            // Skip OOB tiles here — route_with_grab can't clip them.
+            // The iteration loop's !inbounds() handler will route closer.
+            oob_tiles.emplace_back( candidates[i].second );
+            continue;
+        }
+        if( cheb <= 1 ) {
+            // Already adjacent — no pathfinding needed
+            computed.emplace_back( 0, candidates[i].second );
+            best_route = 0;
+        } else {
+            const int dist = zone_sorting::route_length( you, p_bub );
+            if( dist == INT_MAX ) {
+                unreachable_dests.emplace( candidates[i].second );
+                continue;
+            }
+            computed.emplace_back( dist, candidates[i].second );
+            best_route = std::min( best_route, dist );
+        }
+    }
+
+    // Sort the computed portion by actual route distance
+    std::sort( computed.begin(), computed.end(),
+    []( const std::pair<int, tripoint_abs_ms> &a, const std::pair<int, tripoint_abs_ms> &b ) {
+        return a.first < b.first;
+    } );
+
+    // Build final list: route-sorted, then remaining in Chebyshev order, then OOB tiles
+    std::vector<tripoint_abs_ms> src_sorted;
+    src_sorted.reserve( candidates.size() );
+    for( const auto &entry : computed ) {
+        src_sorted.emplace_back( entry.second );
+    }
+    for( size_t i = cutoff; i < candidates.size(); i++ ) {
+        if( !unreachable_dests.count( candidates[i].second ) ) {
+            src_sorted.emplace_back( candidates[i].second );
+        }
+    }
+    for( const tripoint_abs_ms &p : oob_tiles ) {
+        src_sorted.emplace_back( p );
+    }
 
     // iterate over zone positions and look for items to move
     for( const tripoint_abs_ms &src : src_sorted ) {
@@ -12547,16 +12625,53 @@ bool zone_sort_activity_actor::stage_think( player_activity &act, Character &you
         // before we move any item, check if player is at or
         // adjacent to the loot source tile
         if( !is_adjacent_or_closer ) {
+            add_msg_debug( debugmode::DF_ACTIVITY,
+                           "zone_sort THINK: routing to source (%d,%d,%d) from (%d,%d)",
+                           src.x(), src.y(), src.z(),
+                           you.pos_bub().x(), you.pos_bub().y() );
             // check if we found path to source / adjacent tile
             if( !zone_sorting::route_to_destination( you, act, src_bub, stage ) ) {
+                add_msg_debug( debugmode::DF_ACTIVITY,
+                               "zone_sort THINK: route to source FAILED, trying next" );
                 continue;
             }
             return false;
         }
+        add_msg_debug( debugmode::DF_ACTIVITY,
+                       "zone_sort THINK: adjacent to source (%d,%d,%d), entering DO",
+                       src.x(), src.y(), src.z() );
         stage = DO;
         break;
     }
     return true;
+}
+
+void zone_sort_activity_actor::return_items_to_source( Character &you,
+        const tripoint_bub_ms &src_bub )
+{
+    // Purge stale item_locations (can expire if items merged during multi-turn pickup)
+    picked_up_stuff.erase(
+        std::remove_if( picked_up_stuff.begin(), picked_up_stuff.end(),
+    []( const item_location & loc ) {
+        return !loc.get_item();
+    } ),
+    picked_up_stuff.end() );
+    for( item_location &item : picked_up_stuff ) {
+        if( item.get_item() ) {
+            // Place the item back at the source tile
+            put_into_vehicle_or_drop_ret_locs( you, item_drop_reason::deliberate,
+            { *item }, src_bub );
+            // Remove from carrier (inventory or grabbed vehicle)
+            if( const vehicle_cursor *veh_curs = item.veh_cursor() ) {
+                vehicle &cart = veh_curs->veh;
+                cart.remove_item( cart.part( veh_curs->part ), item.get_item() );
+            } else if( item.carrier() ) {
+                item.carrier()->i_rem( item.get_item() );
+            }
+        }
+    }
+    picked_up_stuff.clear();
+    dropoff_coords.clear();
 }
 
 void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
@@ -12568,6 +12683,19 @@ void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
     const tripoint_abs_ms src( placement );
     const tripoint_bub_ms src_bub = here.get_bub( src );
     const tripoint_abs_ms abspos = you.pos_abs();
+
+    add_msg_debug( debugmode::DF_ACTIVITY,
+                   "zone_sort DO: pos=(%d,%d) src=(%d,%d,%d) has_dest=%d picked=%zu dropoffs=%zu",
+                   you.pos_bub().x(), you.pos_bub().y(),
+                   src.x(), src.y(), src.z(),
+                   you.has_destination() ? 1 : 0,
+                   picked_up_stuff.size(), dropoff_coords.size() );
+    DebugLog( D_INFO, DC_ALL ) << "zone_sort DO: pos=(" << you.pos_bub().x() << "," << you.pos_bub().y()
+                               << ") src=(" << src.x() << "," << src.y() << "," << src.z()
+                               << ") has_dest=" << you.has_destination()
+                               << " picked=" << picked_up_stuff.size()
+                               << " dropoffs=" << dropoff_coords.size()
+                               << " unreachable=" << unreachable_dests.size();
 
     // Dropping off
     if( !dropoff_coords.empty() && !picked_up_stuff.empty() ) {
@@ -12624,9 +12752,36 @@ void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
                 dest_iter = dropoff_coords.erase( dest_iter ); // Done dropping stuff here.
             } else {
                 dest_iter++; // Evaluate next dropoff
-                // FIXME: If none of the adjacent squares were valid, but we have other squares that we could drop them at then we need to handle that.
-                // That means we need to path to a new one. But only if there's nothing to pick up for sorting(?)
             }
+        }
+
+        // Items remain but no adjacent destinations. Route to nearest reachable
+        // dropoff, trying closest-first. Skip if still at source (keep picking up).
+        if( !picked_up_stuff.empty() && !dropoff_coords.empty() &&
+            !you.has_destination() && square_dist( you.pos_bub(), src_bub ) > 1 ) {
+            std::sort( dropoff_coords.begin(), dropoff_coords.end(),
+            [&abspos]( const tripoint_abs_ms & a, const tripoint_abs_ms & b ) {
+                return square_dist( abspos, a ) < square_dist( abspos, b );
+            } );
+
+            bool routed = false;
+            auto dest_it = dropoff_coords.begin();
+            while( dest_it != dropoff_coords.end() ) {
+                if( zone_sorting::route_to_destination( you, act, here.get_bub( *dest_it ), stage ) ) {
+                    routed = true;
+                    break;
+                }
+                unreachable_dests.insert( *dest_it );
+                dest_it = dropoff_coords.erase( dest_it );
+            }
+
+            if( !routed ) {
+                // All dropoff destinations unreachable. Return items to source.
+                // Don't erase source -- other items may have different reachable destinations.
+                return_items_to_source( you, src_bub );
+                stage = THINK;
+            }
+            return;
         }
     }
 
@@ -12634,6 +12789,9 @@ void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
     // before we move any item, check if player is at or
     // adjacent to the loot source tile
     if( !is_adjacent_or_closer ) {
+        add_msg_debug( debugmode::DF_ACTIVITY,
+                       "zone_sort DO: NOT adjacent to src (dist=%d), back to THINK",
+                       square_dist( you.pos_bub(), src_bub ) );
         stage = THINK;
         return;
     }
@@ -12693,17 +12851,41 @@ void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
             }
         }
 
+        // For the first item, verify at least one destination is reachable.
+        // Prevents picking up items only to find all destinations blocked.
+        if( picked_up_stuff.empty() && !unreachable_dests.empty() ) {
+            bool has_reachable_dest = false;
+            for( const tripoint_abs_ms &possible_dest : dest_set ) {
+                if( !unreachable_dests.count( possible_dest ) &&
+                    !here.is_open_air( here.get_bub( possible_dest ) ) ) {
+                    has_reachable_dest = true;
+                    break;
+                }
+            }
+            if( !has_reachable_dest ) {
+                add_msg_debug( debugmode::DF_ACTIVITY,
+                               "zone_sort DO: item '%s' has no reachable dests (%zu all unreachable), skip",
+                               thisitem.tname(), dest_set.size() );
+                continue;
+            }
+        }
+
         // FIXME HACK: teleports thisitem into inventory
         item copy_thisitem( thisitem );
         item_location thisitem_loc;
         if( you.is_avatar() && you.as_avatar()->get_grab_type() == object_type::VEHICLE ) {
-            // Resolve the item location if we put it into a vehicle...
+            // Try putting item into grabbed vehicle, but not if cart IS the
+            // source tile — that would cause infinite re-pickup.
             const tripoint_bub_ms cart_position = you.pos_bub() + you.as_avatar()->grab_point;
-            if( std::optional<vpart_reference> ovp = get_map().veh_at( cart_position ).cargo() ) {
-                vehicle &veh = ovp->vehicle();
-                std::optional<vehicle_stack::iterator> vehstack = veh.add_item( here, ovp->part(), copy_thisitem );
-                if( vehstack ) {
-                    thisitem_loc = item_location( vehicle_cursor( veh, ovp->part_index() ), &*vehstack.value() );
+            if( cart_position != src_bub ) {
+                if( std::optional<vpart_reference> ovp = get_map().veh_at( cart_position ).cargo() ) {
+                    vehicle &veh = ovp->vehicle();
+                    std::optional<vehicle_stack::iterator> vehstack = veh.add_item( here, ovp->part(),
+                            copy_thisitem );
+                    if( vehstack ) {
+                        thisitem_loc = item_location( vehicle_cursor( veh, ovp->part_index() ),
+                                                      &*vehstack.value() );
+                    }
                 }
             }
         }
@@ -12728,6 +12910,9 @@ void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
 
         if( dropoff_coords.empty() ) {
             for( const tripoint_abs_ms &possible_dest : dest_set ) {
+                if( unreachable_dests.count( possible_dest ) ) {
+                    continue;
+                }
                 const tripoint_bub_ms dest_bub = here.get_bub( possible_dest );
                 if( here.is_open_air( dest_bub ) ) {
                     you.add_msg_if_player( _( "You can't sort things into the air!" ) );
@@ -12753,11 +12938,130 @@ void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
     }
 
     if( picked_up_stuff.empty() ) {
-        //this location is sorted
+        // No items picked up — remove source to prevent infinite THINK/DO loop.
+        add_msg_debug( debugmode::DF_ACTIVITY,
+                       "zone_sort DO: no items picked up at src, erasing src, back to THINK" );
+        coord_set.erase( src );
         stage = THINK;
         dropoff_coords.clear();
     } else if( !dropoff_coords.empty() && !you.has_destination() )  {
-        zone_sorting::route_to_destination( you, act, here.get_bub( dropoff_coords.front() ), stage );
+        // Purge item_locations invalidated by inventory restacking.
+        auto stale = std::remove_if( picked_up_stuff.begin(), picked_up_stuff.end(),
+        []( const item_location & loc ) {
+            return !loc.get_item();
+        } );
+        if( stale != picked_up_stuff.end() ) {
+            add_msg_debug( debugmode::DF_ACTIVITY,
+                           "zone_sort DO: purged %zu stale item_locations from picked_up_stuff",
+                           std::distance( stale, picked_up_stuff.end() ) );
+            picked_up_stuff.erase( stale, picked_up_stuff.end() );
+        }
+        if( picked_up_stuff.empty() ) {
+            // All items merged into stacks, nothing to deliver.
+            add_msg_debug( debugmode::DF_ACTIVITY,
+                           "zone_sort DO: all picked items lost (merged?), back to THINK" );
+            coord_set.erase( src );
+            stage = THINK;
+            dropoff_coords.clear();
+            return;
+        }
+
+        bool match = false;
+        tripoint_abs_ms destination;
+
+        // Find a dropoff location that can take all the items picked up.
+        for( tripoint_abs_ms &dest : dropoff_coords ) {
+            std::vector<item_location> placed_items;
+
+            match = true;
+
+            for( item_location &item : picked_up_stuff ) {
+                std::vector<item_location> placed_item = put_into_vehicle_or_drop_ret_locs( you,
+                        item_drop_reason::deliberate, { *item }, here.get_bub( dest ) );
+
+                if( placed_item.empty() ) {
+                    match = false;
+                    break;
+
+                } else {
+                    placed_items.emplace_back( placed_item.front() );
+                }
+            }
+
+            // Get rid of the placed items, as we really only wanted to know if they COULD be placed.
+            for( item_location &item : placed_items ) {
+                item.remove_item();
+            }
+
+            if( match ) {
+                destination = dest;
+                break;
+            }
+        }
+
+        if( !match ) {
+            // Couldn't find any destination that would take all items. Fallback to one that can accept
+            // the first one that has a usable destination.
+            // Note that we always have to be able to handle the situation where a destination is full
+            // when we get there due to things happening in the mean time (like other characters sorting
+            // stuff into that location as we move there), so we leave the handling of unsortable items
+            // in the inventory to that handling for now.
+            for( tripoint_abs_ms &dest : dropoff_coords ) {
+                std::vector<item_location> placed_items;
+
+                match = true;
+
+                for( item_location &item : picked_up_stuff ) {
+                    std::vector<item_location> placed_item = put_into_vehicle_or_drop_ret_locs( you,
+                            item_drop_reason::deliberate, { *item }, here.get_bub( dest ) );
+
+                    if( placed_item.empty() ) {
+                        match = false;
+                        break;
+
+                    } else {
+                        placed_items.emplace_back( placed_item.front() );
+                        match = true;
+                        break;
+                    }
+                }
+
+                // Get rid of the placed items, as we really only wanted to know if they COULD be placed.
+                for( item_location &item : placed_items ) {
+                    item.remove_item();
+                }
+
+                if( match ) {
+                    destination = dest;
+                    break;
+                }
+            }
+        }
+
+        if( !match ) {
+            add_msg( m_bad, _( "None of the items picked up can be sorted because they won't fit anywhere." ) );
+            stage = LAST;
+            return;
+        }
+
+        add_msg_debug( debugmode::DF_ACTIVITY,
+                       "zone_sort DO: routing to dest (%d,%d,%d) with %zu items",
+                       destination.x(), destination.y(), destination.z(),
+                       picked_up_stuff.size() );
+        DebugLog( D_INFO, DC_ALL ) << "zone_sort DO: routing to dest ("
+                                   << destination.x() << "," << destination.y() << ","
+                                   << destination.z() << ") with " << picked_up_stuff.size() << " items";
+        if( !zone_sorting::route_to_destination( you, act, here.get_bub( destination ), stage ) ) {
+            // Can't reach destination. Mark it unreachable, return items, and retry.
+            // Don't erase source -- other items may have different reachable destinations.
+            add_msg_debug( debugmode::DF_ACTIVITY,
+                           "zone_sort DO: route to dest FAILED, marking unreachable, back to THINK" );
+            DebugLog( D_INFO, DC_ALL ) << "zone_sort DO: route to dest FAILED, marking unreachable";
+            unreachable_dests.insert( destination );
+            return_items_to_source( you, src_bub );
+            stage = THINK;
+        }
+
     } else if( !you.has_destination() ) {
         debugmsg( "Sort activity has items to sort but no valid destination, this is a bug" );
         // Completely kick us out of this activity, something's gone wrong and we don't know what's going on.
@@ -12778,6 +13082,7 @@ void zone_sort_activity_actor::serialize( JsonOut &jsout ) const
     jsout.member( "picked_up_stuff", picked_up_stuff );
     jsout.member( "dropoff_coords", dropoff_coords );
     jsout.member( "pickup_failure_reported", pickup_failure_reported );
+    jsout.member( "unreachable_dests", unreachable_dests );
 
     jsout.end_object();
 }
@@ -12799,6 +13104,9 @@ std::unique_ptr<activity_actor> zone_sort_activity_actor::deserialize( JsonValue
     // Element introduced 2026-01-26. Existence check to be removed when support for older saves is dropped.
     if( data.has_bool( "pickup_failure_reported" ) ) {
         data.read( "pickup_failure_reported", actor.pickup_failure_reported );
+    }
+    if( data.has_member( "unreachable_dests" ) ) {
+        data.read( "unreachable_dests", actor.unreachable_dests );
     }
     return actor.clone();
 }

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -4003,10 +4003,19 @@ class zone_sort_activity_actor : public zone_activity_actor
         // Place(s) that the current stuff can be dropped off at.
         std::vector<tripoint_abs_ms> dropoff_coords;
         bool pickup_failure_reported = false;
-        // Source tiles where routing failed this session (written in stage_think).
-        // Prevents retrying A* for sources known to be unreachable.
+        // Source tiles where routing failed or cart blocked pickup this cycle.
+        // Cleared when player position or grab state changes (per stage_think).
         // Destination reachability is probed fresh per-source in stage_do.
-        std::unordered_set<tripoint_abs_ms> unreachable_dests;
+        std::unordered_set<tripoint_abs_ms> unreachable_sources;
+
+        // State for position-based clearing of unreachable_sources.
+        // When position or grab orientation changes, sources are re-probed.
+        tripoint_abs_ms last_think_position;
+        object_type last_think_grab_type = object_type::NONE;
+        tripoint_rel_ms last_think_grab_point;
+        // Forces a clear on first stage_think call (fresh construction or deserialization).
+        // Avoids edge case where default-initialized values match real game state.
+        bool force_clear_unreachable = true;
 
         // Returns all picked up items to the source tile and clears sorting state.
         // Used when routing to a destination fails.

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -4003,8 +4003,9 @@ class zone_sort_activity_actor : public zone_activity_actor
         // Place(s) that the current stuff can be dropped off at.
         std::vector<tripoint_abs_ms> dropoff_coords;
         bool pickup_failure_reported = false;
-        // Tiles where routing failed this session (both sources and destinations).
-        // Prevents retrying A* for locations known to be unreachable.
+        // Source tiles where routing failed this session (written in stage_think).
+        // Prevents retrying A* for sources known to be unreachable.
+        // Destination reachability is probed fresh per-source in stage_do.
         std::unordered_set<tripoint_abs_ms> unreachable_dests;
 
         // Returns all picked up items to the source tile and clears sorting state.

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -4010,12 +4010,12 @@ class zone_sort_activity_actor : public zone_activity_actor
 
         // State for position-based clearing of unreachable_sources.
         // When position or grab orientation changes, sources are re-probed.
-        tripoint_abs_ms last_think_position;
-        object_type last_think_grab_type = object_type::NONE;
-        tripoint_rel_ms last_think_grab_point;
+        tripoint_abs_ms last_think_position; // NOLINT(cata-serialize)
+        object_type last_think_grab_type = object_type::NONE; // NOLINT(cata-serialize)
+        tripoint_rel_ms last_think_grab_point; // NOLINT(cata-serialize)
         // Forces a clear on first stage_think call (fresh construction or deserialization).
         // Avoids edge case where default-initialized values match real game state.
-        bool force_clear_unreachable = true;
+        bool force_clear_unreachable = true; // NOLINT(cata-serialize)
 
         // Returns all picked up items to the source tile and clears sorting state.
         // Used when routing to a destination fails.

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -4003,6 +4003,13 @@ class zone_sort_activity_actor : public zone_activity_actor
         // Place(s) that the current stuff can be dropped off at.
         std::vector<tripoint_abs_ms> dropoff_coords;
         bool pickup_failure_reported = false;
+        // Tiles where routing failed this session (both sources and destinations).
+        // Prevents retrying A* for locations known to be unreachable.
+        std::unordered_set<tripoint_abs_ms> unreachable_dests;
+
+        // Returns all picked up items to the source tile and clears sorting state.
+        // Used when routing to a destination fails.
+        void return_items_to_source( Character &you, const tripoint_bub_ms &src_bub );
 };
 
 #endif // CATA_SRC_ACTIVITY_ACTOR_DEFINITIONS_H

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -844,6 +844,121 @@ static bool tile_blocks_vehicle( const map &here, const tripoint_bub_ms &pos,
     return false;
 }
 
+// Cache routes computed by route_length() for reuse by route_to_destination().
+// Avoids recomputing the same A* when the sorter probes route distance and
+// then immediately routes to the same destination.
+namespace
+{
+struct zone_route_cache {
+    tripoint_bub_ms start;
+    object_type grab_type = object_type::NONE;
+    tripoint_rel_ms grab_point;
+    // (destination center, route). Empty route means unreachable.
+    std::vector<std::pair<tripoint_bub_ms, std::vector<tripoint_bub_ms>>> entries;
+    bool initialized = false;
+
+    void ensure_valid( const Character &who ) {
+        object_type gt = object_type::NONE;
+        tripoint_rel_ms gp;
+        if( who.is_avatar() ) {
+            gt = who.as_avatar()->get_grab_type();
+            gp = who.as_avatar()->grab_point;
+        }
+        if( !initialized || start != who.pos_bub() || grab_type != gt || grab_point != gp ) {
+            start = who.pos_bub();
+            grab_type = gt;
+            grab_point = gp;
+            entries.clear();
+            initialized = true;
+        }
+    }
+
+    const std::vector<tripoint_bub_ms> *find( const tripoint_bub_ms &dest ) const {
+        for( const auto &e : entries ) {
+            if( e.first == dest ) {
+                return &e.second;
+            }
+        }
+        return nullptr;
+    }
+
+    void store( const tripoint_bub_ms &dest, std::vector<tripoint_bub_ms> route ) {
+        entries.emplace_back( dest, std::move( route ) );
+    }
+};
+
+zone_route_cache g_route_cache;
+} // namespace
+
+// Check if a straight push or pull path works, skipping the full A*.
+// Only applies when grab direction is aligned with travel direction
+// (push) or opposite (pull), and every tile on the line is passable
+// for both the player and the dragged vehicle.
+static std::vector<tripoint_bub_ms> try_straight_grab_path(
+    const map &here, const tripoint_bub_ms &start, const pathfinding_target &target,
+    const tripoint_rel_ms &cur_grab, vehicle &grabbed_veh )
+{
+    const tripoint_bub_ms &dest = target.center;
+    const point d( dest.x() - start.x(), dest.y() - start.y() );
+    const point ad( std::abs( d.x ), std::abs( d.y ) );
+
+    // Must be a pure cardinal or diagonal direction
+    if( ( ad.x != ad.y && ad.x > 0 && ad.y > 0 ) || ( ad.x == 0 && ad.y == 0 ) ) {
+        return {};
+    }
+
+    const point s( d.x > 0 ? 1 : ( d.x < 0 ? -1 : 0 ), d.y > 0 ? 1 : ( d.y < 0 ? -1 : 0 ) );
+    const tripoint_rel_ms dir( s.x, s.y, 0 );
+
+    const bool is_push = cur_grab == dir;
+    const bool is_pull = cur_grab == -dir;
+    if( !is_push && !is_pull ) {
+        return {};
+    }
+
+    const int num_steps = std::max( ad.x, ad.y );
+    std::vector<tripoint_bub_ms> route;
+    route.reserve( num_steps );
+
+    tripoint_bub_ms player = start;
+    tripoint_bub_ms vehicle_pos = start + cur_grab;
+
+    for( int step = 0; step < num_steps; step++ ) {
+        const tripoint_bub_ms next_player = player + dir;
+        tripoint_bub_ms next_vehicle;
+        if( is_push ) {
+            next_vehicle = vehicle_pos + dir;
+        } else {
+            // Pull: vehicle follows to player's old position
+            next_vehicle = player;
+        }
+
+        // Player passability (exclude grabbed vehicle - it vacates on push)
+        if( here.move_cost( next_player, &grabbed_veh ) == 0 ) {
+            return {};
+        }
+
+        // Vehicle passability
+        if( tile_blocks_vehicle( here, next_vehicle, is_pull ) ) {
+            return {};
+        }
+        const optional_vpart_position ovp_check = here.veh_at( next_vehicle );
+        if( ovp_check && &ovp_check->vehicle() != &grabbed_veh ) {
+            return {};
+        }
+
+        route.push_back( next_player );
+        if( target.contains( next_player ) ) {
+            return route;
+        }
+
+        player = next_player;
+        vehicle_pos = next_vehicle;
+    }
+
+    return {};
+}
+
 // State is (player_position, grab_direction), so it finds routes where
 // both the player and the dragged vehicle can physically move.
 // Returns an empty vector if no path exists or if the player isn't
@@ -880,6 +995,15 @@ static std::vector<tripoint_bub_ms> route_with_grab(
                    "route_with_grab: start=(%d,%d) grab=(%d,%d) target=(%d,%d) r=%d",
                    start.x(), start.y(), start_grab.x(), start_grab.y(),
                    target.center.x(), target.center.y(), target.r );
+
+    // Fast path: if grab is aligned with travel direction, check the
+    // straight line before spinning up the full A* with its 157K-state arrays.
+    ret = try_straight_grab_path( here, start, target, start_grab, grabbed_veh );
+    if( !ret.empty() ) {
+        add_msg_debug( debugmode::DF_ACTIVITY,
+                       "route_with_grab: straight line path len=%zu", ret.size() );
+        return ret;
+    }
 
     const int max_length = you.get_pathfinding_settings().max_length;
     const int pad = 16;
@@ -924,7 +1048,11 @@ static std::vector<tripoint_bub_ms> route_with_grab(
     gscore[start_state] = 0;
     open[start_state] = true;
     parent[start_state] = start_state;
-    pq.emplace( 2 * rl_dist( start, t ), start_state );
+    // Tighter heuristic: minimum cost per tile is 4 (player move_cost=2 +
+    // vehicle drag=2 on flat road), minus 2 for one possible sideways move
+    // (vehicle stays put, cost=2). Uses square_dist (Chebyshev = min steps)
+    // instead of rl_dist to stay admissible regardless of trigdist setting.
+    pq.emplace( std::max( 0, 4 * square_dist( start, t ) - 2 ), start_state );
 
     // Movement offsets: W, E, N, S, NE, SW, NW, SE
     constexpr std::array<int, 8> x_off{ { -1,  1,  0,  0,  1, -1, -1, 1 } };
@@ -1071,7 +1199,7 @@ static std::vector<tripoint_bub_ms> route_with_grab(
             open[next_state] = true;
             gscore[next_state] = newg;
             parent[next_state] = cur_state;
-            const int h = 2 * rl_dist( next3d, t );
+            const int h = std::max( 0, 4 * square_dist( next3d, t ) - 2 );
             pq.emplace( newg + h, next_state );
         }
     }
@@ -1108,31 +1236,46 @@ bool route_to_destination( Character &you, player_activity &act,
     const map &here = get_map();
     std::vector<tripoint_bub_ms> route;
 
-    // Use grab-aware A* when dragging a single-tile vehicle - searches over
-    // (position, grab_direction) state so both player and cart can move.
+    // Check if route_length() already computed a path for this destination.
+    g_route_cache.ensure_valid( you );
     bool used_grab_routing = false;
-    if( you.is_avatar() && you.as_avatar()->get_grab_type() == object_type::VEHICLE ) {
-        const tripoint_bub_ms veh_pos = you.pos_bub() + you.as_avatar()->grab_point;
-        const optional_vpart_position ovp = here.veh_at( veh_pos );
-        if( ovp && ovp->vehicle().get_points().size() == 1 ) {
-            // Single-tile vehicle: use grab-aware A*. If no path found,
-            // treat as unreachable (don't fall back to player-only routing
-            // which would cause cart collisions).
-            used_grab_routing = true;
-            route = route_with_grab( here, you, pathfinding_target::adjacent( dest ) );
+    bool from_cache = false;
+    if( const std::vector<tripoint_bub_ms> *cached = g_route_cache.find( dest ) ) {
+        if( !cached->empty() ) {
+            route = *cached;
+            from_cache = true;
+            used_grab_routing = ( you.is_avatar() &&
+                                  you.as_avatar()->get_grab_type() == object_type::VEHICLE );
+        }
+    }
+
+    if( route.empty() && !from_cache ) {
+        // Use grab-aware A* when dragging a single-tile vehicle - searches over
+        // (position, grab_direction) state so both player and cart can move.
+        if( you.is_avatar() && you.as_avatar()->get_grab_type() == object_type::VEHICLE ) {
+            const tripoint_bub_ms veh_pos = you.pos_bub() + you.as_avatar()->grab_point;
+            const optional_vpart_position ovp = here.veh_at( veh_pos );
+            if( ovp && ovp->vehicle().get_points().size() == 1 ) {
+                // Single-tile vehicle: use grab-aware A*. If no path found,
+                // treat as unreachable (don't fall back to player-only routing
+                // which would cause cart collisions).
+                used_grab_routing = true;
+                route = route_with_grab( here, you, pathfinding_target::adjacent( dest ) );
+            } else {
+                // Multi-tile vehicle or no vehicle at grab point: use normal
+                // pathfinding (grab-aware A* doesn't support multi-tile).
+                route = here.route( you, pathfinding_target::adjacent( dest ) );
+            }
         } else {
-            // Multi-tile vehicle or no vehicle at grab point: use normal
-            // pathfinding (grab-aware A* doesn't support multi-tile).
             route = here.route( you, pathfinding_target::adjacent( dest ) );
         }
-    } else {
-        route = here.route( you, pathfinding_target::adjacent( dest ) );
     }
 
     add_msg_debug( debugmode::DF_ACTIVITY,
                    "route_to_dest: dest=(%d,%d) %s route_len=%zu %s",
                    dest.x(), dest.y(),
-                   used_grab_routing ? "grab_astar" : "normal_astar",
+                   from_cache ? "cached" :
+                   ( used_grab_routing ? "grab_astar" : "normal_astar" ),
                    route.size(),
                    route.empty() ? "FAILED" : "OK" );
 
@@ -1561,6 +1704,12 @@ void move_item( Character &you, const std::optional<vpart_reference> &vpr_src,
 }
 int route_length( const Character &you, const tripoint_bub_ms &dest )
 {
+    g_route_cache.ensure_valid( you );
+
+    if( const std::vector<tripoint_bub_ms> *cached = g_route_cache.find( dest ) ) {
+        return cached->empty() ? INT_MAX : static_cast<int>( cached->size() );
+    }
+
     const map &here = get_map();
     std::vector<tripoint_bub_ms> route;
 
@@ -1576,6 +1725,7 @@ int route_length( const Character &you, const tripoint_bub_ms &dest )
         route = here.route( you, pathfinding_target::adjacent( dest ) );
     }
 
+    g_route_cache.store( dest, route );
     return route.empty() ? INT_MAX : static_cast<int>( route.size() );
 }
 } //namespace zone_sorting

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -2,11 +2,15 @@
 #include "activity_item_handling.h" // IWYU pragma: associated
 
 #include <algorithm>
+#include <array>
+#include <climits>
 #include <cmath>
 #include <cstdlib>
 #include <list>
 #include <memory>
 #include <optional>
+#include <ostream>
+#include <queue>
 #include <set>
 #include <string>
 #include <tuple>
@@ -761,13 +765,380 @@ static void move_item( Character &you, item &it, const int quantity, const tripo
 namespace zone_sorting
 {
 
+// Number of grab direction slots: 3x3 grid encoding (x+1)*3 + (y+1), index 4 = center = unused.
+static constexpr int GRAB_DIRS = 9;
+
+static int grab_to_idx( const tripoint_rel_ms &g )
+{
+    return ( g.x() + 1 ) * 3 + ( g.y() + 1 );
+}
+
+static tripoint_rel_ms idx_to_grab( int idx )
+{
+    return tripoint_rel_ms( idx / 3 - 1, idx % 3 - 1, 0 );
+}
+
+static int grab_state_index( const point_bub_ms &pos, int grab_idx )
+{
+    return ( pos.x() * MAPSIZE_Y + pos.y() ) * GRAB_DIRS + grab_idx;
+}
+
+static point_bub_ms state_to_pos( int state_idx )
+{
+    int pos_idx = state_idx / GRAB_DIRS;
+    return point_bub_ms( pos_idx / MAPSIZE_Y, pos_idx % MAPSIZE_Y );
+}
+
+// Estimate vehicle drag difficulty using FLAT/ROAD terrain flags (matching
+// wheel terrain_modifiers): non-FLAT +4, FLAT non-ROAD +3, FLAT+ROAD +0.
+static int veh_drag_cost( const map &here, const tripoint_bub_ms &pos )
+{
+    const int base = here.move_cost_ter_furn( pos );
+    if( base <= 0 ) {
+        return 0;
+    }
+    if( !here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_FLAT, pos ) ) {
+        return base + 4;
+    }
+    if( !here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_ROAD, pos ) ) {
+        return base + 3;
+    }
+    return base;
+}
+
+// Check if a tile would cause a vehicle collision, matching part_collision
+// logic: impassable tiles block, bashable non-flat terrain/furniture blocks.
+// allow_doors: pull moves pass true (vehicle follows player through opened
+// doors); push/zigzag pass false (vehicle goes to unvisited tiles).
+static bool tile_blocks_vehicle( const map &here, const tripoint_bub_ms &pos,
+                                 bool allow_doors = true )
+{
+    const int ter_furn_cost = here.move_cost_ter_furn( pos );
+
+    // Impassable terrain (walls, closed windows, locked doors).
+    if( ter_furn_cost == 0 ) {
+        if( allow_doors ) {
+            // Openable doors: player opens them during auto-move, vehicle follows.
+            const bool is_door = ( here.ter( pos ).obj().open &&
+                                   here.ter( pos ).obj().has_flag( ter_furn_flag::TFLAG_DOOR ) ) ||
+                                 ( here.has_furn( pos ) && here.furn( pos ).obj().open &&
+                                   here.furn( pos ).obj().has_flag( ter_furn_flag::TFLAG_DOOR ) );
+            if( is_door ) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // Flat ground (move_cost 2) never causes collision.
+    if( ter_furn_cost == 2 ) {
+        return false;
+    }
+
+    // Bashable non-flat terrain/furniture causes collision (bushes, open
+    // windows, fences). NOCOLLIDE excluded (e.g. railroad tracks).
+    if( here.is_bashable_ter_furn( pos, false ) &&
+        !here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_NOCOLLIDE, pos ) ) {
+        return true;
+    }
+
+    return false;
+}
+
+// State is (player_position, grab_direction), so it finds routes where
+// both the player and the dragged vehicle can physically move.
+// Returns an empty vector if no path exists or if the player isn't
+// dragging a single-tile vehicle.
+static std::vector<tripoint_bub_ms> route_with_grab(
+    const map &here, const Character &you, const pathfinding_target &target )
+{
+    std::vector<tripoint_bub_ms> ret;
+
+    if( !you.is_avatar() || you.as_avatar()->get_grab_type() != object_type::VEHICLE ) {
+        return ret;
+    }
+
+    const tripoint_bub_ms start = you.pos_bub();
+    const tripoint_rel_ms start_grab = you.as_avatar()->grab_point;
+    const tripoint_bub_ms veh_pos = start + start_grab;
+    const optional_vpart_position ovp = here.veh_at( veh_pos );
+    if( !ovp ) {
+        add_msg_debug( debugmode::DF_ACTIVITY,
+                       "route_with_grab: no vehicle at grab point (%d,%d,%d)+(%d,%d,%d)",
+                       start.x(), start.y(), start.z(),
+                       start_grab.x(), start_grab.y(), start_grab.z() );
+        return ret;
+    }
+    vehicle &grabbed_veh = ovp->vehicle();
+    if( grabbed_veh.get_points().size() > 1 ) {
+        add_msg_debug( debugmode::DF_ACTIVITY,
+                       "route_with_grab: multi-tile vehicle (%zu parts), skipping",
+                       grabbed_veh.get_points().size() );
+        return ret;
+    }
+
+    add_msg_debug( debugmode::DF_ACTIVITY,
+                   "route_with_grab: start=(%d,%d) grab=(%d,%d) target=(%d,%d) r=%d",
+                   start.x(), start.y(), start_grab.x(), start_grab.y(),
+                   target.center.x(), target.center.y(), target.r );
+
+    const int max_length = you.get_pathfinding_settings().max_length;
+    const int pad = 16;
+    const tripoint_bub_ms &t = target.center;
+
+    point_bub_ms min_bound( std::min( start.x(), t.x() ) - pad,
+                            std::min( start.y(), t.y() ) - pad );
+    point_bub_ms max_bound( std::max( start.x(), t.x() ) + pad,
+                            std::max( start.y(), t.y() ) + pad );
+    min_bound.x() = std::max( min_bound.x(), 0 );
+    min_bound.y() = std::max( min_bound.y(), 0 );
+    max_bound.x() = std::min( max_bound.x(), MAPSIZE_X );
+    max_bound.y() = std::min( max_bound.y(), MAPSIZE_Y );
+
+    const int total_states = MAPSIZE_X * MAPSIZE_Y * GRAB_DIRS;
+
+    // Reuse heap-allocated arrays across calls
+    static std::vector<bool> closed;
+    static std::vector<bool> open;
+    static std::vector<int> gscore;
+    static std::vector<int> parent;
+
+    if( static_cast<int>( closed.size() ) != total_states ) {
+        closed.resize( total_states );
+        open.resize( total_states );
+        gscore.resize( total_states );
+        parent.resize( total_states );
+    }
+
+    std::fill( closed.begin(), closed.end(), false );
+    std::fill( open.begin(), open.end(), false );
+
+    // Priority queue: (f-score, state_index), smallest f-score first
+    using pq_entry = std::pair<int, int>;
+    std::priority_queue<pq_entry, std::vector<pq_entry>, std::greater<>> pq;
+
+    const int start_grab_idx = grab_to_idx( start_grab );
+    const int start_state = grab_state_index( start.xy(), start_grab_idx );
+    gscore[start_state] = 0;
+    open[start_state] = true;
+    parent[start_state] = start_state;
+    pq.emplace( 2 * rl_dist( start, t ), start_state );
+
+    // Movement offsets: W, E, N, S, NE, SW, NW, SE
+    constexpr std::array<int, 8> x_off{ { -1,  1,  0,  0,  1, -1, -1, 1 } };
+    constexpr std::array<int, 8> y_off{ {  0,  0, -1,  1, -1,  1, -1, 1 } };
+
+    bool done = false;
+    int found_state = -1;
+    int states_explored = 0;
+
+    while( !pq.empty() ) {
+        const auto [cur_score, cur_state] = pq.top();
+        pq.pop();
+
+        if( closed[cur_state] ) {
+            continue;
+        }
+
+        states_explored++;
+        const int cur_g = gscore[cur_state];
+        if( cur_g > max_length ) {
+            DebugLog( D_INFO, DC_ALL ) << "route_with_grab: ABORTED at max_length="
+                                       << max_length << " states_explored=" << states_explored
+                                       << " grab=(" << start_grab.x() << "," << start_grab.y() << ")";
+            return ret;
+        }
+
+        const point_bub_ms cur_pos = state_to_pos( cur_state );
+        const int cur_grab_idx = cur_state % GRAB_DIRS;
+        const tripoint_rel_ms cur_grab = idx_to_grab( cur_grab_idx );
+        const tripoint_bub_ms cur3d( cur_pos, start.z() );
+
+        if( target.contains( cur3d ) ) {
+            done = true;
+            found_state = cur_state;
+            break;
+        }
+
+        closed[cur_state] = true;
+
+        for( size_t i = 0; i < 8; i++ ) {
+            const point_bub_ms next_pos( cur_pos.x() + x_off[i], cur_pos.y() + y_off[i] );
+
+            if( next_pos.x() < min_bound.x() || next_pos.x() >= max_bound.x() ||
+                next_pos.y() < min_bound.y() || next_pos.y() >= max_bound.y() ) {
+                continue;
+            }
+
+            const tripoint_bub_ms next3d( next_pos, start.z() );
+
+            // Player passability (ignore grabbed vehicle - it vacates the tile on push)
+            int tile_cost = here.move_cost( next3d, &grabbed_veh );
+            if( tile_cost == 0 ) {
+                // Allow closed doors (cost 4, matching main pathfinder).
+                // Exclude windows - multi-step open, vehicle can't follow through.
+                const bool is_door = ( here.ter( next3d ).obj().open &&
+                                       here.ter( next3d ).obj().has_flag( ter_furn_flag::TFLAG_DOOR ) ) ||
+                                     ( here.furn( next3d ).obj().open &&
+                                       here.furn( next3d ).obj().has_flag( ter_furn_flag::TFLAG_DOOR ) );
+                if( is_door ) {
+                    tile_cost = 4;
+                } else {
+                    continue;
+                }
+            }
+
+            const tripoint_rel_ms dp( x_off[i], y_off[i], 0 );
+            tripoint_rel_ms dp_veh = -cur_grab;
+            tripoint_rel_ms next_grab = cur_grab;
+            bool vehicle_moves = true;
+            bool is_zigzag = false;
+            bool is_push = false;
+
+            if( dp == cur_grab ) {
+                // PUSH: vehicle moves in same direction as player
+                dp_veh = dp;
+                is_push = true;
+            } else if( std::abs( dp.x() + dp_veh.x() ) != 2 &&
+                       std::abs( dp.y() + dp_veh.y() ) != 2 ) {
+                // SIDEWAYS: vehicle stays put, grab rotates
+                next_grab = -( dp + dp_veh );
+                vehicle_moves = false;
+            } else if( ( dp.x() == cur_grab.x() || dp.y() == cur_grab.y() ) &&
+                       cur_grab.x() != 0 && cur_grab.y() != 0 ) {
+                // ZIGZAG: player is diagonal to vehicle, moves partially away
+                dp_veh.x() = dp.x() == -dp_veh.x() ? 0 : dp_veh.x();
+                dp_veh.y() = dp.y() == -dp_veh.y() ? 0 : dp_veh.y();
+                next_grab = -dp_veh;
+                is_zigzag = true;
+            } else {
+                // PULL: vehicle moves to player's old position
+                next_grab = -dp;
+                // dp_veh stays as -cur_grab (initialized above)
+            }
+
+            // Vehicle terrain cost: FLAT/ROAD flag penalties for dragging.
+            int veh_terrain_cost = 0;
+
+            if( vehicle_moves ) {
+                const tripoint_bub_ms veh_new( cur_pos + cur_grab.xy() + dp_veh.xy(), start.z() );
+                // Use veh_at() for other-vehicle check - multi-tile vehicles have
+                // passable parts (aisles) where move_cost > 0 but collision still occurs.
+                const optional_vpart_position ovp_new = here.veh_at( veh_new );
+                const bool other_veh = ovp_new && &ovp_new->vehicle() != &grabbed_veh;
+                // Push/zigzag: vehicle goes to unvisited tiles, doors stay closed.
+                const bool allow_doors = !( is_push || is_zigzag );
+                const bool veh_blocked = other_veh || tile_blocks_vehicle( here, veh_new, allow_doors );
+                if( veh_blocked ) {
+                    // Zigzag recovery: fall back to pull when vehicle move collides.
+                    // Only for zigzag - game doesn't recover push collisions.
+                    if( is_zigzag ) {
+                        dp_veh = -cur_grab;
+                        next_grab = -dp;
+                        const tripoint_bub_ms veh_recover( cur_pos + cur_grab.xy() + dp_veh.xy(),
+                                                           start.z() );
+                        const optional_vpart_position ovp_rec = here.veh_at( veh_recover );
+                        const bool rec_other_veh = ovp_rec && &ovp_rec->vehicle() != &grabbed_veh;
+                        if( rec_other_veh || tile_blocks_vehicle( here, veh_recover ) ) {
+                            continue;
+                        }
+                        veh_terrain_cost = veh_drag_cost( here, veh_recover );
+                    } else {
+                        continue;
+                    }
+                } else {
+                    veh_terrain_cost = veh_drag_cost( here, veh_new );
+                }
+            }
+
+            const int next_grab_idx = grab_to_idx( next_grab );
+            const int next_state = grab_state_index( next_pos, next_grab_idx );
+
+            if( closed[next_state] ) {
+                continue;
+            }
+
+            // Diagonal penalty (same as main A*)
+            const bool diagonal = cur_pos.x() != next_pos.x() && cur_pos.y() != next_pos.y();
+            const int newg = cur_g + tile_cost + veh_terrain_cost + ( diagonal ? 1 : 0 );
+
+            if( open[next_state] && newg >= gscore[next_state] ) {
+                continue;
+            }
+
+            open[next_state] = true;
+            gscore[next_state] = newg;
+            parent[next_state] = cur_state;
+            const int h = 2 * rl_dist( next3d, t );
+            pq.emplace( newg + h, next_state );
+        }
+    }
+
+    if( !done ) {
+        add_msg_debug( debugmode::DF_ACTIVITY,
+                       "route_with_grab: NO PATH FOUND from (%d,%d) grab=(%d,%d) to (%d,%d) explored=%d",
+                       start.x(), start.y(), start_grab.x(), start_grab.y(),
+                       target.center.x(), target.center.y(), states_explored );
+        DebugLog( D_INFO, DC_ALL ) << "route_with_grab: NO PATH FOUND from ("
+                                   << start.x() << "," << start.y()
+                                   << ") grab=(" << start_grab.x() << "," << start_grab.y()
+                                   << ") to (" << target.center.x() << "," << target.center.y()
+                                   << ") explored=" << states_explored
+                                   << " bounds=(" << min_bound.x() << "," << min_bound.y()
+                                   << ")-(" << max_bound.x() << "," << max_bound.y() << ")";
+        return ret;
+    }
+
+    // Reconstruct path: collect player positions from found_state back to start
+    int trace = found_state;
+    while( trace != start_state ) {
+        const point_bub_ms pos = state_to_pos( trace );
+        ret.emplace_back( pos, start.z() );
+        trace = parent[trace];
+    }
+    std::reverse( ret.begin(), ret.end() );
+
+    add_msg_debug( debugmode::DF_ACTIVITY,
+                   "route_with_grab: found path len=%zu from (%d,%d) to (%d,%d) first_step=(%d,%d)",
+                   ret.size(), start.x(), start.y(),
+                   target.center.x(), target.center.y(),
+                   ret.empty() ? -1 : ret.front().x(), ret.empty() ? -1 : ret.front().y() );
+    DebugLog( D_INFO, DC_ALL ) << "route_with_grab: found path len=" << ret.size()
+                               << " from (" << start.x() << "," << start.y()
+                               << ") grab=(" << start_grab.x() << "," << start_grab.y()
+                               << ") to (" << target.center.x() << "," << target.center.y()
+                               << ") first_step=(" << ( ret.empty() ? -1 : ret.front().x() )
+                               << "," << ( ret.empty() ? -1 : ret.front().y() ) << ")";
+    return ret;
+}
+
 bool route_to_destination( Character &you, player_activity &act,
                            const tripoint_bub_ms &dest, zone_activity_stage &stage )
 {
     const map &here = get_map();
-    //attempt to route to out-of-bubble position
     std::vector<tripoint_bub_ms> route;
-    route = here.route( you, pathfinding_target::adjacent( dest ) );
+
+    // Use grab-aware A* when dragging a single-tile vehicle - searches over
+    // (position, grab_direction) state so both player and cart can move.
+    bool used_grab_routing = false;
+    if( you.is_avatar() && you.as_avatar()->get_grab_type() == object_type::VEHICLE ) {
+        used_grab_routing = true;
+        route = route_with_grab( here, you, pathfinding_target::adjacent( dest ) );
+    } else {
+        route = here.route( you, pathfinding_target::adjacent( dest ) );
+    }
+
+    add_msg_debug( debugmode::DF_ACTIVITY,
+                   "route_to_dest: dest=(%d,%d) %s route_len=%zu %s",
+                   dest.x(), dest.y(),
+                   used_grab_routing ? "grab_astar" : "normal_astar",
+                   route.size(),
+                   route.empty() ? "FAILED" : "OK" );
+    DebugLog( D_INFO, DC_ALL ) << "route_to_dest: dest=(" << dest.x() << "," << dest.y()
+                               << ") " << ( used_grab_routing ? "grab_astar" : "normal_astar" )
+                               << " route_len=" << route.size()
+                               << " " << ( route.empty() ? "FAILED" : "OK" );
+
     if( route.empty() ) {
         add_msg( m_info, _( "%s can't reach the source tile.  Try to sort out loot without a cart." ),
                  you.disp_name() );
@@ -937,8 +1308,17 @@ bool has_items_to_sort( Character &you, const tripoint_abs_ms &src,
         }
 
         if( !you.can_add( *it ) ) {
-            *pickup_failure = true;
-            continue;
+            bool vehicle_can_hold = false;
+            if( you.is_avatar() && you.as_avatar()->get_grab_type() == object_type::VEHICLE ) {
+                const tripoint_bub_ms cart_pos = you.pos_bub() + you.as_avatar()->grab_point;
+                if( std::optional<vpart_reference> ovp = get_map().veh_at( cart_pos ).cargo() ) {
+                    vehicle_can_hold = ovp->items().free_volume() >= it->volume();
+                }
+            }
+            if( !vehicle_can_hold ) {
+                *pickup_failure = true;
+                continue;
+            }
         }
 
         if( sort_skip_item( you, it, other_activity_items,
@@ -1179,6 +1559,19 @@ void move_item( Character &you, const std::optional<vpart_reference> &vpr_src,
             break;
         }
     }
+}
+int route_length( const Character &you, const tripoint_bub_ms &dest )
+{
+    const map &here = get_map();
+    std::vector<tripoint_bub_ms> route;
+
+    if( you.is_avatar() && you.as_avatar()->get_grab_type() == object_type::VEHICLE ) {
+        route = route_with_grab( here, you, pathfinding_target::adjacent( dest ) );
+    } else {
+        route = here.route( you, pathfinding_target::adjacent( dest ) );
+    }
+
+    return route.empty() ? INT_MAX : static_cast<int>( route.size() );
 }
 } //namespace zone_sorting
 

--- a/src/activity_item_handling.h
+++ b/src/activity_item_handling.h
@@ -117,6 +117,11 @@ std::optional<bool> unload_item( Character &you, const tripoint_abs_ms &src,
 void move_item( Character &you, const std::optional<vpart_reference> &vpr_src,
                 const tripoint_bub_ms &src_bub, const std::unordered_set<tripoint_abs_ms> &dest_set,
                 item &it, int &num_processed );
+
+// Returns A* route length from the player to a tile adjacent to dest.
+// Uses grab-aware routing when the player is dragging a vehicle.
+// Returns INT_MAX if unreachable.
+int route_length( const Character &you, const tripoint_bub_ms &dest );
 } //namespace zone_sorting
 
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -9,6 +9,7 @@
 #include <functional>
 #include <memory>
 #include <numeric>
+#include <ostream>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -7162,6 +7163,17 @@ action_id Character::get_next_auto_move_direction()
         // they will cancel the auto-move on the next cycle (as the distance increases).
         if( std::max( { diff.x(), diff.y(), diff.z()} ) > 1 ) {
             // We're off course, possibly stumbling or stuck, cancel auto move
+            add_msg_debug( debugmode::DF_ACTIVITY,
+                           "auto_move: OFF COURSE pos=(%d,%d) expected=(%d,%d) diff=(%d,%d,%d) route_left=%zu",
+                           pos_bub().x(), pos_bub().y(),
+                           next_expected_position->x(), next_expected_position->y(),
+                           diff.x(), diff.y(), diff.z(), auto_move_route.size() );
+            DebugLog( D_INFO, DC_ALL ) << "auto_move: OFF COURSE pos=("
+                                       << pos_bub().x() << "," << pos_bub().y()
+                                       << ") expected=(" << next_expected_position->x()
+                                       << "," << next_expected_position->y()
+                                       << ") diff=(" << diff.x() << "," << diff.y()
+                                       << "," << diff.z() << ") route_left=" << auto_move_route.size();
             return ACTION_NULL;
         }
     }
@@ -7170,6 +7182,17 @@ action_id Character::get_next_auto_move_direction()
     auto_move_route.erase( auto_move_route.begin() );
 
     tripoint_rel_ms dp = *next_expected_position - pos_bub();
+
+    add_msg_debug( debugmode::DF_ACTIVITY,
+                   "auto_move: step dp=(%d,%d) pos=(%d,%d) target=(%d,%d) route_left=%zu",
+                   dp.x(), dp.y(), pos_bub().x(), pos_bub().y(),
+                   next_expected_position->x(), next_expected_position->y(),
+                   auto_move_route.size() );
+    DebugLog( D_INFO, DC_ALL ) << "auto_move: step dp=(" << dp.x() << "," << dp.y()
+                               << ") pos=(" << pos_bub().x() << "," << pos_bub().y()
+                               << ") target=(" << next_expected_position->x()
+                               << "," << next_expected_position->y()
+                               << ") route_left=" << auto_move_route.size();
 
     return get_movement_action_from_delta( dp, iso_rotate::yes );
 }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -9,7 +9,6 @@
 #include <functional>
 #include <memory>
 #include <numeric>
-#include <ostream>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -7168,12 +7167,6 @@ action_id Character::get_next_auto_move_direction()
                            pos_bub().x(), pos_bub().y(),
                            next_expected_position->x(), next_expected_position->y(),
                            diff.x(), diff.y(), diff.z(), auto_move_route.size() );
-            DebugLog( D_INFO, DC_ALL ) << "auto_move: OFF COURSE pos=("
-                                       << pos_bub().x() << "," << pos_bub().y()
-                                       << ") expected=(" << next_expected_position->x()
-                                       << "," << next_expected_position->y()
-                                       << ") diff=(" << diff.x() << "," << diff.y()
-                                       << "," << diff.z() << ") route_left=" << auto_move_route.size();
             return ACTION_NULL;
         }
     }
@@ -7188,11 +7181,6 @@ action_id Character::get_next_auto_move_direction()
                    dp.x(), dp.y(), pos_bub().x(), pos_bub().y(),
                    next_expected_position->x(), next_expected_position->y(),
                    auto_move_route.size() );
-    DebugLog( D_INFO, DC_ALL ) << "auto_move: step dp=(" << dp.x() << "," << dp.y()
-                               << ") pos=(" << pos_bub().x() << "," << pos_bub().y()
-                               << ") target=(" << next_expected_position->x()
-                               << "," << next_expected_position->y()
-                               << ") route_left=" << auto_move_route.size();
 
     return get_movement_action_from_delta( dp, iso_rotate::yes );
 }

--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <cstdlib>
-#include <ostream>
 
 #include "avatar.h"
 #include "cata_assert.h"
@@ -202,12 +201,6 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
                    pushing ? "PUSH" : pulling ? "PULL" : zigzag ? "ZIGZAG" : "???",
                    dp.x(), dp.y(), prev_grab.x(), prev_grab.y(),
                    dp_veh.x(), dp_veh.y(), next_grab.x(), next_grab.y() );
-    DebugLog( D_INFO, DC_ALL ) << "grabbed_veh_move: "
-                               << ( pushing ? "PUSH" : pulling ? "PULL" : zigzag ? "ZIGZAG" : "???" )
-                               << " dp=(" << dp.x() << "," << dp.y()
-                               << ") grab=(" << prev_grab.x() << "," << prev_grab.y()
-                               << ") dp_veh=(" << dp_veh.x() << "," << dp_veh.y()
-                               << ") next_grab=(" << next_grab.x() << "," << next_grab.y() << ")";
 
     // Make sure the mass and pivot point are correct
     grabbed_vehicle->invalidate_mass();
@@ -311,8 +304,6 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
         add_msg_debug( debugmode::DF_ACTIVITY,
                        "grabbed_veh_move: STR FAIL str_req=%d str=%d angle=%d",
                        str_req, str, bad_veh_angle ? 1 : 0 );
-        DebugLog( D_INFO, DC_ALL ) << "grabbed_veh_move: STR FAIL str_req=" << str_req
-                                   << " str=" << str << " angle=" << ( bad_veh_angle ? 1 : 0 );
         u.mod_moves( -to_moves<int>( 1_seconds ) );
         return true;
     }
@@ -416,9 +407,6 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
         add_msg_debug( debugmode::DF_ACTIVITY,
                        "grabbed_veh_move: COLLISION with '%s' dp_veh=(%d,%d)",
                        blocker_name, dp_veh.x(), dp_veh.y() );
-        DebugLog( D_INFO, DC_ALL ) << "grabbed_veh_move: COLLISION with '"
-                                   << blocker_name << "' dp_veh=(" << dp_veh.x()
-                                   << "," << dp_veh.y() << ")";
         u.grab_point = prev_grab;
         grabbed_vehicle->face = initial_veh_face;
         return true;
@@ -432,9 +420,6 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
     add_msg_debug( debugmode::DF_ACTIVITY,
                    "grabbed_veh_move: SUCCESS displacing veh by (%d,%d) new_grab=(%d,%d)",
                    final_dp_veh.x(), final_dp_veh.y(), next_grab.x(), next_grab.y() );
-    DebugLog( D_INFO, DC_ALL ) << "grabbed_veh_move: SUCCESS displacing veh by ("
-                               << final_dp_veh.x() << "," << final_dp_veh.y()
-                               << ") new_grab=(" << next_grab.x() << "," << next_grab.y() << ")";
 
     here.displace_vehicle( *grabbed_vehicle, final_dp_veh );
     here.rebuild_vehicle_level_caches();

--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <ostream>
 
 #include "avatar.h"
 #include "cata_assert.h"
@@ -175,6 +176,10 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
         pushing = true;
     } else if( std::abs( dp.x() + dp_veh.x() ) != 2 && std::abs( dp.y() + dp_veh.y() ) != 2 ) {
         // Not actually moving the vehicle, don't do the checks
+        add_msg_debug( debugmode::DF_ACTIVITY,
+                       "grabbed_veh_move: SIDEWAYS dp=(%d,%d) grab=(%d,%d)->(%d,%d)",
+                       dp.x(), dp.y(), prev_grab.x(), prev_grab.y(),
+                       -( dp.x() + dp_veh.x() ), -( dp.y() + dp_veh.y() ) );
         u.grab_point = - ( dp + dp_veh );
         return false;
     } else if( ( dp.x() == prev_grab.x() || dp.y() == prev_grab.y() ) &&
@@ -191,6 +196,18 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
         next_grab = - dp;
         pulling = true;
     }
+
+    add_msg_debug( debugmode::DF_ACTIVITY,
+                   "grabbed_veh_move: %s dp=(%d,%d) grab=(%d,%d) dp_veh=(%d,%d) next_grab=(%d,%d)",
+                   pushing ? "PUSH" : pulling ? "PULL" : zigzag ? "ZIGZAG" : "???",
+                   dp.x(), dp.y(), prev_grab.x(), prev_grab.y(),
+                   dp_veh.x(), dp_veh.y(), next_grab.x(), next_grab.y() );
+    DebugLog( D_INFO, DC_ALL ) << "grabbed_veh_move: "
+                               << ( pushing ? "PUSH" : pulling ? "PULL" : zigzag ? "ZIGZAG" : "???" )
+                               << " dp=(" << dp.x() << "," << dp.y()
+                               << ") grab=(" << prev_grab.x() << "," << prev_grab.y()
+                               << ") dp_veh=(" << dp_veh.x() << "," << dp_veh.y()
+                               << ") next_grab=(" << next_grab.x() << "," << next_grab.y() << ")";
 
     // Make sure the mass and pivot point are correct
     grabbed_vehicle->invalidate_mass();
@@ -291,6 +308,11 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
         if( !bad_veh_angle ) {
             add_msg( m_bad, _( "You lack the strength to move the %s." ), grabbed_vehicle->name );
         }
+        add_msg_debug( debugmode::DF_ACTIVITY,
+                       "grabbed_veh_move: STR FAIL str_req=%d str=%d angle=%d",
+                       str_req, str, bad_veh_angle ? 1 : 0 );
+        DebugLog( D_INFO, DC_ALL ) << "grabbed_veh_move: STR FAIL str_req=" << str_req
+                                   << " str=" << str << " angle=" << ( bad_veh_angle ? 1 : 0 );
         u.mod_moves( -to_moves<int>( 1_seconds ) );
         return true;
     }
@@ -391,6 +413,12 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
 
     if( final_dp_veh == tripoint_rel_ms::invalid ) {
         add_msg( _( "The %s collides with %s." ), grabbed_vehicle->name, blocker_name );
+        add_msg_debug( debugmode::DF_ACTIVITY,
+                       "grabbed_veh_move: COLLISION with '%s' dp_veh=(%d,%d)",
+                       blocker_name, dp_veh.x(), dp_veh.y() );
+        DebugLog( D_INFO, DC_ALL ) << "grabbed_veh_move: COLLISION with '"
+                                   << blocker_name << "' dp_veh=(" << dp_veh.x()
+                                   << "," << dp_veh.y() << ")";
         u.grab_point = prev_grab;
         grabbed_vehicle->face = initial_veh_face;
         return true;
@@ -400,6 +428,13 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
     if( u.grab_point != tripoint_rel_ms::zero ) {
         u.grab_point = next_grab;
     }
+
+    add_msg_debug( debugmode::DF_ACTIVITY,
+                   "grabbed_veh_move: SUCCESS displacing veh by (%d,%d) new_grab=(%d,%d)",
+                   final_dp_veh.x(), final_dp_veh.y(), next_grab.x(), next_grab.y() );
+    DebugLog( D_INFO, DC_ALL ) << "grabbed_veh_move: SUCCESS displacing veh by ("
+                               << final_dp_veh.x() << "," << final_dp_veh.y()
+                               << ") new_grab=(" << next_grab.x() << "," << next_grab.y() << ")";
 
     here.displace_vehicle( *grabbed_vehicle, final_dp_veh );
     here.rebuild_vehicle_level_caches();

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2396,9 +2396,6 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
                         add_msg_debug( debugmode::DF_ACTIVITY,
                                        "auto_move: get_next returned zero, aborting.  pos=(%d,%d)",
                                        player_character.pos_bub().x(), player_character.pos_bub().y() );
-                        DebugLog( D_INFO, DC_ALL ) << "auto_move: get_next returned zero, aborting at pos=("
-                                                   << player_character.pos_bub().x() << ","
-                                                   << player_character.pos_bub().y() << ")";
                         player_character.abort_automove();
                     }
                     dest_delta = dest_next;
@@ -2414,34 +2411,25 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
                                    "auto_move: move(%d,%d) FAILED at pos=(%d,%d), aborting",
                                    dest_delta.x(), dest_delta.y(),
                                    player_character.pos_bub().x(), player_character.pos_bub().y() );
-                    DebugLog( D_INFO, DC_ALL ) << "auto_move: move(" << dest_delta.x() << ","
-                                               << dest_delta.y() << ") FAILED at pos=("
-                                               << player_character.pos_bub().x() << ","
-                                               << player_character.pos_bub().y() << "), aborting";
                     player_character.abort_automove();
                 } else if( player_character.pos_bub() == pos_before &&
                            dest_delta != point_rel_ms::zero ) {
-                    // Move "succeeded" but player didn't move. Check if terrain or
-                    // furniture changed (door opened) - if so, next step will walk through.
+                    // General auto-move safety: catches cases where move() returns true
+                    // ("handled") but the player didn't actually move. Covers grabbed
+                    // vehicle collisions, NPC interactions, and any future similar cases.
+                    // Check if terrain/furniture changed (door opened) - if so, next
+                    // step will walk through, so don't abort.
                     const ter_id ter_after = here.ter( dest_tile );
                     const furn_id furn_after = here.furn( dest_tile );
                     if( ter_before != ter_after || furn_before != furn_after ) {
                         add_msg_debug( debugmode::DF_ACTIVITY,
                                        "auto_move: pos unchanged but ter/furn changed at (%d,%d), continuing",
                                        dest_tile.x(), dest_tile.y() );
-                        DebugLog( D_INFO, DC_ALL ) << "auto_move: pos unchanged but ter/furn changed at ("
-                                                   << dest_tile.x() << "," << dest_tile.y()
-                                                   << "), continuing (door opened?)";
                     } else {
-                        // Genuine collision - walk_move returns true for "handled"
-                        // even when grabbed_veh_move hit an obstacle.
                         add_msg_debug( debugmode::DF_ACTIVITY,
                                        "auto_move: move(%d,%d) returned OK but pos unchanged at (%d,%d), aborting",
                                        dest_delta.x(), dest_delta.y(),
                                        pos_before.x(), pos_before.y() );
-                        DebugLog( D_INFO, DC_ALL ) << "auto_move: move returned OK but pos unchanged at ("
-                                                   << pos_before.x() << "," << pos_before.y()
-                                                   << "), aborting";
                         player_character.abort_automove();
                     }
                 }

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2393,13 +2393,57 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
                     act = player_character.get_next_auto_move_direction();
                     const point_rel_ms dest_next = get_delta_from_movement_action( act, iso_rotate::yes );
                     if( dest_next == point_rel_ms::zero ) {
+                        add_msg_debug( debugmode::DF_ACTIVITY,
+                                       "auto_move: get_next returned zero, aborting.  pos=(%d,%d)",
+                                       player_character.pos_bub().x(), player_character.pos_bub().y() );
+                        DebugLog( D_INFO, DC_ALL ) << "auto_move: get_next returned zero, aborting at pos=("
+                                                   << player_character.pos_bub().x() << ","
+                                                   << player_character.pos_bub().y() << ")";
                         player_character.abort_automove();
                     }
                     dest_delta = dest_next;
                 }
+                const tripoint_bub_ms pos_before = player_character.pos_bub();
+                const tripoint_bub_ms dest_tile = pos_before +
+                                                  tripoint_rel_ms( dest_delta, 0 );
+                const ter_id ter_before = here.ter( dest_tile );
+                const furn_id furn_before = here.furn( dest_tile );
                 if( !avatar_action::move( player_character, here, tripoint_rel_ms( dest_delta, 0 ) ) ) {
                     // auto-move should be canceled due to a failed move or obstacle
+                    add_msg_debug( debugmode::DF_ACTIVITY,
+                                   "auto_move: move(%d,%d) FAILED at pos=(%d,%d), aborting",
+                                   dest_delta.x(), dest_delta.y(),
+                                   player_character.pos_bub().x(), player_character.pos_bub().y() );
+                    DebugLog( D_INFO, DC_ALL ) << "auto_move: move(" << dest_delta.x() << ","
+                                               << dest_delta.y() << ") FAILED at pos=("
+                                               << player_character.pos_bub().x() << ","
+                                               << player_character.pos_bub().y() << "), aborting";
                     player_character.abort_automove();
+                } else if( player_character.pos_bub() == pos_before &&
+                           dest_delta != point_rel_ms::zero ) {
+                    // Move "succeeded" but player didn't move. Check if terrain or
+                    // furniture changed (door opened) - if so, next step will walk through.
+                    const ter_id ter_after = here.ter( dest_tile );
+                    const furn_id furn_after = here.furn( dest_tile );
+                    if( ter_before != ter_after || furn_before != furn_after ) {
+                        add_msg_debug( debugmode::DF_ACTIVITY,
+                                       "auto_move: pos unchanged but ter/furn changed at (%d,%d), continuing",
+                                       dest_tile.x(), dest_tile.y() );
+                        DebugLog( D_INFO, DC_ALL ) << "auto_move: pos unchanged but ter/furn changed at ("
+                                                   << dest_tile.x() << "," << dest_tile.y()
+                                                   << "), continuing (door opened?)";
+                    } else {
+                        // Genuine collision - walk_move returns true for "handled"
+                        // even when grabbed_veh_move hit an obstacle.
+                        add_msg_debug( debugmode::DF_ACTIVITY,
+                                       "auto_move: move(%d,%d) returned OK but pos unchanged at (%d,%d), aborting",
+                                       dest_delta.x(), dest_delta.y(),
+                                       pos_before.x(), pos_before.y() );
+                        DebugLog( D_INFO, DC_ALL ) << "auto_move: move returned OK but pos unchanged at ("
+                                                   << pos_before.x() << "," << pos_before.y()
+                                                   << "), aborting";
+                        player_character.abort_automove();
+                    }
                 }
 
                 if( get_option<bool>( "AUTO_FEATURES" ) && get_option<bool>( "AUTO_MOPPING" ) &&


### PR DESCRIPTION
#### Summary
Bugfixes "Fix zone sorting with grabbed single-tile vehicle via grab-aware pathfinding"

#### Purpose of change

Supersedes #85229 (which only handled routing failures gracefully).

After the sorting refactor in #83640 and #84311 (and subsequent fixes in #84273, #84800, #84810, #84930, #84974, #85058), zone sorting physically walks the player between source and destination tiles. When you grab a single-tile vehicle like a Rolling Trash Can and start sorting, several things go wrong:

1. The pathfinder ignores the grabbed vehicle entirely - it finds a path for the player, but auto-move fails because the vehicle collides with terrain. The activity is silently lost with no message.
2. When `route_to_destination()` fails, nothing handles the failure and the activity loops forever, running expensive destination probing every turn (the freeze/hang from #85229).
3. Stale item references in `picked_up_stuff` cause a SIGSEGV - items can get merged during restacking across successive pickups, invalidating safe_references that are later dereferenced without a null check.

#### Describe the solution

The core fix is a separate A* pathfinder (`route_with_grab`) that knows about the grabbed vehicle. It uses state=(position, grab_direction) giving ~157K states per z-level, and simulates the actual push/pull/sideways/zigzag mechanics from grab.cpp at each expansion step. Both the player and the vehicle are checked for passability.

Supporting changes:

**Vehicle collision detection** - `tile_blocks_vehicle()` matches the logic from `vehicle::part_collision`: impassable terrain blocks, flat ground (move_cost 2) is always fine, bashable non-flat terrain (bushes, furniture, fences) causes collision. An `allow_doors` parameter handles the asymmetry between move types - push/zigzag send the vehicle to tiles the player never walks through (doors stay closed, must block), while pull sends it to the player's old position (doors already opened).

**Terrain drag cost** - `veh_drag_cost()` adds penalties for missing FLAT/ROAD terrain flags to the A* cost, so routes prefer paved surfaces over grass/dirt. This matches how `vehicle_wheel_traction()` applies wheel `terrain_modifiers` - the ROAD flag is what actually differentiates asphalt from grass (both have move_cost 2 for walking).

**Route-distance source sorting** - `stage_think` now sorts source tiles by actual A* route length instead of Chebyshev distance. Pre-sorts by Chebyshev as a lower bound, computes A* lazily, and cuts off early when the remaining Chebyshev distances can't beat the best route found so far.

**Failure handling** - `return_items_to_source()` helper puts items back when routing fails. `unreachable_dests` set tracks tiles where routing failed so we don't retry them or skip source tiles that have items bound for other reachable destinations (addresses @PatrikLundell's feedback on #85229).

**SIGSEGV fix** - purge stale item_locations with `remove_if(!loc.get_item())` before the "find valid destination" section. The main dropoff loop already had this guard but this section was missing it.

**Auto-move collision detection** - in handle_action.cpp, check whether the player's position actually changed after `avatar_action::move()` returns success. `grabbed_veh_move()` returns true on collision (meaning "handled"), which propagates up through `walk_move()` and `avatar_action::move()`, making auto-move think the step succeeded. Now we catch this and abort cleanly.

**Personal zones** - `cache_avatar_location()` called in `stage_init` and `stage_think` so personal zone positions stay in sync as the player moves.

#### Describe alternatives you've considered

Extending the main A* in pathfinding.cpp with grab state was considered but rejected - the main pathfinder uses flat_index(pos) arrays and a global singleton, so adding a 9x state multiplier for grab direction would bloat all pathfinding, not just sorting. A separate function is cleaner and only runs when actually dragging a vehicle.

For terrain costs, querying the actual wheel terrain_modifiers from the vehicle's parts would be more accurate but adds complexity for little benefit. The hardcoded FLAT/ROAD penalties match standard wheel definitions and cover the common cases.

#### Testing

- Grabbed a Rolling Trash Can next to an evac shelter with Unsorted zone inside and Default zone across the road. Sorting walks around the building pulling the cart, stays on asphalt where possible, and delivers items correctly.
- Narrow doorway between source and destination - cart is pulled through after player opens the door.
- Closed glass door in push direction - A* routes around it instead of colliding.
- Items on tiles only reachable through broken window frames or past other vehicles - added to unreachable_dests, remaining tiles still sorted.
- Personal zones move correctly with the player during sorting.
- Normal sorting without a grabbed container works as before.

#### Additional context

Only single-tile vehicles are supported - multi-tile vehicles fall back to unreachable_dests (the rotation and multi-part collision problem is much harder). The grab-aware A* is only used by zone sorting, not by manual auto-move.

This addresses @ShnitzelX2's report in #84311 that "shopping cart + sorting = freeze" and builds on @PatrikLundell's feedback in #85229 about not discarding source tiles that have items for other destinations.