### PR TITLE
Consistent multi-activity zone names/descriptions

### DIFF
--- a/data/json/zones.json
+++ b/data/json/zones.json
@@ -30,51 +30,51 @@
   {
     "id": "CHOP_TREES",
     "type": "LOOT_ZONE",
-    "name": "Chop Trees",
+    "name": "Work: Chop Trees",
     "display_field": "fd_chop_trees_zone",
-    "description": "Designate an area to chop down trees."
+    "description": "Designate a zone to chop down trees."
   },
   {
     "id": "CONSTRUCTION_BLUEPRINT",
     "type": "LOOT_ZONE",
-    "name": "Construction: Blueprint",
+    "name": "Work: Construction Blueprint",
     "display_field": "fd_construction_blueprint_zone",
-    "description": "Designate a blueprint zone for construction."
+    "description": "Designate a zone to build a construction on each tile."
   },
   {
     "id": "DISASSEMBLE",
     "type": "LOOT_ZONE",
-    "name": "Disassembly Work",
+    "name": "Work: Disassembly",
     "display_field": "fd_disassembly_work_zone",
     "description": "Items in this zone are marked for disassembly."
   },
   {
     "id": "FARM_PLOT",
     "type": "LOOT_ZONE",
-    "name": "Farm: Plot",
+    "name": "Work: Farm Plot",
     "display_field": "fd_farm_plot_zone",
-    "description": "Designate a farm plot for tilling and planting."
+    "description": "Designate a farm zone for tilling, planting, fertilizing, and harvesting a seed type."
   },
   {
     "id": "FISHING_SPOT",
     "type": "LOOT_ZONE",
-    "name": "Fishing Spot",
+    "name": "Work: Fishing Spot",
     "display_field": "fd_fishing_spot_zone",
-    "description": "Designate an area to fish from."
+    "description": "Designate a zone to fish from."
   },
   {
     "id": "MINING",
     "type": "LOOT_ZONE",
-    "name": "Mine Terrain",
+    "name": "Work: Mine Terrain",
     "display_field": "fd_mine_terrain_zone",
-    "description": "Designate an area to mine."
+    "description": "Designate a zone to mine."
   },
   {
     "id": "MOPPING",
     "type": "LOOT_ZONE",
-    "name": "Mop Tile",
+    "name": "Work: Mop Tile",
     "display_field": "fd_mop_tile_zone",
-    "description": "Designate an area to mop clean."
+    "description": "Designate a zone to mop tiles clean."
   },
   {
     "id": "NO_AUTO_PICKUP",
@@ -128,9 +128,9 @@
   {
     "id": "VEHICLE_DECONSTRUCT",
     "type": "LOOT_ZONE",
-    "name": "Vehicle Deconstruct Zone",
+    "name": "Work: Vehicle Deconstruct",
     "display_field": "fd_vehicle_deconstruct_zone",
-    "description": "Any vehicles in this area are marked for deconstruction."
+    "description": "Any vehicles in this zone are marked for deconstruction."
   },
   {
     "id": "VEHICLE_PATROL",
@@ -142,14 +142,14 @@
   {
     "id": "VEHICLE_REPAIR",
     "type": "LOOT_ZONE",
-    "name": "Vehicle Repair Zone",
+    "name": "Work: Vehicle Repair",
     "display_field": "fd_vehicle_repair_zone",
-    "description": "Any vehicles in this area are marked for repair work."
+    "description": "Any vehicles in this zone are marked for repair work."
   },
   {
     "id": "STUDY_ZONE",
     "type": "LOOT_ZONE",
-    "name": "Study Zone",
+    "name": "Work: Study",
     "display_field": "fd_study_zone",
     "description": "NPCs will find and read books from this zone until no more books can be learned from."
   }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Interface "consistent multi-activity zone names/descriptions"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

All of the multi-activity zones involve work, but they all have different names, which makes them hard to reliably find in the large zone list. Zones are interchangeably referred to as "areas" in their descriptions.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

- All multi-activity zones are now labelled "Work" zones, e.g. "Work: Mop Tile".
- All multi-activity zone descriptions now use the term "zone" only

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Zone list with tabs? Maybe in the future.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<img width="508" height="249" alt="image" src="https://github.com/user-attachments/assets/9797d715-5358-4d43-a3b2-18970e296404" />

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
