### PR TITLE
Move ACT_START_FIRE to activity_actor

### DIFF
--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -3188,6 +3188,40 @@ class heat_activity_actor : public activity_actor
         heater heater_data;
 };
 
+
+class fire_start_activity_actor : public activity_actor
+{
+    private:
+        fire_start_activity_actor() = default;
+    public:
+        fire_start_activity_actor( const tripoint_abs_ms &fire_placement, const item_location &fire_starter,
+                                   int potential_skill_gain, int initial_moves ) :
+            fire_placement( fire_placement ), fire_starter( fire_starter ),
+            potential_skill_gain( potential_skill_gain ), initial_moves( initial_moves ) {
+        };
+        const activity_id &get_type() const override {
+            static const activity_id ACT_START_FIRE( "ACT_START_FIRE" );
+            return ACT_START_FIRE;
+        }
+
+        void start( player_activity &act, Character & ) override;
+        void do_turn( player_activity &act, Character &who ) override;
+        void finish( player_activity &act, Character &who ) override;
+
+        std::unique_ptr<activity_actor> clone() const override {
+            return std::make_unique<fire_start_activity_actor>( *this );
+        }
+
+        void serialize( JsonOut &jsout ) const override;
+        static std::unique_ptr<activity_actor> deserialize( JsonValue &jsin );
+
+    private:
+        tripoint_abs_ms fire_placement;
+        item_location fire_starter;
+        int potential_skill_gain;
+        int initial_moves; // NOLINT(cata-serialize)
+};
+
 class wear_activity_actor : public activity_actor
 {
     public:

--- a/src/activity_handlers.h
+++ b/src/activity_handlers.h
@@ -190,7 +190,6 @@ bool resume_for_multi_activities( Character &you );
 void fill_liquid_do_turn( player_activity *act, Character *you );
 void find_mount_do_turn( player_activity *act, Character *you );
 void repair_item_do_turn( player_activity *act, Character *you );
-void start_fire_do_turn( player_activity *act, Character *you );
 void travel_do_turn( player_activity *act, Character *you );
 
 // defined in activity_handlers.cpp
@@ -199,7 +198,6 @@ do_turn_functions;
 
 /** activity_finish functions: */
 void repair_item_finish( player_activity *act, Character *you );
-void start_fire_finish( player_activity *act, Character *you );
 
 int move_cost( const item &it, const tripoint_bub_ms &src, const tripoint_bub_ms &dest );
 int move_cost_cart( const item &it, const tripoint_bub_ms &src, const tripoint_bub_ms &dest,

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -103,7 +103,6 @@
 
 static const activity_id ACT_FIRSTAID( "ACT_FIRSTAID" );
 static const activity_id ACT_REPAIR_ITEM( "ACT_REPAIR_ITEM" );
-static const activity_id ACT_START_FIRE( "ACT_START_FIRE" );
 
 static const damage_type_id damage_acid( "acid" );
 static const damage_type_id damage_bash( "bash" );
@@ -1653,11 +1652,8 @@ std::optional<int> firestarter_actor::use( Character *p, item &it,
 
     // skill gains are handled by the activity, but stored here in the index field
     const int potential_skill_gain = moves_modifier * ( std::min( 10.0, moves_cost_fast / 100.0 ) + 2 );
-    p->assign_activity( ACT_START_FIRE, moves, potential_skill_gain,
-                        0, it.tname() );
-    p->activity.targets.emplace_back( *p, &it );
-    p->activity.values.push_back( g->natural_light_level( pos.z() ) );
-    p->activity.placement = here->get_abs( pos );
+    p->assign_activity( fire_start_activity_actor( here->get_abs( pos ), form_loc( *p, here, pos, it ),
+                        potential_skill_gain, moves ) );
     // charges to use are handled by the activity
     return 0;
 }

--- a/src/savegame_legacy.cpp
+++ b/src/savegame_legacy.cpp
@@ -23,7 +23,6 @@ static const activity_id ACT_PICKUP( "ACT_PICKUP" );
 static const activity_id ACT_PULP( "ACT_PULP" );
 static const activity_id ACT_RELOAD( "ACT_RELOAD" );
 static const activity_id ACT_REPAIR_ITEM( "ACT_REPAIR_ITEM" );
-static const activity_id ACT_START_FIRE( "ACT_START_FIRE" );
 
 namespace std
 {
@@ -220,7 +219,7 @@ void player_activity::deserialize_legacy_type( int legacy_type, activity_id &des
         ACT_MOVE_ITEMS,
         activity_id::NULL_ID(), // ACT_ADV_INVENTORY is uistate.open_menu now
         activity_id::NULL_ID(), // ACT_ARMOR_LAYERS is uistate.open_menu now
-        ACT_START_FIRE,
+        activity_id::NULL_ID(), // ACT_START_FIRE is an actor now
         ACT_OPEN_GATE,
         ACT_FILL_LIQUID,
         ACT_HOTWIRE_CAR,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Infrastructure "move ACT_START_FIRE to activity_actor"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Update legacy activities.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

See title.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

- Started a fire with a lighter in the inventory using 100 tinder.
- Started a fire with a pair of glasses on the ground using 100 tinder.
- Autosaved/loaded while fire-starting, no errors.
- Loaded a save from 0.H while fire-starting, legacy activity cancelled gracefully.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

The use of `form_loc()` is probably not optimal in `iuse_actor`

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
