### PR TITLE
Add `forest` artifact recharge option

### DIFF
--- a/data/mods/Xedra_Evolved/procgen/nether_cult_procgen.json
+++ b/data/mods/Xedra_Evolved/procgen/nether_cult_procgen.json
@@ -18,6 +18,14 @@
         "max_charges": { "range": [ 1, 6 ], "power": 25 },
         "recharge_type": "lunar",
         "time": [ "2 h", "3 h" ]
+      },
+      {
+        "weight": 100,
+        "charges": { "range": [ 0, 6 ], "power": 25 },
+        "charges_per_use": { "range": [ 1, 1 ], "power": 25 },
+        "max_charges": { "range": [ 1, 6 ], "power": 25 },
+        "recharge_type": "forest",
+        "time": [ "2 h", "3 h" ]
       }
     ],
     "active_procgen_values": [

--- a/doc/JSON/ARTIFACTS.md
+++ b/doc/JSON/ARTIFACTS.md
@@ -92,6 +92,7 @@ The various ways this artifact can charge and use charges.
 - **lunar** This artifact takes 'time' amount of time to recharge, only recharges at night time.
 - **full_moon** This artifact takes 'time' amount of time to recharge, only recharges on the nights of the full moon
 - **new_moon** This artifact takes 'time' amount of time to recharge, only recharges on the nights of the new moon
+- **forest** This artifact takes 'time' amount of time to recharge, only recharges in a wooded area (forest, thick forest, and swamp tiles) and character is outside.
 
 #### recharge_conditions
 

--- a/doc/JSON/ARTIFACTS.md
+++ b/doc/JSON/ARTIFACTS.md
@@ -92,7 +92,7 @@ The various ways this artifact can charge and use charges.
 - **lunar** This artifact takes 'time' amount of time to recharge, only recharges at night time.
 - **full_moon** This artifact takes 'time' amount of time to recharge, only recharges on the nights of the full moon
 - **new_moon** This artifact takes 'time' amount of time to recharge, only recharges on the nights of the new moon
-- **forest** This artifact takes 'time' amount of time to recharge, only recharges in a wooded area (forest, thick forest, and swamp tiles) and character is outside.
+- **forest** This artifact takes 'time' amount of time to recharge, only recharges in a wooded area (forest, thick forest, and swamp tiles) and character is both outside and not in a city.
 
 #### recharge_conditions
 

--- a/doc/JSON/MAGIC.md
+++ b/doc/JSON/MAGIC.md
@@ -916,7 +916,7 @@ The field `charge_info` supports the following:
 Identifier           | Description
 ---                  |---
 `regenerate_ammo`    | `true`.
-`recharge_type`      | Can be one of: `lunar`, `periodic`, `solar_cloudy`, `solar_sunny`, or `none`.
+`recharge_type`      | Can be one of: `lunar`, `periodic`, `solar_cloudy`, `solar_sunny`, `forest` or `none`.
 `time`               | Time required per charge.
 `recharge_condition` | (optional) Similar to `has` from enchantments: can be one of `held`, `worn`, `wield`.  If omitted, the item recharges regardless, even if dropped.
 

--- a/src/relic.cpp
+++ b/src/relic.cpp
@@ -545,7 +545,7 @@ static bool can_recharge_lunar( const item &it, Character *carrier, const tripoi
 }
 
 // checks if the relic is in the appropriate location to be able to recharge from being in a forest.
-static bool can_recharge_forest( Character *carrier, const tripoint_bub_ms &pos )
+static bool can_recharge_forest( const tripoint_bub_ms &pos )
 {
     const tripoint_abs_omt omt_were_at = project_to<coords::omt>( get_map().get_abs( pos ) );
     return get_map().is_outside( pos ) && overmap_buffer.ter( omt_were_at )->is_wooded() &&
@@ -609,7 +609,7 @@ void relic::try_recharge( item &parent, Character *carrier, const tripoint_bub_m
             return;
         }
         case relic_recharge_type::FOREST: {
-            if( can_recharge_forest( carrier, pos ) ) {
+            if( can_recharge_forest( pos ) ) {
                 charge.accumulate_charge( parent );
             }
             return;

--- a/src/relic.cpp
+++ b/src/relic.cpp
@@ -610,7 +610,7 @@ void relic::try_recharge( item &parent, Character *carrier, const tripoint_bub_m
                 charge.accumulate_charge( parent );
             }
             return;
-        }  
+        }
         case relic_recharge_type::FOREST: {
             if( can_recharge_forest( parent, carrier, pos ) ) {
                 charge.accumulate_charge( parent );

--- a/src/relic.cpp
+++ b/src/relic.cpp
@@ -545,7 +545,7 @@ static bool can_recharge_lunar( const item &it, Character *carrier, const tripoi
 }
 
 // checks if the relic is in the appropriate location to be able to recharge from being in a forest.
-static bool can_recharge_forest( const item &it, Character *carrier, const tripoint_bub_ms &pos )
+static bool can_recharge_forest( Character *carrier, const tripoint_bub_ms &pos )
 {
     const tripoint_abs_omt omt_were_at = project_to<coords::omt>( get_map().get_abs( pos ) );
 	return get_map().is_outside( pos ) && overmap_buffer.ter( omt_were_at )->is_wooded() && !overmap_buffer.is_in_city( omt_were_at );

--- a/src/relic.cpp
+++ b/src/relic.cpp
@@ -609,7 +609,7 @@ void relic::try_recharge( item &parent, Character *carrier, const tripoint_bub_m
             return;
         }
         case relic_recharge_type::FOREST: {
-            if( can_recharge_forest( parent, carrier, pos ) ) {
+            if( can_recharge_forest( carrier, pos ) ) {
                 charge.accumulate_charge( parent );
             }
             return;

--- a/src/relic.cpp
+++ b/src/relic.cpp
@@ -548,7 +548,8 @@ static bool can_recharge_lunar( const item &it, Character *carrier, const tripoi
 static bool can_recharge_forest( const item &it, Character *carrier, const tripoint_bub_ms &pos )
 {
     const tripoint_abs_omt omt_were_at = project_to<coords::omt>( get_map().get_abs( pos ) );
-	return get_map().is_outside( pos ) && overmap_buffer.ter( omt_were_at )->is_wooded() && !overmap_buffer.is_in_city( omt_were_at );
+    return get_map().is_outside( pos ) && overmap_buffer.ter( omt_were_at )->is_wooded() &&
+           !overmap_buffer.is_in_city( omt_were_at );
 }
 
 void relic::try_recharge( item &parent, Character *carrier, const tripoint_bub_ms &pos )

--- a/src/relic.cpp
+++ b/src/relic.cpp
@@ -549,7 +549,8 @@ static bool can_recharge_lunar( const item &it, Character *carrier, const tripoi
 // checks if the relic is in the appropriate location to be able to recharge from being in a forest.
 static bool can_recharge_forest( const item &it, Character *carrier, const tripoint_bub_ms &pos )
 {
-    return get_map().is_outside( pos ) && overmap_buffer.ter( carrier->pos_abs_omt() ).obj().is_wooded() &&
+    return get_map().is_outside( pos ) &&
+           overmap_buffer.ter( carrier->pos_abs_omt() ).obj().is_wooded() &&
            ( carrier == nullptr ||
              carrier->is_worn( it ) || carrier->is_wielding( it ) );
 }

--- a/src/relic.cpp
+++ b/src/relic.cpp
@@ -18,7 +18,6 @@
 #include "magic_enchantment.h"
 #include "map.h"
 #include "omdata.h"
-#include "overmap.h"
 #include "overmapbuffer.h"
 #include "rng.h"
 #include "translations.h"

--- a/src/relic.cpp
+++ b/src/relic.cpp
@@ -18,15 +18,13 @@
 #include "magic_enchantment.h"
 #include "map.h"
 #include "omdata.h"
+#include "overmap.h"
 #include "overmapbuffer.h"
 #include "rng.h"
 #include "translations.h"
 #include "type_id.h"
 #include "weather.h"
 #include "weather_type.h"
-
-static const oter_type_str_id oter_type_forest( "forest" );
-static const oter_type_str_id oter_type_forest_thick( "forest_thick" );
 
 /*
  * A little helper function to tell if you can load one ammo into a gun.
@@ -549,9 +547,8 @@ static bool can_recharge_lunar( const item &it, Character *carrier, const tripoi
 // checks if the relic is in the appropriate location to be able to recharge from being in a forest.
 static bool can_recharge_forest( const item &it, Character *carrier, const tripoint_bub_ms &pos )
 {
-    return get_map().is_outside( pos ) && overmap_buffer.ter( carrier->pos_abs_omt() ).obj().is_wooded() &&
-           ( carrier == nullptr ||
-             carrier->is_worn( it ) || carrier->is_wielding( it ) );
+    const tripoint_abs_omt omt_were_at = project_to<coords::omt>( get_map().get_abs( pos ) );
+	return get_map().is_outside( pos ) && overmap_buffer.ter( omt_were_at )->is_wooded() && !overmap_buffer.is_in_city( omt_were_at );
 }
 
 void relic::try_recharge( item &parent, Character *carrier, const tripoint_bub_ms &pos )

--- a/src/relic.cpp
+++ b/src/relic.cpp
@@ -7,6 +7,7 @@
 
 #include "calendar.h"
 #include "character.h"
+#include "coordinates.h"
 #include "creature.h"
 #include "debug.h"
 #include "enum_conversions.h"

--- a/src/relic.h
+++ b/src/relic.h
@@ -154,6 +154,7 @@ enum class relic_recharge_type : int {
     NEW_MOON,
     SOLAR_SUNNY,
     SOLAR_CLOUDY,
+    FOREST,
     NUM
 };
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Features "Add `forest` artifact recharge option"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Thought this would be a fun addition for weird artifacts in XE and druid items in Magiclysm

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the `forest` artifact recharge type, where charges only accumulate in a forest (determined using `is_wooded` so swamps also count). 

As a demonstration, add it as a possible condition to nether cult artifacts in XE.

Note that despite the name this doesn't only apply to procgen artifacts, it can be used for e.g. Magiclysm magical items with refilling charges as well. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Gave the Magiclysm Ring of Blades the forest recharge type, spawned one, used it in the evac shelter, and waited two hours. Charges remained at 4/5

Teleported to a forest, waited two hours, charges refilled to 5/5

Used two charges, teleported to a forest in a city, waited two hours, charges did not refill.

Dumped ring on ground, waited, charges did not refill.

Teleported back to the forest, dumped ring on ground in forest, waited, charges refilled. 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I don't immediately have a Magiclysm item to go with this because I wanted something that's more interesting than "Ring of Animal Friendship" or whatever

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
