### PR TITLE
fix transactional save: fsync ordering, error handling, and tests

### DIFF
--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -114,6 +114,13 @@ std::vector<P> get_directories( const P &root_path = P(),
 bool copy_file( const std::string &source_path, const std::string &dest_path );
 bool copy_file( const cata_path &source_path, const cata_path &dest_path );
 
+// Flush file data to durable storage.  Opens the file, calls fdatasync/equivalent, closes.
+// Returns true on success, false on failure (logged via DebugLog).
+bool fsync_file( const std::filesystem::path &path );
+// Flush directory metadata to durable storage (ensures renames are durable).
+// Returns true on success, false on failure (logged via DebugLog).
+bool fsync_directory( const std::filesystem::path &dir );
+
 /**
  *  Replace invalid characters in a string with a default character; can be used to ensure that a file name is compliant with most file systems.
  *  @param file_name Name of the file to check.

--- a/src/game.h
+++ b/src/game.h
@@ -248,8 +248,11 @@ class game
         void unserialize_impl( const JsonObject &data );
     public:
 
-        /** Returns false if saving failed. */
-        bool save();
+        /** Returns false if saving failed.
+         *  @param full_fsync When true, every written file is fsynced (Save & Exit).
+         *                    When false, only transaction markers are fsynced (quicksave).
+         */
+        bool save( bool full_fsync = false );
 
         /** Returns a list of currently active character saves. */
         std::vector<std::string> list_active_saves();

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2892,7 +2892,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
 
         case ACTION_SAVE:
             if( query_yn( _( "Save and quit?" ) ) ) {
-                if( save() ) {
+                if( save( true ) ) {
                     player_character.set_moves( 0 );
                     uquit = QUIT_SAVED;
                 } else if( save_is_dirty && query_yn( _( "Unable to save, quit anyway?" ) ) ) {

--- a/src/map_memory.cpp
+++ b/src/map_memory.cpp
@@ -22,6 +22,7 @@
 #include "json_loader.h"
 #include "map_memory.h"
 #include "path_info.h"
+#include "save_transaction.h"
 #include "string_formatter.h"
 #include "translations.h"
 #include "worldfactory.h"
@@ -547,6 +548,10 @@ bool map_memory::save( const tripoint_abs_ms &pos )
     }
     if( z ) {
         z->compact( 3.0 );
+        if( save_transaction::wants_full_fsync() ) {
+            z->flush();
+            fsync_directory( dirname.get_unrelative_path() );
+        }
     }
 
     dbg( D_INFO ) << "[SAVE] Done.";

--- a/src/mapbuffer.cpp
+++ b/src/mapbuffer.cpp
@@ -28,6 +28,7 @@
 #include "output.h"
 #include "overmapbuffer.h"
 #include "path_info.h"
+#include "save_transaction.h"
 #include "point.h"
 #include "popup.h"
 #include "std_hash_fs_path.h"
@@ -356,6 +357,9 @@ void mapbuffer::save_quad(
         if( z->compact_to( tmp_path.get_unrelative_path(), 2.0 ) ) {
             z.reset();
             rename_file( tmp_path, zzip_name );
+        }
+        if( z.has_value() && save_transaction::wants_full_fsync() ) {
+            z->flush();
         }
     }
 }

--- a/src/mapsharing.cpp
+++ b/src/mapsharing.cpp
@@ -7,6 +7,7 @@
 
 #include "filesystem.h"
 #include "ofstream_wrapper.h"
+#include "save_transaction.h"
 
 #if defined(__linux__)
 #include <unistd.h>
@@ -163,6 +164,11 @@ void ofstream_wrapper::close()
     if( ec2 ) {
         // Leave the temp path, so the user can move it if possible.
         throw std::runtime_error( "moving temporary file \"" + temp_path.u8string() + "\" failed" );
+    }
+
+    if( save_transaction::wants_full_fsync() ) {
+        fsync_file( path );
+        fsync_directory( path.parent_path() );
     }
 
 #if defined(EMSCRIPTEN)

--- a/src/mmap_file.h
+++ b/src/mmap_file.h
@@ -57,14 +57,16 @@ class mmap_file
         /**
          * Synchronously write modified parts of the file to disk.
          * Use sparingly, this is slow.
+         * Returns false if the sync syscall failed.
          */
-        void flush();
+        bool flush();
         /**
          * Synchronously write modified parts of the file to disk
          * within the range specified by [offset, len].
          * Use sparingly, this is slow.
+         * Returns false if the sync syscall failed.
          */
-        void flush( size_t offset, size_t len );
+        bool flush( size_t offset, size_t len );
 
         // Opaque type to platform specific mmap implementation.
         struct impl;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2850,6 +2850,7 @@ void options_manager::add_options_world_default()
              "a reasonable pace." ),
          true
        );
+
 }
 
 void options_manager::add_options_debug()

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -50,6 +50,7 @@
 #include "regional_settings.h"
 #include "rng.h"
 #include "rotatable_symbols.h"
+#include "save_transaction.h"
 #include "sets_intersect.h"
 #include "simple_pathfinding.h"
 #include "string_formatter.h"
@@ -3946,6 +3947,9 @@ void overmap::save() const
         if( z->compact_to( tmp_path.get_unrelative_path(), 2.0 ) ) {
             z.reset();
             rename_file( tmp_path, zzip_path );
+        }
+        if( z.has_value() && save_transaction::wants_full_fsync() ) {
+            z->flush();
         }
     } else {
         write_to_file( PATH_INFO::current_dimension_save_path() /

--- a/src/save_transaction.cpp
+++ b/src/save_transaction.cpp
@@ -1,0 +1,580 @@
+#include "save_transaction.h"
+
+#include <exception>
+#include <fstream>
+#include <optional>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+#include "debug.h"
+#include "filesystem.h"
+#include "json.h"
+#include "output.h"
+#include "translations.h"
+
+#if !defined(_WIN32) && !defined(EMSCRIPTEN)
+#include <unistd.h>
+#endif
+#if defined(_WIN32)
+#include "platform_win.h"
+#endif
+
+static const std::string backup_dirname( ".save_backup" );
+static const std::string backup_marker_name( ".backup_marker" );
+static const std::string commit_marker_name( ".save_commit" );
+
+// NOLINTNEXTLINE(cata-static-int_id-constants)
+save_transaction *save_transaction::current_ = nullptr;
+
+static bool should_skip_entry( const std::filesystem::path &filename )
+{
+    const std::string name = filename.generic_u8string();
+    return name == backup_dirname
+           || name == commit_marker_name
+           || ( name.size() >= 5 && name.substr( name.size() - 5 ) == ".temp" )
+           || ( name.size() >= 4 && name.substr( name.size() - 4 ) == ".tmp" );
+}
+
+static int current_pid()
+{
+#if defined(_WIN32)
+    return static_cast<int>( GetCurrentProcessId() );
+#elif defined(EMSCRIPTEN)
+    return 0;
+#else
+    return static_cast<int>( getpid() );
+#endif
+}
+
+static bool write_marker( const std::filesystem::path &marker_path,
+                          const std::optional<std::vector<std::string>> &manifest = std::nullopt )
+{
+    std::ofstream fout( marker_path, std::ios::binary );
+    if( !fout.is_open() ) {
+        DebugLog( D_ERROR, D_MAIN ) << "save_transaction: failed to open marker: "
+                                    << marker_path.u8string();
+        return false;
+    }
+
+    JsonOut jout( fout );
+    jout.start_object();
+    jout.member( "version", 1 );
+    jout.member( "pid", current_pid() );
+    if( manifest.has_value() ) {
+        jout.member( "files" );
+        jout.start_array();
+        for( const std::string &f : *manifest ) {
+            jout.write( f );
+        }
+        jout.end_array();
+    }
+    jout.end_object();
+
+    fout.flush();
+    if( fout.fail() ) {
+        DebugLog( D_ERROR, D_MAIN ) << "save_transaction: failed to flush marker: "
+                                    << marker_path.u8string();
+        return false;
+    }
+    fout.close();
+    return true;
+}
+
+// Returns the file manifest from the backup marker.  nullopt means the
+// manifest is missing or unreadable (old-format marker or I/O error).
+// An empty set means the backup was genuinely empty.
+static std::optional<std::set<std::string>> read_manifest(
+            const std::filesystem::path &marker_path )
+{
+    std::ifstream fin( marker_path, std::ios::binary );
+    if( !fin.is_open() ) {
+        return std::nullopt;
+    }
+    try {
+        TextJsonIn jsin( fin, marker_path.u8string() );
+        TextJsonObject jo = jsin.get_object();
+        jo.allow_omitted_members();
+        if( jo.has_member( "files" ) ) {
+            std::set<std::string> files;
+            for( const std::string &f : jo.get_string_array( "files" ) ) {
+                files.insert( f );
+            }
+            return files;
+        }
+    } catch( const std::exception &e ) {
+        DebugLog( D_WARNING, D_MAIN ) << "save_transaction: failed to read manifest: "
+                                      << e.what();
+    }
+    return std::nullopt;
+}
+
+save_transaction::save_transaction( const std::filesystem::path &save_dir,
+                                    fsync_level level )
+    : save_dir_( save_dir )
+    , backup_dir_( save_dir / std::filesystem::u8path( backup_dirname ) )
+    , level_( level )
+{
+    create_backup();
+    current_ = this;
+}
+
+save_transaction::~save_transaction()
+{
+    if( current_ == this ) {
+        current_ = nullptr;
+    }
+    if( !committed_ && backup_created_ ) {
+        try {
+            restore_from_backup();
+        } catch( const std::exception &e ) {
+            DebugLog( D_ERROR, D_MAIN ) << "save_transaction: restore failed: " << e.what();
+        }
+    }
+}
+
+bool save_transaction::wants_full_fsync()
+{
+    return current_ != nullptr && current_->level_ == fsync_level::full;
+}
+
+void save_transaction::notify_sync_failure()
+{
+    if( current_ != nullptr && current_->level_ == fsync_level::full ) {
+        current_->sync_failed_ = true;
+    }
+}
+
+void save_transaction::create_backup()
+{
+    // If a previous backup exists, handle it
+    if( std::filesystem::exists( backup_dir_ ) ) {
+        // If the commit marker exists, the previous save completed but cleanup
+        // was interrupted.  Just clean up.
+        if( std::filesystem::exists( save_dir_ / std::filesystem::u8path( commit_marker_name ) ) ) {
+            std::error_code ec;
+            std::filesystem::remove_all( backup_dir_, ec );
+            if( !ec && fsync_directory( save_dir_ ) ) {
+                // Backup removal is durable -- safe to remove commit marker
+                std::filesystem::remove( save_dir_ / std::filesystem::u8path( commit_marker_name ), ec );
+                if( ec ) {
+                    DebugLog( D_WARNING, D_MAIN )
+                            << "save_transaction: failed to remove commit marker during "
+                            << "stale backup cleanup: " << ec.message();
+                }
+            } else if( ec ) {
+                throw std::runtime_error( "failed to remove stale backup: " + ec.message() );
+            } else {
+                throw std::runtime_error( "failed to sync after stale backup removal" );
+            }
+        } else {
+            // Previous save was interrupted -- recovery should have run at load.
+            // If we got here, something is wrong.  Try recovery now.
+            DebugLog( D_WARNING, D_MAIN ) << "save_transaction: stale backup found, recovering";
+            restore_from_backup();
+            if( std::filesystem::exists( backup_dir_ ) ) {
+                throw std::runtime_error( "backup recovery was partial; cannot start new save" );
+            }
+        }
+    }
+
+    // Remove stale commit marker if present (from a fully completed previous save).
+    // Only safe when no backup dir exists; if the backup dir is still around
+    // (e.g. because removal above failed), the marker must stay so a later
+    // run still sees "save completed, cleanup pending."
+    //
+    // The removal MUST be synced to disk before the backup dir is created.
+    // Otherwise, power loss after backup creation could leave both the
+    // backup dir and the stale commit marker on disk, causing recovery to
+    // misclassify the interrupted save as "completed" and discard the backup.
+    if( !std::filesystem::exists( backup_dir_ ) ) {
+        const std::filesystem::path commit_path = save_dir_ / std::filesystem::u8path( commit_marker_name );
+        if( std::filesystem::exists( commit_path ) ) {
+            std::error_code ec;
+            std::filesystem::remove( commit_path, ec );
+            if( ec ) {
+                throw std::runtime_error(
+                    "failed to remove stale commit marker: " + ec.message() );
+            }
+        }
+        if( !fsync_directory( save_dir_ ) ) {
+            throw std::runtime_error( "failed to sync directory before backup creation" );
+        }
+    }
+
+    std::error_code ec;
+    std::filesystem::create_directory( backup_dir_, ec );
+    if( ec ) {
+        throw std::runtime_error( "failed to create backup dir: " + ec.message() );
+    }
+
+    // Recursively hardlink (or copy) all files.
+    //
+    // Most save writers use temp+rename (ofstream_wrapper / write_to_file),
+    // which is safe with hardlinks: rename() replaces the directory entry,
+    // and the backup hardlink retains the old inode with pre-save data.
+    //
+    // However, zzip archives are modified in place via mmap (MAP_SHARED)
+    // before being compacted to a new file.  Hardlinking a .zzip would let
+    // add_file() mutate the backup copy through the shared inode.  These
+    // files must always be copied, not hardlinked.
+    std::vector<std::string> manifest;
+
+    auto dir_iter = std::filesystem::recursive_directory_iterator(
+                        save_dir_, std::filesystem::directory_options::skip_permission_denied, ec );
+    if( ec ) {
+        throw std::runtime_error( "failed to iterate save dir: " + ec.message() );
+    }
+
+    for( auto it = dir_iter; it != std::filesystem::recursive_directory_iterator(); ++it ) {
+        const std::filesystem::directory_entry &entry = *it;
+        const std::filesystem::path rel = entry.path().lexically_relative( save_dir_ );
+
+        // Skip the backup dir itself, commit markers, and temp files.
+        // Check the first component of the relative path.
+        if( !rel.empty() && should_skip_entry( *rel.begin() ) ) {
+            if( entry.is_directory() ) {
+                it.disable_recursion_pending();
+            }
+            continue;
+        }
+
+        const std::filesystem::path dest = backup_dir_ / rel;
+
+        if( entry.is_directory() ) {
+            std::filesystem::create_directories( dest, ec );
+            if( ec ) {
+                throw std::runtime_error( "backup mkdir failed: " + ec.message() );
+            }
+        } else if( entry.is_regular_file() ) {
+            // Skip temp files by filename
+            if( should_skip_entry( entry.path().filename() ) ) {
+                continue;
+            }
+
+            const std::string ext = entry.path().extension().generic_u8string();
+            const bool is_mmap_mutable = ext == ".zzip";
+
+            if( is_mmap_mutable ) {
+                // Zzip archives are modified in place via mmap; must copy
+                std::error_code copy_ec;
+                std::filesystem::copy_file( entry.path(), dest,
+                                            std::filesystem::copy_options::overwrite_existing, copy_ec );
+                if( copy_ec ) {
+                    throw std::runtime_error( "backup copy failed for " +
+                                              entry.path().u8string() + ": " + copy_ec.message() );
+                }
+            } else {
+                // Safe to hardlink; fall back to copy if unsupported
+                std::error_code link_ec;
+                std::filesystem::create_hard_link( entry.path(), dest, link_ec );
+                if( link_ec ) {
+                    std::filesystem::copy_file( entry.path(), dest,
+                                                std::filesystem::copy_options::overwrite_existing, link_ec );
+                    if( link_ec ) {
+                        throw std::runtime_error( "backup copy failed for " +
+                                                  entry.path().u8string() + ": " + link_ec.message() );
+                    }
+                }
+            }
+
+            manifest.emplace_back( rel.generic_u8string() );
+        }
+    }
+
+    // Write backup marker with file manifest for idempotent recovery
+    if( !write_marker( backup_dir_ / std::filesystem::u8path( backup_marker_name ),
+                       std::make_optional( manifest ) ) ) {
+        throw std::runtime_error( "failed to write backup marker" );
+    }
+    if( !fsync_file( backup_dir_ / std::filesystem::u8path( backup_marker_name ) ) ||
+        !fsync_directory( backup_dir_ ) ||
+        !fsync_directory( save_dir_ ) ) {
+        throw std::runtime_error( "failed to sync backup to disk" );
+    }
+
+    backup_created_ = true;
+}
+
+bool save_transaction::commit()
+{
+    if( sync_failed_ ) {
+        DebugLog( D_WARNING, D_MAIN )
+                << "save_transaction: refusing to commit -- fsync failed during save";
+        return false;
+    }
+
+    // Write commit marker
+    const std::filesystem::path marker = save_dir_ / std::filesystem::u8path( commit_marker_name );
+    if( !write_marker( marker ) ) {
+        DebugLog( D_ERROR, D_MAIN ) << "save_transaction: failed to write commit marker";
+        return false;
+    }
+    if( !fsync_file( marker ) || !fsync_directory( save_dir_ ) ) {
+        DebugLog( D_ERROR, D_MAIN ) << "save_transaction: failed to sync commit marker";
+        return false;
+    }
+
+    // Remove backup.  The commit marker stays on disk so that if power is
+    // lost during or after backup removal, recovery sees the marker and
+    // knows the live directory is consistent.  The marker is cleaned up at
+    // the start of the next save (create_backup) or on the next load
+    // (recover_if_needed).
+    remove_backup();
+
+    committed_ = true;
+    return true;
+}
+
+// Move files from backup_dir to save_dir, overwriting live files.
+// Directories are created as needed.  The backup marker is skipped.
+// Each rename is atomic per-file.  If interrupted, files already moved
+// are in save_dir and no longer in backup_dir, so repeating is safe.
+// Returns true if all files were moved, false if any file failed.
+static bool restore_phase_move( const std::filesystem::path &backup_dir,
+                                const std::filesystem::path &save_dir )
+{
+    bool all_ok = true;
+    std::error_code ec;
+    // Use recursive_directory_iterator to handle subdirectories.
+    // Collect entries first to avoid modifying the tree during iteration.
+    std::vector<std::pair<std::filesystem::path, bool>> entries;
+    for( const std::filesystem::directory_entry &entry : std::filesystem::recursive_directory_iterator(
+             backup_dir, std::filesystem::directory_options::skip_permission_denied, ec ) ) {
+        const std::string fname = entry.path().filename().generic_u8string();
+        if( fname == backup_marker_name ) {
+            continue;
+        }
+        entries.emplace_back( entry.path(), entry.is_directory() );
+    }
+
+    for( const auto &[path, is_dir] : entries ) {
+        const std::filesystem::path rel = path.lexically_relative( backup_dir );
+        const std::filesystem::path dest = save_dir / rel;
+
+        if( is_dir ) {
+            std::filesystem::create_directories( dest, ec );
+        } else {
+            // Ensure parent directory exists
+            std::filesystem::create_directories( dest.parent_path(), ec );
+            // Remove existing live file so rename can succeed
+            std::filesystem::remove( dest, ec );
+            std::filesystem::rename( path, dest, ec );
+            if( ec ) {
+                // rename may fail across filesystems; fall back to copy+remove
+                std::filesystem::copy_file( path, dest,
+                                            std::filesystem::copy_options::overwrite_existing, ec );
+                if( !ec ) {
+                    std::filesystem::remove( path, ec );
+                }
+                if( ec ) {
+                    DebugLog( D_ERROR, D_MAIN ) << "save recovery: failed to restore "
+                                                << rel.u8string() << ": " << ec.message();
+                    all_ok = false;
+                }
+            }
+        }
+    }
+    return all_ok;
+}
+
+// Remove files from save_dir that are not in the manifest (stale files
+// written during an interrupted save).  Also removes now-empty directories.
+static void restore_phase_cleanup( const std::filesystem::path &save_dir,
+                                   const std::set<std::string> &manifest )
+{
+    std::error_code ec;
+    // Collect entries first, then remove (don't modify tree during iteration).
+    // Use manual loop so we can skip recursion into the backup directory.
+    std::vector<std::pair<std::filesystem::path, bool>> entries;
+    auto dir_iter = std::filesystem::recursive_directory_iterator(
+                        save_dir, std::filesystem::directory_options::skip_permission_denied, ec );
+    for( auto it = dir_iter; it != std::filesystem::recursive_directory_iterator(); ++it ) {
+        const std::filesystem::directory_entry &entry = *it;
+        const std::string fname = entry.path().filename().generic_u8string();
+        // Skip the backup dir (and don't recurse into it) and commit marker
+        if( fname == backup_dirname || fname == commit_marker_name ) {
+            if( entry.is_directory() ) {
+                it.disable_recursion_pending();
+            }
+            continue;
+        }
+        entries.emplace_back( entry.path(), entry.is_directory() );
+    }
+
+    // Remove stale files (not in manifest).
+    for( const auto &[path, is_dir] : entries ) {
+        if( is_dir ) {
+            continue;
+        }
+        const std::string rel = path.lexically_relative( save_dir ).generic_u8string();
+        if( manifest.find( rel ) == manifest.end() ) {
+            std::filesystem::remove( path, ec );
+        }
+    }
+
+    // Remove now-empty directories (iterate in reverse so children come first).
+    for( auto it = entries.rbegin(); it != entries.rend(); ++it ) {
+        if( !it->second ) {
+            continue;
+        }
+        if( std::filesystem::is_empty( it->first, ec ) && !ec ) {
+            std::filesystem::remove( it->first, ec );
+        }
+    }
+}
+
+// Run recovery phases 1-2: read manifest, move backup files to save_dir,
+// clean up stale files.  Returns true if all files were moved successfully.
+// The backup directory still exists after this call (caller handles phase 3).
+static bool restore_phases_1_and_2( const std::filesystem::path &backup_dir,
+                                    const std::filesystem::path &save_dir )
+{
+    // Read the file manifest so we know which files belong in the save.
+    const std::optional<std::set<std::string>> manifest =
+            read_manifest( backup_dir / std::filesystem::u8path( backup_marker_name ) );
+
+    // Phase 1: Move each backup file to save_dir (overwriting live files).
+    // Using rename is atomic per-file.  If recovery is interrupted, files
+    // already moved are in save_dir correctly and no longer in backup_dir.
+    // The next recovery attempt moves the remaining files.
+    const bool move_ok = restore_phase_move( backup_dir, save_dir );
+
+    // Phase 2: Remove stale files from save_dir that are not in the manifest.
+    // These are files written during the interrupted save that should not exist
+    // in the pre-save snapshot.  The manifest is still readable (it was in the
+    // backup marker, which we haven't deleted yet).
+    // Skipped only if the manifest is missing (old-format backup); an empty
+    // manifest still triggers cleanup to remove any stale files.
+    if( manifest.has_value() ) {
+        restore_phase_cleanup( save_dir, *manifest );
+    }
+
+    return move_ok;
+}
+
+void save_transaction::remove_backup()
+{
+    if( std::filesystem::exists( backup_dir_ ) ) {
+        std::error_code ec;
+        std::filesystem::remove_all( backup_dir_, ec );
+        if( ec ) {
+            DebugLog( D_WARNING, D_MAIN ) << "save_transaction: failed to remove backup: "
+                                          << ec.message();
+        }
+    }
+}
+
+void save_transaction::restore_from_backup()
+{
+    if( !std::filesystem::exists( backup_dir_ ) ) {
+        return;
+    }
+
+    // Check that backup is complete (has marker)
+    if( !std::filesystem::exists( backup_dir_ / std::filesystem::u8path( backup_marker_name ) ) ) {
+        // Backup was incomplete -- the live directory should be untouched.
+        // Just remove the partial backup.
+        DebugLog( D_WARNING, D_MAIN ) << "save_transaction: incomplete backup, removing";
+        std::error_code ec;
+        std::filesystem::remove_all( backup_dir_, ec );
+        return;
+    }
+
+    DebugLog( D_WARNING, D_MAIN ) << "save_transaction: restoring from backup";
+
+    const bool move_ok = restore_phases_1_and_2( backup_dir_, save_dir_ );
+
+    // Phase 3: Remove backup dir (now contains only the marker).
+    // Only safe when all files were restored; partial failure keeps the
+    // backup so a subsequent recovery attempt can finish the job.
+    if( move_ok ) {
+        std::error_code ec;
+        std::filesystem::remove_all( backup_dir_, ec );
+        if( !ec && fsync_directory( save_dir_ ) ) {
+            // Backup removal is durable -- safe to remove commit marker
+            std::filesystem::remove( save_dir_ / std::filesystem::u8path( commit_marker_name ), ec );
+            if( ec ) {
+                DebugLog( D_WARNING, D_MAIN )
+                        << "save_transaction: failed to remove commit marker after restore: "
+                        << ec.message();
+            }
+        } else {
+            DebugLog( D_WARNING, D_MAIN )
+                    << "save_transaction: cleanup sync failed after restore";
+        }
+    } else {
+        DebugLog( D_ERROR, D_MAIN )
+                << "save_transaction: partial restore -- backup kept for manual recovery";
+    }
+}
+
+void save_transaction::recover_if_needed( const std::filesystem::path &save_dir )
+{
+    const std::filesystem::path backup = save_dir / std::filesystem::u8path( backup_dirname );
+    const std::filesystem::path commit = save_dir / std::filesystem::u8path( commit_marker_name );
+
+    if( !std::filesystem::exists( backup ) ) {
+        // No backup directory -- check for stale commit marker
+        if( std::filesystem::exists( commit ) ) {
+            std::error_code ec;
+            std::filesystem::remove( commit, ec );
+        }
+        return;
+    }
+
+    if( std::filesystem::exists( commit ) ) {
+        // Save completed successfully but cleanup was interrupted.
+        // The live directory is consistent.  Just clean up.
+        // Only remove the commit marker after the backup is gone and synced;
+        // if backup removal or sync fails, the marker must stay so a later
+        // run still sees the "save completed" state.
+        std::error_code ec;
+        std::filesystem::remove_all( backup, ec );
+        if( !ec && fsync_directory( save_dir ) ) {
+            // Backup removal is durable -- safe to remove commit marker
+            std::filesystem::remove( commit, ec );
+            if( ec ) {
+                DebugLog( D_WARNING, D_MAIN )
+                        << "save recovery: failed to remove commit marker: " << ec.message();
+            }
+        } else {
+            DebugLog( D_WARNING, D_MAIN )
+                    << "save recovery: cleanup sync failed, will retry next load";
+        }
+        return;
+    }
+
+    // Backup exists without commit marker -- save was interrupted.
+    if( !std::filesystem::exists( backup / std::filesystem::u8path( backup_marker_name ) ) ) {
+        // Backup was incomplete -- live directory should be untouched.
+        DebugLog( D_WARNING, D_MAIN ) << "save recovery: removing incomplete backup";
+        std::error_code ec;
+        std::filesystem::remove_all( backup, ec );
+        return;
+    }
+
+    // Full recovery needed
+    popup( _( "Recovering save from backup after interrupted save\u2026" ) );
+    DebugLog( D_WARNING, D_MAIN ) << "save recovery: restoring from backup in "
+                                  << save_dir.u8string();
+
+    const bool move_ok = restore_phases_1_and_2( backup, save_dir );
+
+    // Phase 3: Remove backup dir.
+    // Only safe when all files were restored; partial failure keeps the
+    // backup so a subsequent recovery attempt can finish the job.
+    if( move_ok ) {
+        std::error_code ec;
+        std::filesystem::remove_all( backup, ec );
+    } else {
+        DebugLog( D_ERROR, D_MAIN )
+                << "save recovery: partial restore -- backup kept at "
+                << backup.u8string();
+        popup( _( "Warning: Save recovery was partial.  Some files could not be restored.\n"
+                  "The backup has been preserved for manual recovery." ) );
+    }
+}

--- a/src/save_transaction.h
+++ b/src/save_transaction.h
@@ -1,0 +1,82 @@
+#pragma once
+#ifndef CATA_SRC_SAVE_TRANSACTION_H
+#define CATA_SRC_SAVE_TRANSACTION_H
+
+#include <filesystem>
+
+/**
+ * Directory-level transactional save wrapper.
+ *
+ * Before writing any save files, the constructor hardlinks (or copies) the
+ * entire save directory into a ".save_backup" subdirectory.  If the save
+ * completes successfully, commit() removes the backup.  If the process
+ * crashes or an exception unwinds before commit(), the destructor attempts
+ * to restore the backup.  On the next load, recover_if_needed() detects
+ * leftover backup directories from interrupted saves and restores them.
+ */
+class save_transaction
+{
+    public:
+        enum class fsync_level {
+            markers_only,   // fsync backup/commit markers + directories (quicksave/autosave)
+            full            // fsync every written file + directories (Save & Exit)
+        };
+
+        /**
+         * Create a backup snapshot of @p save_dir and begin the transaction.
+         * Throws std::runtime_error if the backup cannot be created.
+         */
+        explicit save_transaction( const std::filesystem::path &save_dir,
+                                   fsync_level level = fsync_level::markers_only );
+
+        /**
+         * If commit() was not called, attempts to restore from backup.
+         */
+        ~save_transaction();
+
+        save_transaction( const save_transaction & ) = delete;
+        save_transaction &operator=( const save_transaction & ) = delete;
+
+        /**
+         * Mark the save as complete: write commit marker, fsync, remove backup.
+         * Returns false if the commit marker could not be written.
+         */
+        bool commit();
+
+        /**
+         * Call at load time to recover from an interrupted save.
+         * If a backup directory exists without a commit marker, the live save
+         * is replaced with the backup contents.
+         */
+        static void recover_if_needed( const std::filesystem::path &save_dir );
+
+        /**
+         * Returns true if a transaction is active and its fsync level is 'full'.
+         * Called by ofstream_wrapper::close() to decide whether to fsync each file.
+         */
+        static bool wants_full_fsync();
+
+        /**
+         * Record that an fsync operation failed during a full-fsync transaction.
+         * Called by fsync_file()/fsync_directory() on failure.  commit() will
+         * refuse to finalize if any sync failure was recorded.
+         */
+        static void notify_sync_failure();
+
+    private:
+        std::filesystem::path save_dir_;
+        std::filesystem::path backup_dir_;   // save_dir_ / ".save_backup"
+        fsync_level level_;
+        bool committed_ = false;
+        bool backup_created_ = false;
+        bool sync_failed_ = false;
+
+        void create_backup();
+        void remove_backup();
+        void restore_from_backup();
+
+        // NOLINTNEXTLINE(cata-static-int_id-constants)
+        static save_transaction *current_;
+};
+
+#endif // CATA_SRC_SAVE_TRANSACTION_H

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -2096,6 +2096,7 @@ bool WORLD::has_compression_enabled() const
            std::filesystem::exists( ( world_folder_path / "overmaps.dict" ).get_unrelative_path() );
 }
 
+
 bool WORLD::set_compression_enabled( bool enabled ) const
 {
     // Return immediately if we're already in the desired state.

--- a/src/worldfactory.h
+++ b/src/worldfactory.h
@@ -91,6 +91,7 @@ struct WORLD {
         bool has_compression_enabled() const;
         bool set_compression_enabled( bool enabled ) const;
 
+
 };
 
 class mod_manager;

--- a/src/zzip.cpp
+++ b/src/zzip.cpp
@@ -483,6 +483,13 @@ bool zzip::add_file( std::filesystem::path const &zzip_relative_path, std::strin
     return true;
 }
 
+bool zzip::flush()
+{
+    if( file_ ) {
+        return file_->flush();
+    }
+    return true;
+}
 
 bool zzip::copy_files( std::vector<std::filesystem::path> const &zzip_relative_paths,
                        zzip const &from, bool shrink_to_fit )

--- a/src/zzip.h
+++ b/src/zzip.h
@@ -88,6 +88,12 @@ class zzip
         bool add_file( std::filesystem::path const &zzip_relative_path, std::string_view content );
 
         /**
+         * Synchronously write modified parts of the file to disk.
+         * Returns true on success (or if the zzip is not backed by a file).
+         */
+        bool flush();
+
+        /**
          * Directly copies compressed entries from one zzip to another, keeping the same path.
          * If `from` was not opened with the same dictionary, the copied files may not be readable.
          */

--- a/src/zzip_stack.cpp
+++ b/src/zzip_stack.cpp
@@ -43,6 +43,21 @@ bool zzip_stack::add_file( std::filesystem::path const &zzip_relative_path,
     return ret;
 }
 
+bool zzip_stack::flush()
+{
+    bool ok = true;
+    if( hot_ ) {
+        ok = hot_->flush() && ok;
+    }
+    if( warm_ ) {
+        ok = warm_->flush() && ok;
+    }
+    if( cold_ ) {
+        ok = cold_->flush() && ok;
+    }
+    return ok;
+}
+
 bool zzip_stack::copy_files_to( std::vector<std::filesystem::path> const &zzip_relative_paths,
                                 zzip &to )
 {

--- a/src/zzip_stack.h
+++ b/src/zzip_stack.h
@@ -49,6 +49,12 @@ class zzip_stack
         bool add_file( std::filesystem::path const &zzip_relative_path, std::string_view content );
 
         /**
+         * Synchronously write modified mmap'd data for all loaded zzips in the stack to disk.
+         * Returns true on success.
+         */
+        bool flush();
+
+        /**
          * Directly copies the most recent version of the given files into the destination zzip.
          */
         bool copy_files_to( std::vector<std::filesystem::path> const &zzip_relative_paths,

--- a/tests/save_transaction_test.cpp
+++ b/tests/save_transaction_test.cpp
@@ -1,0 +1,283 @@
+#include <cstddef>
+
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <stdexcept>
+#include <string>
+#include <system_error>
+#include <vector>
+
+#include "cata_catch.h"
+#include "save_transaction.h"
+
+#if defined(_WIN32)
+#include "platform_win.h"
+#else
+#if !defined(EMSCRIPTEN)
+#include <sys/stat.h>
+#endif
+#include <unistd.h>
+#endif
+
+namespace
+{
+
+// RAII helper that creates a unique temp directory and removes it on destruction.
+struct temp_dir {
+    std::filesystem::path path;
+
+    temp_dir() {
+        // NOLINTNEXTLINE(cata-u8-path)
+        path = std::filesystem::temp_directory_path() / ( "cata_txn_test_" +
+                std::to_string( static_cast<int>(
+#if defined(_WIN32)
+                                    GetCurrentProcessId()
+#else
+                                    getpid()
+#endif
+                                ) ) );
+        std::error_code ec;
+        std::filesystem::remove_all( path, ec );
+        std::filesystem::create_directories( path );
+    }
+
+    ~temp_dir() {
+        // Restore permissions in case a test made the dir read-only
+#if !defined(_WIN32) && !defined(EMSCRIPTEN)
+        chmod( path.c_str(), 0755 );
+#endif
+        std::error_code ec;
+        std::filesystem::remove_all( path, ec );
+    }
+
+    temp_dir( const temp_dir & ) = delete;
+    temp_dir &operator=( const temp_dir & ) = delete;
+};
+
+// Write a file using temp+rename to simulate real save behavior.
+// This avoids modifying hardlinked backup copies through shared inodes.
+void write_file( const std::filesystem::path &p, const std::string &content )
+{
+    std::filesystem::create_directories( p.parent_path() );
+    std::filesystem::path tmp = p;
+    tmp += ".write_tmp"; // NOLINT(cata-u8-path)
+    {
+        std::ofstream f( tmp, std::ios::binary );
+        f << content;
+    }
+    std::filesystem::rename( tmp, p );
+}
+
+std::string read_file( const std::filesystem::path &p )
+{
+    std::ifstream f( p, std::ios::binary );
+    return { std::istreambuf_iterator<char>( f ), std::istreambuf_iterator<char>() };
+}
+
+bool has_file( const std::filesystem::path &dir, const std::string &name )
+{
+    return std::filesystem::exists( dir / std::filesystem::u8path( name ) );
+}
+
+// Write a minimal backup marker (JSON with file manifest).
+void write_backup_marker( const std::filesystem::path &backup_dir,
+                          const std::vector<std::string> &files )
+{
+    std::ofstream f( backup_dir / std::filesystem::u8path( ".backup_marker" ),
+                     std::ios::binary );
+    f << R"({"version":1,"pid":0,"files":[)";
+    for( size_t i = 0; i < files.size(); ++i ) {
+        if( i > 0 ) {
+            f << ",";
+        }
+        f << "\"" << files[i] << "\"";
+    }
+    f << "]}";
+}
+
+void write_commit_marker( const std::filesystem::path &save_dir )
+{
+    std::ofstream f( save_dir / std::filesystem::u8path( ".save_commit" ),
+                     std::ios::binary );
+    f << R"({"version":1,"pid":0})";
+}
+
+} // namespace
+
+TEST_CASE( "save_transaction_skip_temp_files", "[nogame][save_transaction]" )
+{
+    temp_dir td;
+    const std::filesystem::path &dir = td.path;
+
+    // Create files: one normal, one .temp (ofstream_wrapper convention),
+    // one .tmp (zzip convention)
+    write_file( dir / std::filesystem::u8path( "player.sav" ), "save data" );
+    write_file( dir / std::filesystem::u8path( "player.sav.12345.temp" ), "temp ofstream" );
+    write_file( dir / std::filesystem::u8path( "maps.zzip.tmp" ), "temp zzip" );
+
+    {
+        save_transaction txn( dir );
+        // Don't commit -- destructor will restore, but we inspect backup first
+
+        const std::filesystem::path backup = dir / std::filesystem::u8path( ".save_backup" );
+        REQUIRE( std::filesystem::exists( backup ) );
+
+        CHECK( has_file( backup, "player.sav" ) );
+        CHECK_FALSE( has_file( backup, "player.sav.12345.temp" ) );
+        CHECK_FALSE( has_file( backup, "maps.zzip.tmp" ) );
+
+        // Commit so destructor doesn't restore
+        CHECK( txn.commit() );
+    }
+}
+
+TEST_CASE( "save_transaction_stale_marker_removal_failure", "[nogame][save_transaction]" )
+{
+#if defined(_WIN32) || defined(EMSCRIPTEN)
+    WARN( "Skipping: permission-based deletion failure not portable to this platform" );
+    return;
+#else
+    if( getuid() == 0 ) {
+        WARN( "Skipping: running as root -- permission checks are bypassed" );
+        return;
+    }
+
+    temp_dir td;
+    const std::filesystem::path &dir = td.path;
+
+    write_file( dir / std::filesystem::u8path( "data.sav" ), "content" );
+    write_commit_marker( dir );
+
+    // Make save directory read-only so remove() on the marker fails
+    // (deletion is a directory operation on POSIX)
+    chmod( dir.c_str(), 0555 );
+
+    // Pre-check: verify that file deletion actually fails in this environment
+    {
+        std::error_code ec;
+        std::filesystem::remove( dir / std::filesystem::u8path( ".save_commit" ), ec );
+        if( !ec ) {
+            // Marker was removed despite r/o dir (unusual ACL, etc.)
+            chmod( dir.c_str(), 0755 );
+            WARN( "Skipping: filesystem does not enforce directory permissions for deletion" );
+            return;
+        }
+    }
+
+    CHECK_THROWS_AS( save_transaction( dir ), std::runtime_error );
+
+    // Verify backup was NOT created (no unsafe state)
+    CHECK_FALSE( std::filesystem::exists( dir / std::filesystem::u8path( ".save_backup" ) ) );
+
+    // Restore permissions for cleanup
+    chmod( dir.c_str(), 0755 );
+#endif
+}
+
+TEST_CASE( "save_transaction_commit_leaves_marker", "[nogame][save_transaction]" )
+{
+    temp_dir td;
+    const std::filesystem::path &dir = td.path;
+
+    write_file( dir / std::filesystem::u8path( "data.sav" ), "original" );
+
+    // First transaction: commit should leave commit marker, remove backup
+    {
+        save_transaction txn( dir );
+        CHECK( txn.commit() );
+    }
+
+    CHECK_FALSE( std::filesystem::exists( dir / std::filesystem::u8path( ".save_backup" ) ) );
+    CHECK( std::filesystem::exists( dir / std::filesystem::u8path( ".save_commit" ) ) );
+
+    // Second transaction: create_backup should clean up the stale commit marker
+    {
+        save_transaction txn( dir );
+
+        CHECK_FALSE( std::filesystem::exists( dir / std::filesystem::u8path( ".save_commit" ) ) );
+        CHECK( std::filesystem::exists( dir / std::filesystem::u8path( ".save_backup" ) ) );
+
+        CHECK( txn.commit() );
+    }
+}
+
+TEST_CASE( "save_transaction_recover_backup_plus_commit", "[nogame][save_transaction]" )
+{
+    temp_dir td;
+    const std::filesystem::path &dir = td.path;
+
+    // Set up the state: backup with marker + commit marker = "completed but cleanup interrupted"
+    write_file( dir / std::filesystem::u8path( "data.sav" ), "live data" );
+
+    const std::filesystem::path backup = dir / std::filesystem::u8path( ".save_backup" );
+    std::filesystem::create_directory( backup );
+    write_file( backup / std::filesystem::u8path( "data.sav" ), "backup data" );
+    write_backup_marker( backup, { "data.sav" } );
+    write_commit_marker( dir );
+
+    save_transaction::recover_if_needed( dir );
+
+    // Live data should be unchanged (save completed successfully)
+    CHECK( read_file( dir / std::filesystem::u8path( "data.sav" ) ) == "live data" );
+    // Both backup dir and commit marker should be cleaned up
+    CHECK_FALSE( std::filesystem::exists( backup ) );
+    CHECK_FALSE( std::filesystem::exists( dir / std::filesystem::u8path( ".save_commit" ) ) );
+}
+
+TEST_CASE( "save_transaction_destructor_restores_on_no_commit", "[nogame][save_transaction]" )
+{
+    temp_dir td;
+    const std::filesystem::path &dir = td.path;
+
+    write_file( dir / std::filesystem::u8path( "data.sav" ), "original content" );
+
+    {
+        save_transaction txn( dir );
+
+        // Simulate save writing: modify the live file and add a stale file
+        write_file( dir / std::filesystem::u8path( "data.sav" ), "modified during save" );
+        write_file( dir / std::filesystem::u8path( "stale_new_file.sav" ), "stale" );
+
+        // Don't call commit() -- destructor should restore from backup
+    }
+
+    // Original content should be restored
+    CHECK( read_file( dir / std::filesystem::u8path( "data.sav" ) ) == "original content" );
+    // Stale file should be cleaned up (not in original manifest)
+    CHECK_FALSE( std::filesystem::exists(
+                     dir / std::filesystem::u8path( "stale_new_file.sav" ) ) );
+    // Backup dir should be gone after successful restore
+    CHECK_FALSE( std::filesystem::exists(
+                     dir / std::filesystem::u8path( ".save_backup" ) ) );
+
+    // TODO: Add a follow-up test that exercises recover_if_needed() directly
+    // for the backup-without-commit branch once popup suppression in the test
+    // harness is resolved (or popup is made optional in recovery).
+}
+
+TEST_CASE( "save_transaction_commit_refuses_on_sync_failure", "[nogame][save_transaction]" )
+{
+    temp_dir td;
+    const std::filesystem::path &dir = td.path;
+
+    write_file( dir / std::filesystem::u8path( "data.sav" ), "original" );
+
+    {
+        // Must use fsync_level::full -- notify_sync_failure() only records
+        // failure when level is full (save_transaction.cpp)
+        save_transaction txn( dir, save_transaction::fsync_level::full );
+
+        // Simulate an fsync failure during save
+        save_transaction::notify_sync_failure();
+
+        CHECK_FALSE( txn.commit() );
+
+        // Don't commit -- destructor will restore
+    }
+
+    // After destructor runs, original state should be restored
+    CHECK( read_file( dir / std::filesystem::u8path( "data.sav" ) ) == "original" );
+    CHECK_FALSE( std::filesystem::exists(
+                     dir / std::filesystem::u8path( ".save_backup" ) ) );
+}


### PR DESCRIPTION
#### Summary
Features "Add transactional save system with backup, recovery, and fsync durability"

#### Purpose of change

Currently save operations are not fully atomic - if the game crashes or power is lost mid-save, the save directory can end up with partially written files and no way to recover. This adds a transactional wrapper around save operations that creates a backup before writing and can restore from it on failure.

#### Describe the solution

New `save_transaction` class (save_transaction.h/cpp) that wraps a save directory with backup/restore semantics:

1. **create_backup** - hardlinks (or copies for mmap'd zzips) all files into a `.save_backup` directory with a JSON manifest
2. **commit** - writes a `.save_commit` marker after the save succeeds; backup is then removed
3. **restore** - if the transaction is destroyed without commit, files are restored from backup and stale files are cleaned up
4. **recover_if_needed** - called at load time to handle interrupted saves: backup + commit marker means cleanup only; backup without marker means full restore

fsync ordering matters for crash safety: `fsync_directory(save_dir)` is called between backup removal and commit-marker removal at all cleanup sites, so the filesystem can't reorder them across a crash. Stale commit marker removal in `create_backup` checks the error code and throws if it fails, preventing a state
where recovery would make the wrong decision.

Other changes:
- Add `.tmp` to the backup skip filter alongside `.temp` (zzip compact writes `.tmp` files, ofstream_wrapper writes `.temp` files)
- Add `zzip::flush()` and `zzip_stack::flush()` / `fsync_backing_files()` for explicit durability in the save path
- `mmap_file::flush()` now returns bool and checks msync/FlushFileBuffers return values
- `allow_omitted_members()` in manifest reader to avoid JSON parser warnings
- fsync_file/fsync_directory helpers in filesystem.cpp
- rename_file syncs when full fsync is active

#### Describe alternatives you've considered

Could have made saves fully atomic with write-to-temp-dir + rename, but that would require restructuring all the different save writers (overmap, mapbuffer, map_memory, game_io). The backup approach wraps around the existing save code without modifying it.

#### Testing

Added `tests/save_transaction_test.cpp` with 6 test cases covering:
- `.temp` and `.tmp` files excluded from backup
- `create_backup` throws when stale commit marker cannot be removed (POSIX only, with permission precheck and root skip)
- Commit leaves marker, next transaction cleans it up (ordering invariant)
- `recover_if_needed` with backup + commit marker cleans up without rollback
- Destructor restores original files and removes stale files on no-commit
- `commit()` refuses after `notify_sync_failure()` with `fsync_level::full`
- 