### PR TITLE
Change default test sort order to lexicographical

### DIFF
--- a/tests/catch/catch.hpp
+++ b/tests/catch/catch.hpp
@@ -5290,7 +5290,7 @@ namespace Catch {
         WarnAbout::What warnings = WarnAbout::Nothing;
         ShowDurations::OrNot showDurations = ShowDurations::DefaultForReporter;
         double minDuration = -1;
-        RunTests::InWhatOrder runOrder = RunTests::InDeclarationOrder;
+        RunTests::InWhatOrder runOrder = RunTests::InLexicographicalOrder;
         UseColour::YesOrNo useColour = UseColour::Auto;
         WaitForKeypress::When waitForKeypress = WaitForKeypress::Never;
 
@@ -9847,9 +9847,9 @@ namespace Catch {
             | Opt( config.listReporters )
                 ["--list-reporters"]
                 ( "list all reporters" )
-            | Opt( setTestOrder, "decl|lex|rand" )
+            | Opt( setTestOrder, "lex|decl|rand" )
                 ["--order"]
-                ( "test case order (defaults to decl)" )
+                ( "test case order (defaults to lex)" )
             | Opt( setRngSeed, "'time'|number" )
                 ["--rng-seed"]
                 ( "set a specific seed for random numbers" )


### PR DESCRIPTION
#### Summary
Infrastructure "Change default test sort order to lexicographical"

#### Purpose of change

Testing locally was done in declarative (decl) order by default but CI tests in lexicographical (lex) order.  This has caused confusion for developers in the past since decl order depends on the system.  There are tests that contaminate state so as to cause subsequent tests to break and this prevents seeing those errors by default if they wouldn't be present in CI.

#### Describe the solution

Change the default to lex.

#### Describe alternatives you've considered

<img width="245" alt="insanity wolf wants random tests" src="https://github.com/user-attachments/assets/edbfbde5-25f1-4be9-8a74-75af13525191" />

#### Testing

Before
```bash
$ nice make -j10 TILES=0 TESTS=1 && ./tests/cata_test --list-test-names-only | head
# compile stuff removed here
-----------------------------------------
11:56:21.115 : Starting log.
11:56:21.115 INFO : Cataclysm DDA version 38e5277a38
11:56:21.115 INFO : Default randomness seeded to: 2056590903
act_multiple_construction
npc_act_multiple_construction
camp_blueprint_autocalc
place_active_item_at_various_coordinates
active_items_processed_regularly
non_energy_tool_power_consumption_rate
tool_power_consumption_rate
activity_counter_from_1_to_300
activity_tracker_from_300_to_1
activity_tracker_constant_value

$ ./tests/cata_test --help | grep -C1 order
  --list-reporters                          list all reporters
  --order <decl|lex|rand>                   test case order (defaults to
                                            decl)
```

After
```bash
$ nice make -j10 TILES=0 TESTS=1 && ./tests/cata_test --list-test-names-only | head
# compile stuff removed here
-----------------------------------------
11:58:48.651 : Starting log.
11:58:48.652 INFO : Cataclysm DDA version 38e5277a38
11:58:48.652 INFO : Default randomness seeded to: 3564825214
3D_bresenham
AIM_basic_move_items
All_valid_mutations_can_be_purified
Armor_values_preserved_after_copy-from
Attack_vector_test
Basic_character_modifier_test
Basic_limb_score_test
Bionic_power_capacity
Body_part_armor_vs_damage
Chance_of_bad_mutations_vs_instability

$ ./tests/cata_test --help | grep -C1 order
  --list-reporters                          list all reporters
  --order <lex|decl|rand>                   test case order (defaults to lex)
  --rng-seed <'time'|number>                set a specific seed for random
```

#### Additional context

> I think that should be the default command but I honestly don't know. (If it's not the default, and you know how to make it the default, please help with that)
> The ordering of tests was changed to lexical some time ago so it would be consistent. I changed it in CI but it's very possible that I missed it on local defaults
> - Renech

https://discord.com/channels/598523535169945603/598529174302490644/1470953251347239025

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
