### PR TITLE
Fix sundial crash when sleeping (#85195 regression)

### DIFF
--- a/src/weather_type.cpp
+++ b/src/weather_type.cpp
@@ -102,7 +102,8 @@ void weather_type::load( const JsonObject &jo, std::string_view )
     optional( jo, was_loaded, "map_color", map_color, nc_color_reader{} );
 
     mandatory( jo, was_loaded, "sym", symbol, unicode_codepoint_from_symbol_reader );
-    mandatory( jo, was_loaded, "sun_sym", sun_symbol, unicode_codepoint_from_symbol_reader );
+    optional( jo, was_loaded, "sun_sym", sun_symbol, unicode_codepoint_from_symbol_reader,
+              NULL_UNICODE );
 
     mandatory( jo, was_loaded, "ranged_penalty", ranged_penalty );
     mandatory( jo, was_loaded, "sight_penalty", sight_penalty );

--- a/src/weather_type.cpp
+++ b/src/weather_type.cpp
@@ -103,7 +103,7 @@ void weather_type::load( const JsonObject &jo, std::string_view )
 
     mandatory( jo, was_loaded, "sym", symbol, unicode_codepoint_from_symbol_reader );
     optional( jo, was_loaded, "sun_sym", sun_symbol, unicode_codepoint_from_symbol_reader,
-              NULL_UNICODE );
+              static_cast<uint32_t>( 0x263C ) ); // ☼
 
     mandatory( jo, was_loaded, "ranged_penalty", ranged_penalty );
     mandatory( jo, was_loaded, "sight_penalty", sight_penalty );


### PR DESCRIPTION
#### Summary
Bugfixes "Fix crash to desktop when sleeping caused by sundial division by zero"

#### Purpose of change

Fixes #85273

PR #85195 introduced a division-by-zero crash in `sundial_text_color()`. The function divides by `range_day` in four places, but `range_day` becomes 0 whenever the player is sleeping (or blind, etc.) because `sight_max` is set to 0 in `Character::recalc_sight_limits()`, which makes `unimpaired_range()` return 0.

There are two paths to the crash:

1. Several sidebar widgets use the `sundial_text` var directly, which routes to `sundial_text_color()` unconditionally -- no sky visibility check at all. This crashes everywhere (indoors, underground, etc.).
2. The `sundial_time_text` path has a `can_creature_see_sky()` guard, but that function only checks map position, not sleep state. So sleeping outside or adjacent to an outside tile also crashes through this path.

This explains why the crash is consistent ("load save, go to sleep, crash") regardless of location, and why rolling back #85195 fixes it.

#### Describe the solution

Move the `can_creature_see_sky()` and `range_day` checks to the top of `sundial_text_color()`, before any highlight math. Early-return with "???" when the character cannot see the sky or `range_day` is zero. This also flattens the function by removing a level of nesting.

Also change `sun_sym` from `mandatory` to `optional` in weather type loading. All in-repo weather types already define it, but third-party mods that define weather types from scratch without `sun_sym` would crash on load.

#### Describe alternatives you've considered

- Not participating in troubleshooting this

#### Testing

The existing "not outside" widget test (`clear_map_and_put_player_underground`) still passes through the same early-return path. The crash can be reproduced by loading any save and sleeping -- the fix prevents the division from ever being reached when `range_day` is zero.

#### Additional context

The `sun_sym` change is a separate minor hardening: all bundled mods already have the field, but `mandatory` would break any external mod that defines a `weather_type` without it.