### PR TITLE
Avoid a divide by zero when blind

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -271,7 +271,8 @@ std::string display::sundial_text_color( const Character &u, int width )
     const int moon_pos_idx = static_cast<int>( std::round( azm_moon / scale ) );
 
     weather_manager &weather = get_weather();
-    const int range_day = std::min( u.sight_range( default_daylight_level() ), u.unimpaired_range() );
+    const int range_day = std::max( 1, std::min( u.sight_range( default_daylight_level() ),
+                                                 u.unimpaired_range() ) );
 
     // Sunlight that makes it through the weather is highlighted blue in proportion to sight_range
     const float incident_sun_light = incident_sunlight( weather.weather_id, calendar::turn );


### PR DESCRIPTION
#### Summary

Bugfixes "Avoid a divide by zero when blind"

#### Purpose of change

My sundial code raises `SIGFPE: Arithmetical error` when returning to Sky Island.

#### Describe the solution

I believe this is caused by being blind setting your `range_day` to 0 and then there's a divide by 0.

#### Describe alternatives you've considered

1. Make the dial return `[????]` when the player is blind.

#### Testing

I haven't tested it because the machine I'm on is not my dev machine.

#### Additional context

<details><summary>Stack trace</summary>
<p>


```
VERSION: cdda-experimental-2026-02-12-2021 38e5277-dirty
TYPE: Signal
MESSAGE: SIGFPE: Arithmetical error
STACK TRACE:

    0x564,9d3,1d2,8b1    src/debug.cpp:1,036    bt_full
    0x564,9d3,1d2,8b1    src/debug.cpp:1,301    debug_write_backtrace(std::ostream&)
    0x564,9d3,1a7,0d8    src/crash.cpp:90    log_crash
    0x564,9d3,1a7,425    src/crash.cpp:147    signal_handler
    0x7f5,7cc,23e,4cf    [unknown src]:0    [unknown func]
    0x564,9d3,22d,f6e    src/display.cpp:278    display::sundial_text_color[abi:cxx11](Character const&, int)
    0x564,9d4,048,ecd    src/widget.cpp:1,306    widget::color_text_function_string[abi:cxx11](avatar const&, unsigned int)
    0x564,9d4,04d,e82    src/widget.cpp:998    widget::show[abi:cxx11](avatar const&, unsigned int)
    0x564,9d4,04e,ba0    src/widget.cpp:1,956    widget::layout[abi:cxx11](avatar const&, unsigned int, int, bool)
    0x564,9d4,04e,766    src/widget.cpp:1,917    widget::layout[abi:cxx11](avatar const&, unsigned int, int, bool)
    0x564,9d4,04e,2f2    src/widget.cpp:1,846    widget::layout[abi:cxx11](avatar const&, unsigned int, int, bool)
    0x564,9d4,04e,766    src/widget.cpp:1,917    widget::layout[abi:cxx11](avatar const&, unsigned int, int, bool)
    0x564,9d4,04f,395    src/widget.cpp:1,083    custom_draw_func
    0x564,9d3,31f,0ac    /usr/include/c++/11/bits/std_function.h:590    std::function<int (draw_args const&)>::operator()(draw_args const&) const
    0x564,9d3,31f,0ac    src/game.cpp:3,361    game::draw_panels(bool)
    0x564,9d3,331,23a    src/game.cpp:3,315    game::draw(ui_adaptor&)
    0x564,9d3,f5a,590    src/ui_manager.cpp:455    ui_adaptor::redraw_invalidated()
    0x564,9d3,b11,1cf    src/popup.cpp:295    query_popup::query_once()
    0x564,9d3,b11,901    src/popup.cpp:405    query_popup::query()
    0x564,9d3,a44,821    src/output.cpp:994    popup(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, PopupFlags)
    0x564,9d3,9ec,0c3    src/npctalk.cpp:5,425    operator()
    0x564,9d3,99c,cd4    src/npctalk.cpp:8,056    talk_effect_t::apply(dialogue&) const
    0x564,9d3,267,65f    src/effect_on_condition.cpp:353    effect_on_condition::activate(dialogue&, bool) const
    0x564,9d3,9d3,d6a    src/npctalk.cpp:6,267    run_eocs
    0x564,9d3,9d3,d6a    src/npctalk.cpp:6,390    operator()
    0x564,9d3,99c,cd4    src/npctalk.cpp:8,056    talk_effect_t::apply(dialogue&) const
    0x564,9d3,267,65f    src/effect_on_condition.cpp:353    effect_on_condition::activate(dialogue&, bool) const
    0x564,9d3,9d3,d6a    src/npctalk.cpp:6,267    run_eocs
    0x564,9d3,9d3,d6a    src/npctalk.cpp:6,390    operator()
    0x564,9d3,99c,cd4    src/npctalk.cpp:8,056    talk_effect_t::apply(dialogue&) const
    0x564,9d3,267,65f    src/effect_on_condition.cpp:353    effect_on_condition::activate(dialogue&, bool) const
    0x564,9d3,9d3,d6a    src/npctalk.cpp:6,267    run_eocs
    0x564,9d3,9d3,d6a    src/npctalk.cpp:6,390    operator()
    0x564,9d3,99c,cd4    src/npctalk.cpp:8,056    talk_effect_t::apply(dialogue&) const
    0x564,9d3,267,692    src/effect_on_condition.cpp:356    effect_on_condition::activate(dialogue&, bool) const
    0x564,9d3,9d3,d6a    src/npctalk.cpp:6,267    run_eocs
    0x564,9d3,9d3,d6a    src/npctalk.cpp:6,390    operator()
    0x564,9d3,99c,cd4    src/npctalk.cpp:8,056    talk_effect_t::apply(dialogue&) const
    0x564,9d3,9dc,fb2    src/npctalk.cpp:7,023    operator()
    0x564,9d3,9dc,fb2    /usr/include/c++/11/bits/invoke.h:61    __invoke_impl<void, talk_effect_fun::(anonymous namespace)::f_switch(const JsonObject&, std::string_view, std::string_view)::<lambda(dialogue&)>&, dialogue&>
    0x564,9d3,9dc,fb2    /usr/include/c++/11/bits/invoke.h:111    __invoke_r<void, talk_effect_fun::(anonymous namespace)::f_switch(const JsonObject&, std::string_view, std::string_view)::<lambda(dialogue&)>&, dialogue&>
    0x564,9d3,9dc,fb2    /usr/include/c++/11/bits/std_function.h:290    _M_invoke
    0x564,9d3,99c,cd4    src/npctalk.cpp:8,056    talk_effect_t::apply(dialogue&) const
    0x564,9d3,267,65f    src/effect_on_condition.cpp:353    effect_on_condition::activate(dialogue&, bool) const
    0x564,9d3,400,b82    src/iexamine_actors.cpp:303    eoc_examine_actor::call(Character&, coords::coord_point_ob<tripoint, (coords::origin)5, (coords::scale)0> const&) const
    0x564,9d3,356,f94    src/game.cpp:5,532    game::examine(coords::coord_point_ob<tripoint, (coords::origin)5, (coords::scale)0> const&, bool)
    0x564,9d3,357,6ad    src/game.cpp:5,375    game::examine(bool)
    0x564,9d3,3ab,c02    src/handle_action.cpp:2,533    game::do_regular_action(action_id&, avatar&, std::optional<coords::coord_point_ob<tripoint, (coords::origin)5, (coords::scale)0> > const&)
    0x564,9d3,3ae,f54    src/handle_action.cpp:3,333    game::handle_action()
    0x564,9d3,237,1f1    src/do_turn.cpp:594    do_turn()
    0x564,9d2,d96,c87    src/main.cpp:867    main
    0x7f5,7cc,227,634    [unknown src]:0    [unknown func]
    0x7f5,7cc,227,6e8    [unknown src]:0    [unknown func]
    0x564,9d2,ea1,4f4    [unknown src]:0    [unknown func]
    0xf,fff,fff,fff,fff,fff    [unknown src]:0    [unknown func]

```

</p>
</details> 


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
