### PR TITLE
Fix antiparasitic killing players

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -3265,6 +3265,10 @@
   },
   {
     "type": "effect_type",
+    "id": "dermatik_cured"
+  },
+  {
+    "type": "effect_type",
     "id": "dermatik_visible",
     "name": [ "Wriggling Skin", "Crawling Lump", "Distended Flesh" ],
     "desc": [

--- a/data/json/effects_on_condition/effects_eocs.json
+++ b/data/json/effects_on_condition/effects_eocs.json
@@ -98,7 +98,12 @@
     "id": "EOC_DERMATIK_BIRTH",
     "eoc_type": "EVENT",
     "required_event": "character_loses_effect",
-    "condition": { "compare_string": [ "dermatik", { "context_val": "effect" } ] },
+    "condition": { 
+      "and": [
+        {"compare_string": [ "dermatik", { "context_val": "effect" } ] },
+        {"not": { "u_has_effect" : "dermatik_cured"}}
+      ]
+    },
     "effect": [
       {
         "if": { "math": [ "u_vitamin('dermatik_larva_size') >= 1440" ] },

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -180,6 +180,7 @@ static const efftype_id effect_crushed( "crushed" );
 static const efftype_id effect_datura( "datura" );
 static const efftype_id effect_dazed( "dazed" );
 static const efftype_id effect_dermatik( "dermatik" );
+static const efftype_id effect_dermatik_cured( "dermatik_cured" );
 static const efftype_id effect_docile( "docile" );
 static const efftype_id effect_downed( "downed" );
 static const efftype_id effect_earphones( "earphones" );
@@ -734,6 +735,7 @@ std::optional<int> iuse::antiparasitic( Character *p, item *, const tripoint_bub
     }
     p->add_msg_if_player( _( "You take some antiparasitic medication." ) );
     if( p->has_effect( effect_dermatik ) ) {
+        p->add_effect( effect_dermatik_cured, 1_turns, true );
         p->remove_effect( effect_dermatik );
         p->add_msg_if_player( m_good, _( "The itching sensation under your skin fades away." ) );
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
As #85266 pointed out, taking antiparasitic in the latest version causes death. This is because the death EOC triggers once the "dermatik" effect is removed for any reason, including the use of antiparasitic.

I think this might be obsolete with #85277

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

This change solves the problem by adding a temporary "dermatik_cured" effect that prevents the EOC from occurring while active, lasting 1 turn. Thus we can safely remove the dermatik effect. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

We could rewrite the structure of the dermatik trait to kill only when the cooldown was initially 1, but I don't have the CDDA knowledge to do so. 

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Still a draft build, waiting for compiling. 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
