### PR TITLE
Revert "Chipped away at zone sorting issues" #84974

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -12572,7 +12572,6 @@ void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
     // Dropping off
     if( !dropoff_coords.empty() && !picked_up_stuff.empty() ) {
         auto dest_iter = dropoff_coords.begin();
-
         while( dest_iter != dropoff_coords.end() ) {
             const tripoint_abs_ms drop_dest = *dest_iter;
             // Sometimes we loop back to here while still picking stuff up (because we spent all our moves picking up)
@@ -12595,10 +12594,10 @@ void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
                     }
 
                     // FIXME HACK: teleports item onto ground
+                    you.mod_moves( -you.item_handling_cost( **iter ) );
                     std::vector<item_location> dropped_crap = put_into_vehicle_or_drop_ret_locs( you,
-                            item_drop_reason::deliberate, { **iter }, here.get_bub( drop_dest ), false );
+                            item_drop_reason::deliberate, { **iter }, here.get_bub( drop_dest ) );
                     if( !dropped_crap.empty() ) {
-                        you.mod_moves( -you.item_handling_cost( **iter ) );
                         if( const vehicle_cursor *veh_curs = iter->veh_cursor() ) {
                             vehicle &cart_with_items = veh_curs->veh;
                             cart_with_items.remove_item( cart_with_items.part( veh_curs->part ), iter->get_item() );
@@ -12757,88 +12756,8 @@ void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
         //this location is sorted
         stage = THINK;
         dropoff_coords.clear();
-
     } else if( !dropoff_coords.empty() && !you.has_destination() )  {
-        bool match = false;
-        tripoint_abs_ms destination;
-
-        // Find a dropoff location that can take all the items picked up.
-        for( tripoint_abs_ms &dest : dropoff_coords ) {
-            std::vector<item_location> placed_items;
-
-            match = true;
-
-            for( item_location &item : picked_up_stuff ) {
-                std::vector<item_location> placed_item = put_into_vehicle_or_drop_ret_locs( you,
-                        item_drop_reason::deliberate, { *item }, here.get_bub( dest ), false );
-
-                if( placed_item.empty() ) {
-                    match = false;
-                    break;
-
-                } else {
-                    placed_items.emplace_back( placed_item.front() );
-                }
-            }
-
-            // Get rid of the placed items, as we really only wanted to know if they COULD be placed.
-            for( item_location &item : placed_items ) {
-                item.remove_item();
-            }
-
-            if( match ) {
-                destination = dest;
-                break;
-            }
-        }
-
-        if( !match ) {
-            // Couldn't find any destination that would take all items. Fallback to one that can accept
-            // the first one that has a usable destination.
-            // Note that we always have to be able to handle the situation where a destination is full
-            // when we get there due to things happening in the mean time (like other characters sorting
-            // stuff into that location as we move there), so we leave the handling of unsortable items
-            // in the inventory to that handling for now.
-            for( tripoint_abs_ms &dest : dropoff_coords ) {
-                std::vector<item_location> placed_items;
-
-                match = true;
-
-                for( item_location &item : picked_up_stuff ) {
-                    std::vector<item_location> placed_item = put_into_vehicle_or_drop_ret_locs( you,
-                            item_drop_reason::deliberate, { *item }, here.get_bub( dest ), false );
-
-                    if( placed_item.empty() ) {
-                        match = false;
-                        break;
-
-                    } else {
-                        placed_items.emplace_back( placed_item.front() );
-                        match = true;
-                        break;
-                    }
-                }
-
-                // Get rid of the placed items, as we really only wanted to know if they COULD be placed.
-                for( item_location &item : placed_items ) {
-                    item.remove_item();
-                }
-
-                if( match ) {
-                    destination = dest;
-                    break;
-                }
-            }
-        }
-
-        if( !match ) {
-            add_msg( m_bad, _( "None of the items picked up can be sorted because they won't fit anywhere." ) );
-            stage = LAST;
-            return;
-        }
-
-        zone_sorting::route_to_destination( you, act, here.get_bub( destination ), stage );
-
+        zone_sorting::route_to_destination( you, act, here.get_bub( dropoff_coords.front() ), stage );
     } else if( !you.has_destination() ) {
         debugmsg( "Sort activity has items to sort but no valid destination, this is a bug" );
         // Completely kick us out of this activity, something's gone wrong and we don't know what's going on.

--- a/src/activity_handlers.h
+++ b/src/activity_handlers.h
@@ -170,14 +170,13 @@ void put_into_vehicle_or_drop( Character &you, item_drop_reason, const std::list
 void put_into_vehicle_or_drop( Character &you, item_drop_reason, const std::list<item> &items,
                                map *here, const tripoint_bub_ms &where, bool force_ground = false );
 std::vector<item_location> put_into_vehicle_or_drop_ret_locs( Character &you, item_drop_reason,
-        const std::list<item> &items, tripoint_bub_ms dest = tripoint_bub_ms::invalid,
-        bool allow_overflow = true );
+        const std::list<item> &items, tripoint_bub_ms dest = tripoint_bub_ms::invalid );
 std::vector<item_location> put_into_vehicle_or_drop_ret_locs( Character &you, item_drop_reason,
         const std::list<item> &items, map *here, const tripoint_bub_ms &where,
-        bool force_ground = false, bool allow_overflow = true );
+        bool force_ground = false );
 std::vector<item_location> drop_on_map( Character &you, item_drop_reason reason,
                                         const std::list<item> &items,
-                                        map *here, const tripoint_bub_ms &where, bool allow_overflow = true );
+                                        map *here, const tripoint_bub_ms &where );
 // used in unit tests to avoid triggering user input
 void repair_item_finish( player_activity *act, Character *you, bool no_menu );
 

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -431,7 +431,7 @@ static itype_id get_first_fertilizer_itype( Character &you, const tripoint_abs_m
 
 std::vector<item_location> drop_on_map( Character &you, item_drop_reason reason,
                                         const std::list<item> &items,
-                                        map *here, const tripoint_bub_ms &where, bool allow_overflow )
+                                        map *here, const tripoint_bub_ms &where )
 {
     if( items.empty() ) {
         return {};
@@ -526,11 +526,9 @@ std::vector<item_location> drop_on_map( Character &you, item_drop_reason reason,
     }
     std::vector<item_location> items_dropped;
     for( const item &it : items ) {
-        item &dropped_item = here->add_item_or_charges( where, it, allow_overflow );
-        if( !dropped_item.is_null() ) {
-            items_dropped.emplace_back( map_cursor( here, where ), &dropped_item );
-            item( it ).handle_pickup_ownership( you );
-        }
+        item &dropped_item = here->add_item_or_charges( where, it );
+        items_dropped.emplace_back( map_cursor( here, where ), &dropped_item );
+        item( it ).handle_pickup_ownership( you );
     }
 
     you.recoil = MAX_RECOIL;
@@ -561,7 +559,7 @@ void put_into_vehicle_or_drop( Character &you, item_drop_reason reason,
 
 std::vector<item_location> put_into_vehicle_or_drop_ret_locs( Character &you,
         item_drop_reason reason,
-        const std::list<item> &items, tripoint_bub_ms dest, bool allow_overflow )
+        const std::list<item> &items, tripoint_bub_ms dest )
 {
     map &here = get_map();
 
@@ -570,19 +568,19 @@ std::vector<item_location> put_into_vehicle_or_drop_ret_locs( Character &you,
         dest = you.pos_bub( here );
     }
 
-    return put_into_vehicle_or_drop_ret_locs( you, reason, items, &here, dest, false, allow_overflow );
+    return put_into_vehicle_or_drop_ret_locs( you, reason, items, &here, dest );
 }
 
 std::vector<item_location> put_into_vehicle_or_drop_ret_locs( Character &you,
         item_drop_reason reason,
         const std::list<item> &items,
-        map *here, const tripoint_bub_ms &where, bool force_ground, bool allow_overflow )
+        map *here, const tripoint_bub_ms &where, bool force_ground )
 {
     const std::optional<vpart_reference> vp = here->veh_at( where ).cargo();
     if( vp && !force_ground ) {
         return try_to_put_into_vehicle( you, reason, items, *vp );
     }
-    return drop_on_map( you, reason, items, here, where, allow_overflow );
+    return drop_on_map( you, reason, items, here, where );
 }
 
 static double get_capacity_fraction( int capacity, int volume )


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Fixes #85247
* Fixes #85075
* Closes #85263

These issues were introduced in #84974

#### Describe the solution

In particular the automatic drop-and-remove to "test" if the items can go there before we go there duplicates the drop message, will activate any "on drop" stuff, and means the sorting character has ESP knowledge of a place they might not even see. The handling also improperly removes items at the destination due to charge-stacking behavior.

So,

* Revert #84974

This reverts commit 5a3293fed7287585b1b640ddd504da1bd440106e, reversing changes made to e3f1807a531e039e847ea0ebc5373b366790a952.

#### Describe alternatives you've considered


#### Testing
Reverted locally, ran the reproduction from #85247 and confirmed that log messages were not duplicated and that items with charges were not stacked and erased.

#### Additional context

