### PR TITLE
CVD removal

### DIFF
--- a/data/json/furniture_and_terrain/terrain-manufactured.json
+++ b/data/json/furniture_and_terrain/terrain-manufactured.json
@@ -571,63 +571,6 @@
   },
   {
     "type": "terrain",
-    "id": "t_cvdbody",
-    "name": "CVD machine",
-    "description": "The bulk of a highly technical-looking apparatus controlled by a nearby console.",
-    "symbol": "%",
-    "color": "dark_gray",
-    "move_cost": 0,
-    "coverage": 65,
-    "connect_groups": "WALL",
-    "connects_to": "WALL",
-    "flags": [ "NOITEM", "WALL", "PERMEABLE" ],
-    "bash": {
-      "str_min": 6,
-      "str_max": 150,
-      "sound": "crunch!",
-      "sound_fail": "whack!",
-      "ter_set": "t_floor",
-      "items": [
-        { "item": "e_scrap", "count": [ 1, 4 ], "prob": 50 },
-        { "item": "circuit", "count": [ 1, 6 ], "prob": 50 },
-        { "item": "scrap", "count": [ 2, 8 ], "prob": 50 }
-      ]
-    }
-  },
-  {
-    "type": "terrain",
-    "id": "t_cvdmachine",
-    "name": "CVD control panel",
-    "description": "A VERY expensive-looking apparatus that's labeled 'Chemical Vapor Deposition Machine'.  With the input of certain exceptionally rare chemicals and elements, one could conceivably coat one's weapon with diamond.  While the process is extremely complicated, a previous user has helpfully sketched: Hydrogen + charcoal = smiley face.",
-    "symbol": "&",
-    "color": "cyan",
-    "looks_like": "f_console",
-    "move_cost": 0,
-    "coverage": 50,
-    "flags": [ "TRANSPARENT", "NOITEM", "PERMEABLE" ],
-    "examine_action": "cvdmachine",
-    "bash": {
-      "str_min": 8,
-      "str_max": 150,
-      "sound": "crunch!",
-      "sound_fail": "whack!",
-      "ter_set": "t_metal_floor",
-      "items": [
-        { "item": "processor", "prob": 25 },
-        { "item": "RAM", "count": [ 0, 2 ], "prob": 50 },
-        { "item": "cable", "charges": [ 1, 2 ], "prob": 50 },
-        { "item": "small_lcd_screen", "prob": 25 },
-        { "item": "e_scrap", "count": [ 1, 4 ], "prob": 50 },
-        { "item": "circuit", "count": [ 0, 2 ], "prob": 50 },
-        { "item": "power_supply", "prob": 25 },
-        { "item": "amplifier", "prob": 25 },
-        { "item": "plastic_chunk", "count": [ 4, 10 ], "prob": 50 },
-        { "item": "scrap", "count": [ 2, 6 ], "prob": 50 }
-      ]
-    }
-  },
-  {
-    "type": "terrain",
     "id": "t_nanofab_body",
     "name": "nanofabricator",
     "symbol": "%",

--- a/data/json/obsoletion_and_migration_0.J/terrain.json
+++ b/data/json/obsoletion_and_migration_0.J/terrain.json
@@ -18,5 +18,15 @@
     "type": "ter_furn_migration",
     "from_ter": "t_underbrush_harvested_winter",
     "to_ter": "t_underbrush_harvested"
+  },
+  {
+    "type": "ter_furn_migration",
+    "from_ter": "t_cvdbody",
+    "to_ter": "t_thconc_floor"
+  },
+  {
+    "type": "ter_furn_migration",
+    "from_ter": "t_cvdmachine",
+    "to_ter": "t_thconc_floor"
   }
 ]

--- a/data/json/requirements/materials.json
+++ b/data/json/requirements/materials.json
@@ -191,12 +191,6 @@
     "components": [ [ [ "string_6", 1 ] ] ]
   },
   {
-    "id": "cvd_diamond",
-    "type": "requirement",
-    "//": "Materials required to apply diamond coating (per 250ml volume)",
-    "components": [ [ [ "plasma", 5 ] ], [ [ "charcoal", 25 ], [ "coal_lump", 25 ] ] ]
-  },
-  {
     "id": "autoclave",
     "type": "requirement",
     "//": "Materials required to run one cycle of the furniture autoclave",

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -252,7 +252,6 @@ static const quality_id qual_TREE_TAP( "TREE_TAP" );
 
 static const requirement_id requirement_data_anesthetic( "anesthetic" );
 static const requirement_id requirement_data_autoclave( "autoclave" );
-static const requirement_id requirement_data_cvd_diamond( "cvd_diamond" );
 
 static const skill_id skill_chemistry( "chemistry" );
 static const skill_id skill_cooking( "cooking" );
@@ -352,50 +351,6 @@ bool iexamine::harvestable_now( const tripoint_bub_ms &examp )
 {
     const harvest_id hid = get_map().get_harvest( examp );
     return !hid->is_null() && !hid->empty();
-}
-
-/**
- * Pick an appropriate item and apply diamond coating if possible.
- */
-void iexamine::cvdmachine( Character &you, const tripoint_bub_ms & )
-{
-    // Select an item to which it is possible to apply a diamond coating
-    item_location loc = g->inv_map_splice( []( const item & e ) {
-        return e.has_edged_damage() &&
-               !e.has_flag( flag_DIAMOND ) && !e.has_flag( flag_NO_CVD ) &&
-               ( e.made_of( material_steel ) || e.made_of( material_ch_steel ) ||
-                 e.made_of( material_hc_steel ) || e.made_of( material_lc_steel ) ||
-                 e.made_of( material_mc_steel ) || e.made_of( material_qt_steel ) ||
-                 e.made_of( material_iron ) );
-    }, _( "Apply diamond coating" ), 1, _( "You don't have a suitable item to coat with diamond" ) );
-
-    if( !loc ) {
-        return;
-    }
-
-    // Require materials proportional to selected item volume
-    auto qty = loc->volume() / 250_ml;
-    qty = std::max( 1, qty );
-    requirement_data reqs = *requirement_data_cvd_diamond * qty;
-
-    if( !reqs.can_make_with_inventory( you.crafting_inventory(), is_crafting_component ) ) {
-        popup( "%s", reqs.list_missing() );
-        return;
-    }
-
-    // Consume materials
-    for( const auto &e : reqs.get_components() ) {
-        you.consume_items( e, 1, is_crafting_component );
-    }
-    for( const auto &e : reqs.get_tools() ) {
-        you.consume_tools( e );
-    }
-    you.invalidate_crafting_inventory();
-
-    // Apply flag to item
-    loc->set_flag( flag_DIAMOND );
-    add_msg( m_good, _( "You apply a diamond coating to your %s" ), loc->type_name() );
-    you.mod_moves( -to_moves<int>( 10_seconds ) );
 }
 
 /**
@@ -7473,7 +7428,6 @@ iexamine_functions iexamine_functions_from_string( const std::string &function_n
     static const std::map<std::string, iexamine_examine_function> function_map = {{
             { "none", &iexamine::none },
             { "deployed_furniture", &iexamine::deployed_furniture },
-            { "cvdmachine", &iexamine::cvdmachine },
             { "change_appearance", &iexamine::change_appearance },
             { "genemill", &iexamine::genemill },
             { "nanofab", &iexamine::nanofab },

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -215,13 +215,6 @@ static const json_character_flag json_flag_WING_GLIDE( "WING_GLIDE" );
 
 static const material_id material_bone( "bone" );
 static const material_id material_cac2powder( "cac2powder" );
-static const material_id material_ch_steel( "ch_steel" );
-static const material_id material_hc_steel( "hc_steel" );
-static const material_id material_iron( "iron" );
-static const material_id material_lc_steel( "lc_steel" );
-static const material_id material_mc_steel( "mc_steel" );
-static const material_id material_qt_steel( "qt_steel" );
-static const material_id material_steel( "steel" );
 static const material_id material_wood( "wood" );
 
 static const mtype_id mon_broken_cyborg( "mon_broken_cyborg" );

--- a/src/iexamine.h
+++ b/src/iexamine.h
@@ -72,7 +72,6 @@ void cardreader_robofac( Character &you, const tripoint_bub_ms &examp );
 void cardreader_foodplace( Character &you, const tripoint_bub_ms &examp );
 void intercom( Character &you, const tripoint_bub_ms &examp );
 void intercom_balthazar( Character &you, const tripoint_bub_ms &examp );
-void cvdmachine( Character &you, const tripoint_bub_ms &examp );
 void change_appearance( Character &you, const tripoint_bub_ms &examp );
 void rubble( Character &you, const tripoint_bub_ms &examp );
 void chainfence( Character &you, const tripoint_bub_ms &examp );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "CVD removal"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Rip out the CVD now that it no longer spawns. It's ability to make weapons deadlier by coating them in diamond is not really how this works so it's getting ripped out instead of rehomed.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Obsolete the terrain into concrete, rip out the examine actions, and rip out the requirements object.
The actual diamond coating effect will remain as it is used by mods to enhance weapons and as such still has a place there.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded game that had a CVD and diamond coated weapons. Weapons still there with the diamond coating and the CVD is no concrete floor.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
