### PR TITLE
[Xedra Evolved] Add morale types for dreams and nightmares

### DIFF
--- a/data/mods/Xedra_Evolved/morale_types.json
+++ b/data/mods/Xedra_Evolved/morale_types.json
@@ -47,16 +47,26 @@
   {
     "id": "morale_vw_no_fun",
     "type": "morale_type",
-    "text": "Barred from mortal joys."
+    "text": "Barred from mortal joys"
   },
   {
     "id": "morale_book_lies",
     "type": "morale_type",
-    "text": "Haunted by the Lies."
+    "text": "Haunted by the Lies"
   },
   {
     "id": "morale_game_inventor",
     "type": "morale_type",
-    "text": "Entertained by created dreams."
+    "text": "Entertained by created dreams"
+  },
+  {
+    "id": "morale_sweet_dreams",
+    "type": "morale_type",
+    "text": "Comforted by your sweet dream"
+  },
+  {
+    "id": "morale_nightmare",
+    "type": "morale_type",
+    "text": "Bothered by your nightmare"
   }
 ]


### PR DESCRIPTION
#### Summary
Mods "[Xedra Evolved] Add missing morale types for dreams and nightmares"

#### Purpose of change

Missing morale types would error when checking morale.

#### Describe the solution

- Add morale type for `morale_sweet_dreams` and `morale_nightmare`
- Remove some periods to align xedra morale messages with other messages.

#### Describe alternatives you've considered

None.

#### Testing

Loaded my character and the morale screen no longer errors and shows a line for my dream.

#### Additional context

If any of the Xedra folks want to rephrase this, please feel free to edit if you're a maintainer or drop a comment.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
