### PR TITLE
Multi-activity overhaul part 8: simplify multi-activity backlogging

### DIFF
--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -114,6 +114,7 @@ class multi_zone_activity_actor : public activity_actor
         void do_turn( player_activity &act, Character &you ) override;
         void finish( player_activity &, Character & ) override {};
         // for allowing a return value from do_turn
+        // @return whether this activity should continue to the next turn
         bool simulate_turn( player_activity &act, Character &you, bool check_only );
 
         /** Check whether activity can be done immediately if it has requirements */

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -3729,7 +3729,7 @@ bool out_of_moves( Character &you )
     return false;
 }
 
-void revert_npc_post_activity( Character &you, activity_id act_id, bool no_locations )
+void revert_npc_post_activity( Character &you, activity_id, bool no_locations )
 {
     // if we got here, we need to revert otherwise NPC will be stuck in AI Limbo and have a head explosion.
     if( you.is_npc() && ( you.backlog.empty() || no_locations ) ) {

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1566,9 +1566,9 @@ static activity_reason_info vehicle_work_can_do( const activity_id &, Character 
                 already_working_indexes.push_back( guy.activity_vehicle_part_index );
             }
         }
-        if( player_character.activity_vehicle_part_index != -1 ) {
-            already_working_indexes.push_back( player_character.activity_vehicle_part_index );
-        }
+    }
+    if( you.is_npc() && player_character.activity_vehicle_part_index != -1 ) {
+        already_working_indexes.push_back( player_character.activity_vehicle_part_index );
     }
     return activity_reason_info::ok( result );
 }

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -3350,7 +3350,6 @@ bool multi_farm_activity_actor::multi_activity_do( Character &you,
                here.has_flag( ter_furn_flag::TFLAG_PLOWABLE, src_loc ) &&
                you.has_quality( qual_DIG, 1 ) && !here.has_furn( src_loc ) ) {
         you.assign_activity( churn_activity_actor( 18000, item_location() ) );
-        you.backlog.emplace_front( multi_farm_activity_actor() );
         you.activity.placement = src;
         return false;
     } else if( reason == do_activity_reason::NEEDS_PLANTING ) {
@@ -3369,14 +3368,12 @@ bool multi_farm_activity_actor::multi_activity_do( Character &you,
                 continue;
             }
             iexamine::plant_seed( you, src_loc, itype_id( seed ) );
-            you.backlog.emplace_front( multi_farm_activity_actor() );
             return false;
         }
     } else if( reason == do_activity_reason::NEEDS_FERTILIZING ) {
         itype_id used_fertilizer = get_first_fertilizer_itype( you, src );
         if( !used_fertilizer.is_null() ) {
             iexamine::fertilize_plant( you, src_loc, used_fertilizer );
-            you.backlog.emplace_front( multi_farm_activity_actor() );
         }
         return false;
     }
@@ -3392,7 +3389,6 @@ bool multi_chop_planks_activity_actor::multi_activity_do( Character &you,
 
     if( reason == do_activity_reason::NEEDS_CHOPPING && you.has_quality( qual_AXE, 1 ) ) {
         if( chop_plank_activity( you, src_loc ) ) {
-            you.backlog.emplace_front( multi_chop_planks_activity_actor() );
             return false;
         }
     }
@@ -3409,7 +3405,6 @@ bool multi_butchery_activity_actor::multi_activity_do( Character &you,
     if( reason == do_activity_reason::NEEDS_BUTCHERING ||
         reason == do_activity_reason::NEEDS_BIG_BUTCHERING ) {
         if( butcher_corpse_activity( you, src_loc, reason ) ) {
-            you.backlog.emplace_front( multi_butchery_activity_actor() );
             return false;
         }
     }
@@ -3432,7 +3427,6 @@ bool multi_read_activity_actor::multi_activity_do( Character &you,
             const time_duration time_taken = you.time_to_read( *books[0], you );
             item_location book = item_location( you, books[0] );
             item_location ereader;
-            you.backlog.emplace_front( multi_read_activity_actor() );
             you.assign_activity( read_activity_actor( time_taken, book, ereader, true ) );
             return false;
         }
@@ -3453,7 +3447,6 @@ bool multi_study_activity_actor::multi_activity_do( Character &you,
             you.may_activity_occupancy_after_end_items_loc.push_back( book_loc );
             const time_duration time_taken = you.time_to_read( *book_loc, you );
             item_location ereader;
-            you.backlog.emplace_front( multi_study_activity_actor() );
             you.assign_activity( read_activity_actor( time_taken, book_loc, ereader, true ) );
             return false;
         }
@@ -3479,7 +3472,6 @@ bool multi_build_construction_activity_actor::multi_activity_do( Character &you,
 
     if( reason == do_activity_reason::CAN_DO_CONSTRUCTION ) {
         if( here.partial_con_at( src_loc ) ) {
-            you.backlog.emplace_front( multi_build_construction_activity_actor() );
             you.assign_activity( build_construction_activity_actor( src ) );
             return false;
         }
@@ -3498,7 +3490,6 @@ bool multi_chop_trees_activity_actor::multi_activity_do( Character &you,
 
     if( reason == do_activity_reason::NEEDS_TREE_CHOPPING && you.has_quality( qual_AXE, 1 ) ) {
         if( chop_tree_activity( you, src_loc ) ) {
-            you.backlog.emplace_front( multi_chop_trees_activity_actor() );
             return false;
         }
     }
@@ -3512,7 +3503,6 @@ bool multi_fish_activity_actor::multi_activity_do( Character &you,
     const do_activity_reason &reason = act_info.reason;
 
     if( reason == do_activity_reason::NEEDS_FISHING && you.has_quality( qual_FISHING_ROD, 1 ) ) {
-        you.backlog.emplace_front( multi_fish_activity_actor() );
         // we don't want to keep repeating the fishing activity, just piggybacking on this functions structure to find requirements.
         you.activity = player_activity();
         item_location best_rod_loc( you, &you.best_item_with_quality( qual_FISHING_ROD ) );
@@ -3531,7 +3521,6 @@ bool multi_mine_activity_actor::multi_activity_do( Character &you,
 
     if( reason == do_activity_reason::NEEDS_MINING ) {
         // if have enough batteries to continue etc.
-        you.backlog.emplace_front( multi_mine_activity_actor() );
         if( mine_activity( you, src_loc ) ) {
             return false;
         }
@@ -3547,7 +3536,6 @@ bool multi_mop_activity_actor::multi_activity_do( Character &you,
 
     if( reason == do_activity_reason::NEEDS_MOP ) {
         if( mop_activity( you, src_loc ) ) {
-            you.backlog.emplace_front( multi_mop_activity_actor() );
             return false;
         }
     }
@@ -3562,7 +3550,6 @@ bool multi_vehicle_deconstruct_activity_actor::multi_activity_do( Character &you
 
     if( reason == do_activity_reason::NEEDS_VEH_DECONST ) {
         if( vehicle_activity( you, src_loc, you.activity_vehicle_part_index, VEHICLE_REMOVE ) ) {
-            you.backlog.emplace_front( multi_vehicle_deconstruct_activity_actor() );
             return false;
         }
         you.activity_vehicle_part_index = -1;
@@ -3578,7 +3565,6 @@ bool multi_vehicle_repair_activity_actor::multi_activity_do( Character &you,
 
     if( reason == do_activity_reason::NEEDS_VEH_REPAIR ) {
         if( vehicle_activity( you, src_loc, you.activity_vehicle_part_index, VEHICLE_REPAIR ) ) {
-            you.backlog.emplace_front( multi_vehicle_repair_activity_actor() );
             return false;
         }
 
@@ -3602,8 +3588,6 @@ bool multi_craft_activity_actor::multi_activity_do( Character &you,
                 you.lighting_craft_speed_multiplier( to_craft->get_making() ) > 0 ) {
                 player_activity act = player_activity( craft_activity_actor( to_craft, false ) );
                 you.assign_activity( act );
-                you.backlog.emplace_front( multi_craft_activity_actor() );
-                you.backlog.front().auto_resume = true;
                 return false;
             }
         }
@@ -3635,10 +3619,6 @@ bool multi_disassemble_activity_actor::multi_activity_do( Character &you,
                     act.position = qty;
                     act.index = false;
                     you.assign_activity( act );
-                    // Keep doing
-                    // After assignment of disassemble activity (not multitype anymore)
-                    // the backlog will not be nuked in do_player_activity()
-                    you.backlog.emplace_back( multi_disassemble_activity_actor() );
                     break;
                 }
             }
@@ -3739,11 +3719,10 @@ std::optional<bool> route( Character &you, player_activity &act, const tripoint_
     return false;
 }
 
-bool out_of_moves( Character &you, activity_id act_id )
+bool out_of_moves( Character &you )
 {
     if( you.get_moves() <= 0 ) {
         // Restart activity and break from cycle.
-        you.assign_activity( act_id );
         you.activity_vehicle_part_index = -1;
         return true;
     }
@@ -3753,16 +3732,13 @@ bool out_of_moves( Character &you, activity_id act_id )
 void revert_npc_post_activity( Character &you, activity_id act_id, bool no_locations )
 {
     // if we got here, we need to revert otherwise NPC will be stuck in AI Limbo and have a head explosion.
-    if( you.backlog.empty() || no_locations ) {
+    if( you.is_npc() && ( you.backlog.empty() || no_locations ) ) {
         /**
         * This should really be a debug message, but too many places rely on this broken behavior.
         * debugmsg( "Reverting %s activity for %s, probable infinite loop", activity_to_restore.c_str(),
         *           you.get_name() );
         */
         check_npc_revert( you );
-        if( player_activity( act_id ).is_multi_type() ) {
-            you.assign_activity( activity_id::NULL_ID() );
-        }
     }
     you.activity_vehicle_part_index = -1;
 }

--- a/src/activity_item_handling.h
+++ b/src/activity_item_handling.h
@@ -164,7 +164,7 @@ std::unordered_set<tripoint_abs_ms> no_same_tile_locations( Character &you,
         const activity_id &act_id );
 
 void revert_npc_post_activity( Character &you, activity_id act_id, bool no_locations );
-bool out_of_moves( Character &you, activity_id act_id );
+bool out_of_moves( Character &you );
 std::optional<bool> route( Character &you, player_activity &act, const tripoint_bub_ms &src_bub,
                            requirement_failure_reasons &fail_reason, bool check_only );
 void activity_failure_message( Character &you, activity_id new_activity,

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -5202,7 +5202,11 @@ void Character::assign_activity( const activity_id &type, int moves, int index, 
 
 void Character::assign_activity( const activity_actor &actor )
 {
-    assign_activity( player_activity( actor ) );
+    player_activity act( actor );
+    if( act.is_multi_type() ) {
+        act.auto_resume = true;
+    }
+    assign_activity( act );
 }
 
 void Character::assign_activity( const player_activity &act )
@@ -5281,7 +5285,9 @@ void Character::resume_backlog_activity()
 {
     if( !backlog.empty() && backlog.front().auto_resume ) {
         activity = backlog.front();
-        activity.auto_resume = false;
+        if( !activity.is_multi_type() ) {
+            activity.auto_resume = false;
+        }
         activity.allow_distractions();
         backlog.pop_front();
     }

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -4143,7 +4143,7 @@ bool npc::do_player_activity()
     // to satisfy the infinite loop counter.
     const bool multi_type = activity ? activity.is_multi_type() : false;
     const int moves_before = moves;
-    while( moves > 0 && activity ) {
+    while( moves > 0 && activity && !has_destination() ) {
         activity.do_turn( *this );
         if( !is_active() ) {
             return true;

--- a/tests/act_build_test.cpp
+++ b/tests/act_build_test.cpp
@@ -94,11 +94,6 @@ void run_activities( Character &u, int max_moves )
             u.start_destination_activity();
         }
         u.activity.do_turn( u );
-        // npc plz do your thing
-        if( u.is_npc() && u.activity.is_null() && !u.is_auto_moving() && !u.backlog.empty() &&
-            u.backlog.back().id() == ACT_MULTIPLE_CONSTRUCTION ) {
-            activity_handlers::resume_for_multi_activities( u );
-        }
         turns++;
     }
 }

--- a/tests/act_build_test.cpp
+++ b/tests/act_build_test.cpp
@@ -39,8 +39,6 @@
 #include "type_id.h"
 #include "weather_type.h"
 
-static const activity_id ACT_MULTIPLE_CONSTRUCTION( "ACT_MULTIPLE_CONSTRUCTION" );
-
 static const construction_str_id construction_constr_floor( "constr_floor" );
 static const construction_str_id
 construction_constr_ov_smreb_cage_thconc_floor( "constr_ov_smreb_cage_thconc_floor" );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Infrastructure "multi-activity overhaul part 8: simplify multi-activity backlogging"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Continuing https://github.com/CleverRaven/Cataclysm-DDA/pull/83818

Fixes #85264

Follow-up to both https://github.com/CleverRaven/Cataclysm-DDA/pull/85237 and https://github.com/CleverRaven/Cataclysm-DDA/pull/85211. 85211 passed basic build AND the entire test suite locally, so I'm curious to see if this PR fails on GCC as well.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Remove most of `activity_handlers::resume_for_multi_activities()`, including calls from non-multi-activities. I want to centralize and simplify how multi-activities forward normal activities.

To replace this: instead of multi-activities cancelling and reassigning per-turn, all multi-activities always auto-resume, but they'll cancel if they fail (multi_zone_activity_actor::simulate_turn returns false or assigns a destination). The NPC activity loop therefore must also cancel if a destination activity is present.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

- Successfully deconstructed a vehicle chassis as avatar
- Successfully had NPC deconstruct vehicle chassis, and then again with fetching tools
- NPC successfully mopped in a mop zone
- NPC successfully mined some terrain
- Successfully replicated test case `npc_act_multiple_construction` manually, all `[construction]` test cases successful locally
- Does not segfault on save from 85264

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
