### PR TITLE
Increase dust mask encumbrance, add XL dust mask

### DIFF
--- a/data/json/items/armor/masks.json
+++ b/data/json/items/armor/masks.json
@@ -185,7 +185,7 @@
     "subtypes": [ "ARMOR" ],
     "name": { "str": "dust mask" },
     "description": "A simple piece of cotton that straps over the mouth.  Provides a small amount of protection from airborne illness and dust.",
-    "weight": "168 g",
+    "weight": "6 g",
     "volume": "100 ml",
     "price": "8 USD",
     "price_postapoc": "10 cent",

--- a/data/json/items/armor/masks.json
+++ b/data/json/items/armor/masks.json
@@ -197,7 +197,7 @@
     "material_thickness": 0.1,
     "environmental_protection": 3,
     "flags": [ "VARSIZE", "SKINTIGHT" ],
-    "armor": [ { "encumbrance": 6, "coverage": 100, "covers": [ "mouth" ] } ],
+    "armor": [ { "encumbrance": 6, "coverage": 100, "covers": [ "mouth", "muzzle" ] } ],
     "variant_type": "generic",
     "variants": [
       {

--- a/data/json/items/armor/masks.json
+++ b/data/json/items/armor/masks.json
@@ -197,7 +197,7 @@
     "material_thickness": 0.1,
     "environmental_protection": 3,
     "flags": [ "VARSIZE", "SKINTIGHT" ],
-    "armor": [ { "encumbrance": 1, "coverage": 100, "covers": [ "mouth" ] } ],
+    "armor": [ { "encumbrance": 6, "coverage": 100, "covers": [ "mouth" ] } ],
     "variant_type": "generic",
     "variants": [
       {
@@ -282,6 +282,15 @@
         "append": true
       }
     ]
+  },
+  {
+    "id": "xl_mask_dust",
+    "copy-from": "mask_dust",
+    "type": "ITEM",
+    "subtypes": [ "ARMOR" ],
+    "name": { "str": "dust mask" },
+    "proportional": { "weight": 1.25, "volume": 1.23 },
+    "extend": { "flags": [ "OVERSIZE", "PREFIX_XL" ] }
   },
   {
     "id": "mask_hockey",

--- a/data/json/recipes/armor/head.json
+++ b/data/json/recipes/armor/head.json
@@ -4277,5 +4277,18 @@
     "autolearn": true,
     "components": [ [ [ "helmet_mounting_brackets", 1 ] ], [ [ "helmet_motor", 1 ], [ "helmet_motor_raised", 1 ] ] ],
     "qualities": [ { "id": "DRILL", "level": 2 }, { "id": "THREAD_CUT", "level": 2 }, { "id": "SCREW", "level": 1 } ]
+  },
+  {
+    "result": "xl_mask_dust",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_HEAD",
+    "skill_used": "tailor",
+    "difficulty": 1,
+    "time": "30 m",
+    "autolearn": true,
+    "reversible": { "time": "10 m" },
+    "using": [ [ "tailoring_cotton_patchwork", 1 ] ]
   }
 ]

--- a/data/mods/TEST_DATA/known_bad_density.json
+++ b/data/mods/TEST_DATA/known_bad_density.json
@@ -279,7 +279,6 @@
       "confit_meat",
       "chem_phenol",
       "combination_gun_shotgun",
-      "mask_dust",
       "small_relic",
       "tanned_hide",
       "FlatCoin",

--- a/data/mods/TEST_DATA/known_bad_uncrafts.json
+++ b/data/mods/TEST_DATA/known_bad_uncrafts.json
@@ -1343,6 +1343,7 @@
       "manual_zui_quan",
       "many_years_old_newspaper",
       "mask_dust",
+      "xl_mask_dust",
       "mask_filter",
       "mask_rioter",
       "matchhead_10mm_fmj",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Balance "Increase dust mask encumbrance, add XL dust mask"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

1) It turns out well-fitting dust masks have 0 encumbrance. It wasn't that long ago that we were all wearing masks for a while, and while they were nowhere near as bad as some of the whiners made them out to be, I think it's obvious that it's harder to breathe in one than without one.

2) Encumbrance is the limiter on mutant bite attacks, and if a dusk mask has 0 encumbrance you can bite straight through it.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Increase the encumbrance on a dust mask to 3 (6 if poorly fitted).

Add an XL dust mask, made out of a cotton sheet (cut down to size) and some string. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

2 (4 if poorly fitted)

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Wore a dust mask, it was encumbering.

Mutated ursine muzzle, dust mask was pushed off, spawned an XL dust mask, could wear it. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
