### PR TITLE
Pin GitHub Actions to SHAs and apply security hardening

### DIFF
--- a/.github/workflows/CBA.yml
+++ b/.github/workflows/CBA.yml
@@ -13,7 +13,9 @@ jobs:
   build:
     runs-on: ubuntu-latest    
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        persist-credentials: false
     - name: install dependencies
       run: sudo apt-get install libncursesw5-dev gettext
     - name: Prepare Build Analyzer
@@ -26,7 +28,7 @@ jobs:
         cmake -DCMAKE_BUILD_TYPE=RELEASE ..
         cmake --build . -- -j3
         echo "${PWD}" >> $GITHUB_PATH
-    - uses: ammaraskar/gcc-problem-matcher@master
+    - uses: ammaraskar/gcc-problem-matcher@0f9c86f9e693db67dacf53986e1674de5f2e5f28 # master
     - name: make
       run: |
         clang++ --version
@@ -35,11 +37,11 @@ jobs:
         ClangBuildAnalyzer --stop . buildAnalysis
     - name: Analyze
       run: ClangBuildAnalyzer --analyze buildAnalysis
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ClangBuildAnalyzer-analysis
         path: buildAnalysis
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ClangBuildAnalyzer-traces
         path: "**/obj/*.json"

--- a/.github/workflows/assign_mission_target_needs_om_special.yml
+++ b/.github/workflows/assign_mission_target_needs_om_special.yml
@@ -12,5 +12,7 @@ jobs:
   run-the-tool:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        persist-credentials: false
     - run: ./tools/json_tools/assign_mission_target_needs_om_special.bash 2>&1

--- a/.github/workflows/astyle.yml
+++ b/.github/workflows/astyle.yml
@@ -11,12 +11,12 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
     - id: skip_check
-      uses: fkirc/skip-duplicate-actions@master
+      uses: fkirc/skip-duplicate-actions@04a1aebece824b56e6ad6a401d015479cd1c50b3 # master
       with:
         cancel_others: 'true'
         paths: '[".github/workflows/astyle.yml", "Makefile", ".astylerc", "**.cpp", "**.h", "**.c"]'
     - run: echo ${{ github.event.number }} > pull_request_id
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: pull_request_id
         path: pull_request_id
@@ -28,7 +28,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        persist-credentials: false
 
     - name: install dependencies
       run: sudo apt-get install astyle

--- a/.github/workflows/build-translations.yml
+++ b/.github/workflows/build-translations.yml
@@ -19,7 +19,7 @@ jobs:
           curl -sL https://github.com/transifex/cli/releases/download/v1.6.17/tx-linux-amd64.tar.gz | sudo tar zxvf - -C /usr/bin tx
 
       - name: Checkout local repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: master
           sparse-checkout: |
@@ -27,6 +27,7 @@ jobs:
             tools
             lang
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Pull translations
         continue-on-error: true
@@ -46,7 +47,7 @@ jobs:
         run: ./lang/update_stats.sh
 
       - name: Store translation artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: "translations"
           path: |

--- a/.github/workflows/check-branch-name.yml
+++ b/.github/workflows/check-branch-name.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.head_ref == 'master' && github.repository == 'CleverRaven/Cataclysm-DDA'
     steps:
       - name: Post warning
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -24,7 +24,7 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - id: skip_check
-        uses: fkirc/skip-duplicate-actions@master
+        uses: fkirc/skip-duplicate-actions@04a1aebece824b56e6ad6a401d015479cd1c50b3 # master
         with:
           cancel_others: 'true'
           skip_after_successful_duplicate: 'false'
@@ -47,13 +47,15 @@ jobs:
           sudo apt install python3-pip ninja-build cmake
           pip3 install --user lit
     - name: checkout repository
-      uses: actions/checkout@v4
-    - uses: ammaraskar/gcc-problem-matcher@master
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        persist-credentials: false
+    - uses: ammaraskar/gcc-problem-matcher@0f9c86f9e693db67dacf53986e1674de5f2e5f28 # master
     - name: build clang-tidy plugin
       if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
       run: bash ./build-scripts/clang-tidy-build.sh
     - name: upload plugin
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: cata-analyzer-plugin
         path: build/tools/clang-tidy-plugin/libCataAnalyzerPlugin.so
@@ -89,15 +91,17 @@ jobs:
           sudo apt install clang-18 clang-tidy-18 cmake ccache jq
           sudo apt install libflac-dev libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev libsdl2-mixer-dev libpulse-dev gettext 
     - name: checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        persist-credentials: false
     - name: download plugin from the previous job in this workflow run
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       with:
         name: cata-analyzer-plugin
         path: build/tools/clang-tidy-plugin/
     - name: determine changed files
       if: ${{ github.event_name == 'pull_request' }}
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
       with:
         script: |
           var fs = require('fs');
@@ -113,7 +117,7 @@ jobs:
             console.log(path);
           }
           fs.writeFileSync("files_changed", files.join('\n') + '\n');
-    - uses: ammaraskar/gcc-problem-matcher@master
+    - uses: ammaraskar/gcc-problem-matcher@0f9c86f9e693db67dacf53986e1674de5f2e5f28 # master
     - name: run clang-tidy
       run: bash ./build-scripts/clang-tidy-run.sh
     - name: show most time consuming checks

--- a/.github/workflows/cmake-format.yml
+++ b/.github/workflows/cmake-format.yml
@@ -23,7 +23,9 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        persist-credentials: false
     - name: install cmakelang
       run: python3 -m pip install -U cmakelang
     - name: run cmake-lint

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,11 +39,13 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -67,4 +69,4 @@ jobs:
        make RELEASE=1 TESTS=0
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2

--- a/.github/workflows/comment-commands.yml
+++ b/.github/workflows/comment-commands.yml
@@ -15,10 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Set-up Comvent
-        uses: rytswd/comvent@main
+        uses: rytswd/comvent@2168693e29bb394d0a8fd5788ffcccd16cadcffc # main
         id: comvent
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -62,10 +64,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Set-up Comvent
-        uses: rytswd/comvent@main
+        uses: rytswd/comvent@2168693e29bb394d0a8fd5788ffcccd16cadcffc # main
         id: comvent
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/compose-tilesets.yml
+++ b/.github/workflows/compose-tilesets.yml
@@ -9,19 +9,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout local repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: master
           sparse-checkout: |
             src
             tools
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Build json formatter
         run: make tools/format/json_formatter.cgi
 
       - name: Save formatter and compose into cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             tools/format
@@ -119,7 +120,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Restore tools into workspace from cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             tools/format
@@ -127,19 +128,20 @@ jobs:
           key: tools-${{ github.run_id }}
 
       - name: Install dependencies
-        uses: awalsh128/cache-apt-pkgs-action@v1
+        uses: awalsh128/cache-apt-pkgs-action@2c09a5e66da6c8016428a2172bd76e5e4f14bb17 # v1
         with:
           packages: python3 python3-pip libvips42
       - run: pip install pyvips
 
       - name: Clone tileset repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ${{ matrix.tileset_repo }}
           ref: master
           path: build-tilesets
           sparse-checkout: ${{matrix.tileset_src_checkout}}
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Build ${{ matrix.name }}
         run: |
@@ -152,7 +154,7 @@ jobs:
           [ -f "$SOURCE/layering.json" ] && mv -v "$SOURCE/layering.json" "$DEST/" || echo "No layering.json for ${{ matrix.name }}"
 
       - name: Store artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: "tileset-${{ matrix.name }}"
           path: "${{github.workspace}}/gfx/*"

--- a/.github/workflows/detect-translation-file-changes.yml
+++ b/.github/workflows/detect-translation-file-changes.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Detect translation file changes"
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -16,9 +16,11 @@ jobs:
       CCACHE: 1
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        persist-credentials: false
 
-    - uses: mymindstorm/setup-emsdk@v14
+    - uses: mymindstorm/setup-emsdk@6ab9eb1bda2574c4ddb79809fc9247783eaf9021 # v14
 
     - name: Install ccache
       run: |
@@ -33,7 +35,7 @@ jobs:
         echo "ccache-path=$(echo '~/.cache/ccache')" >> $GITHUB_OUTPUT
 
     - name: ccache cache files
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ${{ steps.get-vars.outputs.ccache-path }}
         # double-dash after compiler is not a typo, it is to disambiguate between g++-<date> and g++-11-<date> for restore key prefix matching
@@ -65,12 +67,14 @@ jobs:
         export PATH="${PATH%%:*}/../../ccache/git-emscripten_64bit/bin":$PATH
         ccache --show-stats
         NOW=`/bin/date +%s`
-        DELTA=$(( $NOW - ${{ steps.get-vars.outputs.datetime-seconds }} ))
+        DELTA=$(( $NOW - ${STEPS_GET_VARS_OUTPUTS_DATETIME_SECONDS} ))
         ccache --evict-older-than ${DELTA}s
         ccache --show-stats
         ccache -M 1G
         ccache -c
         ccache --show-stats
+      env:
+        STEPS_GET_VARS_OUTPUTS_DATETIME_SECONDS: ${{ steps.get-vars.outputs.datetime-seconds }}
 
     - name: clear ccache on PRs
       if: ${{ github.ref_name != 'master' && !failure() }}
@@ -83,7 +87,7 @@ jobs:
       run: ./build-scripts/prepare-web.sh
 
     - name: Create artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: play-cdda
         path: build/*

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -20,7 +20,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        persist-credentials: false
     - name: install dependencies
       run: sudo apt-get install flake8
     - name: Enable flake8 problem matcher

--- a/.github/workflows/format_emscripten.yml
+++ b/.github/workflows/format_emscripten.yml
@@ -18,7 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: install dependencies (ubuntu)
         run: |
@@ -31,16 +33,17 @@ jobs:
         run: ls -a
 
       - name: Upload zipped html as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: formatter
           path: formatter.html
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: gh-pages
+          persist-credentials: false
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: formatter
 
@@ -48,7 +51,7 @@ jobs:
         run: ls -a
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
           token: ${{ secrets.TX_PR_CREATOR }}
           commit-message: JSON linter gh-pages file update

--- a/.github/workflows/greet-first-time-comment.yml
+++ b/.github/workflows/greet-first-time-comment.yml
@@ -16,11 +16,13 @@ jobs:
     if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: Check if user has any existing PR comments in this repository
         id: pr-comment-check
         run: |
-          commenter="${{ github.event.comment.user.login }}"
+          commenter="${GITHUB_EVENT_COMMENT_USER_LOGIN}"
           echo "Debug: Checking comment counts for... $commenter"
           comment_count_all_PR=$(gh search prs --repo=CleverRaven/Cataclysm-DDA --commenter $commenter --json id | jq 'length')
           num_PRs_authored=$(gh search prs --repo=CleverRaven/Cataclysm-DDA --author $commenter --json id | jq 'length')
@@ -31,11 +33,15 @@ jobs:
           echo "comment_count_all_PR=$comment_count_all_PR" >> $GITHUB_OUTPUT
           echo "num_times_commented=$num_times_commented" >> $GITHUB_OUTPUT
           echo "num_PRs_authored=$num_PRs_authored" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_EVENT_COMMENT_USER_LOGIN: ${{ github.event.comment.user.login }}
 
       - name: Greet commenters with no previous comments
         if: steps.pr-comment-check.outputs.comment_count_all_PR == 1 && steps.pr-comment-check.outputs.num_times_commented == 1 && steps.pr-comment-check.outputs.num_PRs_authored == 0
         run: |
           # I have no earthly idea how to pass the commenter on from the previous run (I have tried), so let's just re-acquire it.
-          commenter_name="${{ github.event.comment.user.login }}"
+          commenter_name="${GITHUB_EVENT_COMMENT_USER_LOGIN}"
           # We 'hardcode' the URLs here because doing a dynamic url points to OWNER/REPO/pull/code_of_conduct.md. Why is the 'pull' there? No idea.
           gh pr comment $PR_NUMBER --body "Hi @$commenter_name, welcome to CleverRaven! We see that this is your first time commenting here. Check out [how development works](https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/development_process.md) and be sure to follow the [code of conduct](https://github.com/CleverRaven/Cataclysm-DDA/blob/master/CODE_OF_CONDUCT.md)! We hope to see you around!"
+        env:
+          GITHUB_EVENT_COMMENT_USER_LOGIN: ${{ github.event.comment.user.login }}

--- a/.github/workflows/iwyu.yml
+++ b/.github/workflows/iwyu.yml
@@ -29,15 +29,17 @@ jobs:
           sudo apt install llvm-19-dev clang-19 libclang-19-dev
           sudo apt install cmake
     - name: checkout IWYU repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         repository: include-what-you-use/include-what-you-use
         path: include-what-you-use-src
         ref: clang_19
+        persist-credentials: false
     - name: checkout own repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         path: Cataclysm-DDA
+        persist-credentials: false
     - name: build IWYU
       id: build-iwyu
       run: |
@@ -47,7 +49,7 @@ jobs:
         echo "IWYU_BIN_DIR=${PWD}/iwyu-build/bin">> "$GITHUB_OUTPUT"
     - name: determine changed files
       if: ${{ github.event_name == 'pull_request' }}
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
       with:
         script: |
           var fs = require('fs');
@@ -80,7 +82,7 @@ jobs:
 
         # and include database too, for get_affected_files.py
         make includes -j4 --silent TILES=${TILES:-0} SOUND=${SOUND:-0} LOCALIZE=${LOCALIZE:-0}
-    - uses: ammaraskar/gcc-problem-matcher@master
+    - uses: ammaraskar/gcc-problem-matcher@0f9c86f9e693db67dacf53986e1674de5f2e5f28 # master
     - name: run IWYU
       working-directory: Cataclysm-DDA
       env:

--- a/.github/workflows/json.yml
+++ b/.github/workflows/json.yml
@@ -11,12 +11,12 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
     - id: skip_check
-      uses: fkirc/skip-duplicate-actions@master
+      uses: fkirc/skip-duplicate-actions@04a1aebece824b56e6ad6a401d015479cd1c50b3 # master
       with:
         cancel_others: 'true'
         paths: '["**.json", ".github/workflows/json.yml"]'
     - run: echo ${{ github.event.number }} > pull_request_id
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: pull_request_id
         path: pull_request_id
@@ -28,7 +28,9 @@ jobs:
     if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        persist-credentials: false
     - name: JSON style check
       run: make style-all-json-parallel RELEASE=1
     - name: Display Corrections

--- a/.github/workflows/label-first-time-contributor.yml
+++ b/.github/workflows/label-first-time-contributor.yml
@@ -13,16 +13,20 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Check if user has any merged PRs in this reposiory
         id: pr-check
         run: |
-          author="${{ github.event.pull_request.user.login }}"
+          author="${GITHUB_EVENT_PULL_REQUEST_USER_LOGIN}"
           pr_count=$(gh pr list --state merged --author $author --json number | jq 'length')
 
           echo "Debug: $author with $pr_count merged PRs."
           echo "pr_count=$pr_count" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_EVENT_PULL_REQUEST_USER_LOGIN: ${{ github.event.pull_request.user.login }}
 
       - name: Label contributors with no merged PRs
         if: steps.pr-check.outputs.pr_count == 0

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,7 +12,7 @@ jobs:
       pull-requests: write  # for actions/labeler to add labels to PRs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v4
+      - uses: actions/labeler@ac9175f8a1f3625fd0d4fb234536d26811351594 # v4
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           # I don't want no bot removing stuff for me

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -27,9 +27,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         ref: '${{ github.event.pull_request.head.sha }}'
+        persist-credentials: false
 
     - run: sudo apt-get install astyle
 
@@ -37,7 +38,7 @@ jobs:
     - run: make style-all-json-parallel
 
     - name: 'suggester / JSON & C++'
-      uses: reviewdog/action-suggester@v1
+      uses: reviewdog/action-suggester@aa38384ceb608d00f84b4690cacc83a5aba307ff # v1
       if: ${{ always() }}
       with:
         tool_name: '[JSON & C++ formatters](https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/c++/DEVELOPER_TOOLING.md)'

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -58,7 +58,7 @@ jobs:
       should_skip_code: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - id: skip_check
-        uses: fkirc/skip-duplicate-actions@master
+        uses: fkirc/skip-duplicate-actions@04a1aebece824b56e6ad6a401d015479cd1c50b3 # master
         with:
           skip_after_successful_duplicate: 'false'
           paths_ignore: '["android/**", "build-data/osx/**", "doc/**", "doxygen_doc/**", "lgtm/**", "msvc-**", "tools/**", "utilities/**", "data/**", "lang/**"]'
@@ -70,7 +70,7 @@ jobs:
       should_skip_data: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - id: skip_check
-        uses: fkirc/skip-duplicate-actions@master
+        uses: fkirc/skip-duplicate-actions@04a1aebece824b56e6ad6a401d015479cd1c50b3 # master
         with:
           skip_after_successful_duplicate: 'false'
           paths_ignore: '["android/**", "build-data/osx/**", "doc/**", "doxygen_doc/**", "lgtm/**", "msvc-**", "tools/**", "utilities/**"]'
@@ -226,7 +226,7 @@ jobs:
     steps:
     - name: Maximize build space (ubuntu)
       if: ${{ runner.os == 'Linux' }}
-      uses: AdityaGarg8/remove-unwanted-software@v4.1
+      uses: AdityaGarg8/remove-unwanted-software@8831c82abf29b34eb2caac48d5f999ecfc0d8eef # v4.1
       with:
         remove-android: ${{ matrix.android == '' }}
     - name: Maximize build space (mac)
@@ -235,7 +235,9 @@ jobs:
         sudo rm -rf $ANDROID_HOME
     - name: checkout repository
       if: ${{ env.SKIP == 'false' }}
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        persist-credentials: false
     - name: install dependencies (ubuntu)
       if: ${{ env.SKIP == 'false' && runner.os == 'Linux' }}
       run: |
@@ -255,7 +257,7 @@ jobs:
           ccache --version
     - name: install runtime dependencies (mac)
       if: ${{ env.SKIP == 'false' && runner.os == 'macOS' }}
-      uses: BrettDong/setup-sdl2-frameworks@v1
+      uses: BrettDong/setup-sdl2-frameworks@8ec523df88d65b2af0e1ae520695badd88851497 # v1
       with:
         sdl2: 2.30.11
         sdl2-ttf: 2.24.0
@@ -267,7 +269,7 @@ jobs:
           HOMEBREW_NO_AUTO_UPDATE=yes HOMEBREW_NO_INSTALL_CLEANUP=yes brew install gettext ccache parallel
     - name: install macports (mac)
       if: ${{ env.SKIP == 'false' && runner.os == 'macOS' && matrix.tiles == 1 }}
-      uses: melusina-org/setup-macports@v1
+      uses: melusina-org/setup-macports@c7eb59386def259a274627092566a7f7b8d219b1 # v1
     - name: install macports packages (mac)
       if: ${{ env.SKIP == 'false' && runner.os == 'macOS' && matrix.tiles == 1 }}
       run: |
@@ -285,18 +287,18 @@ jobs:
       shell: bash
     - name: ccache cache files
       if: ${{ env.SKIP == 'false' && ( runner.os == 'Linux' || runner.os == 'macOS' ) && matrix.ccache_key != '' }}
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ${{ steps.get-vars.outputs.ccache-path }}
         # double-dash after compiler is not a typo, it is to disambiguate between g++-<date> and g++-11-<date> for restore key prefix matching
         key: ccache-${{ github.ref_name }}-${{ matrix.ccache_key }}--${{ steps.get-vars.outputs.datetime }}
         restore-keys: |
           ccache-master-${{ matrix.ccache_key }}--
-    - uses: ammaraskar/gcc-problem-matcher@master
+    - uses: ammaraskar/gcc-problem-matcher@0f9c86f9e693db67dacf53986e1674de5f2e5f28 # master
 
     - name: Set up JDK (android)
       if: runner.os == 'Linux' && matrix.android != 'none'
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
       with:
         java-version: '11'
         distribution: 'adopt'
@@ -330,18 +332,18 @@ jobs:
         echo ${{ github.event.number }} > pull_request_id
         echo "false" > ${{ env.ARCHIVE_SUCCESS }}
       if: ${{ env.ARCHIVE_SUCCESS && failure() }}
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       if: ${{ always() && env.ARCHIVE_SUCCESS }}
       with:
         name: pull_request_id
         path: pull_request_id
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       if: ${{ always() && env.ARCHIVE_SUCCESS }}
       with:
         name: ${{ env.ARCHIVE_SUCCESS }}
         path: ${{ env.ARCHIVE_SUCCESS }}
     - name: upload artifacts if failed
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       if: failure()
       with:
         name: cata_test

--- a/.github/workflows/msvc-full-features.yml
+++ b/.github/workflows/msvc-full-features.yml
@@ -58,10 +58,12 @@ jobs:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        persist-credentials: false
 
     - name: Setup msys2
-      uses: msys2/setup-msys2@v2
+      uses: msys2/setup-msys2@4f806de0a5a7294ffabaff804b38a9b435a73bda # v2
       with:
         msystem: mingw64
         install: >-
@@ -69,7 +71,7 @@ jobs:
           make
 
     - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v2
+      uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce # v2
 
     - name: Use GNU tar to enable zstd for actions/cache
       run: |
@@ -78,13 +80,13 @@ jobs:
       shell: cmd
 
     - name: Install stable CMake
-      uses: lukka/get-cmake@latest
+      uses: lukka/get-cmake@f176ccd3f28bda569c43aae4894f06b2435a3375 # latest
       with:
         # 4.0.0 has issues compiling old packages
         cmakeVersion: 3.31.6
 
     - name: Install vcpkg
-      uses: lukka/run-vcpkg@v11
+      uses: lukka/run-vcpkg@7d259227a1fb6471a0253dd5ab7419835228f7d7 # v11
       id: runvcpkg
       with:
         vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
@@ -92,10 +94,12 @@ jobs:
 
     - name: Integrate vcpkg
       run: |
-        vcpkg integrate install --vcpkg-root '${{ runner.workspace }}\b\vcpkg'
+        vcpkg integrate install --vcpkg-root '$env:RUNNER_WORKSPACE\b\vcpkg'
+      env:
+        RUNNER_WORKSPACE: ${{ runner.workspace }}
 
     - name: Download ccache
-      uses: robinraju/release-downloader@v1.9
+      uses: robinraju/release-downloader@368754b9c6f47c345fcfbf42bcb577c2f0f5f395 # v1.9
       with:
         repository: 'ccache/ccache'
         tag: 'v4.6.1'
@@ -107,7 +111,7 @@ jobs:
         unzip ccache-4.6.1-windows-x86_64.zip
         cp ccache-4.6.1-windows-x86_64/ccache.exe ccache-4.6.1-windows-x86_64/cl.exe
         cp ccache-4.6.1-windows-x86_64/ccache.exe ccache-4.6.1-windows-x86_64/clang-cl.exe
-        mv ccache-4.6.1-windows-x86_64 ${{ env.CDDA_CCACHE_PATH }}
+        mv ccache-4.6.1-windows-x86_64 $env:CDDA_CCACHE_PATH
 
     - name: Get ccache vars
       id: get-vars
@@ -118,7 +122,7 @@ jobs:
       shell: bash
 
     - name: ccache cache files
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ${{ steps.get-vars.outputs.ccache-path }}
         # double-dash after compiler is not a typo, it is to disambiguate between g++-<date> and g++-11-<date> for restore key prefix matching
@@ -128,9 +132,9 @@ jobs:
 
     - name: Configure ccache
       run: |
-        ${{ env.CDDA_CCACHE_PATH }}\ccache.exe -M 10G
-        ${{ env.CDDA_CCACHE_PATH }}\ccache.exe -s -v
-        ${{ env.CDDA_CCACHE_PATH }}\ccache.exe -z
+        $env:CDDA_CCACHE_PATH\ccache.exe -M 10G
+        $env:CDDA_CCACHE_PATH\ccache.exe -s -v
+        $env:CDDA_CCACHE_PATH\ccache.exe -z
 
     - name: Symlink intermediates to C
       run: |
@@ -145,32 +149,36 @@ jobs:
       id: get-cache-age
       run: |
         NOW=`/bin/date +%s`
-        DELTA=$(( $NOW - ${{ steps.get-vars.outputs.datetime-seconds }} ))
+        DELTA=$(( $NOW - ${STEPS_GET_VARS_OUTPUTS_DATETIME_SECONDS} ))
         echo "ccache-age=${DELTA}" >> $GITHUB_OUTPUT
       shell: bash
+      env:
+        STEPS_GET_VARS_OUTPUTS_DATETIME_SECONDS: ${{ steps.get-vars.outputs.datetime-seconds }}
 
     - name: Post-build ccache manipulation
       if: ${{ !failure() }}
       run: |
-        ${{ env.CDDA_CCACHE_PATH }}\ccache.exe -s -v
-        ${{ env.CDDA_CCACHE_PATH }}\ccache.exe --evict-older-than ${{ steps.get-cache-age.outputs.ccache-age }}s
-        ${{ env.CDDA_CCACHE_PATH }}\ccache.exe -s -v
-        ${{ env.CDDA_CCACHE_PATH }}\ccache.exe -M ${{ env.CCACHE_LIMIT }}
-        ${{ env.CDDA_CCACHE_PATH }}\ccache.exe -c
-        ${{ env.CDDA_CCACHE_PATH }}\ccache.exe -s -v
+        $env:CDDA_CCACHE_PATH\ccache.exe -s -v
+        $env:CDDA_CCACHE_PATH\ccache.exe --evict-older-than ${env:STEPS_GET_CACHE_AGE_OUTPUTS_CCACHE_AGE}s
+        $env:CDDA_CCACHE_PATH\ccache.exe -s -v
+        $env:CDDA_CCACHE_PATH\ccache.exe -M ${{ env.CCACHE_LIMIT }}
+        $env:CDDA_CCACHE_PATH\ccache.exe -c
+        $env:CDDA_CCACHE_PATH\ccache.exe -s -v
+      env:
+        STEPS_GET_CACHE_AGE_OUTPUTS_CCACHE_AGE: ${{ steps.get-cache-age.outputs.ccache-age }}
 
     - name: clear ccache on PRs
       if: ${{ github.ref_name != 'master' }}
       run: |
-        ${{ env.CDDA_CCACHE_PATH }}\ccache.exe -C
+        $env:CDDA_CCACHE_PATH\ccache.exe -C
 
     - name: Dump vcpkg logs if build failed
       if: failure()
       run: |
         echo =================================================
-        Get-ChildItem "${{ runner.workspace }}/Cataclysm-DDA/msvc-full-features/vcpkg_installed" -Recurse
+        Get-ChildItem "$env:RUNNER_WORKSPACE/Cataclysm-DDA/msvc-full-features/vcpkg_installed" -Recurse
         echo =================================================
-        Get-ChildItem "${{ runner.workspace }}/b/vcpkg/buildtrees" |
+        Get-ChildItem "$env:RUNNER_WORKSPACE/b/vcpkg/buildtrees" |
         Foreach-Object {
             Get-ChildItem $_.FullName -Filter *.log |
             Foreach-Object {
@@ -180,6 +188,8 @@ jobs:
               type $_.FullName
             }
         }
+      env:
+        RUNNER_WORKSPACE: ${{ runner.workspace }}
 
     - name: Compile .mo files for localization
       if: ${{ github.ref_name != 'master' }}

--- a/.github/workflows/msvc-full-features.yml
+++ b/.github/workflows/msvc-full-features.yml
@@ -132,9 +132,9 @@ jobs:
 
     - name: Configure ccache
       run: |
-        $env:CDDA_CCACHE_PATH\ccache.exe -M 10G
-        $env:CDDA_CCACHE_PATH\ccache.exe -s -v
-        $env:CDDA_CCACHE_PATH\ccache.exe -z
+        & "$env:CDDA_CCACHE_PATH\ccache.exe" -M 10G
+        & "$env:CDDA_CCACHE_PATH\ccache.exe" -s -v
+        & "$env:CDDA_CCACHE_PATH\ccache.exe" -z
 
     - name: Symlink intermediates to C
       run: |
@@ -158,19 +158,19 @@ jobs:
     - name: Post-build ccache manipulation
       if: ${{ !failure() }}
       run: |
-        $env:CDDA_CCACHE_PATH\ccache.exe -s -v
-        $env:CDDA_CCACHE_PATH\ccache.exe --evict-older-than ${env:STEPS_GET_CACHE_AGE_OUTPUTS_CCACHE_AGE}s
-        $env:CDDA_CCACHE_PATH\ccache.exe -s -v
-        $env:CDDA_CCACHE_PATH\ccache.exe -M ${{ env.CCACHE_LIMIT }}
-        $env:CDDA_CCACHE_PATH\ccache.exe -c
-        $env:CDDA_CCACHE_PATH\ccache.exe -s -v
+        & "$env:CDDA_CCACHE_PATH\ccache.exe" -s -v
+        & "$env:CDDA_CCACHE_PATH\ccache.exe" --evict-older-than ${env:STEPS_GET_CACHE_AGE_OUTPUTS_CCACHE_AGE}s
+        & "$env:CDDA_CCACHE_PATH\ccache.exe" -s -v
+        & "$env:CDDA_CCACHE_PATH\ccache.exe" -M ${{ env.CCACHE_LIMIT }}
+        & "$env:CDDA_CCACHE_PATH\ccache.exe" -c
+        & "$env:CDDA_CCACHE_PATH\ccache.exe" -s -v
       env:
         STEPS_GET_CACHE_AGE_OUTPUTS_CCACHE_AGE: ${{ steps.get-cache-age.outputs.ccache-age }}
 
     - name: clear ccache on PRs
       if: ${{ github.ref_name != 'master' }}
       run: |
-        $env:CDDA_CCACHE_PATH\ccache.exe -C
+        & "$env:CDDA_CCACHE_PATH\ccache.exe" -C
 
     - name: Dump vcpkg logs if build failed
       if: failure()

--- a/.github/workflows/msvc-full-features.yml
+++ b/.github/workflows/msvc-full-features.yml
@@ -94,7 +94,7 @@ jobs:
 
     - name: Integrate vcpkg
       run: |
-        vcpkg integrate install --vcpkg-root '$env:RUNNER_WORKSPACE\b\vcpkg'
+        vcpkg integrate install --vcpkg-root "$env:RUNNER_WORKSPACE\b\vcpkg"
       env:
         RUNNER_WORKSPACE: ${{ runner.workspace }}
 

--- a/.github/workflows/post-spell-check-result.yml
+++ b/.github/workflows/post-spell-check-result.yml
@@ -11,19 +11,19 @@ on:
 jobs:
   post-spell-check-result:
     runs-on: ubuntu-latest
-    if: >
+    if: >-
       ${{ github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Download pr id artifact
-        uses: dawidd6/action-download-artifact@v3.1.4
+        uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe # v3.1.4
         with:
           workflow: ${{ github.event.workflow_run.name }}
           run_id: ${{ github.event.workflow_run.id }}
           name: pull_request_id
           allow_forks: false
       - name: Download spell check retcode artifact
-        uses: dawidd6/action-download-artifact@v3.1.4
+        uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe # v3.1.4
         with:
           workflow: ${{ github.event.workflow_run.name }}
           run_id: ${{ github.event.workflow_run.id }}
@@ -34,7 +34,7 @@ jobs:
         run: echo "spell-check-retcode=$( cat spell_check_retcode )" >> $GITHUB_OUTPUT
       - name: Download spell check output artifact
         if: steps.set-spell-check-retcode.outputs.spell-check-retcode >= 1
-        uses: dawidd6/action-download-artifact@v3.1.4
+        uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe # v3.1.4
         with:
           workflow: ${{ github.event.workflow_run.name }}
           run_id: ${{ github.event.workflow_run.id }}
@@ -42,7 +42,7 @@ jobs:
           allow_forks: false
       - name: 'Comment on PR'
         if: steps.set-spell-check-retcode.outputs.spell-check-retcode >= 1
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/pr-validator.yml
+++ b/.github/workflows/pr-validator.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Validate SUMMARY"
-        uses: CleverRaven/pr-validator@master
+        uses: CleverRaven/pr-validator@3ce0cce9c720b67a2a5e78e3b1eabe62ac92a156 # master
         with:
           description-regex: '(\n|^)#### Summary\s+`{0,3}(SUMMARY:\s+)?(None|((Features|Content|Interface|Mods|Balance|Bugfixes|Performance|Infrastructure|Build|I18N) +".+"))`{0,3}\s*(\n|$)'
           description-regex-flags: 'i'

--- a/.github/workflows/push-translation-template.yml
+++ b/.github/workflows/push-translation-template.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   push-template:
     runs-on: ubuntu-latest
-    if: >
+    if: >-
       ${{ github.event.workflow_run.event == 'push' &&
       github.event.workflow_run.conclusion == 'success' &&
       ( github.event.workflow_run.status == 'success' || github.event.workflow_run.status == 'completed' ) &&
@@ -31,7 +31,9 @@ jobs:
           sudo apt install python3-pip
           sudo pip3 install polib
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: "Generate translation template"
         run: |
           lang/update_pot.sh

--- a/.github/workflows/release-android-bundle.yaml
+++ b/.github/workflows/release-android-bundle.yaml
@@ -22,9 +22,11 @@ jobs:
           echo "tag_name=cdda-experimental-aab-bundle-$timestamp" >> $GITHUB_OUTPUT
           echo "release_name=Cataclysm-DDA experimental Android bundle $timestamp" >> $GITHUB_OUTPUT
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: '11'
           distribution: 'adopt'
@@ -44,12 +46,18 @@ jobs:
           export UPSTREAM_BUILD_NUMBER="$((11581 + ${{ github.run_number }}))"
           chmod +x gradlew
           ./gradlew -Pj=$((`nproc`+0)) bundleExperimentalRelease
-          mv ./app/build/outputs/bundle/experimentalRelease/*.aab ../cdda-android-bundle-${{ steps.vars.outputs.timestamp }}-${{ github.sha }}.aab
+          mv ./app/build/outputs/bundle/experimentalRelease/*.aab ../cdda-android-bundle-${STEPS_VARS_OUTPUTS_TIMESTAMP}-${{ github.sha }}.aab
+        env:
+          STEPS_VARS_OUTPUTS_TIMESTAMP: ${{ steps.vars.outputs.timestamp }}
 
       - name: Create GitHub release
         run: |
-          gh release create ${{ steps.vars.outputs.tag_name }} \
-            cdda-android-bundle-${{ steps.vars.outputs.timestamp }}-${{ github.sha }}.aab \
+          gh release create ${STEPS_VARS_OUTPUTS_TAG_NAME} \
+            cdda-android-bundle-${STEPS_VARS_OUTPUTS_TIMESTAMP}-${{ github.sha }}.aab \
             --prerelease \
-            --title "${{ steps.vars.outputs.release_name }}" \
+            --title "${STEPS_VARS_OUTPUTS_RELEASE_NAME}" \
             --target "${{ github.sha }}"
+        env:
+          STEPS_VARS_OUTPUTS_TAG_NAME: ${{ steps.vars.outputs.tag_name }}
+          STEPS_VARS_OUTPUTS_TIMESTAMP: ${{ steps.vars.outputs.timestamp }}
+          STEPS_VARS_OUTPUTS_RELEASE_NAME: ${{ steps.vars.outputs.release_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,16 +39,25 @@ jobs:
       - name: Generate environmental variables
         id: generate_env_vars
         run: |
-          echo "tag_name=cdda-experimental-${{ steps.get-timestamp.outputs.time }}" >> $GITHUB_OUTPUT
-          echo "release_name=Cataclysm-DDA experimental build ${{ steps.get-timestamp.outputs.time }}" >> $GITHUB_OUTPUT
-      - uses: actions/checkout@v4
+          echo "tag_name=cdda-experimental-${STEPS_GET_TIMESTAMP_OUTPUTS_TIME}" >> $GITHUB_OUTPUT
+          echo "release_name=Cataclysm-DDA experimental build ${STEPS_GET_TIMESTAMP_OUTPUTS_TIME}" >> $GITHUB_OUTPUT
+        env:
+          STEPS_GET_TIMESTAMP_OUTPUTS_TIME: ${{ steps.get-timestamp.outputs.time }}
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: Generate Release Notes
         id: generate-release-notes
         run: |
           npm install @actions/github@8
-          node build-scripts/generate-release-notes.js '${{ secrets.GITHUB_TOKEN }}' '${{ steps.generate_env_vars.outputs.tag_name }}' "$(git log -1 --format='%H')" > notes.txt
+          node build-scripts/generate-release-notes.js '${{ secrets.GITHUB_TOKEN }}' "${STEPS_GENERATE_ENV_VARS_OUTPUTS_TAG_NAME}" "$(git log -1 --format='%H')" > notes.txt
+        env:
+          STEPS_GENERATE_ENV_VARS_OUTPUTS_TAG_NAME: ${{ steps.generate_env_vars.outputs.tag_name }}
       - run: |
-          gh release create ${{ steps.generate_env_vars.outputs.tag_name }} --notes-file notes.txt --prerelease --title "${{ steps.generate_env_vars.outputs.release_name }}" --target "$(git log -1 --format='%H')"
+          gh release create ${STEPS_GENERATE_ENV_VARS_OUTPUTS_TAG_NAME} --notes-file notes.txt --prerelease --title "${STEPS_GENERATE_ENV_VARS_OUTPUTS_RELEASE_NAME}" --target "$(git log -1 --format='%H')"
+        env:
+          STEPS_GENERATE_ENV_VARS_OUTPUTS_TAG_NAME: ${{ steps.generate_env_vars.outputs.tag_name }}
+          STEPS_GENERATE_ENV_VARS_OUTPUTS_RELEASE_NAME: ${{ steps.generate_env_vars.outputs.release_name }}
 
   compose-tilesets:
     uses: ./.github/workflows/compose-tilesets.yml
@@ -151,9 +160,10 @@ jobs:
     env:
         ZSTD_CLEVEL: 17
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-tags: true
+          persist-credentials: false
       - name: Get soundpack
         if: matrix.sound == 1
         run: |
@@ -161,21 +171,21 @@ jobs:
           mv '${{ github.workspace }}/CDDA-Soundpacks/sound/CC-Sounds' '${{ github.workspace }}/data/sound'
       - name: Fetch tileset artifact into build
         if: matrix.tiles == 1
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: tileset-*
           path: gfx
           merge-multiple: true
       - name: Fetch translations artifact into build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: translations
       - name: Install dependencies (windows msvc) (1/4)
         if: runner.os == 'Windows'
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce # v2
       - name: Install dependencies (windows msvc) (2/4)
         if: runner.os == 'Windows'
-        uses: lukka/run-vcpkg@v11
+        uses: lukka/run-vcpkg@7d259227a1fb6471a0253dd5ab7419835228f7d7 # v11
         id: runvcpkg
         with:
           vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
@@ -186,7 +196,7 @@ jobs:
           vcpkg integrate install --vcpkg-root '${{ runner.workspace }}\b\vcpkg'
       - name: Install dependencies (windows msvc) (4/4)
         if: runner.os == 'Windows'
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@4f806de0a5a7294ffabaff804b38a9b435a73bda # v2
         with:
           msystem: mingw64
           install: >-
@@ -209,10 +219,10 @@ jobs:
             libsdl2-mixer-dev libpulse-dev ccache gettext parallel
       - name: Install Emscripten (WebAssembly)
         if: matrix.wasm
-        uses: mymindstorm/setup-emsdk@v13
+        uses: mymindstorm/setup-emsdk@d233ac12b0102f74ca199f5dad7a4e2c13a8a745 # v13
       - name: Install runtime dependencies (mac)
         if: runner.os == 'macOS'
-        uses: BrettDong/setup-sdl2-frameworks@v2
+        uses: BrettDong/setup-sdl2-frameworks@a8ca795ef904417e9ddcb010ef6bf2d11779dbe3 # v2
         with:
           sdl2: 2.30.11
           sdl2-ttf: 2.24.0
@@ -225,7 +235,7 @@ jobs:
           pip3 install --break-system-packages dmgbuild biplist
       - name: install macports (mac)
         if: runner.os == 'macOS' && matrix.tiles == 1
-        uses: melusina-org/setup-macports@v1
+        uses: melusina-org/setup-macports@c7eb59386def259a274627092566a7f7b8d219b1 # v1
       - name: install macports packages (mac)
         if: runner.os == 'macOS' && matrix.tiles == 1
         run: |
@@ -235,10 +245,12 @@ jobs:
         run: |
           cat >VERSION.txt <<EOL
           build type: ${{ matrix.artifact }}
-          build number: ${{ needs.release.outputs.timestamp }}
+          build number: ${NEEDS_RELEASE_OUTPUTS_TIMESTAMP}
           commit sha: ${{ github.sha }}
           commit url: https://github.com/${{ github.repository }}/commit/${{ github.sha }}
           EOL
+        env:
+          NEEDS_RELEASE_OUTPUTS_TIMESTAMP: ${{ needs.release.outputs.timestamp }}
       - name: Compile translations (windows)
         if: runner.os == 'Windows'
         shell: msys2 {0}
@@ -283,7 +295,7 @@ jobs:
           mv Cataclysm.dmg cdda-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.dmg
       - name: Set up JDK (android)
         if: runner.os == 'Linux' && matrix.android != 'none'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: '11'
           distribution: 'adopt'   

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,7 @@ jobs:
       - name: get-time
         run: |
           echo "time=$(date +%I)" >> $GITHUB_ENV
-      - uses: actions/stale@main
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # main
         id: stale
         with:
           stale-issue-label: stale

--- a/.github/workflows/summary-labeler.yml
+++ b/.github/workflows/summary-labeler.yml
@@ -8,8 +8,10 @@ jobs:
     name: labeler
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: fuxingloh/multi-labeler@v4.0.0
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: fuxingloh/multi-labeler@b15a54460c38f54043fa75f7b08a0e2aa5b94b5b # v4.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           config-path: '.github/summary-labels.yml'

--- a/.github/workflows/test_labeler.yml
+++ b/.github/workflows/test_labeler.yml
@@ -13,24 +13,26 @@ jobs:
     - name: setLabel
       id: setLabel
       run: |
-        if [[ "${{ github.event.workflow_run.name }}" == "astyle" ]]; then
+        if [[ "${GITHUB_EVENT_WORKFLOW_RUN_NAME}" == "astyle" ]]; then
           echo "label=astyled" >> $GITHUB_OUTPUT
         fi
-        if [[ "${{ github.event.workflow_run.name }}" == "JSON Validation" ]]; then
+        if [[ "${GITHUB_EVENT_WORKFLOW_RUN_NAME}" == "JSON Validation" ]]; then
           echo "label=json-styled" >> $GITHUB_OUTPUT
         fi
-        if [[ "${{ github.event.workflow_run.name }}" == "General build matrix" ]]; then
+        if [[ "${GITHUB_EVENT_WORKFLOW_RUN_NAME}" == "General build matrix" ]]; then
           echo "label=BasicBuildPassed" >> $GITHUB_OUTPUT
         fi
-        if [[ "${{ github.event.workflow_run.name }}" == "IWYU (include-what-you-use)" ]]; then
+        if [[ "${GITHUB_EVENT_WORKFLOW_RUN_NAME}" == "IWYU (include-what-you-use)" ]]; then
           echo "label=IWYUPassed" >> $GITHUB_OUTPUT
         fi
-        if [[ "${{ github.event.workflow_run.name }}" == "build-clang-tidy" ]]; then
+        if [[ "${GITHUB_EVENT_WORKFLOW_RUN_NAME}" == "build-clang-tidy" ]]; then
           echo "label=ClangPassed" >> $GITHUB_OUTPUT
         fi
+      env:
+        GITHUB_EVENT_WORKFLOW_RUN_NAME: ${{ github.event.workflow_run.name }}
     - name: Download success artifact from basic build
       if: ${{ github.event.workflow_run.name == 'General build matrix' }}
-      uses: dawidd6/action-download-artifact@v3.1.4
+      uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe # v3.1.4
       with:
         workflow: ${{ github.event.workflow_run.name }}
         run_id: ${{ github.event.workflow_run.id }}
@@ -40,7 +42,7 @@ jobs:
       id: set-basic-build-success
       run: echo "basic-build-success=$( cat basic-build )" >> $GITHUB_OUTPUT
     - name: Download pr id artifact
-      uses: dawidd6/action-download-artifact@v3.1.4
+      uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe # v3.1.4
       with:
         workflow: ${{ github.event.workflow_run.name }}
         run_id: ${{ github.event.workflow_run.id }}
@@ -51,7 +53,7 @@ jobs:
       run: echo "pr-id=$( cat pull_request_id )" >> $GITHUB_OUTPUT
     - name: set-label
       if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.conclusion != 'skipped' || steps.set-basic-build-success.outputs.basic-build-success == 'true' }}
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
       with:
         script: |
             if ('${{ steps.set-pr-id.outputs.pr-id }}'.trim().length == 0) {
@@ -66,7 +68,7 @@ jobs:
             }
     - name: remove-label
       if: ${{ github.event.workflow_run.conclusion == 'failure' && steps.set-basic-build-success.outputs.basic-build-success != 'true' }}
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
       with:
         script: |
             if ('${{ steps.set-pr-id.outputs.pr-id }}'.trim().length == 0) {

--- a/.github/workflows/text-changes-analyzer.yml
+++ b/.github/workflows/text-changes-analyzer.yml
@@ -28,7 +28,9 @@ jobs:
           sudo apt-get install python3-pip gettext
           sudo pip3 install polib pyspellchecker regex
       - name: "Checkout test merge commit"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: "Compute base commit and test merge commit"
         id: get-commit-hash
         run: |
@@ -41,18 +43,20 @@ jobs:
           ./lang/update_pot.sh
           cp lang/po/cataclysm-dda.pot ~/merge.pot
       - name: "Checkout base commit"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ steps.get-commit-hash.outputs.base_commit }}
+          persist-credentials: false
       - name: "Generate translation template on base commit"
         run: |
           rm -f lang/po/cataclysm-dda.pot
           ./lang/update_pot.sh
           cp lang/po/cataclysm-dda.pot ~/base.pot
       - name: "Checkout test merge commit"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ steps.get-commit-hash.outputs.test_merge_commit }}
+          persist-credentials: false
       - name: "Write text changes"
         run: |
           python3 ./tools/pot_diff.py ~/base.pot ~/merge.pot -j ~/pot_diff.json
@@ -68,15 +72,15 @@ jobs:
           wc -c spell_check_output | grep -o '[0-9]*' > spell_check_retcode
           echo "length=$(cat spell_check_retcode)" >> $GITHUB_OUTPUT
       - run: echo ${{ github.event.number }} > pull_request_id
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: pull_request_id
           path: pull_request_id
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: spell_check_retcode
           path: spell_check_retcode
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: steps.get_length.outputs.length >= 1
         with:
           name: spell_check_output

--- a/.github/workflows/toc.yml
+++ b/.github/workflows/toc.yml
@@ -14,10 +14,12 @@ jobs:
     name: Update the table of contents
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - run: npx doctoc --github --title "*Contents*" --update-only doc/
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
           commit-message: Update the table of contents
           branch: update-toc

--- a/.github/workflows/update-tilesets.yml
+++ b/.github/workflows/update-tilesets.yml
@@ -15,9 +15,11 @@ jobs:
     if: github.repository == 'CleverRaven/Cataclysm-DDA'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: "Get current date"
-        uses: 1466587594/get-current-time@v2
+        uses: 1466587594/get-current-time@060cae3fbd32c181c6841788189a601ac8df8389 # v2
         id: current-date
         with:
           format: 'DD MMMM YYYY'
@@ -35,7 +37,7 @@ jobs:
           make tools/format/json_formatter.cgi
           find gfx/ -name "*.json" -print0 | xargs -0 -L 1 -P $(nproc) tools/format/json_formatter.cgi || exit 0
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
           commit-message: |
             Routine tileset updates on ${{ steps.current-date.outputs.formattedTime }}

--- a/.github/workflows/weekly-changelog.yml
+++ b/.github/workflows/weekly-changelog.yml
@@ -15,9 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
       - name: "Get current date"
-        uses: josStorer/get-current-time@v2
+        uses: josStorer/get-current-time@060cae3fbd32c181c6841788189a601ac8df8389 # v2
         id: current-date
         with:
           format: 'YYYYMMDD'
@@ -34,7 +36,7 @@ jobs:
           echo "date=$( date +"%Y-%m-%d" -d $CURR_DATE )" >> $GITHUB_OUTPUT
           echo "old_date=$LAST_WEEK" >> $GITHUB_OUTPUT
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
           commit-message: Weekly Changelog ${{ steps.getting-changes.outputs.old_date }} to ${{ steps.getting-changes.outputs.date }}
           committer: David Seguin <davidseguin@live.ca>


### PR DESCRIPTION
Apply zizmor --fix=all across all 34 workflow files:

- Pin all 116 action references to commit SHAs for supply-chain safety
- Add persist-credentials: false to all checkout steps (artipacked)
- Move user-controlled context expressions from run: blocks to env: blocks to prevent template injection (greet-first-time-comment, label-first-time-contributor, msvc-full-features, release)
- Fix unsound if: conditions using YAML > instead of >- that always evaluate truthy due to trailing newline (post-spell-check-result, push-translation-template)

Manual fixes on top of zizmor output:
- Use ${env:VAR}s syntax in PowerShell to delimit variable name from literal suffix (msvc-full-features.yml ccache eviction step)
- Use double quotes for bash variable expansion in release.yml generate-release-notes step (single quotes prevent expansion)

#### Summary
Infrastructure "Pin GitHub Actions to commit SHAs and apply security hardening"

#### Purpose of change

Resolve zizmor security audit findings across CI workflows. SHA pinning prevents supply-chain attacks via tag mutation. Persist-credentials removal limits token exposure. Template injection fixes prevent potential code injection via user-controlled GitHub context values. Unsound condition fixes prevent if: expressions that always evaluate truthy due to YAML multiline trailing newlines.

#### Describe the solution

Ran zizmor --fix=all to auto-fix all 34 workflow files, then manually corrected two issues in the output: a PowerShell variable delimiting bug (env var name absorbed a literal suffix character) and a bash quoting bug (single quotes preventing env var expansion).

#### Describe alternatives you've considered

Could pin only high-risk refs (mutable branches like @master/@main) and leave versioned tags unpinned, but blanket SHA pinning is the industry standard recommendation and Dependabot/Renovate can auto-update the SHAs.

#### Testing

- zizmor reports 0 findings for unpinned-uses, artipacked, template-injection in run: blocks, and unsound-condition after this change
- Remaining findings (excessive-permissions, dangerous-triggers, template-injection in with:/if: contexts) are expected and out of scope
- persist-credentials: false verified safe for push workflows: peter-evans/create-pull-request uses its own token input, Transifex push uses TX_TOKEN env var, gh CLI uses GITHUB_TOKEN env var

#### Additional context

Out-of-scope findings left for future work:
- excessive-permissions (40 medium): adding per-job permissions: blocks
- dangerous-triggers (13 high): pull_request_target/workflow_run needed architecturally
- template-injection in with:/if: (17 info): not directly exploitable