### PR TITLE
Fix test labeler failures, cache IWYU and clang-tidy builds

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -39,27 +39,37 @@ jobs:
     env:
         COMPILER: clang++-18
     steps:
+    - name: checkout repository
+      if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        persist-credentials: false
+    - name: cache clang-tidy plugin
+      id: plugin-cache
+      if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        path: build/tools/clang-tidy-plugin/libCataAnalyzerPlugin.so
+        key: clang-tidy-plugin-llvm18-ubuntu2404-${{ hashFiles('tools/clang-tidy-plugin/**', 'build-scripts/clang-tidy-build.sh', 'CMakeLists.txt', 'CMakeModules/**') }}
     - name: install LLVM 18
-      if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
+      if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && steps.plugin-cache.outputs.cache-hit != 'true' }}
       run: |
           sudo apt-get update
           sudo apt install llvm-18 llvm-18-dev llvm-18-tools clang-18 clang-tidy-18 clang-tools-18 libclang-18-dev
           sudo apt install python3-pip ninja-build cmake
           pip3 install --user lit
-    - name: checkout repository
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      with:
-        persist-credentials: false
     - uses: ammaraskar/gcc-problem-matcher@0f9c86f9e693db67dacf53986e1674de5f2e5f28 # master
     - name: build clang-tidy plugin
-      if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
+      if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && steps.plugin-cache.outputs.cache-hit != 'true' }}
       run: bash ./build-scripts/clang-tidy-build.sh
     - name: upload plugin
+      if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: cata-analyzer-plugin
         path: build/tools/clang-tidy-plugin/libCataAnalyzerPlugin.so
         retention-days: 1
+        if-no-files-found: ignore
 
 
   run-clang-tidy:
@@ -83,13 +93,13 @@ jobs:
         TILES: 1
         SOUND: 1
         LOCALIZE: 1
-    if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
+    if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
     steps:
     - name: install dependencies
       run: |
           sudo apt-get update
           sudo apt install clang-18 clang-tidy-18 cmake ccache jq
-          sudo apt install libflac-dev libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev libsdl2-mixer-dev libpulse-dev gettext 
+          sudo apt install libflac-dev libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev libsdl2-mixer-dev libpulse-dev gettext
     - name: checkout repository
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:

--- a/.github/workflows/iwyu.yml
+++ b/.github/workflows/iwyu.yml
@@ -29,6 +29,7 @@ jobs:
           sudo apt install llvm-19-dev clang-19 libclang-19-dev
           sudo apt install cmake
     - name: checkout IWYU repository
+      id: iwyu-checkout
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         repository: include-what-you-use/include-what-you-use
@@ -40,11 +41,20 @@ jobs:
       with:
         path: Cataclysm-DDA
         persist-credentials: false
+    - name: cache IWYU build
+      id: iwyu-cache
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        path: iwyu-build
+        key: iwyu-clang19-ubuntu2404-${{ steps.iwyu-checkout.outputs.commit }}
     - name: build IWYU
-      id: build-iwyu
+      if: steps.iwyu-cache.outputs.cache-hit != 'true'
       run: |
         cmake -B iwyu-build -DCMAKE_PREFIX_PATH=/usr/lib/llvm-19 -DCMAKE_BUILD_TYPE=Release include-what-you-use-src
         cmake --build iwyu-build --parallel 4
+    - name: set IWYU paths
+      id: build-iwyu
+      run: |
         echo "IWYU_SRC_DIR=${PWD}/include-what-you-use-src">> "$GITHUB_OUTPUT"
         echo "IWYU_BIN_DIR=${PWD}/iwyu-build/bin">> "$GITHUB_OUTPUT"
     - name: determine changed files

--- a/.github/workflows/test_labeler.yml
+++ b/.github/workflows/test_labeler.yml
@@ -7,7 +7,9 @@ on:
 
 jobs:
   labeling:
-    if: github.repository == 'CleverRaven/Cataclysm-DDA'
+    if: >-
+      github.repository == 'CleverRaven/Cataclysm-DDA' &&
+      github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
     steps:
     - name: setLabel


### PR DESCRIPTION
Depends on #85296 (SHA pinning). Reviewable independently but will have merge conflicts until that PR lands.

test_labeler.yml: Add workflow_run.event == 'pull_request' condition to skip the labeling job on master push events. On master push, no pull_request_id artifact exists, causing download-artifact to fail.

iwyu.yml: Cache the IWYU build directory keyed on the upstream clang_19 branch commit SHA. On cache hit, skip the cmake build step (saves ~3-4 minutes). Split path outputs into a separate step so downstream steps get IWYU_SRC_DIR/IWYU_BIN_DIR regardless of cache.

clang-tidy.yml: Cache libCataAnalyzerPlugin.so keyed on plugin source, build script, CMakeLists.txt, and CMakeModules. On cache hit, skip both LLVM apt-get install and plugin build (saves ~4 minutes). Move checkout before LLVM install so hashFiles() can read the working tree. Add if-no-files-found: ignore to upload-artifact for the case where skip-duplicates triggers with a cold cache.

Also fix operator precedence bug in all three if: conditions in the build-clang-tidy and run-clang-tidy jobs: wrap the OR expression in parentheses so skip-duplicates is always respected. Previously 'A && B || C' evaluated as '(A && B) || C', bypassing skip-duplicates for all non-draft PRs.

#### Summary
Infrastructure "Fix test labeler spurious failures, cache IWYU and clang-tidy plugin builds"

#### Purpose of change

- test_labeler has ~25% failure rate because workflow_run triggers on both PR and master push completions, but only PR runs produce the pull_request_id artifact
- IWYU is built from source every run (~3-4 min) despite the upstream clang_19 branch changing rarely
- clang-tidy plugin is rebuilt every run (~4 min) despite plugin source changing rarely
- clang-tidy if: conditions have an operator precedence bug that bypasses skip-duplicates

#### Describe the solution

- test_labeler: Filter on workflow_run.event == 'pull_request' (same pattern as post-spell-check-result.yml)
- IWYU: Cache iwyu-build directory keyed on upstream commit SHA, gate build on cache miss
- clang-tidy: Cache libCataAnalyzerPlugin.so keyed on hashFiles() of all build inputs, gate LLVM install + build on cache miss
- clang-tidy: Add parentheses to fix 'A && B || C' -> 'A && (B || C)' in three locations

#### Describe alternatives you've considered

For IWYU, considered keying the cache on hashFiles('.github/workflows/iwyu.yml') as well, but the upstream commit already invalidates on any real change. Workflow-level cmake flag changes are rare enough to handle with manual cache clearing.

#### Testing

- test_labeler: Master push workflow_run events should show "Skipped" for the labeling job
- IWYU: Second run on same branch should cache hit and skip the build step
- clang-tidy: Second run without plugin source changes should cache hit and skip LLVM install + build
- clang-tidy precedence fix: skip-duplicates should now correctly skip the build for duplicate pushes on non-draft PRs

#### Additional context

None