### PR TITLE
Cache clang-tidy results with ctcache and tune CI settings

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -90,6 +90,10 @@ jobs:
         COMPILER: clang++-18
         CATA_CLANG_TIDY: clang-tidy-18
         CATA_CLANG_TIDY_SUBSET: ${{ matrix.subset }}
+        CATA_CLANG_TIDY_PROFILE: ${{ github.event_name == 'push' && '1' || '' }}
+        CTCACHE_DIR: ${{ github.workspace }}/.ctcache
+        CTCACHE_LOCAL: 1
+        CTCACHE_SAVE_OUTPUT: 1
         TILES: 1
         SOUND: 1
         LOCALIZE: 1
@@ -100,6 +104,7 @@ jobs:
           sudo apt-get update
           sudo apt install clang-18 clang-tidy-18 cmake ccache jq
           sudo apt install libflac-dev libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev libsdl2-mixer-dev libpulse-dev gettext
+          pip install git+https://github.com/matus-chochlik/ctcache.git
     - name: checkout repository
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
@@ -128,6 +133,14 @@ jobs:
           }
           fs.writeFileSync("files_changed", files.join('\n') + '\n');
     - uses: ammaraskar/gcc-problem-matcher@0f9c86f9e693db67dacf53986e1674de5f2e5f28 # master
+    - name: restore ctcache
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        path: .ctcache
+        key: ctcache-${{ matrix.subset }}-${{ hashFiles('tools/clang-tidy-plugin/**', '.clang-tidy') }}-${{ github.ref }}
+        restore-keys: |
+          ctcache-${{ matrix.subset }}-${{ hashFiles('tools/clang-tidy-plugin/**', '.clang-tidy') }}-refs/heads/master
+          ctcache-${{ matrix.subset }}-${{ hashFiles('tools/clang-tidy-plugin/**', '.clang-tidy') }}-
     - name: run clang-tidy
       run: bash ./build-scripts/clang-tidy-run.sh
     - name: show most time consuming checks

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -39,27 +39,37 @@ jobs:
     env:
         COMPILER: clang++-18
     steps:
+    - name: checkout repository
+      if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        persist-credentials: false
+    - name: cache clang-tidy plugin
+      id: plugin-cache
+      if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        path: build/tools/clang-tidy-plugin/libCataAnalyzerPlugin.so
+        key: clang-tidy-plugin-llvm18-ubuntu2404-${{ hashFiles('tools/clang-tidy-plugin/**', 'build-scripts/clang-tidy-build.sh', 'CMakeLists.txt', 'CMakeModules/**') }}
     - name: install LLVM 18
-      if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
+      if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && steps.plugin-cache.outputs.cache-hit != 'true' }}
       run: |
           sudo apt-get update
           sudo apt install llvm-18 llvm-18-dev llvm-18-tools clang-18 clang-tidy-18 clang-tools-18 libclang-18-dev
           sudo apt install python3-pip ninja-build cmake
           pip3 install --user lit
-    - name: checkout repository
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      with:
-        persist-credentials: false
     - uses: ammaraskar/gcc-problem-matcher@0f9c86f9e693db67dacf53986e1674de5f2e5f28 # master
     - name: build clang-tidy plugin
-      if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
+      if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && steps.plugin-cache.outputs.cache-hit != 'true' }}
       run: bash ./build-scripts/clang-tidy-build.sh
     - name: upload plugin
+      if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: cata-analyzer-plugin
         path: build/tools/clang-tidy-plugin/libCataAnalyzerPlugin.so
         retention-days: 1
+        if-no-files-found: ignore
 
 
   run-clang-tidy:
@@ -83,13 +93,13 @@ jobs:
         TILES: 1
         SOUND: 1
         LOCALIZE: 1
-    if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
+    if: ${{ needs.skip-duplicates.outputs.should_skip != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false) }}
     steps:
     - name: install dependencies
       run: |
           sudo apt-get update
           sudo apt install clang-18 clang-tidy-18 cmake ccache jq
-          sudo apt install libflac-dev libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev libsdl2-mixer-dev libpulse-dev gettext 
+          sudo apt install libflac-dev libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev libsdl2-mixer-dev libpulse-dev gettext
     - name: checkout repository
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:

--- a/.github/workflows/iwyu.yml
+++ b/.github/workflows/iwyu.yml
@@ -29,6 +29,7 @@ jobs:
           sudo apt install llvm-19-dev clang-19 libclang-19-dev
           sudo apt install cmake
     - name: checkout IWYU repository
+      id: iwyu-checkout
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         repository: include-what-you-use/include-what-you-use
@@ -40,11 +41,20 @@ jobs:
       with:
         path: Cataclysm-DDA
         persist-credentials: false
+    - name: cache IWYU build
+      id: iwyu-cache
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        path: iwyu-build
+        key: iwyu-clang19-ubuntu2404-${{ steps.iwyu-checkout.outputs.commit }}
     - name: build IWYU
-      id: build-iwyu
+      if: steps.iwyu-cache.outputs.cache-hit != 'true'
       run: |
         cmake -B iwyu-build -DCMAKE_PREFIX_PATH=/usr/lib/llvm-19 -DCMAKE_BUILD_TYPE=Release include-what-you-use-src
         cmake --build iwyu-build --parallel 4
+    - name: set IWYU paths
+      id: build-iwyu
+      run: |
         echo "IWYU_SRC_DIR=${PWD}/include-what-you-use-src">> "$GITHUB_OUTPUT"
         echo "IWYU_BIN_DIR=${PWD}/iwyu-build/bin">> "$GITHUB_OUTPUT"
     - name: determine changed files

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -88,30 +88,132 @@ jobs:
         run: |
           echo "fail_fast=$([ "$GITHUB_REF_NAME" = "master" -o "$GITHUB_REPOSITORY_OWNER" != "CleverRaven" ] && echo false || echo true)" >> $GITHUB_OUTPUT
           echo "skip_tests=$([ "$GITHUB_REF_NAME" = "master" ] && echo true || echo false)" >> $GITHUB_OUTPUT
-          echo "max_parallel=$([ "$GITHUB_REF_NAME" = "master" -o "$GITHUB_REPOSITORY_OWNER" != "CleverRaven" ] && echo 20 || echo 1)" >> $GITHUB_OUTPUT
+          echo "max_parallel=$([ "$GITHUB_REF_NAME" = "master" -o "$GITHUB_REPOSITORY_OWNER" != "CleverRaven" ] && echo 20 || echo 3)" >> $GITHUB_OUTPUT
+
+  basic_build:
+    needs: [ skip-duplicates-data, matrix-variables ]
+    name: Basic Build and Test (Clang oldest supported, Ubuntu, Curses)
+    runs-on: ubuntu-22.04
+    env:
+        ZSTD_CLEVEL: 17
+        CMAKE: 0
+        COMPILER: clang++-13
+        OS: ubuntu-22.04
+        TILES: 0
+        SOUND: 0
+        LOCALIZE: 1
+        MODS: --mods=magiclysm
+        TEST_STAGE: 1
+        EXTRA_TEST_OPTS: --error-format=github-action
+        NATIVE: linux64
+        PCH: 1
+        RELEASE: 1
+        ARCHIVE_SUCCESS: basic-build
+        CCACHE_LIMIT: 4.5G
+        CCACHE_FILECLONE: true
+        CCACHE_HARDLINK: true
+        CCACHE_NOCOMPRESS: true
+        SKIP: ${{ needs.skip-duplicates-data.outputs.should_skip_data == 'true' }}
+        SKIP_TESTS: ${{ fromJSON(needs.matrix-variables.outputs.skip_tests) }}
+    steps:
+    - name: Maximize build space
+      uses: AdityaGarg8/remove-unwanted-software@8831c82abf29b34eb2caac48d5f999ecfc0d8eef # v4.1
+      with:
+        remove-android: true
+    - name: checkout repository
+      if: ${{ env.SKIP == 'false' }}
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        persist-credentials: false
+    - name: install dependencies
+      if: ${{ env.SKIP == 'false' }}
+      run: |
+          sudo apt-get update
+          sudo apt-get install libncursesw5-dev ccache gettext parallel
+          sudo locale-gen en_US.UTF-8 de_DE.UTF-8
+    - name: install recent ccache
+      if: ${{ env.SKIP == 'false' }}
+      run: |
+          ccache --version
+          sudo apt-get remove --purge -y ccache
+          curl -sL https://github.com/ccache/ccache/releases/download/v4.10.2/ccache-4.10.2-linux-x86_64.tar.xz | sudo tar Jxvf - --strip-components 1 -C /usr/bin ccache-4.10.2-linux-x86_64/ccache
+          ccache --version
+    - name: prepare
+      if: ${{ env.SKIP == 'false' }}
+      run: bash ./build-scripts/requirements.sh
+    - name: Get ccache vars
+      id: get-vars
+      if: ${{ env.SKIP == 'false' }}
+      run: |
+        echo "datetime=$(/bin/date -u "+%Y%m%d%H%M")" >> $GITHUB_OUTPUT
+        echo "datetime-seconds=$(/bin/date +%s)" >> $GITHUB_OUTPUT
+        echo "ccache-path=$HOME/.cache/ccache" >> $GITHUB_OUTPUT
+      shell: bash
+    - name: ccache cache files
+      if: ${{ env.SKIP == 'false' }}
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        path: ${{ steps.get-vars.outputs.ccache-path }}
+        key: ccache-${{ github.ref_name }}-linux-llvm-13--${{ steps.get-vars.outputs.datetime }}
+        restore-keys: |
+          ccache-master-linux-llvm-13--
+    - uses: ammaraskar/gcc-problem-matcher@0f9c86f9e693db67dacf53986e1674de5f2e5f28 # master
+    - name: Build CDDA
+      if: ${{ env.SKIP == 'false' }}
+      run: bash ./build-scripts/gha_compile_only.sh
+    - name: post-build ccache manipulation
+      if: ${{ env.SKIP == 'false' && !failure() }}
+      run: |
+        ccache --show-stats --verbose
+        NOW=`/bin/date +%s`
+        DELTA=$(( $NOW - ${{ steps.get-vars.outputs.datetime-seconds }} ))
+        ccache --evict-older-than ${DELTA}s
+        ccache --show-stats --verbose
+        ccache -M ${{ env.CCACHE_LIMIT }}
+        ccache -c
+        ccache --show-stats --verbose
+    - name: clear ccache on PRs
+      if: ${{ github.ref_name != 'master' && env.SKIP == 'false' && !failure() }}
+      run: |
+        ccache -C
+    - name: run tests
+      if: ${{ env.SKIP == 'false' && env.SKIP_TESTS == 'false' }}
+      run: bash ./build-scripts/gha_test_only.sh
+    - run: |
+        echo ${{ github.event.number }} > pull_request_id
+        echo "true" > basic-build
+      if: ${{ success() }}
+    - run: |
+        echo ${{ github.event.number }} > pull_request_id
+        echo "false" > basic-build
+      if: ${{ failure() }}
+    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      if: ${{ always() }}
+      with:
+        name: pull_request_id
+        path: pull_request_id
+    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      if: ${{ always() }}
+      with:
+        name: basic-build
+        path: basic-build
+    - name: upload artifacts if failed
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      if: failure()
+      with:
+        name: cata_test
+        path: tests/cata_test*
+        if-no-files-found: ignore
+        retention-days: 9
+
   varied_builds:
-    needs: [ skip-duplicates-code, skip-duplicates-data, matrix-variables ]
+    needs: [ basic_build, skip-duplicates-code, skip-duplicates-data, matrix-variables ]
+    if: ${{ github.event.pull_request.draft != true }}
     strategy:
       fail-fast: ${{ fromJSON(needs.matrix-variables.outputs.fail_fast) }}
       max-parallel: ${{ fromJSON(needs.matrix-variables.outputs.max_parallel) }}
       matrix:
         include:
-          - compiler: clang++-13
-            os: ubuntu-22.04
-            tiles: 0
-            sound: 0
-            cmake: 0
-            localize: 1
-            test-stage: 1
-            native: linux64
-            pch: 1
-            archive-success: basic-build
-            dont_skip_data_only_changes: 1
-            mods: --mods=magiclysm
-            title: Basic Build and Test (Clang oldest supported, Ubuntu, Curses)
-            ccache_limit: 4.5G
-            ccache_key: linux-llvm-13
-
           - compiler: clang++
             os: macos-15
             cmake: 0
@@ -211,16 +313,14 @@ jobs:
         LTO: ${{ matrix.lto }}
         LIBBACKTRACE: ${{ matrix.libbacktrace }}
         RELEASE: 1
-        ARCHIVE_SUCCESS: ${{ matrix.archive-success }}
         CCACHE_LIMIT: ${{ matrix.ccache_limit }}
         CCACHE_FILECLONE: true
         CCACHE_HARDLINK: true
         CCACHE_NOCOMPRESS: true
         SKIP: >-
           ${{
-          ( github.event.pull_request.draft == true && matrix.title != 'Basic Build and Test (Clang oldest supported, Ubuntu, Curses)' ) ||
-          ( matrix.dont_skip_data_only_changes == 0 && needs.skip-duplicates.outputs.should_skip_code == 'true' ) ||
-          ( matrix.dont_skip_data_only_changes != 0 && needs.skip-duplicates-mods.outputs.should_skip_data == 'true' )
+          ( matrix.dont_skip_data_only_changes == 0 && needs.skip-duplicates-code.outputs.should_skip_code == 'true' ) ||
+          ( matrix.dont_skip_data_only_changes != 0 && needs.skip-duplicates-data.outputs.should_skip_data == 'true' )
           }}
         SKIP_TESTS: ${{ fromJSON(needs.matrix-variables.outputs.skip_tests) || (matrix.android != '') }}
     steps:
@@ -324,24 +424,6 @@ jobs:
     - name: run tests
       if: ${{ env.SKIP == 'false' && env.SKIP_TESTS == 'false' }}
       run: bash ./build-scripts/gha_test_only.sh
-    - run: |
-        echo ${{ github.event.number }} > pull_request_id
-        echo "true" > ${{ env.ARCHIVE_SUCCESS }}
-      if: ${{ env.ARCHIVE_SUCCESS && success() }}
-    - run: |
-        echo ${{ github.event.number }} > pull_request_id
-        echo "false" > ${{ env.ARCHIVE_SUCCESS }}
-      if: ${{ env.ARCHIVE_SUCCESS && failure() }}
-    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-      if: ${{ always() && env.ARCHIVE_SUCCESS }}
-      with:
-        name: pull_request_id
-        path: pull_request_id
-    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-      if: ${{ always() && env.ARCHIVE_SUCCESS }}
-      with:
-        name: ${{ env.ARCHIVE_SUCCESS }}
-        path: ${{ env.ARCHIVE_SUCCESS }}
     - name: upload artifacts if failed
       uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       if: failure()

--- a/.github/workflows/test_labeler.yml
+++ b/.github/workflows/test_labeler.yml
@@ -7,7 +7,9 @@ on:
 
 jobs:
   labeling:
-    if: github.repository == 'CleverRaven/Cataclysm-DDA'
+    if: >-
+      github.repository == 'CleverRaven/Cataclysm-DDA' &&
+      github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
     steps:
     - name: setLabel

--- a/build-scripts/clang-tidy-run.sh
+++ b/build-scripts/clang-tidy-run.sh
@@ -5,7 +5,7 @@
 echo "Using bash version $BASH_VERSION"
 set -exo pipefail
 
-num_jobs=3
+num_jobs=4
 
 # enable all the switches by default
 BACKTRACE=${BACKTRACE:-1}
@@ -122,7 +122,7 @@ function analyze_files_in_random_order
     if [ -n "$1" ]
     then
         echo "$1" | shuf | \
-            xargs -P "$num_jobs" -n 1 ./build-scripts/clang-tidy-wrapper.sh -quiet
+            xargs -P "$num_jobs" -n 1 ./build-scripts/clang-tidy-wrapper.sh -quiet -p .
     else
         echo "No files to analyze"
     fi

--- a/build-scripts/clang-tidy-wrapper.sh
+++ b/build-scripts/clang-tidy-wrapper.sh
@@ -5,11 +5,24 @@ set -o pipefail
 
 plugin=build/tools/clang-tidy-plugin/libCataAnalyzerPlugin.so
 
+profile_args=""
+if [ "${CATA_CLANG_TIDY_PROFILE:-}" = "1" ]; then
+    profile_args="--enable-check-profile --store-check-profile=clang-tidy-trace"
+fi
+
 if [ -f "$plugin" ]
 then
     set -x
-    LD_PRELOAD=$plugin ${CATA_CLANG_TIDY} --enable-check-profile --store-check-profile=clang-tidy-trace "$@"
+    if command -v clang-tidy-cache >/dev/null 2>&1; then
+        LD_PRELOAD=$plugin clang-tidy-cache "${CATA_CLANG_TIDY}" $profile_args "$@"
+    else
+        LD_PRELOAD=$plugin "${CATA_CLANG_TIDY}" $profile_args "$@"
+    fi
 else
     set -x
-    ${CATA_CLANG_TIDY} "$@"
+    if command -v clang-tidy-cache >/dev/null 2>&1; then
+        clang-tidy-cache "${CATA_CLANG_TIDY}" "$@"
+    else
+        "${CATA_CLANG_TIDY}" "$@"
+    fi
 fi

--- a/tools/clang-tidy-plugin/TextStyleCheck.cpp
+++ b/tools/clang-tidy-plugin/TextStyleCheck.cpp
@@ -87,7 +87,7 @@ void TextStyleCheck::check( const MatchFinder::MatchResult &Result )
             return;
         }
         if( StringRef( SrcMgr.getPresumedLoc( SrcMgr.getSpellingLoc(
-                loc ) ).getFilename() ).equals( "<scratch space>" ) ) {
+                loc ) ).getFilename() ).equals_insensitive( "<scratch space>" ) ) {
             return;
         }
     }


### PR DESCRIPTION
#### Summary
Infrastructure "Cache clang-tidy results with ctcache, conditional profiling, bump parallelism"

#### Purpose of change

Each clang-tidy invocation re-parses the full AST from scratch. On PR re-pushes, indirectly-changed files (often the bulk of the workload) get re-checked despite identical preprocessed content. This wastes CI minutes and slows down feedback loops.

The `--enable-check-profile` flag adds overhead on every PR run even though profile data is only reviewed on master pushes. And `num_jobs=3` underutilizes the 4-vCPU runner.

The `RedundantParenthesesCheck` matcher is structured inefficiently, matching from the child expression upward. Restructuring it to match at the `parenExpr` level gives about a 15% speed improvement on this check.

The `TextStyleCheck` scratch space filename comparison breaks on clang/LLVM 19+ where the casing changed.

#### Describe the solution

- Install [ctcache](https://github.com/matus-chochlik/ctcache) in the `run-clang-tidy` job. ctcache wraps clang-tidy and caches successful results keyed on a hash of command args + preprocessed source, skipping redundant re-analysis. A persistent `actions/cache` step stores the ctcache directory across runs, with per-subset keys that invalidate when the plugin source or `.clang-tidy` config changes, and fall back to the master branch cache for warm starts on new PRs.
- Move `--enable-check-profile` behind a `CATA_CLANG_TIDY_PROFILE` env var that is only set on push-to-master.
- Bump `num_jobs` from 3 to 4 to match the runner vCPU count. With ctcache hits being instant (no AST in memory), 4 parallel processes are safe.
- Restructure `RedundantParenthesesCheck` matcher to bind `paren_expr` at the `parenExpr` level instead of matching from the child up, and use `isMacroID()` instead of comparing expansion locations (~15% faster).
- Fix `TextStyleCheck` scratch space filename comparison to be case-insensitive for LLVM 19+ compatibility.

#### Describe alternatives you've considered

Ignoring the 1-2 hour clang-tidy runs and hoping they go away on their own.

#### Testing

- Push branch, open PR, verify `run-clang-tidy` jobs install ctcache and restore/save cache.
- First run: all cache misses (cold cache), behavior identical to before.
- Re-push: indirectly-changed files should cache-hit (visible in timing reduction).
- Verify profiling runs only on master pushes, not on PRs.
- WarningsAsErrors still fails the job when clang-tidy finds violations.

#### Additional context

The wrapper script falls back to direct clang-tidy invocation when `clang-tidy-cache` is not on PATH, so local development is unaffected.