### PR TITLE
Polymorph State Transfer

### DIFF
--- a/data/json/monsters/misc.json
+++ b/data/json/monsters/misc.json
@@ -259,14 +259,14 @@
     "harvest": "exempt",
     "special_attacks": [
       {
-    "type": "monster_attack",
-    "id": "debug_self_poly",
-    "attack_type": "polymorph_special",
-   "cooldown": 50,
-    "mon_id": "mon_fungaloid",
-   "poly_keep_speed": true,
-    "poly_keep_hp": true,
-    "poly_keep_anger": true
+        "type": "monster_attack",
+        "id": "debug_self_poly",
+        "attack_type": "polymorph_special",
+        "cooldown": 50,
+        "mon_id": "mon_fungaloid",
+        "poly_keep_speed": true,
+        "poly_keep_hp": true,
+        "poly_keep_anger": true
       }
     ],
     "death_function": { "message": "The %s disintegrates!", "corpse_type": "NO_CORPSE" },

--- a/data/json/monsters/misc.json
+++ b/data/json/monsters/misc.json
@@ -236,6 +236,44 @@
     "flags": [ "SEES" ]
   },
   {
+    "id": "mon_poly_special_test",
+    "type": "MONSTER",
+    "name": { "str": "ancient red dragon" },
+    "description": "A towering, hulking dragon, with tremendous, curving horns and shining red scales, its glowing maw peeled back in a hateful grimace as its eyes bore into yours.",
+    "bodytype": "dog",
+    "//": "Zombie faction so they don't attack a clear prop",
+    "default_faction": "zombie",
+    "diff": 50,
+    "volume": "875000 ml",
+    "weight": "4535 g",
+    "hp": 1,
+    "material": [ "paper" ],
+    "symbol": "D",
+    "color": "red",
+    "luminance": 8,
+    "aggression": 100,
+    "morale": 100,
+    "//2": "ahh! it sees you!",
+    "vision_day": 50,
+    "vision_night": 50,
+    "harvest": "exempt",
+    "special_attacks": [
+      {
+    "type": "monster_attack",
+    "id": "debug_self_poly",
+    "attack_type": "polymorph_special",
+   "cooldown": 50,
+    "mon_id": "mon_fungaloid",
+   "poly_keep_speed": true,
+    "poly_keep_hp": true,
+    "poly_keep_anger": true
+      }
+    ],
+    "death_function": { "message": "The %s disintegrates!", "corpse_type": "NO_CORPSE" },
+    "death_drops": "mon_dragon_dummy_drops",
+    "flags": [ "SEES" ]
+  },
+  {
     "id": "mon_generator",
     "type": "MONSTER",
     "name": { "str": "generator" },

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -1449,3 +1449,40 @@ bool gun_actor::shoot( monster &z, const tripoint_bub_ms &target, const gun_mode
     }
     return true;
 }
+
+void polymorph_special::load_internal( const JsonObject &jo, const std::string &/*src*/ )
+{
+    // required
+    mon_id = mtype_id( jo.get_string( "mon_id" ) );
+
+    // optional, default true
+    optional( jo, was_loaded, "poly_keep_speed", keep_speed, true );
+    optional( jo, was_loaded, "poly_keep_hp", keep_hp, true );
+    optional( jo, was_loaded, "poly_keep_anger", keep_anger, true );
+}
+
+bool polymorph_special::call( monster &z ) const
+{
+    const int old_speed = z.get_speed_base();
+    const int old_hp = z.get_hp();
+    const int old_anger = z.anger;
+
+    z.poly( mon_id );
+
+    if( keep_speed ) {
+        z.set_speed_base( old_speed );
+    }
+    if( keep_hp ) {
+        z.set_hp( old_hp );
+    }
+    if( keep_anger ) {
+        z.anger = old_anger;
+    }
+
+    return true;
+}
+
+std::unique_ptr<mattack_actor> polymorph_special::clone() const
+{
+    return std::make_unique<polymorph_special>( *this );
+}

--- a/src/mattack_actors.h
+++ b/src/mattack_actors.h
@@ -301,4 +301,20 @@ class gun_actor : public mattack_actor
         std::unique_ptr<mattack_actor> clone() const override;
 };
 
+class polymorph_special : public mattack_actor
+{
+    public:
+        mtype_id mon_id;
+        bool keep_speed = true;
+        bool keep_hp = true;
+        bool keep_anger = true;
+
+        polymorph_special() = default;
+        ~polymorph_special() override = default;
+
+        void load_internal( const JsonObject &jo, const std::string &src ) override;
+        bool call( monster & ) const override;
+        std::unique_ptr<mattack_actor> clone() const override;
+};
+
 #endif // CATA_SRC_MATTACK_ACTORS_H

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -2024,22 +2024,6 @@ static void poly_keep_speed( monster &mon, const mtype_id &id )
     mon.set_speed_base( old_speed );
 }
 
-static void poly_keep_hp( monster &mon, const mtype_id &id )
-{
-    // Retain old HP after polymorph
-    const int old_hp = mon.get_hp();
-    mon.poly( id );
-    mon.set_hp( old_hp );
-}
-
-static void poly_keep_anger( monster &mon, const mtype_id &id )
-{
-    // Retain old anger after polymorph
-    const int old_anger = mon.anger;
-    mon.poly( id );
-    mon.anger = old_anger;
-}
-
 static bool blobify( monster &blob, monster &target )
 {
     //~ %1$s and %2$s - monster names

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -2024,6 +2024,22 @@ static void poly_keep_speed( monster &mon, const mtype_id &id )
     mon.set_speed_base( old_speed );
 }
 
+static void poly_keep_hp( monster &mon, const mtype_id &id )
+{
+    // Retain old HP after polymorph
+    const int old_hp = mon.get_hp();
+    mon.poly( id );
+    mon.set_hp( old_hp );
+}
+
+static void poly_keep_anger( monster &mon, const mtype_id &id )
+{
+    // Retain old anger after polymorph
+    const int old_anger = mon.anger;
+    mon.poly( id );
+    mon.anger = old_anger;
+}
+
 static bool blobify( monster &blob, monster &target )
 {
     //~ %1$s and %2$s - monster names

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -1327,6 +1327,8 @@ mtype_special_attack MonsterGenerator::create_actor( const JsonObject &obj,
         new_attack = std::make_unique<gun_actor>();
     } else if( attack_type == "spell" ) {
         new_attack = std::make_unique<mon_spellcasting_actor>();
+    } else if( attack_type == "polymorph_special" ) {
+        new_attack = std::make_unique<polymorph_special>();
     } else if( attack_type == "eoc" ) {
         new_attack = std::make_unique<mon_eoc_actor>();
     } else if( attack_type == "invalid" ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
@Standing-Storm and I were talking about the problems with polymorph and I was thinking it should be an easy fix.  It was less easy than my first thoughts but after some wrong turns I was able to figure it out.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Makes a polymorph monster attack that can track current hp, current aggro, in the same way that the slime polymorph tracks current speed remaining so as to not invent time for slimes to spread.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I will probably add some monsters that use this but wanted to get this reviewed for any problems before I devote too much time to it.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I created a debug monster and spawned three in, shot one while the other two polymorphed themselves with full hp the third polymorphed itself and carried over damage from original form.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
