### PR TITLE
Prevent integer overflow in uncraft test

### DIFF
--- a/tests/item_test.cpp
+++ b/tests/item_test.cpp
@@ -1141,9 +1141,8 @@ TEST_CASE( "uncraft_sanity_check", "[item]" )
         }
 
         const units::mass item_weight = target.type->weight;
-
-        const int weight_difference = std::abs( to_milligram( sum_of_components_weight - item_weight ) );
-        const int weight_tolerance = to_milligram( tolerance * item_weight );
+        const units::mass weight_difference = units::fabs( sum_of_components_weight - item_weight );
+        const units::mass weight_tolerance = tolerance * item_weight;
         const bool is_within_tolerance = weight_difference <= weight_tolerance;
 
         if( !is_within_tolerance ) {
@@ -1183,8 +1182,8 @@ TEST_CASE( "uncraft_blacklist_is_pruned", "[item]" )
             sum_of_components_weight += c.type->weight * c.count;
         }
 
-        const int weight_difference = std::abs( to_milligram( sum_of_components_weight - item_weight ) );
-        const int weight_tolerance = to_milligram( tolerance * item_weight );
+        const units::mass weight_difference = units::fabs( sum_of_components_weight - item_weight );
+        const units::mass weight_tolerance = tolerance * item_weight;
         const bool is_within_tolerance = weight_difference <= weight_tolerance;
 
         if( is_within_tolerance ) {


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
#85283 made rollers weight 3200 kg, which apparently resulted in integer overflow and abs() returning negative value (3200000000 mg do not fit into 2147483647 int size limit), showing that item should be removed from bad uncraft list (it should not, it is 3200 kg item that drops 200 kg of steel)
#### Describe the solution
make it units::mass and let it decide what type to use, in case of mass its int64_t
#### Describe alternatives you've considered
use unsigned int - will work for this item, will break again once someone add 4300 kg item
use long long instead, now it can fit 9223372036854775807 mg - was an initial approach, but then i found that there is units::fabs() that is `abs()` specifically for units, and decided it to be a better approach overall
#### Testing
Remoted to 85283, run a test with adjusted code, got no message that drum should be removed
#### Additional context