### PR TITLE
fix auto-move abort on grabbed vehicle collision

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7168,6 +7168,11 @@ action_id Character::get_next_auto_move_direction()
         // they will cancel the auto-move on the next cycle (as the distance increases).
         if( std::max( { diff.x(), diff.y(), diff.z()} ) > 1 ) {
             // We're off course, possibly stumbling or stuck, cancel auto move
+            add_msg_debug( debugmode::DF_ACTIVITY,
+                           "auto_move: OFF COURSE pos=(%d,%d) expected=(%d,%d) diff=(%d,%d,%d) route_left=%zu",
+                           pos_bub().x(), pos_bub().y(),
+                           next_expected_position->x(), next_expected_position->y(),
+                           diff.x(), diff.y(), diff.z(), auto_move_route.size() );
             return ACTION_NULL;
         }
     }
@@ -7176,6 +7181,12 @@ action_id Character::get_next_auto_move_direction()
     auto_move_route.erase( auto_move_route.begin() );
 
     tripoint_rel_ms dp = *next_expected_position - pos_bub();
+
+    add_msg_debug( debugmode::DF_ACTIVITY,
+                   "auto_move: step dp=(%d,%d) pos=(%d,%d) target=(%d,%d) route_left=%zu",
+                   dp.x(), dp.y(), pos_bub().x(), pos_bub().y(),
+                   next_expected_position->x(), next_expected_position->y(),
+                   auto_move_route.size() );
 
     return get_movement_action_from_delta( dp, iso_rotate::yes );
 }

--- a/src/grab.cpp
+++ b/src/grab.cpp
@@ -175,6 +175,10 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
         pushing = true;
     } else if( std::abs( dp.x() + dp_veh.x() ) != 2 && std::abs( dp.y() + dp_veh.y() ) != 2 ) {
         // Not actually moving the vehicle, don't do the checks
+        add_msg_debug( debugmode::DF_ACTIVITY,
+                       "grabbed_veh_move: SIDEWAYS dp=(%d,%d) grab=(%d,%d)->(%d,%d)",
+                       dp.x(), dp.y(), prev_grab.x(), prev_grab.y(),
+                       -( dp.x() + dp_veh.x() ), -( dp.y() + dp_veh.y() ) );
         u.grab_point = - ( dp + dp_veh );
         return false;
     } else if( ( dp.x() == prev_grab.x() || dp.y() == prev_grab.y() ) &&
@@ -191,6 +195,12 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
         next_grab = - dp;
         pulling = true;
     }
+
+    add_msg_debug( debugmode::DF_ACTIVITY,
+                   "grabbed_veh_move: %s dp=(%d,%d) grab=(%d,%d) dp_veh=(%d,%d) next_grab=(%d,%d)",
+                   pushing ? "PUSH" : pulling ? "PULL" : zigzag ? "ZIGZAG" : "???",
+                   dp.x(), dp.y(), prev_grab.x(), prev_grab.y(),
+                   dp_veh.x(), dp_veh.y(), next_grab.x(), next_grab.y() );
 
     // Make sure the mass and pivot point are correct
     grabbed_vehicle->invalidate_mass();
@@ -291,6 +301,9 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
         if( !bad_veh_angle ) {
             add_msg( m_bad, _( "You lack the strength to move the %s." ), grabbed_vehicle->name );
         }
+        add_msg_debug( debugmode::DF_ACTIVITY,
+                       "grabbed_veh_move: STR FAIL str_req=%d str=%d angle=%d",
+                       str_req, str, bad_veh_angle ? 1 : 0 );
         u.mod_moves( -to_moves<int>( 1_seconds ) );
         return true;
     }
@@ -391,6 +404,9 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
 
     if( final_dp_veh == tripoint_rel_ms::invalid ) {
         add_msg( _( "The %s collides with %s." ), grabbed_vehicle->name, blocker_name );
+        add_msg_debug( debugmode::DF_ACTIVITY,
+                       "grabbed_veh_move: COLLISION with '%s' dp_veh=(%d,%d)",
+                       blocker_name, dp_veh.x(), dp_veh.y() );
         u.grab_point = prev_grab;
         grabbed_vehicle->face = initial_veh_face;
         return true;
@@ -400,6 +416,10 @@ bool game::grabbed_veh_move( const tripoint_rel_ms &dp )
     if( u.grab_point != tripoint_rel_ms::zero ) {
         u.grab_point = next_grab;
     }
+
+    add_msg_debug( debugmode::DF_ACTIVITY,
+                   "grabbed_veh_move: SUCCESS displacing veh by (%d,%d) new_grab=(%d,%d)",
+                   final_dp_veh.x(), final_dp_veh.y(), next_grab.x(), next_grab.y() );
 
     here.displace_vehicle( *grabbed_vehicle, final_dp_veh );
     here.rebuild_vehicle_level_caches();


### PR DESCRIPTION
#### Summary
Bugfixes "Fix auto-move silently eating activities on grabbed vehicle collision"

#### Purpose of change

When auto-moving while dragging a vehicle, `move()` can return true ("handled") even though the player didn't actually move (e.g. the grabbed vehicle collided with something). Auto-move treated this as success and kept going, eventually silently aborting the routing activity with no feedback to the player.

Split out from #85251 (1/4).

#### Describe the solution

After `move()` returns true, check if the player's position actually changed. If it didn't and the destination tile's terrain/furniture didn't change either (ruling out door-opening), abort auto-move.

Also adds debug logging to `grabbed_veh_move()` and `get_next_auto_move_direction()` for diagnosing movement failures.

#### Describe alternatives you've considered

Could check the return value of `grabbed_veh_move()` specifically, but the position-based check is more general and catches future similar cases without playing whack-a-mole.

#### Testing

Manual: drag a shopping cart into a wall during auto-move, observe the abort message instead of silent activity loss.

#### Additional context

The remaining 3 PRs in this stack build on this fix.