### PR TITLE
Rebuild anatomy after clearing mutations in test helper

### DIFF
--- a/tests/player_helpers.cpp
+++ b/tests/player_helpers.cpp
@@ -90,6 +90,9 @@ void clear_character( Character &dummy, bool skip_nutrition )
     dummy.inv->clear();
     dummy.remove_weapon();
     dummy.clear_mutations();
+    // clear_mutations() removes traits but does not rebuild bodypart topology.
+    // Rebuild anatomy now so tests see baseline human limbs (e.g. feet, not talons).
+    dummy.set_body();
     dummy.mutation_category_level.clear();
     dummy.clear_bionics();
 


### PR DESCRIPTION
#### Summary
Bugfixes "Fix modded test failures in creature_test anatomy checks"

#### Purpose of change

`clear_character()` calls `clear_mutations()` but never rebuilds bodypart topology. When a mod alters anatomy (Magiclysm granting talons), the stale limbs persist and creature_test's hit-distribution checks fail - feet get 0 hits because the character still has talons.

Currently breaking CI on every PR when run with `--mods=magiclysm`.

#### Describe the solution

Call `set_body()` after `clear_mutations()` in `clear_character()` to restore baseline human anatomy.

#### Describe alternatives you've considered

Fixing it per-test instead of in the shared helper, but that's just asking for the same bug in every future test.

#### Testing

`tests/cata_test --mods=magiclysm --order lex "[anatomy]"` - fails before, passes after.

#### Additional context

Surfaced by #85272 changing default test order to lex.