### PR TITLE
Remove dangling TAIL_THICK_BASH_CRIT_VS_LARGE technique reference

### DIFF
--- a/data/json/mutations/limbs_body_parts.json
+++ b/data/json/mutations/limbs_body_parts.json
@@ -488,7 +488,7 @@
     "base_hp": 35,
     "health_limit": 10,
     "similar_bodypart": "tail",
-    "techniques": [ "TAIL_THICK_BASH", "TAIL_THICK_BASH_NATURAL", "TAIL_THICK_BASH_CRIT_VS_LARGE", "TAIL_THICK_BASH_CRIT_VS_STUMBLE" ],
+    "techniques": [ "TAIL_THICK_BASH", "TAIL_THICK_BASH_NATURAL", "TAIL_THICK_BASH_CRIT_VS_STUMBLE" ],
     "technique_encumbrance_limit": 5,
     "effects_on_hit": [
       {

--- a/src/character_modifier.cpp
+++ b/src/character_modifier.cpp
@@ -180,8 +180,11 @@ float Character::manipulator_score( const std::map<bodypart_str_id, bodypart> &b
                 }
             }
         } else if( id.first->primary_limb_type() != bp_type::num_types ) {
-            bodypart_groups[ id.first->primary_limb_type() ].emplace_back( id.second,
-                    id.first->limbtypes.at( id.first->primary_limb_type() ) );
+            const bp_type primary_type = id.first->primary_limb_type();
+            const auto primary_limb = id.first->limbtypes.find( primary_type );
+            if( primary_limb != id.first->limbtypes.end() ) {
+                bodypart_groups[ primary_type ].emplace_back( id.second, primary_limb->second );
+            }
         }
     }
     for( auto &part : bodypart_groups ) {

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -615,6 +615,7 @@ TEST_CASE( "npc_uses_guns", "[npc_ai]" )
     hostile.inv->clear();
     hostile.remove_weapon();
     hostile.clear_mutations();
+    hostile.set_body();
     hostile.mutation_category_level.clear();
     hostile.clear_bionics();
     REQUIRE( rl_dist( player_character.pos_bub(), hostile.pos_bub() ) >= 4 );
@@ -655,6 +656,7 @@ TEST_CASE( "npc_prefers_guns", "[npc_ai]" )
     hostile.inv->clear();
     hostile.remove_weapon();
     hostile.clear_mutations();
+    hostile.set_body();
     hostile.mutation_category_level.clear();
     hostile.clear_bionics();
     REQUIRE( rl_dist( player_character.pos_bub(), hostile.pos_bub() ) >= 4 );

--- a/tests/player_helpers.cpp
+++ b/tests/player_helpers.cpp
@@ -90,6 +90,9 @@ void clear_character( Character &dummy, bool skip_nutrition )
     dummy.inv->clear();
     dummy.remove_weapon();
     dummy.clear_mutations();
+    // clear_mutations() removes traits but does not rebuild bodypart topology.
+    // Rebuild anatomy now so tests see baseline human limbs (e.g. feet, not talons).
+    dummy.set_body();
     dummy.mutation_category_level.clear();
     dummy.clear_bionics();
 


### PR DESCRIPTION
#### Summary
Bugfixes "Remove dangling technique reference on thick tail body part"

#### Purpose of change

#85269 deleted the `TAIL_THICK_BASH_CRIT_VS_LARGE` technique definition from `mutation_techs.json` but left the reference in the thick tail body part in `limbs_body_parts.json`. When an NPC randomly rolls a thick tail mutation, `pick_technique()` tries to dereference the missing ID and crashes.

#### Describe the solution

Remove the dangling ID from the body part's techniques list.

#### Describe alternatives you've considered

Re-adding the technique definition, but it was intentionally removed.

#### Testing

Reproduced with `tests/cata_test --mods=magiclysm "EOC_attack_test"` (needs RNG that gives the thug a thick tail). Error message: `invalid martial art technique id "TAIL_THICK_BASH_CRIT_VS_LARGE"`.

#### Additional context

One of two CI-breaking issues surfaced by #85272 changing default test order to lex.