### PR TITLE
Add actual weariness to life-or-death combat

### DIFF
--- a/data/json/ui/activity.json
+++ b/data/json/ui/activity.json
@@ -40,6 +40,12 @@
         "text": { "str": "Extreme", "ctxt": "activity description" },
         "color": "red",
         "condition": { "math": [ "u_val('activity_level') == 5" ] }
+      },
+      {
+        "id": "combat",
+        "text": { "str": "Combat", "ctxt": "activity description" },
+        "color": "red",
+        "condition": { "math": [ "u_val('activity_level') == 500" ] }
       }
     ]
   },

--- a/data/json/ui/sidebar-mobile.json
+++ b/data/json/ui/sidebar-mobile.json
@@ -1921,7 +1921,13 @@
         "id": "extreme",
         "text": "Extreme    ",
         "color": "red",
-        "condition": { "math": [ "u_val('activity_level') >= 5" ] }
+        "condition": { "math": [ "u_val('activity_level') == 5" ] }
+      },
+      {
+        "id": "extreme",
+        "text": "Combat     ",
+        "color": "red",
+        "condition": { "math": [ "u_val('activity_level') > 5" ] }
       }
     ],
     "type": "widget"

--- a/data/json/ui/zenfs/activity.json
+++ b/data/json/ui/zenfs/activity.json
@@ -42,6 +42,12 @@
         "text": { "str": "Extreme", "ctxt": "activity description" },
         "color": "red",
         "condition": { "math": [ "u_val('activity_level') == 5" ] }
+      },
+      {
+        "id": "extreme",
+        "text": { "str": "Combat", "ctxt": "activity description" },
+        "color": "red",
+        "condition": { "math": [ "u_val('activity_level') == 500" ] }
       }
     ]
   },

--- a/doc/JSON/NPCs.md
+++ b/doc/JSON/NPCs.md
@@ -1441,7 +1441,7 @@ These can be read or written to with `val()`.
 
 | Value | Supports assignment | Description |
 --- | --- | --- |
-| `activity_level` | ❌ | Current activity level index as a floored integer, from 0-5. Roughly: <pre>0.45 = SLEEP_EXERCISE (floored and returns 0),<br/>0.5 = NO_EXERCISE(floored and returns 0),<br/>1 = LIGHT_EXERCISE,<br/>2 = MODERATE_EXERCISE,<br/>3 = BRISK_EXERCISE,<br/>4 = ACTIVE_EXERCISE,<br/>5 = EXTRA_EXERCISE. |
+| `activity_level` | ❌ | Current activity level index as a floored integer, from 0-5. Roughly: <pre>0.45 = SLEEP_EXERCISE (floored and returns 0),<br/>0.5 = NO_EXERCISE(floored and returns 0),<br/>1 = LIGHT_EXERCISE,<br/>2 = MODERATE_EXERCISE,<br/>3 = BRISK_EXERCISE,<br/>4 = ACTIVE_EXERCISE,<br/>5 = EXTRA_EXERCISE, <br/>500 = COMBAT_EXERCISE. |
 | `age` | ✅ | Current age in years. |
 | `allies` | ❌ | The avatar's number of allies |
 | `anger` | ✅ | Current anger level. Only works for monsters. |

--- a/doc/PLAYER_ACTIVITY.md
+++ b/doc/PLAYER_ACTIVITY.md
@@ -50,7 +50,7 @@ query to stop the activity, and strings that describe it, for example:
 `"verb": "mining"` or
 `"verb": { "ctxt": "instrument", "str": "playing" }`.
 
-* activity_level: Activity level of the activity, harder activities consume more calories over time. Valid values are, from easiest to most demanding of the body: `NO_EXERCISE`, `LIGHT_EXERCISE`, `MODERATE_EXERCISE`, `BRISK_EXERCISE`, `ACTIVE_EXERCISE`, `EXTRA_EXERCISE`.
+* activity_level: Activity level of the activity, harder activities consume more calories over time. Valid values are, from easiest to most demanding of the body: `NO_EXERCISE`, `LIGHT_EXERCISE`, `MODERATE_EXERCISE`, `BRISK_EXERCISE`, `ACTIVE_EXERCISE`, `EXTRA_EXERCISE`, `COMBAT_EXERCISE`.
 
 * interruptable (true): Can this be interrupted.  If false, then popups related
 to e.g. pain or seeing monsters will be suppressed.

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1859,7 +1859,7 @@ void Character::on_try_dodge()
         const float dodge_skill_modifier = ( 20.0f - get_skill_level( skill_dodge ) ) / 20.0f;
         burn_energy_legs( - std::floor( static_cast<float>( base_burn_rate ) * 6.0f *
                                         dodge_skill_modifier ) );
-        set_activity_level( EXTRA_EXERCISE );
+        set_activity_level( COMBAT_EXERCISE );
     }
 }
 
@@ -3414,8 +3414,9 @@ float Character::instantaneous_activity_level() const
 
 int Character::activity_level_index() const
 {
-    // Activity levels are 1, 2, 4, 6, 8, 10
-    // So we can easily cut them in half and round down for an index
+    // Activity levels are 1, 2, 4, 6, 8, 10, 1000
+    // So we can (mostly) easily cut them in half and round down for an index
+    // ...This function is only called for EOCs, maybe we should just return the activity level directly instead of this.
     return std::floor( instantaneous_activity_level() / 2 );
 }
 

--- a/src/character_health.cpp
+++ b/src/character_health.cpp
@@ -1385,16 +1385,18 @@ float Character::maximum_exertion_level() const
 {
     switch( weariness_level() ) {
         case 0:
-            return EXTRA_EXERCISE;
+            return COMBAT_EXERCISE;
         case 1:
-            return ACTIVE_EXERCISE;
+            return EXTRA_EXERCISE;
         case 2:
-            return BRISK_EXERCISE;
+            return ACTIVE_EXERCISE;
         case 3:
-            return MODERATE_EXERCISE;
+            return BRISK_EXERCISE;
         case 4:
-            return LIGHT_EXERCISE;
+            return MODERATE_EXERCISE;
         case 5:
+            return LIGHT_EXERCISE;
+        case 6:
         default:
             return NO_EXERCISE;
     }

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -587,19 +587,27 @@ std::pair<std::string, nc_color> display::weary_malus_text_color( const Characte
 
 std::string display::activity_level_str( float level )
 {
-    static const std::array<translation, 6> activity_descriptions { {
-            to_translation( "activity description", "None" ),
-            to_translation( "activity description", "Light" ),
-            to_translation( "activity description", "Moderate" ),
-            to_translation( "activity description", "Brisk" ),
-            to_translation( "activity description", "Active" ),
-            to_translation( "activity description", "Extreme" ),
-        } };
-    // Activity levels are 1, 2, 4, 6, 8, 10
-    // So we can easily cut them in half and round down for an index
-    int idx = std::floor( level / 2 );
+    // This is either dead code, or we have two activity widgets.
+    // You're probably looking for data/json/ui/activity.json
+    static const std::map<float, translation> activity_descriptions_map {
+        { SLEEP_EXERCISE, to_translation( "activity description", "None" ), },
+        { NO_EXERCISE, to_translation( "activity description", "None" ), },
+        { LIGHT_EXERCISE, to_translation( "activity description", "Light" ), },
+        { MODERATE_EXERCISE, to_translation( "activity description", "Moderate" ), },
+        { BRISK_EXERCISE, to_translation( "activity description", "Brisk" ), },
+        { ACTIVE_EXERCISE, to_translation( "activity description", "Active" ), },
+        { EXTRA_EXERCISE, to_translation( "activity description", "Extreme" ), },
+        { COMBAT_EXERCISE, to_translation( "activity description", "Combat" ), }
+    };
 
-    return activity_descriptions[idx].translated();
+    std::string retval = activity_descriptions_map.begin()->second.translated();
+
+    for( const std::pair<const float, translation> &pair : activity_descriptions_map ) {
+        if( level >= pair.first ) {
+            retval = pair.second.translated();
+        }
+    }
+    return retval;
 }
 
 std::string display::activity_malus_str( const Character &u )

--- a/src/game_constants.h
+++ b/src/game_constants.h
@@ -145,6 +145,7 @@ constexpr float MODERATE_EXERCISE = 4.0f;
 constexpr float BRISK_EXERCISE = 6.0f;
 constexpr float ACTIVE_EXERCISE = 8.0f;
 constexpr float EXTRA_EXERCISE = 10.0f;
+constexpr float COMBAT_EXERCISE = 1000.0f;
 
 const std::map<std::string, float> activity_levels_map = {
     { "SLEEP_EXERCISE", SLEEP_EXERCISE },
@@ -153,7 +154,8 @@ const std::map<std::string, float> activity_levels_map = {
     { "MODERATE_EXERCISE", MODERATE_EXERCISE },
     { "BRISK_EXERCISE", BRISK_EXERCISE },
     { "ACTIVE_EXERCISE", ACTIVE_EXERCISE },
-    { "EXTRA_EXERCISE", EXTRA_EXERCISE }
+    { "EXTRA_EXERCISE", EXTRA_EXERCISE },
+    { "COMBAT_EXERCISE", COMBAT_EXERCISE }
 };
 
 const std::map<float, std::string> activity_levels_str_map = {
@@ -163,7 +165,8 @@ const std::map<float, std::string> activity_levels_str_map = {
     { MODERATE_EXERCISE, "MODERATE_EXERCISE" },
     { BRISK_EXERCISE, "BRISK_EXERCISE" },
     { ACTIVE_EXERCISE, "ACTIVE_EXERCISE" },
-    { EXTRA_EXERCISE, "EXTRA_EXERCISE" }
+    { EXTRA_EXERCISE, "EXTRA_EXERCISE" },
+    { COMBAT_EXERCISE, "COMBAT_EXERCISE" }
 };
 
 // these are the lower bounds of each of the weight classes, determined by the amount of BMI coming from stored calories (fat)

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -648,7 +648,7 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
     }
 
     // Fighting is hard work
-    set_activity_level( EXTRA_EXERCISE );
+    set_activity_level( COMBAT_EXERCISE );
 
     item_location cur_weapon = allow_unarmed ? used_weapon() : get_wielded_item();
     item cur_weap = cur_weapon ? *cur_weapon : null_item_reference();
@@ -975,6 +975,8 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
     burn_energy_arms( std::min( -50, total_stam + deft_bonus ) );
     add_msg_debug( debugmode::DF_MELEE, "Stamina burn base/total (capped at -50): %d/%d", base_stam,
                    total_stam + deft_bonus );
+    // Our COMBAT_EXERCISE is orders of magnitude higher than EXTRA_EXERCISE. Passing it here will result in *absurd* values.
+    // We must pass in EXTRA_EXERCISE at most.
     // Weariness handling - 1 / the value, because it returns what % of the normal speed
     const float weary_mult = exertion_adjusted_move_multiplier( EXTRA_EXERCISE );
     mod_moves( forced_movecost >= 0 ? -forced_movecost : -move_cost * ( 1 / weary_mult ) );
@@ -1033,7 +1035,7 @@ void Character::reach_attack( const tripoint_bub_ms &p, int forced_movecost )
     }
 
     // Fighting is hard work
-    set_activity_level( EXTRA_EXERCISE );
+    set_activity_level( COMBAT_EXERCISE );
 
     creature_tracker &creatures = get_creature_tracker();
     Creature *critter = creatures.creature_at( p );
@@ -1045,6 +1047,8 @@ void Character::reach_attack( const tripoint_bub_ms &p, int forced_movecost )
     recoil = MAX_RECOIL;
 
     // Weariness handling
+    // Our COMBAT_EXERCISE is orders of magnitude higher than EXTRA_EXERCISE. Passing it here will result in *absurd* values.
+    // We must pass in EXTRA_EXERCISE at most.
     // 1 / mult because mult is the percent penalty, in the form 1.0 == 100%
     const float weary_mult = 1.0f / exertion_adjusted_move_multiplier( EXTRA_EXERCISE );
     int move_cost = attack_speed( weapon ) * weary_mult;
@@ -1529,6 +1533,8 @@ std::optional<std::tuple<matec_id, attack_vector_id, sub_bodypart_str_id>>
         float move_cost = attack_speed( used_weap );
         move_cost *= tec_id->move_cost_multiplier( *this );
         move_cost += tec_id->move_cost_penalty( *this );
+        // Our COMBAT_EXERCISE is orders of magnitude higher than EXTRA_EXERCISE. Passing it here will result in *absurd* values.
+        // We must pass in EXTRA_EXERCISE at most.
         float move_mult = exertion_adjusted_move_multiplier( EXTRA_EXERCISE );
         move_cost *= ( 1.0f / move_mult );
         if( get_moves() + get_speed() - move_cost < 0 ) {

--- a/tests/activity_scheduling_helper.cpp
+++ b/tests/activity_scheduling_helper.cpp
@@ -10,6 +10,7 @@
 #include "debug.h"
 #include "item.h"
 #include "map_helpers.h"
+#include "messages.h"
 #include "player_activity.h"
 #include "player_helpers.h"
 #include "stomach.h"
@@ -40,6 +41,16 @@ void activity_schedule::do_turn( avatar &guy ) const
     if( guy.activity.moves_left < 1000 ) {
         guy.activity.moves_left = 4000;
     }
+}
+
+void action_schedule::setup( avatar & ) const
+{
+    add_msg( "Starting cycle" );
+}
+
+void action_schedule::do_turn( avatar &guy ) const
+{
+    action( guy );
 }
 
 void meal_schedule::setup( avatar &guy ) const
@@ -110,7 +121,7 @@ weariness_events do_activity( tasklist tasks, bool do_clear_avatar )
 
         // How many turn's we've been at it
         time_duration turns = 0_seconds;
-        while( turns <= task.interval && !task.instantaneous() ) {
+        while( turns < task.interval && !task.instantaneous() ) {
             // Advance a turn
             calendar::turn += 1_turns;
             turns += 1_seconds;

--- a/tests/activity_scheduling_helper.h
+++ b/tests/activity_scheduling_helper.h
@@ -42,6 +42,19 @@ class activity_schedule : public schedule
         }
 };
 
+class action_schedule : public schedule
+{
+        std::function<void( avatar & )> action;
+    public:
+        void setup( avatar &guy ) const override;
+        void do_turn( avatar &guy ) const override;
+
+        action_schedule( std::function<void( avatar & )> p_action,
+                         const time_duration &ticks ) : action( p_action ) {
+            interval = ticks;
+        }
+};
+
 class meal_schedule : public schedule
 {
         itype_id food;

--- a/tests/weary_test.cpp
+++ b/tests/weary_test.cpp
@@ -7,6 +7,7 @@
 #include "avatar.h"
 #include "calendar.h"
 #include "cata_catch.h"
+#include "creature_tracker.h"
 #include "player_helpers.h"
 #include "type_id.h"
 
@@ -19,6 +20,8 @@ static const activity_id ACT_WAIT( "ACT_WAIT" );
 static const itype_id itype_milk( "milk" );
 static const itype_id itype_sausage( "sausage" );
 
+static const mtype_id pseudo_debug_mon( "pseudo_debug_mon" );
+
 // Set up our scenarios ahead of time
 static const int moves_for_25h = to_seconds<int>( 25_hours ) * 100;
 static const clear_rubble_activity_actor dig_actor( moves_for_25h );
@@ -26,6 +29,7 @@ static const activity_schedule task_dig( dig_actor, 5_minutes );
 static const activity_schedule task_wait( ACT_WAIT, 5_minutes );
 static const activity_schedule task_firstaid( ACT_FIRSTAID, 5_minutes );
 static const activity_schedule task_plant( ACT_PLANT_SEED, 5_minutes );
+static const activity_schedule task_short_wait( ACT_WAIT, 1_minutes );
 static const activity_schedule task_weld( ACT_VEHICLE, 5_minutes );
 static const activity_schedule task_read( ACT_READ, 5_minutes );
 
@@ -49,6 +53,28 @@ TEST_CASE( "weary_assorted_tasks", "[weary][activities]" )
 
     tasklist soldier_12h;
     soldier_12h.enschedule( task_dig, 12_hours );
+
+    creature_tracker &creatures = get_creature_tracker();
+    const action_schedule task_melee(
+    [&creatures]( avatar & guy ) {
+        // We only attack once every 3rd turn.
+        if( !calendar::once_every( 3_seconds ) ) {
+            return;
+        }
+        // This is kind of dumb, but do_activity() wipes the map
+        // so I need to place the monster after that happens.
+        if( creatures.size() < 1 ) {
+            g->place_critter_at( pseudo_debug_mon, tripoint_bub_ms::zero + tripoint::south );
+        }
+        Creature &mon = *creatures.creature_at<Creature>( tripoint_bub_ms::zero + tripoint::south );
+        guy.melee_attack_abstract( mon, false, matec_id( "" ) );
+    },
+    12_seconds );
+    tasklist pugilist_48min_bout;
+    for( int i = 0; i < 12; ++i ) {
+        pugilist_48min_bout.enschedule( task_melee, 3_minutes );
+        pugilist_48min_bout.enschedule( task_short_wait, 1_minutes );
+    }
 
     SECTION( "Light tasks" ) {
         INFO( "\nFirst Aid 8 hours:" );
@@ -106,6 +132,20 @@ TEST_CASE( "weary_assorted_tasks", "[weary][activities]" )
         CHECK( info.transition_minutes( 5, 6, 710_minutes ) == Approx( 710 ).margin( 10 ) );
         CHECK( !info.have_weary_decrease() );
         CHECK( guy.weariness_level() == 6 );
+    }
+
+    SECTION( "Extreme tasks - 48 miute boxing match" ) {
+        clear_avatar();
+        guy.activity_history.set_intake( ( guy.base_bmr() * 1000 * 19 ) / 24 );
+        INFO( guy.debug_weary_info() );
+        weariness_events info = do_activity( pugilist_48min_bout, false );
+        INFO( info.summarize() );
+        INFO( guy.debug_weary_info() );
+        REQUIRE( !info.empty() );
+        CHECK( info.transition_minutes( 0, 1, 15_minutes ) == Approx( 15 ).margin( 2 ) );
+        CHECK( info.transition_minutes( 1, 2, 45_minutes ) == Approx( 45 ).margin( 5 ) );
+        CHECK( !info.have_weary_decrease() );
+        CHECK( guy.weariness_level() == 2 );
     }
 }
 


### PR DESCRIPTION
#### Summary
Balance "Add actual weariness to life-or-death combat"

#### Purpose of change
<insert pictures of day one kill counts in the hundreds> 

This is something that should never be possible. Melee fighting literally hundreds of people, to death, is just not within a normal person's capabilities in one day. It's not even vaguely close! By literally every modern or historical account in the world, melee combat versus another human being is a devastatingly exhausting (weary) activity. Because they have every incentive to kill you, and you have every incentive to not die. You are putting in 100%. Or you're dead.

Our current ingame combat... does not represent anything close to that.

#### Describe the solution
Implement a new exercise level, COMBAT_EXERCISE. This is 100x (two orders of magnitude) higher than EXTRA_EXERCISE. This exercise level is applied during melee combat or dodging.

#### Describe alternatives you've considered


#### Testing
Played around with a fresh blank character for a while. Used a spear, stabbed some zeds, actually got weary after a while (!!). 

Repeated tests versus an infinite immobile training dummy with no breaks. Weariness certainly stacked up!

#### Additional context