### PR TITLE
[Sky Island] Add construction fix for bunker entrance

### DIFF
--- a/data/mods/Sky_Island/dialog_statue.json
+++ b/data/mods/Sky_Island/dialog_statue.json
@@ -1056,14 +1056,7 @@
       },
       {
         "text": "One of my bunker constructions had an error.  Could you help me fix it?",
-        "condition": {
-          "or": [
-            { "math": [ "skyisland_build_bigroom >= 2" ] },
-            { "math": [ "skyisland_build_northroom >= 2" ] },
-            { "math": [ "skyisland_build_westroom >= 2" ] },
-            { "math": [ "skyisland_build_eastroom >= 2" ] }
-          ]
-        },
+        "condition": { "math": [ "skyisland_build_base >= 1" ] },
         "topic": "SKYISLAND_FIX_CONSTRUCTIONS"
       },
       { "text": "Nevermind.", "topic": "SKYISLAND_UPGRADE" }
@@ -1074,6 +1067,24 @@
     "id": "SKYISLAND_FIX_CONSTRUCTIONS",
     "dynamic_line": "Please remove all obstructing appliances or vehicles from the section of the island in question.  Where do you need help with?",
     "responses": [
+      {
+        "text": "I need help with the Bunker Entrance.",
+        "condition": { "math": [ "skyisland_build_base == 1" ] },
+        "effect": [
+          { "run_eocs": "EOC_skyisland_build_base1" },
+          { "u_message": "You hear a grinding sound from beneath the earth.", "popup": true }
+        ],
+        "topic": "SKYISLAND_UPGRADE"
+      },
+      {
+        "text": "I need help with the Miner's Cameo stage of the main room.",
+        "condition": { "math": [ "skyisland_build_bigroom == 1" ] },
+        "effect": [
+          { "run_eocs": "EOC_skyisland_build_bigroom1" },
+          { "u_message": "You hear a grinding sound from beneath the earth.", "popup": true }
+        ],
+        "topic": "SKYISLAND_UPGRADE"
+      },
       {
         "text": "I need help with the Hollow Carver stage of the main room.",
         "condition": { "math": [ "skyisland_build_bigroom == 2" ] },


### PR DESCRIPTION
#### Summary
Mods "[Sky Island] Add construction fix for bunker entrance"

#### Purpose of change

If you've placed furniture it's possible to fail to build an entrance to the bunker. The only way to recover from this is to manually dig some stairs.

#### Describe the solution

Add construction fixes for the first couple of constructions.

#### Testing

1. Placed a few batteries then built the Miner's Cameo recipe.  No stairs or concrete were added.
2. Removed the batteries and asked the island to fix it. The entrance was created.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
