### PR TITLE
Guard mp3_on tick against null carrier

### DIFF
--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -3764,7 +3764,9 @@ void iuse::play_music( Character *p, const tripoint_bub_ms &source, const int vo
 std::optional<int> iuse::mp3_on( Character *p, item *it, const tripoint_bub_ms &pos )
 {
     if( !it->activation_success() ) {
-        p->add_msg_if_player( m_bad, _( "Your %s goes silent for a moment." ), it->tname() );
+        if( p ) {
+            p->add_msg_if_player( m_bad, _( "Your %s goes silent for a moment." ), it->tname() );
+        }
         return std::nullopt;
     }
 


### PR DESCRIPTION
#### Summary
Bugfixes "Fix segfault when a damaged mp3 player ticks on the ground"

#### Purpose of change

Fixes #85330

Dropping a turned-on damaged mp3 player causes a segfault. The item keeps ticking on the ground via `map::process_items`, which passes `nullptr` as the carrier. When `activation_success()` fails (damaged item), `mp3_on` dereferences that null pointer to print a message.

#### Describe the solution

Null-check `p` before calling `add_msg_if_player` in the `activation_success()` failure path. Nobody's around to read the message anyway.

The successful path (`play_music`) already handles null `p` correctly via its `lambda_should_do_effects` guard.

#### Describe alternatives you've considered

Could early-return when `p` is null, but that would also skip `play_music` which works fine without a carrier - a working mp3 player on the ground should still produce ambient sound.

#### Testing

Code review of the call chain: `process_map_items` -> `process_tool` -> `tick` -> `mp3_on`. The `nullptr` carrier is visible at `map.cpp` in `process_map_items`.

#### Additional context

One-line fix matching the pattern used by other tick handlers (e.g. `process_blackpowder_fouling` guards its carrier access the same way).