### PR TITLE
Raise minimum sample count in x_in_y_distribution test

### DIFF
--- a/tests/rng_test.cpp
+++ b/tests/rng_test.cpp
@@ -44,7 +44,7 @@ static void check_x_in_y( double x, double y )
     const epsilon_threshold target_range{ x / y, 0.05 };
     do {
         stats.add( x_in_y( x, y ) );
-    } while( stats.n() < 100 || stats.uncertain_about( target_range ) );
+    } while( stats.n() < 500 || stats.uncertain_about( target_range ) );
     INFO( "Goal: " << x << " / " << y << " ( " << x / y << " )" );
     INFO( "Result: " << stats.avg() );
     INFO( "Samples: " << stats.n() );


### PR DESCRIPTION
#### Summary
Infrastructure "Raise minimum sample count in x_in_y_distribution test"

#### Purpose of change

The `x_in_y_distribution` test is flaky. [Example failure](https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/22041697796/job/63683653728?pr=85338) on an unrelated PR:

```
Goal: 0.771561 / 1.73494 ( 0.444719 )
Result: 0.7
Samples: 110
```

#### Describe the solution

`check_x_in_y` exits its sampling loop when `n >= minimum` AND the confidence interval is no longer uncertain -- meaning it's either confidently inside the target (pass) or confidently outside it (fail). With only 100 minimum samples and Z=5.0, the sample proportion can drift far enough from the true probability that the interval lands entirely outside the target before the loop self-corrects.

The test checks ~2200 (x,y) pairs. At 100 samples, a false rejection needs a ~5-sigma deviation from the true mean (roughly 1-in-3M per pair). Across 2200 pairs, that's a real chance of failure over many CI runs. At 500 minimum samples, the required deviation rises to ~7.4 sigma (roughly 1-in-10T per pair) -- effectively impossible.

No measurable runtime impact -- the test itself goes from ~0.08s to ~0.1s.

#### Describe alternatives you've considered

- Lowering the Z-value would narrow the CI and converge faster, but also weaken per-check confidence. It's shared across many tests so better not to touch it.
- Widening epsilon from 0.05 to 0.1 would help, but weakens detection of genuine distribution bugs.
- A max-iteration cap doesn't help here since the failure mode is the loop exiting *too confidently*, not running forever.

#### Testing

Ran with the exact failing seed (1771184157) plus 6 others -- all pass. Before the fix, seed 1771184157 reliably reproduces the failure.

#### Additional context

None