### PR TITLE
Fix 100% CPU usage with ncurses

### DIFF
--- a/src/end_screen.cpp
+++ b/src/end_screen.cpp
@@ -62,9 +62,7 @@ void end_screen_data::draw_end_screen_ui( bool actually_dead )
 {
     input_context ctxt;
     ctxt.register_action( "TEXT.CONFIRM" );
-#if defined(WIN32) || defined(TILES)
     ctxt.set_timeout( 50 );
-#endif
     end_screen_ui_impl p_impl;
 
     while( true ) {

--- a/src/input_context.cpp
+++ b/src/input_context.cpp
@@ -1012,9 +1012,7 @@ action_id input_context::display_menu( bool permit_execute_action )
         // avoiding inception!
         ctxt.register_action( "HELP_KEYBINDINGS" );
     }
-#if defined(WIN32) || defined(TILES)
     ctxt.set_timeout( 50 );
-#endif
 
     // has the user changed something?
     bool changed = false;

--- a/src/ncurses_def.cpp
+++ b/src/ncurses_def.cpp
@@ -423,9 +423,6 @@ input_event input_manager::get_input_event( const keyboard_mode /*preferred_keyb
         previously_pressed_key = 0;
         // flush any output
         catacurses::doupdate();
-        // could also just do this each time a window is created to ensure every ncurses window has this property,
-        // but this function is virtually free anyway
-        nodelay( stdscr, true );
         key = getch();
         if( key != ERR ) {
             int newch;


### PR DESCRIPTION
#### Summary Bugfixes "Fix 100% CPU usage in ncurses"
Category "Fix ncurses eating 100% of CPU,  search in keybindings, and missing RIP screen"

#### Purpose of change

Fixes #80386 (100% CPU usage), and cleans up some collateral damage the fix caused - RIP screen not showing up.
Also, added an unrelated but technically similar fix: the keybindings search didn't react to the 1st character typed.

#### Testing

Manually tested the RIP screen and keybindings search, in both curses and tiles versions.
