### PR TITLE
[Bugfix] Game start fail when bicycle is set as start vehicle

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1042,13 +1042,14 @@ vehicle *game::place_vehicle_nearby(
     std::vector<std::string> search_types = omt_search_types;
     if( search_types.empty() ) {
         const vehicle &veh = *id->blueprint;
+        std::vector<std::string> water_types = { "river", "lake", "ocean" };
+        std::vector<std::string> land_types = { "road", "field" };
         if( veh.max_ground_velocity( here ) == 0 && veh.can_float( here ) ) {
-            search_types.emplace_back( "river" );
-            search_types.emplace_back( "lake" );
-            search_types.emplace_back( "ocean" );
+            search_types.insert( search_types.end(), water_types.begin(), water_types.end() );
+            search_types.insert( search_types.end(), land_types.begin(), land_types.end() );
         } else {
-            search_types.emplace_back( "road" );
-            search_types.emplace_back( "field" );
+            search_types.insert( search_types.end(), land_types.begin(), land_types.end() );
+            search_types.insert( search_types.end(), water_types.begin(), water_types.end() );
         }
     }
     for( const std::string &search_type : search_types ) {


### PR DESCRIPTION
#### Summary

Bugfixes "Game start fail when bicycle is set as start vehicle"

#### Purpose of change

I added a bicycle as a starting vehicle for the cyclist profession in the game, but encountered a "could not place starting vehicle" error at startup. Debugging revealed the bicycle was incorrectly classified as a boat, causing placement failure due to lack of water terrain, as shown in the screenshot logic. This boat classification is clearly inappropriate for a bicycle. I haven't found a direct fix yet. Considering the diverse combinations of start scenes and profession, I suggest modifying the current binary choice logic to a priority-based placement system: attempt water placement first if classified as a boat, otherwise try land placement.

<img width="1013" height="479" alt="image" src="https://github.com/user-attachments/assets/d4b16f49-899b-4f29-a85d-c208fe4c96d5" />


#### Describe the solution

I modify the current binary choice logic to a priority-based placement system: attempt water placement first if classified as a boat, otherwise try land placement.

#### Describe alternatives you've considered

The most direct fix is identifying the bug in the code logic that determines if a vehicle is classified as a boat. However, considering the flexible combinations of vehicles, there's no definitive field to confirm if a vehicle is a boat. I believe this classification is only a heuristic for estimation, and the handling code based on this logic should be more robust.

#### Testing

I added a bicycle as a starting vehicle for the cyclist profession, but it was misclassified as a boat, causing the game to fail placing it at startup due to the absence of water terrain. When modifying the logic to prioritize terrain placement based on classification, the bicycle—despite the misclassification—first attempts water placement (fails), then falls back to land placement and succeeds.

#### Additional context

Here is a mod I add bicyle as start vehicle for cyclist profession.
[VehicleProfessions.zip](https://github.com/user-attachments/files/25332884/VehicleProfessions.zip)
