### PR TITLE
Overmap Specials can use copy-from

### DIFF
--- a/doc/JSON/JSON_INHERITANCE.md
+++ b/doc/JSON/JSON_INHERITANCE.md
@@ -180,9 +180,9 @@ uncraft
 vehicle_part
 ```
 `overmap_special` and `city_building` only partially support `copy-from`
-- Fixed specials do not support overriding the `overmaps` or `connections` properties
-- City buildings do not support overriding the `overmaps` property
-- Mutable specials do not support overriding the `overmaps`, `root`, `phases`, `check_for_locations`, or `check_for_locations_area` properties
+- Fixed specials do not support overriding or copying the `overmaps` or `connections` properties
+- City buildings do not support overriding or copying the `overmaps` property
+- Mutable specials do not support overriding or copying the `overmaps`, `root`, `phases`, `check_for_locations`, or `check_for_locations_area` properties
 
 To find out if a type supports `copy-from`, you need to know if it has implemented generic_factory.  To find out if this is the case, do the following:
 * Open [init.cpp](https://github.com/CleverRaven/Cataclysm-DDA/tree/master/src/init.cpp)

--- a/doc/JSON/JSON_INHERITANCE.md
+++ b/doc/JSON/JSON_INHERITANCE.md
@@ -179,6 +179,10 @@ terrain
 uncraft
 vehicle_part
 ```
+`overmap_special` and `city_building` only partially support `copy-from`
+- Fixed specials do not support overriding the `overmaps` or `connections` properties
+- City buildings do not support overriding the `overmaps` property
+- Mutable specials do not support overriding the `overmaps`, `root`, `phases`, `check_for_locations`, or `check_for_locations_area` properties
 
 To find out if a type supports `copy-from`, you need to know if it has implemented generic_factory.  To find out if this is the case, do the following:
 * Open [init.cpp](https://github.com/CleverRaven/Cataclysm-DDA/tree/master/src/init.cpp)

--- a/src/overmap_special.cpp
+++ b/src/overmap_special.cpp
@@ -297,27 +297,29 @@ void overmap_special::load( const JsonObject &jo, const std::string_view src )
         eoc = effect_on_conditions::load_inline_eoc( jo.get_member( "eoc" ), src );
         has_eoc_ = true;
     }
-    switch( subtype_ ) {
-        case overmap_special_subtype::fixed: {
-            shared_ptr_fast<fixed_overmap_special_data> fixed_data =
-                make_shared_fast<fixed_overmap_special_data>();
-            optional( jo, was_loaded, "overmaps", fixed_data->terrains );
-            if( is_special ) {
-                optional( jo, was_loaded, "connections", fixed_data->connections );
+    if( !was_loaded ) {
+        switch( subtype_ ) {
+            case overmap_special_subtype::fixed: {
+                shared_ptr_fast<fixed_overmap_special_data> fixed_data =
+                    make_shared_fast<fixed_overmap_special_data>();
+                optional( jo, was_loaded, "overmaps", fixed_data->terrains );
+                if( is_special ) {
+                    optional( jo, was_loaded, "connections", fixed_data->connections );
+                }
+                data_ = std::move( fixed_data );
+                break;
             }
-            data_ = std::move( fixed_data );
-            break;
+            case overmap_special_subtype::mutable_: {
+                shared_ptr_fast<mutable_overmap_special_data> mutable_data =
+                    make_shared_fast<mutable_overmap_special_data>( id );
+                mutable_data->load( jo, was_loaded );
+                data_ = std::move( mutable_data );
+                break;
+            }
+            default:
+                jo.throw_error( string_format( "subtype %s not implemented",
+                                               io::enum_to_string( subtype_ ) ) );
         }
-        case overmap_special_subtype::mutable_: {
-            shared_ptr_fast<mutable_overmap_special_data> mutable_data =
-                make_shared_fast<mutable_overmap_special_data>( id );
-            mutable_data->load( jo, was_loaded );
-            data_ = std::move( mutable_data );
-            break;
-        }
-        default:
-            jo.throw_error( string_format( "subtype %s not implemented",
-                                           io::enum_to_string( subtype_ ) ) );
     }
 
     optional( jo, was_loaded, "city_sizes", constraints_.city_size, { 0, INT_MAX } );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Overmap Specials can use copy-from"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Allow specials to utilizie copy-from without completely breaking them.
The loading code for overmap specials was completely overwriting the overmap/mutable data for the subsequent objects with the data in the copy-from objects, including the no data at all for those properties.
Fixes #85024
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Wrap the relevant switch statement in a conditional that skips loading those portions of the object if the object has been loaded before. So the copy-from object just silent drops those properties if they are present. 
The doc for JSON_INHERITANCE has been updated to reflect the different nature for this copy-from compared to the rest.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Writing proper functions to merge/overwrite/delete/extend the relevant sections of the overmap special objects. However this is over my head currently.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
All normal specials spawn as expected with no broken mapgen. 
Overriding specials with copy-from works as expected, the mapgen is preserved and changing things like adding flags works as well. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
