### PR TITLE
Character randomization sometimes produces 'crossdressing' characters

### DIFF
--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -442,7 +442,11 @@ void Character::randomize( const bool random_scenario, bool play_now )
 
     bool gender_selection = one_in( 2 );
     male = gender_selection;
-    outfit = gender_selection;
+    if( one_in( 10 ) ) {
+        outfit = !gender_selection;
+    } else {
+        outfit = gender_selection;
+    }
     if( !MAP_SHARING::isSharing() ) {
         play_now ? pick_name() : pick_name( true );
     } else {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Followup to #76812

I noticed that this randomization of gender worked differently than the new character menu.

#### Describe the solution
Add the 10% chance to give the randomized character a different gender's outfit.

#### Describe alternatives you've considered
Could probably de-duplicate a bunch of this code so we don't have two different bits of code doing the same thing in different places

#### Testing

#### Additional context
