### PR TITLE
Add gate jobs for IWYU and clang-tidy required checks

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -73,7 +73,7 @@ jobs:
 
 
   run-clang-tidy:
-    needs: build-clang-tidy
+    needs: [skip-duplicates, build-clang-tidy]
     strategy:
       fail-fast: false
       matrix:
@@ -139,3 +139,18 @@ jobs:
         else
           echo "clang-tidy-trace folder not found."
         fi
+
+  clang-tidy-result:
+    if: ${{ always() }}
+    needs: [run-clang-tidy]
+    runs-on: ubuntu-latest
+    steps:
+    - name: require successful clang-tidy
+      run: |
+        result="${{ needs.run-clang-tidy.result }}"
+        if [ "$result" = "success" ] || [ "$result" = "skipped" ]; then
+          echo "clang-tidy result: $result"
+          exit 0
+        fi
+        echo "clang-tidy failed with result: $result"
+        exit 1

--- a/.github/workflows/iwyu.yml
+++ b/.github/workflows/iwyu.yml
@@ -7,19 +7,43 @@ on:
     branches:
     - master
     types: [opened, reopened, synchronize, ready_for_review]
-    paths:
-      - 'src/**'
-      - 'tests/**'
-      - 'tools/iwyu/**'
-      - '**/CMakeLists.txt'
-      - '.github/workflows/iwyu.yml'
 
 # We only care about the latest revision of a PR, so cancel all previous instances.
 concurrency:
   group: iwyu-${{ github.event.pull_request.number || github.ref_name }}
   cancel-in-progress: true
 jobs:
+  check-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ github.event_name == 'push' || steps.changed-files.outputs.result == 'true' }}
+    steps:
+    - name: check for relevant file changes
+      id: changed-files
+      if: ${{ github.event_name == 'pull_request' }}
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+      with:
+        script: |
+          const response = await github.paginate(github.rest.pulls.listFiles,
+            {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            }
+          );
+          const dominated_by = [
+            /^src\//,
+            /^tests\//,
+            /^tools\/iwyu\//,
+            /CMakeLists\.txt$/,
+            /^\.github\/workflows\/iwyu\.yml$/,
+          ];
+          const dominated = response.some(f => dominated_by.some(r => r.test(f.filename)));
+          return dominated;
+
   iwyu:
+    needs: check-changes
+    if: ${{ needs.check-changes.outputs.should_run == 'true' }}
     runs-on: ubuntu-24.04
     env:
         COMPILER: clang++-19
@@ -101,3 +125,18 @@ jobs:
       run: |
         PATH="${PATH}:${IWYU_BIN_DIR}:${IWYU_SRC_DIR}"
         python build-scripts/ci-iwyu-run.py
+
+  iwyu-result:
+    if: ${{ always() }}
+    needs: [iwyu]
+    runs-on: ubuntu-latest
+    steps:
+    - name: require successful IWYU
+      run: |
+        result="${{ needs.iwyu.result }}"
+        if [ "$result" = "success" ] || [ "$result" = "skipped" ]; then
+          echo "IWYU result: $result"
+          exit 0
+        fi
+        echo "IWYU failed with result: $result"
+        exit 1


### PR DESCRIPTION
#### Summary
Infrastructure "Add gate jobs so IWYU and clang-tidy report success on no-code PRs"

#### Purpose of change

Closes #85357.

PRs that don't touch C++ files get stuck forever with IWYU and clang-tidy in "waiting" state because neither check ever reports a status.

Two root causes:
- IWYU has a `paths:` filter on `pull_request`, so the workflow never triggers at all for non-code PRs -- no status reported.
- clang-tidy's `run-clang-tidy` job declares `needs: build-clang-tidy` but references `needs.skip-duplicates.outputs.should_skip`, which it can't access without listing `skip-duplicates` in its needs.

#### Describe the solution

Standard "gate job" pattern (used by Rust, Kubernetes, etc.):

**IWYU:**
- Remove `paths:` filter so the workflow always triggers
- Add lightweight `check-changes` job that uses the GitHub API to check if the PR has relevant files (same patterns as the old filter)
- Gate the `iwyu` job on `check-changes` output
- Add `iwyu-result` job (`if: always()`) that passes when `iwyu` is success or skipped

**Clang-tidy:**
- Fix `run-clang-tidy` needs to `[skip-duplicates, build-clang-tidy]` so it can actually read `should_skip`
- Add `clang-tidy-result` job with the same gate pattern

After merging, maintainers set `iwyu-result` and `clang-tidy-result` as the required checks.

#### Describe alternatives you've considered

Could keep the `paths:` filter and use a separate "no-op" workflow that runs on the complement paths to post a neutral status. More moving parts for the same result, and the check-changes job costs about 10 seconds of ubuntu-latest time -- not worth optimizing away.

#### Testing

- PR that only changes JSON/markdown: `check-changes` detects no relevant files, `iwyu` skips, `iwyu-result` reports success. Same for clang-tidy via `skip-duplicates`.
- PR with C++ changes: everything runs normally, gate jobs report the real result.

#### Additional context

None