### PR TITLE
Bump linux release compiler to clang-18 and optimization flag to -O2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
             tiles: 1
             sound: 1
           - name: Linux Tiles x64
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             android: none
             libbacktrace: 1
             tiles: 1
@@ -101,7 +101,7 @@ jobs:
             ext: tar.gz
             content: application/gzip
           - name: Linux Tiles Sounds x64
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             android: none
             libbacktrace: 1
             tiles: 1
@@ -110,7 +110,7 @@ jobs:
             ext: tar.gz
             content: application/gzip
           - name: Linux Curses x64
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             android: none
             libbacktrace: 1
             tiles: 0
@@ -269,7 +269,7 @@ jobs:
       - name: Build CDDA (linux)
         if: runner.os == 'Linux' && matrix.android == 'none' && !matrix.wasm
         run: |
-          make -j$((`nproc`+0)) TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=1 LIBBACKTRACE=${{ matrix.libbacktrace }} WARN_STALE_DATA=1 PCH=0 bindist
+          make COMPILER=clang++-18 -j$((`nproc`+0)) TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=1 LIBBACKTRACE=${{ matrix.libbacktrace }} WARN_STALE_DATA=1 PCH=0 bindist
           mv cataclysmdda-0.J.tar.gz cdda-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.tar.gz
       - name: Build CDDA (WebAssembly)
         if: matrix.wasm && success()

--- a/Makefile
+++ b/Makefile
@@ -444,7 +444,7 @@ ifeq ($(RELEASE), 1)
     ifeq ($(CXXMACHINE), x86_64-w64-mingw32.static)
       OPTLEVEL = -O3
     else
-      OPTLEVEL = -Os
+      OPTLEVEL = -O2
     endif
   endif
 


### PR DESCRIPTION
#### Summary
Performance "Use clang 18 for linux release builds"

#### Purpose of change
Testing by @akrieger shows that clang 18 with -O2 emits a much, much faster binary than either the gcc-12 we are currently using or gcc-14.

#### Describe the solution
Bump the github runner version so we have clang++-18.
Override the compiler selection to use it.
Change the default optimization flag to -O2 at the same time.

#### Describe alternatives you've considered
There's an enormous variety of different compiler versions and optimization flags we could test to try and find the truly best configuration. It's very likely that this is very close to optimal, but following up with broader testing is a good idea.
The test suite isn't super representative, it would be nice to build a suite of perf tests that try to replicate a representative game session and give us scores on execution time of different action types, maybe later. This would be a really great target for building out a big build matrix and running off everything against each other to find the actual best configuration.
Regardless this represents a massive improvement so let's not put off landing it.
This doesn't touch mac or windows, a similar process might turn up some wins there.

#### Testing
Basically patch in the appropriate compilers and optimization levels and build the test suite, run it while recording execution time, and then compare. It ran roughly half the tests in each of two workers because that's how we normally run the tests and that was the original goal of this investigation. The sum of the times is roughly comparable but noisy.

The end result is:
| Compiler  | Runtime |
| ------------- | ------------- |
| clang 18 -O2  | 396 + 418  |
| gcc 14 -O2 | 427 + 495 |
| gcc 14 -Os | 610 + 711 |
| clang 13 -O2 | 415 + 450 |
| clang 13 -Os | 466 + 549 |

#### Additional context
@akrieger did all the heavy lifting here, all I did was go "hey looks like clang is faster than gcc now we should probably switch" and bother him with probably unnecessary questions while he was doing the real work.