### PR TITLE
[XEDRA Evolved×Bombasticperk] Gender change potion

### DIFF
--- a/data/mods/Xedra_Evolved/items/alchemy.json
+++ b/data/mods/Xedra_Evolved/items/alchemy.json
@@ -373,6 +373,34 @@
     ]
   },
   {
+    "id": "gender_potion",
+    "type": "ITEM",
+    "subtypes": [ "COMESTIBLE" ],
+    "comestible_type": "MED",
+    "name": { "str": "gender change potion" },
+    "description": "This is a potion of change.  It will turn you into the opposite gender.  Turn into your true self, or otherwise experience what lies within the opposite gender.",
+    "weight": "50 g",
+    "volume": "250 ml",
+    "price": "150 cent",
+    "price_postapoc": "5 USD",
+    "material": [ "water" ],
+    "symbol": "!",
+    "color": "light_cyan",
+    "container": "flask_glass",
+    "quench": 2,
+    "healthy": 3,
+    "fun": -1,
+    "flags": [ "NO_INGEST", "WATER_DISSOLVE", "EDIBLE_FROZEN" ],
+    "consumption_effect_on_conditions": [ "change_gender" ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "change_gender",
+    "condition": { "and": [ "u_is_character", { "math": [ "u_gender() == 1" ] } ] },
+    "effect": [ { "math": [ "u_gender() = 0" ] } ],
+    "false_effect": [ { "math": [ "u_gender() = 1" ] } ]
+  },
+  {
     "id": "potion_dex",
     "type": "ITEM",
     "subtypes": [ "COMESTIBLE" ],

--- a/data/mods/Xedra_Evolved/mod_interactions/bombastic_perks/perks/perk_data/Alchemy1.json
+++ b/data/mods/Xedra_Evolved/mod_interactions/bombastic_perks/perks/perk_data/Alchemy1.json
@@ -134,7 +134,7 @@
     "condition": { "and": [ { "u_has_trait": "perk_ALCHEMY4" }, { "not": { "u_has_effect": "mental_exhaustion" } } ] },
     "effect": [
       {
-        "u_roll_remainder": [ "life_extension_potion", "potion_strength", "potion_dex", "hares_leap_potion", "nether_snare" ],
+        "u_roll_remainder": [ "life_extension_potion", "gender_potion", "potion_strength", "potion_dex", "hares_leap_potion", "nether_snare" ],
         "type": "recipe",
         "true_eocs": [ "EOC_SUCCESFUL_ROLL_REMAINDER_ALCHEMY" ],
         "false_eocs": [ "EOC_ALCHEMY3_COLD_IRON" ]

--- a/data/mods/Xedra_Evolved/recipes/alchemy.json
+++ b/data/mods/Xedra_Evolved/recipes/alchemy.json
@@ -390,6 +390,32 @@
   {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
+    "result": "gender_potion",
+    "category": "CC_XEDRA",
+    "subcategory": "CSC_XEDRA_ALCHEMY",
+    "skill_used": "chemistry",
+    "skills_required": [ "firstaid", 4 ],
+    "difficulty": 5,
+    "time": "24 m",
+    "flags": [ "SECRET" ],
+    "proficiencies": [
+      { "proficiency": "prof_intro_chemistry" },
+      { "proficiency": "prof_inorganic_chemistry" },
+      { "proficiency": "prof_intro_chem_synth" },
+      { "proficiency": "prof_pharmaceutical" }
+    ],
+    "qualities": [ { "id": "CHEM", "level": 2 } ],
+    "tools": [ [ [ "surface_heat", 25, "LIST" ] ] ],
+    "components": [
+      [ [ "estrogen", 10 ], [ "birth_control", 30 ] ],
+      [ [ "protein_powder", 30 ] ],
+      [ [ "royal_jelly", 2 ] ],
+      [ [ "water", 2 ] ]
+    ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
     "result": "xe_alchemy_powder_of_revelation",
     "category": "CC_XEDRA",
     "subcategory": "CSC_XEDRA_ALCHEMY",


### PR DESCRIPTION

#### Summary
None

#### Purpose of change
Adds a gender change potion as a level 4 alchemy perk recipe where it turns you into the opposite gender. While this is basically just a fancier way to press the button in the @ screen, it fits the alchemy stuff.

#### Describe the solution
Adds the jsons for it.

#### Describe alternatives you've considered
Keeping it to myself.

#### Testing
![Screenshot_20260217_171832](https://github.com/user-attachments/assets/be776947-6a38-487d-bf45-77b54288d88c)

I used the potion on my char, they turned into the opposite gender. I get a npc and make them use the potion, they also changed into the opposite gender.

#### Additional context
Trans rights and all that jazz!

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
