### PR TITLE
Fix for muzzles breaking gas masks

### DIFF
--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -1072,6 +1072,11 @@ void Item_factory::finalize_post_armor( itype &obj )
         // for each body part this covers we need to add to the overall data for that bp
         if( sub_armor.covers.has_value() ) {
             for( const bodypart_str_id &bp : sub_armor.covers.value() ) {
+                // skip anything contributing 0 coverage
+                const float sub_cov = sub_armor.max_coverage( bp );
+                if( sub_cov <= 0.0f ) {
+                    continue;
+                }
                 bool found = false;
                 // go through and find if the body part already exists
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Body parts you don't have don't break environmental protection (gas masks work again)"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fixes #85245 

Muzzles were breaking gas masks.  I think @GuardianDll was correct that it was an issue in `Item_factory::finalize_post_armor()`.  Namely, it looks like it was taking subparts that a character didn't have (like a muzzle), and using them to get the final protection values... so it was averaging protection values down to 0.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

I added a check in item_factory.cpp to ignore body parts with `sub_cov <= 0.0f`

Gas masks now work, on both an un-mutated human and a human with a (compatible) muzzle.  The DFLT muzzle also doesn't show up in the item description anymore.  Everything else seems to work, and I don't _think_ it breaks anything else?

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

n/a

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Spawned, reloaded, prepared gas mask.  Spawned gangrenous crawler and blew it up.  With a prepared gas mask you are protected, and the mask burns charge as expected.  Without the mask you get poisoned.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

There's still a problem that I _think_ is just the GUI(?): environmental protection shows 4 for the gas mask, if it's prepared or unprepared.  It should show 16 when prepared, I think?

Also, I don't think this addresses the issue in #85371, but they seem like they could be related.  But I didn't test it.

**EDIT:**  Okay, it looks like it's breaking some tests, so it either broke something, or the fix needs to be bigger.  Digging in, but would appreciate extra eyes.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
