### PR TITLE
Fix infinite crystalizing sugar/pulp recycling exploit

### DIFF
--- a/data/json/recipes/food/spice.json
+++ b/data/json/recipes/food/spice.json
@@ -177,7 +177,43 @@
     "tools": [ [ [ "water_boiling_heat", 8, "LIST" ] ], [ [ "screw_press", -1 ] ] ],
     "components": [
       [
-        [ "sweet_fruit_like", 2, "LIST" ],
+        [ "sweet_fruit_like_no_pulp", 2, "LIST" ],
+        [ "coconut_flesh", 2 ],
+        [ "corn_kernels", 3 ],
+        [ "rehydrated_corn_kernels", 3 ],
+        [ "honeydew", 3 ],
+        [ "honeycomb", 1 ],
+        [ "can_corn", 3 ],
+        [ "juice", 3 ]
+      ],
+      [ [ "water_clean", 2 ], [ "water", 2 ] ]
+    ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "result": "crystallizing_sugar_active",
+    "id_suffix": "from_sweets_no_pulp",
+    "category": "CC_FOOD",
+    "subcategory": "CSC_FOOD_OTHER",
+    "skill_used": "cooking",
+    "difficulty": 5,
+    "time": "1 h 45 m",
+    "charges": 10,
+    "//": [ "Full processing variant without pulp byproduct to avoid recycling loops." ],
+    "proficiencies": [ { "proficiency": "prof_knife_skills" } ],
+    "batch_time_factors": [ 20, 1 ],
+    "book_learn": { "cookbook_foodfashions": { "skill_level": 5, "recipe_name": "Improvised Fruit Sugar" } },
+    "qualities": [
+      { "id": "CONTAIN", "level": 1 },
+      { "id": "CUT", "level": 2 },
+      { "id": "BOIL", "level": 2 },
+      { "id": "STRAIN", "level": 2 }
+    ],
+    "tools": [ [ [ "water_boiling_heat", 8, "LIST" ] ], [ [ "screw_press", -1 ] ] ],
+    "components": [
+      [
+        [ "sweet_fruit_like_no_pulp", 2, "LIST" ],
         [ "coconut_flesh", 2 ],
         [ "corn_kernels", 3 ],
         [ "rehydrated_corn_kernels", 3 ],

--- a/data/json/requirements/cooking_components.json
+++ b/data/json/requirements/cooking_components.json
@@ -1154,6 +1154,23 @@
     ]
   },
   {
+    "id": "sweet_fruit_like_no_pulp",
+    "type": "requirement",
+    "//": "Similar to sweet_fruit_like, but removes Juice_pulp to prevent infinte recycling.",
+    "components": [
+      [
+        [ "sweet_fruit", 1, "LIST" ],
+        [ "lemon", 1 ],
+        [ "apple_canned", 1 ],
+        [ "apple_sugar", 1 ],
+        [ "dry_fruit", 1 ],
+        [ "can_peach", 1 ],
+        [ "rehydrated_fruit", 1 ],
+        [ "rhubarb", 2 ]
+      ]
+    ]
+  },
+  {
     "id": "veggy_green",
     "type": "requirement",
     "//": "anything you would consider a leafy green vegetable",


### PR DESCRIPTION


#### Summary
Balance "Fix infinite crystalizing sugar/pulp recycling exploit"

#### Purpose of change
The previous recipe for crystallizing sugar active allowed players to use recycled juice pulp from crystallizing sugar active in the crystallizing sugar active recipe, creating a feedback loop that could produce (near) infinite crystallizing sugar active and pulp. This PR fixes the exploit by creating a no-pulp variant of the sweet_fruit_like requirement and duplicating the crystallizing sugar active recipe to remove the pulp byproduct, while preserving the original recipe for realism as addresed in #84462 .

#### Describe the solution

- Added a new requirement list `sweet_fruit_like_no_pulp`, identical to `sweet_fruit_like` but excluding juice_pulp to prevent recycling.
- Duplicated the crystallizing sugar active recipe:
  - Original recipe remains (produces sugar + pulp) and uses sweet_fruit_like_no_pulp
  - New recipe uses `sweet_fruit_like_no_pulp` and produces sugar only, no pulp byproduct
- No other recipes or global lists were modified, preserving backward compatibility.

#### Describe alternatives you've considered

- Removing juice pulp as a byproduct entirely (would reduce realism)  
- Adjusting sugar output to balance efficiency (not necessary, could complicate gameplay)  
- Allowing pulp to remain in inputs but modifying requirements (would not fully fix the feedback loop)  
The chosen solution preserves realism while eliminating the exploit.

#### Testing

- Tested crafting in-game:
  - Original recipe still produces sugar + pulp
  - New recipe produces sugar only, no pulp
- Verified that pulp cannot be recycled into sugar using the new recipe
- Confirmed no other recipes using `sweet_fruit_like` are affected

#### Additional context

This PR is focused on fixing a feedback loop exploit and does not change crafting times, skill requirements, or difficulty.