### PR TITLE
Fix smoker and kiln starting

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -11389,7 +11389,7 @@ void fire_start_activity_actor::finish( player_activity &act, Character &who )
 
     who.practice( skill_survival, potential_skill_gain, 5 );
 
-    const furn_id &f_id = here.furn( here.get_bub( act.placement ) );
+    const furn_id &f_id = here.furn( here.get_bub( fire_placement ) );
     const bool is_smoking_rack = f_id == furn_f_metal_smoking_rack ||
                                  f_id == furn_f_smoking_rack;
     const bool is_kiln = f_id == furn_f_kiln_empty ||

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -11312,12 +11312,8 @@ void fire_start_activity_actor::do_turn( player_activity &act, Character &who )
 
     item &firestarter = *fire_starter;
 
-    const furn_id f_id = here.furn( here.get_bub( fire_placement ) );
-    const bool is_smoker = f_id == furn_f_smoking_rack ||
-                           f_id == furn_f_metal_smoking_rack;
-
-    if( firestarter.has_flag( flag_REQUIRES_TINDER ) && !is_smoker ) {
-        if( !here.tinder_at( where ) ) {
+    if( firestarter.has_flag( flag_REQUIRES_TINDER ) ) {
+        if( !used_tinder ) {
             inventory_filter_preset preset( []( const item_location & loc ) {
                 return loc->has_flag( flag_TINDER );
             } );
@@ -11334,16 +11330,14 @@ void fire_start_activity_actor::do_turn( player_activity &act, Character &who )
                 return;
             }
 
-            item copy = *tinder;
             bool count_by_charges = tinder->count_by_charges();
             if( count_by_charges ) {
                 tinder->charges--;
-                copy.charges = 1;
             }
-            here.add_item_or_charges( where, copy );
             if( !count_by_charges || tinder->charges <= 0 ) {
                 tinder.remove_item();
             }
+            used_tinder = true;
         }
     }
 
@@ -11417,6 +11411,7 @@ void fire_start_activity_actor::serialize( JsonOut &jsout ) const
     jsout.member( "fire_placement", fire_placement );
     jsout.member( "fire_starter", fire_starter );
     jsout.member( "potential_skill_gain", potential_skill_gain );
+    jsout.member( "used_tinder", used_tinder );
     jsout.end_object();
 }
 
@@ -11427,6 +11422,7 @@ std::unique_ptr<activity_actor> fire_start_activity_actor::deserialize( JsonValu
     data.read( "fire_placement", actor.fire_placement );
     data.read( "fire_starter", actor.fire_starter );
     data.read( "potential_skill_gain", actor.potential_skill_gain );
+    data.read( "used_tinder", actor.used_tinder );
     return actor.clone();
 }
 

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -3198,7 +3198,7 @@ class fire_start_activity_actor : public activity_actor
         fire_start_activity_actor( const tripoint_abs_ms &fire_placement, const item_location &fire_starter,
                                    int potential_skill_gain, int initial_moves ) :
             fire_placement( fire_placement ), fire_starter( fire_starter ),
-            potential_skill_gain( potential_skill_gain ), initial_moves( initial_moves ) {
+            potential_skill_gain( potential_skill_gain ), initial_moves( initial_moves ), used_tinder( false ) {
         };
         const activity_id &get_type() const override {
             static const activity_id ACT_START_FIRE( "ACT_START_FIRE" );
@@ -3221,6 +3221,7 @@ class fire_start_activity_actor : public activity_actor
         item_location fire_starter;
         int potential_skill_gain;
         int initial_moves; // NOLINT(cata-serialize)
+        bool used_tinder;
 };
 
 class wear_activity_actor : public activity_actor


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Fix smoker and kiln starting"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #85002
Fix #84990
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Both of the reported issues were changed by the recent #85254 to migrate the fire starting activity. However there were still bugs related to both that had not been resolved.

Change the location checked for furniture when completing a firestarter activity so it checks the right place for a kiln or smoker. 
- This stops the activity from starting a fire on top of the kiln/smoker.

Add a new field to the fire starter activity for whether or not tinder has been used when required by the firestarter tool. 
- This was required because when attempting to start a fire with something that requires tinder on a tile that the tinder cannot fit, it would spam the player every single turn requesting a piece of tinder that would not end up on the tile the fire was being started on. Now tinder is consumed upon it being selected and the activity has the new field set so it does not ask again. 
- This has a side effect of if the activity later fails and is canceled for some reason, i.e. the actor somehow losing the tool, the tinder is already gone. We can assume that the tinder was destroyed as part of the attempt to start a fire so I think it's a non issue.

The bypass for the smoker to not use tinder even if the firestarter required it was removed as well, the tinder not ending up on the smoker anymore made it unneeded.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
For the tinder fix, I considered adding the same check for kilns to skip tinder consumption but that would not have fixed starting a fire on a tile that was completely full.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested both saves, no issues anymore. Tried starting kilns and smokers with CBMs and various other firestarters with no issues.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
