### PR TITLE
[Sky Island] Hide in raid missions

### DIFF
--- a/data/mods/Sky_Island/missions_and_mapgen.json
+++ b/data/mods/Sky_Island/missions_and_mapgen.json
@@ -448,6 +448,7 @@
     "description": "If you want to get home with your stuff, you'll need to reach one of these nearby exit points.  They're only things that can bring you back to your sanctuary island in one piece.",
     "difficulty": 0,
     "value": 0,
+    "invisible_on_complete": true,
     "start": {
       "assign_mission_target": { "var": { "global_val": "OM_missionspot" } },
       "update_mapgen": { "place_nested": [ { "chunks": [ "mx_exitroom" ], "x": [ 0, 13 ], "y": [ 0, 13 ] } ] }
@@ -461,6 +462,7 @@
     "description": "A very small cluster of warp energy has left shards behind at this location.  All you need to do is find and retrieve them.  There may be threats nearby, but unlike most tasks, no special guards are on-site.  A minimal reward, but little risk.",
     "difficulty": 0,
     "value": 0,
+    "invisible_on_complete": true,
     "start": {
       "assign_mission_target": { "var": { "global_val": "OM_missionspot" } },
       "update_mapgen": { "place_nested": [ { "chunks": [ "mx_treasuregoal" ], "x": [ 0, 13 ], "y": [ 0, 13 ] } ] }
@@ -486,6 +488,7 @@
     "description": "A handful of zombies are congregating at a location where warp resonance is high.  Clear them out for a minimal reward of warp shards.",
     "difficulty": 0,
     "value": 0,
+    "invisible_on_complete": true,
     "start": {
       "assign_mission_target": { "var": { "global_val": "OM_missionspot" } },
       "update_mapgen": {
@@ -515,6 +518,7 @@
     "description": "A horde of low level zombies are congregating at a location where warp resonance is high.  Clear them out for a small reward of warp shards.",
     "difficulty": 0,
     "value": 0,
+    "invisible_on_complete": true,
     "start": {
       "assign_mission_target": { "var": { "global_val": "OM_missionspot" } },
       "update_mapgen": {
@@ -544,6 +548,7 @@
     "description": "A swarm of evolved zombies are congregating at a location where warp resonance is high.  Clear them out for a medium reward of warp shards.",
     "difficulty": 0,
     "value": 0,
+    "invisible_on_complete": true,
     "start": {
       "assign_mission_target": { "var": { "global_val": "OM_missionspot" } },
       "update_mapgen": {
@@ -581,6 +586,7 @@
     "description": "A huge horde of evolved zombies are congregating at a location where warp resonance is high.  Clear them out for a large reward of warp shards.",
     "difficulty": 0,
     "value": 0,
+    "invisible_on_complete": true,
     "start": {
       "assign_mission_target": { "var": { "global_val": "OM_missionspot" } },
       "update_mapgen": {
@@ -618,6 +624,7 @@
     "description": "A swarm of rather powerful zombies are congregating at a location where warp resonance is high.  Clear them out for a large reward of warp shards.",
     "difficulty": 0,
     "value": 0,
+    "invisible_on_complete": true,
     "start": {
       "assign_mission_target": { "var": { "global_val": "OM_missionspot" } },
       "update_mapgen": {
@@ -663,6 +670,7 @@
     "description": "A swarm of extremely dangerous zombies are congregating at a location where warp resonance is high.  Clear them out for a very large reward of warp shards.",
     "difficulty": 0,
     "value": 0,
+    "invisible_on_complete": true,
     "start": {
       "assign_mission_target": { "var": { "global_val": "OM_missionspot" } },
       "update_mapgen": {
@@ -708,6 +716,7 @@
     "description": "A single supremely powerful zombie has been found at a location where warp resonance is high.  Destroy it for a very large reward of warp shards.",
     "difficulty": 0,
     "value": 0,
+    "invisible_on_complete": true,
     "start": {
       "assign_mission_target": { "var": { "global_val": "OM_missionspot" } },
       "update_mapgen": {
@@ -735,6 +744,7 @@
     "description": "A team of supremely powerful zombies has been found at a location where warp resonance is high.  Destroy it for a very large reward of warp shards.",
     "difficulty": 0,
     "value": 0,
+    "invisible_on_complete": true,
     "start": {
       "assign_mission_target": { "var": { "global_val": "OM_missionspot" } },
       "update_mapgen": {
@@ -764,6 +774,7 @@
     "description": "A supremely powerful zombie has been found at a location where warp resonance is high.  Be warned that it will be accompanied by an elite swarm!  Destroy them all for a huge reward of warp shards.",
     "difficulty": 0,
     "value": 0,
+    "invisible_on_complete": true,
     "start": {
       "assign_mission_target": { "var": { "global_val": "OM_missionspot" } },
       "update_mapgen": {
@@ -801,6 +812,7 @@
     "description": "A supremely powerful zombie has been found at a location where warp resonance is high.  Be warned that it will be accompanied by an massive horde of weaker zombies!  Destroy them all for a huge reward of warp shards.",
     "difficulty": 0,
     "value": 0,
+    "invisible_on_complete": true,
     "start": {
       "assign_mission_target": { "var": { "global_val": "OM_missionspot" } },
       "update_mapgen": {
@@ -838,6 +850,7 @@
     "description": "A group of lethal mi-gos are draining a location where warp resonance is high.  Destroy them all for a very large reward of warp shards.",
     "difficulty": 0,
     "value": 0,
+    "invisible_on_complete": true,
     "start": {
       "assign_mission_target": { "var": { "global_val": "OM_missionspot" } },
       "update_mapgen": {
@@ -865,6 +878,7 @@
     "description": "A group of lethal mi-gos are draining a location where warp resonance is high.  Destroy them all for a very large reward of warp shards.",
     "difficulty": 0,
     "value": 0,
+    "invisible_on_complete": true,
     "start": {
       "assign_mission_target": { "var": { "global_val": "OM_missionspot" } },
       "update_mapgen": {
@@ -895,6 +909,7 @@
     "description": "The warp has marked a single human being for death.  They will likely carry a ranged weapon.  They will be alone.  Their sins are not your concern.  All you need to know is that it must be done.",
     "difficulty": 0,
     "value": 0,
+    "invisible_on_complete": true,
     "start": {
       "assign_mission_target": { "var": { "global_val": "OM_missionspot" } },
       "update_mapgen": { "place_npcs": [ { "class": "bandit", "x": [ 1, 22 ], "y": [ 1, 22 ], "target": true } ] }
@@ -920,6 +935,7 @@
     "description": "The warp has marked a single human being for death.  They will likely carry a melee weapon.  They will be alone.  Their sins are not your concern.  All you need to know is that it must be done.",
     "difficulty": 0,
     "value": 0,
+    "invisible_on_complete": true,
     "start": {
       "assign_mission_target": { "var": { "global_val": "OM_missionspot" } },
       "update_mapgen": { "place_npcs": [ { "class": "thug", "x": [ 1, 22 ], "y": [ 1, 22 ], "target": true } ] }
@@ -945,6 +961,7 @@
     "description": "The warp has marked human beings for death.  They may be accompanied.  Their sins are not your concern.  All you need to know is that it must be done.",
     "difficulty": 0,
     "value": 0,
+    "invisible_on_complete": true,
     "start": {
       "assign_mission_target": { "var": { "global_val": "OM_missionspot" } },
       "update_mapgen": {
@@ -978,6 +995,7 @@
     "monster_kill_goal": 10,
     "difficulty": 0,
     "value": 0,
+    "invisible_on_complete": true,
     "end": { "effect": [ { "math": [ "slaughterswon++" ] }, { "u_spawn_item": "warptoken", "count": 1 } ] }
   },
   {
@@ -990,6 +1008,7 @@
     "monster_kill_goal": 50,
     "difficulty": 0,
     "value": 0,
+    "invisible_on_complete": true,
     "end": { "effect": [ { "math": [ "slaughterswon++" ] }, { "u_spawn_item": "warptoken", "count": 3 } ] }
   },
   {
@@ -1002,6 +1021,7 @@
     "monster_kill_goal": 100,
     "difficulty": 0,
     "value": 0,
+    "invisible_on_complete": true,
     "end": { "effect": [ { "math": [ "slaughterswon++" ] }, { "u_spawn_item": "warptoken", "count": 5 } ] }
   },
   {
@@ -1014,6 +1034,7 @@
     "monster_kill_goal": 1,
     "difficulty": 0,
     "value": 0,
+    "invisible_on_complete": true,
     "end": { "effect": [ { "math": [ "slaughterswon++" ] }, { "u_spawn_item": "warptoken", "count": 3 } ] }
   },
   {
@@ -1026,6 +1047,7 @@
     "monster_kill_goal": 3,
     "difficulty": 0,
     "value": 0,
+    "invisible_on_complete": true,
     "end": { "effect": [ { "math": [ "slaughterswon++" ] }, { "u_spawn_item": "warptoken", "count": 4 } ] }
   },
   {
@@ -1038,6 +1060,7 @@
     "monster_kill_goal": 5,
     "difficulty": 0,
     "value": 0,
+    "invisible_on_complete": true,
     "end": { "effect": [ { "math": [ "slaughterswon++" ] }, { "u_spawn_item": "warptoken", "count": 1 } ] }
   },
   {
@@ -1050,6 +1073,7 @@
     "monster_kill_goal": 5,
     "difficulty": 0,
     "value": 0,
+    "invisible_on_complete": true,
     "end": { "effect": [ { "math": [ "slaughterswon++" ] }, { "u_spawn_item": "warptoken", "count": 1 } ] }
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Sky Island] Hide in raid missions"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Hiding in raid missions once they're completed or cancled
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adding `invisible_on_complete: true` to all of the in raid missions so they wont stay in the mission log as completed or failed, eventually flooding your whole log.
This includes the Find the Exit, Kill Zeds, Kill NPCs, Find Warp Shards, it is not added to the construction and upgrade missions. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Ran a few raids, none of the missions stayed in the log.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
