### PR TITLE
Fix `cata_test --order=rand` ordering for no rng-seed

### DIFF
--- a/tests/catch/catch.hpp
+++ b/tests/catch/catch.hpp
@@ -5255,6 +5255,8 @@ namespace Catch {
 #include <vector>
 #include <string>
 
+#include "rng.h"
+
 #ifndef CATCH_CONFIG_CONSOLE_WIDTH
 #define CATCH_CONFIG_CONSOLE_WIDTH 80
 #endif
@@ -5278,7 +5280,7 @@ namespace Catch {
         bool libIdentify = false;
 
         int abortAfter = -1;
-        unsigned int rngSeed = 0;
+        unsigned int rngSeed = rng_get_first_seed();
 
         bool benchmarkNoAnalysis = false;
         unsigned int benchmarkSamples = 100;


### PR DESCRIPTION
#### Summary

Infrastructure "Fix `cata_test --order=rand` ordering for no rng-seed"

#### Purpose of change

`cata_test --order=rand` is using a fixed order of the tests unless the user provided an `--rng-seed` option.

#### Describe the solution

Initialize `rngSeed` using the same `rng_get_first_seed` method that the default random seed uses.  When the user provides `--rng-seed` this value is replaced.  When they do not, the order of the tests is randomized to match the random seed.

#### Describe alternatives you've considered

None.

#### Testing

Before this fix, every time you ran `cata_test --order=rand` you'd get the same test order, but if you provided a `--rng-seed` you'd get a different order, even if the seeds match across the two cases:
```
$ ./tests/cata_test --order=rand --list-test-names-only | head


-----------------------------------------
23:05:05.651 : Starting log.
23:05:05.651 INFO : Cataclysm DDA version 1c9206f8d9
23:05:05.651 INFO : Default randomness seeded to: 1259016215
base64
map_equal_ignoring_keys
simple_requirements_dont_multiply
power_parsing_from_JSON
basal_metabolic_rate_with_various_size_and_metabolism
final_info
what_you_can_eat_with_a_mycus_dependency
helmet_with_face_shield_coverage
expert_shooter_accuracy
submap_fd_migration

$ ./tests/cata_test --order=rand --list-test-names-only | head


-----------------------------------------
23:05:06.771 : Starting log.
23:05:06.771 INFO : Cataclysm DDA version 1c9206f8d9
23:05:06.771 INFO : Default randomness seeded to: 2381044298 👈 different seed
base64                                                       👈 same test ordering
map_equal_ignoring_keys
simple_requirements_dont_multiply
power_parsing_from_JSON
basal_metabolic_rate_with_various_size_and_metabolism
final_info
what_you_can_eat_with_a_mycus_dependency
helmet_with_face_shield_coverage
expert_shooter_accuracy
submap_fd_migration

                      user specifies same seed as previous example 👇
$ ./tests/cata_test --order=rand --list-test-names-only --rng-seed=2381044298 | head


-----------------------------------------
23:05:17.705 : Starting log.
23:05:17.706 INFO : Cataclysm DDA version 1c9206f8d9
23:05:17.706 INFO : Randomness seeded to: 2381044298 👈 same seed as previous example
max_effective_intensity                              👈 different test order
colony_range_erase
number_widgets_with_color
techniques_when_wielded
widget_showing_character_sleepiness_status
default_OMT_is_passable
widget_showing_body_part_status_text
Check_damage_from_weakpoint_sets
cardio_is_affected_by_character_weight
vision_day_indoors
```

After this fix, the order is random, but each seed has a fixed order whether the user provided seed or the system generated it.
```
$ ./tests/cata_test --order=rand --list-test-names-only | head


-----------------------------------------
23:12:47.351 : Starting log.
23:12:47.352 INFO : Cataclysm DDA version 1c9206f8d9
23:12:47.352 INFO : Randomness seeded to: 3398876668
weary_24h_tasks
drying_rate
off_limb_ablative_encumbrance
convert_length
temp_crafting_inv_test_amount
character_height_should_increase_with_their_body_size
doors_should_be_able_to_open_and_close
serialize_sequences
npc_does_healing
remove_effect

$ ./tests/cata_test --order=rand --list-test-names-only | head


-----------------------------------------
23:01:21.000 : Starting log.
23:01:21.001 INFO : Cataclysm DDA version 1c9206f8d9-dirty
23:01:21.001 INFO : Randomness seeded to: 4243450278     👈 different seed as previous example
widgets_showing_avatar_stats_with_color_for_normal_value 👈 different test order
suffering_from_albinism
colony_group_size_and_capacity
fun_for_food_eaten_while_sick
list_splice
math_parser_dialogue_integration
roll_remainder_distribution
submap_graffiti_load
character_should_lose_moves_when_opening_or_closing_doors_or_windows

                      user specifies same seed as previous example 👇
$ ./tests/cata_test --order=rand --list-test-names-only --rng-seed=4243450278 | head


-----------------------------------------
23:01:41.145 : Starting log.
23:01:41.145 INFO : Cataclysm DDA version 1c9206f8d9-dirty
23:01:41.145 INFO : Randomness seeded to: 4243450278     👈 same seed as previous example
widgets_showing_avatar_stats_with_color_for_normal_value 👈 same test order
suffering_from_albinism
colony_group_size_and_capacity
fun_for_food_eaten_while_sick
list_splice
math_parser_dialogue_integration
roll_remainder_distribution
submap_graffiti_load
character_should_lose_moves_when_opening_or_closing_doors_or_windows
```

#### Additional context

1. This is confounding my efforts to find tests that bleed bad state into other tests.
2. Here's a patch that will show you how it's going wrong:
```diff
--- a/tests/catch/catch.hpp
+++ b/tests/catch/catch.hpp
@@ -14206,6 +14206,7 @@ namespace Catch {

             case RunTests::InRandomOrder: {
                 seedRng( config );
+                Catch::cout() << "Random order suffix: " << config.rngSeed() << "\n";
                 TestHasher h{ config.rngSeed() };

                 using hashedTest = std::pair<TestHasher::hash_t, TestCase const*>;
```

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
