### PR TITLE
zone sort: respect terrain/vehicle zone binding

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -10312,6 +10312,8 @@ void unload_loot_activity_actor::stage_do( player_activity &, Character &you )
     zone_sorting::unload_sort_options zone_unload_options = zone_sorting::set_unload_options( you, src,
             false );
 
+    const std::optional<vpart_reference> vp = here.veh_at( src_bub ).cargo();
+
     //Skip items that have already been processed
     for( auto it = items.begin() + num_processed; it < items.end(); ++it ) {
 
@@ -10329,11 +10331,11 @@ void unload_loot_activity_actor::stage_do( player_activity &, Character &you )
             continue;
         }
 
-        const std::optional<vpart_reference> vp = here.veh_at( src_bub ).cargo();
         const std::unordered_set<tripoint_abs_ms> dest_set;
 
         zone_sorting::unload_item( you, src,
-                                   zone_unload_options, vp, it->first, dest_set, num_processed );
+                                   zone_unload_options, it->second ? vp : std::nullopt, it->first, dest_set,
+                                   num_processed );
 
         if( you.get_moves() <= 0 ) {
             return;
@@ -13080,6 +13082,10 @@ void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
     zone_sorting::unload_sort_options zone_unload_options = zone_sorting::set_unload_options( you, src,
             false );
 
+    // Which UNSORTED zone types exist at src? Items only participate in
+    // sorting if the source zone matches their binding (vehicle vs terrain).
+    const bool src_has_terrain_unsorted = mgr.has_terrain( zone_type_LOOT_UNSORTED, src, fac_id );
+    const bool src_has_vehicle_unsorted = mgr.has_vehicle( zone_type_LOOT_UNSORTED, src, fac_id );
 
     const std::optional<vpart_reference> vp = here.veh_at( src_bub ).cargo();
     // Track whether any sortable item failed pickup due to carry/cart capacity.
@@ -13090,8 +13096,16 @@ void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
         ++num_processed;
         item &thisitem = *it->first;
 
+        // Skip items that don't match the source zone binding
+        if( it->second && !src_has_vehicle_unsorted ) {
+            continue;
+        }
+        if( !it->second && !src_has_terrain_unsorted ) {
+            continue;
+        }
+
         if( zone_sorting::sort_skip_item( you, it->first, other_activity_items,
-                                          mgr.has( zone_type_LOOT_IGNORE_FAVORITES, src, fac_id ), src ) ) {
+                                          mgr.has( zone_type_LOOT_IGNORE_FAVORITES, src, fac_id ), src, it->second ) ) {
             continue;
         }
 
@@ -13102,7 +13116,7 @@ void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
             mgr.get_near( zt_id, abspos, MAX_VIEW_DISTANCE, &thisitem, fac_id );
 
         std::optional<bool> move_and_reset = zone_sorting::unload_item( you, src,
-                                             zone_unload_options, vp, it->first, dest_set, num_processed );
+                                             zone_unload_options, it->second ? vp : std::nullopt, it->first, dest_set, num_processed );
         // out of moves, or unloaded item container was destroyed or prompted an activity restart
         if( !move_and_reset ) {
             return;
@@ -13138,7 +13152,7 @@ void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
                     here.add_item_or_charges( dest_bub, copy_thisitem );
                 }
                 you.mod_moves( -you.item_handling_cost( copy_thisitem ) );
-                if( vp ) {
+                if( it->second ) {
                     vp->vehicle().remove_item( vp->part(), &thisitem );
                 } else {
                     here.i_rem( src_bub, &thisitem );
@@ -13221,7 +13235,7 @@ void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
             cart_at_source = ( cart_position == src_bub );
         }
 
-        if( cart_at_source && vp ) {
+        if( cart_at_source && it->second ) {
             // Virtual pickup: cart IS the transport. Leave item in cart cargo,
             // just create an item_location pointing at the original.
             thisitem_loc = item_location( vehicle_cursor( vp->vehicle(), vp->part_index() ),
@@ -13252,7 +13266,7 @@ void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
             }
             you.mod_moves( -you.item_handling_cost( copy_thisitem ) );
             // Remove the item we just copy-teleported
-            if( vp ) {
+            if( it->second ) {
                 vp->vehicle().remove_item( vp->part(), &thisitem );
             } else {
                 here.i_rem( src_bub, &thisitem );
@@ -13401,7 +13415,14 @@ void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
 
         if( !match ) {
             add_msg( m_bad, _( "None of the items picked up can be sorted because they won't fit anywhere." ) );
-            stage = LAST;
+            if( virtual_pickup_active ) {
+                picked_up_stuff.clear();
+                dropoff_coords.clear();
+            } else {
+                return_items_to_source( you, src_bub );
+            }
+            unreachable_sources.emplace( src );
+            stage = THINK;
             return;
         }
 
@@ -13432,9 +13453,16 @@ void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
         }
 
     } else if( !you.has_destination() ) {
-        debugmsg( "Sort activity has items to sort but no valid destination, this is a bug" );
-        // Completely kick us out of this activity, something's gone wrong and we don't know what's going on.
-        stage = LAST;
+        // This can happen legitimately when all destination zones are full
+        // (e.g. vehicle-only dest with full cargo). Return items and move on.
+        if( virtual_pickup_active ) {
+            picked_up_stuff.clear();
+            dropoff_coords.clear();
+        } else {
+            return_items_to_source( you, src_bub );
+        }
+        unreachable_sources.emplace( src );
+        stage = THINK;
     }
 }
 
@@ -13448,7 +13476,26 @@ void zone_sort_activity_actor::serialize( JsonOut &jsout ) const
     jsout.member( "coord_set", coord_set );
     jsout.member( "placement", placement );
     jsout.member( "other_activity_items", other_activity_items );
-    jsout.member( "picked_up_stuff", picked_up_stuff );
+    // Purge stale item_locations before serializing - items on vehicles that
+    // are no longer on the map would trigger debugmsg during serialization.
+    std::vector<item_location> valid_picked;
+    const VehicleList &vehicles = get_map().get_vehicles();
+    for( const item_location &loc : picked_up_stuff ) {
+        if( !loc.get_item() ) {
+            continue;
+        }
+        if( const vehicle_cursor *vc = loc.veh_cursor() ) {
+            bool on_map = std::any_of( vehicles.begin(), vehicles.end(),
+            [vc]( const wrapped_vehicle & wv ) {
+                return wv.v == &vc->veh;
+            } );
+            if( !on_map ) {
+                continue;
+            }
+        }
+        valid_picked.push_back( loc );
+    }
+    jsout.member( "picked_up_stuff", valid_picked );
     jsout.member( "dropoff_coords", dropoff_coords );
     jsout.member( "pickup_failure_reported", pickup_failure_reported );
     jsout.member( "virtual_pickup_active", virtual_pickup_active );

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -13039,16 +13039,8 @@ void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
                 // Defensive: route_length populated dropoff_coords earlier, but
                 // route_to_destination failed from the player's current position.
                 // Both use the same A* in a single turn, so this can't fire normally.
-                if( virtual_pickup_active ) {
-                    // Items are still on the cart - just clear batch state.
-                    add_msg_debug( debugmode::DF_ACTIVITY,
-                                   "zone_sort DO: virtual items kept on cart, source marked unreachable" );
-                    picked_up_stuff.clear();
-                    dropoff_coords.clear();
-                    unreachable_sources.emplace( src );
-                } else {
-                    return_items_to_source( you, src_bub );
-                }
+                return_items_to_source( you, src_bub );
+                unreachable_sources.emplace( src );
                 stage = THINK;
             }
             return;
@@ -13415,12 +13407,7 @@ void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
 
         if( !match ) {
             add_msg( m_bad, _( "None of the items picked up can be sorted because they won't fit anywhere." ) );
-            if( virtual_pickup_active ) {
-                picked_up_stuff.clear();
-                dropoff_coords.clear();
-            } else {
-                return_items_to_source( you, src_bub );
-            }
+            return_items_to_source( you, src_bub );
             unreachable_sources.emplace( src );
             stage = THINK;
             return;
@@ -13438,29 +13425,16 @@ void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
             // Defensive: route_length passed (destination was in dropoff_coords)
             // but route_to_destination failed. Both use the same A* in a single
             // turn, so this shouldn't happen normally.
-            if( virtual_pickup_active ) {
-                add_msg_debug( debugmode::DF_ACTIVITY,
-                               "zone_sort DO: virtual items kept on cart, source marked unreachable" );
-                picked_up_stuff.clear();
-                dropoff_coords.clear();
-                unreachable_sources.emplace( src );
-            } else {
-                add_msg_debug( debugmode::DF_ACTIVITY,
-                               "zone_sort DO: route to dest FAILED, returning items, back to THINK" );
-                return_items_to_source( you, src_bub );
-            }
+            add_msg_debug( debugmode::DF_ACTIVITY,
+                           "zone_sort DO: route to dest FAILED, returning items, back to THINK" );
+            return_items_to_source( you, src_bub );
             stage = THINK;
         }
 
     } else if( !you.has_destination() ) {
         // This can happen legitimately when all destination zones are full
         // (e.g. vehicle-only dest with full cargo). Return items and move on.
-        if( virtual_pickup_active ) {
-            picked_up_stuff.clear();
-            dropoff_coords.clear();
-        } else {
-            return_items_to_source( you, src_bub );
-        }
+        return_items_to_source( you, src_bub );
         unreachable_sources.emplace( src );
         stage = THINK;
     }

--- a/src/activity_item_handling.h
+++ b/src/activity_item_handling.h
@@ -71,11 +71,13 @@ bool sorter_out_of_bounds( Character &you, const T &act )
 bool route_to_destination( Character &you, player_activity &act,
                            const tripoint_bub_ms &dest, zone_activity_stage &stage );
 /**
-* Returns true if the given item should be skipped while sorting
+* Returns true if the given item should be skipped while sorting.
+* from_vehicle indicates whether the item is from vehicle cargo (true) or ground (false).
 */
 bool sort_skip_item( Character &you, const item *it,
                      const std::vector<item_location> &other_activity_items,
-                     bool ignore_favorite, const tripoint_abs_ms &src );
+                     bool ignore_favorite, const tripoint_abs_ms &src,
+                     bool from_vehicle );
 
 /**
 * Sets sorting options given nearby UNLOAD_ALL zones

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -1260,42 +1260,8 @@ std::vector<zone_data const *> zone_manager::get_zones_at( const tripoint_abs_ms
 }
 
 bool zone_manager::custom_loot_has( const tripoint_abs_ms &where, const item *it,
-                                    const zone_type_id &ztype, const faction_id &fac ) const
-{
-    std::vector<zone_data const *> const zones = get_zones_at( where, ztype, fac );
-    if( zones.empty() || !it ) {
-        return false;
-    }
-    item const *const check_it = it->this_or_single_content();
-    for( zone_data const *zone : zones ) {
-        if( !zone->get_enabled() ) {
-            continue;
-        }
-
-        loot_options const &options = dynamic_cast<const loot_options &>( zone->get_options() );
-        std::string const filter_string = options.get_mark();
-        bool has = false;
-        if( ztype == zone_type_LOOT_CUSTOM ) {
-            auto const z = item_filter_from_string( filter_string );
-            has = z( *check_it ) || ( check_it != it && z( *it ) );
-        } else if( ztype == zone_type_LOOT_ITEM_GROUP ) {
-            has = item_group::group_contains_item( item_group_id( filter_string ),
-                                                   check_it->typeId() ) ||
-                  ( check_it != it &&
-                    item_group::group_contains_item( item_group_id( filter_string ),
-                            it->typeId() ) );
-        }
-        if( has ) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
-bool zone_manager::custom_loot_has( const tripoint_abs_ms &where, const item *it,
                                     const zone_type_id &ztype, const faction_id &fac,
-                                    bool from_vehicle ) const
+                                    std::optional<bool> from_vehicle ) const
 {
     std::vector<zone_data const *> const zones = get_zones_at( where, ztype, fac );
     if( zones.empty() || !it ) {
@@ -1306,7 +1272,7 @@ bool zone_manager::custom_loot_has( const tripoint_abs_ms &where, const item *it
         if( !zone->get_enabled() ) {
             continue;
         }
-        if( zone->get_is_vehicle() != from_vehicle ) {
+        if( from_vehicle && zone->get_is_vehicle() != *from_vehicle ) {
             continue;
         }
 

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -1146,12 +1146,24 @@ std::unordered_set<tripoint_abs_ms> zone_manager::get_vzone_set( const zone_type
     return type_iter->second;
 }
 
+bool zone_manager::has_terrain( const zone_type_id &type, const tripoint_abs_ms &where,
+                                const faction_id &fac ) const
+{
+    const auto &it = area_cache.find( zone_data::make_type_hash( type, fac ) );
+    return it != area_cache.end() && it->second.count( where ) > 0;
+}
+
+bool zone_manager::has_vehicle( const zone_type_id &type, const tripoint_abs_ms &where,
+                                const faction_id &fac ) const
+{
+    const auto &it = vzone_cache.find( zone_data::make_type_hash( type, fac ) );
+    return it != vzone_cache.end() && it->second.count( where ) > 0;
+}
+
 bool zone_manager::has( const zone_type_id &type, const tripoint_abs_ms &where,
                         const faction_id &fac ) const
 {
-    const auto &point_set = get_point_set( type, fac );
-    const auto &vzone_set = get_vzone_set( type, fac );
-    return point_set.find( where ) != point_set.end() || vzone_set.find( where ) != vzone_set.end();
+    return has_terrain( type, where, fac ) || has_vehicle( type, where, fac );
 }
 
 bool zone_manager::has_near( const zone_type_id &type, const tripoint_abs_ms &where, int range,
@@ -1257,6 +1269,44 @@ bool zone_manager::custom_loot_has( const tripoint_abs_ms &where, const item *it
     item const *const check_it = it->this_or_single_content();
     for( zone_data const *zone : zones ) {
         if( !zone->get_enabled() ) {
+            continue;
+        }
+
+        loot_options const &options = dynamic_cast<const loot_options &>( zone->get_options() );
+        std::string const filter_string = options.get_mark();
+        bool has = false;
+        if( ztype == zone_type_LOOT_CUSTOM ) {
+            auto const z = item_filter_from_string( filter_string );
+            has = z( *check_it ) || ( check_it != it && z( *it ) );
+        } else if( ztype == zone_type_LOOT_ITEM_GROUP ) {
+            has = item_group::group_contains_item( item_group_id( filter_string ),
+                                                   check_it->typeId() ) ||
+                  ( check_it != it &&
+                    item_group::group_contains_item( item_group_id( filter_string ),
+                            it->typeId() ) );
+        }
+        if( has ) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool zone_manager::custom_loot_has( const tripoint_abs_ms &where, const item *it,
+                                    const zone_type_id &ztype, const faction_id &fac,
+                                    bool from_vehicle ) const
+{
+    std::vector<zone_data const *> const zones = get_zones_at( where, ztype, fac );
+    if( zones.empty() || !it ) {
+        return false;
+    }
+    item const *const check_it = it->this_or_single_content();
+    for( zone_data const *zone : zones ) {
+        if( !zone->get_enabled() ) {
+            continue;
+        }
+        if( zone->get_is_vehicle() != from_vehicle ) {
             continue;
         }
 

--- a/src/clzones.h
+++ b/src/clzones.h
@@ -674,10 +674,8 @@ class zone_manager
                        int range = MAX_DISTANCE, const faction_id &fac = your_fac ) const;
         bool has_loot_dest_near( const tripoint_abs_ms &where ) const;
         bool custom_loot_has( const tripoint_abs_ms &where, const item *it,
-                              const zone_type_id &ztype, const faction_id &fac = your_fac ) const;
-        bool custom_loot_has( const tripoint_abs_ms &where, const item *it,
-                              const zone_type_id &ztype, const faction_id &fac,
-                              bool from_vehicle ) const;
+                              const zone_type_id &ztype, const faction_id &fac = your_fac,
+                              std::optional<bool> from_vehicle = std::nullopt ) const;
         std::vector<zone_data const *> get_near_zones( const zone_type_id &type,
                 const tripoint_abs_ms &where, int range,
                 const faction_id &fac = your_fac ) const;

--- a/src/clzones.h
+++ b/src/clzones.h
@@ -666,11 +666,18 @@ class zone_manager
         void cache_vzones( map *pmap = nullptr );
         bool has( const zone_type_id &type, const tripoint_abs_ms &where,
                   const faction_id &fac = your_fac ) const;
+        bool has_terrain( const zone_type_id &type, const tripoint_abs_ms &where,
+                          const faction_id &fac = your_fac ) const;
+        bool has_vehicle( const zone_type_id &type, const tripoint_abs_ms &where,
+                          const faction_id &fac = your_fac ) const;
         bool has_near( const zone_type_id &type, const tripoint_abs_ms &where,
                        int range = MAX_DISTANCE, const faction_id &fac = your_fac ) const;
         bool has_loot_dest_near( const tripoint_abs_ms &where ) const;
         bool custom_loot_has( const tripoint_abs_ms &where, const item *it,
                               const zone_type_id &ztype, const faction_id &fac = your_fac ) const;
+        bool custom_loot_has( const tripoint_abs_ms &where, const item *it,
+                              const zone_type_id &ztype, const faction_id &fac,
+                              bool from_vehicle ) const;
         std::vector<zone_data const *> get_near_zones( const zone_type_id &type,
                 const tripoint_abs_ms &where, int range,
                 const faction_id &fac = your_fac ) const;


### PR DESCRIPTION
#### Summary
Bugfixes "Respect terrain/vehicle zone binding during sorting"

#### Purpose of change

As PatrikLundell pointed out in #85318, zones are tied to either terrain locations or vehicle parts, not just positions. The movement-based sorting rewrite lost this distinction - `populate_items()`, `sort_skip_item()`, `has_items_to_sort()`, and `coord_set` all work purely positionally. A vehicle parked on a terrain UNSORTED zone makes ground items invisible to sorting, and items can leak across terrain/vehicle bindings.

Follow-up items 2 and 3 from #85318 review discussion. Depends on #85319.

#### Describe the solution

- `populate_items()` always collects both vehicle cargo and ground items (removed the `if(vp)...else` branch). The existing `bool` in `zone_items` pairs carries the distinction.
- New `zone_manager::has_terrain()` / `has_vehicle()` do direct cache lookup to check whether a zone exists in terrain or vehicle cache specifically. `has()` rewritten to delegate instead of copying two full sets.
- New `custom_loot_has()` overload with `from_vehicle` filters zones by `get_is_vehicle()` before checking item filters. Also fixes LOOT_ITEM_GROUP falling through the positional path.
- `sort_skip_item()` gets `from_vehicle` and uses binding-aware lookup for the "already at destination" check.
- `has_items_to_sort()` filters items by source zone binding and restricts virtual pickup to vehicle items.
- `stage_do()` filters by source zone binding, threads `from_vehicle` through the pipeline, uses `it->second` instead of `vp` presence for removal/pickup guards.
- No-fit and no-destination fallbacks changed from hard termination to graceful recovery (mark source unreachable, return to THINK). Vehicle-only dests with full cargo are a normal condition now.

#### Describe alternatives you've considered

Could store separate item lists per zone type, but the existing `pair<item*, bool>` already carries the vehicle/terrain distinction. Just needed to collect both and filter downstream - less invasive that way.

#### Testing

Updated 6 existing tests that created terrain zones but tested vehicle cargo items. Four new tests:
- `zone_sorting_vehicle_on_terrain_unsorted_both_items` - terrain UNSORTED only sorts ground items, vehicle cargo untouched
- `zone_sorting_vehicle_unsorted_zone_ground_items_ignored` - vehicle UNSORTED only sorts cargo, ground items untouched
- `zone_sorting_both_zones_at_same_position` - both zone types sort all items
- `zone_sorting_has_terrain_has_vehicle_helpers` - unit test for the new zone_manager methods

#### Additional context

Zone binding is determined at runtime from zone manager caches (rebuilt from `zone_data::is_vehicle` on load). No serialization changes.