### PR TITLE
Revert lab_subway removal

### DIFF
--- a/data/json/effects_on_condition/misc_effect_on_condition.json
+++ b/data/json/effects_on_condition/misc_effect_on_condition.json
@@ -19,6 +19,14 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "ambient_lab_subway",
+    "recurrence": [ "1 hours", "2 hours" ],
+    "global": true,
+    "condition": { "u_at_om_location": "lab_subway" },
+    "effect": [ { "u_message": "<AMBIENT_LAB_SUBWAY>", "snippet": true, "sound": true } ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "ambient_sewer",
     "recurrence": [ "1 hours", "2 hours" ],
     "global": true,

--- a/data/json/items/book/maps.json
+++ b/data/json/items/book/maps.json
@@ -12,7 +12,7 @@
     "use_action": {
       "type": "reveal_map",
       "radius": 90,
-      "terrain": [ "microlab_sub_connector", "microlab_sub_station", "underground_lab_cargo_stationA" ],
+      "terrain": [ "lab_subway", "microlab_sub_connector", "microlab_sub_station", "underground_lab_cargo_stationA" ],
       "message": "You add the hidden stations to your map"
     }
   },

--- a/data/json/obsoletion_and_migration_0.J/obsolete_eoc.json
+++ b/data/json/obsoletion_and_migration_0.J/obsolete_eoc.json
@@ -1,6 +1,0 @@
-[
-  {
-    "type": "effect_on_condition",
-    "id": "ambient_lab_subway"
-  }
-]

--- a/data/json/obsoletion_and_migration_0.J/obsolete_overmap_terrain.json
+++ b/data/json/obsoletion_and_migration_0.J/obsolete_overmap_terrain.json
@@ -353,7 +353,6 @@
     "oter_ids": {
       "lodge_basement_laboratory_entrance": "omt_obsolete",
       "lab": "empty_rock",
-      "lab_subway": "empty_rock",
       "lab_stairs": "empty_rock",
       "lab_core": "empty_rock",
       "lab_finale": "empty_rock",
@@ -401,7 +400,6 @@
       "central_lab_shaft": "empty_rock",
       "central_lab_entrance": "forest",
       "lab_north": "empty_rock",
-      "lab_subway_north": "empty_rock",
       "lab_stairs_north": "empty_rock",
       "lab_core_north": "empty_rock",
       "lab_finale_north": "empty_rock",
@@ -449,7 +447,6 @@
       "central_lab_shaft_north": "empty_rock",
       "central_lab_entrance_north": "forest",
       "lab_south": "empty_rock",
-      "lab_subway_south": "empty_rock",
       "lab_stairs_south": "empty_rock",
       "lab_core_south": "empty_rock",
       "lab_finale_south": "empty_rock",
@@ -497,7 +494,6 @@
       "central_lab_shaft_south": "empty_rock",
       "central_lab_entrance_south": "forest",
       "lab_east": "empty_rock",
-      "lab_subway_east": "empty_rock",
       "lab_stairs_east": "empty_rock",
       "lab_core_east": "empty_rock",
       "lab_finale_east": "empty_rock",
@@ -545,7 +541,6 @@
       "central_lab_shaft_east": "empty_rock",
       "central_lab_entrance_east": "forest",
       "lab_west": "empty_rock",
-      "lab_subway_west": "empty_rock",
       "lab_stairs_west": "empty_rock",
       "lab_core_west": "empty_rock",
       "lab_finale_west": "empty_rock",
@@ -591,18 +586,7 @@
       "central_lab_finale_west": "empty_rock",
       "central_lab_train_depot_west": "empty_rock",
       "central_lab_shaft_west": "empty_rock",
-      "central_lab_entrance_west": "forest",
-      "lab_subway_ne": "empty_rock",
-      "lab_subway_wn": "empty_rock",
-      "lab_subway_ns": "empty_rock",
-      "lab_subway_ew": "empty_rock",
-      "lab_subway_es": "empty_rock",
-      "lab_subway_sw": "empty_rock",
-      "lab_subway_new": "empty_rock",
-      "lab_subway_nes": "empty_rock",
-      "lab_subway_nsw": "empty_rock",
-      "lab_subway_esw": "empty_rock",
-      "lab_subway_nesw": "empty_rock"
+      "central_lab_entrance_west": "forest"
     }
   }
 ]

--- a/data/json/overmap/overmap_connections.json
+++ b/data/json/overmap/overmap_connections.json
@@ -36,7 +36,10 @@
   {
     "type": "overmap_connection",
     "id": "subway_tunnel",
-    "subtypes": [ { "terrain": "subway", "locations": [ "subterranean_subway" ], "flags": [ "ORTHOGONAL" ] } ]
+    "subtypes": [
+      { "terrain": "subway", "locations": [ "subterranean_subway" ], "flags": [ "ORTHOGONAL" ] },
+      { "terrain": "lab_subway", "locations": [ "lab_subway" ], "flags": [ "ORTHOGONAL" ] }
+    ]
   },
   {
     "type": "overmap_connection",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_transportation.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_transportation.json
@@ -209,6 +209,23 @@
   },
   {
     "type": "overmap_terrain",
+    "id": "lab_subway",
+    "name": "subway",
+    "vision_levels": "underground_stone",
+    "color": "dark_gray",
+    "see_cost": "full_high",
+    "extras": "lab_subway",
+    "mapgen_straight": [ { "builtin": "subway_straight" } ],
+    "mapgen_curved": [ { "builtin": "subway_curved" } ],
+    "mapgen_end": [ { "builtin": "subway_end" } ],
+    "mapgen_tee": [ { "builtin": "subway_tee" } ],
+    "mapgen_four_way": [ { "builtin": "subway_four_way" } ],
+    "spawns": { "group": "GROUP_SUBWAY_LAB", "population": [ 1, 3 ], "chance": 50 },
+    "travel_cost_type": "dirt_road",
+    "flags": [ "LINEAR" ]
+  },
+  {
+    "type": "overmap_terrain",
     "id": [ "sub_ramp_above", "sub_ramp_below" ],
     "name": "subway ramp",
     "vision_levels": "underground_stone",

--- a/data/json/overmap/special_locations.json
+++ b/data/json/overmap/special_locations.json
@@ -92,6 +92,11 @@
   },
   {
     "type": "overmap_location",
+    "id": "lab_subway",
+    "terrains": [ "deep_rock" ]
+  },
+  {
+    "type": "overmap_location",
     "id": "road",
     "terrains": [ "ranch_camp_77", "road", "road_nesw_manhole" ]
   },

--- a/data/mods/TEST_DATA/overmap_terrain_coverage_test/overmap_terrain_coverage_whitelist.json
+++ b/data/mods/TEST_DATA/overmap_terrain_coverage_test/overmap_terrain_coverage_whitelist.json
@@ -139,6 +139,7 @@
       "xedra_fishing_shack_0",
       "xedra_fishing_shack_1",
       "xedra_fishing_shack_2",
+      "microlab_sub_connector",
       "test_forest_very_thick"
     ]
   }

--- a/data/mods/alt_map_key/overmap_terrain_light_gray.json
+++ b/data/mods/alt_map_key/overmap_terrain_light_gray.json
@@ -616,6 +616,13 @@
   },
   {
     "type": "overmap_terrain",
+    "id": "lab_subway",
+    "copy-from": "lab_subway",
+    "name": "subway",
+    "color": "light_gray"
+  },
+  {
+    "type": "overmap_terrain",
     "id": "derelict_property",
     "copy-from": "derelict_property",
     "name": "derelict property",

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -1042,6 +1042,7 @@ bool overmap::generate_sub( const int z )
 {
     cata_assert( z < 0 );
 
+    //TODO: This forces every sub level to generate, otherwise this function doesn't get called for anything below -2 currently.
     bool requires_sub = true;
     std::vector<point_om_omt> subway_points;
     std::vector<point_om_omt> sewer_points;

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -1042,7 +1042,7 @@ bool overmap::generate_sub( const int z )
 {
     cata_assert( z < 0 );
 
-    bool requires_sub = false;
+    bool requires_sub = true;
     std::vector<point_om_omt> subway_points;
     std::vector<point_om_omt> sewer_points;
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Revert the removal of the lab_subway in #85240
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Restore the lab_subway generation as it is what the z-4 subway connections use to connect the subway entrances to each other. 
Restoring this revealed that overmap::generate shortcuts generating lower levels if the omts on the level it generates don't specifically ask for it. With the removal of old labs nothing wanted to generated anything below -2. As an interim solution overmap::generate_sub will run for every sub level
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Z-4 subways generate again and other subways still generate as well on -2 and the conenctors between them
<img width="3203" height="1715" alt="image" src="https://github.com/user-attachments/assets/9e22b914-6060-4528-928d-365d9eb425b3" />

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
