### PR TITLE
Place player in a couple of tests so they can pass in isolation

### DIFF
--- a/tests/char_sight_test.cpp
+++ b/tests/char_sight_test.cpp
@@ -123,6 +123,7 @@ TEST_CASE( "light_and_fine_detail_vision_mod", "[character][sight][light][vision
 
 TEST_CASE( "npc_light_and_fine_detail_vision_mod", "[character][npc][sight][light][vision]" )
 {
+    g->place_player( { 66, 66, 0 } );
     Character &u = get_player_character();
     shared_ptr_fast<npc> guy = make_shared_fast<npc>();
     overmap_buffer.insert_npc( guy );

--- a/tests/monster_test.cpp
+++ b/tests/monster_test.cpp
@@ -635,6 +635,7 @@ TEST_CASE( "monster_broken_verify", "[monster]" )
 TEST_CASE( "limit_mod_size_bonus", "[monster]" )
 {
     clear_creatures();
+    g->place_player( { 66, 66, 0 } );
     const std::string monster_type = "mon_zombie";
     monster &test_monster = spawn_test_monster( monster_type, tripoint_bub_ms::zero );
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

There are two tests that do not pass if you run them in isolation: `light_and_fine_detail_vision_mod` and `limit_mod_size_bonus`.

#### Describe the solution

Call `g->place_player` and now the tests pass.

#### Describe alternatives you've considered

We could call `g->place_player` at the start of the test suite / map initialization and let the tests assume it's been done prior to running them.  I'm not sure where such code would live.

#### Testing

`npc_light_and_fine_detail_vision_mod` before
```
-----------------------------------------
21:00:05.871 : Starting log.
21:00:05.872 INFO : Cataclysm DDA version cdda-experimental-2026-02-18-2253 0953846e99-dirty
21:00:05.872 INFO : Default randomness seeded to: 3050937862

21:00:05.877 INFO : [options] C locale set to C
21:00:05.877 INFO : [options] C++ locale set to C
21:00:08.353 INFO : src/mod_tracker.h:68: Tried check if 'house_detatched5' had a duplicate, but type 'overmap_special' does not track object sources
21:00:08.355 INFO : src/mod_tracker.h:68: Tried check if 'default' had a duplicate, but type 'region_settings_city' does not track object sources
21:00:08.355 INFO : src/mod_tracker.h:68: Tried check if 'default_t_region_groundcover_swamp' had a duplicate, but type 'region_terrain_furniture' does not track object sources
21:00:08.355 INFO : src/mod_tracker.h:68: Tried check if 'forest_thick' had a duplicate, but type 'map_extra_collection' does not track object sources
21:00:08.355 INFO : src/mod_tracker.h:68: Tried check if 'default' had a duplicate, but type 'region_settings_forest_mapgen' does not track object sources
21:00:08.355 INFO : src/mod_tracker.h:68: Tried check if 'biome_forest_thick_default' had a duplicate, but type 'forest_biome_mapgen' does not track object sources
21:00:08.503 WARNING : Dark Days Ahead pack load time:: 1909401us (avg: 1909401us) (count: 1)
21:00:08.503 WARNING : Magiclysm pack load time:: 613364us (avg: 613364us) (count: 1)
21:00:08.503 WARNING : TESTING DATA pack load time:: 54958us (avg: 54958us) (count: 1)
21:00:25.790 INFO : Game data loaded, running Catch2 session:
Filters: npc_light_and_fine_detail_vision_mod

21:00:25.790 ERROR : (error message will follow backtrace)
    0   cata_test                           0x0000000101033e24 debug_write_backtrace(std::__1::basic_ostream<char, std::__1::char_traits<char>>&) + 72
    1   cata_test                           0x0000000101032c48 DebugLog(DebugLevel, DebugClass) + 576
    2   cata_test                           0x0000000101031fc4 realDebugmsg(char const*, char const*, char const*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 276
    3   cata_test                           0x0000000101a770dc npc::place_on_map(map*) + 320
    4   cata_test                           0x0000000101202eb4 game::load_npcs() + 520
    5   cata_test                           0x00000001003e1768 ____C_A_T_C_H____T_E_S_T____8() + 108
    6   cata_test                           0x0000000100a3dd4c Catch::RunContext::invokeActiveTestCase() + 188
    7   cata_test                           0x0000000100a3bf00 Catch::RunContext::runCurrentTest(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>&) + 408
    8   cata_test                           0x0000000100a3b5a4 Catch::RunContext::runTest(Catch::TestCase const&) + 276
    9   cata_test                           0x0000000100a40ce0 Catch::Session::runInternal() + 2280
    10  cata_test                           0x0000000100a40340 Catch::Session::run() + 156
    11  cata_test                           0x0000000100a5a8fc main + 9360
    12  dyld                                0x000000018e5fdd54 start + 7184

    Attempting to repeat stack trace using debug symbols…
    backtrace: Could not extract binary name from line
    backtrace: Could not extract binary name from line
    backtrace: Could not extract binary name from line
    backtrace: Could not extract binary name from line
    backtrace: Could not extract binary name from line
    backtrace: Could not extract binary name from line
    backtrace: Could not extract binary name from line
    backtrace: Could not extract binary name from line
    backtrace: Could not extract binary name from line
    backtrace: Could not extract binary name from line
    backtrace: Could not extract binary name from line
    backtrace: Could not extract binary name from line
    backtrace: Could not extract binary name from line
Backtrace emission took 0 seconds.
(continued from above) ERROR : src/npc.cpp:1221 [void npc::place_on_map(map *)] Failed to place NPC in a valid location near (20,10,-500)===============================================================================
All tests passed (16 assertions in 1 test case)
```

`npc_light_and_fine_detail_vision_mod` after
```
-----------------------------------------
21:01:37.680 : Starting log.
21:01:37.680 INFO : Cataclysm DDA version 0e6874aa32-dirty
21:01:37.680 INFO : Default randomness seeded to: 369789058

21:01:37.687 INFO : [options] C locale set to C
21:01:37.687 INFO : [options] C++ locale set to C
21:01:40.513 INFO : src/mod_tracker.h:68: Tried check if 'house_detatched5' had a duplicate, but type 'overmap_special' does not track object sources
21:01:40.516 INFO : src/mod_tracker.h:68: Tried check if 'default' had a duplicate, but type 'region_settings_city' does not track object sources
21:01:40.516 INFO : src/mod_tracker.h:68: Tried check if 'default_t_region_groundcover_swamp' had a duplicate, but type 'region_terrain_furniture' does not track object sources
21:01:40.516 INFO : src/mod_tracker.h:68: Tried check if 'forest_thick' had a duplicate, but type 'map_extra_collection' does not track object sources
21:01:40.516 INFO : src/mod_tracker.h:68: Tried check if 'default' had a duplicate, but type 'region_settings_forest_mapgen' does not track object sources
21:01:40.516 INFO : src/mod_tracker.h:68: Tried check if 'biome_forest_thick_default' had a duplicate, but type 'forest_biome_mapgen' does not track object sources
21:01:40.684 WARNING : Dark Days Ahead pack load time:: 2204862us (avg: 2204862us) (count: 1)
21:01:40.684 WARNING : Magiclysm pack load time:: 657744us (avg: 657744us) (count: 1)
21:01:40.684 WARNING : TESTING DATA pack load time:: 64274us (avg: 64274us) (count: 1)
21:01:58.112 INFO : Game data loaded, running Catch2 session:
Filters: npc_light_and_fine_detail_vision_mod
===============================================================================
All tests passed (16 assertions in 1 test case)
```

`limit_mod_size_bonus` before
```
Filters: limit_mod_size_bonus

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cata_test is a Catch v2.13.7 host application.
Run with -? for options

-------------------------------------------------------------------------------
limit_mod_size_bonus
-------------------------------------------------------------------------------
../tests/monster_test.cpp:635
...............................................................................

../tests/map_helpers.cpp:205: FAILED:
  REQUIRE( get_creature_tracker().creature_at( start ) == nullptr )
with expansion:
  0x0000000b08e38000 == nullptr

===============================================================================
test cases: 1 | 1 failed
assertions: 2 | 1 passed | 1 failed
```

`limit_mod_size_bonus` after
```
Filters: limit_mod_size_bonus
===============================================================================
All tests passed (14 assertions in 1 test case)
```

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
