### PR TITLE
Fix maybe-uninitialized warning in unseal_and_spill_test

### DIFF
--- a/tests/unseal_and_spill_test.cpp
+++ b/tests/unseal_and_spill_test.cpp
@@ -185,8 +185,8 @@ void unseal_items_containing( contents_change_handler &handler, item_location &r
 
 struct item_initialization {
     itype_id id;
-    bool fill_parent;
-    bool seal;
+    bool fill_parent = false;
+    bool seal = false;
     std::vector<item_initialization> contents;
 };
 


### PR DESCRIPTION
#### Summary
Build "Fix maybe-uninitialized warning in unseal_and_spill_test"

Closes #85430

#### Purpose of change

GCC 14 with `-Werror=maybe-uninitialized` flags `fill_parent` and `seal` in the `item_initialization` struct as potentially uninitialized. The `default:` branch in `scenario_initial_state` calls `FAIL()` without assigning them, and the compiler can't prove that path never reaches the return statement.

Observed in https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/22166648110/job/64095246089?pr=85319

#### Describe the solution

Add `= false` default initializers to both bool members. All actual usage paths already assign them explicitly, so this just satisfies the compiler.

#### Describe alternatives you've considered

Could suppress the warning with a pragma, but that would be silly for a two-character fix.

#### Testing

Builds cleanly with GCC 14 `-Werror=maybe-uninitialized`. No behavioral change since all real code paths already set both fields.

#### Additional context

Introduced by rename in #85384 8fd0ad979f but the bools were always uninitialized - just wasn't caught before.