### PR TITLE
Fix flaky morale ranged kill visibility test

### DIFF
--- a/tests/morale_test.cpp
+++ b/tests/morale_test.cpp
@@ -262,7 +262,7 @@ TEST_CASE( "player_morale_kills_hostile_bandit", "[player_morale]" )
 TEST_CASE( "player_morale_ranged_kill_of_unaware_hostile_bandit", "[player_morale]" )
 {
     map &here = get_map();
-
+    clear_map();
     clear_avatar();
     avatar &player = get_avatar();
     // Set the time to midnight to ensure the bandit doesn't notice the player.


### PR DESCRIPTION
#### Summary
Infrastructure "Fix flaky player_morale_ranged_kill_of_unaware_hostile_bandit test"

#### Purpose of change

The test relies on midnight darkness to ensure an NPC can't see the player, but it never calls `clear_map()`. Stale light sources (terrain, items, fields) from previous tests can illuminate the player position, making `ambient_light_at()` exceed `natural_light_level_cache` and giving the NPC full sight range.

Observed in https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/22170172258/job/64106647712?pr=85403

#### Describe the solution

Add `clear_map()` before `clear_avatar()` so terrain is reset to grass, items/fields/NPCs are cleared, and lighting caches start from a clean state. This is what other visibility-sensitive tests (like char_sight_test) already do.

#### Describe alternatives you've considered

Could also use `clear_map_without_vision()` and let `set_time()` handle the vision rebuild, but `clear_map()` is simpler and the overhead is negligible for a single test.

#### Testing

Builds clean. The one-line fix is straightforward -- the test was missing standard map cleanup that other visibility tests already use.

#### Additional context

None