### PR TITLE
Add dimension travel to the event bus for EOCs to use

### DIFF
--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -1808,6 +1808,7 @@ Every event EOC passes context vars with each of their key value pairs that the 
 | dies_of_starvation | | { "character", `character_id` }  | character / NONE |
 | dies_of_thirst | | { "character", `character_id` }  | character / NONE |
 | digs_into_lava | | NONE  | avatar / NONE |
+| dimension_travel | Triggers after the player travels between dimensions | { "character", `character_id` }<br />{ "from_dimension", `string` }<br />{ "to_dimension", `string` }  | avatar / NONE |
 | disarms_nuke | Triggered via disarm missile computer action in missile silo special | NONE  | avatar / NONE |
 | eats_sewage | Triggered via use action `SEWAGE` | NONE  | avatar / NONE |
 | evolves_mutation | | { "character", `character_id` },<br/> { "from_trait", `trait_id` },<br/> { "to_trait", `trait_id` }, | character / NONE |

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -75,6 +75,7 @@ std::string enum_to_string<event_type>( event_type data )
         case event_type::dies_of_starvation: return "dies_of_starvation";
         case event_type::dies_of_thirst: return "dies_of_thirst";
         case event_type::digs_into_lava: return "digs_into_lava";
+        case event_type::dimension_travel: return "dimension_travel";
         case event_type::disarms_nuke: return "disarms_nuke";
         case event_type::eats_sewage: return "eats_sewage";
         case event_type::evolves_mutation: return "evolves_mutation";
@@ -143,7 +144,7 @@ DEFINE_EVENT_HELPER_FIELDS( event_spec_empty )
 DEFINE_EVENT_HELPER_FIELDS( event_spec_character )
 DEFINE_EVENT_HELPER_FIELDS( event_spec_character_item )
 
-static_assert( static_cast<int>( event_type::num_event_types ) == 105,
+static_assert( static_cast<int>( event_type::num_event_types ) == 106,
                "This static_assert is a reminder to add a definition below when you add a new "
                "event_type.  If your event_spec specialization inherits from another struct for "
                "its fields definition then you probably don't need a definition here." );
@@ -218,6 +219,7 @@ DEFINE_EVENT_FIELDS( uses_debug_menu )
 DEFINE_EVENT_FIELDS( u_var_changed )
 DEFINE_EVENT_FIELDS( vehicle_moves )
 DEFINE_EVENT_FIELDS( character_butchered_corpse )
+DEFINE_EVENT_FIELDS( dimension_travel )
 
 } // namespace event_detail
 

--- a/src/event.h
+++ b/src/event.h
@@ -83,6 +83,7 @@ enum class event_type : int {
     dies_of_starvation,
     dies_of_thirst,
     digs_into_lava,
+    dimension_travel,
     disarms_nuke,
     eats_sewage,
     evolves_mutation,
@@ -191,7 +192,7 @@ struct event_spec_character_item {
     };
 };
 
-static_assert( static_cast<int>( event_type::num_event_types ) == 105,
+static_assert( static_cast<int>( event_type::num_event_types ) == 106,
                "This static_assert is to remind you to add a specialization for your new "
                "event_type below" );
 
@@ -602,6 +603,16 @@ struct event_spec<event_type::dies_of_thirst> : event_spec_character {};
 
 template<>
 struct event_spec<event_type::digs_into_lava> : event_spec_empty {};
+
+template<>
+struct event_spec<event_type::dimension_travel> {
+    static constexpr std::array<event_field, 3> fields = {{
+            { "character", cata_variant_type::character_id },
+            { "from_dimension", cata_variant_type::string },
+            { "to_dimension", cata_variant_type::string },
+        }
+    };
+};
 
 template<>
 struct event_spec<event_type::disarms_nuke> : event_spec_empty {};

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -760,6 +760,7 @@ bool game::start_game()
     get_safemode().load_global();
 
     init_autosave();
+    dimension_prefix.clear();
 
     background_pane background;
     static_popup popup;
@@ -9660,6 +9661,7 @@ bool game::travel_to_dimension( const std::string &new_prefix,
         travel_to_dimension( old_prefix, region_type, npc_travellers, veh );
     }
     game::mon_info_update();
+    get_event_bus().send<event_type::dimension_travel>( player.getID(), old_prefix, dimension_prefix );
     return true;
 }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -760,7 +760,6 @@ bool game::start_game()
     get_safemode().load_global();
 
     init_autosave();
-    dimension_prefix.clear();
 
     background_pane background;
     static_popup popup;

--- a/src/memorial_logger.cpp
+++ b/src/memorial_logger.cpp
@@ -774,6 +774,12 @@ void memorial_logger::notify( const cata::event &e )
                  pgettext( "memorial_female", "Dug a shaft into lava." ) );
             break;
         }
+        case event_type::dimension_travel: {
+            add( pgettext( "memorial_male", "Traveled from '%s' to '%s'." ),
+                 pgettext( "memorial_female", "Traveled from '%s' to '%s'." ),
+                 e.get<std::string>( "from_dimension" ), e.get<std::string>( "to_dimension" ) );
+            break;
+        }
         case event_type::disarms_nuke: {
             add( pgettext( "memorial_male", "Disarmed a nuclear missile." ),
                  pgettext( "memorial_female", "Disarmed a nuclear missile." ) );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Infrastructure "Add dimension travel to the event bus for EOCs to use"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Adds dimension travel to the event bus for EOCs to use
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adds a new event and related infra to make it available
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
<img width="802" height="432" alt="image" src="https://github.com/user-attachments/assets/f1af3a43-b468-44ff-a76c-74d320a051ef" />

```jsonc
  {
    "type": "effect_on_condition",
    "id": "EOC_TESTING",
    "eoc_type": "EVENT",
    "required_event": "dimension_travel",
    "effect": [ { "u_message": "From: '<context_val:from_dimension>' To: '<context_val:to_dimension>'" } ]
  },
```

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
