### PR TITLE
Fix another surroundings menu freeze

### DIFF
--- a/src/text.cpp
+++ b/src/text.cpp
@@ -357,8 +357,9 @@ static std::string trim_substring( std::string_view text, float width )
         trimmed_str += ellipsis;
         float trimmed_width = ImGui::CalcTextSize( trimmed_str.c_str(), nullptr, true ).x;
 
-        // number of characters we can still draw or drew too much estimated by ellipsis width
-        float free_chars = ( width - trimmed_width ) / ellipsis_width;
+        // number of characters we can still draw or drew too much
+        // estimated by average character width of trimmed string
+        float free_chars = ( width - trimmed_width ) / ( trimmed_width / utf8_width( trimmed_str ) );
 
         if( free_chars >= 1.f && last_free != free_chars ) {
             visible_chars += std::floor( free_chars );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fixes #85408

#### Describe the solution

Estimating available space using the ellipsis character was a convenient shortcut since the value was already present. However it breaks with more outlandish combinations of font, fallback font and font settings (and possibly variable-width fonts with huge variations in character width) as demonstrated in the issue. So instead estimate it by average character width of the tested substring.

#### Describe alternatives you've considered

Just don't support variable-width fonts and use the existing simplified algorithm for fixed-width fonts.

#### Testing

Use the font and the config from the issue, load save, open surroundings menu.

#### Additional context
