### PR TITLE
Just show items in holsters on "holster" iuse

### DIFF
--- a/src/item.h
+++ b/src/item.h
@@ -3161,6 +3161,9 @@ class item : public visitable
         std::list<item *> all_known_contents();
         std::list<const item *> all_known_contents() const;
 
+        std::list<item *> all_holstered_items();
+        std::list<const item *> all_holstered_items() const;
+
         std::list<item *> all_ablative_armor();
         std::list<const item *> all_ablative_armor() const;
 

--- a/src/item_container.cpp
+++ b/src/item_container.cpp
@@ -1021,6 +1021,16 @@ std::list<const item *> item::all_known_contents() const
     return contents.all_known_contents();
 }
 
+std::list<item *> item::all_holstered_items()
+{
+    return contents.all_holstered_items();
+}
+
+std::list<const item *> item::all_holstered_items() const
+{
+    return contents.all_holstered_items();
+}
+
 void item::clear_items()
 {
     contents.clear_items();

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -1821,13 +1821,15 @@ std::list<const item *> item_contents::all_known_contents() const
     } );
 }
 
-std::list<item *> item_contents::all_holstered_items() {
+std::list<item *> item_contents::all_holstered_items()
+{
     return all_items_top( []( const item_pocket & pocket ) {
         return pocket.is_type( pocket_type::CONTAINER ) && pocket.is_holster();
     } );
 }
 
-std::list<const item *> item_contents::all_holstered_items() const {
+std::list<const item *> item_contents::all_holstered_items() const
+{
     return all_items_top( []( const item_pocket & pocket ) {
         return pocket.is_type( pocket_type::CONTAINER ) && pocket.is_holster();
     } );

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -1821,6 +1821,18 @@ std::list<const item *> item_contents::all_known_contents() const
     } );
 }
 
+std::list<item *> item_contents::all_holstered_items() {
+    return all_items_top( []( const item_pocket & pocket ) {
+        return pocket.is_type( pocket_type::CONTAINER ) && pocket.is_holster();
+    } );
+}
+
+std::list<const item *> item_contents::all_holstered_items() const {
+    return all_items_top( []( const item_pocket & pocket ) {
+        return pocket.is_type( pocket_type::CONTAINER ) && pocket.is_holster();
+    } );
+}
+
 std::list<item *> item_contents::all_ablative_armor()
 {
     return all_items_top( []( const item_pocket & pocket ) {

--- a/src/item_contents.h
+++ b/src/item_contents.h
@@ -144,6 +144,10 @@ class item_contents
         std::list<item *> all_known_contents();
         std::list<const item *> all_known_contents() const;
 
+        // returns all items contained in holster pockets
+        std::list<item *> all_holstered_items();
+        std::list<const item *> all_holstered_items() const;
+
         // returns all the ablative armor in pockets
         std::list<item *> all_ablative_armor();
         std::list<const item *> all_ablative_armor() const;

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -2790,8 +2790,7 @@ std::optional<int> holster_actor::use( Character *you, item &it, map *here,
     std::string prompt = holster_prompt.empty() ? _( "Holster item" ) : holster_prompt.translated();
     opts.push_back( prompt );
     pos = -1;
-    std::list<item *> all_items = it.all_items_top(
-                                      pocket_type::CONTAINER );
+    std::list<item *> all_items = it.all_holstered_items();
     std::transform( all_items.begin(), all_items.end(), std::back_inserter( opts ),
     []( const item * elem ) {
         return string_format( _( "Draw %s" ), elem->display_name() );


### PR DESCRIPTION
Instead of every bit inside items with multiple pockets. Specially useful for load bearing vests and backpacks with carabiners.

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Interface "Holster iuse just list items in pockets that are flagged as holsters"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fire action is pretty convenient to quick select a gun you have. For guns inside holsters - and holster here means any pocket that works like a holster, so that includes "carabiners and straps" from pockets for example - the iuse will list every item inside that item, for a backpack is too many things.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

This change will filter possible items to just the ones inside actual holster-like pockets. That means, a hiking backpack for example will list only itens in their 2 sheats or one of the 4 carabiner / strap pockets.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

My original intent was to rework this behavior to be more smart in regard to holster state, for example, show individual "Holster wielded gun on pocket 1, pocket 2" as well the multiples draws. In other words, be holster-oriented instead of content-oriented. I believe this would make the iuse behaviour more consistent and probably avoid weird edge cases. Instead, I did this because was the simplest thing with minimal churn, which yet nets some positive experience to make the feature useful. 

Other alternative is just keep using my current way of manually wield the guns, via many keystrokes.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Before:

<img width="619" height="990" alt="Screenshot 2026-02-19 at 17 26 25" src="https://github.com/user-attachments/assets/5ae4c7f5-8995-4875-b557-e9b321635a88" />

I can't even see my rifle!

After:

<img width="471" height="134" alt="Screenshot 2026-02-19 at 17 19 47" src="https://github.com/user-attachments/assets/6abea24d-e024-40c0-a8d5-de8514d2188a" />

Ok, now it's useful

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
