### PR TITLE
[Sky Island] Add generic steel back to warp crafts

### DIFF
--- a/data/mods/Sky_Island/recipes_materials.json
+++ b/data/mods/Sky_Island/recipes_materials.json
@@ -443,6 +443,24 @@
     "flags": [ "BLIND_EASY" ]
   },
   {
+    "result": "steel_chunk",
+    "type": "recipe",
+    "activity_level": "NO_EXERCISE",
+    "category": "CC_WARP",
+    "subcategory": "CSC_WARP_MATERIALS",
+    "id_suffix": "from_tokens",
+    "skill_used": "survival",
+    "difficulty": 0,
+    "time": "1 s",
+    "autolearn": true,
+    "reversible": false,
+    "tools": [ [ [ "fakeitem_infinityore", -1 ] ] ],
+    "components": [ [ [ "warptoken_material", 2 ] ] ],
+    "flags": [ "BLIND_EASY" ],
+    "result_mult": 3,
+    "//": "375 g steel per token"
+  },
+  {
     "result": "budget_steel_chunk",
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
@@ -547,6 +565,24 @@
     "components": [ [ [ "warptoken_material", 2 ] ] ],
     "flags": [ "BLIND_EASY" ],
     "//": "Treating qt_steel as 5x as valuable as mc_steel: 25 cents steel per token"
+  },
+  {
+    "result": "steel_lump",
+    "type": "recipe",
+    "activity_level": "NO_EXERCISE",
+    "category": "CC_WARP",
+    "subcategory": "CSC_WARP_MATERIALS",
+    "id_suffix": "from_tokens",
+    "skill_used": "survival",
+    "difficulty": 0,
+    "time": "1 s",
+    "autolearn": true,
+    "reversible": false,
+    "tools": [ [ [ "fakeitem_infinityore", -1 ] ] ],
+    "components": [ [ [ "warptoken_material", 8 ] ] ],
+    "flags": [ "BLIND_EASY" ],
+    "result_mult": 3,
+    "//": "375 g steel per token"
   },
   {
     "result": "budget_steel_lump",


### PR DESCRIPTION
#### Summary
Mods "[Sky Island] Add generic steel chunk and lump back to warp crafts"

#### Purpose of change

You need these to repair steel stuff.  They were removed in #85153, but it seems we still need them around.

#### Describe the solution

Add in `steel_chunk` and `steel_lump` to the warp crafts.

#### Describe alternatives you've considered

We could change the repair code to accept any steel of a grade greater than or equal to the item uses, but I'm not sure if we'd even want that.

#### Testing

Crafted some chunks and used them to fix a steel object.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
