### PR TITLE
[Sky Island] Three Bug Fixes

### DIFF
--- a/data/mods/Sky_Island/EOCs.json
+++ b/data/mods/Sky_Island/EOCs.json
@@ -468,6 +468,7 @@
       { "math": [ "u_val('rad') = 0" ] },
       { "math": [ "u_val('pkill') = 0" ] },
       { "math": [ "u_oxygen() = u_oxygen_max()" ] },
+      { "math": [ "u_val('stamina') = u_val('stamina_max')" ] },
       { "u_add_effect": "panacea", "duration": "30 s", "intensity": 1 },
       {
         "u_lose_effect": [

--- a/data/mods/Sky_Island/EOCs.json
+++ b/data/mods/Sky_Island/EOCs.json
@@ -467,9 +467,11 @@
       { "math": [ "u_pain() = 0" ] },
       { "math": [ "u_val('rad') = 0" ] },
       { "math": [ "u_val('pkill') = 0" ] },
+      { "math": [ "u_oxygen() = u_oxygen_max()" ] },
       { "u_add_effect": "panacea", "duration": "30 s", "intensity": 1 },
       {
         "u_lose_effect": [
+          "irradiated",
           "corroding",
           "onfire",
           "dazed",

--- a/data/mods/Sky_Island/sickness_checks.json
+++ b/data/mods/Sky_Island/sickness_checks.json
@@ -35,6 +35,7 @@
     "effect": [
       { "u_add_effect": "warpsickness", "intensity": 6, "duration": "PERMANENT" },
       { "u_lose_effect": "warpdisintegration" },
+      { "u_lose_effect": "sleep" },
       {
         "u_message": "Goosebumps cover your skin as a warp pulse passes through you.  You're only one warp pulse from your deadline.",
         "popup": true


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Sky Island] Three Bug Fixes"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #83304
Fixes #73245
Fixes #75207
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
83304 Fix - remove irradiated effect and set oxygen to max in the heal extras EOC

73245 Fix - Apply guardians suggestion to manually clear sleep at the first EOC to warn the player time is running out

75207 Fix - Restore stamina in the heal extras EOC
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested dying via all the aforementioned ways and each effect is properly cleared.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
When dying via radiation, it applies a permanent irradiated effect that has no downsides anymore since heal extras already removes the rad level but this now clears the effect so there's no effect in the @ screen
As for the drowning continuing upon return to the island, just moving once clears it immediately, waiting has the player continue to drown. Setting oxygen to max solves it though.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
