### PR TITLE
HEW report can trigger LIXA quest

### DIFF
--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
@@ -278,7 +278,12 @@
             {
               "not": { "compare_string": [ "no", { "u_val": "dialogue_intercom_completed_robofac_intercom_lixa_sm_1" } ] }
             },
-            { "math": [ "u_portal_storm_recordings_sold > 2" ] }
+            {
+              "or": [
+                { "math": [ "u_portal_storm_recordings_sold > 2" ] },
+                { "math": [ "HEW_lixa_data_sold > 0" ] }
+              ]
+            }
           ]
         },
         "topic": "MISSION_ROBOFAC_INTERCOM_LIXA_SM_1_OFFER"
@@ -1440,7 +1445,8 @@
       "MISSION_ROBOFAC_INTERCOM_LIXA_SM_1_WHAT_ELSE",
       "MISSION_ROBOFAC_INTERCOM_LIXA_SM_1_OFFER_ADVICE",
       "MISSION_ROBOFAC_INTERCOM_LIXA_SM_1_LIXA_ACRONYM",
-      "MISSION_ROBOFAC_INTERCOM_LIXA_SM_1_OFFER_ADVICE_Replacement"
+      "MISSION_ROBOFAC_INTERCOM_LIXA_SM_1_OFFER_ADVICE_Replacement",
+      "MISSION_ROBOFAC_INTERCOM_LIXA_SM_1_OFFER_ADVICE_HEW"
     ],
     "type": "talk_topic",
     "dynamic_line": "During the Cataclysm, we lost contact with one of our sister sites, LIXA.  Aerial surveillance indicates that the facility's inhabitants are deceased, and beyond the now-zombified security detail, the site should be sparsely populated.  We want you to enter the facility and make a copy of what they were researching on the provided thumb drive.  Additionally, we will be providing you with a keycard that should at the very least get you in the front door.\"\n\n\"We're offering a standard 5 HGC for successful retrieval of the data.  If that isn't enough of an incentive, we do have a manifest from before we lost contact with the facility showing a handful of specialized powered suits in inventory.  You are free to take any that are left.",
@@ -1463,6 +1469,11 @@
         "text": "If I lose the ID card or the memory stick, what should I do?",
         "topic": "MISSION_ROBOFAC_INTERCOM_LIXA_SM_1_OFFER_ADVICE_Replacement"
       },
+      {
+        "text": "You told me that the HEW system picked up \"spacetime anomalies\".  What does that mean?",
+        "condition": { "math": [ "HEW_lixa_data_sold > 0" ] },
+        "topic": "MISSION_ROBOFAC_INTERCOM_LIXA_SM_1_OFFER_ADVICE_HEW"
+      },
       { "text": "What else do you have available?", "topic": "TALK_ROBOFAC_INTERCOM_CONTRACTS" }
     ]
   },
@@ -1481,6 +1492,11 @@
     "type": "talk_topic",
     "//": "I feel like this could be phrased better.",
     "dynamic_line": "Well, the ID card wouldn't strictly speaking be necessary if you were to find some way of breaching the facility's security doors.\" The voice pauses for a moment, \"But that said we only have the one ID card, so unless you're confident you can get in without it, please don't lose it.  As for the memory stick I would highly recommend you not lose that as portable drives with the required hardware security modules to interface with secure terminals are in short supply these days.  However there may very well be some on-site for you to scavenge if you're lucky."
+  },
+  {
+    "id": "MISSION_ROBOFAC_INTERCOM_LIXA_SM_1_OFFER_ADVICE_HEW",
+    "type": "talk_topic",
+    "dynamic_line": "&You hear a click as the microphone shuts off.  After several seconds it clicks back on, someone taps the microphone twice to test it - thud thud - and then speaks: \"All I can tell you is that you may encounter extradimensional anomalies, but we cannot be certain which.  I strongly recommend you take an NRE recorder.\""
   },
   {
     "id": "MISSION_ROBOFAC_INTERCOM_LIXA_SM_1_ACCEPTED",

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
@@ -279,10 +279,7 @@
               "not": { "compare_string": [ "no", { "u_val": "dialogue_intercom_completed_robofac_intercom_lixa_sm_1" } ] }
             },
             {
-              "or": [
-                { "math": [ "u_portal_storm_recordings_sold > 2" ] },
-                { "math": [ "HEW_lixa_data_sold > 0" ] }
-              ]
+              "or": [ { "math": [ "u_portal_storm_recordings_sold > 2" ] }, { "math": [ "HEW_lixa_data_sold > 0" ] } ]
             }
           ]
         },

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_trades.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_trades.json
@@ -765,7 +765,7 @@
   {
     "id": "TALK_ROBOFAC_INTERCOM_SELL_HEW_DATA_LIXA",
     "type": "talk_topic",
-    "dynamic_line": "You deposit the sheet in the tray.  After a long silence, the tray opens again, this time with a pile of coins.  \"You've located a severe spacetime disturbance.  Several of the recordings performed unexpected loops in their subroutines.  We also picked up signatures typical of some DARPA laboratories - for this reason, we strongly suggest you avoid the area.\"",
+    "dynamic_line": "You deposit the sheet in the tray.  After a long silence, the tray opens again, this time with a pile of coins.  \"You've located a severe spacetime disturbance.  Notably, several of the recordings performed unexpected loops in their subroutines.  In fact, these anomalies seem to be centered around a facility we are familiar with, and where we have recently performed extensive aerial surveillance.  If you are interested, we are willing to offer you a contract to retrieve something from this location.  Let us know if you are interested.\"",
     "speaker_effect": {
       "effect": [
         { "npc_add_var": "dialogue_intercom_accepted_HEW_recording", "value": "yes" },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Finding LIXA and giving a HEW report to the Hub can trigger Data Retrieval"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Data retrieval is triggered if you sell >2 NRE reports to the Hub.  The dialogue describes that the Hub did some aerial surveillance and figures everyone is dead, and wants you to recover some data.

If the player sells the HEW report for LIXA to the Hub, it would probably immediately trigger their interest in the place.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

The LIXA quest is now triggered if you turn in >2 NRE reports OR turn in the LIXA HEW report.  Getting to the LIXA HEW report requires completing the entire MWS/HEW questline and finding LIXA anyway, so it doesn't really speed up getting the mission.  Just an alternative path.

Also added a special dialogue option to the LIXA quest if you've turned in the HEW report.  You can mention that the Hub admitted the report contained measures of "spacetime anomalies," and ask for more info.  They won't really give you any.  Nice flavor, though.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Just adding the flavor text, not triggering the mission with the report.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Checked the dialogue in game.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
