### PR TITLE
Represent solar panel degradation over time

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -12193,7 +12193,7 @@ void butchery_activity_actor::do_turn( player_activity &act, Character &you )
 
         item &corpse_item = *this_bd->corpse;
         corpse_item.set_var( butcher_progress_time_var(),
-                             to_turns<double>( calendar::turn - calendar::start_of_cataclysm ) );
+                             to_turns<double>( calendar::time_since_cataclysm() ) );
     }
 }
 

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1454,6 +1454,7 @@ void Character::burn_fuel( bionic &bio )
             // There *could* be multiple items. But we only take first.
             intensity *= result.connected_solar.front()->type->solar_efficiency;
         }
+        intensity *= solar_panel_deterioration_factor();
         energy_gain = units::from_joule( intensity );
     }
 

--- a/src/calendar.cpp
+++ b/src/calendar.cpp
@@ -52,6 +52,20 @@ float max_sun_irradiance()
     return 1000.f;
 }
 
+time_duration calendar::time_since_cataclysm()
+{
+    return calendar::turn - calendar::start_of_cataclysm;
+}
+
+float solar_panel_deterioration_factor()
+{
+    constexpr float deterioration_per_year = 0.01f;
+    constexpr float deterioration_per_day = deterioration_per_year / 365.0f;
+
+    const float days_since_cataclysm = to_days<float>( calendar::time_since_cataclysm() );
+    return 1.0f - ( days_since_cataclysm * deterioration_per_day );
+}
+
 time_duration lunar_month()
 {
     return 29.530588853 * 1_days;

--- a/src/calendar.cpp
+++ b/src/calendar.cpp
@@ -59,7 +59,18 @@ time_duration calendar::time_since_cataclysm()
 
 float solar_panel_deterioration_factor()
 {
-    constexpr float deterioration_per_year = 0.01f;
+    // Baseline module deterioration is 0.5% per year
+    constexpr float baseline_deterioration_per_year = 0.005f;
+
+    // This represents aggregated average of many factors, including:
+    // age/generation of the module, extreme post-cataclysm weather events,
+    // lack of maintenance and cleaning, as lack of cleaning also increases the erosion rate
+    //
+    // Once any of those factors are represented in a more systematic way, throw it out or revise it
+    constexpr float additional_deterioration_per_year = 0.005f;
+
+    constexpr float deterioration_per_year = baseline_deterioration_per_year +
+            additional_deterioration_per_year;
     constexpr float deterioration_per_day = deterioration_per_year / 365.0f;
 
     const float days_since_cataclysm = to_days<float>( calendar::time_since_cataclysm() );

--- a/src/calendar.h
+++ b/src/calendar.h
@@ -142,6 +142,9 @@ extern time_point start_of_game;
 extern time_point turn;
 extern season_type initial_season;
 
+/** Time elapsed since the start of the Cataclysm. */
+time_duration time_since_cataclysm();
+
 } // namespace calendar
 
 template<typename T>
@@ -641,6 +644,8 @@ bool is_dawn( const time_point &p );
 float default_daylight_level();
 /* Irradiance (W/m2) on clear day when sun is at 90 degrees */
 float max_sun_irradiance();
+/** Current deterioration coefficient, goes down from 100% by 1% per year */
+float solar_panel_deterioration_factor();
 /** Returns the current sunlight.
  *  Based entirely on astronomical circumstances; does not account for e.g.
  *  weather.

--- a/src/calendar.h
+++ b/src/calendar.h
@@ -644,7 +644,7 @@ bool is_dawn( const time_point &p );
 float default_daylight_level();
 /* Irradiance (W/m2) on clear day when sun is at 90 degrees */
 float max_sun_irradiance();
-/** Current deterioration coefficient, goes down from 100% by 1% per year */
+/** Current solar panel deterioration factor. */
 float solar_panel_deterioration_factor();
 /** Returns the current sunlight.
  *  Based entirely on astronomical circumstances; does not account for e.g.

--- a/src/diary.cpp
+++ b/src/diary.cpp
@@ -126,7 +126,7 @@ void diary::open_summary_page()
     add_to_change_list( get_diary_time_str( calendar::turn, time_acc() ) );
     add_to_change_list( "" );
     add_to_change_list( _( "You have survived:" ) );
-    add_to_change_list( get_diary_time_since_str( calendar::turn - calendar::start_of_cataclysm,
+    add_to_change_list( get_diary_time_since_str( calendar::time_since_cataclysm(),
                         time_acc(), false ) );
     add_to_change_list( _( "You have been playing for:" ) );
     add_to_change_list( get_diary_time_since_str( calendar::turn - calendar::start_of_game,

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -651,7 +651,7 @@ static void GENERATOR_riot_damage( map &md, const tripoint_abs_omt &p, bool is_a
     std::list<tripoint_bub_ms> all_points_in_map;
 
 
-    int days_since_cataclysm = to_days<int>( calendar::turn - calendar::start_of_cataclysm );
+    int days_since_cataclysm = to_days<int>( calendar::time_since_cataclysm() );
 
     // Placeholder / FIXME
     // This assumes that we're only dealing with regular 24x24 OMTs. That is likely not the case.
@@ -7459,7 +7459,7 @@ void map::place_vending( const tripoint_bub_ms &p, const item_group_id &type, bo
     // The chance to find a non-ransacked vending machine reduces greatly with every day after the Cataclysm,
     // unless it's hidden somewhere far away from everyone's eyes (e.g. deep in the lab)
     if( lootable &&
-        !one_in( std::max( to_days<int>( calendar::turn - calendar::start_of_cataclysm ), 0 ) + 4 ) ) {
+        !one_in( std::max( to_days<int>( calendar::time_since_cataclysm() ), 0 ) + 4 ) ) {
         bash( p, 9999 );
         for( const tripoint_bub_ms &loc : points_in_radius( p, 1 ) ) {
             if( one_in( 4 ) ) {

--- a/src/math_parser_diag.cpp
+++ b/src/math_parser_diag.cpp
@@ -1224,7 +1224,7 @@ double time_since_eval( const_dialogue const &d, char /* scope */,
     if( val.is_str() ) {
         std::string const &val_str = val.str( d );
         if( val_str == "cataclysm" ) {
-            ret = to_turns<double>( calendar::turn - calendar::start_of_cataclysm );
+            ret = to_turns<double>( calendar::time_since_cataclysm() );
         } else if( val_str == "midnight" ) {
             ret = to_turns<double>( time_past_midnight( calendar::turn ) );
         } else if( val_str == "noon" ) {

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -684,7 +684,7 @@ void npc::randomize( const npc_class_id &type, const npc_template_id &tem_id )
     catchup_skills();
     set_body();
     recalc_hp();
-    int days_since_cata = to_days<int>( calendar::turn - calendar::start_of_cataclysm );
+    int days_since_cata = to_days<int>( calendar::time_since_cataclysm() );
     double time_influence = days_since_cata >= 180 ? 3.0 : 6.0 - 3.0 * days_since_cata / 180.0;
     double weight_percent = std::clamp<double>( chi_squared_roll( time_influence ) / 5.0,
                             0.2, 5.0 );
@@ -751,7 +751,7 @@ void npc::randomize( const npc_class_id &type, const npc_template_id &tem_id )
 
 void npc::catchup_skills()
 {
-    const int cataclysm_days = to_days<int>( calendar::turn - calendar::start_of_cataclysm );
+    const int cataclysm_days = to_days<int>( calendar::time_since_cataclysm() );
     const int level_cap = get_option<int>( "EXTRA_NPC_SKILL_LEVEL_CAP" );
     const SkillLevelMap &skills_map = get_all_skills();
     // Exp actually multiplied by 100 in Character::practice
@@ -1031,7 +1031,7 @@ void npc::starting_inv_passtime()
         starting_coverage.emplace( part, worn.get_coverage( part ) );
     }
 
-    int days_since_cata = std::min( to_days<int>( calendar::turn - calendar::start_of_cataclysm ),
+    int days_since_cata = std::min( to_days<int>( calendar::time_since_cataclysm() ),
                                     max_time );
     //give storage item if too little volume
     if( worn.volume_capacity() < 10000_ml ) {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -5521,7 +5521,8 @@ units::power vehicle::total_solar_epower( map &here ) const
     // sample it once.
     weather_type_id wtype = current_weather( pos_abs() );
     const float intensity = incident_sun_irradiance( wtype, calendar::turn ) / max_sun_irradiance();
-    return epower * intensity;
+
+    return epower * intensity * solar_panel_deterioration_factor();
 }
 
 units::power vehicle::total_wind_epower( map &here ) const


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Balance "Solar panel output degrades by 1% per year"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
It has a narrative value, helps convey that there's no hope of civilization surviving in the long term. And it makes a potential "5/10 years into cataclysm" start have more implications. Also more realism
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Solar panel/backpack power output drops by 1% a year. Most of them are exposed to UV and not stored in long-term storage in complete darkness, also no-one cleans them.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Changed year to 30, the output went down by about 30%
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
If/when extreme weather events are implemented, acid rains, extreme temporary temperature drops/increases, frequent storms, it should go down even further
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
