### PR TITLE
Fix spells not creating fields

### DIFF
--- a/data/mods/MindOverMatter/powers/electrokinesis.json
+++ b/data/mods/MindOverMatter/powers/electrokinesis.json
@@ -65,8 +65,8 @@
         "( (u_spell_level('electrokinetic_shock_touch') * 1.5) + 7) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
       ]
     },
-    "min_range": 10,
-    "max_range": 10,
+    "min_range": 1,
+    "max_range": 1,
     "min_duration": 100,
     "max_duration": 300,
     "field_id": "fd_electricity",

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -541,11 +541,8 @@ static void damage_targets( const spell &sp, Creature &caster,
             continue;
         }
         Creature *const cr = creatures.creature_at<Creature>( target );
-        if( !cr ) {
-            continue;
-        }
 
-        if( sp.has_flag( spell_flag::TOUCH_REQUIRED ) && !touch_required_hit( caster, *cr ) ) {
+        if( sp.has_flag( spell_flag::TOUCH_REQUIRED ) && cr && !touch_required_hit( caster, *cr ) ) {
             caster.add_msg_if_player( m_bad, _( "Your target avoids your attempt to touch them!" ) );
             continue;
         }
@@ -558,6 +555,10 @@ static void damage_targets( const spell &sp, Creature &caster,
             if( player_character.has_unfulfilled_pyromania() ) {
                 player_character.fulfill_pyromania_sees( here, target );
             }
+        }
+
+        if( !cr ) {
+            continue;
         }
 
         dealt_projectile_attack atk = sp.get_projectile_attack( target, *cr, caster );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Fix spells not creating fields"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fixes #85435

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Reorder the code--create a creature reference first, run the TOUCH_REQUIRED codeblock if the spell has TOUCH_REQUIRED, if you hit, and if there's actually a creature at the location (not in that order--checking creature first), then create the fields and sounds, and then cancel if the spell requires a creature and there isn't one. 

Also somehow the range of Static Touch was set to 10 instead of 1? Fix that too.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Channeled Static Touch on the ground--it fired.

Removed `ground` from Static Touch and tried to channel it on the ground--it aborted.

Used it on a `feral dervish`--the dervish still dodged like crazy until I finally hit.

Channeled Clairvoyance--it worked and created all fields.

<img width="710" height="636" alt="Untitled" src="https://github.com/user-attachments/assets/fc302456-6584-4b32-8baa-9170936639cf" />


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
