### PR TITLE
Make it clear that Anus Fetick is an optional path to the CBM interface, and let a player still complete it if they get the interface another way

### DIFF
--- a/data/json/npcs/exodii/exodii_merchant_missions.json
+++ b/data/json/npcs/exodii/exodii_merchant_missions.json
@@ -801,10 +801,7 @@
         "effect": { "assign_mission": "RUBIK_ANUS_FETICK" },
         "topic": "TALK_DONE"
       },
-      {
-        "text": "What other work do you have?",
-        "topic": "TALK_EXODII_MERCHANT_Jobs"
-      }
+      { "text": "What other work do you have?", "topic": "TALK_EXODII_MERCHANT_Jobs" }
     ]
   },
   {

--- a/data/json/npcs/exodii/exodii_merchant_missions.json
+++ b/data/json/npcs/exodii/exodii_merchant_missions.json
@@ -780,6 +780,32 @@
         "topic": "TALK_DONE"
       }
     ]
+  }
+    "id": "TALK_EXODII_MERCHANT_ANUS_FETICK_ALT",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "//~": "Maybe you could bring us a bit of good tea.  Not literally 'tea' of course.  That's my Anglic street slang.  I mean the stuff that puts you to sleep for surgery.  The Great Grey says your word for it is 'anesthetic'.  You bring us a thousand units of anesthetic, we'll fix you up with a wire and everything.",
+      "str": "Mayhap ye bringin' us a nip o' good tea.  Not 'tea', o'course.  I'm yarkin dockside Anglic here.  Us means the stuff what puts y'to sleep f'r a chirurgery.  The Great Grey says y'r assert for it is 'anus fetick'.  You bring us a thousand unit of 'anus fetick', us'll fix'n ye up with a wire an' a tiff."
+    },
+    "responses": [
+      {
+        "text": "One thousand units of, uh, anesthetic?  And you'll give me an upgrade?  Sure, I'd better start looking.",
+        "condition": {
+          "not": {
+            "or": [
+              { "u_has_mission": "RUBIK_ANUS_FETICK" },
+              { "compare_string": [ "yes", { "u_val": "mission_completed_anusfetick" } ] }
+            ]
+          }
+        },
+        "effect": { "assign_mission": "RUBIK_ANUS_FETICK" },
+        "topic": "TALK_DONE"
+      },
+      {
+        "text": "What other work do you have?",
+        "topic": "TALK_EXODII_MERCHANT_Jobs"
+      }
+    ]
   },
   {
     "id": "MISSION_EXODII_PAY_BACK_RIOT_GEAR",

--- a/data/json/npcs/exodii/exodii_merchant_missions.json
+++ b/data/json/npcs/exodii/exodii_merchant_missions.json
@@ -780,7 +780,8 @@
         "topic": "TALK_DONE"
       }
     ]
-  }
+  },
+  {
     "id": "TALK_EXODII_MERCHANT_ANUS_FETICK_ALT",
     "type": "talk_topic",
     "dynamic_line": {

--- a/data/json/npcs/exodii/exodii_merchant_talk.json
+++ b/data/json/npcs/exodii/exodii_merchant_talk.json
@@ -413,7 +413,9 @@
               "not": {
                 "or": [
                   { "u_has_mission": "RUBIK_ANUS_FETICK" },
-                  { "compare_string": [ "yes", { "u_val": "mission_completed_anusfetick" } ] }
+                  { "compare_string": [ "yes", { "u_val": "mission_completed_anusfetick" } ] },
+                  { "not": { "u_has_trait": "CBM_Interface" } },
+                  { "not": { "u_has_flag": "NO_CBM_INSTALLATION" } }
                 ]
               }
             }
@@ -448,6 +450,17 @@
     },
     "responses": [
       { "text": "Do the Exodii have any work I could do?", "topic": "TALK_EXODII_MERCHANT_Jobs" },
+      {
+        "text": "Are there any materials the Exodii need?",
+        "condition": {
+          "and": [
+            { "u_has_trait": "CBM_Interface" },
+            { "not": { "u_has_mission": "RUBIK_ANUS_FETICK" } },
+            { "not": { "compare_string": [ "yes", { "u_val": "mission_completed_anusfetick" } ] } }
+          ]
+        },
+        "topic": "TALK_EXODII_MERCHANT_ANUS_FETICK_ALT"
+      },
       {
         "text": "I've brought the anesthetic for you.  Can you help me out?",
         "condition": { "and": [ { "u_has_items": { "item": "anesthetic", "count": 1000 } }, { "u_has_mission": "RUBIK_ANUS_FETICK" } ] },

--- a/data/json/npcs/exodii/exodii_merchant_talk_exodization.json
+++ b/data/json/npcs/exodii/exodii_merchant_talk_exodization.json
@@ -195,22 +195,21 @@
         "topic": "TALK_EXODII_MERCHANT_Exodized"
       },
       {
-        "text": "[Install Power Storage CBM] I guess since I'm already a cyborg, I could use some more power.",
+        "text": "[Install Power Storage Mk. II CBM] I guess since I'm already a cyborg, I could use some more power.",
         "condition": { "u_has_trait": "CBM_Interface" },
         "effect": [
           { "u_add_faction_trust": 2 },
           { "u_add_effect": "narcosis", "duration": "30 minutes" },
           { "u_add_effect": "sleep", "duration": "30 minutes" },
           { "u_assign_activity": "ACT_CBM_SURGERY", "duration": "30 minutes" },
-          { "u_add_bionic": "bio_power_storage" }
+          { "u_add_bionic": "bio_power_storage_mkII" }
         ],
         "topic": "TALK_DONE"
       },
       {
-        "text": "How about store credit instead?  [adds $1500 in store credit].",
+        "text": "How about store credit instead?  [adds $400 in store credit].",
         "condition": { "u_has_trait": "CBM_Interface" },
-        "effect": [ { "u_spend_cash": -150000 }, "start_trade" ],
-        "opinion": { "trust": 4, "value": 3 },
+        "effect": [ { "u_spend_cash": -40000 }, { "u_add_faction_trust": 2 }, "start_trade" ],
         "topic": "TALK_DONE"
       },
       {

--- a/data/json/npcs/exodii/exodii_merchant_talk_exodization.json
+++ b/data/json/npcs/exodii/exodii_merchant_talk_exodization.json
@@ -73,7 +73,7 @@
   {
     "id": "TALK_EXODII_MERCHANT_ExodizeTranslate",
     "type": "talk_topic",
-    "dynamic_line": "Hmm.\n\n*Rubik's voice becomes mechanical and distant for a moment, as if a computer takes over speaking.*\n\nIn exchange for the guarantee that you will use these gifts to combat the Great Enemy, this Exodii Node is willing to provide you with a bionic module command plexus, a power supply, and all the necessary infrastructure to obtain further upgrades with standardized CBMs - compact bionic modules.  We will require only a token fee for this service.  We will provide further upgrades as purchased.  Your personal improvement serves our mutual benefit.\n\n*Rubik's voice takes over again.*\n\nClear as a draught?",
+    "dynamic_line": "Hmm.\n\n*Rubik's voice becomes mechanical and distant for a moment, as if a computer takes over speaking.*\n\nIn exchange for the guarantee that you will use these gifts to combat the Great Enemy, this Exodii Node is willing to provide you with a bionic module command plexus, a power supply, and all the necessary infrastructure to obtain further upgrades with standardized CBMs - compact bionic modules.  We will require only a token fee, or an act of service, to earn this package.  We will provide further upgrades as purchased.  Your personal improvement serves our mutual benefit.\n\n*Rubik's voice takes over again.*\n\nClear as a draught?",
     "responses": [
       {
         "text": "If I just keep on killing zombies, you'll help turn me into a cyborg?  Why are we still yarkin', then?  Sign me the heck up.",
@@ -150,25 +150,12 @@
     "id": "TALK_EXODII_MERCHANT_ExodizeMe1",
     "type": "talk_topic",
     "dynamic_line": {
-      "//~": "Great, great, great!  Ha!  We'll fire up the old meat grinder.  Your job is to bring us a bit of good tea.  Not literally 'tea' of course.  That's my Anglic street slang.  I mean the stuff that puts you to sleep for surgery.  The Great Grey says your word for it is 'anesthetic'.  You bring us a thousand units of anesthetic, we'll fix you up with a wire and everything.",
-      "str": "Fine an' fine, an' fine an' fine!  Ha!  Us'll rubber up the ol' gristle mill.  Yer tassed wi' bringin' us a nip o' good tea.  Not 'tea', o'course.  I'm yarkin dockside Anglic here.  Us means the stuff what puts y'to sleep f'r a chirurgery.  The Great Grey says y'r assert for it is 'anus fetick'.  You bring us a thousand unit of 'anus fetick', us'll fix'n ye up with a wire an' a tiff."
+      "//~": "Great, great, great!  Ha!  We'll fire up the old meat grinder.  Maybe you do a job for us, we do a job for you?  Or we could trade, maybe if you bring us a bit of good tea.  Not literally 'tea' of course.  That's my Anglic street slang.  I mean the stuff that puts you to sleep for surgery.  The Great Grey says your word for it is 'anesthetic'.  You bring us a thousand units of anesthetic, we'll fix you up with a wire and everything.",
+      "str": "Fine an' fine, an' fine an' fine!  Ha!  Us'll rubber up the ol' gristle mill.  Mayhap a tit-for-tat, aye?  Or a trade, aye, mayhap wi' bringin' us a nip o' good tea.  Not 'tea', o'course.  I'm yarkin dockside Anglic here.  Us means the stuff what puts y'to sleep f'r a chirurgery.  The Great Grey says y'r assert for it is 'anus fetick'.  You bring us a thousand unit of 'anus fetick', us'll fix'n ye up with a wire an' a tiff."
     },
     "responses": [
       {
-        "text": "One thousand units of, uh, anesthetic, coming up.  <done_conversation_section>",
-        "condition": {
-          "not": {
-            "or": [
-              { "u_has_mission": "RUBIK_ANUS_FETICK" },
-              { "compare_string": [ "yes", { "u_val": "mission_completed_anusfetick" } ] }
-            ]
-          }
-        },
-        "effect": { "assign_mission": "RUBIK_ANUS_FETICK" },
-        "topic": "TALK_EXODII_MERCHANT_Talk"
-      },
-      {
-        "text": "One thousand units of, uh, anesthetic, coming up.  I'd better start looking.",
+        "text": "So I could bring you one thousand units of, uh, anesthetic?  And you'll give me this \"upgrade?\"  Sure, coming right up.  I'd better start looking.",
         "condition": {
           "not": {
             "or": [
@@ -181,14 +168,8 @@
         "topic": "TALK_DONE"
       },
       {
-        "text": "Something's weird, I shouldn't have ever reached this dialogue option.  I'd better go file a bug report.",
-        "condition": {
-          "or": [
-            { "u_has_mission": "RUBIK_ANUS_FETICK" },
-            { "compare_string": [ "yes", { "u_val": "mission_completed_anusfetick" } ] }
-          ]
-        },
-        "topic": "TALK_DONE"
+        "text": "Could I do something else, maybe some kind of job, to earn this \"upgrade?\"",
+        "topic": "TALK_EXODII_MERCHANT_Jobs"
       }
     ]
   },
@@ -202,6 +183,7 @@
     "responses": [
       {
         "text": "[Install CBM Interface] All right.  Let's do this.",
+        "condition": { "not": { "u_has_trait": "CBM_Interface" } },
         "effect": [
           { "u_add_effect": "narcosis", "duration": "2 hours" },
           { "u_add_effect": "sleep", "duration": "2 hours" },
@@ -212,7 +194,37 @@
         ],
         "topic": "TALK_EXODII_MERCHANT_Exodized"
       },
-      { "text": "Hold on.  I need to rethink it again.", "topic": "TALK_DONE" }
+      {
+        "text": "[Install Power Storage CBM] I guess since I'm already a cyborg, I could use some more power.",
+        "condition": { "u_has_trait": "CBM_Interface" },
+        "effect": [
+          { "u_add_faction_trust": 2 },
+          { "u_add_effect": "narcosis", "duration": "30 minutes" },
+          { "u_add_effect": "sleep", "duration": "30 minutes" },
+          { "u_assign_activity": "ACT_CBM_SURGERY", "duration": "30 minutes" },
+          { "u_add_bionic": "bio_power_storage" }
+        ],
+        "topic": "TALK_DONE"
+      },
+      {
+        "text": "How about store credit instead?  [adds $1500 in store credit].",
+        "condition": { "u_has_trait": "CBM_Interface" },
+        "effect": [ { "u_spend_cash": -150000 }, "start_trade" ],
+        "opinion": { "trust": 4, "value": 3 },
+        "topic": "TALK_DONE"
+      },
+      {
+        "text": "Consider it a favor, Rubik.",
+        "condition": { "u_has_trait": "CBM_Interface" },
+        "effect": [ { "u_add_faction_trust": 4 } ],
+        "opinion": { "trust": 7, "value": 5 },
+        "topic": "TALK_DONE"
+      },
+      {
+        "text": "Hold on.  I need to rethink it again.",
+        "condition": { "not": { "u_has_trait": "CBM_Interface" } },
+        "topic": "TALK_DONE"
+      }
     ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Tweak Rubik's Anus Fetick quest dialogue/requirements/rewards"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Had some chats on discord about Anus Fetick.  It's not the only way to get the CBM interface.  However, Rubik's dialogue sort of makes it seem like it is.  And this can unnecessarily discourage players, because anesthetic is quite difficult to come by.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Now, when asking about becoming a cyborg, you can agree to accept the Anus Fetick mission, or ask about jobs and get the Hub 01 scouting job.  Both give you the CBM interface as a possible reward (and have for some time).

If you've got the CBM interface, you can ask Rubik if they need any sort of materials.  They'll offer the Anus Fetick mission.  If you complete it, you can opt for another power upgrade, store credit, or a reputation boost.  The dialogue should also accomodate players who started Anus Fetick without the interface, got the interface through the Hub quest, and still want to finish and get rewarded for Anus Fetick.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Different rewards post CBM interface.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Ran through the dialogue/missions.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
