### PR TITLE
Wired Reflexes Penalty Removal

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -394,11 +394,11 @@
     "id": "bio_dex_enhancer",
     "type": "bionic",
     "name": { "str": "Wired Reflexes" },
-    "description": "Your reaction time has been greatly enhanced with bionic nerve stimulators, giving you a +2 bonus to dexterity while powered.  However, you will suffer penalties while unpowered.",
+    "description": "Your reaction time has been greatly enhanced with bionic nerve stimulators, giving you a +2 bonus to dexterity while powered.",
     "occupied_bodyparts": [ [ "head", 3 ], [ "torso", 6 ], [ "arm_l", 3 ], [ "arm_r", 3 ], [ "leg_l", 7 ], [ "leg_r", 7 ] ],
     "enchantments": [
-      { "condition": "ACTIVE", "values": [ { "value": "DEXTERITY", "add": 5 } ] },
-      { "values": [ { "value": "DEXTERITY", "add": -3 } ] }
+      { "condition": "ACTIVE", "values": [ { "value": "DEXTERITY", "add": 2 } ] },
+      { "values": [ { "value": "DEXTERITY", "add": 0 } ] }
     ],
     "act_cost": "5 J",
     "react_cost": "5 J",


### PR DESCRIPTION

#### Summary
Category: Balance "Wired Reflexes no longer penalizes dexterity when unpowered"

#### Purpose of change
Wired Reflexes currently penalizes the Razor Boy/Girl background excessively because they do not start with any bionic power capacity, nor any way to recharge it. Thus, Razor Boy/Girl starts the game with a massive -3 DEX modifier and no way to circumvent it without finding power storage and power generating CBMs.

Wired Reflexes should not give someone -3 DEX as a baseline. As a combat bionic, it should only function when powered, and not have any penalties associated with it. Especially if you use bionic slots, which would make this bionic extremely unappealing otherwise.

#### Describe the solution

I simply made the passive DEX modifier 0 and changed the active number to +2.

#### Describe alternatives you've considered

The alternative is changing Razor Boy/Girl background to include Power Storage and a way to generate bionic charging system, which they probably should have. But I felt that the -3 DEX penalty on an unpowered bionic was already extremely unnecessary for a low-tier bionic, and this was the easier and more common sense fix.

#### Testing

Only changed baseline values. Game did not crash, and DEX looked normal on a fresh character.

#### Additional context

