### PR TITLE
Added Power Storage and Metabolic Interchange to Razor Boy/Girl

### DIFF
--- a/data/mods/package_bionic_professions/bionic_professions.json
+++ b/data/mods/package_bionic_professions/bionic_professions.json
@@ -959,7 +959,16 @@
     "description": "Through a series of painful and expensive surgeries, you became a walking bionic weapon, your services as a mercenary available to the highest bidder.",
     "points": 5,
     "traits": [ "CBM_Interface" ],
-    "CBMs": [ "bio_razors", "bio_armor_eyes", "bio_sunglasses", "bio_dex_enhancer", "bio_ears", "bio_carbon", "bio_metabolics", "bio_power_storage_mkII" ],
+    "CBMs": [
+      "bio_razors",
+      "bio_armor_eyes",
+      "bio_sunglasses",
+      "bio_dex_enhancer",
+      "bio_ears",
+      "bio_carbon",
+      "bio_metabolics",
+      "bio_power_storage_mkII"
+    ],
     "skills": [ { "level": 2, "name": "melee" }, { "level": 2, "name": "unarmed" }, { "level": 2, "name": "dodge" } ],
     "proficiencies": [ "prof_unarmed_familiar", "prof_claws_familiar", "prof_bionics_familiar", "prof_gross_anatomy" ],
     "items": {

--- a/data/mods/package_bionic_professions/bionic_professions.json
+++ b/data/mods/package_bionic_professions/bionic_professions.json
@@ -959,7 +959,7 @@
     "description": "Through a series of painful and expensive surgeries, you became a walking bionic weapon, your services as a mercenary available to the highest bidder.",
     "points": 5,
     "traits": [ "CBM_Interface" ],
-    "CBMs": [ "bio_razors", "bio_armor_eyes", "bio_sunglasses", "bio_dex_enhancer", "bio_ears", "bio_carbon" ],
+    "CBMs": [ "bio_razors", "bio_armor_eyes", "bio_sunglasses", "bio_dex_enhancer", "bio_ears", "bio_carbon", "bio_metabolics", "bio_power_storage_mkII" ],
     "skills": [ { "level": 2, "name": "melee" }, { "level": 2, "name": "unarmed" }, { "level": 2, "name": "dodge" } ],
     "proficiencies": [ "prof_unarmed_familiar", "prof_claws_familiar", "prof_bionics_familiar", "prof_gross_anatomy" ],
     "items": {


### PR DESCRIPTION
#### Summary
Balance "Added Power Storage and Metabolic Interchange to Razor Boy/Girl"

#### Purpose of change

In the Bionic Professions mod, Razor Boy/Girl do not naturally have any way to power Wired Reflexes, resulting in a permanent -3 DEX on a new character. 

#### Describe the solution

This change simply adds Power Strorage Mk. II and Metabolic Interchange to their starting kit so that they don't start with a crippling stat penalty.

#### Describe alternatives you've considered

Removing the -3 DEX penalty from Wired Reflexes, but this PR was rejected for balance reasons.

#### Testing

Confirmed that Razor Boy/Girl kit works on a fresh save file with this change.
