### PR TITLE
make the devourer upgrades legible

### DIFF
--- a/data/json/monsters/zed_fusion.json
+++ b/data/json/monsters/zed_fusion.json
@@ -284,8 +284,8 @@
   {
     "id": "mon_devourer_hekatonkheire",
     "type": "MONSTER",
-    "name": { "str": "hekatonkheire" },
-    "description": "This creature is made from a mass of human and animal parts assembled by a katamari god or other thoughtless creator being.  When paused it seems as though small versions of this gigantic monstrous abomination strain to birth themselves from its bulk, while other limbs push the straining masses back inside.",
+    "name": { "str": "hundred-handed devourer" },
+    "description": "This creature is made from a mass of human and animal parts assembled in chaotic fashion as if formed by some insane deity.  When paused it seems as though small versions of this gigantic monstrous abomination strain to birth themselves from its bulk, while other limbs push the straining masses back inside.",
     "default_faction": "zombie",
     "copy-from": "mon_devourer",
     "bodytype": "giant",
@@ -339,8 +339,8 @@
   {
     "id": "mon_devourer_daitya",
     "type": "MONSTER",
-    "name": { "str": "daitya" },
-    "description": "Human bodies fused together into a colossus, with heads and limbs sticking out of its bloated body.  The nature of the thing makes it difficult to estimate how close it is to dying, and its capabilities might change if it manages to assimilate more zombies into itself.",
+    "name": { "str": "spawning-bed devourer" },
+    "description": "Human bodies fused together into a colossus, with heads and limbs sticking out of its bloated body ready to break free.  The nature of the thing makes it difficult to estimate how close it is to dying, and its capabilities might change if it manages to assimilate more zombies into itself.",
     "default_faction": "zombie",
     "bodytype": "human",
     "species": [ "ZOMBIE" ],
@@ -461,8 +461,8 @@
   {
     "id": "CLONE_DAMAGE",
     "type": "SPELL",
-    "name": { "str": "Daitya Clone Damage", "//~": "NO_I18N" },
-    "description": { "str": "Damages daitya when clone is created.", "//~": "NO_I18N" },
+    "name": { "str": "Devourer Clone Damage", "//~": "NO_I18N" },
+    "description": { "str": "Damages spawning-bed devourer when clone is created.", "//~": "NO_I18N" },
     "message": "Stale golden light floods the world, and reality stands still.",
     "valid_targets": [ "self" ],
     "effect": "attack",
@@ -476,8 +476,8 @@
   {
     "id": "mon_devourer_daitya_clone",
     "type": "MONSTER",
-    "name": { "str": "daitya clone" },
-    "description": "A smaller version of the Daitya without clones straining to burst free from it's orifices.  Instead every opening on its body is filled with teeth.",
+    "name": { "str": "devourer spawn" },
+    "description": "A mass of hateful flesh formed by a greater whole.  Luckily, this nightmarish nesting doll ends with its first generation, but this malformed abomination is no less frightful for that.  Every opening on its body is filled with teeth.",
     "default_faction": "zombie",
     "bodytype": "human",
     "species": [ "ZOMBIE" ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Interface "Made the dissoluted devourer upgrades more understandable"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
These had absolutely godawful names. They gave you virtually no information as to what they did or what they were, were very difficult to remember or even type, and pedantically speaking, the proper translation is "hecatoncheires". Also, these names broke convention for zombies - zombies were always descriptive improper nouns ("skeletal master". "corrosive zombie". "zombie hulk". "shocker brute".) that immediately inform you what the zombie is, giving them esoteric proper nouns is just bad form.
As far as I can tell, the "daitya" (hindu mythology, a giant, not really specifically anything related to a many limbed giant) is the "clones" one that spawns little copies of itself. And the heka whateverthefuck (greek mythos, hundred handed titan, sure, i guess that works) is the "brute" version that's just really strong. But it's really difficult to infer anything about them because their names don't tell you anything about it unless or even if you google them (and even then it doesn't really tell you "this is a zombie variant") and their descriptions were also kind of poorly written and vague.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
1. Heka-whateverthefuck -> "hundred-handed devourer". Clean up description.
2. Daitya -> "spawning-bed devourer". Clean up description and clarify what it does.
This should hopefully be far more legible.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Different names. Daitya is just awful because it has absolutely nothing to do with what the zombie actually does. Heka whatever is a bit more accurate, since the thing in mythology is actually vaguely related to the in-game monster in question, but calling that is just a bad idea that makes the monster annoying to discuss and just generally difficult to parse. I think "hundred-handed devourer" (a transliteration into English of the thing) works alright though.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I feel like I'm really coming at @Maleclypse here lol. No offense meant but these just weren't it Chief.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
