### PR TITLE
Set lit_level enum class to minimal size to save bytes in level_cache

### DIFF
--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -18,6 +18,8 @@
 #include <utility>
 #include <vector>
 
+#include <stdint.h>
+
 #include "animation.h"
 #include "calendar.h"
 #include "coordinates.h"
@@ -42,7 +44,7 @@ class monster;
 class nc_color;
 class pixel_minimap;
 enum class direction : unsigned int;
-enum class lit_level : int;
+enum class lit_level : uint8_t;
 enum class visibility_type : int;
 
 extern void set_displaybuffer_rendertarget();

--- a/src/level_cache.h
+++ b/src/level_cache.h
@@ -8,6 +8,8 @@
 #include <unordered_map>
 #include <utility>
 
+#include <stdint.h>
+
 #include "coordinates.h"
 #include "map_scale_constants.h"
 #include "mdarray.h"
@@ -15,7 +17,7 @@
 
 // IWYU pragma: no_forward_declare four_quadrants
 class vehicle;
-enum class lit_level : int;
+enum class lit_level : uint8_t;
 
 struct level_cache {
     public:

--- a/src/lightmap.h
+++ b/src/lightmap.h
@@ -4,6 +4,9 @@
 
 #include <cmath> // IWYU pragma: keep
 #include <ostream>
+
+#include <stdint.h>
+
 #include "map_scale_constants.h"
 
 constexpr float LIGHT_SOURCE_LOCAL = 0.1f;
@@ -50,7 +53,7 @@ constexpr inline int LIGHT_RANGE( float b )
                              LIGHT_TRANSPARENCY_OPEN_AIR ) );
 }
 
-enum class lit_level : int {
+enum class lit_level : uint8_t {
     DARK = 0,
     LOW, // Hard to see
     BRIGHT_ONLY, // bright but indistinct


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Performance "Shrink level_cache by 48kb to save almost 1MB of ram (or more with allocator overhead)"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
While investigating snmalloc vs mimalloc for allocator replacements, one oddity that stood out was snmalloc causing the level_cache constructor to take longer to zero itself. This led me to finding out that level_cache is ~800kB large, which is rikidikidonkulous. Any savings here are multiplied by 21 because there are currently 21 Z levels.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Set the size of `lit_level` explicitly to uint8_t
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Game still goes.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
