### PR TITLE
zone sort: refuse overflow and respect zone binding during drops

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -12982,11 +12982,30 @@ void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
                         return;
                     }
 
-                    // FIXME HACK: teleports item onto ground
-                    you.mod_moves( -you.item_handling_cost( **iter ) );
-                    std::vector<item_location> dropped_crap = put_into_vehicle_or_drop_ret_locs( you,
-                            item_drop_reason::deliberate, { **iter }, here.get_bub( drop_dest ) );
-                    if( !dropped_crap.empty() ) {
+                    // Place item at destination directly. Zone binding
+                    // determines the fallback chain: vehicle-only zones skip
+                    // ground, everything else tries cargo then ground.
+                    const zone_type_id drop_zt = mgr.get_near_zone_type_for_item( **iter,
+                                                 drop_dest, 0, fac_id );
+                    const bool vehicle_only = drop_zt != zone_type_id::NULL_ID() &&
+                                              mgr.has_vehicle( drop_zt, drop_dest, fac_id ) &&
+                                              !mgr.has_terrain( drop_zt, drop_dest, fac_id );
+                    bool placed = false;
+                    const tripoint_bub_ms drop_bub = here.get_bub( drop_dest );
+                    if( std::optional<vpart_reference> ovp = here.veh_at( drop_bub ).cargo() ) {
+                        item copy( **iter );
+                        if( ovp->vehicle().add_item( here, ovp->part(), copy ) ) {
+                            placed = true;
+                        }
+                    }
+                    if( !placed && !vehicle_only ) {
+                        item copy( **iter );
+                        item_location ground = here.add_item_or_charges_ret_loc(
+                                                   drop_bub, copy, false );
+                        placed = ground.get_item() != nullptr;
+                    }
+                    if( placed ) {
+                        you.mod_moves( -you.item_handling_cost( **iter ) );
                         if( const vehicle_cursor *veh_curs = iter->veh_cursor() ) {
                             vehicle &cart_with_items = veh_curs->veh;
                             cart_with_items.remove_item( cart_with_items.part( veh_curs->part ), iter->get_item() );
@@ -13139,13 +13158,24 @@ void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
                     continue;
                 }
                 item copy_thisitem( thisitem );
-                // Try vehicle cargo at destination first, fall back to ground
+                // Vehicle-only zones don't fall back to ground placement.
+                // All other zones (terrain, dual-bound) try cargo first, then ground.
+                // No overflow to adjacent tiles in either case.
+                const bool vehicle_only = mgr.has_vehicle( zt_id, dest, fac_id ) &&
+                                          !mgr.has_terrain( zt_id, dest, fac_id );
+                bool placed = false;
                 if( std::optional<vpart_reference> ovp = here.veh_at( dest_bub ).cargo() ) {
-                    if( !ovp->vehicle().add_item( here, ovp->part(), copy_thisitem ) ) {
-                        here.add_item_or_charges( dest_bub, copy_thisitem );
+                    if( ovp->vehicle().add_item( here, ovp->part(), copy_thisitem ) ) {
+                        placed = true;
                     }
-                } else {
-                    here.add_item_or_charges( dest_bub, copy_thisitem );
+                }
+                if( !placed && !vehicle_only ) {
+                    item_location ground = here.add_item_or_charges_ret_loc( dest_bub, copy_thisitem,
+                                           false );
+                    placed = ground.get_item() != nullptr;
+                }
+                if( !placed ) {
+                    continue;
                 }
                 you.mod_moves( -you.item_handling_cost( copy_thisitem ) );
                 if( it->second ) {


### PR DESCRIPTION
#### Summary
Bugfixes "Prevent zone sorting from overflowing items to adjacent tiles"

#### Purpose of change

Follow-up to #85318 (point 4). When zone sorting drops items at a full destination, `_add_item_or_charges` overflows to adjacent tiles (radius 2), placing items outside the intended zone. The old teleport-based sorting refused items that wouldn't fit.

Also fixes a subtler issue: terrain-bound vs vehicle-bound zones weren't distinguished during delivery. A vehicle-only zone with full cargo would spill items to ground, which doesn't make sense for a zone that's specifically bound to vehicle cargo.

UPD: Fixes #85491

#### Describe the solution

Add `bool overflow = true` parameter to the drop wrapper chain (`put_into_vehicle_or_drop`, `drop_on_map`). Zone sorting passes `overflow=false` from both delivery paths.

When overflow is disabled and vehicle cargo is full:
- Skip partial charge splitting (prevents duplication)
- Skip "Unable to fit" message spam
- Skip inventory/wield fallbacks (wrong location for sorting)
- Try ground at the same tile without spilling to neighbors

Zone binding awareness at the sorting level: check `has_vehicle`/`has_terrain` for the destination zone. Vehicle-only zones only accept cargo, no ground fallback. Everything else tries cargo first, then ground - same as before, just without the overflow.

Both delivery paths (adjacent direct delivery in `stage_do` and non-adjacent dropoff via wrappers) get the same treatment.

#### Describe alternatives you've considered

Could have added zone binding awareness inside the drop wrappers themselves, but those are general-purpose utilities used by 15+ callers. Cleaner to handle it at the zone sorting level where we already know the zone type and binding.

#### Testing

4 new test cases:
- `zone_sorting_adjacent_dest_both_full` - cart cargo + ground both full, item stays at source
- `zone_sorting_adjacent_ground_dest_full` - ground-only dest full, item stays at source
- `zone_sorting_vehicle_dest_cargo_full_ground_fallback` - vehicle-only zone, cargo full: item stays at source (no ground fallback)
- `zone_sorting_drop_overflow_disabled` - direct wrapper tests: full ground, full cargo with ground fallback, both full, count_by_charges no-duplication

All `[zones]` tests pass (25 cases, 368 assertions).

#### Additional context

Related: #85318, #85403