### PR TITLE
Batch zone sorting pickups from nearby sources

### DIFF
--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -4083,6 +4083,9 @@ class zone_sort_activity_actor : public zone_activity_actor
         // Forces a clear on first stage_think call (fresh construction or deserialization).
         // Avoids edge case where default-initialized values match real game state.
         bool force_clear_unreachable = true; // NOLINT(cata-serialize)
+        // Persists across do_turn calls so batching fires even when the initial
+        // pickup exhausted moves. Reset after the batching check evaluates.
+        bool picked_up_this_pass = false; // NOLINT(cata-serialize)
 
         // Returns all picked up items to the source tile and clears sorting state.
         // Used when routing to a destination fails.


### PR DESCRIPTION
#### Summary
Performance "Batch zone sorting pickups from nearby sources"

#### Purpose of change

When sorting with zones, the player walks source -> destination -> source -> destination for every single UNSORTED tile. If two sources are right next to each other but the destination is far away, the player still makes a separate round trip for each one. This is especially annoying with scattered loot near a distant stockpile.

Related to the sorting overhaul in #83640, #84311, and the bugfix series in #85229.

#### Describe the solution

After picking up items from a source in stage_do, check if any other unvisited UNSORTED source is strictly closer than the nearest destination. If it has compatible items (same destination zone type) that the player can carry (inventory or grabbed cart volume), detour there first before delivering.

The batching loop mirrors THINK's filters (zone binding, ignore zones, ownership, capacity) and sorts candidates by distance so the closest source is tried first. Adjacent batch targets re-enter DO directly; farther ones use route_to_destination.

A \`picked_up_this_pass\` member variable gates batching to prevent infinite loops when a batch target has no pickable items (zero moves consumed per cycle). It persists across do_turn calls so batching still fires when move exhaustion splits pickup and evaluation into separate turns, then resets after the batching check evaluates.

#### Describe alternatives you've considered

Could have done this in THINK by building multi-source pickup plans, but that would mean reworking the whole stage machine. Doing it as a post-pickup detour in DO is minimal and self-contained -- if batching finds nothing, the existing delivery path runs unchanged.

#### Testing

Two new tests in tests/clzones_test.cpp:

- \`zone_sorting_batches_nearby_sources\`: S1 at player position and S2 one tile east (10 apples each), D ten tiles south. After process_activity, both sources are empty and all 20 apples are in player inventory. Without batching, only S1 gets picked up before the activity routes to D.
- \`zone_sorting_batches_into_grabbed_vehicle\`: Same layout but with a grabbed shopping cart. Verifies the capacity check considers cart cargo volume, not just player inventory.

All 17 existing zone sorting tests pass (115 assertions).

Verified in-game that sorting with scattered loot consolidates pickups before delivering.

#### Additional context

The test harness (process_activity) can't simulate auto-move, so delivery to a non-adjacent destination doesn't complete -- same limitation as all existing sorting tests. The tests verify both sources are emptied and items are carried, which is sufficient to prove batching fired.