### PR TITLE
Fix one typo in src/character_attire.cpp

### DIFF
--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -532,7 +532,7 @@ ret_val<void> Character::can_takeoff( const item &it, const std::list<item> *res
     if( it.has_flag( json_flag_SHAPESHIFTED_ARMOR ) ) {
         return ret_val<void>::make_failure( !is_npc() ?
                                             _( "That item is currently shapeshifted into your form." ) :
-                                            _( "That item is currently shapeshifted into <npcname>;s form." ) );
+                                            _( "That item is currently shapeshifted into <npcname>'s form." ) );
     }
     return ret_val<void>::make_success();
 }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Only one minor typo.
Find it during localization.

#### Describe the solution

change from "<npcname>;s" to "<npcname>'s"

#### Describe alternatives you've considered

#### Testing

#### Additional context