### PR TITLE
Fix surroundings menu hanging on languages with non-latin scripts

### DIFF
--- a/src/text.cpp
+++ b/src/text.cpp
@@ -353,7 +353,7 @@ static std::string trim_substring( std::string_view text, float width )
     float last_free = 0.f;
 
     do {
-        std::string trimmed_str( text.substr( 0, visible_chars ) );
+        std::string trimmed_str = utf8_truncate( std::string( text ), visible_chars );
         trimmed_str += ellipsis;
         float trimmed_width = ImGui::CalcTextSize( trimmed_str.c_str(), nullptr, true ).x;
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fixes #85456

#### Describe the solution

Turns out you shouldn't use `string::substr` (naively) with utf8 strings, so use `utf8_truncate` instead.

#### Describe alternatives you've considered



#### Testing

Checked with save from issue and Russian language, no hang anymore. Also tested Japanese and Chinese, but neither of them hanged before, but maybe just by chance.

#### Additional context

