### PR TITLE
Fix auto-move through vehicle doors and sort vehicle cargo from terrain zones

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -13074,12 +13074,20 @@ void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
     zone_sorting::unload_sort_options zone_unload_options = zone_sorting::set_unload_options( you, src,
             false );
 
-    // Which UNSORTED zone types exist at src? Items only participate in
-    // sorting if the source zone matches their binding (vehicle vs terrain).
-    const bool src_has_terrain_unsorted = mgr.has_terrain( zone_type_LOOT_UNSORTED, src, fac_id );
-    const bool src_has_vehicle_unsorted = mgr.has_vehicle( zone_type_LOOT_UNSORTED, src, fac_id );
-
     const std::optional<vpart_reference> vp = here.veh_at( src_bub ).cargo();
+
+    // When the grabbed cart is at a terrain-only unsorted zone (no vehicle
+    // zone), it's being used for transport - don't re-sort its cargo.
+    // If there IS a vehicle zone on the cart, the user explicitly wants
+    // the cart's cargo sorted.
+    const bool src_has_vehicle_unsorted = mgr.has_vehicle( zone_type_LOOT_UNSORTED, src, fac_id );
+    bool skip_cart_cargo = false;
+    if( !src_has_vehicle_unsorted && you.is_avatar() &&
+        you.as_avatar()->get_grab_type() == object_type::VEHICLE ) {
+        const tripoint_bub_ms cart_pos = you.pos_bub() + you.as_avatar()->grab_point;
+        skip_cart_cargo = ( cart_pos == src_bub );
+    }
+
     // Track whether any sortable item failed pickup due to carry/cart capacity.
     bool cart_or_carry_blocked = false;
     //Skip items that have already been processed
@@ -13088,11 +13096,7 @@ void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
         ++num_processed;
         item &thisitem = *it->first;
 
-        // Skip items that don't match the source zone binding
-        if( it->second && !src_has_vehicle_unsorted ) {
-            continue;
-        }
-        if( !it->second && !src_has_terrain_unsorted ) {
+        if( it->second && skip_cart_cargo ) {
             continue;
         }
 

--- a/tests/clzones_test.cpp
+++ b/tests/clzones_test.cpp
@@ -1034,8 +1034,8 @@ TEST_CASE( "zone_sorting_adjacent_ground_delivery",
     CHECK( !dummy.activity );
 }
 
-// Terrain UNSORTED zone should only sort ground items, not vehicle cargo.
-// Vehicle parked on the same tile should have its cargo left untouched.
+// Terrain UNSORTED zone with grabbed cart at source: ground items get sorted,
+// but the grabbed cart's cargo is protected (used for transport, not as source).
 TEST_CASE( "zone_sorting_vehicle_on_terrain_unsorted_both_items",
            "[zones][items][activities][sorting][vehicle]" )
 {
@@ -1097,7 +1097,9 @@ TEST_CASE( "zone_sorting_vehicle_on_terrain_unsorted_both_items",
     CHECK( !dummy.activity );
 }
 
-// Vehicle UNSORTED zone should only sort vehicle cargo items, not ground items.
+// Vehicle UNSORTED zone with grabbed cart: vehicle zone lets cart cargo be
+// sorted (user explicitly marked the cart). Ground items also eligible since
+// any unsorted zone makes all items at the tile sortable.
 TEST_CASE( "zone_sorting_vehicle_unsorted_zone_ground_items_ignored",
            "[zones][items][activities][sorting][vehicle]" )
 {
@@ -1152,9 +1154,11 @@ TEST_CASE( "zone_sorting_vehicle_unsorted_zone_ground_items_ignored",
     dummy.assign_activity( zone_sort_activity_actor() );
     process_activity( dummy );
 
-    // Vehicle cargo sorted, ground item untouched
-    CHECK( count_items_or_charges( dest_pos, itype_test_apple, std::nullopt ) == 1 );
-    CHECK( count_items_or_charges( src_pos, itype_test_apple, std::nullopt ) == 1 );
+    // Both vehicle cargo and ground items sorted (vehicle zone present,
+    // so cart cargo is not protected; ground items always eligible)
+    CHECK( count_items_or_charges( dest_pos, itype_test_apple, std::nullopt ) == 2 );
+    CHECK( count_items_or_charges( src_pos, itype_test_apple, std::nullopt ) == 0 );
+    CHECK( count_items_or_charges( src_pos, itype_test_apple, cargo ) == 0 );
     CHECK( !dummy.activity );
 }
 
@@ -1215,6 +1219,71 @@ TEST_CASE( "zone_sorting_both_zones_at_same_position",
     process_activity( dummy );
 
     // All items sorted
+    CHECK( count_items_or_charges( dest_pos, itype_test_apple, std::nullopt ) == 2 );
+    CHECK( count_items_or_charges( src_pos, itype_test_apple, std::nullopt ) == 0 );
+    CHECK( count_items_or_charges( src_pos, itype_test_apple, cargo ) == 0 );
+    CHECK( !dummy.activity );
+}
+
+// Terrain-only UNSORTED zone with a non-grabbed vehicle (like a parked van):
+// vehicle cargo should be sorted alongside ground items.
+TEST_CASE( "zone_sorting_terrain_zone_sorts_non_grabbed_vehicle_cargo",
+           "[zones][items][activities][sorting][vehicle]" )
+{
+    avatar &dummy = get_avatar();
+    map &here = get_map();
+
+    clear_avatar();
+    clear_map_without_vision();
+    zone_manager::get_manager().clear();
+
+    const tripoint_bub_ms start_pos( 60, 60, 0 );
+    dummy.setpos( here, start_pos );
+    dummy.clear_destination();
+
+    // Source tile south
+    const tripoint_bub_ms src_pos = start_pos + tripoint::south;
+    const tripoint_abs_ms src_abs = here.get_abs( src_pos );
+    here.ter_set( src_pos, ter_t_floor );
+
+    // Create terrain UNSORTED zone BEFORE spawning vehicle
+    create_tile_zone( "Unsorted", zone_type_LOOT_UNSORTED, src_abs );
+
+    // Spawn a vehicle at source but do NOT grab it (simulates a parked van)
+    vehicle *van = here.add_vehicle( vehicle_prototype_test_shopping_cart,
+                                     src_pos, 0_degrees, 0, 0 );
+    REQUIRE( van != nullptr );
+    van->set_owner( dummy );
+    // No grab - this is a parked vehicle
+
+    zone_manager &mgr = zone_manager::get_manager();
+    mgr.cache_vzones();
+    REQUIRE( mgr.has_terrain( zone_type_LOOT_UNSORTED, src_abs ) );
+    REQUIRE( !mgr.has_vehicle( zone_type_LOOT_UNSORTED, src_abs ) );
+
+    // Destination: terrain LOOT_FOOD zone adjacent
+    const tripoint_bub_ms dest_pos = start_pos + tripoint::east;
+    const tripoint_abs_ms dest_abs = here.get_abs( dest_pos );
+    here.ter_set( dest_pos, ter_t_floor );
+    create_tile_zone( "Food", zone_type_LOOT_FOOD, dest_abs );
+
+    // Place items on ground AND in vehicle cargo
+    here.add_item_or_charges( src_pos, item( itype_test_apple ) );
+    std::optional<vpart_reference> cargo = here.veh_at( src_pos ).cargo();
+    REQUIRE( cargo.has_value() );
+    cargo->vehicle().add_item( here, cargo->part(), item( itype_test_apple ) );
+
+    REQUIRE( count_items_or_charges( src_pos, itype_test_apple, std::nullopt ) == 1 );
+    REQUIRE( count_items_or_charges( src_pos, itype_test_apple, cargo ) == 1 );
+
+    here.invalidate_map_cache( 0 );
+    here.build_map_cache( 0, true );
+
+    dummy.assign_activity( zone_sort_activity_actor() );
+    process_activity( dummy );
+
+    // Both ground and vehicle cargo items sorted (no grab, so no cart
+    // protection - terrain zone sorts everything at the tile)
     CHECK( count_items_or_charges( dest_pos, itype_test_apple, std::nullopt ) == 2 );
     CHECK( count_items_or_charges( src_pos, itype_test_apple, std::nullopt ) == 0 );
     CHECK( count_items_or_charges( src_pos, itype_test_apple, cargo ) == 0 );


### PR DESCRIPTION
#### Summary
Bugfixes "Fix auto-move aborting after opening vehicle doors, and sort vehicle cargo from terrain UNSORTED zones"

#### Purpose of change

Two bugs related to vehicles and zone sorting:

1. Auto-move aborts after opening a vehicle door. The safety check in handle_action.cpp only detected terrain/furniture changes (regular doors), but vehicle doors change `vehicle_part::open` state, not terrain. So it saw "nothing changed" and aborted. This killed zone sorting paths through vehicles and regular auto-move alike.

2. Terrain UNSORTED zones ignored items in vehicle cargo. This is a regression from #85403 - the source-side binding filter was too aggressive, making it impossible to sort items from parked vehicles without creating a vehicle-specific zone on each one.

#### Describe the solution

**Auto-move fix**: Before calling `avatar_action::move()`, snapshot which vehicle part is openable at the destination via `next_part_to_open()`. After the move, compare - if the openable part changed, a vehicle door/trunk/hatch was opened. Don't abort, let `defer_move` do its thing.

**Vehicle cargo fix**: Remove the source-side terrain/vehicle binding filter introduced in #85403. Any UNSORTED zone (terrain or vehicle) at a tile now makes all items there eligible - both ground and vehicle cargo. The grabbed cart's cargo is still protected when there's no vehicle zone on it (transport mode), but if the user explicitly creates a vehicle zone on the cart, its cargo becomes sortable too. Destination-side binding stays as-is.

#### Describe alternatives you've considered

For the auto-move fix, considered checking `defer_move` state directly, but `next_expected_position` is private. The before/after `next_part_to_open` comparison is cleaner and catches all vehicle openable types.

For the cargo fix, considered keeping per-binding source filtering and adding an opt-out. But any UNSORTED zone implicitly says "sort everything here", and making users create vehicle zones on every random vehicle they encounter felt wrong.

#### Testing

All 22 zone tests pass (321 assertions). Added a new test `zone_sorting_terrain_zone_sorts_non_grabbed_vehicle_cargo` that puts items in a non-grabbed vehicle's cargo at a terrain UNSORTED zone and verifies they get sorted. Updated existing binding tests to match new behavior.

Manual testing: spawn prisoner van, drop items inside, set up terrain UNSORTED zone, verify sorting picks up vehicle cargo items. Auto-move through vehicle doors no longer aborts.

#### Additional context

Related to #85403 (zone binding regression) and #85251 (zone sort with grabbed vehicles).