### PR TITLE
Let players leave Smokes' conversation

### DIFF
--- a/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_talk.json
+++ b/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_talk.json
@@ -205,7 +205,8 @@
         "text": "Are you interested in any chemical supplies?",
         "topic": "TALK_EVAC_MERCHANT_DEAL_NEGOTIATE_CHEM",
         "condition": { "u_has_mission": "MISSION_CABIN_CHEMIST_SET_TRADE_ROUTE" }
-      }
+      },
+      { "text": "That's all for now.  <end_talking_bye>", "topic": "TALK_DONE" }
     ]
   },
   {


### PR DESCRIPTION
#### Summary
Interface "Add goodbye option to Smokes' conversation hub"

#### Purpose of change

Smokes' main conversation topic (`TALK_FREE_MERCHANTS_MERCHANT_Talk`) has no exit option. Once you click "I wanted to talk", you're trapped in his dialogue tree until you either trade with him or pick up a mission. Smokes is a nice guy, but sometimes you just want to leave.

#### Describe the solution

Added a standard goodbye response to the Talk hub. Uses the same `<end_talking_bye>` snippet and phrasing as his post-trade dialogue for consistency.

#### Describe alternatives you've considered

Considered just leaving the player trapped forever. Smokes deserves the company, but it felt a bit hostage-situation-y.

#### Testing

Talked to Smokes. Said goodbye. He let me go. Unprecedented.

#### Additional context

None