### PR TITLE
fix solar nest placement

### DIFF
--- a/data/json/mapgen/nested/nested_chunks_roof.json
+++ b/data/json/mapgen/nested/nested_chunks_roof.json
@@ -529,7 +529,8 @@
         "#####"
       ],
       "terrain": { "#": "t_flat_roof" },
-      "furniture": { "#": "f_solar_unit" }
+      "furniture": { "#": "f_solar_unit" },
+      "flags": [ "ERASE_ITEMS_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -546,7 +547,8 @@
         " ##  "
       ],
       "terrain": { "#": "t_flat_roof", "?": "t_flat_roof" },
-      "furniture": { "#": "f_solar_unit_v2", "?": [ [ "f_solar_unit_v2", 1 ], [ "f_null", 1 ] ] }
+      "furniture": { "#": "f_solar_unit_v2", "?": [ [ "f_solar_unit_v2", 1 ], [ "f_null", 1 ] ] },
+      "flags": [ "ERASE_ITEMS_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -572,7 +574,8 @@
         "      "
       ],
       "terrain": { "#": "t_flat_roof" },
-      "furniture": { "#": "f_solar_unit" }
+      "furniture": { "#": "f_solar_unit" },
+      "flags": [ "ERASE_ITEMS_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {
@@ -590,7 +593,8 @@
         "      "
       ],
       "terrain": { "#": "t_flat_roof" },
-      "furniture": { "#": "f_solar_unit_v2" }
+      "furniture": { "#": "f_solar_unit_v2" },
+      "flags": [ "ERASE_ITEMS_BEFORE_PLACING_TERRAIN" ]
     }
   },
   {


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Saw next error in our CI:
`In nested mapgen residential_7kW_solar_v1 in nested mapgen residential_7kW_solar in mapgen s_dive_shop_roof on s_dive_shop_roof_west, setting terrain to t_flat_roof (from t_tar_flat_roof) at (7,10,1) when item joint_roach existed.  Resolve this either by removing the terrain from this mapgen, adding suitable removal commands to the mapgen, or by adding an appropriate clearing flag to the innermost layered mapgen.  Consult the "mapgen flags" section in MAPGEN.md for options.73.445 s: monsters_appear_on_map_as_expected`
#### Describe the solution
Add ERASE_ITEMS_BEFORE_PLACING_TERRAIN flag to solar panel nests i spotted
#### Testing
In CI we trust