### PR TITLE
Fix fire starting deleting firewood instead of fueling the fire

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -11289,7 +11289,7 @@ void fire_start_activity_actor::do_turn( player_activity &act, Character &who )
     map &here = get_map();
     tripoint_bub_ms where = here.get_bub( fire_placement );
     if( !here.is_flammable( where ) ) {
-        try_fuel_fire( act, who, true );
+        try_fuel_fire( who, where );
         if( !here.is_flammable( where ) ) {
             if( here.has_flag_ter( ter_furn_flag::TFLAG_DEEP_WATER, where ) ||
                 here.has_flag_ter( ter_furn_flag::TFLAG_SHALLOW_WATER, where ) ) {

--- a/src/activity_handlers.h
+++ b/src/activity_handlers.h
@@ -157,7 +157,8 @@ struct activity_reason_info {
 };
 
 int get_auto_consume_moves( Character &you, bool food );
-bool try_fuel_fire( player_activity &act, Character &you, bool starting_fire = false );
+bool try_fuel_fire( Character &you,
+                    std::optional<tripoint_bub_ms> fire_target = std::nullopt );
 
 enum class item_drop_reason : int {
     deliberate,

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -4628,14 +4628,14 @@ int get_auto_consume_moves( Character &you, const bool food )
 }
 
 // Try to add fuel to a fire. Return true if there is both fire and fuel; return false otherwise.
-bool try_fuel_fire( player_activity &act, Character &you, const bool starting_fire )
+bool try_fuel_fire( Character &you, std::optional<tripoint_bub_ms> fire_target )
 {
     const tripoint_bub_ms pos = you.pos_bub();
     std::vector<tripoint_bub_ms> adjacent = closest_points_first( pos, 1, PICKUP_RANGE );
 
     map &here = get_map();
     std::optional<tripoint_bub_ms> best_fire =
-        starting_fire ? here.get_bub( act.placement ) : find_best_fire( adjacent, pos );
+        fire_target ? fire_target : find_best_fire( adjacent, pos );
 
     if( !best_fire || !here.accessible_items( *best_fire ) ) {
         return false;
@@ -4672,7 +4672,7 @@ bool try_fuel_fire( player_activity &act, Character &you, const bool starting_fi
 
     // Enough to sustain the fire
     // TODO: It's not enough in the rain
-    if( !starting_fire && ( fd.fuel_produced >= 1.0f || fire_age < 10_minutes ) ) {
+    if( !fire_target && ( fd.fuel_produced >= 1.0f || fire_age < 10_minutes ) ) {
         return true;
     }
 

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -211,7 +211,7 @@ void player_activity::do_turn( Character &you )
     synchronize_type_with_actor();
     // Should happen before activity or it may fail due to 0 moves
     if( *this && type->will_refuel_fires() && have_fire ) {
-        have_fire = try_fuel_fire( *this, you );
+        have_fire = try_fuel_fire( you );
     }
     if( calendar::once_every( 30_minutes ) ) {
         no_food_nearby_for_auto_consume = false;


### PR DESCRIPTION
#### Summary
Bugfixes "Fix fire starting deleting firewood instead of fueling the fire"

#### Purpose of change

Closes #85476

When ACT_START_FIRE was migrated to activity_actor in #85355, `try_fuel_fire()` kept reading the fire position from `player_activity::placement`, which the new actor never sets. Firewood gets moved to absolute {0,0,0} and effectively deleted, then the activity cancels with "there's nothing to light there".

#### Describe the solution

Replace `try_fuel_fire`'s `bool starting_fire` / `player_activity&` parameters with an explicit `std::optional<tripoint_bub_ms> fire_target`. The fire-start actor passes the position directly; the auto-refuel caller passes nothing and finds fires on its own as before.

#### Describe alternatives you've considered

N/A

#### Testing

Build-tested. Verified the only two callers compile and pass the correct arguments.

#### Additional context

The other `act.placement` misuse (in `finish()` for smoker/kiln detection) was already fixed in #85388.