### PR TITLE
Add target practice activity

### DIFF
--- a/data/json/item_actions.json
+++ b/data/json/item_actions.json
@@ -446,6 +446,11 @@
   },
   {
     "type": "item_action",
+    "id": "TARGET_PRACTICE",
+    "name": { "str": "Target practice" }
+  },
+  {
+    "type": "item_action",
     "id": "HEATPACK",
     "name": { "str": "Use" }
   },

--- a/data/json/items/tool/deployable.json
+++ b/data/json/items/tool/deployable.json
@@ -404,5 +404,29 @@
     "symbol": "7",
     "color": "yellow_red",
     "use_action": { "type": "deploy_furn", "furn_type": "f_manual_tire_changer" }
+  },
+  {
+    "id": "target_spinner",
+    "type": "ITEM",
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "spinner target", "str_pl": "spinner targets" },
+    "description": "Two steel plates mounted on a pipe in a double-sided oar design, installed in a sturdy frame with a rotating mechanism. It spins when struck, eventually returning to vertical alignment due to one plate being heavier than the other. You can use it for target practice when stationary targets become too easy.",
+    "weight": "20 kg",
+    "volume": "10 L",
+    "longest_side": "130 cm",
+    "price": "35 USD",
+    "price_postapoc": "10 USD",
+    "material": [ "steel" ],
+    "symbol": "%",
+    "color": "light_gray",
+    "use_action": {
+      "type": "place_trap",
+      "allow_under_player": true,
+      "trap": "tr_target_spinner",
+      "moves": 500,
+      "practice": 0,
+      "done_message": "You set up the spinner target, time to shoot!"
+    },
+    "flags": [ "SINGLE_USE" ]
   }
 ]

--- a/data/json/player_activities.json
+++ b/data/json/player_activities.json
@@ -1014,6 +1014,18 @@
     "can_resume": false
   },
   {
+    "id": "ACT_TARGET_PRACTICE",
+    "type": "activity_type",
+    "activity_level": "LIGHT_EXERCISE",
+    "verb": "practicing marksmanship",
+    "based_on": "neither",
+    "can_resume": false,
+    "interruptable": true,
+    "interruptable_with_kb": true,
+    "refuel_fires": true,
+    "auto_needs": true
+  },
+  {
     "id": "ACT_TENT_PLACE",
     "type": "activity_type",
     "activity_level": "LIGHT_EXERCISE",

--- a/data/json/recipes/recipe_others.json
+++ b/data/json/recipes/recipe_others.json
@@ -3246,6 +3246,36 @@
     "components": [ [ [ "box_medium", 1 ] ] ]
   },
   {
+    "result": "target_spinner",
+    "type": "recipe",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_OTHER",
+    "skill_used": "fabrication",
+    "difficulty": 2,
+    "time": "3 h",
+    "activity_level": "MODERATE_EXERCISE",
+    "autolearn": true,
+    "qualities": [
+      { "id": "HAMMER", "level": 2 },
+      { "id": "SAW_M", "level": 2 },
+      { "id": "DRILL", "level": 3 },
+      { "id": "WRENCH", "level": 2 }
+    ],
+    "components": [
+      [ [ "mil_plate", 1 ], [ "hard_plate", 1 ], [ "alloy_plate", 1 ] ],
+      [
+        [ "mil_plate", 1 ],
+        [ "hard_plate", 1 ],
+        [ "alloy_plate", 1 ],
+        [ "steel_plate", 1 ],
+        [ "steel_lump_any", 1, "LIST" ],
+        [ "sheet_metal", 1 ]
+      ],
+      [ [ "pipe", 8 ] ],
+      [ [ "nuts_bolts", 30 ] ]
+    ]
+  },
+  {
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
     "result": "welding_kit",

--- a/data/json/snippets/target_practice.json
+++ b/data/json/snippets/target_practice.json
@@ -1,0 +1,57 @@
+[
+  {
+    "type": "snippet",
+    "category": "target_practice_common",
+    "text": [
+      "You control your breath to keep your aim steady.",
+      "You pull the trigger slowly, feeling the different stages of the trigger.",
+      "Your focus sharpens, and you can feel the hammer fall before you feel the recoil of the round.",
+      "You try a different grip for a bit, before deciding it's uncomfortable.",
+      "You picture a zombie as you fire.",
+      "You grip the firearm a bit tighter this time."
+    ]
+  },
+  {
+    "type": "snippet",
+    "category": "target_practice_novice",
+    "text": [
+      "You hesitate as you pull the trigger, moving your aim off-target.",
+      "The sound startles you, and you almost drop your gun.",
+      "You hear a click. You forgot the safety."
+    ]
+  },
+  {
+    "type": "snippet",
+    "category": "target_practice_spinner",
+    "text": [
+      "You track the spinning target, gauging the best moment to shoot.",
+      "The target spins chaotically, making it harder to strike. This is harder than it seems.",
+      "You attempt to land several hits on the same side of the spinner targets in one go."
+    ]
+  },
+  {
+    "type": "snippet",
+    "category": "target_practice_coaching_beginner",
+    "text": [
+      "%s explains to you how to properly use the sights.",
+      "%s demonstrates to you how to handle a weapon without hurting yourself.",
+      "%s shows you how to grip the weapon.",
+      "%s shows you how to position your body properly.",
+      "%s points out that you're flinching before the shot, pushing the gun downwards in anticipation.",
+      "%s points out that you tense up too much before taking a shot, and explains how confidence affects accuracy.",
+      "%s explains how to aim with both eyes open.",
+      "%s describes situations wherein single-eye shooting is the preferable option.",
+      "%s demonstrates how to quickly draw your gun."
+    ]
+  },
+  {
+    "type": "snippet",
+    "category": "target_practice_coaching_advanced",
+    "text": [
+      "%s points out slight inconsistencies in your stance.",
+      "%s suggest improvements for using the sights.",
+      "%s applauds your recoil management.",
+      "%s commends the speed at which you ready your weapon, while noting subtle redundancies in your moves."
+    ]
+  }
+]

--- a/data/json/traps.json
+++ b/data/json/traps.json
@@ -920,6 +920,19 @@
   },
   {
     "type": "trap",
+    "id": "tr_target_spinner",
+    "name": "spinner target",
+    "color": "light_gray",
+    "symbol": "%",
+    "visibility": -1,
+    "avoidance": 0,
+    "difficulty": 0,
+    "action": "none",
+    "drops": [ "target_spinner" ],
+    "benign": true
+  },
+  {
+    "type": "trap",
     "id": "tr_unfinished_construction",
     "name": "unfinished construction",
     "color": "white",

--- a/data/json/uncraft/tool/deployable.json
+++ b/data/json/uncraft/tool/deployable.json
@@ -108,5 +108,20 @@
     "time": "15 m",
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 2 } ],
     "components": [ [ [ "lc_steel_lump", 4 ] ], [ [ "lc_steel_chunk", 1 ] ], [ [ "scrap", 4 ] ] ]
+  },
+  {
+    "result": "target_spinner",
+    "type": "uncraft",
+    "activity_level": "MODERATE_EXERCISE",
+    "skill_used": "fabrication",
+    "difficulty": 2,
+    "time": "90 m",
+    "qualities": [
+      { "id": "HAMMER", "level": 2 },
+      { "id": "SAW_M", "level": 1 },
+      { "id": "SCREW", "level": 2 },
+      { "id": "WRENCH", "level": 2 }
+    ],
+    "components": [ [ [ "hard_plate", 1 ] ], [ [ "sheet_metal_small", 3 ] ], [ [ "pipe", 6 ] ], [ [ "nuts_bolts", 25 ] ] ]
   }
 ]

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -121,6 +121,7 @@
 #include "text_snippets.h"
 #include "translation.h"
 #include "translations.h"
+#include "trap.h"
 #include "type_id.h"
 #include "uilist.h"
 #include "uistate.h"
@@ -232,6 +233,7 @@ static const activity_id ACT_START_ENGINES( "ACT_START_ENGINES" );
 static const activity_id ACT_START_FIRE( "ACT_START_FIRE" );
 static const activity_id ACT_STASH( "ACT_STASH" );
 static const activity_id ACT_STUDY_SPELL( "ACT_STUDY_SPELL" );
+static const activity_id ACT_TARGET_PRACTICE( "ACT_TARGET_PRACTICE" );
 static const activity_id ACT_TENT_DECONSTRUCT( "ACT_TENT_DECONSTRUCT" );
 static const activity_id ACT_TENT_PLACE( "ACT_TENT_PLACE" );
 static const activity_id ACT_TOOLMOD_ADD( "ACT_TOOLMOD_ADD" );
@@ -305,6 +307,8 @@ static const furn_str_id furn_f_safe_o( "f_safe_o" );
 static const furn_str_id furn_f_smoking_rack( "f_smoking_rack" );
 
 static const gun_mode_id gun_mode_DEFAULT( "DEFAULT" );
+
+static const trap_str_id tr_target_spinner( "tr_target_spinner" );
 
 static const item_group_id
 Item_spawn_data_SUS_trash_forest_no_manmade( "SUS_trash_forest_no_manmade" );
@@ -485,7 +489,8 @@ bool aim_activity_actor::check_gun_ability_to_shoot( Character &who, item &it )
                                    it.tname() );
             it.remove_fault( fault_fail_to_feed );
             it.set_var( "u_know_round_in_chamber", true );
-        } else if( one_in( std::max( 7.0f, ( 15.0f - ( 4.0f * who.get_skill_level( skill_gun ) ) ) ) ) ) {
+        } else if( one_in( std::max( 7.0f,
+                                     ( 15.0f - ( 4.0f * who.get_skill_level( skill_gun ) ) ) ) ) ) {
             who.add_msg_if_player( m_good,
                                    _( "Your %s has some mechanical malfunction.  You tried to quickly fix it, and it works now!" ),
                                    it.tname() );
@@ -4695,6 +4700,388 @@ std::unique_ptr<activity_actor> fish_activity_actor::deserialize( JsonValue &jsi
     data.read( "fishing_zone", actor.fishing_zone );
     data.read( "fishing_rod", actor.fishing_rod );
     data.read( "fishing_duration", actor.fishing_duration );
+
+    return actor.clone();
+}
+
+void target_practice_activity_actor::start( player_activity &act, Character &who )
+{
+    if( !check_target_valid( who ) ) {
+        act.set_to_null();
+        return;
+    }
+
+    map &here = get_map();
+    tripoint_bub_ms target_local = here.get_bub( target_position );
+    is_spinner_target = ( here.tr_at( target_local ).id == tr_target_spinner );
+
+    if( is_spinner_target ) {
+        who.add_msg_if_player( m_info,
+                               _( "You begin target practice with a spinner target." ) );
+    } else {
+        who.add_msg_if_player( m_info, _( "You begin practicing your marksmanship." ) );
+    }
+
+
+    // Try to employ a follower as a coach
+    const skill_id weapon_skill = gun_loc.get_item()->gun_skill();
+    npc *found_coach = find_coach( who, weapon_skill );
+    if( found_coach ) {
+        coach_id = found_coach->getID();
+        who.add_msg_if_player( m_good, _( "%s offers to coach you during your practice." ),
+                               found_coach->get_name() );
+    }
+
+}
+
+bool target_practice_activity_actor::check_weapon_valid( Character &who )
+{
+    item *gun = gun_loc.get_item();
+    if( !gun ) {
+        who.add_msg_if_player( m_bad, _( "Your weapon is no longer available." ) );
+        return false;
+    }
+
+    if( !who.is_wielding( *gun ) ) {
+        who.add_msg_if_player( m_bad, _( "You aren't holding your weapon anymore." ) );
+        return false;
+    }
+
+    return true;
+}
+
+bool target_practice_activity_actor::check_target_valid( Character &who )
+{
+    map &here = get_map();
+    tripoint_bub_ms target_local = here.get_bub( target_position );
+
+    // Check if target is in range
+    item *gun = gun_loc.get_item();
+    const int range = gun->gun_range( &who );
+    const int distance = rl_dist( who.pos_bub(), target_local );
+
+    if( distance > range ) {
+        who.add_msg_if_player( m_bad, _( "The target is out of range!" ) );
+        return false;
+    }
+
+    if( !who.sees( here, target_local ) ) {
+        who.add_msg_if_player( m_bad, _( "You cannot see the target!" ) );
+        return false;
+    }
+
+    return true;
+}
+
+bool target_practice_activity_actor::attempt_reload( Character &who )
+{
+    item *gun = gun_loc.get_item();
+
+    std::vector<item_location> ammo_locs;
+    item_location reload_target = gun_loc;
+
+    // Try to find compatible loaded magazines, or ammo for guns without detachable magazines
+    ammo_locs = who.find_ammo( *gun, false, 3 );
+
+    // Didn't find loaded magazines, try to find loose ammo for the magazine inside the gun
+    if( ammo_locs.empty() && gun->magazine_current() ) {
+        const item *mag = gun->magazine_current();
+        ammo_locs = who.find_ammo( *mag, false, 3 );
+        reload_target = item_location( gun_loc, const_cast<item *>( mag ) );
+    }
+
+    if( ammo_locs.empty() ) {
+        who.add_msg_if_player( m_bad, _( "You ran out of ammunition." ) );
+        return false;
+    }
+
+    item_location ammo_loc = ammo_locs.front();
+    item *ammo = ammo_loc.get_item();
+
+    int quantity_to_reload = reload_target->ammo_capacity( ammo->ammo_type() );
+
+    if( !reload_target->reload( who, ammo_loc, quantity_to_reload ) ) {
+        who.add_msg_if_player( m_bad, _( "Failed to reload." ) );
+        return false;
+    }
+
+    return true;
+}
+
+void target_practice_activity_actor::fire_shot( Character &who, player_activity &act )
+{
+    item *gun = gun_loc.get_item();
+    map &here = get_map();
+    tripoint_bub_ms target_local = here.get_bub( target_position );
+
+    // Simulate max aim
+    who.recoil = 0;
+
+    int shots_fired = who.fire_gun( here, target_local, 1, *gun );
+
+    if( shots_fired > 0 ) {
+        rounds_fired++;
+    } else {
+        // Firing failed, check if it requires player attention to fix
+        // otherwise it's a simple misfire that can be fixed by firing again
+        if( gun->has_fault_of_type( gun_mechanical_simple ) ) {
+            finish( act, who );
+        }
+    }
+}
+
+void target_practice_activity_actor::show_flavor_message( Character &who,
+        float effective_skill ) const
+{
+    if( one_in( 2 ) ) {
+        return;
+    }
+
+    if( effective_skill < 3.0f && one_in( 2 ) ) {
+        who.add_msg_if_player( m_warning,
+                               SNIPPET.random_from_category( "target_practice_novice" ).value_or( translation() ).translated() );
+    } else {
+        who.add_msg_if_player( m_good,
+                               SNIPPET.random_from_category( "target_practice_common" ).value_or( translation() ).translated() );
+    }
+
+    if( is_spinner_target && one_in( 5 ) ) {
+        who.add_msg_if_player( m_good,
+                               SNIPPET.random_from_category( "target_practice_spinner" ).value_or( translation() ).translated() );
+    }
+}
+
+npc *target_practice_activity_actor::find_coach( Character &who, const skill_id &weapon_skill )
+{
+    map &here = get_map();
+    const float trainee_marksmanship_skill = who.get_skill_level( skill_gun );
+    const float trainee_weapon_skill = who.get_skill_level( weapon_skill );
+
+    std::vector<npc *> potential_coaches = g->get_npcs_if( [&]( const npc & npc ) {
+        if( !npc.is_player_ally() || !npc.is_following() ) {
+            return false;
+        }
+
+        if( !who.sees( here, npc ) || !npc.sees( here, who ) ) {
+            return false;
+        }
+
+        const float npc_marksmanship_skill = npc.get_skill_level( skill_gun );
+        const float npc_weapon_skill = npc.get_skill_level( weapon_skill );
+
+        return npc_marksmanship_skill > trainee_marksmanship_skill ||
+               npc_weapon_skill > trainee_weapon_skill;
+    } );
+
+    npc *best_coach = nullptr;
+    float best_coach_skill = 0.0f;
+
+    // Find the best coach
+    for( npc *coach : potential_coaches ) {
+        const float coach_skill = coach->get_skill_level( skill_gun ) +
+                                  coach->get_skill_level( weapon_skill );
+        if( coach_skill > best_coach_skill ) {
+            best_coach = coach;
+            best_coach_skill = coach_skill;
+        }
+    }
+
+    return best_coach;
+}
+
+void target_practice_activity_actor::apply_coaching( Character &who,
+        const skill_id &weapon_skill )
+{
+    if( coach_id.is_valid() ) {
+        npc *coach_ptr = g->critter_by_id<npc>( coach_id );
+
+        if( !coach_ptr ) {
+            return;
+        }
+
+        const float coach_marksmanship_skill = coach_ptr->get_knowledge_level( skill_gun );
+        const float coach_weapon_skill = coach_ptr->get_knowledge_level( weapon_skill );
+        const float trainee_marksmanship_skill = who.get_skill_level( skill_gun );
+        const float trainee_weapon_skill = who.get_skill_level( weapon_skill );
+
+        // Scale the XP bonus based on the skill delta between the coach and trainee
+        // 1XP (+20%) for each point of skill difference
+        // For reference, the normal XP gain for 1 shot is 5XP, with a bonus 5XP for hitting a living target
+        const int marksmanship_bonus = std::max( 0,
+                                       static_cast<int>( coach_marksmanship_skill - trainee_marksmanship_skill -
+                                               who.get_gun_weariness_factor() ) );
+        const int weapon_bonus = std::max( 0,
+                                           static_cast<int>( coach_weapon_skill - trainee_weapon_skill - who.get_gun_weariness_factor() ) );
+
+        if( marksmanship_bonus > 0 ) {
+            who.practice( skill_gun, marksmanship_bonus );
+        }
+        if( weapon_bonus > 0 ) {
+            who.practice( weapon_skill, weapon_bonus );
+        }
+
+        // Show coaching flavour messages every ~10th shot
+        if( !one_in( 10 ) ) {
+            return;
+        }
+
+        const std::string message_category = ( trainee_marksmanship_skill < 2.0f ||
+                                               trainee_weapon_skill < 2.0f )
+                                             ? "target_practice_coaching_beginner" : "target_practice_coaching_advanced";
+        who.add_msg_if_player( m_good,
+                               SNIPPET.random_from_category( message_category ).value_or( translation() ).translated(),
+                               coach_ptr->get_name() );
+    }
+}
+
+void target_practice_activity_actor::apply_skill_modifiers( Character &who,
+        const skill_id &weapon_skill, float effective_skill ) const
+{
+    // Boost XP gain from using spinner target by 2XP (+40%) when you're skilled, and by 0.5XP (+10%) when you're noob
+    // For reference, the normal XP gain for 1 shot is 5XP, with a bonus 5XP for hitting a living target
+    if( is_spinner_target ) {
+        if( effective_skill > 4 ) {
+            who.practice( weapon_skill, 2 - who.get_gun_weariness_factor() );
+            who.practice( skill_gun, 2 - who.get_gun_weariness_factor() );
+        } else if( one_in( 2 ) ) {
+            who.practice( weapon_skill, 1 - who.get_gun_weariness_factor() );
+            who.practice( skill_gun, 1 - who.get_gun_weariness_factor() );
+        }
+    }
+
+    // Give a hint every ~50 shots
+    if( !is_spinner_target && ( effective_skill > 4 ) && one_in( 50 ) ) {
+        who.add_msg_if_player( m_neutral,
+                               _( "At your level, you could benefit from a spinner target to better refine your skills." ) );
+    }
+}
+
+void target_practice_activity_actor::do_turn( player_activity &act, Character &who )
+{
+    if( !check_weapon_valid( who ) ) {
+        finish( act, who );
+        who.add_msg_if_player( m_bad, _( "Your weapon is gone!" ) );
+        return;
+    }
+
+    // Process artificial/flavor delay between shots
+    if( delay_between_shots > 0 ) {
+        const int moves_this_turn = std::min( delay_between_shots, who.get_moves() );
+        delay_between_shots -= moves_this_turn;
+        who.mod_moves( -moves_this_turn );
+        return;
+    }
+
+    // Fired the planned amount of rounds? C'est fini
+    if( rounds_fired >= rounds_planned ) {
+        finish( act, who );
+        return;
+    }
+
+    // Need a reload?
+    item *gun = gun_loc.get_item();
+    if( gun->ammo_remaining() == 0 ) {
+        if( !attempt_reload( who ) ) {
+            who.add_msg_if_player( m_info,
+                                   _( "You finish your target practice session because you've run out of ammo." ) );
+            finish( act, who );
+            return;
+        }
+    }
+
+    if( !check_target_valid( who ) ) {
+        finish( act, who );
+        return;
+    }
+
+    if( cancel_activity_due_to_gun_weariness( act, who ) ) {
+        return;
+    }
+
+    const skill_id &weapon_skill = gun->gun_skill();
+    const float effective_skill = who.get_skill_level( weapon_skill ) +
+                                  ( who.get_skill_level( skill_gun ) * 0.5f );
+    apply_coaching( who, weapon_skill );
+    apply_skill_modifiers( who, weapon_skill, effective_skill );
+    show_flavor_message( who, effective_skill );
+    fire_shot( who, act );
+
+    // Artificial delay between shots
+    constexpr int base_delay = 1000;
+
+    delay_between_shots = base_delay * ( 1 + ( who.get_gun_weariness_factor() / 3.0f ) );
+}
+
+bool target_practice_activity_actor::cancel_activity_due_to_gun_weariness( player_activity &act,
+        Character &who )
+{
+    if( who.get_gun_weariness_factor() <= 1.0f ||
+        act.is_distraction_ignored( distraction_type::gun_weariness ) ) {
+        return false;
+    }
+
+    if( !who.is_avatar() ) {
+        add_msg_if_player_sees( who, m_bad,
+                                _( "%s puts down their weapon and decides to take a break as they find themselves struggling to maintain focus.  It's a waste of time and ammo to keep shooting at this point." ),
+                                who.get_name() );
+        who.as_npc()->say( _( "It's been good practice, but I need to take a break." ) );
+        return true;
+    }
+
+    return g->cancel_activity_or_ignore_query( distraction_type::gun_weariness,
+            _( "All the shooting has you mentally drained.  You can continue practicing, but it will yield diminishing returns and take more time as you struggle to maintain focus and not slide into mindlessly pulling the trigger." ) );
+}
+
+void target_practice_activity_actor::finish( player_activity &act, Character &who )
+{
+    who.add_msg_if_player( m_good, _( "You finish your target practice session." ) );
+    who.add_msg_if_player( m_info, _( "Rounds fired: %d/%d" ), rounds_fired, rounds_planned );
+
+    act.set_to_null();
+}
+
+
+void target_practice_activity_actor::canceled( player_activity &act, Character &who )
+{
+    finish( act, who );
+}
+
+std::string target_practice_activity_actor::get_progress_message( const player_activity & ) const
+{
+    if( rounds_planned >= 0 ) {
+        return string_format( _( "%d / %d rounds" ), rounds_fired, rounds_planned );
+    }
+    return string_format( _( "%d rounds" ), rounds_fired );
+}
+
+void target_practice_activity_actor::serialize( JsonOut &jsout ) const
+{
+    jsout.start_object();
+
+    jsout.member( "gun_loc", gun_loc );
+    jsout.member( "target_position", target_position );
+    jsout.member( "rounds_planned", rounds_planned );
+    jsout.member( "rounds_fired", rounds_fired );
+    jsout.member( "delay_between_shots", delay_between_shots );
+    jsout.member( "coach_id", coach_id );
+    jsout.member( "is_spinner_target", is_spinner_target );
+
+    jsout.end_object();
+}
+
+std::unique_ptr<activity_actor> target_practice_activity_actor::deserialize( JsonValue &jsin )
+{
+    target_practice_activity_actor actor;
+
+    JsonObject data = jsin.get_object();
+
+    data.read( "gun_loc", actor.gun_loc );
+    data.read( "target_position", actor.target_position );
+    data.read( "rounds_planned", actor.rounds_planned );
+    data.read( "rounds_fired", actor.rounds_fired );
+    data.read( "delay_between_shots", actor.delay_between_shots );
+    data.read( "coach_id", actor.coach_id );
+    data.read( "is_spinner_target", actor.is_spinner_target );
 
     return actor.clone();
 }
@@ -13734,6 +14121,7 @@ deserialize_functions = {
     { ACT_START_FIRE, &fire_start_activity_actor::deserialize },
     { ACT_STASH, &stash_activity_actor::deserialize },
     { ACT_STUDY_SPELL, &study_spell_activity_actor::deserialize },
+    { ACT_TARGET_PRACTICE, &target_practice_activity_actor::deserialize },
     { ACT_TENT_DECONSTRUCT, &tent_deconstruct_activity_actor::deserialize },
     { ACT_TENT_PLACE, &tent_placement_activity_actor::deserialize },
     { ACT_TOOLMOD_ADD, &toolmod_add_activity_actor::deserialize },

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -1622,6 +1622,56 @@ class fish_activity_actor : public activity_actor
         time_duration fishing_duration;
 };
 
+class target_practice_activity_actor : public activity_actor
+{
+    public:
+        target_practice_activity_actor() = default;
+        target_practice_activity_actor(
+            const item_location &gun,
+            const tripoint_abs_ms &target_pos,
+            int rounds = -1 ) :
+            gun_loc( gun ), target_position( target_pos ),
+            rounds_planned( rounds ) {}
+
+        const activity_id &get_type() const override {
+            static const activity_id ACT_TARGET_PRACTICE( "ACT_TARGET_PRACTICE" );
+            return ACT_TARGET_PRACTICE;
+        }
+
+        void start( player_activity &act, Character &who ) override;
+        void do_turn( player_activity &act, Character &who ) override;
+        void finish( player_activity &act, Character &who ) override;
+        void canceled( player_activity &act, Character &who ) override;
+        std::unique_ptr<activity_actor> clone() const override {
+            return std::make_unique<target_practice_activity_actor>( *this );
+        }
+
+        std::string get_progress_message( const player_activity & ) const override;
+
+        void serialize( JsonOut &jsout ) const override;
+        static std::unique_ptr<activity_actor> deserialize( JsonValue &jsin );
+
+    private:
+        item_location gun_loc;
+        tripoint_abs_ms target_position;
+        int rounds_planned = -1;
+        int rounds_fired = 0;
+        int delay_between_shots = 0;
+        character_id coach_id;
+        bool is_spinner_target = false;
+
+        bool check_weapon_valid( Character &who );
+        bool check_target_valid( Character &who );
+        bool attempt_reload( Character &who );
+        void fire_shot( Character &who, player_activity &act );
+        void show_flavor_message( Character &who, float effective_skill ) const;
+        npc *find_coach( Character &who, const skill_id &weapon_skill );
+        void apply_coaching( Character &who, const skill_id &weapon_skill );
+        void apply_skill_modifiers( Character &who, const skill_id &weapon_skill,
+                                    float effective_skill ) const;
+        bool cancel_activity_due_to_gun_weariness( player_activity &act, Character &who );
+};
+
 class migration_cancel_activity_actor : public activity_actor
 {
     public:

--- a/src/activity_type.cpp
+++ b/src/activity_type.cpp
@@ -77,6 +77,7 @@ std::string enum_to_string<distraction_type>( distraction_type data )
         case distraction_type::mutation: return "mutation";
         case distraction_type::oxygen: return "oxygen";
         case distraction_type::withdrawal: return "withdrawal";
+        case distraction_type::gun_weariness: return "gun_weariness";
         // *INDENT-ON*
         default:
             cata_fatal( "Invalid distraction_type in enum_to_string" );

--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -1,3 +1,4 @@
+#include "player_activity.h"
 #include "animation.h"
 
 
@@ -43,6 +44,8 @@
 #include "sdltiles.h"
 #include "weather_type.h"
 #endif
+
+static const activity_id ACT_TARGET_PRACTICE( "ACT_TARGET_PRACTICE" );
 
 namespace
 {
@@ -94,10 +97,25 @@ class explosion_animation : public basic_animation
         }
 };
 
+bool skip_bullet_animation_delay()
+{
+    return get_avatar().activity.id() == ACT_TARGET_PRACTICE;
+}
+
 class bullet_animation : public basic_animation
 {
     public:
         bullet_animation() : basic_animation( 1 ) {
+        }
+
+        void progress() const {
+            draw();
+
+            // Skip artificial animation delay to greatly reduce the realtime
+            // delay between shots during player target practice activity
+            if( !skip_bullet_animation_delay() ) {
+                basic_animation::progress();
+            }
         }
 };
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -22,6 +22,7 @@
 #include "avatar_action.h"
 #include "bionics.h"
 #include "cached_options.h"
+#include "calendar.h"
 #include "cata_utility.h"
 #include "catacharset.h"
 #include "character_attire.h"
@@ -4292,6 +4293,51 @@ float Character::get_arms_stam_mult() const
 float Character::get_legs_stam_mult() const
 {
     return legs_stam_mult;
+}
+
+void Character::recover_gun_weariness() const
+{
+    // Recovery number can be thought of as "shots/bursts per hour"
+    constexpr float baseline_recovery_per_hour = 35.0f;
+    float recovery_per_hour = baseline_recovery_per_hour;
+    // Recover quicker above 200 weariness. At 400, total recovery speed is 70 per hour,
+    // at 300 it's 52.5 per hour, at 200 and below it's back to baseline 35
+
+    // Total recovery rate comes down to recovering fully from 400 to 0 in ~9.5 hours
+    // From 400 to 300 ~1.6 hours
+    // from 300 to 200 ~2.2 hours
+    // from 200 to 100 ~2.8 hours
+    // from 100 to 0   ~2.8 hours
+    if( gun_weariness > 200.0f ) {
+        recovery_per_hour += baseline_recovery_per_hour * ( gun_weariness - 200.0f ) / 200.0f;
+    }
+
+    const float hours_elapsed = to_hours<float>( calendar::turn - gun_weariness_last_updated );
+    const float recovered_within_elapsed_time = recovery_per_hour * hours_elapsed;
+
+    gun_weariness -= recovered_within_elapsed_time;
+    gun_weariness = std::max( 0.0f, gun_weariness );
+    gun_weariness_last_updated = calendar::turn;
+}
+
+void Character::add_gun_weariness()
+{
+    recover_gun_weariness();
+    // maximum is a bit over 400, to allow for factor to be cast to 3 as integer
+    gun_weariness = std::min( gun_weariness + 1.0f, 420.0f );
+}
+
+// This is supposed to be MENTAL weariness, not anything physical
+float Character::get_gun_weariness_factor() const
+{
+    recover_gun_weariness();
+
+    if( gun_weariness <= 100 ) {
+        return 0.0f;
+    } else {
+        // 100 -> 0; 150 -> 0.5; 200 -> 1; 250 -> 1.5; ...; 400 -> 3
+        return ( gun_weariness - 100 ) / 100.0f;
+    }
 }
 
 void Character::recalc_limb_energy_usage()

--- a/src/character.h
+++ b/src/character.h
@@ -631,6 +631,11 @@ class Character : public Creature, public visitable
         int ranged_dex_mod() const;
         int ranged_per_mod() const;
 
+        /** Increase gun weariness */
+        void add_gun_weariness();
+        /** Returns 0.0f if the character isn't meaningfully gun-weary. Max = 3.2f */
+        float get_gun_weariness_factor() const;
+
         /** Setters for stats exclusive to characters */
         void set_str_bonus( int nstr );
         void set_dex_bonus( int ndex );
@@ -1118,6 +1123,14 @@ class Character : public Creature, public visitable
         int blocks_left;
 
         double recoil = MAX_RECOIL;
+
+        /**
+         * Heat meter representing character's mental fatigue from firing a gun, used to limit target practice activity
+         * Without it, the character would be able to become a god level shooter in 1 day from target practice
+         */
+        mutable float gun_weariness = 0.0f;
+        mutable time_point gun_weariness_last_updated = calendar::turn_zero;
+        void recover_gun_weariness() const;
 
         /** Returns true if the player has quiet melee attacks */
         bool is_quiet() const;

--- a/src/enums.h
+++ b/src/enums.h
@@ -353,6 +353,7 @@ enum class distraction_type : int {
     mutation,
     oxygen,
     withdrawal,
+    gun_weariness,
     last,
 };
 

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -377,6 +377,11 @@ void Item_factory::finalize_pre( itype &obj )
         const std::string func2 = "modify_gunmods";
         emplace_usage( obj.use_methods, func2 );
         obj.ammo_scale.emplace( func2, 0 );
+        if( !obj.has_flag( flag_WONT_TRAIN_MARKSMANSHIP ) ) {
+            const std::string func3 = "TARGET_PRACTICE";
+            emplace_usage( obj.use_methods, func3 );
+            obj.ammo_scale.emplace( func3, 0 );
+        }
     }
 
     if( obj.gunmod ) {
@@ -2060,6 +2065,7 @@ void Item_factory::init()
     add_iuse( "SPRAY_CAN", &iuse::spray_can );
     add_iuse( "STIMPACK", &iuse::stimpack );
     add_iuse( "STRONG_ANTIBIOTIC", &iuse::strong_antibiotic );
+    add_iuse( "TARGET_PRACTICE", &iuse::target_practice );
     add_iuse( "TAZER", &iuse::tazer );
     add_iuse( "TELEPORT", &iuse::teleport );
     add_iuse( "THORAZINE", &iuse::thorazine );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -106,12 +106,14 @@
 #include "recipe_dictionary.h"
 #include "requirements.h"
 #include "ret_val.h"
+#include "ranged.h"
 #include "rng.h"
 #include "safe_reference.h"
 #include "sounds.h"
 #include "speech.h"
 #include "stomach.h"
 #include "string_formatter.h"
+#include "string_input_popup.h"
 #include "teleport.h"
 #include "text_snippets.h"
 #include "translation.h"
@@ -253,6 +255,8 @@ static const itype_id itype_advanced_ecig( "advanced_ecig" );
 static const itype_id itype_apparatus( "apparatus" );
 static const itype_id itype_arcade_machine( "arcade_machine" );
 static const itype_id itype_atomic_coffeepot( "atomic_coffeepot" );
+static const itype_id itype_attachable_ear_muffs( "attachable_ear_muffs" );
+static const itype_id itype_attached_ear_plugs_off( "attached_ear_plugs_off" );
 static const itype_id itype_barometer( "barometer" );
 static const itype_id itype_battery( "battery" );
 static const itype_id itype_blood( "blood" );
@@ -267,6 +271,7 @@ static const itype_id itype_detergent( "detergent" );
 static const itype_id itype_ecig( "ecig" );
 static const itype_id itype_efile_photos( "efile_photos" );
 static const itype_id itype_fire( "fire" );
+static const itype_id itype_flight_helmet( "flight_helmet" );
 static const itype_id itype_geiger_on( "geiger_on" );
 static const itype_id itype_hammer( "hammer" );
 static const itype_id itype_handrolled_cig( "handrolled_cig" );
@@ -278,6 +283,7 @@ static const itype_id itype_joint_lit( "joint_lit" );
 static const itype_id itype_liquid_soap( "liquid_soap" );
 static const itype_id itype_log( "log" );
 static const itype_id itype_mask_h20survivor_on( "mask_h20survivor_on" );
+static const itype_id itype_makeshift_ear_plugs_off( "makeshift_ear_plugs_off" );
 static const itype_id itype_mininuke_act( "mininuke_act" );
 static const itype_id itype_multi_cooker( "multi_cooker" );
 static const itype_id itype_multi_cooker_filled( "multi_cooker_filled" );
@@ -288,6 +294,8 @@ static const itype_id itype_nicotine_liquid( "nicotine_liquid" );
 static const itype_id itype_paper( "paper" );
 static const itype_id itype_pot( "pot" );
 static const itype_id itype_pur_tablets( "pur_tablets" );
+static const itype_id itype_powered_earmuffs( "powered_earmuffs" );
+static const itype_id itype_powered_earplugs( "powered_earplugs" );
 static const itype_id itype_radio_car_on( "radio_car_on" );
 static const itype_id itype_radio_mod( "radio_mod" );
 static const itype_id itype_radio_on( "radio_on" );
@@ -313,6 +321,7 @@ static const itype_id itype_weather_reader( "weather_reader" );
 
 static const json_character_flag json_flag_ENHANCED_VISION( "ENHANCED_VISION" );
 static const json_character_flag json_flag_HYPEROPIC( "HYPEROPIC" );
+static const json_character_flag json_flag_IMMUNE_HEARING_DAMAGE( "IMMUNE_HEARING_DAMAGE" );
 static const json_character_flag json_flag_PAIN_IMMUNE( "PAIN_IMMUNE" );
 
 static const mongroup_id GROUP_FISH( "GROUP_FISH" );
@@ -5204,6 +5213,106 @@ std::optional<int> iuse::talking_doll( Character *p, item *it, const tripoint_bu
                               _( "You press a button on the %s to make it talk, but nothing happens." ), it->tname() );
         return std::nullopt;
     }
+}
+
+std::optional<int> iuse::target_practice( Character *p, item *it, const tripoint_bub_ms & )
+{
+    avatar *you = p->as_avatar();
+    if( !you ) {
+        // NPCs can't do target practice yet
+        // Enabling them to woudln't require much though
+        return std::nullopt;
+    }
+
+    static const std::set<itype_id> transforms_into_hearing_protection = {
+        itype_attachable_ear_muffs,
+        itype_powered_earmuffs,
+        itype_powered_earplugs,
+        itype_flight_helmet,
+        itype_attached_ear_plugs_off,
+        itype_makeshift_ear_plugs_off
+    };
+    const bool has_hearing_protection =
+        p->cache_has_item_with( flag_DEAF ) || p->cache_has_item_with( flag_PARTIAL_DEAF ) ||
+    p->has_item_with( [&]( const item & held_item ) {
+        return transforms_into_hearing_protection.count( held_item.typeId() ) > 0;
+    } );
+
+    if( !has_hearing_protection &&
+        !p->has_flag( json_flag_IMMUNE_HEARING_DAMAGE ) ) {
+        p->add_msg_if_player( m_bad,
+                              _( "You need hearing protection, basic earplugs would do." ) );
+        return std::nullopt;
+    }
+
+    if( p->is_blind() ) {
+        p->add_msg_if_player( m_bad,
+                              _( "You need to be able to see for target practice." ) );
+        return std::nullopt;
+    }
+
+    if( p->cant_do_underwater() ) {
+        p->add_msg_if_player( m_bad,
+                              _( "And how exactly are you planning on doing that underwater?" ) );
+        return std::nullopt;
+    }
+
+    if( p->is_limb_broken( body_part_arm_l ) && p->is_limb_broken( body_part_arm_r ) ) {
+        p->add_msg_if_player( m_bad,
+                              _( "Both your arms are broken!  You can't do target practice." ) );
+        return std::nullopt;
+    }
+
+    if( p->is_limb_broken( body_part_arm_l ) || p->is_limb_broken( body_part_arm_r ) ) {
+        const bool is_pistol = it->gun_type() == gun_type_type( "pistol" );
+
+        if( is_pistol ) {
+            p->add_msg_if_player( m_good,
+                                  _( "Even though your arm is broken, you can still get some useful practice with this pistol." ) );
+        } else {
+            p->add_msg_if_player( m_bad,
+                                  _( "Both your arms need to be intact to do target practice with this weapon." ) );
+            return std::nullopt;
+        }
+    }
+
+    if( it->ammo_remaining() == 0 ) {
+        p->add_msg_if_player( m_bad,
+                              _( "You need a loaded gun to start target practice." ) );
+        return std::nullopt;
+    }
+
+    const int max_rounds = 500;
+    int rounds_planned = 100;
+
+    string_input_popup popup;
+    popup
+    .title( _( "How many rounds to fire?" ) )
+    .width( 10 )
+    .description( _( "Enter the number of rounds (500 max):" ) )
+    .edit( rounds_planned );
+
+    if( popup.canceled() ) {
+        return std::nullopt;
+    }
+
+    rounds_planned = std::clamp( rounds_planned, 1, max_rounds );
+
+    const int range = it->gun_range( p );
+    target_handler::trajectory traj = target_handler::mode_select_only( *p->as_avatar(), range );
+
+    if( traj.empty() ) {
+        return std::nullopt;
+    }
+
+    tripoint_bub_ms target = traj.back();
+    tripoint_abs_ms target_abs = get_map().get_abs( target );
+
+    p->assign_activity(
+        target_practice_activity_actor( item_location( *p, it ), target_abs, rounds_planned )
+    );
+
+    return 0;
 }
 
 std::optional<int> iuse::gun_repair( Character *p, item *it, const tripoint_bub_ms & )

--- a/src/iuse.h
+++ b/src/iuse.h
@@ -172,6 +172,7 @@ std::optional<int> spray_can( Character *, item *, const tripoint_bub_ms & );
 std::optional<int> stimpack( Character *, item *, const tripoint_bub_ms & );
 std::optional<int> strong_antibiotic( Character *, item *, const tripoint_bub_ms & );
 std::optional<int> talking_doll( Character *, item *, const tripoint_bub_ms & );
+std::optional<int> target_practice( Character *, item *, const tripoint_bub_ms & );
 std::optional<int> tazer( Character *, item *, const tripoint_bub_ms & );
 std::optional<int> teleport( Character *, item *, const tripoint_bub_ms & );
 std::optional<int> toolmod_attach( Character *, item *, const tripoint_bub_ms & );

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1,3 +1,4 @@
+#include "player_activity.h"
 #include "ranged.h"
 
 #include <algorithm>
@@ -143,6 +144,8 @@ static const character_modifier_id character_modifier_thrown_dex_mod( "thrown_de
 static const damage_type_id damage_bash( "bash" );
 static const damage_type_id damage_cut( "cut" );
 
+static const activity_id ACT_TARGET_PRACTICE( "ACT_TARGET_PRACTICE" );
+
 static const efftype_id effect_downed( "downed" );
 static const efftype_id effect_hit_by_player( "hit_by_player" );
 static const efftype_id effect_on_roof( "on_roof" );
@@ -187,6 +190,7 @@ static const trait_id trait_BRAWLER( "BRAWLER" );
 static const trait_id trait_GUNSHY( "GUNSHY" );
 
 static const trap_str_id tr_practice_target( "tr_practice_target" );
+static const trap_str_id tr_target_spinner( "tr_target_spinner" );
 
 static const std::string gun_mechanical_simple( "gun_mechanical_simple" );
 
@@ -1223,13 +1227,22 @@ int Character::fire_gun( map &here, const tripoint_bub_ms &target, int shots, it
                                body_part_name_accusative( bodypart_id( hurt_part.first ) ) );
     }
 
-    // Practice the base gun skill proportionally to number of hits, but always by one.
     if( !gun.has_flag( flag_WONT_TRAIN_MARKSMANSHIP ) ) {
-        practice( skill_gun, ( hits + 1 ) * 5 );
+        int gun_weariness_xp_penalty = activity.id() == ACT_TARGET_PRACTICE ?
+                                       get_gun_weariness_factor() : 0;
+        add_msg_debug( debugmode::DF_RANGED, "Gun weariness XP penalty: %d", gun_weariness_xp_penalty );
+        add_msg_debug( debugmode::DF_RANGED, "Gun weariness factor: %f", get_gun_weariness_factor() );
+
+        // Practice the marksmanship proportionally to number of hits, but always by one.
+        practice( skill_gun, ( hits + 1 ) * 5 - gun_weariness_xp_penalty );
+        // launchers train weapon skill for both hits and misses.
+        int practice_units = gun_skill == skill_launcher ? curshot : hits;
+        practice( gun_skill, ( practice_units + 1 ) * 5 - gun_weariness_xp_penalty );
+
+        if( gun_skill != skill_archery ) {
+            add_gun_weariness();
+        }
     }
-    // launchers train weapon skill for both hits and misses.
-    int practice_units = gun_skill == skill_launcher ? curshot : hits;
-    practice( gun_skill, ( practice_units + 1 ) * 5 );
 
     if( !gun.is_gun() ) {
         // If we lose our gun as a side effect of firing it, skip the rest of the function.
@@ -3321,10 +3334,11 @@ tripoint_bub_ms target_ui::choose_initial_target()
         return targets[0];
     }
 
-    // Try closest practice target
+    // Try closest practice/spinner target
     std::optional<tripoint_bub_ms> target_spot = find_point_closest_first( src, 0, range, [this,
     &here]( const tripoint_bub_ms & pt ) {
-        return here.tr_at( pt ).id == tr_practice_target && this->you->sees( here, pt );
+        return ( here.tr_at( pt ).id == tr_practice_target || here.tr_at( pt ).id == tr_target_spinner ) &&
+               this->you->sees( here, pt );
     } );
 
     if( target_spot != std::nullopt ) {

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -1149,6 +1149,10 @@ void Character::load( const JsonObject &data )
     data.read( "free_dodges_left", free_dodges_left );
     data.read( "cash", cash );
     data.read( "recoil", recoil );
+    data.read( "gun_weariness", gun_weariness );
+    if( data.has_member( "gun_weariness_last_updated" ) ) {
+        gun_weariness_last_updated = time_point( data.get_int( "gun_weariness_last_updated" ) );
+    }
     data.read( "book_chapters", book_chapters );
     data.read( "in_vehicle", in_vehicle );
     data.read( "last_sleep_check", last_sleep_check );
@@ -1519,6 +1523,8 @@ void Character::store( JsonOut &json ) const
     json.member( "free_dodges_left", free_dodges_left );
     json.member( "cash", cash );
     json.member( "recoil", recoil );
+    json.member( "gun_weariness", gun_weariness );
+    json.member( "gun_weariness_last_updated", to_turn<int>( gun_weariness_last_updated ) );
     json.member( "book_chapters", book_chapters );
     json.member( "in_vehicle", in_vehicle );
     json.member( "id", getID() );


### PR DESCRIPTION
#### Summary
Features "Added target practice. Accessible via (a)ctivation of gun"

#### Purpose of change
Quality of life, immersion, receiving training from NPC's. You can automate the grind to a higher skill level once you obtain a lot of ammo

#### Describe the solution

How training works currently: you shoot at something, you get 5XP for every round/burst fired, and 5 additional XP for every hit that lands into a living target. Target practice uses the same system, every round fired during it is the same as a round fired at an inanimate object and gives you 5XP (if you capture a living armored/regenerating target and target practice on it, bravo, you deserve the additional 5 XP hehe)

There is a 1000 move / 10 second delay between shots to simulate all the things that go into firearm training, it scales with "gun weariness"

### Gun weariness system

I've implemented a mental gun weariness system to put some soft limits on target practice. Note: it ONLY affects target practice and has NO effect outside of it

gun_weariness value represents loss of focus and mental fatigue from firing a lot of rounds in a limited period of time. It's incremented by 1 every time you take a shot/burst fire (even outside of the activity), and it goes down with a 35 per hour baseline, decaying even faster once above 200

    // Total recovery rate comes down to recovering fully from 400 to 0 in ~9.5 hours
    // From 400 to 300 ~1.6 hours
    // from 300 to 200 ~2.2 hours
    // from 200 to 100 ~2.8 hours
    // from 100 to 100 ~2.8 hours

It affects XP gain during target practice

At <100 there's no debuffs 
At 100-200, the delay between shots during target practice begins to increase, scaling from 1x at 100 to 1.33x at 200
At 200-300, it translates into gun weariness factor of 1 - you gain 20% less XP
At 300-400, it translates into gun weariness factor of 2 - you gain 40% less XP
at 400-420, it translates into gun weariness factor of 3 -  you gain 60% less XP (max)


### NPC Coaching

A friendly follower that is a more skilled shot than you will boost the XP gain. Every 1 point of skill difference translates into 1 more (or +20%) XP from each shot. Gun weariness factor also applies here, every point of gun weariness factor reduces the XP bonus from NPC

### Spinner target

Added a cartable spinner target that boosts XP gain. You get +0.5XP (+10%) from every shot if you're "unskilled", and +2XP (+40%) if you're "skilled"

You are "skilled" if your weapon skill + half your marksmanship skill is more than 4. 
Example of boundaries for being "skilled": pistols 2 and marksmanship 4 -> 2 + 4\*0.5 = 4; rifles 3 and marksmanship 2 -> 3 + 2\*0.5 = 4  

This XP bonus is also reduced by the gun weariness factor

### Examples
#### A reasonable day in baseline target practice, without overdoing it but pushing it a little

8 int 0 pistols 0 marksmanship fresh character with a Glock pistol
TOTAL: 12 hours, ~400 rounds fired, 0 -> 2.35 skill gain

42 minutes of practice 224 rounds 0 -> 1.92 skill (+1.92)
<- Skill gain penalty of 20% starts here ->
25 minutes of practice 100 rounds 1.92  -> 2.09 (+0.17)
<- Skill gain penalty of 40% starts here ->
29 minutes of practice 100 rounds 2.09  -> 2.20 (+0.11)
40 more rounds 2.20  -> 2.28 (+0.08)
<- Skill gain penalty of 60% starts here ->


Wait 1 hour - skill gain penalty still at 40%
Wait 2 hours - skill gain penalty still at 20%
Wait 1 hour - skill gain penalty is gone, but barely
10 more rounds  2.28  -> 2.35 (+0.07)
<- Skill gain penalty of 20% is back ->

Wait 6 hours - skill gain penalty is gone completely and gun-weariness is at 0, you can repeat the cycle

So, about 300 rounds fired in the morning and 300 rounds fired before sleep would be the most cost and time efficient way to do target practice

#### Target practice for 24 hours straight
In the first 12 hours you fire ~2000 rounds, 0->3.30 skill gain
And again, 12 hours ~2000 rounds, 3.30->4.13 skill gain

So you can still "rush" it, but it'll be quite cost-inefficient, taking twice as much time, nullifying your NPC/spinner target bonus and reducing the base XP gain by 60% 

#### Additional context
The system can be extended to be used with archery, and NPC's could do target practice too
