### PR TITLE
[MoM] Add the hopalong, a teleporting wild rabbit

### DIFF
--- a/data/mods/MindOverMatter/monstergroups/monstergroups_edited.json
+++ b/data/mods/MindOverMatter/monstergroups/monstergroups_edited.json
@@ -219,6 +219,12 @@
     "monsters": [ { "monster": "mon_bandersnatch", "weight": 20, "starts": "8 days", "cost_multiplier": 5 } ]
   },
   {
+    "id": "GROUP_RABBIT_WILD",
+    "type": "monstergroup",
+    "default": "mon_wild_rabbit",
+    "monsters": [ { "monster": "mon_wild_rabbit_blinker", "weight": 10, "cost_multiplier": 1 } ]
+  },
+  {
     "id": "GROUP_DEERS",
     "type": "monstergroup",
     "monsters": [

--- a/data/mods/MindOverMatter/monstergroups/monstergroups_new.json
+++ b/data/mods/MindOverMatter/monstergroups/monstergroups_new.json
@@ -376,6 +376,11 @@
     "monsters": [ { "monster": "mon_deer_fawn", "weight": 80 }, { "monster": "mon_fear_deer_fawn", "weight": 20 } ]
   },
   {
+    "id": "GROUP_REPRODUCTION_WILD_RABBIT_BLINKER_BABIES",
+    "type": "monstergroup",
+    "monsters": [ { "monster": "mon_wild_rabbit_baby", "weight": 65 }, { "monster": "mon_wild_rabbit_blinker_baby", "weight": 35 } ]
+  },
+  {
     "id": "GROUP_EGG_COCKATRICE",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_cockatrice_chick", "weight": 100 } ]

--- a/data/mods/MindOverMatter/monsters/animal_psychics.json
+++ b/data/mods/MindOverMatter/monsters/animal_psychics.json
@@ -541,5 +541,58 @@
     "melee_damage": [ { "damage_type": "cut", "amount": 1 }, { "damage_type": "heat", "amount": 3 } ],
     "upgrades": { "age_grow": 330, "into": "mon_fear_deer" },
     "extend": { "flags": [ "TEEP_IMMUNE" ] }
+  },
+  {
+    "id": "mon_wild_rabbit_blinker",
+    "type": "MONSTER",
+    "name": { "str": "hopalong" },
+    "description": "A brown-coated cottontail rabbit, with a fluffy white tail.  Its small size and docile nature makes it easy prey for predators, at least the ones that can catch it.  You can't tell which one of the two cottontail species from the region this is.  You can tell there's something different about it, though, when it suddenly vanishes and reappears nearby.",
+    "copy-from": "mon_rabbit_base",
+    "looks_like": "mon_rabbit",
+    "weight": "1200 g",
+    "reproduction": {
+      "baby_type": { "baby_monster_group": "GROUP_REPRODUCTION_WILD_RABBIT_BLINKER_BABIES" },
+      "baby_count": 5,
+      "baby_timer": 28
+    },
+    "special_attacks": [
+      {
+        "type": "leap",
+        "cooldown": { "math": [ "1 + rand(2)" ] },
+        "move_cost": 50,
+        "allow_no_target": true,
+        "max_range": 6,
+        "message": "%1$s vanishes and reappears elsewhere!",
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } }
+      },
+      {
+        "id": "psi_rabbit_blinker_blinking",
+        "type": "spell",
+        "spell_data": { "id": "teleport_blink_monster", "min_level": 10 },
+        "cooldown": 30,
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } },
+        "monster_message": "%1$s vanishes and reappears elsewhere!"
+      }
+    ]
+  },
+  {
+    "id": "mon_wild_rabbit_blinker_baby",
+    "type": "MONSTER",
+    "name": { "str": "hopalong kit" },
+    "description": "A tiny and very cute hopalong kit.",
+    "copy-from": "mon_rabbit_baby_base",
+    "looks_like": "mon_rabbit_baby",
+    "upgrades": { "age_grow": 23, "into": "mon_wild_rabbit" },
+    "special_attacks": [
+      {
+        "type": "leap",
+        "cooldown": { "math": [ "10 + rand(20)" ] },
+        "move_cost": 50,
+        "allow_no_target": true,
+        "max_range": 4,
+        "message": "%1$s vanishes and reappears elsewhere!",
+        "condition": { "not": { "u_has_flag": "NO_PSIONICS" } }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[MoM] Add the hopalong, a teleporting wild rabbit"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Idea I had while out on a walk.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the hopalong, a teleporting wild rabbit. They can blink around (or would if blink spells on monsters currently worked). That's it.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Spawned one, it teleported away from me at light speed.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I did not see a teleporting rabbit while on my walk.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
