### PR TITLE
Changing to/from prone stance takes around a second

### DIFF
--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -126,6 +126,7 @@ static const trait_id trait_CHITIN3( "CHITIN3" );
 static const trait_id trait_CHITIN_FUR3( "CHITIN_FUR3" );
 static const trait_id trait_COMPOUND_EYES( "COMPOUND_EYES" );
 static const trait_id trait_DEBUG_CLOAK( "DEBUG_CLOAK" );
+static const trait_id trait_DEFT( "DEFT" );
 static const trait_id trait_INSECT_ARMS( "INSECT_ARMS" );
 static const trait_id trait_INSECT_ARMS_OK( "INSECT_ARMS_OK" );
 static const trait_id trait_PROF_DICEMASTER( "PROF_DICEMASTER" );
@@ -1280,6 +1281,10 @@ void avatar::set_movement_mode( const move_mode_id &new_mode )
         if( is_hauling() && new_mode->stop_hauling() ) {
             stop_hauling();
         }
+
+        // Going prone or standing up takes 50 to 150 moves
+        mod_moves( -move_mode_switch_cost( move_mode, new_mode ) );
+
         add_msg( new_mode->change_message( true, get_steed_type() ) );
         move_mode = new_mode;
         // Enchantments based on move modes can stack inappropriately without a recalc here

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -1349,6 +1349,18 @@ void avatar::cycle_move_mode()
     }
 }
 
+void avatar::cycle_move_mode_skip_prone()
+{
+    move_mode_id next = current_movement_mode()->cycle();
+    for( size_t i = 0; i < move_modes_by_speed().size(); i++ ) {
+        if( next != move_mode_prone && can_switch_to( next ) ) {
+            set_movement_mode( next );
+            break;
+        }
+        next = next->cycle();
+    }
+}
+
 void avatar::cycle_move_mode_reverse()
 {
     const move_mode_id prev = current_movement_mode()->cycle_reverse();

--- a/src/avatar.h
+++ b/src/avatar.h
@@ -311,6 +311,8 @@ class avatar : public Character
 
         // Cycles to the next move mode.
         void cycle_move_mode();
+        // Cycles to the next move mode, skipping prone.
+        void cycle_move_mode_skip_prone();
         // Cycles to the previous move mode.
         void cycle_move_mode_reverse();
         // Resets to walking.

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2196,6 +2196,26 @@ bool Character::can_switch_to( const move_mode_id &mode ) const
     return get_steed_type() != steed_type::NONE || mode->type() != move_mode_type::RUNNING || can_run();
 }
 
+float Character::move_mode_switch_cost( const move_mode_id &old_mode,
+                                        const move_mode_id &new_mode ) const
+{
+    // Both going prone and standing up take ~1 second, more if clumsy and less if deft
+    if( ( old_mode->type() == move_mode_type::PRONE && new_mode->type() != move_mode_type::PRONE ) ||
+        ( old_mode->type() != move_mode_type::PRONE && new_mode->type() == move_mode_type::PRONE ) ) {
+        if( has_trait( trait_DEFT ) ) {
+            return 50.0f;
+        }
+
+        if( has_trait( trait_CLUMSY ) ) {
+            return 150.0f;
+        }
+
+        return 100.0f;
+    }
+
+    return 0;
+}
+
 void Character::process_turn()
 {
     map &here = get_map();

--- a/src/character.h
+++ b/src/character.h
@@ -1050,6 +1050,7 @@ class Character : public Creature, public visitable
         void make_clatter_sound() const;
 
         bool can_switch_to( const move_mode_id &mode ) const;
+        float move_mode_switch_cost( const move_mode_id &old_mode, const move_mode_id &new_mode ) const;
         steed_type get_steed_type() const;
         virtual void set_movement_mode( const move_mode_id &mode ) = 0;
 

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1849,9 +1849,20 @@ static void open_movement_mode_menu()
 
     for( size_t i = 0; i < modes.size(); ++i ) {
         const move_mode_id &curr = modes[i];
+
+        std::string label = curr->name();
+
+        const float required_moves = player_character.move_mode_switch_cost(
+                                         player_character.current_movement_mode(), curr );
+        const float required_seconds = required_moves / player_character.get_speed();
+
+        if( required_seconds > 0 ) {
+            label += string_format( _( " (%.2f s)" ), required_seconds );
+        }
+
         as_m.entries.emplace_back( static_cast<int>( i ), player_character.can_switch_to( curr ),
                                    curr->letter(),
-                                   curr->name() );
+                                   label );
     }
     as_m.entries.emplace_back( cycle,
                                player_character.can_switch_to( player_character.current_movement_mode()->cycle() ),

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2343,7 +2343,7 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             break;
 
         case ACTION_CYCLE_MOVE:
-            player_character.cycle_move_mode();
+            player_character.cycle_move_mode_skip_prone();
             break;
 
         case ACTION_CYCLE_MOVE_REVERSE:


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Balance "Going prone/sanding up takes 1 second"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Make bipods make more sense, now there's actually a tradeoff you're making (before there was only the dodge penalty while you're aiming prone). Also it's harder to go prone to avoid grenade damage
And it just makes more sense in general
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
If you're deft, changing stance to/from prone takes 50 moves (~0.5 seconds), baseline character 100 moves (~1 second), clumsy character 150 (~1.5 seconds)

<img width="343" height="195" alt="Screenshot 2026-02-22 at 22 32 27" src="https://github.com/user-attachments/assets/7fc918a9-55ae-42dd-b14c-1b16d89b1cf8" />
<img width="329" height="172" alt="Screenshot 2026-02-22 at 22 32 35" src="https://github.com/user-attachments/assets/31c8d5d0-d182-4541-85cb-e87663c28b3c" />

Here with some speed penalties from falling from a tree
<img width="267" height="152" alt="Screenshot 2026-02-22 at 22 50 16" src="https://github.com/user-attachments/assets/21a58fb9-a9af-4521-8fa5-1aa2bc681009" />
<img width="284" height="159" alt="Screenshot 2026-02-22 at 22 50 22" src="https://github.com/user-attachments/assets/388531ed-7048-4861-a0cb-c334da6c7073" />


<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Make it depend on the weight carried, athletics, base stats, health, stamina, weariness, limb score, free hand availability, but you see the problem here. I'm making it simple and forgiving/optimistic as a first (and maybe last) iteration 
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
