### PR TITLE
Blocking costs Stamina

### DIFF
--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -2025,8 +2025,8 @@ bool Character::block_hit( Creature *source, bodypart_id &bp_hit, damage_instanc
     }
 
     // Now that blocks cost stamina, break out if stamina is too low
-    // TODO: More complicated calculation. Dodge checks your dodge chance 
-    // which is affected by stamina, pain, and so on and when it hits 
+    // TODO: More complicated calculation. Dodge checks your dodge chance
+    // which is affected by stamina, pain, and so on and when it hits
     // zero, that's when you get the message that you can't dodge, but
     // currently none of that affects blocking
     if( get_stamina() < 2000 ) {

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -60,6 +60,7 @@
 #include "mtype.h"
 #include "mutation.h"
 #include "npc.h"
+#include "options.h"
 #include "output.h"
 #include "pimpl.h"
 #include "pocket_type.h"
@@ -156,6 +157,8 @@ static const move_mode_id move_mode_prone( "prone" );
 static const skill_id skill_melee( "melee" );
 static const skill_id skill_spellcraft( "spellcraft" );
 static const skill_id skill_unarmed( "unarmed" );
+
+static const std::string player_base_stamina_burn_rate( "PLAYER_BASE_STAMINA_BURN_RATE" );
 
 static const trait_id trait_ARM_TENTACLES( "ARM_TENTACLES" );
 static const trait_id trait_ARM_TENTACLES_4( "ARM_TENTACLES_4" );
@@ -2207,6 +2210,16 @@ bool Character::block_hit( Creature *source, bodypart_id &bp_hit, damage_instanc
                            _( "<npcname> blocks %1$s of the damage with their %2$s!" ),
                            damage_blocked_description, thing_blocked_with );
     add_msg_debug( debugmode::DF_MELEE, "Blocked damage %.1f / %.1f", total_damage, damage_blocked );
+
+    // stamina cost for blocking, 2/3rds more than dodge cost since blocking is not based on enemy skill 
+    // TODO: account for enemy melee scale, add diminishing returns. 
+    const int base_burn_rate = get_option<int>( player_base_stamina_burn_rate );
+    const float block_skill_modifier = ( 20.0f - get_skill_level( skill_melee ) ) / 20.0f;
+    const float block_stamina_cost = static_cast<float>( base_burn_rate )  * 10.0f *
+                                        block_skill_modifier;
+    burn_energy_legs( -block_stamina_cost );
+    set_activity_level( EXTRA_EXERCISE );
+    add_msg_debug( debugmode::DF_MELEE, "Blocking stamina cost %.1f", block_stamina_cost );
 
     // fire martial arts block-triggered effects
     martial_arts_data->ma_onblock_effects( *this );

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -158,8 +158,6 @@ static const skill_id skill_melee( "melee" );
 static const skill_id skill_spellcraft( "spellcraft" );
 static const skill_id skill_unarmed( "unarmed" );
 
-static const std::string player_base_stamina_burn_rate( "PLAYER_BASE_STAMINA_BURN_RATE" );
-
 static const trait_id trait_ARM_TENTACLES( "ARM_TENTACLES" );
 static const trait_id trait_ARM_TENTACLES_4( "ARM_TENTACLES_4" );
 static const trait_id trait_ARM_TENTACLES_8( "ARM_TENTACLES_8" );
@@ -175,6 +173,8 @@ static const trait_id trait_VINES2( "VINES2" );
 static const trait_id trait_VINES3( "VINES3" );
 
 static const weapon_category_id weapon_category_UNARMED( "UNARMED" );
+
+static const std::string player_base_stamina_burn_rate( "PLAYER_BASE_STAMINA_BURN_RATE" );
 
 static void player_hit_message( Character *attacker, const std::string &message,
                                 Creature &t, int dam, bool crit = false, bool technique = false, const std::string &wp_hit = {} );
@@ -2025,6 +2025,10 @@ bool Character::block_hit( Creature *source, bodypart_id &bp_hit, damage_instanc
     }
 
     // Now that blocks cost stamina, break out if stamina is too low
+    // TODO: More complicated calculation. Dodge checks your dodge chance 
+    // which is affected by stamina, pain, and so on and when it hits 
+    // zero, that's when you get the message that you can't dodge, but
+    // currently none of that affects blocking
     if( get_stamina() < 2000 ) {
         add_msg_if_player( m_warning,
                            _( "You're close to exhaustion and cannot block effectively." ) );

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -2024,6 +2024,13 @@ bool Character::block_hit( Creature *source, bodypart_id &bp_hit, damage_instanc
         return false;
     }
 
+    // Now that blocks cost stamina, break out if stamina is too low
+     if( get_stamina() < 2000 ) {
+         add_msg_if_player( m_warning,
+                       _( "You're close to exhaustion and cannot block effectively." ) );
+        return false;
+     }
+
     // Melee skill and reaction score governs if you can react in time
     // Skill of 5 without relevant encumbrance guarantees a block attempt
     float melee_skill = has_active_bionic( bio_cqb ) ? 5 : get_skill_level( skill_melee );
@@ -2211,11 +2218,11 @@ bool Character::block_hit( Creature *source, bodypart_id &bp_hit, damage_instanc
                            damage_blocked_description, thing_blocked_with );
     add_msg_debug( debugmode::DF_MELEE, "Blocked damage %.1f / %.1f", total_damage, damage_blocked );
 
-    // stamina cost for blocking, 2/3rds more than dodge cost since blocking is not based on enemy skill 
+    // stamina cost for blocking, based on dodge
     // TODO: account for enemy melee scale, add diminishing returns. 
     const int base_burn_rate = get_option<int>( player_base_stamina_burn_rate );
     const float block_skill_modifier = ( 20.0f - get_skill_level( skill_melee ) ) / 20.0f;
-    const float block_stamina_cost = static_cast<float>( base_burn_rate )  * 10.0f *
+    const float block_stamina_cost = static_cast<float>( base_burn_rate )  * 6.0f *
                                         block_skill_modifier;
     burn_energy_legs( -block_stamina_cost );
     set_activity_level( EXTRA_EXERCISE );

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -2219,7 +2219,7 @@ bool Character::block_hit( Creature *source, bodypart_id &bp_hit, damage_instanc
     add_msg_debug( debugmode::DF_MELEE, "Blocked damage %.1f / %.1f", total_damage, damage_blocked );
 
     // stamina cost for blocking, based on dodge
-    // TODO: account for enemy melee scale, add diminishing returns. 
+    // TODO: account for enemy melee scale, add diminishing returns.
     const int base_burn_rate = get_option<int>( player_base_stamina_burn_rate );
     const float block_skill_modifier = ( 20.0f - get_skill_level( skill_melee ) ) / 20.0f;
     const float block_stamina_cost = static_cast<float>( base_burn_rate )  * 6.0f *

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -2029,7 +2029,7 @@ bool Character::block_hit( Creature *source, bodypart_id &bp_hit, damage_instanc
         add_msg_if_player( m_warning,
                            _( "You're close to exhaustion and cannot block effectively." ) );
         return false;
-     }
+    }
 
     // Melee skill and reaction score governs if you can react in time
     // Skill of 5 without relevant encumbrance guarantees a block attempt

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -2223,7 +2223,7 @@ bool Character::block_hit( Creature *source, bodypart_id &bp_hit, damage_instanc
     const int base_burn_rate = get_option<int>( player_base_stamina_burn_rate );
     const float block_skill_modifier = ( 20.0f - get_skill_level( skill_melee ) ) / 20.0f;
     const float block_stamina_cost = static_cast<float>( base_burn_rate )  * 6.0f *
-                                        block_skill_modifier;
+                                     block_skill_modifier;
     burn_energy_legs( -block_stamina_cost );
     set_activity_level( EXTRA_EXERCISE );
     add_msg_debug( debugmode::DF_MELEE, "Blocking stamina cost %.1f", block_stamina_cost );

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -2025,9 +2025,9 @@ bool Character::block_hit( Creature *source, bodypart_id &bp_hit, damage_instanc
     }
 
     // Now that blocks cost stamina, break out if stamina is too low
-     if( get_stamina() < 2000 ) {
-         add_msg_if_player( m_warning,
-                       _( "You're close to exhaustion and cannot block effectively." ) );
+    if( get_stamina() < 2000 ) {
+        add_msg_if_player( m_warning,
+                           _( "You're close to exhaustion and cannot block effectively." ) );
         return false;
      }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Balance "Blocking costs Stamina"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Previously it didn't. Can you believe it?

You can see this on live--spawn a set of hard arm guards and set melee and unarmed to 10, and just pass turns against an ordinary zombie.  You'll also need some effect to make you immune to grabs (breaking grabs costs stamina), but if you have that, you'll get down to around 2500 stamina and stay there, dodging every time you regenerate just enough to dodge. Blocking never takes over and drops your stamina, because blocking is free. 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add a stamina cost to blocking. Right now, I just copied over the stamina cost from dodging. You can argue that it should cost less, but right now blocking still has a lot of advantages over dodging (enemy melee skill doesn't matter, it only takes your skill into account, for example):

https://github.com/CleverRaven/Cataclysm-DDA/blob/6b07a8025a5c1a3926685eb63fe0a9208cb82dd4/src/melee.cpp#L2128-L2136

Add a lower limit (2000 stamina) below which you don't block, and a message to warn the player they've reached this point.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Created an XE Sylph (for grab immunity to avoid grab breaks polluting the test). Gave myself Melee 10 and Unarmed 10 and a set of hard arm guards. Passed turns while a zombie attacked me. When I got down to 2000 stamina, I did not block or dodge and got hit. Once stamina regenerated a bit, I started blocking again.

In an actual vanilla situation where you're not immune to grabs, breaking grabs takes stamina and you would not hit this equilibrium (plus you would be attacking and pay stamina to do that).

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
