### PR TITLE
Stop NPCs teaching you unlearnable proficiencies

### DIFF
--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -836,7 +836,7 @@ static std::string training_select_menu( const Character &c, const std::string &
     }
     for( const proficiency_id &p : c.known_proficiencies() ) {
         std::string entry = string_format( "%s: %s", _( "Proficiency" ), p->name() );
-        nmenu.addentry( i, p->is_teachable(), MENU_AUTOASSIGN, entry );
+        nmenu.addentry( i, p->can_learn() && p->is_teachable(), MENU_AUTOASSIGN, entry );
         trainlist.emplace_back( p.c_str() );
         i++;
     }


### PR DESCRIPTION
#### Summary
Bugfixes "Stop NPCs teaching you unlearnable proficiencies"

#### Purpose of change
An NPC with an unlearnable proficiency could teach you that unlearnable proficiency just because they had it.

#### Describe the solution
Remove this oversight.

#### Describe alternatives you've considered


#### Testing
Recommended test: Debug yourself some unlearnable proficiencies (human autopsies etc), swap to NPC, mind control original character, notice they can't/won't teach you it.

#### Additional context
