### PR TITLE
Fix zone sorting loops and premature termination

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -13154,15 +13154,11 @@ void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
         }
     }
 
-    // Rotate virtual-batch state when a batch has been fully delivered.
+    // Reset iteration state when a batch has been fully delivered.
     // Must happen before items.begin() + num_processed arithmetic below.
-    bool had_virtual_batch = false;
     if( picked_up_stuff.empty() ) {
-        had_virtual_batch = virtual_pickup_active;
         virtual_pickup_active = false;
-        if( had_virtual_batch ) {
-            num_processed = 0;
-        }
+        num_processed = 0;
     }
 
     bool is_adjacent_or_closer = square_dist( you.pos_bub(), src_bub ) <= 1;

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -13211,7 +13211,7 @@ void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
         }
 
         if( zone_sorting::sort_skip_item( you, it->first, other_activity_items,
-                                          mgr.has( zone_type_LOOT_IGNORE_FAVORITES, src, fac_id ), src, it->second ) ) {
+                                          mgr.has( zone_type_LOOT_IGNORE_FAVORITES, src, fac_id ), src ) ) {
             continue;
         }
 
@@ -13544,7 +13544,7 @@ void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
                     }
                     if( zone_sorting::sort_skip_item( you, it, other_activity_items,
                                                       mgr.has( zone_type_LOOT_IGNORE_FAVORITES, candidate, fac_id ),
-                                                      candidate, from_veh ) ) {
+                                                      candidate ) ) {
                         continue;
                     }
                     // Destination compatibility: exact zone-type match

--- a/src/activity_item_handling.h
+++ b/src/activity_item_handling.h
@@ -72,12 +72,10 @@ bool route_to_destination( Character &you, player_activity &act,
                            const tripoint_bub_ms &dest, zone_activity_stage &stage );
 /**
 * Returns true if the given item should be skipped while sorting.
-* from_vehicle indicates whether the item is from vehicle cargo (true) or ground (false).
 */
 bool sort_skip_item( Character &you, const item *it,
                      const std::vector<item_location> &other_activity_items,
-                     bool ignore_favorite, const tripoint_abs_ms &src,
-                     bool from_vehicle );
+                     bool ignore_favorite, const tripoint_abs_ms &src );
 
 /**
 * Sets sorting options given nearby UNLOAD_ALL zones


### PR DESCRIPTION
#### Summary
Bugfixes "Fix zone sorting infinite loop with appliances and premature termination"

#### Purpose of change

Two zone sorting bugs that both result in items never getting sorted:

1. **The butter loop** (#85491): terrain-bound zones (like LOOT_FOOD) on tiles with vehicle appliances (fridges, carts) cause infinite re-sorting. Items delivered to a fridge land in vehicle cargo, but `sort_skip_item` only checks `has_terrain` for ground items and `has_vehicle` for cargo items. Cargo items at terrain-bound zones are never recognized as "already sorted", so sorting picks them up and delivers them again forever.

2. **Premature termination**: when a source has items going to different destinations (e.g. perishable food to PFOOD and dry goods to FOOD), only the first batch gets sorted. After delivering and returning, `num_processed` keeps its stale value from the previous item-loop pass. The repopulated items list is shorter (delivered items gone), so `begin() + num_processed` overshoots. The source gets erased and the activity ends with remaining items unsorted. Discovered while testing the fix for the first issue.

#### Describe the solution

1. Make `sort_skip_item` binding-agnostic: use `mgr.has()` instead of `has_terrain`/`has_vehicle` conditional. Items in vehicle cargo at a terrain-bound zone are now correctly recognized as sorted. Same for `custom_loot_has` - drop the `from_vehicle` parameter entirely. This matches what actually happens during delivery: `move_item` tries cargo first via `veh_at`, so items routinely end up in vehicle storage regardless of zone binding.

2. Reset `num_processed` unconditionally when `picked_up_stuff` empties (not just when `virtual_pickup_active` was true). Physical delivery also empties the pickup list and needs the offset reset, not just virtual batching.

#### Describe alternatives you've considered

For (1), could add vehicle-binding awareness to zone creation when placing appliances, but that would be a much bigger change touching zone UI and wouldn't fix existing saves. The binding distinction for sort-skipping just isn't useful - if items are at the right zone type, they're sorted, period.

For (2), could track per-destination progress instead of a single offset, but that's way more complexity than needed. The offset just needs to go back to zero when the item list changes.

#### Testing

Added two new test cases in `tests/clzones_test.cpp`:

- `zone_sorting_terrain_zone_vehicle_cargo_no_loop`: places a cart with food at a terrain-bound LOOT_FOOD + UNSORTED tile. Without the fix, sorting loops until the turn limit. With the fix, item stays in cargo and activity completes.

- `zone_sorting_multi_dest_processes_all_items`: source with apple (perishable -> PFOOD) and bitter almond (non-perishable -> FOOD), destinations at carefully chosen distances to trigger the stale offset bug. Without the fix, bitter almond stays at source. With the fix, both items reach their destinations.

All 24 existing `[zones][sorting]` test cases still pass (176 assertions).

Tested manually with a save that had the butter loop issue - sorting now completes.

#### Additional context

N/A