### PR TITLE
Replace per-tile A* with Dijkstra flood for zone sorting

### DIFF
--- a/src/activity_item_handling.h
+++ b/src/activity_item_handling.h
@@ -121,7 +121,15 @@ void move_item( Character &you, const std::optional<vpart_reference> &vpr_src,
 // Returns A* route length from the player to a tile adjacent to dest.
 // Uses grab-aware routing when the player is dragging a vehicle.
 // Returns INT_MAX if unreachable.
-int route_length( const Character &you, const tripoint_bub_ms &dest );
+int route_length( const Character &who, const tripoint_bub_ms &dest );
+
+// Weighted movement cost from player to adjacent(dest) via cached Dijkstra flood.
+// Returns INT_MAX if unreachable, OOB, or different z-level.
+int flood_distance( const Character &who, const tripoint_bub_ms &dest );
+
+// Force recomputation of the flood cache on the next flood_distance() call.
+// Needed when terrain changes without player movement (e.g. tests).
+void invalidate_flood_cache();
 } //namespace zone_sorting
 
 


### PR DESCRIPTION
#### Summary
Performance "Replace per-tile A* with Dijkstra flood for zone sorting distances"

#### Purpose of change

Zone sorting uses multiple individual A* calls (`route_length()`) per THINK cycle to sort sources and probe destinations by real walking distance. Each call is O(N log N) over the map, and THINK runs them for every source tile and every candidate destination. With many zones this adds up.

Depends on #85504 which fixes some sorting loops that this branch builds on top of.

#### Describe the solution

Single-source Dijkstra flood from the player position, computed once per position/grab-state change (~17K tiles, sub-millisecond). All subsequent distance lookups are O(1) via `flood_distance()`.

Two flood variants:
- **Normal flood**: standard Dijkstra using `map::move_cost()`, with door fallback matching the main pathfinder (terrain doors cost 4, vehicle doors 10/12 with approach-side context via `is_outside` check).
- **Grab flood**: Dijkstra over (position, grab_direction) state space (~157K states), replicating `route_with_grab()` push/pull/sideways/zigzag mechanics. Falls back to normal flood for multi-tile vehicles.

Replaces `route_length()` and `square_dist` calls in:
- THINK source sorting (was Chebyshev pre-sort + lazy A* + early termination, now just sort by flood distance)
- Dropoff coordinate probing (both primary and fallback)
- Dropoff routing sort
- Batching distance checks

Cross-z tiles get INT_MAX from the single-z flood and are handled separately -- appended after flood-sorted same-z tiles for sources and destinations, skipped entirely for batching.

Also fixes while touching the code:
- `route_to_destination` failures now mark source as unreachable (was silently retried every THINK)
- Delivery route failures remove the failing destination from `dropoff_coords` instead of abandoning the whole source
- Batching skipped when all destinations are cross-z or unreachable

#### Describe alternatives you've considered

Extending the main A* pathfinder with a flood mode -- rejected because the main pathfinder uses a global singleton with flat_index arrays, and adding grab state would bloat all pathfinding. Separate flood function is cleaner.

Caching individual A* results (the old `g_route_cache`) -- already existed but only cached the last result. Full flood is simpler and faster than managing a per-destination cache.

#### Testing

- New `zone_sorting_flood_distance` test: open field ordering, wall detour, enclosed tile unreachable, door cost, adjacency, OOB, cross-z.
- New `zone_sorting_flood_distance_with_grab` test: narrow gap with cart, multi-tile vehicle fallback.
- All 26 existing `[zones][sorting]` tests pass (198 assertions, ~4 seconds).
- `make astyle` clean.

#### Additional context

The flood cache invalidates on player position or grab state change. For tests, also invalidated on activity start (UNINIT -> INIT) to handle map rebuilds between test cases.