### PR TITLE
Fix sub_body_part string extractor crash on copy-from

### DIFF
--- a/lang/string_extractor/parsers/sub_body_part.py
+++ b/lang/string_extractor/parsers/sub_body_part.py
@@ -2,7 +2,7 @@ from ..write_text import write_text
 
 
 def parse_sub_body_part(json, origin):
-    write_text(json["name"], origin,
+    write_text(json.get("name"), origin,
                comment="Name of sub body part")
     write_text(json.get("name_multiple"), origin,
                comment="Name of sub body part")


### PR DESCRIPTION
#### Summary
Bugfixes "Fix sub_body_part string extractor crash on copy-from objects"

#### Purpose of change

#85363 added `beak_bird_*` sub_body_parts using `copy-from` without explicit `name` fields, crashing the string extractor on every PR's `analyze-text-changes` CI.

#### Describe the solution

`json["name"]` -> `json.get("name")` in `sub_body_part.py`, matching `body_part.py`. `write_text()` already handles None.

#### Describe alternatives you've considered

Adding explicit `name` fields to the JSON, but that duplicates strings already extracted from the copy-from source.

#### Testing

String extraction runs without crash.

#### Additional context

N/A