### PR TITLE
fix incorrect string format

### DIFF
--- a/tests/item_test.cpp
+++ b/tests/item_test.cpp
@@ -1146,7 +1146,7 @@ TEST_CASE( "uncraft_sanity_check", "[item]" )
         const bool is_within_tolerance = weight_difference <= weight_tolerance;
 
         if( !is_within_tolerance ) {
-            INFO( string_format( "Item %s weight %s gram, but it's uncrafting recipe (including crafting with 'reversible: true') has components with total weight of %s gram.  It should be within %.0f%%.",
+            INFO( string_format( "Item %s weight %d gram, but it's uncrafting recipe (including crafting with 'reversible: true') has components with total weight of %d gram.  It should be within %.0f%%.",
                                  target.typeId().str(), to_gram( item_weight ),
                                  to_gram( sum_of_components_weight ), tolerance * 100.f ) );
             CHECK( is_within_tolerance );


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Spotted 
```c++
(~[slow] ~[.],starting_items)=> ../tests/item_test.cpp:1152: FAILED:
(~[slow] ~[.],starting_items)=>   CHECK( is_within_tolerance )
(~[slow] ~[.],starting_items)=> with expansion:
Error: (~[slow] ~[.],starting_items)=>   false
(~[slow] ~[.],starting_items)=> with message:
(~[slow] ~[.],starting_items)=>   invalid format specifier
```
in #85482
#### Describe the solution
Use proper specifiers
#### Testing
In CI we trust