### PR TITLE
Whitelist contents of Pocket

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -4959,6 +4959,13 @@
   },
   {
     "type": "keybinding",
+    "id": "FAV_WHITELIST_CONTENTS",
+    "category": "INVENTORY",
+    "name": "Whitelist Contents",
+    "bindings": [ { "input_method": "keyboard_char", "key": "W" }, { "input_method": "keyboard_code", "key": "w", "mod": [ "shift" ] } ]
+  },
+  {
+    "type": "keybinding",
     "id": "FAV_BLACKLIST",
     "category": "INVENTORY",
     "name": "Switch to modifying blacklist",

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -485,20 +485,20 @@ bool pocket_favorite_callback::key( const input_context &ctxt, const input_event
             }
         }
         return true;
-    } else if ( action == "FAV_WHITELIST_CONTENTS" ) {
+    } else if( action == "FAV_WHITELIST_CONTENTS" ) {
         const cata::flat_set<itype_id> whitelisted_items = selected_pocket->settings.get_item_whitelist();
         bool modified = false;
-        for ( auto item : selected_pocket->all_items_top() ) {
-            if ( whitelisted_items.find( item->typeId() ) == whitelisted_items.end() ) {
+        for( item *item : selected_pocket->all_items_top() ) {
+            if( whitelisted_items.find( item->typeId() ) == whitelisted_items.end() ) {
                 selected_pocket->settings.whitelist_item( item->typeId() );
                 modified = true;
             }
         }
-        if ( modified ) {
+        if( modified ) {
             selected_pocket->settings.set_was_edited();
         }
         return true;
-    } else if ( action == "FAV_CLEAR") {
+    } else if( action == "FAV_CLEAR") {
         if( query_yn( _( "Are you sure you want to clear settings for pocket %d?" ), pocket_num ) ) {
             selected_pocket->settings.clear();
             selected_pocket->settings.set_was_edited();
@@ -529,7 +529,7 @@ bool pocket_favorite_callback::key( const input_context &ctxt, const input_event
         cmenu.addentry( 10, true, inp_mngr.get_first_char_for_action( "FAV_DEL_PRESET", "INVENTORY" ),
                         ctxt.get_action_name( "FAV_DEL_PRESET" ) );
         cmenu.addentry( 11, true, inp_mngr.get_first_char_for_action( "FAV_WHITELIST_CONTENTS", "INVENTORY" ),
-                        ctxt.get_action_name("FAV_WHITELIST_CONTENTS") );
+                        ctxt.get_action_name( "FAV_WHITELIST_CONTENTS" ) );
         cmenu.addentry( 12, true, inp_mngr.get_first_char_for_action( "FAV_CLEAR", "INVENTORY" ),
                         ctxt.get_action_name( "FAV_CLEAR" ) );
         cmenu.query();

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -528,7 +528,8 @@ bool pocket_favorite_callback::key( const input_context &ctxt, const input_event
                         ctxt.get_action_name( "FAV_APPLY_PRESET" ) );
         cmenu.addentry( 10, true, inp_mngr.get_first_char_for_action( "FAV_DEL_PRESET", "INVENTORY" ),
                         ctxt.get_action_name( "FAV_DEL_PRESET" ) );
-        cmenu.addentry( 11, true, inp_mngr.get_first_char_for_action( "FAV_WHITELIST_CONTENTS", "INVENTORY" ),
+        cmenu.addentry( 11, true, inp_mngr.get_first_char_for_action( "FAV_WHITELIST_CONTENTS",
+                        "INVENTORY" ),
                         ctxt.get_action_name( "FAV_WHITELIST_CONTENTS" ) );
         cmenu.addentry( 12, true, inp_mngr.get_first_char_for_action( "FAV_CLEAR", "INVENTORY" ),
                         ctxt.get_action_name( "FAV_CLEAR" ) );

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -485,7 +485,16 @@ bool pocket_favorite_callback::key( const input_context &ctxt, const input_event
             }
         }
         return true;
-    } else if( action == "FAV_CLEAR" ) {
+    } else if ( action == "FAV_WHITELIST_CONTENTS" ) {
+        const cata::flat_set<itype_id> whitelisted_items = selected_pocket->settings.get_item_whitelist();
+        for (auto item : selected_pocket->all_items_top()) {
+            if (whitelisted_items.find(item->typeId()) == whitelisted_items.end()) {
+                selected_pocket->settings.whitelist_item(item->typeId());
+            }
+        }
+        selected_pocket->settings.set_was_edited();
+        return true;
+    } else if ( action == "FAV_CLEAR") {
         if( query_yn( _( "Are you sure you want to clear settings for pocket %d?" ), pocket_num ) ) {
             selected_pocket->settings.clear();
             selected_pocket->settings.set_was_edited();
@@ -515,7 +524,9 @@ bool pocket_favorite_callback::key( const input_context &ctxt, const input_event
                         ctxt.get_action_name( "FAV_APPLY_PRESET" ) );
         cmenu.addentry( 10, true, inp_mngr.get_first_char_for_action( "FAV_DEL_PRESET", "INVENTORY" ),
                         ctxt.get_action_name( "FAV_DEL_PRESET" ) );
-        cmenu.addentry( 11, true, inp_mngr.get_first_char_for_action( "FAV_CLEAR", "INVENTORY" ),
+        cmenu.addentry( 11, true, inp_mngr.get_first_char_for_action( "FAV_WHITELIST_CONTENTS", "INVENTORY" ),
+                        ctxt.get_action_name("FAV_WHITELIST_CONTENTS") );
+        cmenu.addentry( 12, true, inp_mngr.get_first_char_for_action( "FAV_CLEAR", "INVENTORY" ),
                         ctxt.get_action_name( "FAV_CLEAR" ) );
         cmenu.query();
 
@@ -555,6 +566,9 @@ bool pocket_favorite_callback::key( const input_context &ctxt, const input_event
                 ev = "FAV_DEL_PRESET";
                 break;
             case 11:
+                ev = "FAV_WHITELIST_CONTENTS";
+                break;
+            case 12:
                 ev = "FAV_CLEAR";
                 break;
             default:
@@ -2816,7 +2830,8 @@ void pocket_management_menu( const std::string &title, const std::vector<item *>
         { "FAV_CONTEXT_MENU", translation() },
         { "FAV_SAVE_PRESET", translation() },
         { "FAV_APPLY_PRESET", translation() },
-        { "FAV_DEL_PRESET", translation() }
+        { "FAV_DEL_PRESET", translation() },
+        { "FAV_WHITELIST_CONTENTS", translation() }
     };
     // Override CONFIRM with FAV_CONTEXT_MENU
     pocket_selector.allow_confirm = false;

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -487,12 +487,16 @@ bool pocket_favorite_callback::key( const input_context &ctxt, const input_event
         return true;
     } else if ( action == "FAV_WHITELIST_CONTENTS" ) {
         const cata::flat_set<itype_id> whitelisted_items = selected_pocket->settings.get_item_whitelist();
-        for (auto item : selected_pocket->all_items_top()) {
-            if (whitelisted_items.find(item->typeId()) == whitelisted_items.end()) {
-                selected_pocket->settings.whitelist_item(item->typeId());
+        bool modified = false;
+        for ( auto item : selected_pocket->all_items_top() ) {
+            if ( whitelisted_items.find( item->typeId() ) == whitelisted_items.end() ) {
+                selected_pocket->settings.whitelist_item( item->typeId() );
+                modified = true;
             }
         }
-        selected_pocket->settings.set_was_edited();
+        if ( modified ) {
+            selected_pocket->settings.set_was_edited();
+        }
         return true;
     } else if ( action == "FAV_CLEAR") {
         if( query_yn( _( "Are you sure you want to clear settings for pocket %d?" ), pocket_num ) ) {
@@ -576,7 +580,7 @@ bool pocket_favorite_callback::key( const input_context &ctxt, const input_event
 
         }
         const std::vector<input_event> evlist = inp_mngr.get_input_for_action( ev, "INVENTORY" );
-        if( cmenu.ret >= 0 && cmenu.ret <= 11 && !evlist.empty() ) {
+        if( cmenu.ret >= 0 && cmenu.ret <= 12 && !evlist.empty() ) {
             return key( ctxt, evlist.front(), -1, menu );
         }
         return true;

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -498,7 +498,7 @@ bool pocket_favorite_callback::key( const input_context &ctxt, const input_event
             selected_pocket->settings.set_was_edited();
         }
         return true;
-    } else if( action == "FAV_CLEAR") {
+    } else if( action == "FAV_CLEAR" ) {
         if( query_yn( _( "Are you sure you want to clear settings for pocket %d?" ), pocket_num ) ) {
             selected_pocket->settings.clear();
             selected_pocket->settings.set_was_edited();


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Interface "Add the ability to whitelist the contents of a pocket"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Make it easier to whitelist a lot of stuff at the same time.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adds an interface option to the pocket menu to whitelist the contents of a pocket, making it much easier to do a lot of whitelisting at once.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Multiselect in the whitelisting UI but that seemed way more intense than this solution.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Created a new character, shoved some items in their backpack, pressed the whitelist contents option and observed the items being added to the whitelist. Did it again and confirm no duplicates, remove 1 or 2 items from the whitelist and then whitelisted the contents again, only the missing items were added.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
<img width="839" height="582" alt="image" src="https://github.com/user-attachments/assets/18f15bf6-bb53-4f4f-8157-378e80b517b4" />
<img width="228" height="307" alt="image" src="https://github.com/user-attachments/assets/6f7e78df-04fd-4b3d-a043-44336c30cad5" />
<img width="1195" height="591" alt="image" src="https://github.com/user-attachments/assets/99c6a30a-3abd-4d13-ab18-ecd7bf6b3d3c" />

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
