### PR TITLE
Add weight gates to zone sort batching

### DIFF
--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -1794,6 +1794,21 @@
     "vitamins": [ [ "vitC", 14 ], [ "iron", 1 ], [ "fruit_allergen", 1 ] ]
   },
   {
+    "id": "test_heavy_boulder",
+    "type": "ITEM",
+    "subtypes": [ "COMESTIBLE" ],
+    "comestible_type": "FOOD",
+    "category": "food",
+    "name": { "str": "test heavy boulder" },
+    "description": "A very heavy edible boulder for testing weight limits.",
+    "volume": "1500 ml",
+    "weight": "10 kg",
+    "color": "dark_gray",
+    "symbol": "*",
+    "calories": 1,
+    "material": [ "test_material" ]
+  },
+  {
     "id": "test_egg",
     "type": "ITEM",
     "subtypes": [ "COMESTIBLE" ],

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -4118,6 +4118,10 @@ class zone_sort_activity_actor : public zone_activity_actor
         // Persists across do_turn calls so batching fires even when the initial
         // pickup exhausted moves. Reset after the batching check evaluates.
         bool picked_up_this_pass = false; // NOLINT(cata-serialize)
+        // Worst terrain tile on route to destination for drag feasibility checks.
+        // Computed once when dropoff_coords is first populated in stage_do,
+        // persists across do_turn re-entries within the same source.
+        std::optional<tripoint_bub_ms> drag_worst_tile; // NOLINT(cata-serialize)
 
         // Returns all picked up items to the source tile and clears sorting state.
         // Used when routing to a destination fails.

--- a/src/activity_item_handling.h
+++ b/src/activity_item_handling.h
@@ -122,6 +122,12 @@ void move_item( Character &you, const std::optional<vpart_reference> &vpr_src,
 // Uses grab-aware routing when the player is dragging a vehicle.
 // Returns INT_MAX if unreachable.
 int route_length( const Character &you, const tripoint_bub_ms &dest );
+
+// Worst-terrain tile on the route to nearest dropoff destination for a
+// grabbed single-tile vehicle.  Returns nullopt if no grabbed vehicle,
+// multi-tile vehicle, or trivial/unreachable route.
+std::optional<tripoint_bub_ms> worst_drag_tile_on_route(
+    const Character &who, const std::vector<tripoint_abs_ms> &dropoff_coords );
 } //namespace zone_sorting
 
 

--- a/src/map.h
+++ b/src/map.h
@@ -840,6 +840,12 @@ class map
         // TODO: Remove the ugly sinking vehicle hack
         float vehicle_wheel_traction( const vehicle &veh, bool ignore_movement_modifiers = false );
 
+        // Traction at a hypothetical position (for drag feasibility checks).
+        // Computes wheel positions as at_origin + part.precalc[0] instead of
+        // using the vehicle's actual map position.
+        float vehicle_wheel_traction( const vehicle &veh, const tripoint_bub_ms &at_origin,
+                                      bool ignore_movement_modifiers = false );
+
         // Executes vehicle-vehicle collision based on vehicle::collision results
         // Returns impulse of the executed collision
         // If vector contains collisions with vehicles other than veh2, they will be ignored

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4935,6 +4935,11 @@ double vehicle::coeff_water_drag( map &here ) const
 
 float vehicle::k_traction( map &here, float wheel_traction_area ) const
 {
+    return k_traction( here, wheel_traction_area, weight_on_wheels( here ) );
+}
+
+float vehicle::k_traction( map &here, float wheel_traction_area, units::mass mass ) const
+{
     if( in_deep_water ) {
         return can_float( here ) ? 1.0f : -1.0f;
     }
@@ -4949,12 +4954,41 @@ float vehicle::k_traction( map &here, float wheel_traction_area ) const
     if( fraction_without_traction == 0 ) {
         return 1.0f;
     }
-    const float mass_penalty = fraction_without_traction * to_kilogram( weight_on_wheels( here ) );
+    const float mass_penalty = fraction_without_traction * to_kilogram( mass );
     float traction = std::min( 1.0f, wheel_traction_area / mass_penalty );
     add_msg_debug( debugmode::DF_VEHICLE, "%s has traction %.2f", name, traction );
 
     // For now make it easy until it gets properly balanced: add a low cap of 0.1
     return std::max( 0.1f, traction );
+}
+
+int vehicle::drag_str_req_at( map &here, const tripoint_bub_ms &tile_pos,
+                              units::mass projected_mass ) const
+{
+    const int max_str = projected_mass / 10_kilogram;
+    if( !sufficient_wheel_config() ) {
+        return max_str;
+    }
+    const int n = static_cast<int>( wheelcache.size() );
+    const int base = max_str / 10;
+    int mc = 0;
+    for( const int p : wheelcache ) {
+        const tripoint_bub_ms wp = tile_pos + part( p ).precalc[0];
+        // Exclude self: at current position the vehicle is on the tile;
+        // at a hypothetical position there is no vehicle, so this is a no-op.
+        const int mapcost = here.move_cost( wp, this );
+        mc += base * mapcost / n;
+    }
+    const int eff = ( n > 4 || n == 1 ) ? 4 : n;
+    int str_req = mc / eff + 1;
+    const float wta = here.vehicle_wheel_traction( *this, tile_pos );
+    str_req = static_cast<int>( str_req / k_traction( here, wta, projected_mass ) );
+    return std::min( str_req, max_str );
+}
+
+int vehicle::drag_str_req_at( map &here, const tripoint_bub_ms &tile_pos ) const
+{
+    return drag_str_req_at( here, tile_pos, total_mass( here ) );
 }
 
 units::power vehicle::static_drag( bool actual ) const

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1808,6 +1808,15 @@ class vehicle
          * Affects safe velocity, acceleration and handling difficulty.
          */
         float k_traction( map &here, float wheel_traction_area ) const;
+        // k_traction with explicit mass (for projected drag feasibility checks).
+        float k_traction( map &here, float wheel_traction_area, units::mass mass ) const;
+
+        // Drag strength required to move this vehicle through tile_pos at
+        // given mass.  For single-tile wheeled vehicles.  Returns the str_req
+        // that must be <= get_arm_str() for dragging to succeed.
+        int drag_str_req_at( map &here, const tripoint_bub_ms &tile_pos,
+                             units::mass projected_mass ) const;
+        int drag_str_req_at( map &here, const tripoint_bub_ms &tile_pos ) const;
         /*@}*/
 
         // Extra drag on the vehicle from components other than wheels.

--- a/tests/clzones_test.cpp
+++ b/tests/clzones_test.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "activity_actor_definitions.h"
+#include "activity_item_handling.h"
 #include "avatar.h"
 #include "calendar.h"
 #include "cata_catch.h"
@@ -36,6 +37,7 @@ static const itype_id itype_backpack( "backpack" );
 static const itype_id itype_belt223( "belt223" );
 static const itype_id itype_test_apple( "test_apple" );
 static const itype_id itype_test_bitter_almond( "test_bitter_almond" );
+static const itype_id itype_test_heavy_boulder( "test_heavy_boulder" );
 static const itype_id itype_test_milk( "test_milk" );
 static const itype_id
 itype_test_watertight_open_sealed_container_250ml( "test_watertight_open_sealed_container_250ml" );
@@ -1855,4 +1857,214 @@ TEST_CASE( "zone_sorting_multi_dest_processes_all_items",
     // Both items should be gone from source - sorted to their destinations
     CHECK( count_items_or_charges( src_pos, itype_test_apple, std::nullopt ) == 0 );
     CHECK( count_items_or_charges( src_pos, itype_test_bitter_almond, std::nullopt ) == 0 );
+}
+
+// Without a grabbed vehicle, zone sorting should stop picking up items once
+// carried weight exceeds the player's weight capacity.  Prevents the player
+// from overloading themselves while auto-sorting.
+TEST_CASE( "zone_sorting_no_grab_weight_gate",
+           "[zones][items][activities][sorting][weight]" )
+{
+    avatar &dummy = get_avatar();
+    map &here = get_map();
+
+    clear_avatar();
+    clear_map_without_vision();
+    zone_manager::get_manager().clear();
+
+    const tripoint_bub_ms start_pos( 60, 60, 0 );
+    dummy.setpos( here, start_pos );
+    dummy.clear_destination();
+    // Backpack for stashing items (large volume, won't be the bottleneck)
+    dummy.worn.wear_item( dummy, item( itype_backpack ), false, false );
+
+    // With default str 8: weight_capacity = 13 + 8*4 = 45 kg.
+    // Each boulder is 10 kg.  After picking up 4 (40 kg), the fifth would
+    // push carried weight to 50 kg > 45 kg, so the weight gate should block it.
+    const int num_boulders = 5;
+
+    // Source: UNSORTED at player position
+    const tripoint_abs_ms start_abs = here.get_abs( start_pos );
+    here.ter_set( start_pos, ter_t_floor );
+    create_tile_zone( "Unsorted", zone_type_LOOT_UNSORTED, start_abs );
+    for( int i = 0; i < num_boulders; i++ ) {
+        here.add_item_or_charges( start_pos, item( itype_test_heavy_boulder ) );
+    }
+
+    // Destination: LOOT_FOOD 8 tiles south (non-adjacent, forces pickup-then-route)
+    const tripoint_bub_ms dest_pos = start_pos + tripoint( 0, 8, 0 );
+    const tripoint_abs_ms dest_abs = here.get_abs( dest_pos );
+    here.ter_set( dest_pos, ter_t_floor );
+    create_tile_zone( "Food", zone_type_LOOT_FOOD, dest_abs );
+
+    for( int y = start_pos.y(); y <= dest_pos.y(); ++y ) {
+        here.ter_set( tripoint_bub_ms( start_pos.x(), y, 0 ), ter_t_floor );
+    }
+
+    here.invalidate_map_cache( 0 );
+    here.build_map_cache( 0, true );
+
+    dummy.assign_activity( zone_sort_activity_actor() );
+    process_activity( dummy );
+
+    // Weight gate should have blocked some items from being picked up.
+    const int remaining = count_items_or_charges( start_pos, itype_test_heavy_boulder, std::nullopt );
+    int carried = 0;
+    dummy.visit_items( [&carried]( const item * it, const item * ) {
+        if( it->typeId() == itype_test_heavy_boulder ) {
+            carried++;
+        }
+        return VisitResponse::NEXT;
+    } );
+
+    CAPTURE( remaining );
+    CAPTURE( carried );
+    CAPTURE( dummy.weight_carried().value() );
+    CAPTURE( dummy.weight_capacity().value() );
+    // Should have picked up some but not all
+    CHECK( carried > 0 );
+    CHECK( carried < num_boulders );
+    CHECK( remaining > 0 );
+    // Carried weight should be at or below capacity
+    CHECK( dummy.weight_carried() <= dummy.weight_capacity() );
+}
+
+// With a grabbed cart, zone sorting should stop loading items into the cart
+// once the projected mass would exceed the player's drag strength on the
+// worst terrain tile of the delivery route.
+TEST_CASE( "zone_sorting_drag_weight_gate",
+           "[zones][items][activities][sorting][weight][vehicle]" )
+{
+    avatar &dummy = get_avatar();
+    map &here = get_map();
+
+    clear_avatar();
+    clear_map_without_vision();
+    zone_manager::get_manager().clear();
+
+    // Low strength so the drag gate triggers at reasonable weights.
+    // str 4 -> arm_str ~4, weight_capacity = 13+16 = 29 kg
+    dummy.str_max = 4;
+    dummy.str_cur = 4;
+    dummy.set_str_bonus( 0 );
+
+    const tripoint_bub_ms start_pos( 60, 60, 0 );
+    dummy.setpos( here, start_pos );
+    dummy.clear_destination();
+    // Backpack for overflow items
+    dummy.worn.wear_item( dummy, item( itype_backpack ), false, false );
+
+    // Cart adjacent to player (south) and grab it
+    const tripoint_bub_ms cart_pos = start_pos + tripoint::south;
+    // Leave terrain as grass (default from clear_map) -- no ROAD/FLAT flags,
+    // so traction is poor and drag becomes harder.
+    vehicle *cart = here.add_vehicle( vehicle_prototype_test_shopping_cart,
+                                      cart_pos, 0_degrees, 0, 0 );
+    REQUIRE( cart != nullptr );
+    cart->set_owner( dummy );
+    dummy.grab( object_type::VEHICLE, tripoint_rel_ms::south );
+    REQUIRE( dummy.get_grab_type() == object_type::VEHICLE );
+
+    // Source: UNSORTED at player position (set to floor so items are accessible)
+    const tripoint_abs_ms start_abs = here.get_abs( start_pos );
+    here.ter_set( start_pos, ter_t_floor );
+    create_tile_zone( "Unsorted", zone_type_LOOT_UNSORTED, start_abs );
+    const int num_boulders = 20;
+    for( int i = 0; i < num_boulders; i++ ) {
+        here.add_item_or_charges( start_pos, item( itype_test_heavy_boulder ) );
+    }
+
+    // Destination: LOOT_FOOD 8 tiles south.  Route goes over grass, which
+    // has poor traction and makes dragging harder.
+    const tripoint_bub_ms dest_pos = start_pos + tripoint( 0, 8, 0 );
+    const tripoint_abs_ms dest_abs = here.get_abs( dest_pos );
+    create_tile_zone( "Food", zone_type_LOOT_FOOD, dest_abs );
+
+    here.invalidate_map_cache( 0 );
+    here.build_map_cache( 0, true );
+
+    const int arm_str = dummy.get_arm_str();
+    CAPTURE( arm_str );
+    CAPTURE( cart->total_mass( here ).value() );
+
+    // Verify drag_str_req_at produces meaningful values on grass
+    {
+        // With just the cart's own mass, drag should be easy
+        const int easy_req = cart->drag_str_req_at( here, dest_pos );
+        CAPTURE( easy_req );
+        CHECK( easy_req <= arm_str );
+
+        // Find the threshold mass where drag gate trips
+        int threshold_kg = -1;
+        for( int extra_kg = 10; extra_kg <= 300; extra_kg += 10 ) {
+            units::mass proj = cart->total_mass( here ) + extra_kg * 1_kilogram;
+            int req = cart->drag_str_req_at( here, dest_pos, proj );
+            if( req > arm_str ) {
+                threshold_kg = extra_kg;
+                break;
+            }
+        }
+        CAPTURE( threshold_kg );
+        REQUIRE( threshold_kg > 0 );
+
+        units::mass heavy = cart->total_mass( here ) + 200_kilogram;
+        const int hard_req = cart->drag_str_req_at( here, dest_pos, heavy );
+        CAPTURE( hard_req );
+        REQUIRE( hard_req > arm_str );
+    }
+
+    // Verify worst_drag_tile_on_route works for our layout
+    {
+        std::vector<tripoint_abs_ms> test_dropoffs = { here.get_abs( dest_pos ) };
+        auto worst = zone_sorting::worst_drag_tile_on_route( dummy, test_dropoffs );
+        REQUIRE( worst.has_value() );
+        if( worst ) {
+            int req_at_worst = cart->drag_str_req_at( here, *worst,
+                               cart->total_mass( here ) + 200_kilogram );
+            CAPTURE( req_at_worst );
+            CAPTURE( worst->x() );
+            CAPTURE( worst->y() );
+            REQUIRE( req_at_worst > arm_str );
+        }
+    }
+
+    // Also directly test that drag gate would catch late items
+    {
+        units::mass after_10 = cart->total_mass( here ) + 100_kilogram;
+        std::vector<tripoint_abs_ms> test_drops = { here.get_abs( dest_pos ) };
+        auto wt = zone_sorting::worst_drag_tile_on_route( dummy, test_drops );
+        if( wt ) {
+            int req10 = cart->drag_str_req_at( here, *wt, after_10 );
+            CAPTURE( req10 );
+            // After loading 10 boulders (100kg), should exceed arm_str
+            REQUIRE( req10 > arm_str );
+        }
+    }
+
+    dummy.assign_activity( zone_sort_activity_actor() );
+    process_activity( dummy );
+
+    // Count items in cart cargo
+    int in_cart = 0;
+    std::optional<vpart_reference> cargo = here.veh_at( cart_pos ).cargo();
+    if( cargo.has_value() ) {
+        in_cart = count_items_or_charges( cart_pos, itype_test_heavy_boulder, cargo );
+    }
+    int at_source = count_items_or_charges( start_pos, itype_test_heavy_boulder, std::nullopt );
+    int carried = 0;
+    dummy.visit_items( [&carried]( const item * it, const item * ) {
+        if( it->typeId() == itype_test_heavy_boulder ) {
+            carried++;
+        }
+        return VisitResponse::NEXT;
+    } );
+
+    CAPTURE( in_cart );
+    CAPTURE( carried );
+    CAPTURE( at_source );
+    // Drag gate should have limited how many went into the cart.
+    // Some items may overflow to inventory (body weight gate applies there too).
+    // The key check: not all items were picked up.
+    CHECK( in_cart + carried + at_source == num_boulders );
+    CHECK( at_source > 0 );
 }

--- a/tests/clzones_test.cpp
+++ b/tests/clzones_test.cpp
@@ -1878,9 +1878,14 @@ TEST_CASE( "zone_sorting_no_grab_weight_gate",
     // Backpack for stashing items (large volume, won't be the bottleneck)
     dummy.worn.wear_item( dummy, item( itype_backpack ), false, false );
 
-    // With default str 8: weight_capacity = 13 + 8*4 = 45 kg.
-    // Each boulder is 10 kg.  After picking up 4 (40 kg), the fifth would
-    // push carried weight to 50 kg > 45 kg, so the weight gate should block it.
+    // Use a below-average STR to cover weaker characters (Refugee Center
+    // beggars and similar NPCs can have very poor stats).
+    // str 6: weight_capacity = 13 + 6*4 = 37 kg.
+    // Each boulder is 10 kg.  After picking up 3 (30 kg), the fourth would
+    // push carried weight to 40 kg > 37 kg, so the weight gate should block it.
+    dummy.str_max = 6;
+    dummy.str_cur = 6;
+    dummy.set_str_bonus( 0 );
     const int num_boulders = 5;
 
     // Source: UNSORTED at player position

--- a/tests/player_helpers.cpp
+++ b/tests/player_helpers.cpp
@@ -16,6 +16,7 @@
 #include "character_id.h"
 #include "character_martial_arts.h"
 #include "coordinates.h"
+#include "enums.h"
 #include "game.h"
 #include "inventory.h"
 #include "item.h"
@@ -218,6 +219,7 @@ void clear_avatar()
 {
     avatar &avatar = get_avatar();
     clear_character( avatar );
+    avatar.grab( object_type::NONE );
     avatar.clear_identified();
     avatar.clear_nutrition();
     avatar.reset_all_missions();


### PR DESCRIPTION
#### Summary
Features "Add drag feasibility and weight gates to zone sort batching"

#### Purpose of change

Zone sorting with a grabbed shopping cart happily loads 200 kg of boulders into it even though the player can barely drag it across grass afterwards. Without a cart, the player stuffs their backpack until they can barely move. Neither is great behavior for an automated system that's supposed to be convenient.

#### Describe the solution

Two new gates in the stage_do pickup loop:

**Drag feasibility gate** (with grabbed cart): before adding an item to the cart, compute the projected total mass and check `drag_str_req_at()` on the worst terrain tile of the cached delivery route. If the projected strength requirement exceeds `get_arm_str()`, skip the item and stop loading.

**No-grab weight gate** (carrying by hand): stop picking up when carried weight would exceed `weight_capacity()`. Keeps the player from overloading into a crawl.

Supporting refactors:
- `vehicle::drag_str_req_at()` extracted from `grabbed_veh_move()` in grab.cpp into a reusable method on vehicle. Takes an arbitrary tile position and optional projected mass.
- `vehicle::k_traction()` gets a mass-parameter overload so drag checks can project future mass without modifying the vehicle.
- `map::vehicle_wheel_traction()` gets a hypothetical-position overload (same logic as the existing one but uses an arbitrary origin instead of the vehicle's current position).
- `zone_sorting::worst_drag_tile_on_route()` scans the cached A* route for the tile with the highest drag requirement.

The drag_worst_tile variable is a member of `zone_sort_activity_actor` (not a local in stage_do) so it survives across do_turn re-entries when move exhaustion splits pickup across multiple turns.

Batching also respects both gates: the per-item capacity check in the batching loop mirrors the pickup gates so a batching detour won't overload.

#### Describe alternatives you've considered

Could have checked drag at the destination tile only, but the worst tile on the route is what actually matters - a stretch of grass between two roads is the bottleneck. Could also have used a fixed weight cap instead of the actual drag formula, but that would ignore wheel type, traction, and terrain differences. Ironically, the "simple" approach would need more fudge factors to feel right.

#### Testing

Two new test cases in `tests/clzones_test.cpp`:

- `zone_sorting_no_grab_weight_gate`: 5 x 10 kg boulders, no cart, default str 8. Verifies that carried weight stays at or below capacity and some items remain at source.
- `zone_sorting_drag_weight_gate`: 20 x 10 kg boulders, shopping cart on grass, str 4. Verifies `drag_str_req_at` threshold exists, `worst_drag_tile_on_route` finds a tile, and that after sorting not all items were loaded (drag gate fired).

Both tests also validate the underlying functions in isolation before running the full sorting activity.

#### Additional context

The `test_heavy_boulder` item (10 kg COMESTIBLE/FOOD) was added to TEST_DATA for these tests.