### PR TITLE
Fix CI skip-detection refs, Makefile parallel safety, and test tag syntax

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -219,8 +219,8 @@ jobs:
         SKIP: >-
           ${{
           ( github.event.pull_request.draft == true && matrix.title != 'Basic Build and Test (Clang oldest supported, Ubuntu, Curses)' ) ||
-          ( matrix.dont_skip_data_only_changes == 0 && needs.skip-duplicates.outputs.should_skip_code == 'true' ) ||
-          ( matrix.dont_skip_data_only_changes != 0 && needs.skip-duplicates-mods.outputs.should_skip_data == 'true' )
+          ( matrix.dont_skip_data_only_changes == 0 && needs.skip-duplicates-code.outputs.should_skip_code == 'true' ) ||
+          ( matrix.dont_skip_data_only_changes != 0 && needs.skip-duplicates-data.outputs.should_skip_data == 'true' )
           }}
         SKIP_TESTS: ${{ fromJSON(needs.matrix-variables.outputs.skip_tests) || (matrix.android != '') }}
     steps:
@@ -353,5 +353,5 @@ jobs:
   #emscripten:
   #  needs: [ skip-duplicates-code, varied_builds ]
   #  uses: ./.github/workflows/emscripten.yml
-  #  if: ${{ needs.skip-duplicates.outputs.should_skip_code != 'true' && success() && github.event.pull_request.draft == false }}
+  #  if: ${{ needs.skip-duplicates-code.outputs.should_skip_code != 'true' && success() && github.event.pull_request.draft == false }}
   #  secrets: inherit

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -63,7 +63,7 @@ $(PCH_P): $(PCH_H)
 TEST_BATCHES = "crafting_skill_gain" "[slow]\ ~crafting_skill_gain" "~[slow]\ ~[.]"
 
 $(TEST_BATCHES): $(TEST_TARGET)
-	cd .. && tests/$(TEST_TARGET) --min-duration 0.2 --rng-seed time --order lex $@
+	cd .. && tests/$(TEST_TARGET) --min-duration 0.2 --rng-seed time --order lex --user-dir test_user_dir_$$$$ $@
 
 check: $(TEST_TARGET) $(TEST_BATCHES)
 

--- a/tests/archery_damage_test.cpp
+++ b/tests/archery_damage_test.cpp
@@ -119,7 +119,7 @@ static void test_archery_balance( const itype_id &weapon_type, const itype_id &a
     }
 }
 
-TEST_CASE( "archery_damage_thresholds", "[balance],[archery]" )
+TEST_CASE( "archery_damage_thresholds", "[balance] [archery]" )
 {
     // undodgable bolt fired with a guaranteed crit 10 times
 

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -1281,7 +1281,7 @@ static void test_skill_progression( const recipe_id &test_recipe, int expected_t
     CHECK( actual_turns_taken == expected_turns_taken );
 }
 
-TEST_CASE( "crafting_skill_gain", "[skill],[crafting],[slow]" )
+TEST_CASE( "crafting_skill_gain", "[skill] [crafting] [slow]" )
 {
     SECTION( "lvl 0 -> 1" ) {
         GIVEN( "nominal morale" ) {

--- a/tests/creature_in_field_test.cpp
+++ b/tests/creature_in_field_test.cpp
@@ -11,7 +11,7 @@
 
 static const vproto_id vehicle_prototype_handjack( "handjack" );
 
-TEST_CASE( "creature_in_field", "[monster],[field]" )
+TEST_CASE( "creature_in_field", "[monster] [field]" )
 {
     static const tripoint_bub_ms target_location{ 5, 5, 0 };
     clear_map_without_vision();

--- a/tests/explosion_balance_test.cpp
+++ b/tests/explosion_balance_test.cpp
@@ -221,7 +221,7 @@ static void check_vehicle_damage( const itype_id &explosive_id, const std::strin
     CHECK( after_hp_total <= ceil( before_hp_total * damage_upper_bound ) );
 }
 
-TEST_CASE( "grenade_lethality_scaling_with_size", "[grenade],[explosion],[balance]" )
+TEST_CASE( "grenade_lethality_scaling_with_size", "[grenade] [explosion] [balance]" )
 {
     // We want monsters of different sizes with the same armor to test that we aren't scaling damage with size.
     float tiny = get_damage_vs_target( "mon_spawn_raptor" );
@@ -243,14 +243,14 @@ TEST_CASE( "grenade_lethality_scaling_with_size", "[grenade],[explosion],[balanc
     CHECK( large_armored == Approx( huge_armored ).margin( 1.0 ) );
 }
 
-TEST_CASE( "grenade_lethality", "[grenade],[explosion],[balance],[slow]" )
+TEST_CASE( "grenade_lethality", "[grenade] [explosion] [balance] [slow]" )
 {
     check_lethality( itype_grenade_act, 0, 0.99, 0.06, outcome_type::Kill );
     check_lethality( itype_grenade_act, 5, 0.95, 0.06, outcome_type::Kill );
     check_lethality( itype_grenade_act, 15, 0.40, 0.06, outcome_type::Casualty );
 }
 
-TEST_CASE( "grenade_vs_vehicle", "[grenade],[explosion],[balance]" )
+TEST_CASE( "grenade_vs_vehicle", "[grenade] [explosion] [balance]" )
 {
     /* as of test writing, car hp is 17653. 0.998 of that means the grenade
      * has to do more than 36 points of damage to 'fail', which isn't remotely

--- a/tests/monster_attack_test.cpp
+++ b/tests/monster_attack_test.cpp
@@ -191,7 +191,7 @@ TEST_CASE( "monster_attack", "[vision][reachability]" )
                            true, false, true );
 }
 
-TEST_CASE( "monster_throwing_sanity_test", "[throwing],[balance]" )
+TEST_CASE( "monster_throwing_sanity_test", "[throwing] [balance]" )
 {
     std::array<float, 6> expected_average_damage_at_range = { 0, 0, 8.5, 6.5, 5, 3.25 };
     clear_map_without_vision();

--- a/tests/reload_option_test.cpp
+++ b/tests/reload_option_test.cpp
@@ -29,7 +29,7 @@ static const itype_id itype_m134( "m134" );
 static const itype_id itype_sw_619( "sw_619" );
 static const itype_id itype_water_clean( "water_clean" );
 
-TEST_CASE( "revolver_reload_option", "[reload],[reload_option],[gun]" )
+TEST_CASE( "revolver_reload_option", "[reload] [reload_option] [gun]" )
 {
     avatar dummy;
     dummy.worn.wear_item( dummy, item( itype_backpack ), false, false );
@@ -55,7 +55,7 @@ TEST_CASE( "revolver_reload_option", "[reload],[reload_option],[gun]" )
     CHECK( gun_speedloader_option.qty() == speedloader->ammo_capacity( gun_ammo_type ) );
 }
 
-TEST_CASE( "magazine_reload_option", "[reload],[reload_option],[gun]" )
+TEST_CASE( "magazine_reload_option", "[reload] [reload_option] [gun]" )
 {
     avatar dummy;
     dummy.worn.wear_item( dummy, item( itype_backpack ), false, false );
@@ -74,7 +74,7 @@ TEST_CASE( "magazine_reload_option", "[reload],[reload_option],[gun]" )
     CHECK( gun_option.qty() == 1 );
 }
 
-TEST_CASE( "belt_reload_option", "[reload],[reload_option],[gun]" )
+TEST_CASE( "belt_reload_option", "[reload] [reload_option] [gun]" )
 {
     avatar dummy;
     dummy.set_body();
@@ -101,7 +101,7 @@ TEST_CASE( "belt_reload_option", "[reload],[reload_option],[gun]" )
     CHECK( gun_option.qty() == 1 );
 }
 
-TEST_CASE( "canteen_reload_option", "[reload],[reload_option],[liquid]" )
+TEST_CASE( "canteen_reload_option", "[reload] [reload_option] [liquid]" )
 {
     avatar dummy;
     dummy.worn.wear_item( dummy, item( itype_backpack ), false, false );

--- a/tests/reload_time_test.cpp
+++ b/tests/reload_time_test.cpp
@@ -73,7 +73,7 @@ static void check_reload_time( const itype_id &weapon, const itype_id &ammo,
     CHECK( spent_moves < expected_upper );
 }
 
-TEST_CASE( "reload_from_inventory_times", "[reload],[inventory],[balance]" )
+TEST_CASE( "reload_from_inventory_times", "[reload] [inventory] [balance]" )
 {
     // Build a list of gear loadouts ranked by expected firing speed.
     clear_avatar();

--- a/tests/reloading_test.cpp
+++ b/tests/reloading_test.cpp
@@ -180,7 +180,7 @@ TEST_CASE( "reload_magazines", "[reload]" )
 
 }
 
-TEST_CASE( "reload_gun_with_casings", "[reload],[gun]" )
+TEST_CASE( "reload_gun_with_casings", "[reload] [gun]" )
 {
 
     SECTION( "empty gun" ) {
@@ -246,7 +246,7 @@ TEST_CASE( "reload_gun_with_casings", "[reload],[gun]" )
     }
 }
 
-TEST_CASE( "reload_gun_with_magazine", "[reload],[gun]" )
+TEST_CASE( "reload_gun_with_magazine", "[reload] [gun]" )
 {
     SECTION( "empty gun" ) {
         item gun( itype_glock_19 );
@@ -514,7 +514,7 @@ TEST_CASE( "liquid_reloading", "[reload]" )
     }
 }
 
-TEST_CASE( "speedloader_reloading", "[reload],[gun]" )
+TEST_CASE( "speedloader_reloading", "[reload] [gun]" )
 {
     SECTION( "empty gun" ) {
         item gun( itype_sw_610 );
@@ -638,7 +638,7 @@ TEST_CASE( "speedloader_reloading", "[reload],[gun]" )
     }
 }
 
-TEST_CASE( "gunmod_reloading", "[reload],[gun]" )
+TEST_CASE( "gunmod_reloading", "[reload] [gun]" )
 {
     SECTION( "empty gun and gunmod" ) {
         item gun( itype_debug_modular_m4_carbine );
@@ -804,7 +804,7 @@ TEST_CASE( "gunmod_reloading", "[reload],[gun]" )
     }
 }
 
-TEST_CASE( "reload_gun_with_integral_magazine", "[reload],[gun]" )
+TEST_CASE( "reload_gun_with_integral_magazine", "[reload] [gun]" )
 {
     Character &dummy = get_avatar();
 
@@ -825,7 +825,7 @@ TEST_CASE( "reload_gun_with_integral_magazine", "[reload],[gun]" )
     REQUIRE( gun->remaining_ammo_capacity() == 0 );
 }
 
-TEST_CASE( "reload_gun_with_integral_magazine_using_speedloader", "[reload],[gun]" )
+TEST_CASE( "reload_gun_with_integral_magazine_using_speedloader", "[reload] [gun]" )
 {
     Character &dummy = get_avatar();
 
@@ -868,7 +868,7 @@ TEST_CASE( "reload_gun_with_integral_magazine_using_speedloader", "[reload],[gun
     REQUIRE( dummy.has_item( *speedloader ) );
 }
 
-TEST_CASE( "reload_gun_with_swappable_magazine", "[reload],[gun]" )
+TEST_CASE( "reload_gun_with_swappable_magazine", "[reload] [gun]" )
 {
     Character &dummy = get_avatar();
 
@@ -945,7 +945,7 @@ static void reload_a_revolver( Character &dummy, item &gun, item &ammo )
     }
 }
 
-TEST_CASE( "automatic_reloading_action", "[reload],[gun]" )
+TEST_CASE( "automatic_reloading_action", "[reload] [gun]" )
 {
     Character &dummy = get_avatar();
 
@@ -1130,7 +1130,7 @@ TEST_CASE( "automatic_reloading_action", "[reload],[gun]" )
 }
 
 // TODO: nested containers and frozen liquids.
-TEST_CASE( "reload_liquid_container", "[reload],[liquid]" )
+TEST_CASE( "reload_liquid_container", "[reload] [liquid]" )
 {
     Character &dummy = get_avatar();
     clear_avatar();

--- a/tests/throwing_test.cpp
+++ b/tests/throwing_test.cpp
@@ -171,7 +171,7 @@ static constexpr throw_test_pstats mid_skill_base_stats = { MAX_SKILL / 2, 8, 8,
 static constexpr throw_test_pstats hi_skill_base_stats = { MAX_SKILL, 8, 8, 8 };
 static constexpr throw_test_pstats hi_skill_athlete_stats = { MAX_SKILL, 12, 12, 12 };
 
-TEST_CASE( "basic_throwing_sanity_tests", "[throwing],[balance]" )
+TEST_CASE( "basic_throwing_sanity_tests", "[throwing] [balance]" )
 {
     avatar &p = get_avatar();
     clear_map_without_vision();
@@ -216,7 +216,7 @@ TEST_CASE( "basic_throwing_sanity_tests", "[throwing],[balance]" )
     }
 }
 
-TEST_CASE( "throwing_skill_impact_test", "[throwing],[balance]" )
+TEST_CASE( "throwing_skill_impact_test", "[throwing] [balance]" )
 {
     avatar &p = get_avatar();
     clear_map_without_vision();
@@ -304,7 +304,7 @@ static void test_player_kills_monster(
     CHECK( num_failures <= 1 );
 }
 
-TEST_CASE( "player_kills_zombie_before_reach", "[throwing],[balance][scenario]" )
+TEST_CASE( "player_kills_zombie_before_reach", "[throwing] [balance] [scenario]" )
 {
     avatar &p = get_avatar();
     clear_map_without_vision();
@@ -314,7 +314,7 @@ TEST_CASE( "player_kills_zombie_before_reach", "[throwing],[balance][scenario]" 
     }
 }
 
-TEST_CASE( "time_to_throw_independent_of_number_of_projectiles", "[throwing],[balance]" )
+TEST_CASE( "time_to_throw_independent_of_number_of_projectiles", "[throwing] [balance]" )
 {
     Character &you = get_avatar();
     clear_avatar();


### PR DESCRIPTION
#### Summary
Infrastructure "Fix CI skip-detection job references, test Makefile parallel safety, and test tag syntax"

#### Purpose of change

Three small, independent test infrastructure fixes found during a test system audit:

1. **matrix.yml SKIP condition references non-existent jobs.** The `SKIP` env var references `needs.skip-duplicates` and `needs.skip-duplicates-mods`, but the declared jobs are `skip-duplicates-code` and `skip-duplicates-data`. This either makes skip-detection silently no-op or errors out.

2. **`tests/Makefile` parallel shard runs can collide on filesystem state.** The batch targets all write to the default `test_user_dir/`. With `make -jN check` they stomp on each other. CI scripts already pass unique `--user-dir` per shard -- the Makefile was the only surface missing this.

3. **Comma-separated TEST_CASE tags are deprecated (v2) and removed (v3).** 25 declarations across 9 files used `[tag1],[tag2]`. Also fixed one missing space between adjacent tags in `throwing_test.cpp`.

#### Describe the solution

- matrix.yml: corrected job references to `skip-duplicates-code` / `skip-duplicates-data`. Same for the commented emscripten block.
- tests/Makefile: added `--user-dir test_user_dir_$$$$` (expands to shell PID, unique per concurrent shard).
- Test tags: `],[` -> `] [` across all affected files, plus one `][` -> `] [` fix.

#### Describe alternatives you've considered

- For the Makefile, could have used `.NOTPARALLEL` to force sequential execution, but that penalizes people who want `make -j` for faster local runs. Could also restructure into numbered targets, but that triples the recipe for no gain.
- For tags, could have also unified the `][` vs `] [` style split across the whole suite (~619 adjacent vs ~45 spaced), but both are valid in v2 and v3. Only the comma syntax actually breaks.

#### Testing

The tag and workflow changes are mechanical and have no behavioral impact on test outcomes. The Makefile change adds a CLI flag at runtime only.

#### Additional context

None