### PR TITLE
Add bounds checks for fake_part_at before indexing into parts

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -8005,7 +8005,7 @@ int vehicle::damage_direct( map &here, vehicle_part &vp, int dmg, const damage_t
         coeff_air_changed = true;
 
         // update the fake part
-        if( vp.has_fake ) {
+        if( vp.has_fake && vp.fake_part_at < static_cast<int>( parts.size() ) ) {
             parts[vp.fake_part_at].base = vp.base;
         }
         // refresh cache in case the broken part has changed the status

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1295,7 +1295,9 @@ bool vehicle::can_close( int part_index, Character &who )
                 if( doors::check_mon_blocking_door( who, abs_part_pos( parts[partID] ) ) ) {
                     return false;
                 }
-                if( parts[partID].has_fake && parts[parts[partID].fake_part_at].is_active_fake ) {
+                if( parts[partID].has_fake &&
+                    parts[partID].fake_part_at < static_cast<int>( parts.size() ) &&
+                    parts[parts[partID].fake_part_at].is_active_fake ) {
                     partID = parts[partID].fake_part_at;
                 } else {
                     partID = -1;


### PR DESCRIPTION
#### Summary
Bugfixes "Add missing bounds checks for fake_part_at in vehicle damage and door closing"

#### Purpose of change

`damage_direct` and `can_close` index into the `parts` vector using `fake_part_at` without checking bounds first. Other call sites (`remove_part`, `refresh`) already have this guard. Observed as a SIGSEGV during riot-damage mapgen while investigating a CI failure in https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/22366266242/job/64733012315?pr=85522.

#### Describe the solution

Add the same `fake_part_at < static_cast<int>( parts.size() )` check that `remove_part` and `refresh` already use.

#### Describe alternatives you've considered

Could use `parts.at()` for a throwing bounds check instead, but the silent skip matches the existing convention at the other call sites.

#### Testing

Compiles cleanly with `-Werror`. The crash is intermittent and seed-dependent so couldn't reliably reproduce locally.

#### Additional context

None