### PR TITLE
Mark overmap_terrain_coverage test as mayfail

### DIFF
--- a/tests/overmap_test.cpp
+++ b/tests/overmap_test.cpp
@@ -473,7 +473,7 @@ static void finalize_item_counts( std::unordered_map<itype_id, float> &item_coun
 // Toggle this to enable the (very very very expensive) item demographics test.
 static bool enable_item_demographics = false;
 
-TEST_CASE( "overmap_terrain_coverage", "[overmap][slow]" )
+TEST_CASE( "overmap_terrain_coverage", "[overmap][slow][!mayfail]" )
 {
     // The goal of this test is to generate a lot of overmaps, and count up how
     // many times we see each terrain, so that we can check that everything


### PR DESCRIPTION
#### Summary
Infrastructure "Mark overmap_terrain_coverage test as mayfail"

#### Purpose of change

`overmap_terrain_coverage` fails intermittently due to RNG-dependent overmap generation, blocking CI on unrelated PRs.

#### Describe the solution

Tag the test with `[!mayfail]` so Catch2 treats failures as expected -- the test still runs and reports results, but won't produce a non-zero exit code.

#### Describe alternatives you've considered

Not much really -- mapgen tests need more attention than a quick threshold tweak can give them.

#### Testing

N/A

#### Additional context

None.