### PR TITLE
Mark monsters_appear_on_map_as_expected test as mayfail

### DIFF
--- a/tests/monster_test.cpp
+++ b/tests/monster_test.cpp
@@ -1081,7 +1081,7 @@ static void dormant_monsters_spawn_correctly( const tripoint_abs_omt &origin )
     CHECK( g->num_creatures() == num_creatures_prev - 1UL );
 }
 
-TEST_CASE( "monsters_appear_on_map_as_expected", "[monster][map][hordes]" )
+TEST_CASE( "monsters_appear_on_map_as_expected", "[monster][map][hordes][!mayfail]" )
 {
     tripoint_abs_omt origin{ 90, 90, 0 };
     // This clear_area call is very expensive, so just do it once for all the related


### PR DESCRIPTION
#### Summary
Infrastructure "Mark monsters_appear_on_map_as_expected test as mayfail"

#### Purpose of change

`monsters_appear_on_map_as_expected` fails intermittently due to RNG, blocking CI on unrelated PRs.

#### Describe the solution

Tag the test with `[!mayfail]` so Catch2 treats failures as expected -- the test still runs and reports results, but won't produce a non-zero exit code.

#### Describe alternatives you've considered

Not much -- mapgen tests need more attention than a quick threshold tweak can give them.

#### Testing

N/A

#### Additional context

Same idea as #85525.