### PR TITLE
Add IWYU suggested fixes to PRs via reviewdog

### DIFF
--- a/.github/workflows/iwyu-linter.yml
+++ b/.github/workflows/iwyu-linter.yml
@@ -1,0 +1,92 @@
+name: IWYU Suggester
+
+on:
+  pull_request_target:
+    types: ['opened', 'reopened', 'synchronize', 'ready_for_review']
+    paths:
+      - '**.cpp'
+      - '**.h'
+      - '**.c'
+  pull_request:
+    types: ['opened', 'reopened', 'synchronize', 'ready_for_review']
+    paths:
+      - '**.cpp'
+      - '**.h'
+      - '**.c'
+
+concurrency:
+  group: iwyu-linter-${{ github.event.pull_request.number }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+jobs:
+  iwyu-suggest:
+    if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.draft == false }}
+    runs-on: ubuntu-24.04
+    env:
+      COMPILER: clang++-19
+    steps:
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        ref: '${{ github.event.pull_request.head.sha }}'
+        persist-credentials: false
+
+    - name: install LLVM 19
+      run: sudo apt install llvm-19-dev clang-19 libclang-19-dev cmake
+
+    - name: checkout IWYU repository
+      id: iwyu-checkout
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        repository: include-what-you-use/include-what-you-use
+        path: include-what-you-use-src
+        ref: clang_19
+        persist-credentials: false
+
+    - name: cache IWYU build
+      id: iwyu-cache
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        path: iwyu-build
+        key: iwyu-clang19-ubuntu2404-${{ steps.iwyu-checkout.outputs.commit }}
+
+    - name: build IWYU
+      if: steps.iwyu-cache.outputs.cache-hit != 'true'
+      run: |
+        cmake -B iwyu-build -DCMAKE_PREFIX_PATH=/usr/lib/llvm-19 \
+              -DCMAKE_BUILD_TYPE=Release include-what-you-use-src
+        cmake --build iwyu-build --parallel 4
+
+    - name: determine changed files
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+      with:
+        script: |
+          var fs = require('fs');
+          const response = await github.paginate(github.rest.pulls.listFiles,
+            {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            }
+          );
+          const files = response.map(x => x.filename);
+          for (const path of files) { console.log(path); }
+          fs.writeFileSync("files_changed", files.join('\n') + '\n');
+
+    - name: create compilation database
+      run: |
+        cmake -B build \
+          -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+          -DCMAKE_CXX_COMPILER=$COMPILER \
+          -DCMAKE_BUILD_TYPE=Release .
+        make includes -j4 --silent
+
+    - name: run IWYU and apply fixes
+      run: |
+        export PATH="${PWD}/iwyu-build/bin:${PWD}/include-what-you-use-src:${PATH}"
+        python build-scripts/ci-iwyu-suggest.py
+
+    - name: 'suggester / IWYU'
+      uses: reviewdog/action-suggester@aa38384ceb608d00f84b4690cacc83a5aba307ff # v1
+      if: ${{ always() }}
+      with:
+        tool_name: 'IWYU'

--- a/.github/workflows/iwyu-linter.yml
+++ b/.github/workflows/iwyu-linter.yml
@@ -77,8 +77,12 @@ jobs:
         cmake -B build \
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
           -DCMAKE_CXX_COMPILER=$COMPILER \
-          -DCMAKE_BUILD_TYPE=Release .
-        make includes -j4 --silent
+          -DCMAKE_BUILD_TYPE=Release \
+          -DTILES=${TILES:-0} \
+          -DSOUND=${SOUND:-0} \
+          -DLOCALIZE=${LOCALIZE:-0} \
+          .
+        make includes -j4 --silent TILES=${TILES:-0} SOUND=${SOUND:-0} LOCALIZE=${LOCALIZE:-0}
 
     - name: run IWYU and apply fixes
       run: |

--- a/build-scripts/ci-iwyu-suggest.py
+++ b/build-scripts/ci-iwyu-suggest.py
@@ -1,0 +1,175 @@
+# Companion to ci-iwyu-run.py for the IWYU suggester workflow.
+# Runs IWYU and pipes the output through fix_includes.py to apply
+# fixes in-place. reviewdog/action-suggester then diffs against
+# the original and posts suggested changes on the PR.
+
+import os
+import subprocess
+import sys
+
+from pathlib import Path
+
+CHANGED_FILES_INDEX = "files_changed"
+GET_AFFECTED_FILES_SCRIPT = "build-scripts/get_affected_files.py"
+BLACKLIST_PATH = "tools/iwyu/bad_files.txt"
+
+
+def main():
+    print("::group::Determining files to analyze")
+
+    changed_files = get_changed_files()
+    print("changed files:")
+    print_list(changed_files)
+
+    affected_files = get_affected_files(changed_files)
+    print("affected files:")
+    print_list(affected_files)
+
+    files_to_analyze = filter_analyzable_files(affected_files)
+    print("files to analyze:")
+    print_list(files_to_analyze)
+    print("::endgroup::")
+
+    if not files_to_analyze:
+        print("Nothing to analyze!")
+        return
+
+    run_iwyu_and_fix(files_to_analyze)
+
+
+def get_changed_files() -> list[Path]:
+    files_index = Path(CHANGED_FILES_INDEX)
+    if not files_index.exists():
+        print("no changed files index -- analyzing entire codebase")
+        return generate_global_file_list()
+    paths = []
+    with open(files_index) as f:
+        for line in f.readlines():
+            line = line.strip()
+            if line:
+                paths.append(Path(line))
+    return paths
+
+
+def get_affected_files(changed_files: list[Path]) -> list[Path]:
+    global_files = set(Path(x) for x in [
+        ".github/workflows/iwyu-linter.yml",
+        "build-scripts/ci-iwyu-suggest.py",
+        "build-scripts/get_affected_files.py",
+        "tools/iwyu",
+        "CMakeLists.txt",
+        "src/CMakeLists.txt",
+        "tests/CMakeLists.txt",
+    ])
+    for changed in changed_files:
+        if changed in global_files or any(
+                parent in global_files for parent in changed.parents):
+            print("File %s affects global config, analyzing all files"
+                  % changed)
+            return generate_global_file_list()
+
+    if not Path(CHANGED_FILES_INDEX).exists():
+        return generate_global_file_list()
+
+    out = subprocess.run(
+        [GET_AFFECTED_FILES_SCRIPT,
+         "--changed-files-list", CHANGED_FILES_INDEX],
+        capture_output=True, encoding="utf-8")
+    if out.returncode != 0:
+        print("get_affected_files.py failed (code %d)" % out.returncode,
+              file=sys.stderr)
+        print("stdout: %s" % out.stdout, file=sys.stderr)
+        print("stderr: %s" % out.stderr, file=sys.stderr)
+        sys.exit(1)
+    return [Path(line.strip()) for line in out.stdout.splitlines()
+            if line.strip()]
+
+
+def generate_global_file_list() -> list[Path]:
+    paths = []
+    for d in [Path("src"), Path("tests")]:
+        for item in os.listdir(d):
+            p = d / item
+            if p.is_file() and p.suffix == ".cpp":
+                paths.append(p)
+    paths.sort()
+    return paths
+
+
+def filter_analyzable_files(in_files: list[Path]) -> list[Path]:
+    blacklist = []
+    with open(BLACKLIST_PATH, "r") as f:
+        for line in f.readlines():
+            line = line.strip()
+            if line and not line.startswith("#"):
+                blacklist.append(line)
+
+    result = []
+    for p in in_files:
+        if p.suffix != ".cpp":
+            continue
+        p_str = str(p.as_posix())
+        if not any(pattern in p_str for pattern in blacklist):
+            result.append(p)
+    return result
+
+
+def run_iwyu_and_fix(files: list[Path]):
+    cdda_root = Path(__file__).parent.parent
+    mapping_path = cdda_root / "tools/iwyu/cata.imp"
+
+    iwyu_args = ["iwyu_tool.py"]
+    iwyu_args.extend(str(f) for f in files)
+    iwyu_args.extend(["-p", "build", "--jobs", "4"])
+    iwyu_args.extend(["--"])
+    iwyu_args.extend([
+        "-Xiwyu", "--mapping_file=%s" % mapping_path,
+        "-Xiwyu", "--cxx17ns",
+        "-Xiwyu", "--comment_style=long",
+        "-Xiwyu", "--max_line_length=1000"])
+
+    fix_args = ["fix_includes.py", "--nosafe_headers", "--reorder"]
+
+    print("::group::IWYU + fix_includes output")
+    print("Running IWYU: %s" % " ".join(iwyu_args[:5]))
+    print("Piping through: %s" % " ".join(fix_args))
+    sys.stdout.flush()
+
+    # Only pipe stdout to fix_includes -- stderr must stay separate
+    # so it doesn't corrupt the IWYU output format.
+    iwyu_proc = subprocess.Popen(
+        iwyu_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    fix_proc = subprocess.Popen(
+        fix_args, stdin=iwyu_proc.stdout, stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT, encoding="utf-8")
+    iwyu_proc.stdout.close()
+
+    fix_output, _ = fix_proc.communicate()
+    _, iwyu_stderr = iwyu_proc.communicate()
+    iwyu_proc.wait()
+
+    if iwyu_stderr:
+        print("IWYU stderr:")
+        print(iwyu_stderr.decode("utf-8", errors="replace"))
+    if fix_output:
+        print("fix_includes output:")
+        print(fix_output)
+    print("::endgroup::")
+    print("IWYU exit code: %d, fix_includes exit code: %d"
+          % (iwyu_proc.returncode, fix_proc.returncode))
+
+
+def print_list(things: list):
+    line = ""
+    for thing in things:
+        thing = str(thing)
+        if len(line) + len(thing) > 1000:
+            print("  %s" % line)
+            line = ""
+        line = "%s %s" % (line, thing)
+    if line:
+        print("  %s" % line)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/weather_type.cpp
+++ b/src/weather_type.cpp
@@ -1,5 +1,7 @@
 #include "weather_type.h"
 
+#include <deque>
+
 #include "condition.h"
 #include "debug.h"
 #include "flexbuffer_json.h"

--- a/src/weather_type.cpp
+++ b/src/weather_type.cpp
@@ -1,7 +1,5 @@
 #include "weather_type.h"
 
-#include <deque>
-
 #include "condition.h"
 #include "debug.h"
 #include "flexbuffer_json.h"


### PR DESCRIPTION
#### Summary
Infrastructure "Add IWYU suggested fixes to PRs via reviewdog"

#### Purpose of change

The astyle linter already posts click-to-apply suggested changes on PRs via reviewdog. IWYU only posts annotations that tell you what to fix but don't let you apply with one click. This adds the same convenience for IWYU.

#### Describe the solution

New workflow (`.github/workflows/iwyu-linter.yml`) that mirrors the existing `linter.yml` pattern:
- Runs on `pull_request_target` for write access on fork PRs
- Builds IWYU (reuses the same cache as `iwyu.yml`)
- Runs IWYU on affected files, pipes output through `fix_includes.py` to apply fixes in-place
- `reviewdog/action-suggester` diffs against the original and posts suggested changes

New script `build-scripts/ci-iwyu-suggest.py` handles file selection (same logic as `ci-iwyu-run.py` -- changed files, transitive deps, blacklist filtering) and the IWYU-to-fix_includes pipeline.

The existing `iwyu.yml` check is unchanged -- it stays as the pass/fail gate.

#### Describe alternatives you've considered

Merging into `linter.yml` as a second job -- decided against it since IWYU needs a heavy build environment (LLVM 19, cmake compile DB) that has nothing to do with the astyle job.

#### Testing

Verified locally that the IWYU raw output pipes correctly through `fix_includes.py` and produces the expected diff.

Tested end-to-end on a fork PR with a deliberate unused include: https://github.com/dumb-kevin/Cataclysm-DDA/pull/1 -- the workflow successfully posted a click-to-apply suggestion to remove the unused `#include <list>`.

#### Additional context

Note: this workflow uses `pull_request_target`, so it won't trigger until merged to master (same as the existing `linter.yml`). The fork test above confirms it works once on the default branch.