### PR TITLE
[XE] Fixes opening keypad locked doors via deduction

### DIFF
--- a/data/json/mapgen/xedra_fishing_shack.json
+++ b/data/json/mapgen/xedra_fishing_shack.json
@@ -37,14 +37,7 @@
         {
           "id": "eoc_xedra_unlock_elock",
           "condition": { "compare_string": [ "yes", { "u_val": "knows_xedra_field_station_3_passcode" } ] },
-          "effect": [
-            { "u_location_variable": { "global_val": "door_transform" }, "min_radius": 1, "max_radius": 2 },
-            {
-              "u_transform_radius": 2,
-              "ter_furn_transform": "unlock_elock",
-              "target_var": { "global_val": "door_transform" }
-            }
-          ],
+          "effect": [ { "u_transform_radius": 2, "ter_furn_transform": "unlock_elock_xedra3" } ],
           "false_effect": { "u_message": "You press four random buttons and nothing happens.", "popup": true }
         }
       ]
@@ -52,7 +45,7 @@
   },
   {
     "type": "ter_furn_transform",
-    "id": "unlock_elock",
+    "id": "unlock_elock_xedra3",
     "terrain": [
       {
         "result": [ "t_door_metal_c" ],

--- a/data/mods/Xedra_Evolved/furniture_and_terrain/terrain-doors.json
+++ b/data/mods/Xedra_Evolved/furniture_and_terrain/terrain-doors.json
@@ -55,10 +55,10 @@
     "can_resume": false,
     "interruptable": false,
     "interruptable_with_kb": false,
-    "completion_eoc": "EOC_UNLOCK_ELOCK"
+    "completion_eoc": "EOC_UNLOCK_ELOCK_ACTUAL"
   },
   {
-    "id": "EOC_UNLOCK_ELOCK",
+    "id": "EOC_UNLOCK_ELOCK_ACTUAL",
     "type": "effect_on_condition",
     "condition": { "roll_contested": { "math": [ "u_skill('deduction')" ] }, "difficulty": 12 },
     "effect": [

--- a/data/mods/Xedra_Evolved/furniture_and_terrain/terrain-doors.json
+++ b/data/mods/Xedra_Evolved/furniture_and_terrain/terrain-doors.json
@@ -47,6 +47,27 @@
     }
   },
   {
+    "id": "ACT_KEYPAD_ENTRY",
+    "type": "activity_type",
+    "activity_level": "NO_EXERCISE",
+    "verb": "pressing keys",
+    "based_on": "speed",
+    "can_resume": false,
+    "interruptable": false,
+    "interruptable_with_kb": false,
+    "completion_eoc": "EOC_UNLOCK_ELOCK"
+  },
+  {
+    "id": "EOC_UNLOCK_ELOCK",
+    "type": "effect_on_condition",
+    "condition": { "roll_contested": { "math": [ "u_skill('deduction')" ] }, "difficulty": 12 },
+    "effect": [
+      { "u_transform_radius": 2, "ter_furn_transform": "unlock_elock" },
+      { "u_message": "The numpad glows green and emits a happy chirp as the door unlocks.", "popup": true }
+    ],
+    "false_effect": { "u_message": "The numpad flashes while beeping angrily at you.", "popup": true }
+  },
+  {
     "type": "terrain",
     "id": "t_door_elocked",
     "name": "closed wood door with an electronic lock",
@@ -74,23 +95,8 @@
       "effect_on_conditions": [
         {
           "id": "eoc_unlock_elock",
-          "condition": { "roll_contested": { "math": [ "u_skill('deduction')" ] }, "difficulty": 12 },
-          "effect": [
-            { "u_location_variable": { "global_val": "door_transform" }, "min_radius": 1, "max_radius": 2 },
-            {
-              "u_transform_radius": 2,
-              "ter_furn_transform": "unlock_elock",
-              "target_var": { "global_val": "door_transform" }
-            },
-            {
-              "u_transform_radius": 2,
-              "ter_furn_transform": "unlock_elock",
-              "target_var": { "global_val": "door_transform" },
-              "time_in_future": [ "2 seconds", "10 seconds" ]
-            },
-            { "u_message": "The numpad glows green and emits a happy chirp as the door unlocks.", "popup": true }
-          ],
-          "false_effect": { "u_message": "The numpad flashes while beeping angrily at you.", "popup": true }
+          "condition": { "u_query": "Try to deduce the key code?", "default": false },
+          "effect": [ { "u_assign_activity": "ACT_KEYPAD_ENTRY", "duration": "1 seconds" } ]
         }
       ]
     },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[XE] Fixes opening keypad locked doors via deduction"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #85444
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Change the EOC to open the door to not use a variable, the ter_furn_transform will use the players position when it fires which is enough. Using the variable that covered a large area around the player would sometimes miss the door when firing the ter_furn_transform.

At the same time, I encountered two related issues.
First the examine action and EOC take 0 time so the player could just spam the guesses as fast as they wanted.
I added a forced one second no exercise activity to examining the doors if the player chooses to try to guess the combination.
The player is asked if they want to try since it now takes time, plus it clarifies what the player is doing when they examine those doors.
Second the xedra fishing shack mission from #84688 used the same bugged solution for it's keypad locked door
I ported the same ter_furn_transform fix to it. I also fixed a name collision between its ter_furn_transform and the XE ter_furn_transform. 
I did not add a forced activity to this one since it cannot be guessed so there is no free actions here.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Finding a generic way to have a single activity that is the player pressing keys on the keypads for similar doors but without hard coding an activity actor I did not come up with a simple solution. The activity has to use an on completion eoc property to trigger the doors opening so each group of doors would require their own activity.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Opened every single keypad door as expected. Tame is spent when entering combinations for success or failure.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
