### PR TITLE
Cache vcpkg installed packages in MSVC CI

### DIFF
--- a/.github/workflows/msvc-full-features.yml
+++ b/.github/workflows/msvc-full-features.yml
@@ -98,6 +98,12 @@ jobs:
       env:
         RUNNER_WORKSPACE: ${{ runner.workspace }}
 
+    - name: Cache vcpkg installed packages
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        path: msvc-full-features/vcpkg_installed
+        key: vcpkg-installed-${{ hashFiles('msvc-full-features/vcpkg.json', '.github/vcpkg_triplets/x64-windows-static.cmake') }}-1b6e030cf096faf4f82d7b7025de8b2abee3e3df
+
     - name: Download ccache
       uses: robinraju/release-downloader@368754b9c6f47c345fcfbf42bcb577c2f0f5f395 # v1.9
       with:


### PR DESCRIPTION
#### Summary
Build "Cache vcpkg installed packages in MSVC CI"

#### Purpose of change

The `run-vcpkg` action sets `VCPKG_BINARY_SOURCES=clear;x-gha,readwrite`, but the `x-gha` backend was [removed from vcpkg in mid-2025](https://github.com/lukka/run-vcpkg/issues/251). Every CI run downloads and compiles all vcpkg dependencies from scratch, which is slow and breaks when upstream servers have transient outages -- e.g. [this run](https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/22383807040/job/64790110177?pr=85529) failing because `gitlab.freedesktop.org` returned 502/504 during freetype downloads.

#### Describe the solution

Add an `actions/cache` step that caches `msvc-full-features/vcpkg_installed/`. The cache key includes a hash of `vcpkg.json` + the triplet file, plus the pinned vcpkg commit. On cache hit, vcpkg's MSBuild integration sees packages already installed and skips all downloads/builds. On miss, normal behavior (download + build from source).

#### Describe alternatives you've considered

- `restore-keys` prefix matching for partial cache hits -- risky with vcpkg since mismatched commits can cause ABI issues, so exact match is safer.
- Fixing the `x-gha` backend -- that's upstream vcpkg's problem and the [removal was intentional](https://devblogs.microsoft.com/cppblog/whats-new-in-vcpkg-june-2025/).
- vcpkg [binary caching to GitHub Packages](https://learn.microsoft.com/en-us/vcpkg/consume/binary-caching-github-packages) via NuGet -- much more setup for the same outcome.

#### Testing

- First CI run will be a cache miss, normal build.
- Re-run or subsequent push should hit the cache and skip vcpkg installation entirely.

#### Additional context

None