### PR TITLE
Auto-retry flaky RNG tests with new seeds in CI

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -324,6 +324,26 @@ jobs:
     - name: run tests
       if: ${{ env.SKIP == 'false' && env.SKIP_TESTS == 'false' }}
       run: bash ./build-scripts/gha_test_only.sh
+    - name: Collect retry failure reports
+      if: ${{ always() && env.SKIP == 'false' && env.SKIP_TESTS == 'false' }}
+      id: retry
+      run: |
+        if [ -f retry_summary.txt ]; then
+          python3 tools/format_retry_comment.py \
+            --summary retry_summary.txt \
+            --job-title "${{ matrix.title }}" > retry_comment.md || true
+          if [ -s retry_comment.md ]; then
+            echo "has_failures=true" >> $GITHUB_OUTPUT
+          fi
+        fi
+    - name: Upload retry failure report
+      if: ${{ always() && steps.retry.outputs.has_failures == 'true' }}
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      with:
+        name: retry-failures-${{ matrix.title || 'unknown' }}
+        path: retry_comment.md
+        if-no-files-found: ignore
+        retention-days: 1
     - run: |
         echo ${{ github.event.number }} > pull_request_id
         echo "true" > ${{ env.ARCHIVE_SUCCESS }}

--- a/.github/workflows/post-retry-result.yml
+++ b/.github/workflows/post-retry-result.yml
@@ -1,0 +1,144 @@
+name: Post Flaky Test Retry Result
+
+
+on:
+  workflow_run:
+    workflows: ["General build matrix"]
+    types:
+      - completed
+
+
+jobs:
+  post-retry-result:
+    runs-on: ubuntu-latest
+    if: >-
+      ${{ github.event.workflow_run.event == 'pull_request' }}
+    steps:
+      - name: Download pr id artifact
+        uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe # v3.1.4
+        with:
+          workflow: ${{ github.event.workflow_run.name }}
+          run_id: ${{ github.event.workflow_run.id }}
+          name: pull_request_id
+          allow_forks: false
+        continue-on-error: true
+        id: pr-id
+      - name: Download retry failure artifacts
+        uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe # v3.1.4
+        with:
+          workflow: ${{ github.event.workflow_run.name }}
+          run_id: ${{ github.event.workflow_run.id }}
+          name: retry-failures-.*
+          name_is_regexp: true
+          allow_forks: false
+        continue-on-error: true
+        id: retry
+      - name: 'Post or update PR comment'
+        if: steps.pr-id.outcome == 'success'
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            // Read PR number
+            const issue_number = Number(fs.readFileSync('./pull_request_id').toString().trim());
+            if (!issue_number) {
+              console.log("No valid PR number found. Exiting.");
+              return;
+            }
+
+            const marker = '### :warning: Flaky Test Retries';
+            const hasRetryArtifacts = '${{ steps.retry.outcome }}' === 'success';
+
+            // Collect all retry markdown fragments
+            let body = '';
+            if (hasRetryArtifacts) {
+              const fragments = [];
+              // Each artifact is downloaded into a directory named after the artifact
+              const entries = fs.readdirSync('.', { withFileTypes: true });
+              for (const entry of entries) {
+                if (entry.isDirectory() && entry.name.startsWith('retry-failures-')) {
+                  const mdPath = path.join(entry.name, 'retry_comment.md');
+                  if (fs.existsSync(mdPath)) {
+                    const content = fs.readFileSync(mdPath, 'utf8').trim();
+                    if (content) {
+                      fragments.push(content);
+                    }
+                  }
+                }
+              }
+              if (fragments.length > 0) {
+                body = [
+                  marker,
+                  '',
+                  `Tests tagged with \`[retry]\` failed in [this CI run](${ process.env.RUN_URL }).`,
+                  "🚨 These failures don't block merging if they pass on retry, but **please check if your changes could be responsible.** Persistent failures across retries indicate a real problem.",
+                  '',
+                  '---',
+                  '',
+                  fragments.join('\n'),
+                ].join('\n');
+              }
+            }
+
+            // Fetch existing comments to find previous retry reports
+            console.log("Fetching comments for PR %d", issue_number);
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue_number,
+            });
+            const prevComments = comments
+              .filter(c => c.user.type === 'Bot' && c.user.login === 'github-actions[bot]')
+              .filter(c => c.body.startsWith(marker));
+
+            if (!body) {
+              // No retry failures this run -- minimize any old comments
+              for (const comment of prevComments) {
+                if (!comment.minimized_reason) {
+                  console.log("Minimizing outdated retry comment (id: %d)", comment.id);
+                  await github.graphql(`
+                    mutation($id: ID!) {
+                      minimizeComment(input: { subjectId: $id, classifier: OUTDATED }) {
+                        clientMutationId
+                      }
+                    }
+                  `, { id: comment.node_id });
+                }
+              }
+              console.log("No retry failures to report. Exiting.");
+              return;
+            }
+
+            // Check if the exact same comment already exists
+            if (prevComments.some(c => c.body === body)) {
+              console.log("Identical retry comment already exists. Exiting.");
+              return;
+            }
+
+            // Minimize old retry comments
+            for (const comment of prevComments) {
+              if (!comment.minimized_reason) {
+                console.log("Minimizing outdated retry comment (id: %d)", comment.id);
+                await github.graphql(`
+                  mutation($id: ID!) {
+                    minimizeComment(input: { subjectId: $id, classifier: OUTDATED }) {
+                      clientMutationId
+                    }
+                  }
+                `, { id: comment.node_id });
+              }
+            }
+
+            // Post new comment
+            console.log("Posting retry failure comment on PR %d", issue_number);
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue_number,
+              body: body,
+            });

--- a/build-scripts/gha_test_only.sh
+++ b/build-scripts/gha_test_only.sh
@@ -13,7 +13,7 @@ cata_test_opts="--min-duration 20 --use-colour yes --rng-seed time --order lex $
 # We might need binaries installed via pip, so ensure that our personal bin dir is on the PATH
 export PATH=$HOME/.local/bin:$PATH
 # export so run_test can read it when executed by parallel
-export cata_test_opts 
+export cata_test_opts
 
 function run_test
 {
@@ -38,6 +38,67 @@ function run_test
 }
 export -f run_test
 
+# Retry [retry]-tagged tests that failed in the initial run.
+# Reads retry_failed_*.txt files (one test name per line) produced by the
+# test binary, re-runs each with a new RNG seed up to 2 more times.
+# Writes retry_summary.txt for the comment formatter.
+function retry_failed_tests
+{
+    local test_bin="$1"
+    local pattern="$2"
+    shift 2
+    local extra_args=("$@")
+    local max_retries=2
+
+    local failed_tests
+    failed_tests=$(cat $pattern 2>/dev/null | sort -u)
+    rm -f $pattern
+    if [ -z "$failed_tests" ]; then
+        # No [retry] failures found. If we were called after a test failure,
+        # it means non-[retry] tests failed.
+        return 1
+    fi
+
+    echo "--- Retrying failed [retry]-tagged tests ---"
+
+    local any_still_failing=false
+    true > retry_summary.txt
+
+    while IFS= read -r test_name; do
+        [ -z "$test_name" ] && continue
+        local passed=false
+        local attempts=1
+
+        for attempt in $(seq 2 $((max_retries + 1))); do
+            attempts=$attempt
+            echo "Retry attempt $attempt for: $test_name"
+            if $WINE "$test_bin" ${cata_test_opts} "$test_name" \
+                --user-dir=retry_user_dir/ \
+                "${extra_args[@]}" 2>&1; then
+                passed=true
+                echo "  -> passed on attempt $attempt"
+                break
+            fi
+        done
+
+        if $passed; then
+            printf 'passed\t%s\t%s\n' "$attempts" "$test_name" >> retry_summary.txt
+        else
+            printf 'failed\t%s\t%s\n' "$attempts" "$test_name" >> retry_summary.txt
+            any_still_failing=true
+        fi
+    done <<< "$failed_tests"
+
+    echo "--- Retry summary ---"
+    cat retry_summary.txt
+
+    if $any_still_failing; then
+        echo "Some tests still failing after all retries"
+        return 1
+    fi
+    return 0
+}
+
 if [ "$CMAKE" = "1" ]
 then
     bin_path="./"
@@ -49,16 +110,36 @@ then
         build_type=Debug
     fi
 
-    # Run regular tests
-    [ -f "${bin_path}cata_test" ] && parallel ${parallel_opts} "run_test $(printf %q "${bin_path}")'/cata_test' '('{}')=> ' --user-dir=test_user_dir_{#} {}" ::: "[slow] ~starting_items" "~[slow] ~[.],starting_items"
-    [ -f "${bin_path}cata_test-tiles" ] && parallel ${parallel_opts} "run_test $(printf %q "${bin_path}")'/cata_test-tiles' '('{}')=> ' --user-dir=test_user_dir_{#} {}" ::: "[slow] ~starting_items" "~[slow] ~[.],starting_items"
+    # Run regular tests; capture exit code so retry_failed_tests can run under set -e
+    test_result=0
+    if [ -f "${bin_path}cata_test" ]; then
+        parallel ${parallel_opts} "run_test $(printf %q "${bin_path}")'/cata_test' '('{}')=> ' --user-dir=test_user_dir_{#} --retry-failed=retry_failed_cmake_{#}.txt {}" ::: "[slow] ~starting_items" "~[slow] ~[.],starting_items" || test_result=$?
+        if [ $test_result -ne 0 ]; then
+            retry_failed_tests "${bin_path}cata_test" 'retry_failed_cmake_*.txt' || exit 1
+        fi
+    fi
+    test_result=0
+    if [ -f "${bin_path}cata_test-tiles" ]; then
+        parallel ${parallel_opts} "run_test $(printf %q "${bin_path}")'/cata_test-tiles' '('{}')=> ' --user-dir=test_user_dir_{#} --retry-failed=retry_failed_cmake_tiles_{#}.txt {}" ::: "[slow] ~starting_items" "~[slow] ~[.],starting_items" || test_result=$?
+        if [ $test_result -ne 0 ]; then
+            retry_failed_tests "${bin_path}cata_test-tiles" 'retry_failed_cmake_tiles_*.txt' || exit 1
+        fi
+    fi
 else
     export ASAN_OPTIONS=detect_odr_violation=1
     export UBSAN_OPTIONS=print_stacktrace=1
-    parallel -j "$num_test_jobs" ${parallel_opts} "run_test './tests/cata_test' '('{}')=> ' --user-dir=test_user_dir_{#} {}" ::: "[slow] ~starting_items" "~[slow] ~[.],starting_items"
+    test_result=0
+    parallel -j "$num_test_jobs" ${parallel_opts} "run_test './tests/cata_test' '('{}')=> ' --user-dir=test_user_dir_{#} --retry-failed=retry_failed_{#}.txt {}" ::: "[slow] ~starting_items" "~[slow] ~[.],starting_items" || test_result=$?
+    if [ $test_result -ne 0 ]; then
+        retry_failed_tests './tests/cata_test' 'retry_failed_*.txt' || exit 1
+    fi
     if [ -n "$MODS" ]
     then
-        parallel -j "$num_test_jobs" ${parallel_opts} "run_test './tests/cata_test' 'Mods-('{}')=> ' $(printf %q "${MODS}") --user-dir=modded_{#} {}" ::: "[slow] ~starting_items" "~[slow] ~[.],starting_items"
+        test_result=0
+        parallel -j "$num_test_jobs" ${parallel_opts} "run_test './tests/cata_test' 'Mods-('{}')=> ' $(printf %q "${MODS}") --user-dir=modded_{#} --retry-failed=retry_failed_mods_{#}.txt {}" ::: "[slow] ~starting_items" "~[slow] ~[.],starting_items" || test_result=$?
+        if [ $test_result -ne 0 ]; then
+            retry_failed_tests './tests/cata_test' 'retry_failed_mods_*.txt' ${MODS} || exit 1
+        fi
     fi
 
     if [ -n "$TEST_STAGE" ]

--- a/tests/monster_test.cpp
+++ b/tests/monster_test.cpp
@@ -1081,7 +1081,7 @@ static void dormant_monsters_spawn_correctly( const tripoint_abs_omt &origin )
     CHECK( g->num_creatures() == num_creatures_prev - 1UL );
 }
 
-TEST_CASE( "monsters_appear_on_map_as_expected", "[monster][map][hordes]" )
+TEST_CASE( "monsters_appear_on_map_as_expected", "[monster][map][hordes][retry]" )
 {
     tripoint_abs_omt origin{ 90, 90, 0 };
     // This clear_area call is very expensive, so just do it once for all the related

--- a/tests/overmap_test.cpp
+++ b/tests/overmap_test.cpp
@@ -473,7 +473,7 @@ static void finalize_item_counts( std::unordered_map<itype_id, float> &item_coun
 // Toggle this to enable the (very very very expensive) item demographics test.
 static bool enable_item_demographics = false;
 
-TEST_CASE( "overmap_terrain_coverage", "[overmap][slow]" )
+TEST_CASE( "overmap_terrain_coverage", "[overmap][slow][retry]" )
 {
     // The goal of this test is to generate a lot of overmaps, and count up how
     // many times we see each terrain, so that we can check that everything

--- a/tests/water_movement_test.cpp
+++ b/tests/water_movement_test.cpp
@@ -921,7 +921,7 @@ static std::map<std::string, swim_result> expected_results = {
     {"move: walk, stats: minimum, skills: professional, gear: none, traits: webbed hands and feet", swim_result{74, 364}},
 };
 
-TEST_CASE( "check_swim_move_cost_and_distance_values", "[swimming][slow]" )
+TEST_CASE( "check_swim_move_cost_and_distance_values", "[swimming][slow][retry]" )
 {
     setup_test_lake();
 

--- a/tools/format_retry_comment.py
+++ b/tools/format_retry_comment.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Format retry_summary.txt into a markdown PR comment fragment.
+
+Reads the tab-separated retry summary produced by gha_test_only.sh
+and outputs a markdown table for aggregation into a GitHub PR comment.
+
+Usage:
+    format_retry_comment.py [--job-title TITLE] [--summary FILE]
+"""
+
+import argparse
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--job-title", default="Unknown Build",
+        help="CI job title for this report"
+    )
+    parser.add_argument(
+        "--summary", default="retry_summary.txt",
+        help="Path to retry_summary.txt"
+    )
+    args = parser.parse_args()
+
+    try:
+        with open(args.summary) as f:
+            lines = f.read().strip().splitlines()
+    except FileNotFoundError:
+        return
+
+    if not lines:
+        return
+
+    entries = []
+    for line in lines:
+        parts = line.split("\t")
+        if len(parts) == 3:
+            result, attempts, test_name = parts
+            entries.append((test_name, result, attempts))
+
+    if not entries:
+        return
+
+    print("**{}**\n".format(args.job_title))
+    print("| Test | Result | Attempts |")
+    print("|------|--------|----------|")
+    for test_name, result, attempts in sorted(entries):
+        if result == "passed":
+            icon = ":white_check_mark:"
+        else:
+            icon = ":x:"
+        print("| `{}` | {} {} | {} |".format(
+            test_name, icon, result, attempts))
+    print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
#### Summary
Infrastructure "Auto-retry flaky RNG tests with new seeds in CI"

#### Purpose of change

Flaky RNG tests like `overmap_terrain_coverage` and `monsters_appear_on_map_as_expected` randomly fail in CI, blocking unrelated PRs. The current options are either `[!mayfail]` (which effectively hides failures so nobody notices real regressions) or the re-run-and-pray loop.

Related: #85525, #85526

#### Describe the solution

New `[retry]` tag for tests. When a `[retry]`-tagged test fails, the CI script automatically re-runs it with a fresh RNG seed, up to 3 total attempts. If it passes on retry, the build succeeds. If all 3 attempts fail, the build fails normally.

Either way, a PR comment is posted showing what happened -- which tests were retried, whether they recovered or not. Previous retry comments get collapsed as outdated on new pushes.

How it works:
- `CataListener` in test_main.cpp detects `[retry]`-tagged test failures and writes their names to a text file (`--retry-failed` flag)
- `gha_test_only.sh` reads the text file after the test run, and re-runs each failed test with `--rng-seed time` (new seed) up to 2 more times, tracking results in a tab-separated summary
- `tools/format_retry_comment.py` turns the summary into a markdown table
- `post-retry-result.yml` (workflow_run) collects fragments from all matrix jobs and posts/updates the PR comment

Tagged 3 known flaky tests: `overmap_terrain_coverage`, `monsters_appear_on_map_as_expected`, `check_swim_move_cost_and_distance_values`.

#### Describe alternatives you've considered

- `[!mayfail]` -- tests that don't fail CI might as well not exist. Nobody realistically checks logs.
- Whole-suite re-run -- wastes 30+ minutes of CI time for a single flaky test.
- Patching Catch2 for inline per-test retries -- Catch2 v2 has no virtual methods in the execution chain, so this would require modifying the vendored header. The shell-level approach avoids that entirely.
- More detailed per-assertion JSON reporting from the listener -- tried it, added ~300 lines of custom JSON serialization and a big Python formatter. Stripped it back to just test names + a simple summary table. Assertion details are already in the CI log for anyone who needs them.

#### Testing

- Built and ran locally with a temporary always-failing `[retry][nogame]` test. Verified: listener writes test name to the retry file on failure, doesn't write on pass. Shell retry loop correctly re-runs, reports results, and returns appropriate exit codes.
- Verified non-[retry] test failures correctly propagate (retry function returns 1 when no retry files exist).
- Tested the formatter with mock multi-attempt data.
- [Proof of concept of the comment format](https://github.com/dumb-kevin/Cataclysm-DDA/pull/3) (uses an earlier prototype but same visual idea).

#### Additional context

Preview of what the PR comment looks like:

> **Basic Build (GCC 12, Curses)**
>
> | Test | Result | Attempts |
> |------|--------|----------|
> | `overmap_terrain_coverage` | :white_check_mark: passed | 2 |
> | `monsters_appear_on_map_as_expected` | :x: failed | 3 |