### PR TITLE
Hub 01 CBM interface & autodoc spawning overhaul

### DIFF
--- a/data/json/effects_on_condition/npc_eocs/exodii_npc_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/exodii_npc_eocs.json
@@ -1,0 +1,11 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_EXODII_HATES_YOU",
+    "effect": [
+      { "math": [ "faction_like('exodii') = -100" ] },
+      { "math": [ "faction_respect('exodii') = -100" ] },
+      { "math": [ "faction_trust('exodii') = -100" ] }
+    ]
+  }
+]

--- a/data/json/mapgen/robofaq_locs/EOC_robofac_hq_updater.json
+++ b/data/json/mapgen/robofaq_locs/EOC_robofac_hq_updater.json
@@ -72,5 +72,18 @@
         }
       ]
     }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_ROBOFAC_HQ_FORCE_PLACE_ANCILLA_AUTODOC",
+    "condition": { "math": [ "ancilla_autodoc_placed != 1" ] },
+    "effect": [
+      { "mapgen_update": "robofachq_ancilla_bar_autodoc", "om_terrain": "robofachq_subcc_a1" },
+      {
+        "u_location_variable": { "global_val": "ancilla_autodoc_loc" },
+        "target_params": { "om_terrain": "robofachq_subcc_a1" }
+      },
+      { "math": [ "ancilla_autodoc_placed = 1" ] }
+    ]
   }
 ]

--- a/data/json/mutations/cybernetic_traits.json
+++ b/data/json/mutations/cybernetic_traits.json
@@ -10,13 +10,46 @@
   {
     "type": "mutation",
     "id": "CBM_Interface",
-    "name": { "str": "Standard Neurobionic Interface" },
+    "name": { "str": "Exodii Neurobionic Interface" },
     "points": 0,
     "description": "You have a matrix in your central nervous system that acts as a universal control and installation bus for compact bionic modules.",
     "valid": false,
     "purifiable": false,
     "types": [ "Cybernetic" ],
     "cancels": [ "NO_CBM_INSTALLATION" ]
+  },
+  {
+    "type": "mutation",
+    "id": "Hub01_CBM_Interface",
+    "name": { "str": "Hub 01 Neurobionic Interface" },
+    "points": 0,
+    "description": "You have a matrix in your central nervous system that acts as a universal control and installation bus for compact bionic modules.  You also have a USB port installed behind your ear.",
+    "valid": false,
+    "purifiable": false,
+    "types": [ "Cybernetic" ],
+    "cancels": [ "NO_CBM_INSTALLATION" ]
+  },
+  {
+    "type": "mutation",
+    "id": "CBM_Interface_brain_lesion",
+    "name": { "str": "Minor brain lesion" },
+    "points": 0,
+    "description": "You have a minor brain lesion and some leftover metal in your brain - the remnants of removing and reinstalling a CBM interface.",
+    "valid": false,
+    "purifiable": false,
+    "starting_trait": false,
+    "enchantments": [ { "values": [ { "value": "INTELLIGENCE", "add": -1 }, { "value": "DEXTERITY", "add": -1 } ] } ]
+  },
+  {
+    "type": "mutation",
+    "id": "CBM_Interface_brain_lesion_2",
+    "name": { "str": "Major brain lesion" },
+    "points": 0,
+    "description": "You have a major brain lesion and lots of leftover metal in your brain - the remnants of removing and reinstalling a CBM interface.  Twice.  Smart move.",
+    "valid": false,
+    "purifiable": false,
+    "starting_trait": false,
+    "enchantments": [ { "values": [ { "value": "INTELLIGENCE", "add": -4 }, { "value": "DEXTERITY", "add": -4 } ] } ]
   },
   {
     "type": "mutation",

--- a/data/json/mutations/cybernetic_traits.json
+++ b/data/json/mutations/cybernetic_traits.json
@@ -10,7 +10,7 @@
   {
     "type": "mutation",
     "id": "CBM_Interface",
-    "name": { "str": "Exodii Neurobionic Interface" },
+    "name": { "str": "Standard Neurobionic Interface" },
     "points": 0,
     "description": "You have a matrix in your central nervous system that acts as a universal control and installation bus for compact bionic modules.",
     "valid": false,

--- a/data/json/npcs/exodii/exodii_merchant_missions.json
+++ b/data/json/npcs/exodii/exodii_merchant_missions.json
@@ -307,7 +307,12 @@
       },
       {
         "text": "Could I become a cyborg, like yourself?",
-        "condition": { "not": { "u_has_trait": "CBM_Interface" } },
+        "condition": {
+          "and": [
+            { "not": { "u_has_trait": "CBM_Interface" } },
+            { "not": { "compare_string": [ "yes", { "u_val": "Rubik_exodized_u" } ] } }
+          ]
+        },
         "effect": [ { "u_add_faction_trust": 5 } ],
         "opinion": { "trust": 4, "value": 3 },
         "topic": "TALK_EXODII_MERCHANT_ExodizeMe2"
@@ -678,7 +683,12 @@
       },
       {
         "text": "Could I become a cyborg, like yourself?",
-        "condition": { "not": { "u_has_trait": "CBM_Interface" } },
+        "condition": {
+          "and": [
+            { "not": { "u_has_trait": "CBM_Interface" } },
+            { "not": { "compare_string": [ "yes", { "u_val": "Rubik_exodized_u" } ] } }
+          ]
+        },
         "effect": [ { "u_add_faction_trust": 5 } ],
         "opinion": { "trust": 4, "value": 3 },
         "topic": "TALK_EXODII_MERCHANT_ExodizeMe2"
@@ -877,7 +887,12 @@
       },
       {
         "text": "Could I become a cyborg, like yourself?",
-        "condition": { "not": { "u_has_trait": "CBM_Interface" } },
+        "condition": {
+          "and": [
+            { "not": { "u_has_trait": "CBM_Interface" } },
+            { "not": { "compare_string": [ "yes", { "u_val": "Rubik_exodized_u" } ] } }
+          ]
+        },
         "effect": [ { "u_add_faction_trust": 5 } ],
         "opinion": { "trust": 4, "value": 3 },
         "topic": "TALK_EXODII_MERCHANT_ExodizeMe2"

--- a/data/json/npcs/exodii/exodii_merchant_talk.json
+++ b/data/json/npcs/exodii/exodii_merchant_talk.json
@@ -398,7 +398,8 @@
           "and": [
             { "compare_string": [ "yes", { "u_val": "mission_completed_anusfetick" } ] },
             { "not": { "u_has_trait": "CBM_Interface" } },
-            { "not": { "u_has_flag": "NO_CBM_INSTALLATION" } }
+            { "not": { "u_has_flag": "NO_CBM_INSTALLATION" } },
+            { "not": { "compare_string": [ "yes", { "u_val": "Rubik_exodized_u" } ] } }
           ]
         },
         "topic": "TALK_EXODII_MERCHANT_ExodizeMe2"
@@ -430,7 +431,7 @@
       {
         "text": "Can you help me with CBM surgery?",
         "topic": "TALK_EXODII_MERCHANT_Bionic_Install",
-        "condition": { "u_has_trait": "CBM_Interface" }
+        "condition": { "or": [ { "u_has_trait": "CBM_Interface" }, { "u_has_trait": "Hub01_CBM_Interface" } ] }
       },
       {
         "text": "Can you turn me into a cyborg RIGHT NOW?  I'm a developer for this game, you know.",
@@ -463,7 +464,13 @@
       },
       {
         "text": "I've brought the anesthetic for you.  Can you help me out?",
-        "condition": { "and": [ { "u_has_items": { "item": "anesthetic", "count": 1000 } }, { "u_has_mission": "RUBIK_ANUS_FETICK" } ] },
+        "condition": {
+          "and": [
+            { "u_has_items": { "item": "anesthetic", "count": 1000 } },
+            { "u_has_mission": "RUBIK_ANUS_FETICK" },
+            { "not": { "compare_string": [ "yes", { "u_val": "Rubik_exodized_u" } ] } }
+          ]
+        },
         "effect": [ { "u_sell_item": "anesthetic", "count": 1000 }, { "finish_mission": "RUBIK_ANUS_FETICK", "success": true } ],
         "topic": "TALK_EXODII_MERCHANT_ExodizeMe2"
       },
@@ -1672,8 +1679,43 @@
       "str": "If'n you're full an' plenty, this'n's happy to make the call, for a shiny farthing."
     },
     "responses": [
-      { "text": "I've got some stuff I'd like to install.", "topic": "TALK_DONE", "effect": "bionic_install" },
-      { "text": "Would you be able to take out one of my implants?", "topic": "TALK_DONE", "effect": "bionic_remove" }
+      {
+        "text": "I've got some stuff I'd like to install.",
+        "condition": { "u_has_trait": "CBM_Interface" },
+        "topic": "TALK_DONE",
+        "effect": "bionic_install"
+      },
+      {
+        "text": "Would you be able to take out one of my implants?",
+        "condition": { "u_has_trait": "CBM_Interface" },
+        "topic": "TALK_DONE",
+        "effect": "bionic_remove"
+      },
+      {
+        "text": "I've got some stuff I'd like to install.",
+        "condition": { "u_has_trait": "Hub01_CBM_Interface" },
+        "topic": "TALK_EXODII_MERCHANT_Found_Hub01_CBM_interface"
+      },
+      {
+        "text": "Would you be able to take out one of my implants?",
+        "condition": { "u_has_trait": "Hub01_CBM_Interface" },
+        "topic": "TALK_EXODII_MERCHANT_Found_Hub01_CBM_interface"
+      }
+    ]
+  },
+  {
+    "id": "TALK_EXODII_MERCHANT_Found_Hub01_CBM_interface",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "//~": "&Rubik pulls out a glowing, green terminal while a surgical robot rolls in to do standard pre-surgical checks.  \"Right, let's see what we can do for you.\"  Then the surgical robot starts to beep loudly and blurts out words you don't understand in a mechanical voice.  Rubik stares at it a moment, then stares at you.  \"Well, well, well.  Looks like you got your interface swapped out.  I won't hear any excuses.  We've had some tech and some workers go missing, and we've heard from a few trade partners that a certain bunker is offering stolen cybernetics.  You've got two minutes to get out of here.  Got it?\"",
+      "str": "&Rubik pulls out a glowing, green terminal while a surgical robot rolls in to do standard pre-surgical checks.  \"Rightly then, let us'n see what can do 'ye for.\"  Then the surgical robot starts to beep loudly and blurts out words you don't understand in a mechanical voice.  Rubik stares at it a moment, then stares at you.  \"Well now.  Seems to this'n ye've had yer interface swapped.  I'll hear no excuses.  We've had some tech an' stompers gone missin', an' word aroun' says a certain bunker offerin' stolen steelies.  Ye've two minutes to traipse out o'here.  Ken it.\""
+    },
+    "responses": [
+      {
+        "text": "Two minutes?  Ah, shit.",
+        "topic": "TALK_DONE",
+        "effect": { "run_eocs": "EOC_EXODII_HATES_YOU", "time_in_future": [ "100 seconds", "140 seconds" ] }
+      }
     ]
   },
   {

--- a/data/json/npcs/exodii/exodii_merchant_talk_exodization.json
+++ b/data/json/npcs/exodii/exodii_merchant_talk_exodization.json
@@ -209,7 +209,6 @@
       },
       {
         "text": "Actually, Rubik.  This feels strange to say, but I already have a bionic interface.  The scientists from that bunker, Hub 01, installed it.  What I really want is for you to remove it, and replace it with your interface.",
-        
         "condition": { "and": [ { "u_has_trait": "Hub01_CBM_Interface" }, { "not": { "u_has_trait": "CBM_Interface_brain_lesion" } } ] },
         "topic": "TALK_EXODII_MERCHANT_Remove_Hub01_CBM_interface_1"
       },

--- a/data/json/npcs/exodii/exodii_merchant_talk_exodization.json
+++ b/data/json/npcs/exodii/exodii_merchant_talk_exodization.json
@@ -209,7 +209,8 @@
       },
       {
         "text": "Actually, Rubik.  This feels strange to say, but I already have a bionic interface.  The scientists from that bunker, Hub 01, installed it.  What I really want is for you to remove it, and replace it with your interface.",
-        "condition": { "u_has_trait": "Hub01_CBM_Interface" },
+        
+        "condition": { "and": [ { "u_has_trait": "Hub01_CBM_Interface" }, { "not": { "u_has_trait": "CBM_Interface_brain_lesion" } } ] },
         "topic": "TALK_EXODII_MERCHANT_Remove_Hub01_CBM_interface_1"
       },
       {
@@ -236,12 +237,12 @@
     "id": "TALK_EXODII_MERCHANT_Remove_Hub01_CBM_interface_1",
     "type": "talk_topic",
     "dynamic_line": {
-      "//~": "&Rubik stares at you for a very long moment, and then rubs their chin, and scratches at a bit of metal on their head.  \"Right, well that explains where our missing warehouses and robots went.  You came clean, and Rubik appreciates that.  Yeah, we can remove it, but not without risk.  Might leave you with a little less brain than before, I'm afraid.  But despite your honesty, we can't trade with you or let you stick around if you refuse, now.  So we can take it out, and you might be a bit duller, or you can keep it, and I'll give you a ten minute head start before the stompys come after you.  Sorry that it has to be this way.\"",
-      "str": "&Rubik stares at you for a very long moment, and then rubs their chin, and scratches at a bit of metal on their head.  \"Rightly then, that tells where the missin' shinies n' stompers went.  Ye came clean, an' ol' Rubik prizes that.  Aye.  We can take it out.  But not wi'out risk.  Might leave ye wi' a mite less wits than afore, I'm afeared.  Yet for all yet honesty, we can't trade wi' ye nor let ye tarry if ye refuse, now.  So we take it out, an' ye may be the duller for it.  Or ye keep it, an' I'll grant ye' ten minutes' head start afore the stompers come huntin'.  Sorry.  Must be so.\""
+      "//~": "&Rubik stares at you for a very long moment, rubs their chin, and scratches at a bit of metal on their head.  \"Right, well that explains where our missing warehouses and robots went.  You came clean, and Rubik appreciates that.  Yeah, we can remove it, but not without risk.  Might leave you with a little less brain than before, I'm afraid.  But despite your honesty, we can't trade with you or let you stick around if you refuse, now.  So we can take it out, and you might be a bit duller, or you can keep it, and I'll give you a ten minute head start before the stompys come after you.  Sorry that it has to be this way.\"",
+      "str": "&Rubik stares at you for a very long moment, rubs their chin, and scratches at a bit of metal on their head.  \"Rightly then, that tells where the missin' shinies n' stompers went.  Ye came clean, an' ol' Rubik prizes that.  Aye.  We can take it out.  But not wi'out risk.  Might leave ye wi' a mite less wits than afore, I'm afeared.  Yet for all yet honesty, we can't trade wi' ye nor let ye tarry if ye refuse, now.  So we take it out, an' ye may be the duller for it.  Or ye keep it, an' I'll grant ye' ten minutes' head start afore the stompers come huntin'.  Sorry.  Must be so.\""
     },
     "responses": [
       {
-        "text": "[Replace Hub 01 CBM interface with Exodii CBM interface; -1 Intelligence, -1 Dexterity]  I think it's worth the risk.  Get this thing out of me.",
+        "text": "[Replace Hub 01 CBM interface with Exodii CBM interface; -1 Intelligence, -1 Dexterity]  I think it's worth the risk, especially so we can keep working together.  Get this thing out of me.",
         "effect": [
           { "u_add_effect": "narcosis", "duration": "2 hours" },
           { "u_add_effect": "sleep", "duration": "2 hours" },
@@ -249,6 +250,8 @@
           { "u_lose_trait": "Hub01_CBM_Interface" },
           { "u_add_trait": "CBM_Interface" },
           { "u_add_trait": "CBM_Interface_brain_lesion" },
+          { "u_add_bionic": "bio_power_storage" },
+          { "u_add_bionic": "bio_cable" },
           { "u_add_var": "Rubik_exodized_u", "value": "yes" }
         ],
         "topic": "TALK_EXODII_MERCHANT_Exodized_Alt"

--- a/data/json/npcs/exodii/exodii_merchant_talk_exodization.json
+++ b/data/json/npcs/exodii/exodii_merchant_talk_exodization.json
@@ -183,12 +183,7 @@
     "responses": [
       {
         "text": "[Install CBM Interface] All right.  Let's do this.",
-        "condition": {
-          "and": [
-            { "not": { "u_has_trait": "CBM_Interface" } },
-            { "not": { "u_has_trait": "Hub01_CBM_Interface" } }
-          ]
-        },
+        "condition": { "and": [ { "not": { "u_has_trait": "CBM_Interface" } }, { "not": { "u_has_trait": "Hub01_CBM_Interface" } } ] },
         "effect": [
           { "u_add_effect": "narcosis", "duration": "2 hours" },
           { "u_add_effect": "sleep", "duration": "2 hours" },
@@ -303,9 +298,15 @@
     "dynamic_line": "*makes a stiff, bowing gesture and leads you out of the shop and down a stone pathway towards one of the larger buildings in the compound.  A thick steel door slides aside to reveal a gloomy, rust-dusted corridor.  At the end of the corridor is a clean appearing surgical suite, not too different from any other surgical suite aside from the dim lighting and the surgeon itself.  At the head of the surgical table is a contraption reminiscent of an upside-down spider, its multiple glistening medical limbs curling gently in eager anticipation of your approach.  You have little time to question your choices before you feel a sharp pinch in your left shoulder, and the world drifts away.\n\nYou awaken on a comfortable bed, your chest and throat sore but otherwise well.  As the haze of anesthesia fades, you notice several tiny, sore wounds on your chest and arms.  A humanoid cyborg, not Rubik, notices that you are awake and wordlessly gestures you to follow, leading you back to Rubik's store.\n\n\"Ah, an' you're with the stars 'n lights again, an I'm ken.  'Tis grand.  Those wee CBMs will do ye little an fine, but they are a start.  Now us'n can sell you all you like, an' help with install, should ye wish.\"",
     "speaker_effect": { "effect": { "mapgen_update": "tier1_CBM_shop_update", "om_terrain": "exodii_base_x0y2z1" } },
     "responses": [
-      { "text": "Feels good to get that Hub 01 tech out of my head, but I don't really feel much different.  So I'm a cyborg like you, now?", "topic": "TALK_EXODII_MERCHANT_Exodized2" },
+      {
+        "text": "Feels good to get that Hub 01 tech out of my head, but I don't really feel much different.  So I'm a cyborg like you, now?",
+        "topic": "TALK_EXODII_MERCHANT_Exodized2"
+      },
       { "text": "<done_conversation_section>", "topic": "TALK_EXODII_MERCHANT_Talk" },
-      { "text": "<end_talking_leave>  Thanks for swapping out my brain implants.  <end_talking_bye>", "topic": "TALK_DONE" }
+      {
+        "text": "<end_talking_leave>  Thanks for swapping out my brain implants.  <end_talking_bye>",
+        "topic": "TALK_DONE"
+      }
     ]
   },
   {

--- a/data/json/npcs/exodii/exodii_merchant_talk_exodization.json
+++ b/data/json/npcs/exodii/exodii_merchant_talk_exodization.json
@@ -183,14 +183,20 @@
     "responses": [
       {
         "text": "[Install CBM Interface] All right.  Let's do this.",
-        "condition": { "not": { "u_has_trait": "CBM_Interface" } },
+        "condition": {
+          "and": [
+            { "not": { "u_has_trait": "CBM_Interface" } },
+            { "not": { "u_has_trait": "Hub01_CBM_Interface" } }
+          ]
+        },
         "effect": [
           { "u_add_effect": "narcosis", "duration": "2 hours" },
           { "u_add_effect": "sleep", "duration": "2 hours" },
           { "u_assign_activity": "ACT_CBM_SURGERY", "duration": "2 hours" },
           { "u_add_bionic": "bio_power_storage" },
           { "u_add_bionic": "bio_cable" },
-          { "u_add_trait": "CBM_Interface" }
+          { "u_add_trait": "CBM_Interface" },
+          { "u_add_var": "Rubik_exodized_u", "value": "yes" }
         ],
         "topic": "TALK_EXODII_MERCHANT_Exodized"
       },
@@ -205,6 +211,11 @@
           { "u_add_bionic": "bio_power_storage_mkII" }
         ],
         "topic": "TALK_DONE"
+      },
+      {
+        "text": "Actually, Rubik.  This feels strange to say, but I already have a bionic interface.  The scientists from that bunker, Hub 01, installed it.  What I really want is for you to remove it, and replace it with your interface.",
+        "condition": { "u_has_trait": "Hub01_CBM_Interface" },
+        "topic": "TALK_EXODII_MERCHANT_Remove_Hub01_CBM_interface_1"
       },
       {
         "text": "How about store credit instead?  [adds $400 in store credit].",
@@ -223,6 +234,34 @@
         "text": "Hold on.  I need to rethink it again.",
         "condition": { "not": { "u_has_trait": "CBM_Interface" } },
         "topic": "TALK_DONE"
+      }
+    ]
+  },
+  {
+    "id": "TALK_EXODII_MERCHANT_Remove_Hub01_CBM_interface_1",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "//~": "&Rubik stares at you for a very long moment, and then rubs their chin, and scratches at a bit of metal on their head.  \"Right, well that explains where our missing warehouses and robots went.  You came clean, and Rubik appreciates that.  Yeah, we can remove it, but not without risk.  Might leave you with a little less brain than before, I'm afraid.  But despite your honesty, we can't trade with you or let you stick around if you refuse, now.  So we can take it out, and you might be a bit duller, or you can keep it, and I'll give you a ten minute head start before the stompys come after you.  Sorry that it has to be this way.\"",
+      "str": "&Rubik stares at you for a very long moment, and then rubs their chin, and scratches at a bit of metal on their head.  \"Rightly then, that tells where the missin' shinies n' stompers went.  Ye came clean, an' ol' Rubik prizes that.  Aye.  We can take it out.  But not wi'out risk.  Might leave ye wi' a mite less wits than afore, I'm afeared.  Yet for all yet honesty, we can't trade wi' ye nor let ye tarry if ye refuse, now.  So we take it out, an' ye may be the duller for it.  Or ye keep it, an' I'll grant ye' ten minutes' head start afore the stompers come huntin'.  Sorry.  Must be so.\""
+    },
+    "responses": [
+      {
+        "text": "[Replace Hub 01 CBM interface with Exodii CBM interface; -1 Intelligence, -1 Dexterity]  I think it's worth the risk.  Get this thing out of me.",
+        "effect": [
+          { "u_add_effect": "narcosis", "duration": "2 hours" },
+          { "u_add_effect": "sleep", "duration": "2 hours" },
+          { "u_assign_activity": "ACT_CBM_SURGERY", "duration": "2 hours" },
+          { "u_lose_trait": "Hub01_CBM_Interface" },
+          { "u_add_trait": "CBM_Interface" },
+          { "u_add_trait": "CBM_Interface_brain_lesion" },
+          { "u_add_var": "Rubik_exodized_u", "value": "yes" }
+        ],
+        "topic": "TALK_EXODII_MERCHANT_Exodized_Alt"
+      },
+      {
+        "text": "Sorry, Rubik, but that doesn't sound worth it.  Thanks for the head start.  Guess I better go, before the Exodii start shooting.",
+        "topic": "TALK_DONE",
+        "effect": { "run_eocs": "EOC_EXODII_HATES_YOU", "time_in_future": [ "500 seconds", "700 seconds" ] }
       }
     ]
   },
@@ -256,6 +295,17 @@
       { "text": "So I'm a cyborg now?  I don't really feel much different.", "topic": "TALK_EXODII_MERCHANT_Exodized2" },
       { "text": "<done_conversation_section>", "topic": "TALK_EXODII_MERCHANT_Talk" },
       { "text": "<end_talking_leave>  Thanks for the brain implants.  <end_talking_bye>", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "TALK_EXODII_MERCHANT_Exodized_Alt",
+    "type": "talk_topic",
+    "dynamic_line": "*makes a stiff, bowing gesture and leads you out of the shop and down a stone pathway towards one of the larger buildings in the compound.  A thick steel door slides aside to reveal a gloomy, rust-dusted corridor.  At the end of the corridor is a clean appearing surgical suite, not too different from any other surgical suite aside from the dim lighting and the surgeon itself.  At the head of the surgical table is a contraption reminiscent of an upside-down spider, its multiple glistening medical limbs curling gently in eager anticipation of your approach.  You have little time to question your choices before you feel a sharp pinch in your left shoulder, and the world drifts away.\n\nYou awaken on a comfortable bed, your chest and throat sore but otherwise well.  As the haze of anesthesia fades, you notice several tiny, sore wounds on your chest and arms.  A humanoid cyborg, not Rubik, notices that you are awake and wordlessly gestures you to follow, leading you back to Rubik's store.\n\n\"Ah, an' you're with the stars 'n lights again, an I'm ken.  'Tis grand.  Those wee CBMs will do ye little an fine, but they are a start.  Now us'n can sell you all you like, an' help with install, should ye wish.\"",
+    "speaker_effect": { "effect": { "mapgen_update": "tier1_CBM_shop_update", "om_terrain": "exodii_base_x0y2z1" } },
+    "responses": [
+      { "text": "Feels good to get that Hub 01 tech out of my head, but I don't really feel much different.  So I'm a cyborg like you, now?", "topic": "TALK_EXODII_MERCHANT_Exodized2" },
+      { "text": "<done_conversation_section>", "topic": "TALK_EXODII_MERCHANT_Talk" },
+      { "text": "<end_talking_leave>  Thanks for swapping out my brain implants.  <end_talking_bye>", "topic": "TALK_DONE" }
     ]
   },
   {

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/NPC_ANCILLA_DOCTOR.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/NPC_ANCILLA_DOCTOR.json
@@ -130,7 +130,7 @@
         "condition": { "and": [ { "u_has_trait": "CBM_Interface_brain_lesion" }, { "u_has_trait": "CBM_Interface" } ] }
       },
       {
-        "text": "I HAVE A MINOR BRAIN LESION AND NO CBM INTERFACE, WHICH SHOULDN'T BE POSSIBLE! [IF YOU SEE THIS OPTION IN A NORMAL GAME PLEASE FILE A BUG REPORT]",
+        "text": "I HAVE A MINOR BRAIN LESION AND NO CBM INTERFACE, WHICH SHOULDN'T BE POSSIBLE!  [IF YOU SEE THIS OPTION IN A NORMAL GAME PLEASE FILE A BUG REPORT]",
         "topic": "TALK_DONE",
         "condition": {
           "and": [

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/NPC_ANCILLA_DOCTOR.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/NPC_ANCILLA_DOCTOR.json
@@ -125,9 +125,20 @@
         "condition": { "u_has_trait": "Hub01_CBM_Interface" }
       },
       {
-        "text": "So… I may have let the Exodii take out your interface.  And then I may have let them install their interface.  Let's say I wanted you to swap them.  Again.  What's that gonna cost me?",
+        "text": "So… believe it or not, I've swapped my bionic interfaces.  Let's say I wanted you to swap them again, in favor of a new Hub 01 interface.  What's that gonna cost me?",
         "topic": "TALK_ANCILLA_DOCTOR_SWAP_INTERFACE_AGAIN",
         "condition": { "and": [ { "u_has_trait": "CBM_Interface_brain_lesion" }, { "u_has_trait": "CBM_Interface" } ] }
+      },
+      {
+        "text": "I HAVE A MINOR BRAIN LESION AND NO CBM INTERFACE, WHICH SHOULDN'T BE POSSIBLE! [IF YOU SEE THIS OPTION IN A NORMAL GAME PLEASE FILE A BUG REPORT]",
+        "topic": "TALK_DONE",
+        "condition": {
+          "and": [
+            { "u_has_trait": "CBM_Interface_brain_lesion" },
+            { "not": { "u_has_trait": "CBM_Interface" } },
+            { "not": { "u_has_trait": "Hub01_CBM_Interface" } }
+          ]
+        }
       },
       { "text": "I could use your medical assistance.", "topic": "TALK_ANCILLA_DOCTOR_AID" },
       { "text": "I need to trade some medical supplies.", "topic": "TALK_ANCILLA_DOCTOR", "effect": "start_trade" },
@@ -176,7 +187,7 @@
   {
     "id": "TALK_ANCILLA_DOCTOR_CYBERNETICS_INFO",
     "type": "talk_topic",
-    "dynamic_line": "&The doc cracks a wry grin.  \"Yup, believe it or not, motherfucker, we can soup you up with some metal and plastic and turn you into a Terminator.  Well, theoretically.  Need the implants, which we're short on.  In any case, Hub 01 graciously provides us all the tech and some supplies.  So, for a DISCOUNTED fee of 20 HGCs, I can install a bionic interface in your brain - totally safe, mind you - and fit you with a power supply, a charging cable, and some integrated tools.  Crazy shit, huh?\"",
+    "dynamic_line": "&The doc cracks a wry grin.  \"Yup, believe it or not, motherfucker, we can soup you up with some metal and plastic and turn you into a Terminator.  Well, theoretically.  Need the implants, which we're short on.  In any case, Hub 01 graciously provides us all the tech and some supplies.  So, for a DISCOUNTED fee of 20 HGCs, I can install a bionic interface in your brain - totally safe, mind you - and fit you with a power supply, a battery compartment to keep it charged, and an integrated two-way radio.  Crazy shit, huh?\"",
     "responses": [
       {
         "text": "Actually, I'm <u_name>.  I was told to see you about field-testing the new cybernetics.",
@@ -202,15 +213,19 @@
         "effect": [
           {
             "if": { "u_has_trait": "CBM_Interface" },
-            "then": [ { "u_lose_trait": "Hub01_CBM_Interface" }, { "math": [ "hub01_found_u_exodii_interface = 1" ] } ]
+            "then": [
+              { "u_lose_trait": "CBM_Interface" },
+              { "u_add_trait": "CBM_Interface_brain_lesion" },
+              { "math": [ "hub01_found_u_exodii_interface = 1" ] }
+            ]
           },
           { "u_add_effect": "narcosis", "duration": "2 hours" },
           { "u_add_effect": "sleep", "duration": "2 hours" },
           { "u_assign_activity": "ACT_CBM_SURGERY", "duration": "2 hours" },
           { "u_add_trait": "Hub01_CBM_Interface" },
           { "u_add_bionic": "bio_power_storage" },
-          { "u_add_bionic": "bio_cable" },
-          { "u_add_bionic": "bio_tools" },
+          { "u_add_bionic": "bio_batteries" },
+          { "u_add_bionic": "bio_radio" },
           { "u_consume_item": "RobofacCoin", "count": 20, "popup": true }
         ],
         "topic": "TALK_ANCILLA_DOCTOR_INSTALLED_HUB01_INTERFACE"
@@ -222,22 +237,26 @@
   {
     "id": "TALK_ANCILLA_DOCTOR_INSTALL_INTERFACE_REWARD_A",
     "type": "talk_topic",
-    "dynamic_line": "Right, they told me about you.  I guess we owe a lot of this to your efforts, yeah?  So, we can soup you up with some metal and plastic and turn you into a Terminator.  Well, theoretically.  Need the implants, which we're short on.  In any case, Hub 01 graciously provides us all the tech and some supplies.  For you?  No charge.  I can install a bionic interface in your brain - totally safe, mind you - and fit you with a power supply, a charging cable, and some integrated tools.  Crazy shit, huh?\"",
+    "dynamic_line": "Right, they told me about you.  I guess we owe a lot of this to your efforts, yeah?  So, we can soup you up with some metal and plastic and turn you into a Terminator.  Well, theoretically.  Need the implants, which we're short on.  In any case, Hub 01 graciously provides us all the tech and some supplies.  For you?  No charge.  I can install a bionic interface in your brain - totally safe, mind you - and fit you with a power supply, a battery compartment, and an integrated commlink.  Crazy shit, huh?\"",
     "responses": [
       {
         "text": "[Install Hub 01 CBM interface]  Turn me into a cyborg?  For free?  Let's do it.",
         "effect": [
           {
             "if": { "u_has_trait": "CBM_Interface" },
-            "then": [ { "u_lose_trait": "Hub01_CBM_Interface" }, { "math": [ "hub01_found_u_exodii_interface = 1" ] } ]
+            "then": [
+              { "u_lose_trait": "CBM_Interface" },
+              { "u_add_trait": "CBM_Interface_brain_lesion" },
+              { "math": [ "hub01_found_u_exodii_interface = 1" ] }
+            ]
           },
           { "u_add_effect": "narcosis", "duration": "2 hours" },
           { "u_add_effect": "sleep", "duration": "2 hours" },
           { "u_assign_activity": "ACT_CBM_SURGERY", "duration": "2 hours" },
           { "u_add_trait": "Hub01_CBM_Interface" },
           { "u_add_bionic": "bio_power_storage" },
-          { "u_add_bionic": "bio_cable" },
-          { "u_add_bionic": "bio_tools" }
+          { "u_add_bionic": "bio_batteries" },
+          { "u_add_bionic": "bio_radio" }
         ],
         "topic": "TALK_ANCILLA_DOCTOR_INSTALLED_HUB01_INTERFACE"
       },
@@ -248,7 +267,7 @@
   {
     "id": "TALK_ANCILLA_DOCTOR_INSTALL_INTERFACE_REWARD_B",
     "type": "talk_topic",
-    "dynamic_line": "Right, they told me about you.  I guess you know the drill and how these things work.  I'll use the machine to take out that hostile Exodii tech, install the upgraded Hub 01 unit, and top you up with some extra power and a toolset, if you don't have one already.  The new interface is backwards compatible with the Exodii bionics, so no worries there.  I've been given 10 HCG to give you for the Exodii interface scrap - and I was told that's a condition for the surgery, and to remind you that thing'll give you cancer, anyway.  You ready?\"",
+    "dynamic_line": "Right, they told me about you.  I guess you know the drill and how these things work.  I'll use the machine to take out that hostile Exodii tech, install the upgraded Hub 01 unit, and top you up with some extra power, a battery compartment, and a commlink, if you don't have those already.  The new interface is backwards compatible with the Exodii bionics, so no worries there.  I've been given 10 HGC to pay YOU for the Exodii interface scrap.  Remember, the Hub keeping your old interface is a condition for the surgery, and that old thing would've given you cancer, anyway.  So, good riddance, yeah?  You ready?\"",
     "responses": [
       {
         "text": "[Exchange your Exodii CBM interface for the Hub 01 CBM interface and 10 HGC]  Let's do it.",
@@ -259,8 +278,10 @@
           { "u_assign_activity": "ACT_CBM_SURGERY", "duration": "2 hours" },
           { "u_lose_trait": "CBM_Interface" },
           { "u_add_trait": "Hub01_CBM_Interface" },
+          { "u_add_trait": "CBM_Interface_brain_lesion" },
           { "u_add_bionic": "bio_power_storage" },
-          { "u_add_bionic": "bio_tools" },
+          { "u_add_bionic": "bio_batteries" },
+          { "u_add_bionic": "bio_radio" },
           { "u_spawn_item": "RobofacCoin", "count": 10 }
         ],
         "topic": "TALK_ANCILLA_DOCTOR_INSTALLED_HUB01_INTERFACE"
@@ -296,7 +317,7 @@
     "dynamic_line": "…you what?  Seriously?  I mean, yeah, I can do it again.  But look, I'll give it to you straight:  your brain isn't gonna be the same after.  I'm not even sure you'll live.  I'll tell you what… I'll discount it to 10 HGCs, but I get to keep your shit if you die.  Deal?",
     "responses": [
       {
-        "text": "[10 HGC - swap CBM interfaces - MAJOR RISK OF BRAIN DAMAGE]  It's worth the risk.  Get this thing out of me!",
+        "text": "[10 HGC - swap CBM interfaces - MAJOR RISK OF BRAIN DAMAGE]  It's worth the risk.  Swap them!",
         "condition": { "u_has_items": { "item": "RobofacCoin", "count": 10 } },
         "effect": [
           { "u_add_effect": "narcosis", "duration": "2 hours" },

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/NPC_ANCILLA_DOCTOR.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/NPC_ANCILLA_DOCTOR.json
@@ -95,12 +95,241 @@
       "sentinel": "ancilla_doctor_meet"
     },
     "responses": [
-      { "text": "Could you help me with some bionics?", "topic": "TALK_ANCILLA_DOCTOR_BIONICS" },
+      {
+        "text": "I'm <u_name>.  I was told to see you about field-testing the new cybernetics.",
+        "topic": "TALK_ANCILLA_DOCTOR_INSTALL_INTERFACE_REWARD_A",
+        "condition": {
+          "and": [
+            { "math": [ "hub01_promised_cbm_reward == 1" ] },
+            { "not": { "u_has_trait": "CBM_Interface_brain_lesion" } },
+            { "not": { "u_has_trait": "Hub01_CBM_Interface" } }
+          ]
+        }
+      },
+      {
+        "text": "I'm <u_name>.  I was told to see you about replacing my Exodii interface with the updated Hub 01 interface.",
+        "topic": "TALK_ANCILLA_DOCTOR_INSTALL_INTERFACE_REWARD_B",
+        "condition": {
+          "and": [
+            { "math": [ "hub01_promised_cbm_reward == 1" ] },
+            { "not": { "u_has_trait": "Hub01_CBM_Interface" } },
+            { "not": { "u_has_trait": "CBM_Interface_brain_lesion" } },
+            { "u_has_trait": "CBM_Interface" }
+          ]
+        }
+      },
+      { "text": "What services do you offer?", "topic": "TALK_ANCILLA_DOCTOR_SERVICES" },
+      {
+        "text": "Could you help me with some bionics?",
+        "topic": "TALK_ANCILLA_DOCTOR_BIONICS",
+        "condition": { "u_has_trait": "Hub01_CBM_Interface" }
+      },
+      {
+        "text": "So… I may have let the Exodii take out your interface. And then I may have let them install their interface.  Let's say I wanted you to swap them.  Again.  What's that gonna cost me?",
+        "topic": "TALK_ANCILLA_DOCTOR_SWAP_INTERFACE_AGAIN",
+        "condition": { "and": [ { "u_has_trait": "CBM_Interface_brain_lesion" }, { "u_has_trait": "CBM_Interface" } ] }
+      },
       { "text": "I could use your medical assistance.", "topic": "TALK_ANCILLA_DOCTOR_AID" },
       { "text": "I need to trade some medical supplies.", "topic": "TALK_ANCILLA_DOCTOR", "effect": "start_trade" },
       { "text": "Is there anything I can help you with?", "topic": "TALK_ANCILLA_DOCTOR_WORK" },
       { "text": "…", "topic": "TALK_DONE" }
     ]
+  },
+  {
+    "id": "TALK_ANCILLA_DOCTOR_SERVICES",
+    "type": "talk_topic",
+    "dynamic_line": "Primarily I run the new Hub 01 automated medical suite.  DON'T touch the machine.  You might lose a finger.  Or worse.  In any case, I can offer medical services in exchange for HGC, and can trade you medical supplies.  We are also accepting applications for the cutting-edge Hub 01 Cybernetic Enhancements Program, if you're interested.",
+    "responses": [
+      {
+        "text": "What?!  Seriously?  Cybernetics?  Tell me more!",
+        "topic": "TALK_ANCILLA_DOCTOR_CYBERNETICS_INFO",
+        "condition": {
+          "and": [ { "not": { "u_has_trait": "Hub01_CBM_Interface" } }, { "not": { "u_has_trait": "CBM_Interface_brain_lesion" } } ]
+        }
+      },
+      {
+        "text": "Actually, I'm <u_name>.  I was told to see you about field-testing the new cybernetics.",
+        "topic": "TALK_ANCILLA_DOCTOR_INSTALL_INTERFACE_REWARD_A",
+        "condition": {
+          "and": [
+            { "math": [ "hub01_promised_cbm_reward == 1" ] },
+            { "not": { "u_has_trait": "Hub01_CBM_Interface" } },
+            { "not": { "u_has_trait": "CBM_Interface_brain_lesion" } }
+          ]
+        }
+      },
+      {
+        "text": "Actually, I'm <u_name>.  I was told to see you about replacing my Exodii interface with the updated Hub 01 interface.",
+        "topic": "TALK_ANCILLA_DOCTOR_INSTALL_INTERFACE_REWARD_B",
+        "condition": {
+          "and": [
+            { "math": [ "hub01_promised_cbm_reward == 1" ] },
+            { "u_has_trait": "CBM_Interface" },
+            { "not": { "u_has_trait": "CBM_Interface_brain_lesion" } }
+          ]
+        }
+      },
+      { "text": "Okay, thanks.", "topic": "TALK_ANCILLA_DOCTOR" },
+      { "text": "<end_talking_nevermind>", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "TALK_ANCILLA_DOCTOR_CYBERNETICS_INFO",
+    "type": "talk_topic",
+    "dynamic_line": "&The doc cracks a wry grin.  \"Yup, believe it or not, motherfucker, we can soup you up with some metal and plastic and turn you into a Terminator.  Well, theoretically.  Need the implants, which we're short on.  In any case, Hub 01 graciously provides us all the tech and some supplies.  So, for a DISCOUNTED fee of 20 HGCs, I can install a bionic interface in your brain - totally safe, mind you - and fit you with a power supply, a charging cable, and some integrated tools.  Crazy shit, huh?\"",
+    "responses": [
+      {
+        "text": "Actually, I'm <u_name>.  I was told to see you about field-testing the new cybernetics.",
+        "topic": "TALK_ANCILLA_DOCTOR_INSTALL_INTERFACE_REWARD_A",
+        "condition": {
+          "and": [ { "math": [ "hub01_promised_cbm_reward == 1" ] }, { "not": { "u_has_trait": "CBM_Interface_brain_lesion" } } ]
+        }
+      },
+      {
+        "text": "Actually, I'm <u_name>.  I was told to see you about replacing my Exodii interface with the updated Hub 01 interface.",
+        "topic": "TALK_ANCILLA_DOCTOR_INSTALL_INTERFACE_REWARD_B",
+        "condition": {
+          "and": [
+            { "math": [ "hub01_promised_cbm_reward == 1" ] },
+            { "u_has_trait": "CBM_Interface" },
+            { "not": { "u_has_trait": "CBM_Interface_brain_lesion" } }
+          ]
+        }
+      },
+      {
+        "text": "[20 HGC - Install Hub 01 CBM interface]  Twenty HGC to turn me into a cyborg?  Let's do it.",
+        "condition": { "u_has_items": { "item": "RobofacCoin", "count": 20 } },
+        "effect": [
+          {
+            "if": { "u_has_trait": "CBM_Interface" },
+            "then": [ { "u_lose_trait": "Hub01_CBM_Interface" }, { "math": [ "hub01_found_u_exodii_interface = 1" ] } ]
+          },
+          { "u_add_effect": "narcosis", "duration": "2 hours" },
+          { "u_add_effect": "sleep", "duration": "2 hours" },
+          { "u_assign_activity": "ACT_CBM_SURGERY", "duration": "2 hours" },
+          { "u_add_trait": "Hub01_CBM_Interface" },
+          { "u_add_bionic": "bio_power_storage" },
+          { "u_add_bionic": "bio_cable" },
+          { "u_add_bionic": "bio_tools" },
+          { "u_consume_item": "RobofacCoin", "count": 20, "popup": true }
+        ],
+        "topic": "TALK_ANCILLA_DOCTOR_INSTALLED_HUB01_INTERFACE"
+      },
+      { "text": "Maybe later.  Let's talk about something else.", "topic": "TALK_ANCILLA_DOCTOR" },
+      { "text": "<end_talking_nevermind>", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "TALK_ANCILLA_DOCTOR_INSTALL_INTERFACE_REWARD_A",
+    "type": "talk_topic",
+    "dynamic_line": "Right, they told me about you.  I guess we owe a lot of this to your efforts, yeah?  So, we can soup you up with some metal and plastic and turn you into a Terminator.  Well, theoretically.  Need the implants, which we're short on.  In any case, Hub 01 graciously provides us all the tech and some supplies.  For you?  No charge.  I can install a bionic interface in your brain - totally safe, mind you - and fit you with a power supply, a charging cable, and some integrated tools.  Crazy shit, huh?\"",
+    "responses": [
+      {
+        "text": "[Install Hub 01 CBM interface]  Turn me into a cyborg?  For free?  Let's do it.",
+        "effect": [
+          {
+            "if": { "u_has_trait": "CBM_Interface" },
+            "then": [ { "u_lose_trait": "Hub01_CBM_Interface" }, { "math": [ "hub01_found_u_exodii_interface = 1" ] } ]
+          },
+          { "u_add_effect": "narcosis", "duration": "2 hours" },
+          { "u_add_effect": "sleep", "duration": "2 hours" },
+          { "u_assign_activity": "ACT_CBM_SURGERY", "duration": "2 hours" },
+          { "u_add_trait": "Hub01_CBM_Interface" },
+          { "u_add_bionic": "bio_power_storage" },
+          { "u_add_bionic": "bio_cable" },
+          { "u_add_bionic": "bio_tools" }
+        ],
+        "topic": "TALK_ANCILLA_DOCTOR_INSTALLED_HUB01_INTERFACE"
+      },
+      { "text": "Maybe later.  Let's talk about something else.", "topic": "TALK_ANCILLA_DOCTOR" },
+      { "text": "<end_talking_nevermind>", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "TALK_ANCILLA_DOCTOR_INSTALL_INTERFACE_REWARD_B",
+    "type": "talk_topic",
+    "dynamic_line": "Right, they told me about you.  I guess you know the drill and how these things work.  I'll use the machine to take out that hostile Exodii tech, install the upgraded Hub 01 unit, and top you up with some extra power and a toolset, if you don't have one already.  The new interface is backwards compatable with the Exodii bionics, so no worries there.  I've been given 10 HCG to give you for the Exodii interface scrap - and I was told that's a condition for the surgery, and to remind you that thing'll give you cancer, anyway.  You ready?\"",
+    "responses": [
+      {
+        "text": "[Exchange your Exodii CBM interface for the Hub 01 CBM interface and 10 HGC]  Let's do it.",
+        "effect": [
+          { "math": [ "hub01_found_u_exodii_interface = 1" ] },
+          { "u_add_effect": "narcosis", "duration": "2 hours" },
+          { "u_add_effect": "sleep", "duration": "2 hours" },
+          { "u_assign_activity": "ACT_CBM_SURGERY", "duration": "2 hours" },
+          { "u_lose_trait": "CBM_Interface" },
+          { "u_add_trait": "Hub01_CBM_Interface" },
+          { "u_add_bionic": "bio_power_storage" },
+          { "u_add_bionic": "bio_tools" },
+          { "u_spawn_item": "RobofacCoin", "count": 10 }
+        ],
+        "topic": "TALK_ANCILLA_DOCTOR_INSTALLED_HUB01_INTERFACE"
+      },
+      { "text": "Maybe later.  Let's talk about something else.", "topic": "TALK_ANCILLA_DOCTOR" },
+      { "text": "<end_talking_nevermind>", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "TALK_ANCILLA_DOCTOR_INSTALLED_HUB01_INTERFACE",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "math": [ "hub01_found_u_exodii_interface == 1" ],
+      "yes": "&The doc lays you down on the bed and tells you not to move - you're all too familiar with this process, having done it with the Exodii already.  You close your eyes and relax.  In an instant you wake up, now resting in a silent room.\n\nYou reach behind your ear and feel a bandage - underneath is a small metal port, and your fingers can make out several bumps that feel like USB connections.  The doctor sees you and grins.\n\n\"Ah, great, you're up.  All done.  Quite the cyborg already, weren't we?  No worries.  Doc Stevens Junior over here got that old, obsolete tech out without a problem.  The new stuff is ready to go, with the fresh upgrades to boot.  If we get any new implants from the Hub, you'll be free to come by and buy them.  Otherwise, happy to install any you can scavenge from those killer robots.  Just make sure they're packaged and sterile.\"",
+      "no": "&The doc lays you down on the bed and tells you not to move.  The last thing you see is the robotic arm of the device slowly descend toward your neck.  A syringe full of some liquid is then plunged into your skin, and you wake up, resting in a silent room.\n\nYou reach behind your ear and feel a bandage - underneath is a small metal port, and your fingers can make out several bumps that feel like USB connections.  The doctor sees you and grins.\n\n\"Ah, great, you're up.  All done.  If we get any new implants from the Hub, you'll be free to come by and buy them.  Otherwise, happy to install any you can scavenge from those killer robots.  Just make sure they're packaged and sterile.\""
+    },
+    "responses": [
+      {
+        "text": "Feels about the same.  Thanks, Doc.",
+        "condition": { "math": [ "hub01_found_u_exodii_interface == 1" ] },
+        "topic": "TALK_DONE"
+      },
+      {
+        "text": "I'm a cyborg now?  Doesn't feel too much different.  Guess I should go experiment with whatever the hell you did to me.  Thanks, I guess.",
+        "condition": { "math": [ "hub01_found_u_exodii_interface != 1" ] },
+        "topic": "TALK_DONE"
+      }
+    ]
+  },
+  {
+    "id": "TALK_ANCILLA_DOCTOR_SWAP_INTERFACE_AGAIN",
+    "type": "talk_topic",
+    "dynamic_line": "… you what?  Seriously?  I mean, yeah, I can do it again.  But look, I'll give it to you straight:  your brain isn't gonna be the same after.  I'm not even sure you'll live.  I'll tell you what… I'll discount it to 10 HGCs, but I get to keep your shit if you die.  Deal?",
+    "responses": [
+      {
+        "text": "[10 HGC - swap CBM interfaces - MAJOR RISK OF BRAIN DAMAGE]  It's worth the risk.  Get this thing out of me!",
+        "condition": { "u_has_items": { "item": "RobofacCoin", "count": 10 } },
+        "effect": [
+          { "u_add_effect": "narcosis", "duration": "2 hours" },
+          { "u_add_effect": "sleep", "duration": "2 hours" },
+          { "u_assign_activity": "ACT_CBM_SURGERY", "duration": "2 hours" },
+          { "u_lose_trait": "CBM_Interface" },
+          { "u_lose_trait": "CBM_Interface_brain_lesion" },
+          { "u_add_trait": "Hub01_CBM_Interface" },
+          { "u_add_trait": "CBM_Interface_brain_lesion_2" },
+          { "u_consume_item": "RobofacCoin", "count": 10, "popup": true }
+        ],
+        "topic": "TALK_ANCILLA_DOCTOR_SWAPPED_INTERFACE_AGAIN"
+      },
+      { "text": "Maybe later.  Let's talk about something else.", "topic": "TALK_ANCILLA_DOCTOR" },
+      { "text": "<end_talking_nevermind>", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "TALK_ANCILLA_DOCTOR_SWAPPED_INTERFACE_AGAIN",
+    "type": "talk_topic",
+    "dynamic_line": "&Everything after that moment is a blur in your memory.  You wake up.  For a moment, you're back in your bed.  Was the cataclysm all a dream?  Then you look around, and see Doc Stevens.  You come to your senses.",
+    "responses": [
+      {
+        "text": "Well, I feel pretty much the same.  Seems like there weren't any complications!",
+        "topic": "TALK_ANCILLA_DOCTOR_SWAPPED_INTERFACE_AGAIN_2"
+      }
+    ]
+  },
+  {
+    "id": "TALK_ANCILLA_DOCTOR_SWAPPED_INTERFACE_AGAIN_2",
+    "type": "talk_topic",
+    "dynamic_line": "&Doc Stevens stares at you confusedly.  Then he squints at you.  Then he just shrugs his shoulders.  \"Yeah, what you said… same for me.  I think.\"  Then the doctor's eyes go wide and he raises his eyebrows.  He takes a sharp breath.  Then he turns and walks away.",
+    "responses": [ { "text": "… What?", "topic": "TALK_DONE" } ]
   },
   {
     "id": "TALK_ANCILLA_DOCTOR_AID",
@@ -155,7 +384,6 @@
         "effect": "bionic_remove_allies",
         "condition": { "not": { "npc_has_effect": "currently_busy" } }
       },
-      { "text": "Oh no, I was wondering if you knew where to get some.", "topic": "TALK_ANCILLA_DOCTOR_FIND_BIONICS" },
       { "text": "<end_talking_nevermind>", "topic": "TALK_NONE" }
     ]
   },
@@ -180,12 +408,6 @@
       }
     ],
     "responses": [ { "text": "…", "topic": "TALK_DONE" } ]
-  },
-  {
-    "type": "talk_topic",
-    "id": "TALK_ANCILLA_DOCTOR_FIND_BIONICS",
-    "dynamic_line": "If you want to carve up cyborg corpses, find someone at the bar, not me.",
-    "responses": [ { "text": "…", "topic": "TALK_ANCILLA_DOCTOR" } ]
   },
   {
     "type": "talk_topic",

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/NPC_ANCILLA_DOCTOR.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/NPC_ANCILLA_DOCTOR.json
@@ -248,7 +248,7 @@
   {
     "id": "TALK_ANCILLA_DOCTOR_INSTALL_INTERFACE_REWARD_B",
     "type": "talk_topic",
-    "dynamic_line": "Right, they told me about you.  I guess you know the drill and how these things work.  I'll use the machine to take out that hostile Exodii tech, install the upgraded Hub 01 unit, and top you up with some extra power and a toolset, if you don't have one already.  The new interface is backwards compatable with the Exodii bionics, so no worries there.  I've been given 10 HCG to give you for the Exodii interface scrap - and I was told that's a condition for the surgery, and to remind you that thing'll give you cancer, anyway.  You ready?\"",
+    "dynamic_line": "Right, they told me about you.  I guess you know the drill and how these things work.  I'll use the machine to take out that hostile Exodii tech, install the upgraded Hub 01 unit, and top you up with some extra power and a toolset, if you don't have one already.  The new interface is backwards compatible with the Exodii bionics, so no worries there.  I've been given 10 HCG to give you for the Exodii interface scrap - and I was told that's a condition for the surgery, and to remind you that thing'll give you cancer, anyway.  You ready?\"",
     "responses": [
       {
         "text": "[Exchange your Exodii CBM interface for the Hub 01 CBM interface and 10 HGC]  Let's do it.",

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/NPC_ANCILLA_DOCTOR.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/NPC_ANCILLA_DOCTOR.json
@@ -125,7 +125,7 @@
         "condition": { "u_has_trait": "Hub01_CBM_Interface" }
       },
       {
-        "text": "So… I may have let the Exodii take out your interface. And then I may have let them install their interface.  Let's say I wanted you to swap them.  Again.  What's that gonna cost me?",
+        "text": "So… I may have let the Exodii take out your interface.  And then I may have let them install their interface.  Let's say I wanted you to swap them.  Again.  What's that gonna cost me?",
         "topic": "TALK_ANCILLA_DOCTOR_SWAP_INTERFACE_AGAIN",
         "condition": { "and": [ { "u_has_trait": "CBM_Interface_brain_lesion" }, { "u_has_trait": "CBM_Interface" } ] }
       },
@@ -293,7 +293,7 @@
   {
     "id": "TALK_ANCILLA_DOCTOR_SWAP_INTERFACE_AGAIN",
     "type": "talk_topic",
-    "dynamic_line": "… you what?  Seriously?  I mean, yeah, I can do it again.  But look, I'll give it to you straight:  your brain isn't gonna be the same after.  I'm not even sure you'll live.  I'll tell you what… I'll discount it to 10 HGCs, but I get to keep your shit if you die.  Deal?",
+    "dynamic_line": "…you what?  Seriously?  I mean, yeah, I can do it again.  But look, I'll give it to you straight:  your brain isn't gonna be the same after.  I'm not even sure you'll live.  I'll tell you what… I'll discount it to 10 HGCs, but I get to keep your shit if you die.  Deal?",
     "responses": [
       {
         "text": "[10 HGC - swap CBM interfaces - MAJOR RISK OF BRAIN DAMAGE]  It's worth the risk.  Get this thing out of me!",
@@ -329,7 +329,7 @@
     "id": "TALK_ANCILLA_DOCTOR_SWAPPED_INTERFACE_AGAIN_2",
     "type": "talk_topic",
     "dynamic_line": "&Doc Stevens stares at you confusedly.  Then he squints at you.  Then he just shrugs his shoulders.  \"Yeah, what you said… same for me.  I think.\"  Then the doctor's eyes go wide and he raises his eyebrows.  He takes a sharp breath.  Then he turns and walks away.",
-    "responses": [ { "text": "… What?", "topic": "TALK_DONE" } ]
+    "responses": [ { "text": "…What?", "topic": "TALK_DONE" } ]
   },
   {
     "id": "TALK_ANCILLA_DOCTOR_AID",

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
@@ -555,6 +555,26 @@
         "condition": { "and": [ { "math": [ "has_var(u_timer_hub_waiting_on_warehouse)" ] }, { "math": [ "hub01_stole_warehouse != 1" ] } ] },
         "topic": "TALK_ROBOFAC_INTERCOM_BUY_EXODII_WAREHOUSE_4c"
       },
+      {
+        "text": "You mentioned that the Exodii I brought you would be useful for some kind of technology.  Any news on that?",
+        "condition": {
+          "and": [
+            { "math": [ "has_var(u_timer_hub_waiting_on_autodoc)" ] },
+            { "math": [ "hub01_told_u_about_warehouse_autodoc != 1" ] }
+          ]
+        },
+        "topic": "TALK_EXODI_INTERCOM_AUTODOC_A"
+      },
+      {
+        "text": "Any news on that Exodii surgical-thing?",
+        "condition": {
+          "and": [
+            { "math": [ "has_var(u_timer_hub_waiting_on_autodoc)" ] },
+            { "math": [ "hub01_told_u_about_warehouse_autodoc == 1" ] }
+          ]
+        },
+        "topic": "TALK_EXODI_INTERCOM_AUTODOC_B"
+      },
       { "text": "<end_talking_leave>", "topic": "TALK_DONE" }
     ]
   },
@@ -1391,7 +1411,8 @@
         "effect": [
           { "u_lose_var": "dialogue_hub_u_waiting_on_warehouse" },
           { "u_lose_var": "timer_hub_waiting_on_warehouse" },
-          { "math": [ "hub01_told_u_about_warehouse = 1" ] }
+          { "math": [ "hub01_told_u_about_warehouse = 1" ] },
+          { "math": [ "hub01_told_u_about_warehouse_autodoc = 1" ] }
         ],
         "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"
       },
@@ -1414,6 +1435,119 @@
         "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"
       },
       { "text": "I'll check in later.", "topic": "TALK_ROBOFAC_INTERCOM_SERVICES" }
+    ]
+  },
+  {
+    "id": "TALK_EXODI_INTERCOM_AUTODOC_A",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "math": [ "time_since(u_timer_hub_waiting_on_autodoc) >= time('14 d')" ],
+      "yes": "&The intercom clicks off and there is a long moment of silence, before it clicks back on again with a new person on the other end.  \"Yes, hello.  Right.  Yes.  Indeed, the technology we recovered was instrumental in developing new medical technology we are making available for our contractors, like yourself.  You can find a new, public medical suite across the street, in the old basement of the weather station - you should be able to find the stairs just inside the entrance.  Please feel free to make use of its services.\"",
+      "no": {
+        "math": [ "time_since(u_timer_hub_waiting_on_autodoc) >= time('12 d')" ],
+        "yes": "Our newest project will be ready for field testing within the week.  We suggest checking back regularly.",
+        "no": {
+          "math": [ "time_since(u_timer_hub_waiting_on_autodoc) >= time('7 d')" ],
+          "yes": "This project is ongoing, but is advancing quickly.  We expect research to be done in a matter of weeks.",
+          "no": "The project is ongoing, and we expect it will take weeks or months until it is ready for testing.  We suggest you check back in next week."
+        }
+      }
+    },
+    "responses": [
+      {
+        "text": "A new medical facility across the street, in the basement?  I guess I can go check it out.",
+        "condition": { "math": [ "time_since(u_timer_hub_waiting_on_autodoc) >= time('14 d')" ] },
+        "effect": [ { "u_lose_var": "dialogue_hub_u_waiting_on_autodoc" }, { "u_lose_var": "timer_hub_waiting_on_autodoc" } ],
+        "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"
+      },
+      {
+        "text": "I'll check in later.",
+        "topic": "TALK_ROBOFAC_INTERCOM_SERVICES",
+        "condition": { "math": [ "time_since(u_timer_hub_waiting_on_autodoc) < time('14 d')" ] }
+      }
+    ]
+  },
+  {
+    "id": "TALK_EXODI_INTERCOM_AUTODOC_B",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "math": [ "time_since(u_timer_hub_waiting_on_autodoc) >= time('14 d')" ],
+      "yes": "&The intercom clicks off and there is a long moment of silence, before it clicks back on again with a new person on the other end.  \"Yes, hello.  Right.  Yes.  Indeed, we have been able to reconstruct the automatic medical device, and due to your efforts, and the efforts of other contractors and Hub scientists, we were able to reverse engineer the cybernetic implants the Exodii make use of.  You can find a new, public medical suite across the street, in the old basement of the weather station - you should be able to find the stairs just inside the entrance.  Please feel free to make use of its services.  As previously discussed, we would like to invite you to join our new program, where select mercenaries will be allowed to field test new cybernetic enhancements.  Doctor Stevens at the facility will give you more information.  In fact, as a reward for your service, we are prepared to install some very useful cybernetic enhancements that we developed as a part of these efforts.\"",
+      "no": {
+        "math": [ "time_since(u_timer_hub_waiting_on_autodoc) >= time('12 d')" ],
+        "yes": "Our newest project will be ready for field testing within days.  We suggest checking back regularly.",
+        "no": {
+          "math": [ "time_since(u_timer_hub_waiting_on_autodoc) >= time('7 d')" ],
+          "yes": "We expect the surgical suite to be ready in approximately one week.",
+          "no": "The project is ongoing, and we expect it will take weeks or months until it is ready for testing.  We suggest you check back in next week."
+        }
+      }
+    },
+    "responses": [
+      {
+        "text": "Actually, I'm familiar with these cybernetics.  I already have an interface installed by the Exodii.",
+        "condition": {
+          "and": [ { "math": [ "time_since(u_timer_hub_waiting_on_autodoc) >= time('14 d')" ] }, { "u_has_trait": "CBM_Interface" } ]
+        },
+        "effect": [
+          { "u_lose_var": "dialogue_hub_u_waiting_on_autodoc" },
+          { "u_lose_var": "timer_hub_waiting_on_autodoc" },
+          { "math": [ "hub01_promised_cbm_reward = 1" ] }
+        ],
+        "topic": "TALK_EXODI_INTERCOM_AUTODOC_B_EXODII_INTERFACE"
+      },
+      {
+        "text": "Cybernetics?  What do you mean by that?",
+        "condition": {
+          "and": [
+            { "math": [ "time_since(u_timer_hub_waiting_on_autodoc) >= time('14 d')" ] },
+            { "not": { "u_has_trait": "CBM_Interface" } }
+          ]
+        },
+        "effect": [
+          { "u_lose_var": "dialogue_hub_u_waiting_on_autodoc" },
+          { "u_lose_var": "timer_hub_waiting_on_autodoc" },
+          { "math": [ "hub01_promised_cbm_reward = 1" ] }
+        ],
+        "topic": "TALK_EXODI_INTERCOM_AUTODOC_B_CYBERNETICS_INFO"
+      },
+      {
+        "text": "I guess I can go check the new medical facility out.  Across the street in the basement, right?",
+        "condition": { "math": [ "time_since(u_timer_hub_waiting_on_autodoc) >= time('14 d')" ] },
+        "effect": [
+          { "u_lose_var": "dialogue_hub_u_waiting_on_autodoc" },
+          { "u_lose_var": "timer_hub_waiting_on_autodoc" },
+          { "math": [ "hub01_promised_cbm_reward = 1" ] }
+        ],
+        "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"
+      },
+      {
+        "text": "I'll check in later.",
+        "topic": "TALK_ROBOFAC_INTERCOM_SERVICES",
+        "condition": { "math": [ "time_since(u_timer_hub_waiting_on_autodoc) < time('14 d')" ] }
+      }
+    ]
+  },
+  {
+    "id": "TALK_EXODI_INTERCOM_AUTODOC_B_EXODII_INTERFACE",
+    "type": "talk_topic",
+    "dynamic_line": "&The intercom is silent for a long moment, then it clicks off, then back on, with the same voice as before:  \"Interesting.  We'll inform Doc Stevens.  We would be willing to pay you to study this device, whether you wish to participate in the field testing units or not.  Unfortunately, based on our research, this Exodii technology was a complete dead end, with no room for improvement, and it carries significant risks, including cancer and increased risk of internal bleeding.  Our improved interface is completely safe and will be of great benefit to u- to mankind.  To boot, it will remain compatable with whatever bionic modules we can continue to recover from the Exodii.  We suggest you have Doc Stevens swap it out immediately.\"",
+    "responses": [
+      {
+        "text": "I'll keep that in mind, and maybe I'll check out the new facility.  Across the street in the basement, right?",
+        "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"
+      }
+    ]
+  },
+  {
+    "id": "TALK_EXODI_INTERCOM_AUTODOC_B_CYBERNETICS_INFO",
+    "type": "talk_topic",
+    "dynamic_line": "The Exodii made their \"workers\" out of human beings, each implanted with a computer-brain interface.  This allows to interface with electronic bionic modules, including things like integrated toolsets, rangefinders, and radios.  Unfortunately, the Exodii interfaces are not particularly advanced or safe, and come with serious cancer risks, among other problems.  Our improved interface is completely safe and will be of great benefit to u- to mankind.  To boot, it will remain compatable with whatever bionic modules we can continue to recover from the Exodii.",
+    "responses": [
+      {
+        "text": "I'll keep that in mind, and maybe I'll check out the new facility.  Across the street in the basement, right?",
+        "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"
+      }
     ]
   }
 ]

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
@@ -1531,7 +1531,7 @@
   {
     "id": "TALK_EXODI_INTERCOM_AUTODOC_B_EXODII_INTERFACE",
     "type": "talk_topic",
-    "dynamic_line": "&The intercom is silent for a long moment, then it clicks off, then back on, with the same voice as before:  \"Interesting.  We'll inform Doc Stevens.  We would be willing to pay you to study this device, whether you wish to participate in the field testing units or not.  Unfortunately, based on our research, this Exodii technology was a complete dead end, with no room for improvement, and it carries significant risks, including cancer and increased risk of internal bleeding.  Our improved interface is completely safe and will be of great benefit to u- to mankind.  To boot, it will remain compatable with whatever bionic modules we can continue to recover from the Exodii.  We suggest you have Doc Stevens swap it out immediately.\"",
+    "dynamic_line": "&The intercom is silent for a long moment, then it clicks off, then back on, with the same voice as before:  \"Interesting.  We'll inform Doc Stevens.  We would be willing to pay you to study this device, whether you wish to participate in the field testing units or not.  Unfortunately, based on our research, this Exodii technology was a complete dead end, with no room for improvement, and it carries significant risks, including cancer and increased risk of internal bleeding.  Our improved interface is completely safe and will be of great benefit to u- to mankind.  To boot, it will remain compatible with whatever bionic modules we can continue to recover from the Exodii.  We suggest you have Doc Stevens swap it out immediately.\"",
     "responses": [
       {
         "text": "I'll keep that in mind, and maybe I'll check out the new facility.  Across the street in the basement, right?",
@@ -1542,7 +1542,7 @@
   {
     "id": "TALK_EXODI_INTERCOM_AUTODOC_B_CYBERNETICS_INFO",
     "type": "talk_topic",
-    "dynamic_line": "The Exodii made their \"workers\" out of human beings, each implanted with a computer-brain interface.  This allows to interface with electronic bionic modules, including things like integrated toolsets, rangefinders, and radios.  Unfortunately, the Exodii interfaces are not particularly advanced or safe, and come with serious cancer risks, among other problems.  Our improved interface is completely safe and will be of great benefit to u- to mankind.  To boot, it will remain compatable with whatever bionic modules we can continue to recover from the Exodii.",
+    "dynamic_line": "The Exodii made their \"workers\" out of human beings, each implanted with a computer-brain interface.  This allows to interface with electronic bionic modules, including things like integrated toolsets, rangefinders, and radios.  Unfortunately, the Exodii interfaces are not particularly advanced or safe, and come with serious cancer risks, among other problems.  Our improved interface is completely safe and will be of great benefit to u- to mankind.  To boot, it will remain compatible with whatever bionic modules we can continue to recover from the Exodii.",
     "responses": [
       {
         "text": "I'll keep that in mind, and maybe I'll check out the new facility.  Across the street in the basement, right?",

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
@@ -139,7 +139,9 @@
         "condition": { "and": [ { "u_has_mission": "MISSION_ROBOFAC_INTERCOM_CIRCUIT_SAFARI" }, { "u_has_item": "broken_exodii_worker" } ] },
         "effect": [
           { "u_consume_item": "broken_exodii_worker", "count": 1, "popup": true },
-          { "finish_mission": "MISSION_ROBOFAC_INTERCOM_CIRCUIT_SAFARI", "success": true }
+          { "finish_mission": "MISSION_ROBOFAC_INTERCOM_CIRCUIT_SAFARI", "success": true },
+          { "math": [ "u_timer_hub_waiting_on_autodoc = time('now')" ] },
+          { "u_add_var": "dialogue_hub_u_waiting_on_autodoc", "value": "yes" }
         ],
         "topic": "MISSION_ROBOFAC_INTERCOM_CIRCUIT_SAFARI_COMPLETE"
       },
@@ -148,7 +150,9 @@
         "condition": { "and": [ { "u_has_mission": "MISSION_ROBOFAC_INTERCOM_CIRCUIT_SAFARI" }, { "u_has_item": "exodii_chop_shop_head" } ] },
         "effect": [
           { "u_consume_item": "exodii_chop_shop_head", "count": 1, "popup": true },
-          { "finish_mission": "MISSION_ROBOFAC_INTERCOM_CIRCUIT_SAFARI", "success": true }
+          { "finish_mission": "MISSION_ROBOFAC_INTERCOM_CIRCUIT_SAFARI", "success": true },
+          { "math": [ "u_timer_hub_waiting_on_autodoc = time('now')" ] },
+          { "u_add_var": "dialogue_hub_u_waiting_on_autodoc", "value": "yes" }
         ],
         "topic": "MISSION_ROBOFAC_INTERCOM_CIRCUIT_SAFARI_COMPLETE_ALT"
       },
@@ -315,7 +319,8 @@
                   "not": { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_chop_shop" } ] }
                 },
                 { "not": { "math": [ "robofac_chop_shop_scientist_1_is_dead == 1" ] } },
-                { "math": [ "hub01_stole_warehouse == 1" ] }
+                { "math": [ "hub01_stole_warehouse == 1" ] },
+                { "not": { "math": [ "ancilla_autodoc_placed == 1" ] } }
               ]
             },
             {
@@ -325,7 +330,8 @@
                   "not": { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_chop_shop" } ] }
                 },
                 { "not": { "math": [ "robofac_chop_shop_scientist_1_is_dead == 1" ] } },
-                { "math": [ "ancilla_fortress_placed == 1" ] }
+                { "math": [ "ancilla_fortress_placed == 1" ] },
+                { "not": { "math": [ "ancilla_autodoc_placed == 1" ] } }
               ]
             }
           ]
@@ -342,8 +348,12 @@
                 {
                   "not": { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_circuit_safari" } ] }
                 },
+                {
+                  "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_robot_sm_1" } ]
+                },
                 { "math": [ "hub01_stole_warehouse == 1" ] },
-                { "math": [ "hub01_told_u_about_warehouse == 1" ] }
+                { "math": [ "hub01_told_u_about_warehouse == 1" ] },
+                { "not": { "math": [ "ancilla_autodoc_placed == 1" ] } }
               ]
             },
             {
@@ -352,7 +362,11 @@
                 {
                   "not": { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_circuit_safari" } ] }
                 },
-                { "math": [ "ancilla_fortress_placed == 1" ] }
+                {
+                  "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_robot_sm_1" } ]
+                },
+                { "math": [ "ancilla_fortress_placed == 1" ] },
+                { "not": { "math": [ "ancilla_autodoc_placed == 1" ] } }
               ]
             }
           ]
@@ -1476,7 +1490,7 @@
     ],
     "type": "talk_topic",
     "dynamic_line": {
-      "math": [ "hub01_promised_warehouse_info == 1" ],
+      "math": [ "hub01_told_u_about_warehouse_autodoc == 1" ],
       "yes": "As you are aware, we have recovered advanced equipment from the Exodii warehouse.  Analysis indicates it may constitute an automated surgical suite; however, additional hardware is required to fully assemble and activate the system.  Given your successful retrieval of the Trifacet, we are offering you the contract as a priority.  Research is in need of an Exodii \"worker\".\"\n\n\"The Exodii have demonstrated extreme hazard potential.  Accordingly, should you accept this contract, a prototype HOUND unit will be assigned to you to assist in your operation.\"\n\n\"This contract includes the standard hazard pay of 4 HGC and an indefinite license to use the HOUND unit.  Additionally, we anticipate that your involvement will facilitate critical technical developments, which may become available to you in due course.",
       "no": "Our robotics research division has requested new robot specimens.  Given your successful retrieval of the Trifacet, we are offering you the contract as a priority.  Research is in need of an Exodii \"worker\".\"\n\n\"The Exodii have demonstrated extreme hazard potential.  Accordingly, should you accept this contract, a prototype HOUND unit will be assigned to you to assist in your operation.\"\n\n\"This contract includes the standard hazard pay of 4 HGC and an indefinite license to use the HOUND unit.  Additionally, we anticipate that your involvement will facilitate critical technical developments, which may become available to you in due course."
     },
@@ -1563,13 +1577,21 @@
   {
     "id": "MISSION_ROBOFAC_INTERCOM_CIRCUIT_SAFARI_COMPLETE",
     "type": "talk_topic",
-    "dynamic_line": "&The intercom's tray slides open, filled with your payment.  \"Excellent.  In addition to your contracting fee you may keep the HOUND.  We would appreciate periodic reports on its field performance.  If you remain interested in this project, we encourage you to check in from time to time.\"",
+    "dynamic_line": {
+      "math": [ "hub01_told_u_about_warehouse_autodoc == 1" ],
+      "yes": "&The intercom's tray slides open, filled with your payment.  \"Excellent.  In addition to your contracting fee you may keep the HOUND.  We would appreciate periodic reports on its field performance.\"\n\nYou hear a THUNK as something covers the microphone, and through scratches and muffled words, you heard \"Permission--tell-----okay.\"\n\nYou then hear the intercom click off, there is a moment of silence, and it clicks on again.  \"Ahem, so, as discussed earlier, we think this unit will lead to some important developments that will need field testing.  If things go as planned we will happily offer you a place in our field testing program.  Please occasionally check with us about project status.\"",
+      "no": "&The intercom's tray slides open, filled with your payment.  \"Excellent.  In addition to your contracting fee you may keep the HOUND.  We would appreciate periodic reports on its field performance.\""
+    },
     "responses": [ { "text": "Thank you.", "topic": "TALK_ROBOFAC_INTERCOM_SERVICES" } ]
   },
   {
     "id": "MISSION_ROBOFAC_INTERCOM_CIRCUIT_SAFARI_COMPLETE_ALT",
     "type": "talk_topic",
-    "dynamic_line": "&The intercom is silent a long moment, and then you hear a keyboard clacking and the tray slides open, filled with your payment.  \"Yes, this will do.  In addition to your contracting fee you may of course keep the HOUND.  We would appreciate periodic reports on its field performance.  If you remain interested in this project, we encourage you to check in from time to time.\"",
+    "dynamic_line": {
+      "math": [ "hub01_told_u_about_warehouse_autodoc == 1" ],
+      "yes": "&The intercom is silent a long moment, and then you hear a keyboard clacking and the tray slides open, filled with your payment.  \"Yes, this will do.  In addition to your contracting fee you may of course keep the HOUND.  We would appreciate periodic reports on its field performance.\"\n\nYou hear a THUNK as something covers the microphone, and through scratches and muffled words, you heard \"Permission--tell-----okay.\"\n\nYou then hear the intercom click off, there is a moment of silence, and it clicks on again.  \"Ahem, so, as discussed earlier, we think this unit will lead to some important developments that will need field testing.  If things go as planned we will happily offer you a place in our field testing program.  Please occasionally check with us about project status.\"",
+      "no": "&The intercom is silent a long moment, and then you hear a keyboard clacking and the tray slides open, filled with your payment.  \"Yes, this will do.  In addition to your contracting fee you may of course keep the HOUND.  We would appreciate periodic reports on its field performance.\""
+    },
     "responses": [ { "text": "Thank you.", "topic": "TALK_ROBOFAC_INTERCOM_SERVICES" } ]
   },
   {
@@ -2080,7 +2102,8 @@
         { "u_spawn_item": "RobofacCoin", "count": 4 },
         { "u_add_var": "dialogue_intercom_completed_robofac_intercom_circuit_safari", "value": "yes" },
         { "math": [ "u_hub01_completed_missions++" ] },
-        { "math": [ "hub01_has_cbm_interface_tech = 1" ] }
+        { "math": [ "hub01_has_cbm_interface_tech = 1" ] },
+        { "run_eocs": "EOC_ROBOFAC_HQ_FORCE_PLACE_ANCILLA_AUTODOC", "time_in_future": "14 days" }
       ]
     },
     "origins": [ "ORIGIN_SECONDARY" ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Hub 01 CBM interface and AutoDoc overhaul"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Toward Hub 01 CBMs.  I've been doing recent work on missions to escalate Exodii-Hub 01 tensions, and give the Hub 01 access to AutoDoc tech. It's now time to overhaul the AutoDoc spawn and start implementing the Hub CBM tech, and to make it possible for the Exodii to hate you for doing it.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

1. Added a "Hub 01 Neurobionic Interface."  <s>Changes the "Standard Neurobionic Interface" to "Exodii Neurobionic Interface."</s> (reverted the struck-out name change - unnecessary and complicates things for in-repo mods that use the CBM_interface)
2. Changes intercom dialogue to allow the AutoDoc to spawn early under certain conditions.
3. Changes Doc Steven's dialogue.  He now discusses and installs the Hub 01 interface.  He will only offer CBM services to someone with the Hub 01 CBM interface.
4. Changes Rubik's dialogue to make them interact with the player having the Hub 01 interface.

The Hub Ancillary AutoDoc now spawns under one of four conditions:

1. As before, it has been 80 days since the cataclysm.  In the background, the Hub and mercs have stolen the tech and figured it out.
2. It has been 45 days and the Ancilla fortress has spawned, and the player has completed Circuit Safari (giving the Hub 01 an Exodii interface to study), and then waited 2 weeks.
3. The player got the mission to find the Exodii warehouse, successfully sold it to Hub 01, and allowed them to steal it, giving them AutoDoc tech.  If they don't do Circuit Safari, they have to wait the full 80 days since the cataclysm.
4. The player helped Hub 01 steal the warehouse, then completed Circuit Safari and waited 2 weeks.

If the player had no role in the AutoDoc spawning, they will be charged 20 HGC for the "privilege" of applying to the cybernetics program, and getting the interface installed.  If they already have an Exodii interface, replacing it results in a minor brain lesion (-1 int, -1 dex) that the doctor WON'T warn about (because they're assholes and they probably don't know).  If the player told the Hub they have the exodii tech, they'll actually pay 10 HGC to swap it out and keep the tech for study.

If the player blindly helped get some of the tech without pressing for info, they'll still be charged 20 HGC. If the player helped get all the tech and negotiated information throughout, they'll be given the interface for free.

If the player gets the Hub interface, then meets Rubik and asks them to swap it for the Exodii one, he'll do it, no problem.  He will warn the player about the minor brain lesion (because Rubik isn't a major asshole).  However, Rubik will warn the player that if they don't agree, that despite their honesty, the Exodii won't trade with them anymore.

If the player gets a Hub interface and tries to trick Rubik into installing CBMs, Rubik will get pissed and give them 2 minutes to run before the Exodii turn hostile.  The player should know better.

If the player gets the Hub 01 interface, then the Exodii interface + minor brain lesion, and is dumb enough to go back to the Hub to get it swapped AGAIN... they'll do it.  Cheap.  But the player will end up with a major brain lesion (-4 INT and -4 DEX).  The player is warned about the extreme risk of brain damage.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Been building up to this for a while, so the alternative was just not doing it.  Happy to consider any proposed changes, of course.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Tried to run through all the dialogue and scenarios.  Seems good to me, but I think live testing is needed.  It's a lot of complex dialogue trees.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Future PRs should:
- Address the need for Hub specific CBMs.
- Make it so, at some point, the Exodii find out about the Hub CBMs, even if the player tries to hide it.
- Consider gating the CBM install behind some kind of Ancilla reputation, but I don't think there's sufficient opportunity to get that reputation yet.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
