### PR TITLE
Some extra tales to tell the drinking veterans at the Ancilla Bar

### DIFF
--- a/data/json/npcs/robofac/robofac_ancilla_npcs/BAR_ENCOUNTER_MERCENARIES/BEM_chatting_veterans.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/BAR_ENCOUNTER_MERCENARIES/BEM_chatting_veterans.json
@@ -54,6 +54,11 @@
         "topic": "BEM_CHATTING_VETERANS_TELL_STORY_OK"
       },
       {
+        "text": "Tell them about the time you hunted down an Exodii worker for the intercom.",
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_circuit_safari" } ] },
+        "topic": "BEM_CHATTING_VETERANS_TELL_STORY_OK"
+      },
+      {
         "text": "Recall the time you were tricked into fighting against distorted versions of yourself while lost in a place beyond time.",
         "condition": { "math": [ "visited_a_portal_dungeon == 1" ] },
         "topic": "BEM_CHATTING_VETERANS_TELL_STORY_IMPRESSIVE"
@@ -104,10 +109,91 @@
         "topic": "BEM_CHATTING_VETERANS_TELL_STORY_TOWER"
       },
       {
+        "text": "Recall the quiet farmstead, and the terrible tale of being slowly transformed into a creature made of black glass.",
+        "condition": { "u_has_trait": "NOT_GLASS" },
+        "topic": "BEM_CHATTING_VETERANS_TELL_STORY_IMPRESSIVE"
+      },
+      {
+        "text": "Regale the tale of the glowing church and the otherwordly strings.",
+        "condition": { "compare_string": [ "yes", { "u_val": "knows_xedra_field_station_1" } ] },
+        "topic": "BEM_CHATTING_VETERANS_TELL_STORY_OK"
+      },
+      {
+        "text": "Tell them a story about the dimension of glowing strings…",
+        "condition": { "math": [ "u_string_dimension_visits >= 1" ] },
+        "topic": "BEM_CHATTING_VETERANS_TELL_STORY_STRING_DIMENSION"
+      },
+      {
+        "text": "Recall the ruins in the woods, and the small, dish-faced creatures dancing behind the fence.",
+        "condition": { "compare_string": [ "yes", { "u_val": "knows_xedra_field_station_2" } ] },
+        "topic": "BEM_CHATTING_VETERANS_TELL_STORY_OK"
+      },
+      {
+        "text": "Show them the red mp3 player, and tell them, no, really, it TALKS to you, and is leading you somewhere.  You swear.",
+        "condition": { "u_has_item": "mp3_reverberation" },
+        "trial": { "type": "PERSUADE", "difficulty": 25 },
+        "success": { "topic": "BEM_CHATTING_VETERANS_TELL_STORY_OK" },
+        "failure": { "topic": "BEM_CHATTING_VETERANS_TELL_STORY_BAD" }
+      },
+      {
         "text": "[LIE] Just make something up.",
         "trial": { "type": "LIE", "difficulty": 15 },
         "success": { "topic": "BEM_CHATTING_VETERANS_TELL_STORY_IMPRESSIVE" },
         "failure": { "topic": "BEM_CHATTING_VETERANS_TELL_STORY_BAD" }
+      }
+    ]
+  },
+  {
+    "id": "BEM_CHATTING_VETERANS_TELL_STORY_STRING_DIMENSION",
+    "type": "talk_topic",
+    "dynamic_line": "&The mercenaries listen carefully as you begin to tell them about your journey into the dimension of glowing strings…",
+    "responses": [
+      {
+        "text": "Tell them all about the sea of black nothingness and the criss-crossing glowing strings, and hope they believe you.",
+        "trial": { "type": "PERSUADE", "difficulty": 25 },
+        "success": { "topic": "BEM_CHATTING_VETERANS_TELL_STORY_IMPRESSIVE" },
+        "failure": { "topic": "BEM_CHATTING_VETERANS_TELL_STORY_BAD" }
+      },
+      {
+        "text": "Show them the glowing string as you recall the tale of the other world, proving such things exist.",
+        "condition": { "u_has_item": "inert_glowing_string" },
+        "topic": "BEM_CHATTING_VETERANS_TELL_STORY_IMPRESSIVE"
+      },
+      {
+        "text": "Tell them about the inverted ziggurat, the strange device underground, and the hypercube it housed.  They have to believe it was the only way home!",
+        "condition": { "math": [ "u_string_dimension_ziggurat_exit >= 1" ] },
+        "trial": { "type": "PERSUADE", "difficulty": 25 },
+        "success": { "topic": "BEM_CHATTING_VETERANS_TELL_STORY_IMPRESSIVE" },
+        "failure": { "topic": "BEM_CHATTING_VETERANS_TELL_STORY_BAD" }
+      },
+      {
+        "text": "Speak about the inverted ziggurat and show them the hypercube that helped you escape.",
+        "condition": { "u_has_item": "string_dimension_hypercube" },
+        "topic": "BEM_CHATTING_VETERANS_TELL_STORY_IMPRESSIVE"
+      },
+      {
+        "text": "Tell them about the inverted metal ziggurat, the hissing doors, and the mummified zombies.  Show them the otherwordly steel equipment to prove your tale.",
+        "condition": {
+          "or": [
+            { "u_has_item": "string_dimension_partigiana_ixwa" },
+            { "u_has_item": "string_dimension_helmet_conical" },
+            { "u_has_item": "string_dimension_chainmail_suit" },
+            { "u_has_item": "string_dimension_mirror_cuirass" }
+          ]
+        },
+        "topic": "BEM_CHATTING_VETERANS_TELL_STORY_IMPRESSIVE"
+      },
+      {
+        "text": "Also tell them the story of the domed ruin and its undead, cyborg inhabitants.  It's so crazy it has to be true, right?",
+        "condition": { "compare_string": [ "yes", { "u_val": "u_found_string_dimension_exodii" } ] },
+        "trial": { "type": "PERSUADE", "difficulty": 25 },
+        "success": { "topic": "BEM_CHATTING_VETERANS_TELL_STORY_IMPRESSIVE" },
+        "failure": { "topic": "BEM_CHATTING_VETERANS_TELL_STORY_BAD" }
+      },
+      {
+        "text": "Recall the story of the domed ruin, and show them the odd, plastic key you recovered from the walking corpse.",
+        "condition": { "u_has_item": "id_exodii_string_dimension" },
+        "topic": "BEM_CHATTING_VETERANS_TELL_STORY_IMPRESSIVE"
       }
     ]
   },

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/BAR_ENCOUNTER_MERCENARIES/BEM_chatting_veterans.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/BAR_ENCOUNTER_MERCENARIES/BEM_chatting_veterans.json
@@ -114,7 +114,7 @@
         "topic": "BEM_CHATTING_VETERANS_TELL_STORY_IMPRESSIVE"
       },
       {
-        "text": "Regale the tale of the glowing church and the otherwordly strings.",
+        "text": "Regale the tale of the glowing church and the otherworldly strings.",
         "condition": { "compare_string": [ "yes", { "u_val": "knows_xedra_field_station_1" } ] },
         "topic": "BEM_CHATTING_VETERANS_TELL_STORY_OK"
       },
@@ -172,7 +172,7 @@
         "topic": "BEM_CHATTING_VETERANS_TELL_STORY_IMPRESSIVE"
       },
       {
-        "text": "Tell them about the inverted metal ziggurat, the hissing doors, and the mummified zombies.  Show them the otherwordly steel equipment to prove your tale.",
+        "text": "Tell them about the inverted metal ziggurat, the hissing doors, and the mummified zombies.  Show them the otherworldly steel equipment to prove your tale.",
         "condition": {
           "or": [
             { "u_has_item": "string_dimension_partigiana_ixwa" },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "New stories to tell at the Ancilla bar"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

The Ancilla bar spawns veterans sometimes that you can tell stories to.  I added a few more.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Added options to tell them about:

- The Vitrified Farm, if you visited and survived (obviously)
- The Barricaded Rural Church of glowing string
- Morgantown
- The string dimension (with various persuasion checks if you don't have proof, and the ability to show various items you brought back as proof)
- Circuit Safari completion
- The red mp3 player.  It's communicating with you.  Seriously.  You swear you're not crazy.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Other tales.  More to come, if inspiration strikes.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Tested the dialogue.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
