### PR TITLE
Skip test labeler for non-PR and cancelled workflow runs

### DIFF
--- a/.github/workflows/test_labeler.yml
+++ b/.github/workflows/test_labeler.yml
@@ -4,12 +4,15 @@ on:
   workflow_run:
     workflows: ["astyle", "JSON Validation", "General build matrix"]
     types: [completed]
+    branches-ignore:
+      - master
 
 jobs:
   labeling:
     if: >-
       github.repository == 'CleverRaven/Cataclysm-DDA' &&
-      github.event.workflow_run.event == 'pull_request'
+      github.event.workflow_run.event == 'pull_request' &&
+      (github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure')
     runs-on: ubuntu-latest
     steps:
     - name: setLabel


### PR DESCRIPTION
#### Summary
Infrastructure "Skip test labeler for non-PR and cancelled workflow runs"

#### Purpose of change

The test_labeler fires on all `workflow_run` completions. Push-to-master runs show up as skipped noise, and cancelled PR runs crash on missing artifacts (e.g. https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/22447959824).

#### Describe the solution

- `branches-ignore: [master]` prevents the workflow from being created for push-to-master completions (the filter matches the triggering workflow's `head_branch`)
- Conclusion guard (`success` or `failure` only) skips cancelled/timed_out runs that never uploaded artifacts

#### Describe alternatives you've considered

`if_no_artifact_found: ignore` on the download steps, but that would silently swallow real failures and still waste runner time.

#### Testing

Checked last 10 failed runs via API - all triggered by cancelled matrix runs. The conclusion guard would have skipped all of them.

#### Additional context

None