### PR TITLE
Make butter un-fun to eat directly

### DIFF
--- a/data/json/items/comestibles/dairy.json
+++ b/data/json/items/comestibles/dairy.json
@@ -140,7 +140,7 @@
     "material": [ "milk" ],
     "volume": "15 ml",
     "flags": [ "NO_AUTO_CONSUME" ],
-    "fun": -10,
+    "fun": -7,
     "vitamins": [ [ "milk_allergen", 1 ] ]
   },
   {

--- a/data/json/items/comestibles/dairy.json
+++ b/data/json/items/comestibles/dairy.json
@@ -140,7 +140,7 @@
     "material": [ "milk" ],
     "volume": "15 ml",
     "flags": [ "NO_AUTO_CONSUME" ],
-    "fun": -1,
+    "fun": -10,
     "vitamins": [ [ "milk_allergen", 1 ] ]
   },
   {


### PR DESCRIPTION
#### Summary
Balance "Make butter un-fun to eat directly"

#### Purpose of change
Eating raw butter carries essentially no downsides. You can force-feed butter to your companions. What.

#### Describe the solution
Much bigger morale penalty, butter cannot be put into larder

#### Describe alternatives you've considered
-Eating raw butter should *also* make you nauseous

-Just make butter inedible, because eating butter by itself is extremely unusual, very much in the minority

#### Testing
Simple value change

#### Additional context

