### PR TITLE
Fix division by zero crash in vehicle bash pathfinding

### DIFF
--- a/src/pathfinding.cpp
+++ b/src/pathfinding.cpp
@@ -280,6 +280,9 @@ int map::cost_to_pass( const tripoint_bub_ms &cur, const tripoint_bub_ms &p,
                     hp *= 2;
                 }
 
+                if( damage == 0 ) {
+                    return PF_IMPASSABLE;
+                }
                 return 2 * hp / damage + 8 + 4;
             } else {
                 const vehicle_part &vp = veh->part( part );


### PR DESCRIPTION
#### Summary
Bugfixes "Fix crash when NPC with non-bash weapon pathfinds near vehicle obstacles"

#### Purpose of change

Fixes #85551, #84572. The pathfinder converts damage types to bash via `bash_conversion_factor`, but only `bash` has a non-zero factor. When a creature only deals cut/stab/etc., the converted total is 0 and `2 * hp / damage + 8 + 4` crashes.

#### Describe the solution

Guard against `damage == 0` before the division and return `PF_IMPASSABLE`, since zero bash-equivalent damage means the creature can't bash through anyway.

#### Describe alternatives you've considered

N/A

#### Testing

#### Additional context

Diagnosed by @RenechCDDA in #84572.