### PR TITLE
Broken nanofab in collapsed office tower

### DIFF
--- a/data/json/furniture_and_terrain/terrain-manufactured.json
+++ b/data/json/furniture_and_terrain/terrain-manufactured.json
@@ -602,6 +602,16 @@
   },
   {
     "type": "terrain",
+    "id": "t_nanofab_body_broken",
+    "name": "broken nanofabricator",
+    "copy-from": "t_nanofab_body",
+    "symbol": "%",
+    "description": "A great column of advanced machinery.  Within this self-contained, miniaturized factory, several 3D printers work in tandem with a robotic assembler to manufacture nearly any inorganic object.  It is broken beyond repair and it is generally nothing but a useless hunk of steel.",
+    "color": "dark_gray",
+    "delete": { "flags": [ "NANOFAB_TABLE" ] }
+  },
+  {
+    "type": "terrain",
     "id": "t_nanofab",
     "name": "nanofabricator control panel",
     "symbol": "&",

--- a/data/json/mapgen/collapsed_tower.json
+++ b/data/json/mapgen/collapsed_tower.json
@@ -178,7 +178,7 @@
         " ": "t_thconc_floor_flesh",
         "?": "t_nanofab",
         "r": "t_metal_floor",
-        "/": "t_nanofab_body",
+        "/": "t_nanofab_body_broken",
         "Y": "t_thconc_floor_olight",
         "p": "t_metal_floor"
       },


### PR DESCRIPTION

#### Summary
None

#### Purpose of change
You'd think the fact that the whole office tower building has collapsed and the cataclysm happening in general would give clue on the fact that it wont work, but it apparently doesnt. So i make it a bit more obvious.

#### Describe the solution
Adds broken nanofabricator body, replace nanofab body in collapsed tower with the broken one

#### Describe alternatives you've considered
Bash the nanofab area some more.

#### Testing
![Screenshot_20260227_094959](https://github.com/user-attachments/assets/afaac598-ba92-4f4e-b940-333187af2d97)


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
