### PR TITLE
Fix wrapping in extended descriptions

### DIFF
--- a/src/surroundings_menu.cpp
+++ b/src/surroundings_menu.cpp
@@ -1075,8 +1075,7 @@ void surroundings_menu::draw_monster_tab()
             if( ImGui::BeginChild( "info", ImVec2( 0.0f, str_height_to_pixels( info_height ) ) ) ) {
                 if( monster_data.selected_entry ) {
                     draw_extended_description(
-                        monster_data.selected_entry->get_selected_entity()->extended_description(),
-                        str_width_to_pixels( width ), info_scroll );
+                        monster_data.selected_entry->get_selected_entity()->extended_description(), info_scroll );
                 }
             }
             ImGui::EndChild();
@@ -1155,8 +1154,7 @@ void surroundings_menu::draw_terfurn_tab()
             if( ImGui::BeginChild( "info", ImVec2( 0.0f, str_height_to_pixels( info_height ) ) ) ) {
                 if( terfurn_data.selected_entry ) {
                     draw_extended_description(
-                        terfurn_data.selected_entry->get_selected_entity()->extended_description(),
-                        str_width_to_pixels( width ), info_scroll );
+                        terfurn_data.selected_entry->get_selected_entity()->extended_description(), info_scroll );
                 }
             }
             ImGui::EndChild();

--- a/src/ui_extended_description.cpp
+++ b/src/ui_extended_description.cpp
@@ -10,6 +10,7 @@
 #include "mapdata.h"
 #include "point.h"
 #include "string_formatter.h"
+#include "text.h"
 #include "translations.h"
 #include "type_id.h"
 #include "ui_manager.h"
@@ -70,8 +71,7 @@ static void draw_graffiti_text( const tripoint_bub_ms &p )
     }
 }
 
-void draw_extended_description( const std::vector<std::string> &description, const uint64_t width,
-                                cataimgui::scroll &s )
+void draw_extended_description( const std::vector<std::string> &description, cataimgui::scroll &s )
 {
     cataimgui::set_scroll( s );
 
@@ -79,7 +79,8 @@ void draw_extended_description( const std::vector<std::string> &description, con
         if( s == "--" ) {
             ImGui::Separator();
         } else {
-            cataimgui::draw_colored_text( s, c_light_gray, width );
+            cataimgui::TextColoredParagraph( c_light_gray, s );
+            ImGui::NewLine();
         }
     }
 }
@@ -159,7 +160,7 @@ void extended_description_window::draw_creature_tab()
     if( ImGui::BeginTabItem( title.c_str(), nullptr, flags ) ) {
         cur_target = description_target::creature;
         if( !creature_description.empty() ) {
-            draw_extended_description( creature_description, str_width_to_pixels( TERMX ), info_scroll );
+            draw_extended_description( creature_description, info_scroll );
         } else {
             cataimgui::draw_colored_text( _( "You do not see any creature here." ), c_light_gray );
         }
@@ -178,7 +179,7 @@ void extended_description_window::draw_furniture_tab()
     if( ImGui::BeginTabItem( title.c_str(), nullptr, flags ) ) {
         cur_target = description_target::furniture;
         if( !furniture_description.empty() ) {
-            draw_extended_description( furniture_description, str_width_to_pixels( TERMX ), info_scroll );
+            draw_extended_description( furniture_description, info_scroll );
         } else {
             cataimgui::draw_colored_text( _( "You do not see any furniture here." ), c_light_gray );
         }
@@ -198,7 +199,7 @@ void extended_description_window::draw_terrain_tab()
     if( ImGui::BeginTabItem( title.c_str(), nullptr, flags ) ) {
         cur_target = description_target::terrain;
         if( !terrain_description.empty() ) {
-            draw_extended_description( terrain_description, str_width_to_pixels( TERMX ), info_scroll );
+            draw_extended_description( terrain_description, info_scroll );
         } else {
             cataimgui::draw_colored_text( _( "You can't see the terrain here." ), c_light_gray );
         }
@@ -218,7 +219,7 @@ void extended_description_window::draw_vehicle_tab()
     if( ImGui::BeginTabItem( title.c_str(), nullptr, flags ) ) {
         cur_target = description_target::vehicle;
         if( !veh_app_description.empty() ) {
-            draw_extended_description( veh_app_description, str_width_to_pixels( TERMX ), info_scroll );
+            draw_extended_description( veh_app_description, info_scroll );
         } else {
             cataimgui::draw_colored_text( _( "You can't see vehicles or appliances here." ), c_light_gray );
         }

--- a/src/ui_extended_description.h
+++ b/src/ui_extended_description.h
@@ -2,7 +2,6 @@
 #ifndef CATA_SRC_UI_EXTENDED_DESCRIPTION_H
 #define CATA_SRC_UI_EXTENDED_DESCRIPTION_H
 
-#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -19,8 +18,7 @@ enum class description_target : int {
     num_targets
 };
 
-void draw_extended_description( const std::vector<std::string> &description, uint64_t width,
-                                cataimgui::scroll &s );
+void draw_extended_description( const std::vector<std::string> &description, cataimgui::scroll &s );
 
 class extended_description_window : public cataimgui::window
 {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fixes #85566

#### Describe the solution

Use `TextColoredParagraph` instead of `draw_colored_text`.

#### Describe alternatives you've considered



#### Testing

Looked at descriptions before and after, with both fixed and variable-width fonts.

#### Additional context

`TextColoredParagraph` still seems to have a little bit of weirdness in its wrapping, but that's a different issue.

<img width="440" height="156" alt="grafik" src="https://github.com/user-attachments/assets/8aa3a568-790a-4e9f-a07c-773031af5803" />
