### PR TITLE
Pat can replace lost/damaged AR glasses/earpiece

### DIFF
--- a/data/json/npcs/robofac/robofac_ancilla_npcs/PAT/NPC_Pat.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/PAT/NPC_Pat.json
@@ -581,7 +581,7 @@
         ]
       },
       {
-        "text": "Could I get another pair of AR glasses?  Here's 10 HGC for suppies.",
+        "text": "Could I get another pair of AR glasses?  Here's 10 HGC for supplies.",
         "topic": "TALK_ROBOFAC_MERC_PAT_REMAKE_AR_GLASSES_YES",
         "condition": {
           "and": [

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/PAT/NPC_Pat.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/PAT/NPC_Pat.json
@@ -215,28 +215,6 @@
         ]
       },
       {
-        "text": "These glasses are a bit clunky.  Think we can improve them at all?",
-        "topic": "TALK_ROBOFAC_MERC_PAT_IMPROVE_GEAR_NO",
-        "condition": {
-          "and": [
-            { "compare_string": [ "yes", { "u_val": "robofac_pat_gave_gear" } ] },
-            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_started_earpiece" } ] } },
-            { "not": { "math": [ "time_since(robofac_timer_waiting_on_pat) >= time('14 d')" ] } }
-          ]
-        }
-      },
-      {
-        "text": "We've had these glasses for a while.  They're clunky, fragile, and go through batteries pretty quick.  Think we can improve them at all?",
-        "topic": "TALK_ROBOFAC_MERC_PAT_IMPROVE_GEAR_YES",
-        "condition": {
-          "and": [
-            { "compare_string": [ "yes", { "u_val": "robofac_pat_gave_gear" } ] },
-            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_started_earpiece" } ] } },
-            { "math": [ "time_since(robofac_timer_waiting_on_pat) >= time('14 d')" ] }
-          ]
-        }
-      },
-      {
         "text": "So, no easy way to say this, but I let some robots turn me into a cyborg.  Pretty cool, yeah?",
         "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG",
         "condition": {
@@ -275,7 +253,7 @@
         }
       },
       {
-        "text": "Hey, check out this military-grade AR unit.  Think we can do something with it?",
+        "text": "Hey, check out this Hub 01 AR unit.  Think we can do something with it?",
         "topic": "TALK_ROBOFAC_MERC_PAT_MAKE_EARPIECE_HVAH",
         "condition": {
           "and": [
@@ -364,6 +342,11 @@
             { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_mws_4" } ] }
           ]
         }
+      },
+      {
+        "text": "About the equipment we use…",
+        "topic": "TALK_ROBOFAC_MERC_PAT_GEAR_MENU",
+        "condition": { "compare_string": [ "yes", { "u_val": "robofac_pat_gave_gear" } ] }
       },
       {
         "text": "Just came by to chat.",
@@ -542,6 +525,168 @@
     "responses": [ { "text": "[Have a chat then say goodbye]", "topic": "TALK_DONE" } ]
   },
   {
+    "id": "TALK_ROBOFAC_MERC_PAT_GEAR_MENU",
+    "type": "talk_topic",
+    "dynamic_line": "Whatsup?",
+    "responses": [
+      {
+        "text": "These glasses are a bit clunky.  Think we can improve them at all?",
+        "topic": "TALK_ROBOFAC_MERC_PAT_IMPROVE_GEAR_NO",
+        "condition": {
+          "and": [
+            { "compare_string": [ "yes", { "u_val": "robofac_pat_gave_gear" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_started_earpiece" } ] } },
+            { "not": { "math": [ "time_since(robofac_timer_waiting_on_pat) >= time('14 d')" ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_talked_about_gear_improvement" } ] } }
+          ]
+        }
+      },
+      {
+        "text": "We've had these glasses for a while.  They're clunky, fragile, and go through batteries pretty quick.  Think we can improve them at all?",
+        "topic": "TALK_ROBOFAC_MERC_PAT_IMPROVE_GEAR_YES",
+        "condition": {
+          "and": [
+            { "compare_string": [ "yes", { "u_val": "robofac_pat_gave_gear" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_started_earpiece" } ] } },
+            { "math": [ "time_since(robofac_timer_waiting_on_pat) >= time('14 d')" ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_talked_about_gear_improvement" } ] } }
+          ]
+        }
+      },
+      {
+        "text": "What do you need if I want another pair of AR glasses?",
+        "topic": "TALK_ROBOFAC_MERC_PAT_REMAKE_AR_GLASSES_NO",
+        "condition": { "compare_string": [ "yes", { "u_val": "robofac_pat_gave_gear" } ] },
+        "effect": { "u_add_var": "robofac_pat_told_u_about_remaking_glasses", "value": "yes" }
+      },
+      {
+        "text": "Could I get another pair of AR glasses?  Here are the electronics you need.",
+        "topic": "TALK_ROBOFAC_MERC_PAT_REMAKE_AR_GLASSES_YES",
+        "condition": {
+          "and": [
+            { "compare_string": [ "yes", { "u_val": "robofac_pat_gave_gear" } ] },
+            { "compare_string": [ "yes", { "u_val": "robofac_pat_told_u_about_remaking_glasses" } ] },
+            { "u_has_items": { "item": "eink_tablet_pc", "count": 2 } },
+            { "u_has_items": { "item": "ar_glasses_advanced", "count": 1 } },
+            { "u_has_items": { "item": "two_way_radio", "count": 2 } },
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }
+          ]
+        },
+        "effect": [
+          { "u_consume_item": "eink_tablet_pc", "count": 2, "popup": true },
+          { "u_consume_item": "ar_glasses_advanced", "count": 1, "popup": true },
+          { "u_consume_item": "two_way_radio", "count": 2, "popup": true },
+          { "math": [ "robofac_timer_waiting_on_pat = time('now')" ] },
+          { "u_add_var": "robofac_pat_remaking_glasses", "value": "yes" }
+        ]
+      },
+      {
+        "text": "Could I get another pair of AR glasses?  Here's 10 HGC for suppies.",
+        "topic": "TALK_ROBOFAC_MERC_PAT_REMAKE_AR_GLASSES_YES",
+        "condition": {
+          "and": [
+            { "compare_string": [ "yes", { "u_val": "robofac_pat_gave_gear" } ] },
+            { "compare_string": [ "yes", { "u_val": "robofac_pat_told_u_about_remaking_glasses" } ] },
+            { "u_has_items": { "item": "RobofacCoin", "count": 10 } },
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }
+          ]
+        },
+        "effect": [
+          { "u_consume_item": "RobofacCoin", "count": 10, "popup": true },
+          { "math": [ "robofac_timer_waiting_on_pat = time('now')" ] },
+          { "u_add_var": "robofac_pat_remaking_glasses", "value": "yes" }
+        ]
+      },
+      {
+        "text": "It's been a day.  Are the AR glasses done?",
+        "topic": "TALK_ROBOFAC_MERC_PAT_REMAKE_AR_GLASSES_DONE",
+        "condition": {
+          "and": [
+            { "compare_string": [ "yes", { "u_val": "robofac_pat_remaking_glasses" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } },
+            { "math": [ "time_since(robofac_timer_waiting_on_pat) >= time('1 d')" ] }
+          ]
+        },
+        "effect": [
+          { "u_spawn_item": "ar_glasses_advanced_pat", "count": 1 },
+          { "math": [ "robofac_timer_waiting_on_pat = time('now')" ] },
+          { "u_lose_var": "robofac_pat_remaking_glasses" }
+        ]
+      },
+      {
+        "text": "What do you need if I want another earpiece?",
+        "topic": "TALK_ROBOFAC_MERC_PAT_REMAKE_EARPIECE_NO",
+        "condition": { "compare_string": [ "yes", { "u_val": "robofac_pat_finished_earpiece" } ] },
+        "effect": { "u_add_var": "robofac_pat_told_u_about_remaking_earpiece", "value": "yes" }
+      },
+      {
+        "text": "Could I get another earpiece?  Here's a couple HGC for supplies.",
+        "topic": "TALK_ROBOFAC_MERC_PAT_REMAKE_EARPIECE_YES",
+        "condition": {
+          "and": [
+            { "compare_string": [ "yes", { "u_val": "robofac_pat_finished_earpiece" } ] },
+            { "compare_string": [ "yes", { "u_val": "robofac_pat_told_u_about_remaking_earpiece" } ] },
+            { "u_has_items": { "item": "RobofacCoin", "count": 2 } },
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }
+          ]
+        },
+        "effect": [
+          { "u_consume_item": "RobofacCoin", "count": 2, "popup": true },
+          { "u_add_var": "robofac_pat_remaking_earpiece", "value": "yes" }
+        ]
+      },
+      {
+        "text": "It's been a day.  Is the earpiece done?",
+        "topic": "TALK_ROBOFAC_MERC_PAT_REMAKE_EARPIECE_DONE",
+        "condition": {
+          "and": [
+            { "compare_string": [ "yes", { "u_val": "robofac_pat_remaking_earpiece" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } },
+            { "math": [ "time_since(robofac_timer_waiting_on_pat) >= time('1 d')" ] }
+          ]
+        },
+        "effect": [ { "u_spawn_item": "pat_earpiece", "count": 1 }, { "u_lose_var": "robofac_pat_remaking_earpiece" } ]
+      },
+      { "text": "Let's talk about something else…", "topic": "TALK_ROBOFAC_MERC_PAT" }
+    ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_REMAKE_AR_GLASSES_NO",
+    "type": "talk_topic",
+    "dynamic_line": "Pair'a advanced AR glasses, 2 two-way radios, and 2 tablet PCs.  Or, ya' cough up 10 HGC, and I'll scrounge up the pahts myself.  Cool?",
+    "responses": [ { "text": "Cool.", "topic": "TALK_ROBOFAC_MERC_PAT" } ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_REMAKE_EARPIECE_NO",
+    "type": "talk_topic",
+    "dynamic_line": "No prob.  Just cough up 2 HGC, and I'll scrounge up the pahts myself.  Cool?",
+    "responses": [ { "text": "Cool.", "topic": "TALK_ROBOFAC_MERC_PAT" } ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_REMAKE_AR_GLASSES_YES",
+    "type": "talk_topic",
+    "dynamic_line": "&Pat whips out their soldering iron and starts to clear their desk.  \"Wicked.  Come back tomorrah.\"",
+    "responses": [ { "text": "Thanks, Pat.  See you tomorrow.", "topic": "TALK_DONE" } ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_REMAKE_EARPIECE_YES",
+    "type": "talk_topic",
+    "dynamic_line": "&Pat whips out their soldering iron and starts to clear their desk.  \"Wicked.  Come back tomorrah.\"",
+    "responses": [ { "text": "Thanks, Pat.  See you tomorrow.", "topic": "TALK_DONE" } ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_REMAKE_AR_GLASSES_DONE",
+    "type": "talk_topic",
+    "dynamic_line": "&Pat picks up a new pair of modified AR glasses, wipes the lenses, and hands them over to you.  \"Careful with this set, yeah?\"",
+    "responses": [ { "text": "Thanks, Pat.  See you later.", "topic": "TALK_DONE" } ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_REMAKE_EARPIECE_DONE",
+    "type": "talk_topic",
+    "dynamic_line": "&Pat whistles sharply and tosses the earpiece in the air.  You catch it.  Pat chuckles.  \"Don' lose that one, got it?\"",
+    "responses": [ { "text": "Thanks, Pat.  See you later.", "topic": "TALK_DONE" } ]
+  },
+  {
     "id": "TALK_ROBOFAC_MERC_PAT_MISSION_FRIEND_1",
     "type": "talk_topic",
     "dynamic_line": "Actually, yeah, I been thinkin' about this a lot.  I'm probably bettah suited stayin' heah, an' you're bettah out in the field.  I'm wonderin' if maybe we team up.  Partners.  Whaddaya think?",
@@ -643,7 +788,13 @@
     "id": "TALK_ROBOFAC_MERC_PAT_IMPROVE_GEAR_YES",
     "type": "talk_topic",
     "dynamic_line": "I think this is about as good as my post-apocalyptic engineering will take us, eh?  Unless our employer chips in, or you can dig up one of those cutting-edge military AR units, I think we're S-O-L.",
-    "responses": [ { "text": "Yeah, alright.  Maybe sometime in the future.", "topic": "TALK_ROBOFAC_MERC_PAT" } ]
+    "responses": [
+      {
+        "text": "Yeah, alright.  Maybe sometime in the future.",
+        "topic": "TALK_ROBOFAC_MERC_PAT",
+        "effect": { "u_add_var": "robofac_pat_talked_about_gear_improvement", "value": "yes" }
+      }
+    ]
   },
   {
     "id": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Features "Pat can replace missing transponder gear"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

If you are interacting with pat, and you destroy or lose your glasses or earpiece, you were SOL.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Pat can replace the AR glasses or the earpiece, depending on which you've been given.  They will do it for materials, or for HGC.  You have to wait a day to get the new stuff.

These options are all nested in their own dialogue option, now, where most equipment chatter will go.  This will keep things tidy.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

n/a

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Ran through the dialogue in game.  Working as intended.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
