### PR TITLE
Pat notices and comments if you vanish to the void spider lair with transponder active

### DIFF
--- a/data/json/effects_on_condition/item_eocs.json
+++ b/data/json/effects_on_condition/item_eocs.json
@@ -409,11 +409,13 @@
             { "npc_near_om_location": "radio_tower_reverberation_mp3", "range": 3 },
             { "npc_near_om_location": "string_dimension_crossroads", "range": 3 },
             { "npc_near_om_location": "mine_spiral_finale_s", "range": 3 },
+            { "npc_near_om_location": "void_spider_lair", "range": 3 },
             { "math": [ "robofac_pat_lost_signal_highlands == 1" ] },
             { "math": [ "robofac_pat_lost_signal_radiosphere == 1" ] },
             { "math": [ "robofac_pat_lost_signal_cabin_reverb == 1" ] },
             { "math": [ "robofac_pat_lost_signal_labyrinth == 1" ] },
-            { "math": [ "robofac_pat_lost_signal_string_dimension == 1" ] }
+            { "math": [ "robofac_pat_lost_signal_string_dimension == 1" ] },
+            { "math": [ "robofac_pat_lost_signal_spider_dimension == 1" ] }
           ]
         }
       ]
@@ -681,6 +683,19 @@
       },
       {
         "if": {
+          "and": [
+            { "npc_near_om_location": "void_spider_lair", "range": 3 },
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_saw_spider_dimension" } ] } }
+          ]
+        },
+        "then": [
+          { "u_message": "Your earpiece is filled with static and your HUD glitches.", "popup": true },
+          { "u_add_var": "robofac_pat_saw_spider_dimension", "value": "yes" },
+          { "math": [ "robofac_pat_lost_signal_spider_dimension = 1" ] }
+        ]
+      },
+      {
+        "if": {
           "and": [ { "npc_near_om_location": "field", "range": 10 }, { "math": [ "robofac_pat_lost_signal_highlands == 1" ] } ]
         },
         "then": [
@@ -737,6 +752,18 @@
             "popup": true
           },
           { "math": [ "robofac_pat_lost_signal_string_dimension = 0" ] }
+        ]
+      },
+      {
+        "if": {
+          "and": [ { "npc_near_om_location": "field", "range": 10 }, { "math": [ "robofac_pat_lost_signal_spider_dimension == 1" ] } ]
+        },
+        "then": [
+          {
+            "u_message": "You hear a chirp in your earpiece and Pat's voice comes over the line: \"Theah ya' go.  Got ya' back.  Lost the signal a while back, but she's strong now, and I got some images comin' in…  what in the livin' fuck?  Holy shit, looks like I should catch up.  We can talk latah.  Glad ya' back.  Ovah.\"",
+            "popup": true
+          },
+          { "math": [ "robofac_pat_lost_signal_spider_dimension = 0" ] }
         ]
       }
     ]

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/PAT/NPC_Pat_HEW.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/PAT/NPC_Pat_HEW.json
@@ -88,6 +88,11 @@
         "topic": "TALK_PAT_ADVICE_MISSION_ROBOFAC_INTERCOM_MWS_4_SPIRAL_MINE",
         "condition": { "compare_string": [ "yes", { "u_val": "robofac_pat_saw_spiral_mine" } ] }
       },
+      {
+        "text": "[Distorted images of the spider's lair] Well, I guess that might've been a good place",
+        "topic": "TALK_PAT_ADVICE_MISSION_ROBOFAC_INTERCOM_MWS_4_VOID_SPIDER_LAIR",
+        "condition": { "compare_string": [ "yes", { "u_val": "robofac_pat_saw_spider_dimension" } ] }
+      },
       { "text": "Hmm.  Well, I guess we'll just see what I can find.", "topic": "TALK_DONE" }
     ]
   },
@@ -186,5 +191,11 @@
     "type": "talk_topic",
     "dynamic_line": "I'd say that theah was an elaborate prank, if it weren't for the fuckin' wicked crazy shit inside.  Yeah.  Scan it from the parking lot, will ya'?",
     "responses": [ { "text": "Guess I'll give it a try.", "topic": "TALK_PAT_ADVICE_MISSION_ROBOFAC_INTERCOM_MWS_4" } ]
+  },
+  {
+    "id": "TALK_PAT_ADVICE_MISSION_ROBOFAC_INTERCOM_MWS_4_VOID_SPIDER_LAIR",
+    "type": "talk_topic",
+    "dynamic_line": "Well, yeah, I'd fuckin' say so.  You don' plan to go back theah, though, right?  That fuckin' spidah, man.  I don' like spidahs.",
+    "responses": [ { "text": "I guess if I'm ever back there, I could try.", "topic": "TALK_PAT_ADVICE_MISSION_ROBOFAC_INTERCOM_MWS_4" } ]
   }
 ]

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/PAT/NPC_Pat_HEW.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/PAT/NPC_Pat_HEW.json
@@ -196,6 +196,8 @@
     "id": "TALK_PAT_ADVICE_MISSION_ROBOFAC_INTERCOM_MWS_4_VOID_SPIDER_LAIR",
     "type": "talk_topic",
     "dynamic_line": "Well, yeah, I'd fuckin' say so.  You don' plan to go back theah, though, right?  That fuckin' spidah, man.  I don' like spidahs.",
-    "responses": [ { "text": "I guess if I'm ever back there, I could try.", "topic": "TALK_PAT_ADVICE_MISSION_ROBOFAC_INTERCOM_MWS_4" } ]
+    "responses": [
+      { "text": "I guess if I'm ever back there, I could try.", "topic": "TALK_PAT_ADVICE_MISSION_ROBOFAC_INTERCOM_MWS_4" }
+    ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Pat can comment on the Void Weaver"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Pat comments on other dimensions and strange places.  Didn't comment on the Void Weaver.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Pat will now recognize if you get sent to the void spider dimension with their gear active.  They'll comment if you make it back to the real world, and the surface.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

n/a

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Visited void weaver lair, returned, talked to Pat in person and over radio.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

PR for void spider dimension HEW report to follow shortly.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
