### PR TITLE
Add consistency checks for dangling references

### DIFF
--- a/build-scripts/get_all_mods.py
+++ b/build-scripts/get_all_mods.py
@@ -92,7 +92,7 @@ for r, d, f in os.walk('data/mods'):
         ident = os.path.basename(mod.path)
         if ident in obsolete_mods:
             continue
-        mods_this_time.append(os.path.basename(mod.path))
+        add_mods([os.path.basename(mod.path)])
     mods_lists.append(','.join(mods_this_time))
     mods_this_time.clear()
 

--- a/data/json/items/armor/combat_exoskeleton.json
+++ b/data/json/items/armor/combat_exoskeleton.json
@@ -267,7 +267,7 @@
     "subtypes": [ "TOOL", "ARMOR", "ARTIFACT" ],
     "name": { "str": "combat exoskeleton mk2", "str_pl": "combat exoskeletons mk2" },
     "description": "These were the second wave of military combat exoskeleton, and got a lot of media attention, with popular Navy commercials featuring them heavily.  The exoskeleton itself is strapped on an environmental suit with an integrated life-support system.  A variety of webbing, magnets, and clips allows the attachment of special armor plating onto the frame.",
-    "looks_like": "power_armor_basic",
+    "looks_like": "combat_exoskeleton_medium",
     "use_action": {
       "type": "transform",
       "msg": "You turn the exoskeleton on.\n>>Initiating boot sequence…\n//Loading DoubleOS v2.86…\n//Loading calibration profile…\n//Activating atmospheric filtration…\n//Activating liquid cooling…\n//Activating sound dampeners…\n>>Boot successful.",

--- a/data/json/items/comestibles/carnivore.json
+++ b/data/json/items/comestibles/carnivore.json
@@ -2443,7 +2443,7 @@
     "name": { "str": "chunk of mutagenic flesh", "str_pl": "chunks of mutagenic flesh" },
     "description": "A chunk of raw meat with a weirdly off-green coloration.  You could eat it as-is, but are you sure you want to?",
     "flags": [ "RAW", "TRADER_AVOID" ],
-    "smoking_result": " ",
+    "smoking_result": "null",
     "vitamins": [ [ "mutagenic_slurry", 12 ], [ "meat_allergen", 1 ] ]
   }
 ]

--- a/data/json/items/tool/cooking.json
+++ b/data/json/items/tool/cooking.json
@@ -7,7 +7,7 @@
     "category": "tools",
     "description": "A kit containing all the specialized knives you need to debone, skin, and prepare cuts of meat from an animal.",
     "copy-from": "base_kitchen_knife",
-    "looks_like": "knife_butcher",
+    "looks_like": "knife_huge",
     "weight": "1170 g",
     "volume": "800 ml",
     "longest_side": "40 cm",

--- a/data/json/start_locations.json
+++ b/data/json/start_locations.json
@@ -306,7 +306,13 @@
     "type": "start_location",
     "id": "sloc_library",
     "name": "Library",
-    "terrain": [ "s_library", "s_library_1", "s_library_2", "s_library_3", "urban_library" ]
+    "terrain": [
+      "s_library",
+      "s_library_1",
+      "s_library_2",
+      "s_library_3",
+      { "om_terrain": "urban_library", "om_terrain_match_type": "PREFIX" }
+    ]
   },
   {
     "type": "start_location",

--- a/data/mods/Limb_WIP/mod_interactions/mindovermatter/vitakinesis_eoc.json
+++ b/data/mods/Limb_WIP/mod_interactions/mindovermatter/vitakinesis_eoc.json
@@ -9,7 +9,7 @@
           "EOC_VITAKIN_RESTORE_LIMB_LEFT_LEG",
           "EOC_VITAKIN_RESTORE_LIMB_RIGHT_ARM",
           "EOC_VITAKIN_RESTORE_LIMB_LEFT_ARM",
-          "EOC_PORTAL_NULL_AWAKENING"
+          "EOC_MOM_NO_EFFECT"
         ],
         "names": [ "Restore Right Leg", "Restore Left Leg", "Restore Right Arm", "Restore Left Arm", "Nevermind" ],
         "keys": [ "1", "2", "3", "4", "5" ],

--- a/data/mods/MA/start_locations.json
+++ b/data/mods/MA/start_locations.json
@@ -13,12 +13,7 @@
     "type": "start_location",
     "id": "sloc_road_MA",
     "name": "Road",
-    "terrain": [
-      "road_nesw_manhole",
-      { "om_terrain": "road_straight", "om_terrain_match_type": "PREFIX" },
-      { "om_terrain": "road_curved", "om_terrain_match_type": "PREFIX" },
-      { "om_terrain": "road_end", "om_terrain_match_type": "PREFIX" }
-    ],
+    "terrain": [ "road_nesw_manhole", { "om_terrain": "road", "om_terrain_match_type": "TYPE" } ],
     "city_sizes": [ 0, 16 ],
     "city_distance": [ 0, -1 ],
     "allowed_z_levels": [ 0, 0 ],
@@ -30,7 +25,7 @@
     "name": "House",
     "terrain": [
       "house_w_1",
-      "house_two_story_basement",
+      "house_2story_basement",
       "house_crack1",
       "house_crack2",
       "house_crack3",

--- a/data/mods/MMA/professions.json
+++ b/data/mods/MMA/professions.json
@@ -27,6 +27,7 @@
         ]
       }
     },
+    "traits": [ "CBM_Interface" ],
     "CBMs": [
       "bio_power_storage_mkII",
       "bio_armor_arms",

--- a/data/mods/Magiclysm/Spells/attunements/Alchemist.json
+++ b/data/mods/Magiclysm/Spells/attunements/Alchemist.json
@@ -10,7 +10,7 @@
     "extra_effects": [ { "id": "eoc_summon_setup", "hit_self": true } ],
     "shape": "blast",
     "valid_targets": [ "self" ],
-    "flags": [ "CONJURATION_SPELL", "SOMATIC", "CONCENTRATE", "VERBAL" ],
+    "flags": [ "CONJURATION_SPELL", "SOMATIC", "CONCENTRATE", "VERBAL", "PERMANENT_ALL_LEVELS" ],
     "max_level": 35,
     "min_damage": 1,
     "max_damage": 8,

--- a/data/mods/Magiclysm/Spells/item_only.json
+++ b/data/mods/Magiclysm/Spells/item_only.json
@@ -942,6 +942,11 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_SUMMON_MUSHROOMS",
+    "effect": [ { "u_cast_spell": { "id": "mag_summon_mushrooms", "min_level": 1 }, "targeted": false } ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_CALL_FORAGING_BEETLES",
     "//": "Consider changing this into a periodic for foraging in the area with randomized returns",
     "effect": [

--- a/data/mods/MindOverMatter/effectoncondition/eoc_power_effects.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_power_effects.json
@@ -234,7 +234,7 @@
         }
       ]
     },
-    "effect": [ { "run_eocs": "EOC_perk_blood_drinking_heal_hp_check" } ]
+    "effect": [ { "run_eocs": "EOC_MOM_PSYCHIC_VAMPIRE_HEAL_HP" } ]
   },
   {
     "type": "effect_on_condition",
@@ -526,6 +526,12 @@
         "allow_cancel": true
       }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_MOM_PSYCHIC_VAMPIRE_HEAL_HP",
+    "//": "Overridden by mod_interactions/bombastic_perks when that mod is loaded",
+    "effect": [  ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/MindOverMatter/mod_interactions/bombastic_perks/psychic_vampire_heal.json
+++ b/data/mods/MindOverMatter/mod_interactions/bombastic_perks/psychic_vampire_heal.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_MOM_PSYCHIC_VAMPIRE_HEAL_HP",
+    "effect": [ { "run_eocs": "EOC_perk_blood_drinking_heal_hp_check" } ]
+  }
+]

--- a/data/mods/MindOverMatter/powers/clairsentience_eoc.json
+++ b/data/mods/MindOverMatter/powers/clairsentience_eoc.json
@@ -21,7 +21,7 @@
     "id": "EOC_CLAIR_RAD_SENSE",
     "effect": [
       {
-        "run_eoc_selector": [ "EOC_CLAIR_RAD_SENSE_SELF", "EOC_CLAIR_RAD_SENSE_OUTSIDE", "EOC_PORTAL_NULL_AWAKENING" ],
+        "run_eoc_selector": [ "EOC_CLAIR_RAD_SENSE_SELF", "EOC_CLAIR_RAD_SENSE_OUTSIDE", "EOC_MOM_NO_EFFECT" ],
         "names": [ "Check yourself", "Check your surroundings", "Nevermind" ],
         "keys": [ "1", "2", "3" ],
         "descriptions": [

--- a/data/mods/MindOverMatter/powers/electrokinesis.json
+++ b/data/mods/MindOverMatter/powers/electrokinesis.json
@@ -560,7 +560,7 @@
     "description": { "str": "Creates a tool used to hack robots.  It's a bug if you have it.", "//~": "NO_I18N" },
     "valid_targets": [ "self" ],
     "skill": "metaphysics",
-    "flags": [ "PSIONIC", "SILENT", "NO_HANDS", "NO_LEGS", "NO_EXPLOSION_SFX" ],
+    "flags": [ "PSIONIC", "SILENT", "NO_HANDS", "NO_LEGS", "NO_EXPLOSION_SFX", "PERMANENT" ],
     "effect": "spawn_item",
     "effect_str": "electro_robot_interface",
     "shape": "blast",

--- a/data/mods/MindOverMatter/powers/pyrokinesis_eoc.json
+++ b/data/mods/MindOverMatter/powers/pyrokinesis_eoc.json
@@ -43,7 +43,7 @@
           "EOC_PYROKIN_CAUTERIZE_LEFT_LEG",
           "EOC_PYROKIN_CAUTERIZE_RIGHT_LEG",
           "EOC_PYROKIN_CAUTERIZE_BODY",
-          "EOC_PORTAL_NULL_AWAKENING"
+          "EOC_MOM_NO_EFFECT"
         ],
         "names": [ "Left Arm", "Right Arm", "Head", "Left Leg", "Right Leg", "Torso", "Nevermind." ],
         "keys": [ "1", "2", "3", "4", "5", "6", "7" ],
@@ -609,7 +609,7 @@
           "EOC_SPELL_PYROKIN_SUMMON_HEAT_3",
           "EOC_SPELL_PYROKIN_SUMMON_HEAT_4",
           "EOC_SPELL_PYROKIN_BANISH_HEAT",
-          "EOC_PORTAL_NULL_AWAKENING"
+          "EOC_MOM_NO_EFFECT"
         ],
         "names": [
           "Minor thermogenesis",

--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -3882,7 +3882,7 @@
     "volume": "140 L",
     "power_armor": true,
     "symbol": "T",
-    "looks_like": "power_armor_basic",
+    "looks_like": "combat_exoskeleton_medium",
     "color": "light_gray",
     "pocket_data": [
       {

--- a/data/mods/Xedra_Evolved/items/comestibles/med.json
+++ b/data/mods/Xedra_Evolved/items/comestibles/med.json
@@ -112,12 +112,7 @@
     "recurrence": [ "16 hours", "16 hours" ],
     "condition": { "u_has_trait": "BLOOD_OF_SAINTS" },
     "global": true,
-    "effect": [
-      { "run_eocs": "EOC_REDUCE_VAMPVIRUS" },
-      { "run_eocs": "EOC_REDUCE_VAMPVIRUS1" },
-      { "run_eocs": "EOC_REDUCE_VAMPVIRUS2" },
-      { "run_eocs": "EOC_REDUCE_VAMPVIRUS3" }
-    ]
+    "effect": [ { "run_eocs": "EOC_REDUCE_VAMPVIRUS" }, { "run_eocs": "EOC_REDUCE_VAMPVIRUS3" } ]
   },
   {
     "id": "bloodthorne_druid_bandage_01",

--- a/data/mods/Xedra_Evolved/items/gracken_trait_improvements.json
+++ b/data/mods/Xedra_Evolved/items/gracken_trait_improvements.json
@@ -91,7 +91,7 @@
       "type": "effect_on_conditions",
       "consume": true,
       "description": "You graft this organ onto your body replacing whatever was there before.",
-      "effect_on_conditions": [ "shade_hands" ]
+      "effect_on_conditions": [ "gracken_shade_hands" ]
     }
   },
   {

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_mutation_spells.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_mutation_spells.json
@@ -126,7 +126,7 @@
     "name": { "str": "Cultivate Goblin Fruit Real", "//~": "NO_I18N" },
     "description": { "str": "The actual spell that calls forth a goblin fruit.  It's a bug if you have it.", "//~": "NO_I18N" },
     "skill": "deduction",
-    "flags": [ "SPAWN_GROUP" ],
+    "flags": [ "SPAWN_GROUP", "PERMANENT" ],
     "valid_targets": [ "self" ],
     "effect": "spawn_item",
     "effect_str": "spell_spawned_goblin_fruit",

--- a/data/mods/Xedra_Evolved/obsoletion_and_migration/spells.json
+++ b/data/mods/Xedra_Evolved/obsoletion_and_migration/spells.json
@@ -466,7 +466,7 @@
     "name": { "str": "Seed Bearer Real", "//~": "NO_I18N" },
     "description": { "str": "The actual spell that calls forth seeds.  It's a bug if you have it.", "//~": "NO_I18N" },
     "skill": "deduction",
-    "flags": [ "SPAWN_GROUP" ],
+    "flags": [ "SPAWN_GROUP", "PERMANENT" ],
     "valid_targets": [ "self" ],
     "effect": "spawn_item",
     "effect_str": "farming_seeds",

--- a/data/mods/aftershock_exoplanet/items/armor/exosuit/exosuit_frame.json
+++ b/data/mods/aftershock_exoplanet/items/armor/exosuit/exosuit_frame.json
@@ -10,7 +10,7 @@
     "material": [ "titanium" ],
     "power_armor": true,
     "symbol": "T",
-    "looks_like": "power_armor_basic",
+    "looks_like": "combat_exoskeleton_medium",
     "color": "light_gray",
     "pocket_data": [
       {
@@ -387,7 +387,7 @@
     "weight": "30 kg",
     "volume": "130 L",
     "symbol": "t",
-    "looks_like": "power_armor_basic",
+    "looks_like": "combat_exoskeleton_medium",
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",

--- a/data/mods/aftershock_exoplanet/maps/overmap_locations.json
+++ b/data/mods/aftershock_exoplanet/maps/overmap_locations.json
@@ -18,12 +18,6 @@
     "terrain": [ "afs_crashed_escape_pod" ]
   },
   {
-    "type": "start_location",
-    "id": "sloc_crashed_gunship",
-    "name": "Crashed gunship",
-    "terrain": [ "afs_crashed_gunship" ]
-  },
-  {
     "type": "overmap_location",
     "id": "ravine_edge",
     "terrains": [ "ravine_edge" ]

--- a/data/mods/innawood/experience_eocs.json
+++ b/data/mods/innawood/experience_eocs.json
@@ -6,9 +6,9 @@
     "condition": { "mod_is_loaded": "innawood" },
     "effect": [
       { "math": [ "u_bonus_exp += 25" ] },
-      { "run_eocs": "EOC_on_kill_check_exp", "condition": { "mod_is_loaded": "bombastic_perks" } },
-      { "run_eocs": "EOC_perk_ma_kill_check_exp", "condition": { "mod_is_loaded": "perk_melee_system" } },
-      { "run_eocs": "EOC_on_kill_check_exp_sorcerer", "condition": { "mod_is_loaded": "sorcerer" } }
+      { "run_eocs": "EOC_innawood_bombastic_perks_bridge" },
+      { "run_eocs": "EOC_innawood_perk_melee_bridge" },
+      { "run_eocs": "EOC_innawood_sorcerer_bridge" }
     ]
   },
   {
@@ -18,9 +18,27 @@
     "condition": { "mod_is_loaded": "innawood" },
     "effect": [
       { "math": [ "u_bonus_exp += ( owed_material_tokens * 2 ) / 5" ] },
-      { "run_eocs": "EOC_on_kill_check_exp", "condition": { "mod_is_loaded": "bombastic_perks" } },
-      { "run_eocs": "EOC_perk_ma_kill_check_exp", "condition": { "mod_is_loaded": "perk_melee_system" } },
-      { "run_eocs": "EOC_on_kill_check_exp_sorcerer", "condition": { "mod_is_loaded": "sorcerer" } }
+      { "run_eocs": "EOC_innawood_bombastic_perks_bridge" },
+      { "run_eocs": "EOC_innawood_perk_melee_bridge" },
+      { "run_eocs": "EOC_innawood_sorcerer_bridge" }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_innawood_bombastic_perks_bridge",
+    "//": "Overridden by mod_interactions/bombastic_perks when that mod is loaded",
+    "effect": [  ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_innawood_perk_melee_bridge",
+    "//": "Overridden by mod_interactions/perk_melee_system when that mod is loaded",
+    "effect": [  ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_innawood_sorcerer_bridge",
+    "//": "Overridden by mod_interactions/sorcerer when that mod is loaded",
+    "effect": [  ]
   }
 ]

--- a/data/mods/innawood/mod_interactions/bombastic_perks/experience_eocs.json
+++ b/data/mods/innawood/mod_interactions/bombastic_perks/experience_eocs.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_innawood_bombastic_perks_bridge",
+    "effect": [ { "run_eocs": "EOC_on_kill_check_exp" } ]
+  }
+]

--- a/data/mods/innawood/mod_interactions/perk_melee_system/experience_eocs.json
+++ b/data/mods/innawood/mod_interactions/perk_melee_system/experience_eocs.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_innawood_perk_melee_bridge",
+    "effect": [ { "run_eocs": "EOC_perk_ma_kill_check_exp" } ]
+  }
+]

--- a/data/mods/innawood/mod_interactions/sorcerer/experience_eocs.json
+++ b/data/mods/innawood/mod_interactions/sorcerer/experience_eocs.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_innawood_sorcerer_bridge",
+    "effect": [ { "run_eocs": "EOC_on_kill_check_exp_sorcerer" } ]
+  }
+]

--- a/src/flexbuffer_json.h
+++ b/src/flexbuffer_json.h
@@ -224,6 +224,7 @@ class JsonValue : Json
         using Json::throw_error;
         using Json::throw_error_after;
         using Json::string_error;
+        using Json::get_root_source_path;
 
         // optionally-fatal reading into values by reference
         // returns true if the data was read successfully, false otherwise

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2436,6 +2436,14 @@ void Item_factory::check_definitions() const
                                       type->default_container->c_str() );
             }
         }
+        if( !type->repairs_like.is_empty() && !has_template( type->repairs_like ) ) {
+            msg += string_format( "invalid repairs_like %s\n", type->repairs_like.c_str() );
+        }
+        if( type->source_monster != mtype_id::NULL_ID() &&
+            !type->source_monster.is_valid() ) {
+            msg += string_format( "invalid source_monster %s\n",
+                                  type->source_monster.c_str() );
+        }
 
         for( const auto &e : type->emits ) {
             if( !e.is_valid() ) {
@@ -2468,6 +2476,27 @@ void Item_factory::check_definitions() const
             static const std::set<std::string> allowed_ctypes = { "FOOD", "DRINK", "MED", "INVALID" };
             if( allowed_ctypes.count( type->comestible->comesttype ) == 0 ) {
                 msg += string_format( "Invalid comestible type %s\n", type->comestible->comesttype );
+            }
+            if( !type->comestible->cooks_like.is_empty() &&
+                !has_template( type->comestible->cooks_like ) ) {
+                msg += string_format( "invalid cooks_like %s\n",
+                                      type->comestible->cooks_like.c_str() );
+            }
+            if( !type->comestible->smoking_result.is_null() &&
+                !type->comestible->smoking_result.is_empty() &&
+                !has_template( type->comestible->smoking_result ) ) {
+                msg += string_format( "invalid smoking_result %s\n",
+                                      type->comestible->smoking_result.c_str() );
+            }
+            if( type->comestible->rot_spawn.rot_spawn_monster != mtype_id::NULL_ID() &&
+                !type->comestible->rot_spawn.rot_spawn_monster.is_valid() ) {
+                msg += string_format( "invalid rot_spawn monster %s\n",
+                                      type->comestible->rot_spawn.rot_spawn_monster.c_str() );
+            }
+            if( type->comestible->rot_spawn.rot_spawn_group != mongroup_id::NULL_ID() &&
+                !type->comestible->rot_spawn.rot_spawn_group.is_valid() ) {
+                msg += string_format( "invalid rot_spawn group %s\n",
+                                      type->comestible->rot_spawn.rot_spawn_group.c_str() );
             }
         }
         if( type->brewable ) {

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -561,6 +561,16 @@ void spell_type::check_consistency()
             }
         }
 
+        if( ( sp_t.effect_name == "summon" || sp_t.effect_name == "spawn_item" ||
+              sp_t.effect_name == "summon_monster" ) &&
+            !sp_t.spell_tags[spell_flag::PERMANENT] &&
+            !sp_t.spell_tags[spell_flag::PERMANENT_ALL_LEVELS] &&
+            sp_t.max_duration.is_constant() && sp_t.max_duration.constant() == 0 &&
+            sp_t.min_duration.is_constant() && sp_t.min_duration.constant() == 0 ) {
+            debugmsg( "spell %s uses effect \"%s\" but has zero duration without PERMANENT flag",
+                      sp_t.id.c_str(), sp_t.effect_name );
+        }
+
         if( sp_t.exp_for_level_formula_id.has_value() &&
             sp_t.exp_for_level_formula_id.value()->num_params != 1 ) {
             debugmsg( "ERROR: %s exp_for_level_formula_id has params that != 1!", sp_t.id.c_str() );

--- a/tests/recipe_cycle_test.cpp
+++ b/tests/recipe_cycle_test.cpp
@@ -1,0 +1,132 @@
+#include <cstddef>
+#include <algorithm>
+#include <map>
+#include <set>
+#include <utility>
+#include <vector>
+
+#include "cata_catch.h"
+#include "recipe.h"
+#include "recipe_dictionary.h"
+#include "requirements.h"
+#include "type_id.h"
+
+// Detect net-positive craft/uncraft exploits.
+//
+// Two cases:
+// 1. With provenance (player-crafted items remember components):
+//    disassembly of uniform groups (all alts same type) must not
+//    yield more than the minimum craft input.
+// 2. Without provenance (world-spawned items have empty components):
+//    disassembly uses front() of each group, which must not exceed
+//    the maximum the player could have used for that component.
+
+// Sum min or max counts from uniform groups (all alts same type).
+static std::map<itype_id, int> uniform_group_counts(
+    const requirement_data::alter_item_comp_vector &groups, bool use_max )
+{
+    std::map<itype_id, int> result;
+
+    for( const std::vector<item_comp> &alts : groups ) {
+        if( alts.empty() ) {
+            continue;
+        }
+
+        std::set<itype_id> types;
+        for( const item_comp &comp : alts ) {
+            types.insert( comp.type );
+        }
+        if( types.size() != 1 ) {
+            continue;
+        }
+
+        const itype_id &comp_type = *types.begin();
+        int count = alts[0].count;
+        for( size_t i = 1; i < alts.size(); ++i ) {
+            if( use_max ) {
+                count = std::max( count, alts[i].count );
+            } else {
+                count = std::min( count, alts[i].count );
+            }
+        }
+        result[comp_type] += count;
+    }
+    return result;
+}
+
+// Max craft input per component: best count per type in each group, summed.
+static std::map<itype_id, int> max_possible_counts(
+    const requirement_data::alter_item_comp_vector &groups )
+{
+    std::map<itype_id, int> result;
+
+    for( const std::vector<item_comp> &alts : groups ) {
+        std::map<itype_id, int> group_best;
+        for( const item_comp &comp : alts ) {
+            auto it = group_best.find( comp.type );
+            if( it == group_best.end() ) {
+                group_best[comp.type] = comp.count;
+            } else {
+                it->second = std::max( it->second, comp.count );
+            }
+        }
+        for( const auto &[type, count] : group_best ) {
+            result[type] += count;
+        }
+    }
+    return result;
+}
+
+TEST_CASE( "no_net_positive_craft_uncraft_cycles", "[recipe]" )
+{
+    for( const auto &[id, r] : recipe_dict ) {
+        if( !r.is_reversible() ) {
+            continue;
+        }
+
+        const requirement_data::alter_item_comp_vector &craft_comps =
+            r.simple_requirements().get_components();
+        const requirement_data disas = r.disassembly_requirements();
+        const requirement_data::alter_item_comp_vector &disas_comps =
+            disas.get_components();
+
+        std::map<itype_id, int> craft_min =
+            uniform_group_counts( craft_comps, false );
+        std::map<itype_id, int> disas_max =
+            uniform_group_counts( disas_comps, true );
+
+        // With-provenance: uniform groups only.
+        for( const auto &[comp_id, yield] : disas_max ) {
+            auto it = craft_min.find( comp_id );
+            if( it == craft_min.end() ) {
+                continue;
+            }
+            INFO( "recipe: " << id.str() );
+            INFO( "component: " << comp_id.str() );
+            CAPTURE( it->second );
+            CAPTURE( yield );
+            CHECK( yield <= it->second );
+        }
+
+        // No-provenance: front() of each disassembly group vs max craft input.
+        std::map<itype_id, int> disas_front;
+        for( const std::vector<item_comp> &alts : disas_comps ) {
+            if( !alts.empty() ) {
+                disas_front[alts.front().type] += alts.front().count;
+            }
+        }
+        std::map<itype_id, int> craft_max = max_possible_counts( craft_comps );
+        for( const auto &[comp_id, yield] : disas_front ) {
+            auto it = craft_max.find( comp_id );
+            if( it == craft_max.end() ) {
+                continue;
+            }
+            INFO( "recipe: " << id.str() );
+            INFO( "component: " << comp_id.str() );
+            INFO( "(no-provenance front() path)" );
+            CAPTURE( it->second );
+            CAPTURE( yield );
+            CHECK( yield <= it->second );
+        }
+    }
+}


### PR DESCRIPTION
#### Summary
Infrastructure "Add consistency checks for dangling references and fix existing ones"

#### Purpose of change

Various JSON fields that reference other game entities (item IDs, overmap terrains, EOCs, monster types) were not validated during `check_consistency()`, so typos or stale references after renames would silently break things at runtime. A few such broken references already existed.

#### Describe the solution

**New C++ checks:**
- `effect_on_condition.cpp` - collect EOC string references during `load_inline_eoc`, validate they all resolve to real IDs in `check_consistency()`. Error messages include both the mod source and the JSON file path for easy lookup.
- `item_factory.cpp` - validate `repairs_like`, `source_monster`, `cooks_like`, `smoking_result`, `rot_spawn` monster/group
- `magic.cpp` - warn on summon/spawn_item/summon_monster spells with zero duration and no PERMANENT flag
- `profession.cpp` - non-hobby professions with starting CBMs must have a trait that cancels `NO_CBM_INSTALLATION` (e.g. `CBM_Interface`)
- `start_location.cpp` - validate `om_terrain` references exist for all match types (exact, type, subtype, prefix, contains)

**JSON fixes (items):**
- `looks_like` pointing at removed `power_armor_basic` -> `combat_exoskeleton_medium` (3 files: combat_exoskeleton.json, TEST_DATA/items.json, aftershock exosuit_frame.json)
- `looks_like` pointing at removed `knife_butcher` -> `knife_huge` (cooking.json)
- `smoking_result: " "` hack on `mutflesh` -> proper `"null"` (carnivore.json)

**JSON fixes (start locations):**
- `urban_library` changed to PREFIX match to pick up `urban_library_*` variants
- MA mod: `house_two_story_basement` -> `house_2story_basement` (typo in rename), road entries consolidated to TYPE match
- Aftershock: removed `sloc_crashed_gunship` - the terrain `afs_crashed_gunship` never existed as an overmap terrain (the gunship is a map extra, `mx_gunship`; the scenario uses that, not an omt)

**JSON fixes (EOC dangling references):**
- MindOverMatter: `EOC_PORTAL_NULL_AWAKENING` -> `EOC_MOM_NO_EFFECT` (3 places in eoc_selector menus)
- MindOverMatter: `EOC_perk_blood_drinking_heal_hp_check` was a cross-mod dependency on BombasticPerks. Replaced with `mod_interactions/bombastic_perks/` bridge pattern - no-op base EOC when BombasticPerks isn't loaded, delegates to the real one when it is.
- Xedra Evolved: removed stale refs to `EOC_REDUCE_VAMPVIRUS1` and `EOC_REDUCE_VAMPVIRUS2` from `EOC_BLOOD_OF_SAINTS_AGAINST_VAMPIRISM` caller. These were merged into `EOC_REDUCE_VAMPVIRUS` in #78774 but the caller wasn't updated. Also fixed `shade_hands` -> `gracken_shade_hands`.
- Innawood: cross-mod EOC references (`EOC_on_kill_check_exp` etc.) replaced with bridge pattern using `mod_interactions/` overrides. Base mod defines no-op stubs, `mod_interactions/{bombastic_perks,perk_melee_system,sorcerer}/` files override when those mods are active.
- Magiclysm: added missing `EOC_SUMMON_MUSHROOMS` definition (was referenced but never defined)

**JSON fixes (spells):**
- Added `PERMANENT_ALL_LEVELS` to Magiclysm Alchemist summon spell (zero duration without it)
- Added `PERMANENT` to MoM electrokinesis `spawn_item` spell and two Xedra `spawn_item` spells (Cultivate Goblin Fruit, Seed Bearer)

**JSON fixes (professions):**
- Added `CBM_Interface` to MMA cyborg martial artist and MoM Fifth Sun profession (had starting CBMs but no interface trait)

**Build script fix:**
- `get_all_mods.py`: use `add_mods()` instead of raw `append()` when collecting individual mods. The old code skipped dependency resolution and compatibility checks, so mods could be tested without their prerequisites.

**Other:**
- `flexbuffer_json.h`: expose `get_root_source_path()` on `JsonValue` (was protected, needed for EOC error context)

**New test:**
- `recipe_cycle_test.cpp` - checks for net-positive craft/uncraft exploits. Two cases: with-provenance (player-crafted items, checks uniform component groups) and without-provenance (world-spawned items, checks front()-based disassembly path).

#### Describe alternatives you've considered

For cross-mod EOC dependencies (Innawood, MoM psychic vampire), the alternative was to keep inline `mod_is_loaded` conditions, but that means the referenced EOC string fails validation when the other mod isn't loaded. The `mod_interactions/` bridge pattern is already used elsewhere in the codebase and avoids the dangling reference entirely.

For `looks_like` validation -- currently not enforced. There are ~52 unique broken item `looks_like` values (27 truly missing IDs, 25 cross-type references like items pointing at furniture). Enforcement is feasible but needs a separate cleanup pass, especially for the cross-type cases that are an intentional pattern for appliances.

#### Testing

- Full build (`make TILES=1`): clean
- `[recipe]` test tag: 7060 assertions in 5 test cases, all pass

#### Additional context

The `mod_interactions/` directory loading mechanism (in `init.cpp`) only loads subdirectory contents when the named mod is also active in the world, so bridge EOCs correctly resolve at load time without hard mod dependencies.