### PR TITLE
Fix overmap determinism test failure from static city init

### DIFF
--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -1420,7 +1420,9 @@ void overmap::place_special_forced( const overmap_special_id &special_id,
                                     const tripoint_om_omt &p,
                                     om_direction::type dir )
 {
-    static city invalid_city;
+    // Dummy city for place_special's road-connection fallback.
+    // "" avoids city() default ctor that eats RNG via SNIPPET.
+    static const city invalid_city( "" );
     place_special( *special_id, p, dir, invalid_city, false, true );
 }
 /**


### PR DESCRIPTION
#### Summary
Infrastructure "Fix overmap determinism test failure from static city init"

#### Purpose of change

`place_special_forced()` has a `static city` using the default constructor, which calls `SNIPPET.expand()` and eats RNG on first call only. This makes `overmap_generation_is_deterministic` fail on some seeds when it regenerates overmaps in the same process.

#### Describe the solution

Use `city("")` to skip snippet expansion. The city is just a dummy for `place_special`'s road-connection fallback and never needs a name.

#### Describe alternatives you've considered

Making the parameter a pointer instead of a reference, but that touches too many call sites.

#### Testing

N/A

#### Additional context

Found by fuzzy-testing that particular test after seeing a random failure in CI.

Only affects tests -- in normal gameplay the static is always uninitialized at process start.