### PR TITLE
Remove ability to toggle map memory from the players control

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -142,8 +142,6 @@ std::string action_ident( action_id act )
             return "LEVEL_DOWN";
         case ACTION_MOVE_UP:
             return "LEVEL_UP";
-        case ACTION_TOGGLE_MAP_MEMORY:
-            return "toggle_map_memory";
         case ACTION_CENTER:
             return "center";
         case ACTION_SHIFT_N:
@@ -415,7 +413,6 @@ bool can_action_change_worldstate( const action_id act )
 {
     switch( act ) {
         // Shift view
-        case ACTION_TOGGLE_MAP_MEMORY:
         case ACTION_CENTER:
         case ACTION_SHIFT_N:
         case ACTION_SHIFT_NE:

--- a/src/action.h
+++ b/src/action.h
@@ -77,8 +77,6 @@ enum action_id : int {
 
     // Viewport movement actions and related
     /**@{*/
-    /** Toggle memorized tiles being shown */
-    ACTION_TOGGLE_MAP_MEMORY,
     /** Center the viewport on character */
     ACTION_CENTER,
     /** Move viewport north */

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -139,7 +139,6 @@ static const trait_id trait_WHISKERS_RAT( "WHISKERS_RAT" );
 avatar::avatar()
 {
     player_map_memory = std::make_unique<map_memory>();
-    show_map_memory = true;
     active_mission = nullptr;
     grab_type = object_type::NONE;
     calorie_diary.emplace_front( );
@@ -222,11 +221,6 @@ void avatar::longpull( const std::string &name )
     Creature::longpull( name, traj.back() );
 }
 
-void avatar::toggle_map_memory()
-{
-    show_map_memory = !show_map_memory;
-}
-
 bool avatar::is_map_memory_valid() const
 {
     return player_map_memory->is_valid();
@@ -237,7 +231,7 @@ bool avatar::should_show_map_memory() const
     if( !you_know_where_you_are() ) {
         return false;
     }
-    return show_map_memory;
+    return true;
 }
 
 bool avatar::save_map_memory()

--- a/src/avatar.h
+++ b/src/avatar.h
@@ -141,7 +141,6 @@ class avatar : public Character
         using Character::query_yn;
         bool query_yn( const std::string &mes ) const override;
 
-        void toggle_map_memory();
         //! @copydoc map_memory::is_valid() const
         bool is_map_memory_valid() const;
         bool should_show_map_memory() const;
@@ -407,7 +406,6 @@ class avatar : public Character
         std::string save_id;
 
         std::unique_ptr<map_memory> player_map_memory;
-        bool show_map_memory;
 
         friend class debug_menu::mission_debug;
         /**

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2521,7 +2521,6 @@ input_context get_default_mode_input_context()
     ctxt.register_action( "pause" );
     ctxt.register_action( "LEVEL_DOWN", to_translation( "Descend stairs" ) );
     ctxt.register_action( "LEVEL_UP", to_translation( "Ascend stairs" ) );
-    ctxt.register_action( "toggle_map_memory" );
     ctxt.register_action( "center" );
     ctxt.register_action( "shift_n" );
     ctxt.register_action( "shift_ne" );

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -246,7 +246,6 @@ input_context game::get_player_input( std::string &action )
         // The list of allowed actions in death-cam mode in game::handle_action
         // *INDENT-OFF*
         for( const action_id id : {
-            ACTION_TOGGLE_MAP_MEMORY,
             ACTION_CENTER,
             ACTION_SHIFT_N,
             ACTION_SHIFT_NE,
@@ -2141,10 +2140,6 @@ static bool has_vehicle_control( avatar &player_character )
 static void do_deathcam_action( const action_id &act, avatar &player_character )
 {
     switch( act ) {
-        case ACTION_TOGGLE_MAP_MEMORY:
-            player_character.toggle_map_memory();
-            break;
-
         case ACTION_CENTER:
             player_character.view_offset.x() = g->driving_view_offset.x();
             player_character.view_offset.y() = g->driving_view_offset.y();

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -1670,8 +1670,6 @@ void avatar::store( JsonOut &json ) const
     }
     json.end_array();
 
-    json.member( "show_map_memory", show_map_memory );
-
     json.member( "assigned_invlet" );
     json.start_array();
     for( const auto &iter : inv->assigned_invlet ) {
@@ -1814,8 +1812,6 @@ void avatar::load( const JsonObject &data )
     if( active_mission && active_mission->has_failed() ) {
         update_active_mission();
     }
-
-    data.read( "show_map_memory", show_map_memory );
 
     for( JsonArray pair : data.get_array( "assigned_invlet" ) ) {
         inv->assigned_invlet[static_cast<char>( pair.get_int( 0 ) )] =


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Interface "Remove ability to toggle map memory from the players control"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Title.
It is silly that the player can turn off the map memory by hand. There is no good reason to be able to do this and only causes a problem if the player somehow sets the unbound keybind and toggles it.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Deletes the keybind and associated execution of it
Removes the boolean for tracking the state of displaying map memory and associated serialization/deserialization

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded a save that had the keybind set and map memory toggled off. 
No errors and map memory visible as soon as loaded in.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
