### PR TITLE
Show molle capacity in item info

### DIFF
--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -2742,7 +2742,6 @@ void item_contents::info( std::vector<iteminfo> &info, const iteminfo_query *par
     if( parts->test( iteminfo_parts::DESCRIPTION_POCKETS ) ) {
         // start by saying what items are attached to this directly
         if( !additional_pockets.empty() ) {
-            insert_separation_line( info );
             info.emplace_back( "CONTAINER", _( "<bold>This item incorporates</bold>:" ) );
             for( const item &it : additional_pockets ) {
                 info.emplace_back( "CONTAINER", string_format( _( "%s." ),

--- a/src/item_info.cpp
+++ b/src/item_info.cpp
@@ -4258,9 +4258,11 @@ std::vector<iteminfo> item::get_info( const iteminfo_query *parts, int batch ) c
                 const int size = actor->size;
                 const int vacancies = size - get_contents().get_additional_space_used();
                 insert_separation_line( info );
-                info.emplace_back( "CONTAINER", _( "* <bold><info>MOLLE-compatible</info> pouches can be attached to this item</bold>." ) );
-                info.emplace_back( "CONTAINER", _( "Total space: " ), _( "<num>.  " ), iteminfo::no_newline, size  );
-                info.emplace_back( "CONTAINER", _( "Spare space: " ), _( "<num>." ), iteminfo::no_flags, vacancies );
+                info.emplace_back( "CONTAINER",
+                                   _( "* <bold><info>MOLLE-compatible</info> pouches can be attached to this item</bold>." ) );
+                info.emplace_back( "CONTAINER", _( "Total space: " ), _( "<num>.  " ), iteminfo::no_newline, size );
+                info.emplace_back( "CONTAINER", _( "Spare space: " ), _( "<num>." ), iteminfo::no_flags,
+                                   vacancies );
             }
             contents.info( info, parts );
             contents_info( info, parts, batch, debug );

--- a/src/item_info.cpp
+++ b/src/item_info.cpp
@@ -4251,6 +4251,17 @@ std::vector<iteminfo> item::get_info( const iteminfo_query *parts, int batch ) c
 
         } else if( blockname == "contents" ) {
 
+            const use_function *action = type->get_use( "attach_molle" );
+            if( action ) {
+                const molle_attach_actor *actor = dynamic_cast<const molle_attach_actor *>
+                                                  ( action->get_actor_ptr() );
+                const int size = actor->size;
+                const int vacancies = size - get_contents().get_additional_space_used();
+                insert_separation_line( info );
+                info.emplace_back( "CONTAINER", _( "* <bold><info>MOLLE-compatible</info> pouches can be attached to this item</bold>." ) );
+                info.emplace_back( "CONTAINER", _( "Total space: " ), _( "<num>.  " ), iteminfo::no_newline, size  );
+                info.emplace_back( "CONTAINER", _( "Spare space: " ), _( "<num>." ), iteminfo::no_flags, vacancies );
+            }
             contents.info( info, parts );
             contents_info( info, parts, batch, debug );
 


### PR DESCRIPTION
#### Summary
Interface "Show total/spare sapce of MOLLE item in item info."
#### Purpose of change
Close #82694 
#### Describe the solution
Add lines that tells how many molle pocket can be attached.
#### Describe alternatives you've considered

#### Testing
Game compiles and lines in item info are displayed as expected.
![95da4634970a304e006848e697c8a786c8175cad](https://github.com/user-attachments/assets/9cee728e-0891-4a2d-be66-ffcfb38088cc)
#### Additional context