### PR TITLE
Fix multicooker segfault by flattening nested recipes in its UI

### DIFF
--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -7604,7 +7604,7 @@ std::optional<int> iuse::multicooker( Character *p, item *it, const tripoint_bub
                 for( const recipe * const &rec : recipes_to_add ) {
                     dishes.push_back( rec );
                     const bool can_make = rec->deduped_requirements().can_make_with_inventory(
-                                          crafting_inv, rec->get_component_filter() );
+                                              crafting_inv, rec->get_component_filter() );
                     dmenu.addentry( counter++, can_make, -1, rec->result_name( /*decorated=*/true ) );
                 }
             }

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -7592,11 +7592,21 @@ std::optional<int> iuse::multicooker( Character *p, item *it, const tripoint_bub
         for( const recipe * const &r : get_avatar().get_learned_recipes().in_category(
                  crafting_category_CC_FOOD ) ) {
             if( multicooked_subcats.count( r->subcategory ) > 0 ) {
-                dishes.push_back( r );
-                const bool can_make = r->deduped_requirements().can_make_with_inventory(
-                                          crafting_inv, r->get_component_filter() );
+                std::vector<const recipe *> recipes_to_add;
+                if( r->is_nested() ) {
+                    for( const recipe_id &rid : r->nested_category_data ) {
+                        recipes_to_add.push_back( &rid.obj() );
+                    }
+                } else {
+                    recipes_to_add.push_back( r );
+                }
 
-                dmenu.addentry( counter++, can_make, -1, r->result_name( /*decorated=*/true ) );
+                for( const recipe * const &rec : recipes_to_add ) {
+                    dishes.push_back( rec );
+                    const bool can_make = rec->deduped_requirements().can_make_with_inventory(
+                                          crafting_inv, rec->get_component_filter() );
+                    dmenu.addentry( counter++, can_make, -1, rec->result_name( /*decorated=*/true ) );
+                }
             }
         }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Fix multicooker crashes when using nested recipe"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #83834
Also fixes #84491 as those both nested recipes.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
When trying to cook pemmican (or any nested recipe) with the multicooker, it'll treat nested recipes as if it's a normal recipe. This PR makes it check if it's a nested recipe and unrolls it's subrecipes, adding those instead.

The subrecipes don't get category checked, they just rely on whatever category the nested recipe is.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Replacing the multicooker UI with a menu that supports nested recipes.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I cooked each single version of pemmican. Checked that the nested pemmican isn't listed.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
