### PR TITLE
Pat will set up a commlink with you, if you have a Hub 01 interface and the correct CBMs

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -1106,6 +1106,14 @@
     "passive_pseudo_items": [ "fake_radio" ]
   },
   {
+    "id": "bio_radio_pat",
+    "type": "bionic",
+    "name": { "str": "Modified Infolink" },
+    "description": "A compact communications device has been built into your ears, enabling you to communicate over radio waves.  This one has custom software for communicating with your pal Pat.",
+    "occupied_bodyparts": [ [ "head", 2 ] ],
+    "passive_pseudo_items": [ "fake_radio", "integrated_pat_transponder", "integrated_pat_radio" ]
+  },
+  {
     "id": "bio_radscrubber",
     "type": "bionic",
     "name": { "str": "Radiation Scrubber System" },

--- a/data/json/effects_on_condition/item_eocs.json
+++ b/data/json/effects_on_condition/item_eocs.json
@@ -372,7 +372,13 @@
     "condition": { "and": [ "u_exists", "u_is_avatar" ] },
     "effect": [
       {
-        "if": { "or": [ { "u_has_item": "military_vis_aug_system_on" }, { "u_has_item": "robofac_head_rig_ar_on" } ] },
+        "if": {
+          "or": [
+            { "u_has_item": "military_vis_aug_system_on" },
+            { "u_has_item": "robofac_head_rig_ar_on" },
+            { "and": [ { "u_has_item": "integrated_ar" }, { "u_has_trait": "Hub01_CBM_Interface" } ] }
+          ]
+        },
         "then": [ { "run_eocs": [ "EOC_pat_AR_activate" ] } ]
       }
     ]
@@ -381,7 +387,7 @@
     "type": "effect_on_condition",
     "id": "EOC_pat_AR_activate",
     "condition": { "math": [ "robofac_pat_is_dead == 1" ] },
-    "effect": { "if": { "one_in_chance": 1000 }, "then": { "u_message": "Your earpiece is eerily silent." } },
+    "effect": { "if": { "one_in_chance": 1000 }, "then": { "u_message": "Your comm is eerily silent." } },
     "false_effect": { "run_eocs": [ "EOC_pat_AR_scan" ] }
   },
   {

--- a/data/json/items/bionics.json
+++ b/data/json/items/bionics.json
@@ -881,6 +881,20 @@
     "difficulty": 4
   },
   {
+    "id": "bio_radio_pat",
+    "copy-from": "bionic_general",
+    "type": "ITEM",
+    "subtypes": [ "BIONIC_ITEM" ],
+    "name": { "str": "Modified Infolink CBM" },
+    "looks_like": "bio_int_enhancer",
+    "description": "A wireless communications device that integrates with the ear canal to enable hands-free communication over radio waves.  This one has custom software for communicating with your pal Pat.",
+    "price": "500 USD",
+    "price_postapoc": "10 USD",
+    "flags": [ "TRADER_AVOID" ],
+    "weight": "100 g",
+    "difficulty": 4
+  },
+  {
     "id": "bio_radscrubber",
     "copy-from": "bionic_general_npc_usable",
     "type": "ITEM",

--- a/data/json/items/fake.json
+++ b/data/json/items/fake.json
@@ -87,7 +87,7 @@
     "subtypes": [ "TOOL", "ARMOR" ],
     "copy-from": "fake_item",
     "name": { "str": "Infolink: Pat's Transponder (off)", "str_pl": "Infolinks: Pat's Transponder (off)" },
-    "description": "Custom software installed on your Infolink CBM for connecting to Pat's radio frequency.  If you have an integrated AR system CBM, or a compatable AR headset, activating this will put you in constant contact with Pat.  It is currently inactive.  Activate it to turn it on.",
+    "description": "Custom software installed on your Infolink CBM for connecting to Pat's radio frequency.  If you have an integrated AR system CBM, or a compatible AR headset, activating this will put you in constant contact with Pat.  It is currently inactive.  Activate it to turn it on.",
     "use_action": [
       {
         "type": "transform",
@@ -105,7 +105,7 @@
     "type": "ITEM",
     "subtypes": [ "TOOL", "ARMOR" ],
     "name": { "str": "Infolink: Pat's Transponder (on)", "str_pl": "Infolinks: Pat's Transponder (on)" },
-    "description": "Custom software installed on your Infolink CBM for connecting to Pat's radio frequency.  If you have an integrated AR system CBM, or a compatable AR headset, this will put you in constant contact with Pat.  It is currently active.  Activate it to turn it off.",
+    "description": "Custom software installed on your Infolink CBM for connecting to Pat's radio frequency.  If you have an integrated AR system CBM, or a compatible AR headset, this will put you in constant contact with Pat.  It is currently active.  Activate it to turn it off.",
     "extend": { "flags": [ "SPAWN_ACTIVE" ] },
     "use_action": [
       {

--- a/data/json/items/fake.json
+++ b/data/json/items/fake.json
@@ -66,6 +66,57 @@
     "tick_action": [ "RADIO_TICK" ]
   },
   {
+    "id": "integrated_pat_radio",
+    "type": "ITEM",
+    "subtypes": [ "TOOL", "ARMOR" ],
+    "copy-from": "fake_item",
+    "name": { "str": "Infolink: Call Pat", "str_pl": "Infolinks: Call Pat" },
+    "description": "Custom software installed in your Infolink CBM for talking to Pat on your agreed-upon radio frequency.  Activate it to hail Pat.",
+    "use_action": [
+      {
+        "type": "effect_on_conditions",
+        "description": "Hail Pat on the radio",
+        "effect_on_conditions": [ "EOC_ROBOFAC_PAT_CHATTING_ON_RADIO" ]
+      }
+    ],
+    "flags": [ "INTEGRATED", "UNBREAKABLE", "PERSONAL", "NO_REPAIR", "ALLOWS_NATURAL_ATTACKS" ]
+  },
+  {
+    "id": "integrated_pat_transponder",
+    "type": "ITEM",
+    "subtypes": [ "TOOL", "ARMOR" ],
+    "copy-from": "fake_item",
+    "name": { "str": "Infolink: Pat's Transponder (off)", "str_pl": "Infolinks: Pat's Transponder (off)" },
+    "description": "Custom software installed on your Infolink CBM for connecting to Pat's radio frequency.  If you have an integrated AR system CBM, or a compatable AR headset, activating this will put you in constant contact with Pat.  It is currently inactive.  Activate it to turn it on.",
+    "use_action": [
+      {
+        "type": "transform",
+        "menu_text": "Connect to Pat's system and start transmitting data",
+        "msg": "You switch on the transponder.",
+        "target": "integrated_pat_transponder_on"
+      }
+    ],
+    "tick_action": { "type": "effect_on_conditions", "effect_on_conditions": [ "EOC_pat_advanced_AR_activate" ] },
+    "flags": [ "INTEGRATED", "UNBREAKABLE", "PERSONAL", "NO_REPAIR", "ALLOWS_NATURAL_ATTACKS" ]
+  },
+  {
+    "id": "integrated_pat_transponder_on",
+    "copy-from": "integrated_pat_transponder",
+    "type": "ITEM",
+    "subtypes": [ "TOOL", "ARMOR" ],
+    "name": { "str": "Infolink: Pat's Transponder (on)", "str_pl": "Infolinks: Pat's Transponder (on)" },
+    "description": "Custom software installed on your Infolink CBM for connecting to Pat's radio frequency.  If you have an integrated AR system CBM, or a compatable AR headset, this will put you in constant contact with Pat.  It is currently active.  Activate it to turn it off.",
+    "extend": { "flags": [ "SPAWN_ACTIVE" ] },
+    "use_action": [
+      {
+        "type": "transform",
+        "menu_text": "Disconnect from Pat's system and stop transmitting data",
+        "msg": "You switch off the transponder.",
+        "target": "integrated_pat_transponder"
+      }
+    ]
+  },
+  {
     "id": "integrated_ar",
     "type": "ITEM",
     "subtypes": [ "TOOL", "ARMOR" ],

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/PAT/NPC_Pat.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/PAT/NPC_Pat.json
@@ -223,8 +223,7 @@
             { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_knows_u_cyborg" } ] } },
             { "compare_string": [ "yes", { "u_val": "robofac_pat_gave_gear" } ] }
           ]
-        },
-        "effect": { "u_add_var": "robofac_pat_knows_u_cyborg", "value": "yes" }
+        }
       },
       {
         "text": "So, remember that whole cyborg thing?  I managed to get an AR system implanted.  Think we can use it to communicate and share info?",
@@ -239,6 +238,61 @@
           ]
         },
         "effect": { "u_add_var": "robofac_pat_said_no_to_exodii_AR_CBM", "value": "yes" }
+      },
+      {
+        "text": "Have you heard about the Cybernetic Enhancements Program?  Doc Stevens across the street hooked me up with a cybernetic inferface, believe it or not.",
+        "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_HUB01",
+        "condition": {
+          "and": [
+            { "u_has_trait": "Hub01_CBM_Interface" },
+            { "compare_string": [ "yes", { "u_val": "robofac_pat_gave_gear" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_knows_u_cyborg" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_said_no_to_exodii_AR_CBM" } ] } }
+          ]
+        },
+        "effect": { "u_add_var": "robofac_pat_knows_u_cyborg", "value": "yes" }
+      },
+      {
+        "text": "Hey, remember that whole cyborg thing?  Have you heard about the Cybernetic Enhancements Program with Doc Stevens, across the street?  I've upgraded to a new cybernetic interface that has a USB port, believe it or not.  Maybe we can use it to communicate.",
+        "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_HUB01",
+        "condition": {
+          "and": [
+            { "u_has_trait": "Hub01_CBM_Interface" },
+            { "compare_string": [ "yes", { "u_val": "robofac_pat_gave_gear" } ] },
+            { "compare_string": [ "yes", { "u_val": "robofac_pat_knows_u_cyborg" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_said_no_to_exodii_AR_CBM" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_gave_transponder_CBM" } ] } }
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_said_use_the_earpiece" } ] } }
+          ]
+        }
+      },
+      {
+        "text": "Hey, remember that whole cyborg thing?  Have you heard about the Cybernetic Enhancements Program with Doc Stevens, across the street?  I've upgraded to a new cybernetic interface that has a USB port, believe it or not.  Think we can use my integrated AR system now?",
+        "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_HUB01_AR",
+        "condition": {
+          "and": [
+            { "u_has_trait": "Hub01_CBM_Interface" },
+            { "u_has_items": { "item": "integrated_ar", "count": 1 } },
+            { "compare_string": [ "yes", { "u_val": "robofac_pat_gave_gear" } ] },
+            { "compare_string": [ "yes", { "u_val": "robofac_pat_knows_u_cyborg" } ] },
+            { "compare_string": [ "yes", { "u_val": "robofac_pat_said_no_to_exodii_AR_CBM" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_said_use_the_earpiece" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_gave_transponder_CBM" } ] } }
+          ]
+        }
+      },
+      {
+        "text": "I picked up an Infolink CBM.  Think we can use my integrated electronics to communicate, now?",
+        "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_HUB01_AR_INFOLINK_YES",
+        "condition": {
+          "and": [
+            { "u_has_trait": "Hub01_CBM_Interface" },
+            { "u_has_items": { "item": "integrated_ar", "count": 1 } },
+            { "compare_string": [ "yes", { "u_val": "robofac_pat_gave_gear" } ] },
+            { "compare_string": [ "yes", { "u_val": "robofac_pat_said_use_the_earpiece" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_gave_transponder_CBM" } ] } }
+          ]
+        }
       },
       {
         "text": "Hey, check out this military-grade AR unit.  Think we can do something with it?",
@@ -799,15 +853,168 @@
   {
     "id": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG",
     "type": "talk_topic",
-    "dynamic_line": "Well, no kiddin' huh?  If it wasn't for the whole end'a'the'world thing, I'd call ya' crazy, but this freakin' world keeps gettin' weirder by the day.  On the bright side, maybe you can score some kinda fancy implant so we can ditch the ugly-ass AR glasses, yeah?  Lemme know if ya' find one, nut-ckle-head, hah!  Get it?  Nuts n' bolts.",
+    "dynamic_line": {
+      "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ],
+      "yes": "&The radio is silent for a moment, then Pat chirps back in, laughing.  \"Yeah, right.  Come by heah sometime and show me your integrated toastah, and maybe I'll believe ya'.\"",
+      "no": "&Pat stares at you for a second, and then starts to laugh.  \"Oh, yah?  Well, no kiddin' huh?  If it wasn't for the whole end'a'the'world thing, I'd call ya' crazy, but this freakin' world keeps gettin' weirder by the day… wait, wait, wait, nah.  You're fuckin' with me, right?  Almost had me!\""
+    }
+    "responses": [
+      {
+        "text": "[Use your Infolink to chirp Pat's radio]",
+        "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
+        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_radio" } ]
+      },
+      {
+        "text": "[Open your finger and show off the Fingerhack]",
+        "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
+        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_fingerhack" } ]
+      },
+      {
+        "text": "[Light up your LED Tattoo]",
+        "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
+        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_tattoo_led" } ]
+      },
+      {
+        "text": "[Open your finger and show off the Fingerpick]",
+        "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
+        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_lockpick" } ]
+      },
+      {
+        "text": "[Show off your Shotgun Arm] This…  is my BOOMSTICK!",
+        "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
+        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_shotgun" } ]
+      },
+      {
+        "text": "[Arm and trigger your Alarm System]",
+        "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
+        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_alarm" } ]
+      },
+      {
+        "text": "[Extend your Bionic Claws] Check it out, bub.",
+        "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
+        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_claws" } ]
+      },
+      {
+        "text": "[Do some sick moves using your Uncanny Dodge]",
+        "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
+        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_uncanny_dodge" } ]
+      },
+      {
+        "text": "[Charge up your EMP Projector]",
+        "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
+        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_emp_armgun" } ]
+      },
+      {
+        "text": "[Light your Finger Lighter] Need a light?",
+        "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
+        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_lighter" } ]
+      },
+      {
+        "text": "[Wiggle your Squeeky Ankles] Well, I didn't say it was anything useful…",
+        "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
+        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_ankles" } ]
+      },
+      {
+        "text": "[Loudly ZAP your Super Stun Gun]",
+        "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
+        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_taser" } ]
+      },
+      {
+        "text": "[Use your Weather Reader to perfetly predict atmospheric conditions] Who needs a weather station when you've got implants?",
+        "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
+        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_meteorologist" } ]
+      },
+      {
+        "text": "[Briefly activate your Cloaking Device]",
+        "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
+        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_cloak" } ]
+      },
+      {
+        "text": "[Activate your Chain Lightning to cast a bolt between your hands]",
+        "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
+        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_chain_lightning" } ]
+      },
+      {
+        "text": "[Show off your Fingertip Razors and wiggle your eyebrows]",
+        "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
+        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_razors" } ]
+      },
+      {
+        "text": "[Activate your Protective Lenses]",
+        "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
+        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_armor_eyes" } ]
+      },
+      {
+        "text": "[Warp your face using your Facial Distortion]",
+        "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
+        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_face_mask" } ]
+      },
+      {
+        "text": "[Blink in space using Probability Travel]",
+        "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
+        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_probability_travel" } ]
+      },
+      {
+        "text": "[Show off your Monomolecular Blade]",
+        "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
+        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_blade" } ]
+      },
+      {
+        "text": "[Unroll your Cable Charger from your hip] This is my charging system, believe it or not.",
+        "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
+        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_cable" } ]
+      },
+      {
+        "text": "[Zap the wall with your Finger Laser]",
+        "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
+        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_laser" } ]
+      },
+      {
+        "text": "[Show off your Intravenous Needletip]",
+        "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
+        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_syringe" } ]
+      },
+      {
+        "text": "[Fire up your Integrated Multimeter and start touching things on Pat's desk]",
+        "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
+        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_multimeter" } ]
+      },
+      {
+        "text": "[Use your Artificial Night Generator to dim the room]",
+        "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
+        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_night" } ]
+      },
+      {
+        "text": "[Fire up your Integrated Circuitry Toolkit and touch a bit on solder on the desk]",
+        "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
+        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_electrokit" } ]
+      },
+      {
+        "text": "[Show off your Autonomous Surgical Scalpels]",
+        "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
+        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_surgical_razor" } ]
+      },
+      {
+        "text": "[ZIT-ZIT - whir up the impact wrench in your Integrated Multitool]",
+        "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
+        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_tools" } ]
+      },
+      { "text": "Maybe I'll visit in person…", "condition": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] }, "topic": "TALK_ROBOFAC_MERC_PAT" }
+      { "text": "Yeah, just kidding…", "topic": "TALK_ROBOFAC_MERC_PAT" }
+    ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
+    "type": "talk_topic",
+    "dynamic_line": "Well holy shit!  That's freakin' nuts!  Maybe you can score some kinda fancy implant so we can ditch the ugly-ass AR glasses, yeah?  Lemme know if ya' find one, ya' nut-ckle-head, hah!  Get it?  Nuts n' bolts.",
     "responses": [
       {
         "text": "Actually, I have an implanted AR system.  Think you could use it?",
         "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_EXODII_AR",
         "condition": { "and": [ { "u_has_items": { "item": "integrated_ar", "count": 1 } }, { "u_has_trait": "CBM_Interface" } ] },
-        "effect": { "u_add_var": "robofac_pat_said_no_to_exodii_AR_CBM", "value": "yes" }
+        "effect": [ { "u_add_var": "robofac_pat_said_no_to_exodii_AR_CBM", "value": "yes" }, { "u_add_var": "robofac_pat_knows_u_cyborg", "value": "yes" } ]
       },
-      { "text": "Yeah, alright.", "topic": "TALK_ROBOFAC_MERC_PAT" }
+      { "text": "Yeah, alright.", "topic": "TALK_ROBOFAC_MERC_PAT", "effect": { "u_add_var": "robofac_pat_knows_u_cyborg", "value": "yes" } }
     ]
   },
   {
@@ -819,6 +1026,57 @@
         "text": "Yeah, alright.  I'll come back if my bionic interface becomes accessible to you.",
         "topic": "TALK_ROBOFAC_MERC_PAT"
       }
+    ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_HUB01",
+    "type": "talk_topic",
+    "dynamic_line": "I have, I have.  I hear they're stickin' radios in the skull's of some mercs.  You too, eh?  Crazy shit.  Maybe you can score some kinda fancy implant so we can ditch the ugly-ass AR glasses, yeah?  Lemme know if ya' find one, ya' nut-ckle-head, hah!  Get it?  Nuts n' bolts.",
+    "responses": [
+      {
+        "text": "Actually, I have an implanted AR system.  Think you could use it?",
+        "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_HUB01_AR",
+        "condition": { "and": [ { "u_has_items": { "item": "integrated_ar", "count": 1 } }, { "u_has_trait": "Hub01_CBM_Interface" } ] }
+      },
+      { "text": "Yeah, alright.", "topic": "TALK_ROBOFAC_MERC_PAT" }
+    ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_HUB01_AR",
+    "type": "talk_topic",
+    "dynamic_line": "No shit?  You also got a radio we can use?  If so, I'll plug my computah heah into your USB port, and see what we can do.  Platonically, of course.",
+    "responses": [
+      { "text": "Yup, I have an Infolink CBM, too.", "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_HUB01_AR_INFOLINK_YES", "condition": { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } } },
+      { "text": "No, I don't have a radio CBM.", "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_HUB01_AR_INFOLINK_NO", "condition": { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, "effect": { "u_add_var": "robofac_pat_said_use_the_earpiece", "value": "yes" } },
+      { "text": "Maybe I should come talk to you in person about this.  I'll swing by sometime.", "topic": "TALK_ROBOFAC_MERC_PAT", "condition": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } },
+      { "text": "Let's talk about this some other time.", "topic": "TALK_ROBOFAC_MERC_PAT" }
+    ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_HUB01_AR_INFOLINK_NO",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ],
+      "yes": "Absolutely.  Come by heah sometime and show me, and we'll see what we can do.",
+      "no": "&Pat pulls out their laptop, sparks the makeshift car battery they use to power it, then boots it up.  \"Alright, now we're talkin'.  Like I said, I'll have to plug into your USB jack, Jack.  Ready?\""
+    }
+    "responses": [
+      { "text": "Let's talk about this some other time.", "topic": "TALK_ROBOFAC_MERC_PAT" },
+      { "text": "Let's talk about this some other time.", "topic": "TALK_ROBOFAC_MERC_PAT" }
+    ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_HUB01_AR_INFOLINK_YES",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ],
+      "yes": "Absolutely.  Come by heah sometime and show me, and we'll see what we can do.",
+      "no": "&Pat pulls out their laptop, sparks the makeshift car battery they use to power it, then boots it up.  \"Alright, now we're talkin'.  Like I said, I'll have to plug into your USB jack, Jack.  Ready?\""
+    }
+    "responses": [
+      { "text": "Sure, I'll come by in person.", "topic": "TALK_ROBOFAC_MERC_PAT", "condition": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }
+      { "text": "[Give Pat access to your USB port] Let's do it.", "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_HUB01_AR_INFOLINK_INSTALLED", "condition": { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, "effect": { "u_add_var": "robofac_pat_gave_transponder_CBM", "value": "yes" } }
+      { "text": "Actually, let's talk about this some other time.", "topic": "TALK_ROBOFAC_MERC_PAT" }
     ]
   },
   {

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/PAT/NPC_Pat.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/PAT/NPC_Pat.json
@@ -240,7 +240,7 @@
         "effect": { "u_add_var": "robofac_pat_said_no_to_exodii_AR_CBM", "value": "yes" }
       },
       {
-        "text": "Have you heard about the Cybernetic Enhancements Program?  Doc Stevens across the street hooked me up with a cybernetic inferface, believe it or not.",
+        "text": "Have you heard about the Cybernetic Enhancements Program?  Doc Stevens across the street hooked me up with a cybernetic interface, believe it or not.",
         "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_HUB01",
         "condition": {
           "and": [

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/PAT/NPC_Pat.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/PAT/NPC_Pat.json
@@ -1006,7 +1006,7 @@
         }
       },
       {
-        "text": "[Use your Weather Reader to perfetly predict atmospheric conditions] Who needs a weather station when you've got implants?",
+        "text": "[Use your Weather Reader to perfectly recite current atmospheric conditions] Who needs a weather station when you've got implants?",
         "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
         "condition": {
           "and": [

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/PAT/NPC_Pat.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/PAT/NPC_Pat.json
@@ -247,10 +247,14 @@
             { "u_has_trait": "Hub01_CBM_Interface" },
             { "compare_string": [ "yes", { "u_val": "robofac_pat_gave_gear" } ] },
             { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_knows_u_cyborg" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_knows_u_hub01_cyborg" } ] } },
             { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_said_no_to_exodii_AR_CBM" } ] } }
           ]
         },
-        "effect": { "u_add_var": "robofac_pat_knows_u_cyborg", "value": "yes" }
+        "effect": [
+          { "u_add_var": "robofac_pat_knows_u_cyborg", "value": "yes" },
+          { "u_add_var": "robofac_pat_knows_u_hub01_cyborg", "value": "yes" }
+        ]
       },
       {
         "text": "Hey, remember that whole cyborg thing?  Have you heard about the Cybernetic Enhancements Program with Doc Stevens, across the street?  I've upgraded to a new cybernetic interface that has a USB port, believe it or not.  Maybe we can use it to communicate.",
@@ -260,11 +264,13 @@
             { "u_has_trait": "Hub01_CBM_Interface" },
             { "compare_string": [ "yes", { "u_val": "robofac_pat_gave_gear" } ] },
             { "compare_string": [ "yes", { "u_val": "robofac_pat_knows_u_cyborg" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_knows_u_hub01_cyborg" } ] } },
             { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_said_no_to_exodii_AR_CBM" } ] } },
-            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_gave_transponder_CBM" } ] } }
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_gave_transponder_CBM" } ] } },
             { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_said_use_the_earpiece" } ] } }
           ]
-        }
+        },
+        "effect": { "u_add_var": "robofac_pat_knows_u_hub01_cyborg", "value": "yes" }
       },
       {
         "text": "Hey, remember that whole cyborg thing?  Have you heard about the Cybernetic Enhancements Program with Doc Stevens, across the street?  I've upgraded to a new cybernetic interface that has a USB port, believe it or not.  Think we can use my integrated AR system now?",
@@ -276,6 +282,23 @@
             { "compare_string": [ "yes", { "u_val": "robofac_pat_gave_gear" } ] },
             { "compare_string": [ "yes", { "u_val": "robofac_pat_knows_u_cyborg" } ] },
             { "compare_string": [ "yes", { "u_val": "robofac_pat_said_no_to_exodii_AR_CBM" } ] },
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_knows_u_hub01_cyborg" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_said_use_the_earpiece" } ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_gave_transponder_CBM" } ] } }
+          ]
+        },
+        "effect": { "u_add_var": "robofac_pat_knows_u_hub01_cyborg", "value": "yes" }
+      },
+      {
+        "text": "I picked up an Integrated AR System CBM.  Think we can use my integrated electronics to communicate, now?",
+        "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_HUB01_AR",
+        "condition": {
+          "and": [
+            { "u_has_trait": "Hub01_CBM_Interface" },
+            { "u_has_items": { "item": "integrated_ar", "count": 1 } },
+            { "compare_string": [ "yes", { "u_val": "robofac_pat_gave_gear" } ] },
+            { "compare_string": [ "yes", { "u_val": "robofac_pat_knows_u_cyborg" } ] },
+            { "compare_string": [ "yes", { "u_val": "robofac_pat_knows_u_hub01_cyborg" } ] },
             { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_said_use_the_earpiece" } ] } },
             { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_gave_transponder_CBM" } ] } }
           ]
@@ -288,8 +311,11 @@
           "and": [
             { "u_has_trait": "Hub01_CBM_Interface" },
             { "u_has_items": { "item": "integrated_ar", "count": 1 } },
+            { "u_has_bionics": "bio_radio" },
             { "compare_string": [ "yes", { "u_val": "robofac_pat_gave_gear" } ] },
             { "compare_string": [ "yes", { "u_val": "robofac_pat_said_use_the_earpiece" } ] },
+            { "compare_string": [ "yes", { "u_val": "robofac_pat_knows_u_cyborg" } ] },
+            { "compare_string": [ "yes", { "u_val": "robofac_pat_knows_u_hub01_cyborg" } ] },
             { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_gave_transponder_CBM" } ] } }
           ]
         }
@@ -857,149 +883,293 @@
       "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ],
       "yes": "&The radio is silent for a moment, then Pat chirps back in, laughing.  \"Yeah, right.  Come by heah sometime and show me your integrated toastah, and maybe I'll believe ya'.\"",
       "no": "&Pat stares at you for a second, and then starts to laugh.  \"Oh, yah?  Well, no kiddin' huh?  If it wasn't for the whole end'a'the'world thing, I'd call ya' crazy, but this freakin' world keeps gettin' weirder by the day… wait, wait, wait, nah.  You're fuckin' with me, right?  Almost had me!\""
-    }
+    },
     "responses": [
       {
         "text": "[Use your Infolink to chirp Pat's radio]",
         "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
-        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_radio" } ]
+        "condition": {
+          "and": [
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } },
+            { "u_has_bionics": "bio_radio" }
+          ]
+        }
       },
       {
         "text": "[Open your finger and show off the Fingerhack]",
         "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
-        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_fingerhack" } ]
+        "condition": {
+          "and": [
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } },
+            { "u_has_bionics": "bio_fingerhack" }
+          ]
+        }
       },
       {
         "text": "[Light up your LED Tattoo]",
         "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
-        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_tattoo_led" } ]
+        "condition": {
+          "and": [
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } },
+            { "u_has_bionics": "bio_tattoo_led" }
+          ]
+        }
       },
       {
         "text": "[Open your finger and show off the Fingerpick]",
         "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
-        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_lockpick" } ]
+        "condition": {
+          "and": [
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } },
+            { "u_has_bionics": "bio_lockpick" }
+          ]
+        }
       },
       {
         "text": "[Show off your Shotgun Arm] This…  is my BOOMSTICK!",
         "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
-        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_shotgun" } ]
+        "condition": {
+          "and": [
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } },
+            { "u_has_bionics": "bio_shotgun" }
+          ]
+        }
       },
       {
         "text": "[Arm and trigger your Alarm System]",
         "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
-        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_alarm" } ]
+        "condition": {
+          "and": [
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } },
+            { "u_has_bionics": "bio_alarm" }
+          ]
+        }
       },
       {
         "text": "[Extend your Bionic Claws] Check it out, bub.",
         "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
-        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_claws" } ]
+        "condition": {
+          "and": [
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } },
+            { "u_has_bionics": "bio_claws" }
+          ]
+        }
       },
       {
         "text": "[Do some sick moves using your Uncanny Dodge]",
         "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
-        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_uncanny_dodge" } ]
+        "condition": {
+          "and": [
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } },
+            { "u_has_bionics": "bio_uncanny_dodge" }
+          ]
+        }
       },
       {
-        "text": "[Charge up your EMP Projector]",
+        "text": "[Charge up your EMP Projector to make a cool noise]",
         "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
-        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_emp_armgun" } ]
+        "condition": {
+          "and": [
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } },
+            { "u_has_bionics": "bio_emp_armgun" }
+          ]
+        }
       },
       {
         "text": "[Light your Finger Lighter] Need a light?",
         "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
-        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_lighter" } ]
+        "condition": {
+          "and": [
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } },
+            { "u_has_bionics": "bio_lighter" }
+          ]
+        }
       },
       {
         "text": "[Wiggle your Squeeky Ankles] Well, I didn't say it was anything useful…",
         "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
-        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_ankles" } ]
+        "condition": {
+          "and": [
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } },
+            { "u_has_bionics": "bio_ankles" }
+          ]
+        }
       },
       {
         "text": "[Loudly ZAP your Super Stun Gun]",
         "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
-        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_taser" } ]
+        "condition": {
+          "and": [
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } },
+            { "u_has_bionics": "bio_taser" }
+          ]
+        }
       },
       {
         "text": "[Use your Weather Reader to perfetly predict atmospheric conditions] Who needs a weather station when you've got implants?",
         "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
-        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_meteorologist" } ]
+        "condition": {
+          "and": [
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } },
+            { "u_has_bionics": "bio_meteorologist" }
+          ]
+        }
       },
       {
         "text": "[Briefly activate your Cloaking Device]",
         "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
-        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_cloak" } ]
+        "condition": {
+          "and": [
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } },
+            { "u_has_bionics": "bio_cloak" }
+          ]
+        }
       },
       {
         "text": "[Activate your Chain Lightning to cast a bolt between your hands]",
         "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
-        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_chain_lightning" } ]
+        "condition": {
+          "and": [
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } },
+            { "u_has_bionics": "bio_chain_lightning" }
+          ]
+        }
       },
       {
         "text": "[Show off your Fingertip Razors and wiggle your eyebrows]",
         "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
-        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_razors" } ]
+        "condition": {
+          "and": [
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } },
+            { "u_has_bionics": "bio_razors" }
+          ]
+        }
       },
       {
         "text": "[Activate your Protective Lenses]",
         "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
-        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_armor_eyes" } ]
+        "condition": {
+          "and": [
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } },
+            { "u_has_bionics": "bio_armor_eyes" }
+          ]
+        }
       },
       {
         "text": "[Warp your face using your Facial Distortion]",
         "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
-        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_face_mask" } ]
+        "condition": {
+          "and": [
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } },
+            { "u_has_bionics": "bio_face_mask" }
+          ]
+        }
       },
       {
         "text": "[Blink in space using Probability Travel]",
         "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
-        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_probability_travel" } ]
+        "condition": {
+          "and": [
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } },
+            { "u_has_bionics": "bio_probability_travel" }
+          ]
+        }
       },
       {
         "text": "[Show off your Monomolecular Blade]",
         "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
-        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_blade" } ]
+        "condition": {
+          "and": [
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } },
+            { "u_has_bionics": "bio_blade" }
+          ]
+        }
       },
       {
         "text": "[Unroll your Cable Charger from your hip] This is my charging system, believe it or not.",
         "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
-        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_cable" } ]
+        "condition": {
+          "and": [
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } },
+            { "u_has_bionics": "bio_cable" }
+          ]
+        }
       },
       {
         "text": "[Zap the wall with your Finger Laser]",
         "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
-        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_laser" } ]
+        "condition": {
+          "and": [
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } },
+            { "u_has_bionics": "bio_laser" }
+          ]
+        }
       },
       {
         "text": "[Show off your Intravenous Needletip]",
         "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
-        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_syringe" } ]
+        "condition": {
+          "and": [
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } },
+            { "u_has_bionics": "bio_syringe" }
+          ]
+        }
       },
       {
         "text": "[Fire up your Integrated Multimeter and start touching things on Pat's desk]",
         "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
-        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_multimeter" } ]
+        "condition": {
+          "and": [
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } },
+            { "u_has_bionics": "bio_multimeter" }
+          ]
+        }
       },
       {
         "text": "[Use your Artificial Night Generator to dim the room]",
         "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
-        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_night" } ]
+        "condition": {
+          "and": [
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } },
+            { "u_has_bionics": "bio_night" }
+          ]
+        }
       },
       {
         "text": "[Fire up your Integrated Circuitry Toolkit and touch a bit on solder on the desk]",
         "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
-        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_electrokit" } ]
+        "condition": {
+          "and": [
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } },
+            { "u_has_bionics": "bio_electrokit" }
+          ]
+        }
       },
       {
         "text": "[Show off your Autonomous Surgical Scalpels]",
         "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
-        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_surgical_razor" } ]
+        "condition": {
+          "and": [
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } },
+            { "u_has_bionics": "bio_surgical_razor" }
+          ]
+        }
       },
       {
-        "text": "[ZIT-ZIT - whir up the impact wrench in your Integrated Multitool]",
+        "text": "[ZIT-ZIT-ZOOO - whir up the impact wrench in your Integrated Multitool]",
         "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_2",
-        "condition": [ { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, { "u_has_bionics": "bio_tools" } ]
+        "condition": {
+          "and": [
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } },
+            { "u_has_bionics": "bio_tools" }
+          ]
+        }
       },
-      { "text": "Maybe I'll visit in person…", "condition": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] }, "topic": "TALK_ROBOFAC_MERC_PAT" }
+      {
+        "text": "Maybe I'll visit in person…",
+        "condition": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] },
+        "topic": "TALK_ROBOFAC_MERC_PAT"
+      },
       { "text": "Yeah, just kidding…", "topic": "TALK_ROBOFAC_MERC_PAT" }
     ]
   },
@@ -1012,9 +1182,16 @@
         "text": "Actually, I have an implanted AR system.  Think you could use it?",
         "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_EXODII_AR",
         "condition": { "and": [ { "u_has_items": { "item": "integrated_ar", "count": 1 } }, { "u_has_trait": "CBM_Interface" } ] },
-        "effect": [ { "u_add_var": "robofac_pat_said_no_to_exodii_AR_CBM", "value": "yes" }, { "u_add_var": "robofac_pat_knows_u_cyborg", "value": "yes" } ]
+        "effect": [
+          { "u_add_var": "robofac_pat_said_no_to_exodii_AR_CBM", "value": "yes" },
+          { "u_add_var": "robofac_pat_knows_u_cyborg", "value": "yes" }
+        ]
       },
-      { "text": "Yeah, alright.", "topic": "TALK_ROBOFAC_MERC_PAT", "effect": { "u_add_var": "robofac_pat_knows_u_cyborg", "value": "yes" } }
+      {
+        "text": "Yeah, alright.",
+        "topic": "TALK_ROBOFAC_MERC_PAT",
+        "effect": { "u_add_var": "robofac_pat_knows_u_cyborg", "value": "yes" }
+      }
     ]
   },
   {
@@ -1044,11 +1221,29 @@
   {
     "id": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_HUB01_AR",
     "type": "talk_topic",
-    "dynamic_line": "No shit?  You also got a radio we can use?  If so, I'll plug my computah heah into your USB port, and see what we can do.  Platonically, of course.",
+    "dynamic_line": "No shit?  You also got some kind of internal radio we can use?  If so, I'll plug my computah heah into your USB port, and see what we can do.  Platonically, of course.",
     "responses": [
-      { "text": "Yup, I have an Infolink CBM, too.", "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_HUB01_AR_INFOLINK_YES", "condition": { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } } },
-      { "text": "No, I don't have a radio CBM.", "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_HUB01_AR_INFOLINK_NO", "condition": { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, "effect": { "u_add_var": "robofac_pat_said_use_the_earpiece", "value": "yes" } },
-      { "text": "Maybe I should come talk to you in person about this.  I'll swing by sometime.", "topic": "TALK_ROBOFAC_MERC_PAT", "condition": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } },
+      {
+        "text": "Yup, I have an Infolink CBM, too.",
+        "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_HUB01_AR_INFOLINK_YES",
+        "condition": {
+          "and": [
+            { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } },
+            { "u_has_bionics": "bio_radio" }
+          ]
+        }
+      },
+      {
+        "text": "No, I don't have an internal radio CBM.",
+        "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_HUB01_AR_INFOLINK_NO",
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } },
+        "effect": { "u_add_var": "robofac_pat_said_use_the_earpiece", "value": "yes" }
+      },
+      {
+        "text": "Maybe I should come talk to you in person about this.  I'll swing by sometime.",
+        "topic": "TALK_ROBOFAC_MERC_PAT",
+        "condition": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] }
+      },
       { "text": "Let's talk about this some other time.", "topic": "TALK_ROBOFAC_MERC_PAT" }
     ]
   },
@@ -1056,13 +1251,22 @@
     "id": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_HUB01_AR_INFOLINK_NO",
     "type": "talk_topic",
     "dynamic_line": {
-      "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ],
-      "yes": "Absolutely.  Come by heah sometime and show me, and we'll see what we can do.",
-      "no": "&Pat pulls out their laptop, sparks the makeshift car battery they use to power it, then boots it up.  \"Alright, now we're talkin'.  Like I said, I'll have to plug into your USB jack, Jack.  Ready?\""
-    }
+      "compare_string": [ "yes", { "u_val": "robofac_pat_finished_earpiece" } ],
+      "yes": "Well, I guess an integrated radio'd be nice, but just use the earpiece you have for the headset, yeah?  It should work with that USB port just the same.",
+      "no": "&Pat reaches into their pocket and pulls out a small earpiece with some inline electronics.  \"Heah, I've been workin' on this for a while.  You can plug it right into your USB port there, and stick this part here in your ear.  If the earpiece is active, I'll be able to chat and talk with you, yeah?  Turn it off if you need privacy.\""
+    },
     "responses": [
-      { "text": "Let's talk about this some other time.", "topic": "TALK_ROBOFAC_MERC_PAT" },
-      { "text": "Let's talk about this some other time.", "topic": "TALK_ROBOFAC_MERC_PAT" }
+      {
+        "text": "Great, I'll just use the earpiece for now.",
+        "topic": "TALK_ROBOFAC_MERC_PAT",
+        "condition": { "compare_string": [ "yes", { "u_val": "robofac_pat_finished_earpiece" } ] }
+      },
+      {
+        "text": "Huh, cool.  Thanks, Pat.  Talk to you soon.",
+        "topic": "TALK_DONE",
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_finished_earpiece" } ] } },
+        "effect": [ { "u_spawn_item": "pat_earpiece", "count": 1 }, { "u_lose_var": "robofac_pat_finished_earpiece" } ]
+      }
     ]
   },
   {
@@ -1072,12 +1276,31 @@
       "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ],
       "yes": "Absolutely.  Come by heah sometime and show me, and we'll see what we can do.",
       "no": "&Pat pulls out their laptop, sparks the makeshift car battery they use to power it, then boots it up.  \"Alright, now we're talkin'.  Like I said, I'll have to plug into your USB jack, Jack.  Ready?\""
-    }
+    },
     "responses": [
-      { "text": "Sure, I'll come by in person.", "topic": "TALK_ROBOFAC_MERC_PAT", "condition": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }
-      { "text": "[Give Pat access to your USB port] Let's do it.", "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_HUB01_AR_INFOLINK_INSTALLED", "condition": { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } }, "effect": { "u_add_var": "robofac_pat_gave_transponder_CBM", "value": "yes" } }
+      {
+        "text": "Sure, I'll come by in person.",
+        "topic": "TALK_ROBOFAC_MERC_PAT",
+        "condition": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] }
+      },
+      {
+        "text": "[Give Pat access to your USB port] Let's do it.",
+        "topic": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_HUB01_AR_INFOLINK_INSTALLED",
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "robofac_pat_chatting_on_radio" } ] } },
+        "effect": [
+          { "u_add_var": "robofac_pat_gave_transponder_CBM", "value": "yes" },
+          { "u_lose_bionic": "bio_radio" },
+          { "u_add_bionic": "bio_radio_pat" }
+        ]
+      },
       { "text": "Actually, let's talk about this some other time.", "topic": "TALK_ROBOFAC_MERC_PAT" }
     ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_TELL_U_CYBORG_HUB01_AR_INFOLINK_INSTALLED",
+    "type": "talk_topic",
+    "dynamic_line": "&Pat plugs their laptop into your USB port and starts to clack away.  After 10 minutes, you hear a BEEP.  Your Infolink resets, and Pat unplugs you.  \"All done.  The Hub made that shit theah easy.  All I had to do… well, it isn't impahtant.  Should be able to toggle ya' integrated transpondah to keep connected to me, now.  You can also just call me up on the comm, now, yeah?\"",
+    "responses": [ { "text": "Thanks, Pat.", "topic": "TALK_ROBOFAC_MERC_PAT" } ]
   },
   {
     "id": "TALK_ROBOFAC_MERC_PAT_MAKE_EARPIECE_MVAS",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Pat can use Hub 01 Infolink & AR system"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Pat can already watch you and contact you via various AR devices, and will comment on you being a cyborg.  Since Hub 01 installs an interface on you with a USB slot, it's feasible that you and Pat could set up a system of communication using your CBMs.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

You could already tell Pat you're a cyborg.  Now, if you have the Exodii interface, you can tell Pat you're a cyborg, but you have to prove it by showing off one of your CBMs with a visible effect (e.g., shotgun arm).  Like before, if you propose to Pat using an AR system, they'll turn you down, since they have no way to access it in your current state.

If you're a Hub 01 cyborg, Pat will have heard of the Hub 01 cybernetics program.  If you have an AR system CBM and an Infolink CBM, Pat can modify your CBMs by USB to allow you to call Pat, and allow Pat to monitor you, from afar, with no additional equipment.  This is mechanically accomplished by simply replacing the player's `bio_radio` with a custom `bio_radio_pat`, which is just a `bio_radio` but with two extra integrated items.  In universe, it's just tuning your Infolink to you and Pat's agreed-upon frequency.

If you are a Hub 01 cyborg with an AR system but no Infolink (which shouldn't happen, unless you uninstall the Infolink the Hub gives you for free), Pat will fast-track you to the existing transponder earpiece.  The transponder earpiece now works with the integrated AR system.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Allowing Pat to use the Exodii interface somehow, but I think it's better to lock this content behind the Hub 01 interface.  Maybe in the future if there's ever a storyline to convince Pat to ditch the Hub in favor of the Exodii.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Went through the dialogue in various different ways.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
