### PR TITLE
Add grid power resolution pass for appliances

### DIFF
--- a/data/mods/TEST_DATA/appliance.json
+++ b/data/mods/TEST_DATA/appliance.json
@@ -145,6 +145,45 @@
     "variants": [ { "symbols": "{", "symbols_broken": "*" } ]
   },
   {
+    "type": "ITEM",
+    "id": "test_high_drain_lamp",
+    "name": { "str": "high-drain lamp" },
+    "description": "A test lamp with high power draw for deterministic deficit testing.",
+    "weight": "2500 g",
+    "material": [ "plastic", "steel" ],
+    "volume": "2 L",
+    "longest_side": "170 cm",
+    "price": "90 USD",
+    "price_postapoc": "5 USD",
+    "symbol": "L",
+    "color": "white",
+    "looks_like": "f_floor_lamp",
+    "melee_damage": { "bash": 5 }
+  },
+  {
+    "id": "ap_test_high_drain_lamp",
+    "type": "vehicle_part",
+    "name": { "str": "high-drain lamp" },
+    "item": "test_high_drain_lamp",
+    "categories": [ "lighting" ],
+    "color": "white",
+    "broken_color": "blue",
+    "durability": 20,
+    "description": "A test lamp that draws 1 kW for deterministic deficit testing.",
+    "epower": "-1 kW",
+    "bonus": 200,
+    "damage_modifier": 10,
+    "looks_like": "f_floor_lamp",
+    "breaks_into": [
+      { "item": "cable", "charges": [ 1, 4 ] },
+      { "item": "steel_chunk", "count": [ 0, 2 ] },
+      { "item": "scrap", "count": [ 1, 2 ] }
+    ],
+    "flags": [ "CIRCLE_LIGHT", "APPLIANCE", "ENABLED_DRAINS_EPOWER", "CTRL_ELECTRONIC" ],
+    "requirements": { "removal": { "time": "6 m" } },
+    "variants": [ { "symbols": "*", "symbols_broken": "-" } ]
+  },
+  {
     "id": "test_storage_battery",
     "type": "ITEM",
     "subtypes": [ "MAGAZINE" ],

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -714,6 +714,71 @@ void map::on_vehicle_moved( const int smz )
     set_pathfinding_cache_dirty( smz );
 }
 
+void map::resolve_appliance_grid_power()
+{
+    const int minz = zlevels ? -OVERMAP_DEPTH : abs_sub.z();
+    const int maxz = zlevels ? OVERMAP_HEIGHT : abs_sub.z();
+    std::unordered_set<vehicle *> resolved;
+
+    for( int zlev = minz; zlev <= maxz; ++zlev ) {
+        const level_cache *cache = get_cache_lazy( zlev );
+        if( !cache ) {
+            continue;
+        }
+        for( vehicle *veh : cache->vehicle_list ) {
+            if( !veh->is_appliance() ) {
+                continue;
+            }
+            if( resolved.count( veh ) ) {
+                continue;
+            }
+            bool has_power_disabled = false;
+            for( const vpart_reference &vp : veh->get_all_parts() ) {
+                if( vp.part().power_disabled ) {
+                    has_power_disabled = true;
+                    break;
+                }
+            }
+            if( !has_power_disabled ) {
+                continue;
+            }
+            // found a candidate -- resolve its entire grid
+            std::map<vehicle *, float> grid = veh->search_connected_vehicles( *this );
+            int total_charge = 0;
+            for( const auto &[grid_veh, loss] : grid ) {
+                total_charge += grid_veh->battery_power_level().first;
+            }
+            if( total_charge > 0 ) {
+                for( const auto &[grid_veh, loss] : grid ) {
+                    if( !grid_veh->is_appliance() ) {
+                        continue;
+                    }
+                    for( const vpart_reference &vp : grid_veh->get_all_parts() ) {
+                        vehicle_part &pt = vp.part();
+                        if( !pt.power_disabled ) {
+                            continue;
+                        }
+                        if( pt.is_unavailable() ) {
+                            pt.power_disabled = false;
+                            continue;
+                        }
+                        if( pt.enabled ) {
+                            // user re-enabled it manually, just clear the flag
+                            pt.power_disabled = false;
+                            continue;
+                        }
+                        pt.enabled = true;
+                        pt.power_disabled = false;
+                    }
+                }
+            }
+            for( const auto &[grid_veh, loss] : grid ) {
+                resolved.insert( grid_veh );
+            }
+        }
+    }
+}
+
 void map::vehmove()
 {
     // give vehicles movement points
@@ -781,6 +846,8 @@ void map::vehmove()
         veh_pair.first->recalculate_enchantment_cache();
         veh_pair.first->idle( *this, /* on_map = */ veh_pair.second );
     }
+
+    resolve_appliance_grid_power();
 
     // refresh vehicle zones for moved vehicles
     zone_manager::get_manager().cache_vzones( this );

--- a/src/map.h
+++ b/src/map.h
@@ -770,6 +770,9 @@ class map
         int extra_cost( const tripoint_bub_ms &cur, const tripoint_bub_ms &p,
                         const pathfinding_settings &settings,
                         PathfindingFlags p_special ) const;
+        // Re-enables appliance parts that were disabled by power_parts() deficit
+        // when the connected grid actually has battery charge available.
+        void resolve_appliance_grid_power();
     public:
 
         // Vehicles: Common to 2D and 3D

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -5757,16 +5757,19 @@ void vehicle::power_parts( map &here )
         // Scoops need a special case since they consume power during actual use
         for( const vpart_reference &vp : get_enabled_parts( "SCOOP" ) ) {
             vp.part().enabled = false;
+            vp.part().power_disabled = true;
         }
         // Rechargers need special case since they consume power on demand
         for( const vpart_reference &vp : get_enabled_parts( "RECHARGE" ) ) {
             vp.part().enabled = false;
+            vp.part().power_disabled = true;
         }
 
         for( const vpart_reference &vp : get_enabled_parts( VPFLAG_ENABLED_DRAINS_EPOWER ) ) {
             vehicle_part &pt = vp.part();
             if( pt.info().epower < 0_W ) {
                 pt.enabled = false;
+                pt.power_disabled = true;
             }
         }
 

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -531,6 +531,8 @@ struct vehicle_part {
          */
         bool removed = false; // NOLINT(cata-serialize)
         bool enabled = true;
+        // set by power_parts() on deficit, cleared by grid resolution on recovery
+        bool power_disabled = false; // NOLINT(cata-serialize)
 
         /** ID of player passenger */
         character_id passenger_id;

--- a/tests/vehicle_power_test.cpp
+++ b/tests/vehicle_power_test.cpp
@@ -9,22 +9,36 @@
 #include "character.h"
 #include "coordinates.h"
 #include "debug.h"
+#include "enums.h"
 #include "item.h"
 #include "map.h"
 #include "map_helpers.h"
+#include "map_scale_constants.h"
 #include "options_helpers.h"
+#include "player_helpers.h"
 #include "point.h"
+#include "ret_val.h"
 #include "type_id.h"
 #include "units.h"
+#include "veh_appliance.h"
+#include "veh_type.h"
 #include "vehicle.h"
 #include "vpart_position.h"
+#include "vpart_range.h"
 #include "weather_type.h"
 
 static const efftype_id effect_blind( "blind" );
 
 static const itype_id fuel_type_battery( "battery" );
+static const itype_id itype_test_high_drain_lamp( "test_high_drain_lamp" );
+static const itype_id itype_test_power_cord( "test_power_cord" );
 static const itype_id itype_test_power_cord_25_loss( "test_power_cord_25_loss" );
+static const itype_id itype_test_standing_lamp( "test_standing_lamp" );
+static const itype_id itype_test_storage_battery( "test_storage_battery" );
 
+static const vpart_id vpart_ap_test_high_drain_lamp( "ap_test_high_drain_lamp" );
+static const vpart_id vpart_ap_test_standing_lamp( "ap_test_standing_lamp" );
+static const vpart_id vpart_ap_test_storage_battery( "ap_test_storage_battery" );
 static const vpart_id vpart_frame( "frame" );
 static const vpart_id vpart_small_storage_battery( "small_storage_battery" );
 
@@ -340,3 +354,259 @@ TEST_CASE( "maximum_reverse_velocity", "[vehicle][power][reverse]" )
     }
 }
 
+static void connect_power_cord( const tripoint_bub_ms &src_pos, const tripoint_bub_ms &dst_pos )
+{
+    map &here = get_map();
+    const optional_vpart_position target_vp = here.veh_at( dst_pos );
+    const optional_vpart_position source_vp = here.veh_at( src_pos );
+    REQUIRE( target_vp.has_value() );
+    REQUIRE( source_vp.has_value() );
+    REQUIRE( &target_vp->vehicle() != &source_vp->vehicle() );
+
+    item cord( itype_test_power_cord );
+    ret_val<void> result = cord.link_to( target_vp, source_vp, link_state::vehicle_port );
+    REQUIRE( result.success() );
+}
+
+// Helper: find the index of the first part with ENABLED_DRAINS_EPOWER on a vehicle
+static int find_consumer_part_idx( vehicle &veh )
+{
+    for( const vpart_reference &vp : veh.get_all_parts() ) {
+        if( vp.info().has_flag( "ENABLED_DRAINS_EPOWER" ) ) {
+            return vp.part_index();
+        }
+    }
+    return -1;
+}
+
+TEST_CASE( "power_parts_sets_power_disabled_flag_on_deficit", "[vehicle][power][grid]" )
+{
+    clear_map_without_vision();
+    clear_avatar();
+    map &here = get_map();
+    Character &player_character = get_player_character();
+
+    const tripoint_bub_ms battery_pos( HALF_MAPSIZE_X + 2, HALF_MAPSIZE_Y + 2, 0 );
+    const tripoint_bub_ms lamp_pos( HALF_MAPSIZE_X + 4, HALF_MAPSIZE_Y + 2, 0 );
+
+    // Use the 1 kW lamp so power_to_energy_bat produces a non-zero delta
+    // deterministically (1 kW * 1s = 1 kJ, roll_remainder(1.0) = 1 always).
+    std::optional<item> battery_item( itype_test_storage_battery );
+    std::optional<item> lamp_item( itype_test_high_drain_lamp );
+    place_appliance( here, battery_pos, vpart_ap_test_storage_battery, player_character, battery_item );
+    place_appliance( here, lamp_pos, vpart_ap_test_high_drain_lamp, player_character, lamp_item );
+
+    connect_power_cord( battery_pos, lamp_pos );
+
+    vehicle &lamp_veh = here.veh_at( lamp_pos )->vehicle();
+    vehicle &bat_veh = here.veh_at( battery_pos )->vehicle();
+    const int consumer_idx = find_consumer_part_idx( lamp_veh );
+    REQUIRE( consumer_idx != -1 );
+
+    // Drain battery completely
+    bat_veh.discharge_battery( here, 100000000 );
+    REQUIRE( bat_veh.fuel_left( here, fuel_type_battery ) == 0 );
+
+    // Force the consumer enabled so power_parts() can disable it
+    lamp_veh.part( consumer_idx ).enabled = true;
+    lamp_veh.part( consumer_idx ).power_disabled = false;
+
+    calendar::turn += 1_turns;
+    here.vehmove();
+
+    // power_parts() should have disabled the consumer AND set the flag.
+    // Note: resolve_appliance_grid_power() runs after but won't re-enable
+    // because the battery is at 0.
+    CHECK_FALSE( lamp_veh.part( consumer_idx ).enabled );
+    CHECK( lamp_veh.part( consumer_idx ).power_disabled );
+}
+
+TEST_CASE( "grid_power_resolution_reenables_appliances", "[vehicle][power][grid]" )
+{
+    clear_map_without_vision();
+    clear_avatar();
+    map &here = get_map();
+    Character &player_character = get_player_character();
+
+    const tripoint_bub_ms battery_pos( HALF_MAPSIZE_X + 2, HALF_MAPSIZE_Y + 2, 0 );
+    const tripoint_bub_ms lamp_pos( HALF_MAPSIZE_X + 4, HALF_MAPSIZE_Y + 2, 0 );
+
+    std::optional<item> battery_item( itype_test_storage_battery );
+    std::optional<item> lamp_item( itype_test_standing_lamp );
+    place_appliance( here, battery_pos, vpart_ap_test_storage_battery, player_character, battery_item );
+    place_appliance( here, lamp_pos, vpart_ap_test_standing_lamp, player_character, lamp_item );
+
+    connect_power_cord( battery_pos, lamp_pos );
+
+    vehicle &lamp_veh = here.veh_at( lamp_pos )->vehicle();
+    vehicle &bat_veh = here.veh_at( battery_pos )->vehicle();
+    const int consumer_idx = find_consumer_part_idx( lamp_veh );
+    REQUIRE( consumer_idx != -1 );
+
+    // Simulate the state after power_parts() deficit: consumer disabled with flag set.
+    // (The deficit fires stochastically via roll_remainder for small consumers like -20W,
+    // so we set the state directly rather than waiting for random rounding.)
+    lamp_veh.part( consumer_idx ).enabled = false;
+    lamp_veh.part( consumer_idx ).power_disabled = true;
+
+    // Battery has charge -- resolution should re-enable the consumer
+    REQUIRE( bat_veh.fuel_left( here, fuel_type_battery ) > 0 );
+
+    calendar::turn += 1_turns;
+    here.vehmove();
+    CHECK( lamp_veh.part( consumer_idx ).enabled );
+    CHECK_FALSE( lamp_veh.part( consumer_idx ).power_disabled );
+}
+
+TEST_CASE( "grid_power_no_recovery_without_power", "[vehicle][power][grid]" )
+{
+    clear_map_without_vision();
+    clear_avatar();
+    map &here = get_map();
+    Character &player_character = get_player_character();
+
+    const tripoint_bub_ms battery_pos( HALF_MAPSIZE_X + 2, HALF_MAPSIZE_Y + 2, 0 );
+    const tripoint_bub_ms lamp_pos( HALF_MAPSIZE_X + 4, HALF_MAPSIZE_Y + 2, 0 );
+
+    std::optional<item> battery_item( itype_test_storage_battery );
+    std::optional<item> lamp_item( itype_test_standing_lamp );
+    place_appliance( here, battery_pos, vpart_ap_test_storage_battery, player_character, battery_item );
+    place_appliance( here, lamp_pos, vpart_ap_test_standing_lamp, player_character, lamp_item );
+
+    connect_power_cord( battery_pos, lamp_pos );
+
+    vehicle &lamp_veh = here.veh_at( lamp_pos )->vehicle();
+    vehicle &bat_veh = here.veh_at( battery_pos )->vehicle();
+    const int consumer_idx = find_consumer_part_idx( lamp_veh );
+    REQUIRE( consumer_idx != -1 );
+
+    // Simulate power deficit state
+    lamp_veh.part( consumer_idx ).enabled = false;
+    lamp_veh.part( consumer_idx ).power_disabled = true;
+
+    // Drain all battery power
+    bat_veh.discharge_battery( here, 100000000 );
+    REQUIRE( bat_veh.fuel_left( here, fuel_type_battery ) == 0 );
+
+    calendar::turn += 1_turns;
+    here.vehmove();
+    CHECK_FALSE( lamp_veh.part( consumer_idx ).enabled );
+    CHECK( lamp_veh.part( consumer_idx ).power_disabled );
+
+    // another turn, still no power
+    calendar::turn += 1_turns;
+    here.vehmove();
+    CHECK_FALSE( lamp_veh.part( consumer_idx ).enabled );
+    CHECK( lamp_veh.part( consumer_idx ).power_disabled );
+}
+
+TEST_CASE( "user_disabled_appliance_not_reenabled", "[vehicle][power][grid]" )
+{
+    clear_map_without_vision();
+    clear_avatar();
+    map &here = get_map();
+    Character &player_character = get_player_character();
+
+    const tripoint_bub_ms battery_pos( HALF_MAPSIZE_X + 2, HALF_MAPSIZE_Y + 2, 0 );
+    const tripoint_bub_ms lamp_pos( HALF_MAPSIZE_X + 4, HALF_MAPSIZE_Y + 2, 0 );
+
+    std::optional<item> battery_item( itype_test_storage_battery );
+    std::optional<item> lamp_item( itype_test_standing_lamp );
+    place_appliance( here, battery_pos, vpart_ap_test_storage_battery, player_character, battery_item );
+    place_appliance( here, lamp_pos, vpart_ap_test_standing_lamp, player_character, lamp_item );
+
+    connect_power_cord( battery_pos, lamp_pos );
+
+    vehicle &lamp_veh = here.veh_at( lamp_pos )->vehicle();
+    const int consumer_idx = find_consumer_part_idx( lamp_veh );
+    REQUIRE( consumer_idx != -1 );
+
+    // user manually disables the lamp (power_disabled stays false)
+    lamp_veh.part( consumer_idx ).enabled = false;
+    lamp_veh.part( consumer_idx ).power_disabled = false;
+
+    calendar::turn += 1_turns;
+    here.vehmove();
+
+    // resolution should not touch user-disabled parts
+    CHECK_FALSE( lamp_veh.part( consumer_idx ).enabled );
+    CHECK_FALSE( lamp_veh.part( consumer_idx ).power_disabled );
+}
+
+TEST_CASE( "non_appliance_vehicle_not_auto_recovered", "[vehicle][power][grid]" )
+{
+    clear_map_without_vision();
+    clear_avatar();
+    map &here = get_map();
+
+    // build a regular (non-appliance) vehicle with a frame, battery, and a consumer part
+    const tripoint_bub_ms veh_pos( HALF_MAPSIZE_X + 2, HALF_MAPSIZE_Y + 2, 0 );
+    vehicle *veh = here.add_vehicle( vehicle_prototype_none, veh_pos, 0_degrees, 0, 0 );
+    REQUIRE( veh != nullptr );
+    const int frame_idx = veh->install_part( here, point_rel_ms::zero, vpart_frame );
+    REQUIRE( frame_idx != -1 );
+    const int bat_idx = veh->install_part( here, point_rel_ms::zero, vpart_small_storage_battery );
+    REQUIRE( bat_idx != -1 );
+    veh->refresh();
+    here.add_vehicle_to_cache( veh );
+
+    // charge battery, then drain it
+    veh->charge_battery( here, 500 );
+    REQUIRE( veh->fuel_left( here, fuel_type_battery ) > 0 );
+
+    // the small_storage_battery vehicle is NOT an appliance
+    REQUIRE_FALSE( veh->is_appliance() );
+
+    // manually simulate a power deficit disable
+    veh->part( bat_idx ).enabled = false;
+    veh->part( bat_idx ).power_disabled = true;
+
+    calendar::turn += 1_turns;
+    here.vehmove();
+
+    // resolution should skip non-appliance vehicles
+    CHECK_FALSE( veh->part( bat_idx ).enabled );
+}
+
+TEST_CASE( "grid_power_cross_turn_recovery", "[vehicle][power][grid]" )
+{
+    clear_map_without_vision();
+    clear_avatar();
+    map &here = get_map();
+    Character &player_character = get_player_character();
+
+    const tripoint_bub_ms battery_pos( HALF_MAPSIZE_X + 2, HALF_MAPSIZE_Y + 2, 0 );
+    const tripoint_bub_ms lamp_pos( HALF_MAPSIZE_X + 4, HALF_MAPSIZE_Y + 2, 0 );
+
+    std::optional<item> battery_item( itype_test_storage_battery );
+    std::optional<item> lamp_item( itype_test_standing_lamp );
+    place_appliance( here, battery_pos, vpart_ap_test_storage_battery, player_character, battery_item );
+    place_appliance( here, lamp_pos, vpart_ap_test_standing_lamp, player_character, lamp_item );
+
+    connect_power_cord( battery_pos, lamp_pos );
+
+    vehicle &lamp_veh = here.veh_at( lamp_pos )->vehicle();
+    vehicle &bat_veh = here.veh_at( battery_pos )->vehicle();
+    const int consumer_idx = find_consumer_part_idx( lamp_veh );
+    REQUIRE( consumer_idx != -1 );
+
+    // Simulate power deficit state with drained battery
+    bat_veh.discharge_battery( here, 100000000 );
+    REQUIRE( bat_veh.fuel_left( here, fuel_type_battery ) == 0 );
+    lamp_veh.part( consumer_idx ).enabled = false;
+    lamp_veh.part( consumer_idx ).power_disabled = true;
+
+    // second turn, still no power -- flag persists
+    calendar::turn += 1_turns;
+    here.vehmove();
+    CHECK_FALSE( lamp_veh.part( consumer_idx ).enabled );
+    CHECK( lamp_veh.part( consumer_idx ).power_disabled );
+
+    // third turn, charge battery -- should recover
+    bat_veh.charge_battery( here, 1000 );
+    REQUIRE( bat_veh.fuel_left( here, fuel_type_battery ) > 0 );
+    calendar::turn += 1_turns;
+    here.vehmove();
+    CHECK( lamp_veh.part( consumer_idx ).enabled );
+    CHECK_FALSE( lamp_veh.part( consumer_idx ).power_disabled );
+}


### PR DESCRIPTION
#### Summary
Bugfixes "Re-enable appliances after transient power grid deficit"

#### Purpose of change

Appliances (freezers, fridges, lamps) get permanently disabled when the player walks near their base. `power_parts()` runs per-vehicle and does a Dijkstra traversal to find connected batteries. If the traversal fails to find a remote battery (submap loading order, off-map vehicles, stale cable coordinates), it sees a battery deficit and permanently sets `enabled = false` on all power-consuming parts. There's no recovery path -- the player has to manually re-enable each appliance every time.

This is the most common player-facing grid bug. Related: #83514, #84611.

#### Describe the solution

Add a per-part `power_disabled` flag on `vehicle_part` and a resolution pass in `map::vehmove()`.

When `power_parts()` disables a consumer due to deficit, it also sets `power_disabled = true`. After all vehicles idle, `resolve_appliance_grid_power()` checks each appliance grid's total battery level. If power is available, it re-enables parts that were power-disabled and clears the flag.

Key design decisions:
- Per-part bool, not a set of indices -- immune to index shifts from part removal (`do_remove_part_actual` runs `parts.erase()` before the idle loop)
- Not serialized -- rebuilds naturally each session via the deficit/recovery cycle
- **Appliance-only scope** -- `is_appliance()` gate at both candidate collection and re-enable, so normal vehicle power behavior is completely unchanged
- **User intent preserved** -- parts disabled by the player (where `power_disabled` is false) are never touched by the resolution pass
- Unavailable parts guarded -- broken or carried parts get the flag cleared but aren't re-enabled
- Runs after idle loop but before `process_items()`, so corrected `enabled` state is visible to FRIDGE/FREEZER temperature checks

Known limitations:
- Old saves: since `power_disabled` isn't serialized, appliances already disabled by the bug in pre-fix saves won't auto-recover until they hit a new deficit+recovery cycle
- If a grid has barely enough charge (total > 0 but insufficient for actual consumption), `power_parts()` disables consumers each turn and resolution re-enables them. No gameplay effect -- this happens within a single turn before any consumer logic runs
- Resolution iterates `level_cache::vehicle_list`, same as `vehmove()`. Off-map-only flagged appliances won't be considered until a grid member appears in cache (off-map force-load runs once every 5 turns)

6 new tests covering: deficit flag-setting (with 1 kW test appliance for deterministic `roll_remainder`), resolution re-enable, no recovery without power, user-disabled preservation, non-appliance exclusion, cross-turn persistence and recovery.

#### Describe alternatives you've considered

The "proper" fix is a persistent `power_network` entity that owns topology and resolves power centrally after all vehicles report, instead of the current per-vehicle Dijkstra. That's planned as follow-up phases but requires significant refactoring. This resolution pass gives immediate relief with ~70 lines of new logic in map.cpp.

perkel66 proposed calling `power_parts()` on all newly active vehicles after `update_vehicle_list()` completes (comment on #83514, reports 100+ hours without disconnections). Similar spirit but this approach adds the recovery path too, not just prevention.

#### Testing

- 6 new tests tagged `[vehicle][power][grid]`, all pass
- Full vehicle test suite (71 cases, 487K assertions) passes

#### Additional context

This is phase 1 of a larger grid power architecture rework. Follow-up phases (each standalone):

- **Phase 2 -- Persistence and time-catchup**: persistent `power_network` class with stable IDs, off-map solar/wind generation via rated values + weather backfill, removes the 5-turn force-load polling gap
- **Phase 3 -- Persistent topology**: cable edges stored in network graph with vehicle IDs, event-driven topology updates on place/remove/connect/disconnect, removes per-turn Dijkstra entirely

Open bugs this doesn't address yet: cable disconnection on bubble entry/exit (#83712), extension cord traversal failures (#84588, #82836), off-map solar not generating, `charge_linked_batteries()` rounding issues.