### PR TITLE
make nail amounts more realistic

### DIFF
--- a/data/json/itemgroups/supplies.json
+++ b/data/json/itemgroups/supplies.json
@@ -179,7 +179,7 @@
     "type": "item_group",
     "container-item": "box_small",
     "on_overflow": "spill",
-    "items": [ { "item": "nail", "charges": [ 23 ] } ]
+    "items": [ { "item": "nail", "count": 23 } ]
   },
   {
     "id": "nail_box_1lb",
@@ -193,7 +193,7 @@
     "type": "item_group",
     "container-item": "box_small",
     "on_overflow": "spill",
-    "items": [ { "item": "nail", "charges": [ 115 ] } ]
+    "items": [ { "item": "nail", "count": 115 } ]
   },
   {
     "id": "nail_box_5lb",
@@ -207,7 +207,7 @@
     "type": "item_group",
     "container-item": "box_small",
     "on_overflow": "spill",
-    "items": [ { "item": "nail", "charges": [ 230 ] } ]
+    "items": [ { "item": "nail", "count": 230 } ]
   },
   {
     "id": "nail_box_10lb",
@@ -221,7 +221,7 @@
     "type": "item_group",
     "container-item": "box_small",
     "on_overflow": "spill",
-    "items": [ { "item": "nail", "charges": [ 345 ] } ]
+    "items": [ { "item": "nail", "count": 345 } ]
   },
   {
     "id": "nail_box_15lb",

--- a/data/json/itemgroups/supplies.json
+++ b/data/json/itemgroups/supplies.json
@@ -175,11 +175,60 @@
     "items": [ { "item": "charcoal", "charges": [ 200, 5000 ] } ]
   },
   {
-    "id": "nail_box_part",
+    "id": "nail_box_1lb_full",
     "type": "item_group",
     "container-item": "box_small",
     "on_overflow": "spill",
-    "items": [ { "item": "nail", "charges": [ 300, 600 ] } ]
+    "items": [ { "item": "nail", "charges": [ 23 ] } ]
+  },
+  {
+    "id": "nail_box_1lb",
+    "type": "item_group",
+    "container-item": "box_small",
+    "on_overflow": "spill",
+    "items": [ { "item": "nail", "charges": [ 7, 23 ] } ]
+  },
+  {
+    "id": "nail_box_5lb_full",
+    "type": "item_group",
+    "container-item": "box_small",
+    "on_overflow": "spill",
+    "items": [ { "item": "nail", "charges": [ 115 ] } ]
+  },
+  {
+    "id": "nail_box_5lb",
+    "type": "item_group",
+    "container-item": "box_small",
+    "on_overflow": "spill",
+    "items": [ { "item": "nail", "charges": [ 35, 115 ] } ]
+  },
+  {
+    "id": "nail_box_10lb_full",
+    "type": "item_group",
+    "container-item": "box_small",
+    "on_overflow": "spill",
+    "items": [ { "item": "nail", "charges": [ 230 ] } ]
+  },
+  {
+    "id": "nail_box_10lb",
+    "type": "item_group",
+    "container-item": "box_small",
+    "on_overflow": "spill",
+    "items": [ { "item": "nail", "charges": [ 69, 230 ] } ]
+  },
+  {
+    "id": "nail_box_15lb_full",
+    "type": "item_group",
+    "container-item": "box_small",
+    "on_overflow": "spill",
+    "items": [ { "item": "nail", "charges": [ 345 ] } ]
+  },
+  {
+    "id": "nail_box_15lb",
+    "type": "item_group",
+    "container-item": "box_small",
+    "on_overflow": "spill",
+    "items": [ { "item": "nail", "charges": [ 103, 345 ] } ]
   },
   {
     "id": "nicotine_liquid_bottle_part",
@@ -252,7 +301,14 @@
       { "item": "lc_wire", "prob": 40, "count": [ 5, 10 ] },
       { "item": "screen_mesh", "prob": 40, "count": [ 5, 10 ] },
       { "item": "spike", "prob": 40, "count": [ 5, 10 ] },
-      { "group": "nail_box_part", "prob": 80, "count": [ 1, 10 ] },
+      { "group": "nail_box_1lb_full", "prob": 95, "count": [ 12, 24 ] },
+      { "group": "nail_box_5lb_full", "prob": 80, "count": [ 1, 10 ] },
+      { "group": "nail_box_10lb_full", "prob": 75, "count": [ 1, 10 ] },
+      { "group": "nail_box_15lb_full", "prob": 70, "count": [ 1, 10 ] },
+      { "group": "nail_box_1lb", "prob": 95, "count": [ 6, 24 ] },
+      { "group": "nail_box_5lb", "prob": 90, "count": [ 1, 10 ] },
+      { "group": "nail_box_10lb", "prob": 85, "count": [ 1, 10 ] },
+      { "group": "nail_box_15lb", "prob": 80, "count": [ 1, 10 ] },
       { "item": "hinge", "prob": 60, "count": [ 5, 10 ] },
       { "item": "tempered_glass_sheet", "prob": 30, "count": [ 5, 20 ] },
       { "item": "rigid_plastic_sheet", "prob": 30, "count": [ 5, 20 ] }
@@ -336,7 +392,14 @@
           { "item": "wood_panel", "prob": 300, "count": [ 15, 40 ] },
           { "item": "log", "prob": 200, "count": [ 5, 10 ] },
           { "item": "stick_long", "prob": 100, "count": [ 10, 20 ] },
-          { "group": "nail_box_part", "prob": 80, "count": [ 2, 6 ] },
+          { "group": "nail_box_1lb_full", "prob": 90, "count": [ 10, 20 ] },
+          { "group": "nail_box_5lb_full", "prob": 85, "count": [ 2, 6 ] },
+          { "group": "nail_box_10lb_full", "prob": 80, "count": [ 1, 6 ] },
+          { "group": "nail_box_15lb_full", "prob": 75, "count": [ 1, 4 ] },
+          { "group": "nail_box_1lb", "prob": 95, "count": [ 6, 20 ] },
+          { "group": "nail_box_5lb", "prob": 90, "count": [ 2, 6 ] },
+          { "group": "nail_box_10lb", "prob": 85, "count": [ 1, 6 ] },
+          { "group": "nail_box_15lb", "prob": 80, "count": [ 1, 4 ] },
           { "item": "stick", "prob": 50, "count": [ 5, 10 ] }
         ],
         "prob": 100
@@ -366,7 +429,14 @@
           { "item": "wood_panel", "prob": 30, "count": [ 2, 3 ] },
           { "item": "stick_long", "prob": 30, "count": [ 5, 10 ] },
           { "item": "stick", "prob": 50, "count": [ 1, 7 ] },
-          { "group": "nail_box_part", "prob": 100, "count": [ 1, 5 ] }
+          { "group": "nail_box_1lb_full", "prob": 100, "count": [ 6, 24 ] },
+          { "group": "nail_box_5lb_full", "prob": 95, "count": [ 1, 10 ] },
+          { "group": "nail_box_10lb_full", "prob": 95, "count": [ 1, 10 ] },
+          { "group": "nail_box_15lb_full", "prob": 90, "count": [ 1, 10 ] },
+          { "group": "nail_box_1lb", "prob": 100, "count": [ 1, 24 ] },
+          { "group": "nail_box_5lb", "prob": 95, "count": [ 1, 10 ] },
+          { "group": "nail_box_10lb", "prob": 95, "count": [ 1, 10 ] },
+          { "group": "nail_box_15lb", "prob": 90, "count": [ 1, 10 ] }
         ],
         "prob": 100
       },
@@ -467,7 +537,14 @@
       { "item": "pipe", "prob": 20, "count": [ 5, 10 ] },
       { "item": "polycarbonate_sheet", "prob": 10, "count": [ 1, 3 ] },
       [ "vac_mold", 3 ],
-      { "group": "nail_box_part", "prob": 90, "count": [ 1, 3 ] },
+      { "group": "nail_box_1lb_full", "prob": 90, "count": [ 1, 12 ] },
+      { "group": "nail_box_5lb_full", "prob": 80, "count": [ 1, 3 ] },
+      { "group": "nail_box_10lb_full", "prob": 75, "count": [ 1, 3 ] },
+      { "group": "nail_box_15lb_full", "prob": 70, "count": [ 1, 3 ] },
+      { "group": "nail_box_1lb", "prob": 95, "count": [ 1, 12 ] },
+      { "group": "nail_box_5lb", "prob": 90, "count": [ 1, 3 ] },
+      { "group": "nail_box_10lb", "prob": 85, "count": [ 1, 3 ] },
+      { "group": "nail_box_15lb", "prob": 80, "count": [ 1, 2 ] },
       [ "hose", 15 ],
       [ "string_36", 40 ],
       { "item": "22_blank", "prob": 30, "count": [ 1, 4 ] },

--- a/data/json/mapgen_palettes/container_yard.json
+++ b/data/json/mapgen_palettes/container_yard.json
@@ -473,7 +473,7 @@
     "object": {
       "mapgensize": [ 1, 1 ],
       "furniture": { " ": [ [ "f_crate_c", 90 ], [ "f_cardboard_box", 10 ] ] },
-      "items": { " ": { "item": "nail_box_part", "chance": 95, "repeat": [ 10, 20 ] } }
+      "items": { " ": { "item": "nail_box_10lb_full", "chance": 95, "repeat": [ 10, 20 ] } }
     }
   },
   {


### PR DESCRIPTION


<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Features "Made nail amounts more realistic"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
This change simply makes the nail spawns in nail boxes more accurate to how they are in real life. This is to make it more realistic and varied.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
I made 8 different new item groups. 4 of them to handle situations where boxes of nails should be guaranteed to be full and 4 where they aren't. The ones not guaranteed to be full have a chance to spawn with about 30%-100% of the amount of nails they should be spawning with. Each itemgroup has a different number of nails sorted by weight (i.e. 1lb,5lb,10lb,15lb).
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Making unique boxes and buckets for nails instead of using box_small for the container.
Balance the percent chance of the boxes themselves spawning and the amount that spawn.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
1. Opened testing world and  spawned each newly created item group 10 times each.
2. Spawned item groups using the newly created item groups 10 times each.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I'm not good at balancing things so the chance of boxes themselves spawning and the amount that spawn should be looked at with a grain of salt.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
