### PR TITLE
Add off-map grid generation and persistent power_network class

### DIFF
--- a/data/mods/TEST_DATA/vehicle.json
+++ b/data/mods/TEST_DATA/vehicle.json
@@ -305,6 +305,26 @@
     ]
   },
   {
+    "id": "wind_turbine_test",
+    "type": "vehicle",
+    "name": "Wind turbine test",
+    "parts": [
+      { "x": 0, "y": 0, "parts": [ "frame#vertical", "wind_turbine" ] },
+      { "x": 1, "y": 0, "parts": [ "frame#vertical", "large_storage_battery" ] },
+      { "x": 0, "y": -1, "parts": [ "frame#vertical", "seat", "large_storage_battery" ] }
+    ]
+  },
+  {
+    "id": "water_wheel_test",
+    "type": "vehicle",
+    "name": "Water wheel test",
+    "parts": [
+      { "x": 0, "y": 0, "parts": [ "frame#vertical", "water_wheel" ] },
+      { "x": 1, "y": 0, "parts": [ "frame#vertical", "large_storage_battery" ] },
+      { "x": 0, "y": -1, "parts": [ "frame#vertical", "seat", "large_storage_battery" ] }
+    ]
+  },
+  {
     "id": "obstacle_test",
     "type": "vehicle",
     "name": "TEST obstacle boards",

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -174,6 +174,7 @@
 #include "pickup.h"
 #include "player_activity.h"
 #include "popup.h"
+#include "power_network.h"
 #include "profession.h"
 #include "proficiency.h"
 #include "recipe.h"
@@ -687,6 +688,7 @@ void game::setup()
     clear_zombies();
     critter_tracker->clear_npcs();
     faction_manager_ptr->clear();
+    power_networks_ptr->clear();
     mission::clear_all();
     Messages::clear_messages();
     timed_events = timed_event_manager();
@@ -2965,6 +2967,11 @@ void game::unique_npc_despawn( const std::string &id )
 spell_events &game::spell_events_subscriber()
 {
     return *spell_events_ptr;
+}
+
+power_network_manager &game::power_networks()
+{
+    return *power_networks_ptr;
 }
 
 void game::disp_NPC_epilogues()

--- a/src/game.h
+++ b/src/game.h
@@ -84,6 +84,7 @@ class monster;
 class npc;
 class npc_template;
 class overmap;
+class power_network_manager;
 class save_t;
 class scenario;
 class scent_map;
@@ -1147,6 +1148,7 @@ class game
         pimpl<memorial_logger> memorial_logger_ptr; // NOLINT(cata-serialize)
         pimpl<spell_events> spell_events_ptr; // NOLINT(cata-serialize)
         pimpl<eoc_events> eoc_events_ptr; // NOLINT(cata-serialize)
+        pimpl<power_network_manager> power_networks_ptr;
 
         map &m; // NOLINT(cata-serialize)
         // 'current_map' will be identical to 'm' as you can save only at the top of the main loop.
@@ -1171,6 +1173,7 @@ class game
         queued_eocs queued_global_effect_on_conditions;
 
         spell_events &spell_events_subscriber();
+        power_network_manager &power_networks();
 
         pimpl<creature_tracker> critter_tracker;
         pimpl<faction_manager> faction_manager_ptr; // NOLINT(cata-serialize)

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -83,6 +83,7 @@
 #include "overmapbuffer.h"
 #include "pathfinding.h"
 #include "pocket_type.h"
+#include "power_network.h"
 #include "projectile.h"
 #include "ranged.h"
 #include "relic.h"
@@ -730,6 +731,9 @@ void map::resolve_off_map_grid_generation()
         in_bubble.insert( cache->vehicle_list.begin(), cache->vehicle_list.end() );
     }
 
+    power_network_manager &pnm = g->power_networks();
+    pnm.begin_rebuild();
+
     for( vehicle *veh : in_bubble ) {
         if( resolved.count( veh ) ) {
             continue;
@@ -746,6 +750,9 @@ void map::resolve_off_map_grid_generation()
             }
         }
 
+        // Record every grid in the power network manager
+        pnm.add_grid( veh, grid );
+
         if( !has_off_map_renewables ) {
             continue;
         }
@@ -761,6 +768,8 @@ void map::resolve_off_map_grid_generation()
             }
         }
     }
+
+    pnm.finish_rebuild();
 }
 
 void map::resolve_appliance_grid_power()

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -714,6 +714,55 @@ void map::on_vehicle_moved( const int smz )
     set_pathfinding_cache_dirty( smz );
 }
 
+void map::resolve_off_map_grid_generation()
+{
+    const int minz = zlevels ? -OVERMAP_DEPTH : abs_sub.z();
+    const int maxz = zlevels ? OVERMAP_HEIGHT : abs_sub.z();
+    std::unordered_set<vehicle *> resolved;
+
+    // Build set of in-bubble vehicles for fast membership check
+    std::unordered_set<vehicle *> in_bubble;
+    for( int zlev = minz; zlev <= maxz; ++zlev ) {
+        const level_cache *cache = get_cache_lazy( zlev );
+        if( !cache ) {
+            continue;
+        }
+        in_bubble.insert( cache->vehicle_list.begin(), cache->vehicle_list.end() );
+    }
+
+    for( vehicle *veh : in_bubble ) {
+        if( resolved.count( veh ) ) {
+            continue;
+        }
+        std::map<vehicle *, float> grid = veh->search_connected_vehicles( *this );
+        bool has_off_map_renewables = false;
+        for( const auto &[grid_veh, loss] : grid ) {
+            resolved.insert( grid_veh );
+            if( !in_bubble.count( grid_veh ) &&
+                ( !grid_veh->solar_panels.empty() ||
+                  !grid_veh->wind_turbines.empty() ||
+                  !grid_veh->water_wheels.empty() ) ) {
+                has_off_map_renewables = true;
+            }
+        }
+
+        if( !has_off_map_renewables ) {
+            continue;
+        }
+        // Process each off-map source individually so charge_battery()
+        // computes the correct cable loss path from that source.
+        for( const auto &[grid_veh, loss] : grid ) {
+            if( in_bubble.count( grid_veh ) ) {
+                continue;
+            }
+            int energy = grid_veh->catchup_off_map_renewables( calendar::turn );
+            if( energy > 0 ) {
+                grid_veh->charge_battery( *this, energy );
+            }
+        }
+    }
+}
+
 void map::resolve_appliance_grid_power()
 {
     const int minz = zlevels ? -OVERMAP_DEPTH : abs_sub.z();
@@ -847,6 +896,7 @@ void map::vehmove()
         veh_pair.first->idle( *this, /* on_map = */ veh_pair.second );
     }
 
+    resolve_off_map_grid_generation();
     resolve_appliance_grid_power();
 
     // refresh vehicle zones for moved vehicles

--- a/src/map.h
+++ b/src/map.h
@@ -770,6 +770,9 @@ class map
         int extra_cost( const tripoint_bub_ms &cur, const tripoint_bub_ms &p,
                         const pathfinding_settings &settings,
                         PathfindingFlags p_special ) const;
+        // Catches up renewable generation (solar/wind/water) for off-map vehicles
+        // that are connected to in-bubble grids via cables.
+        void resolve_off_map_grid_generation();
         // Re-enables appliance parts that were disabled by power_parts() deficit
         // when the connected grid actually has battery charge available.
         void resolve_appliance_grid_power();

--- a/src/power_network.cpp
+++ b/src/power_network.cpp
@@ -1,0 +1,168 @@
+#include "power_network.h"
+
+#include <utility>
+
+#include "flexbuffer_json.h"
+#include "json.h"
+#include "units.h"
+#include "vehicle.h"
+
+void power_network_node::serialize( JsonOut &json ) const
+{
+    json.start_object();
+    json.member( "pos", position );
+    json.member( "solar", rated_solar );
+    json.member( "wind", rated_wind );
+    json.member( "water", rated_water );
+    json.member( "consumption", rated_consumption );
+    json.member( "battery_cap", battery_capacity_kJ );
+    json.end_object();
+}
+
+void power_network_node::deserialize( const JsonObject &data )
+{
+    data.read( "pos", position );
+    data.read( "solar", rated_solar );
+    data.read( "wind", rated_wind );
+    data.read( "water", rated_water );
+    data.read( "consumption", rated_consumption );
+    data.read( "battery_cap", battery_capacity_kJ );
+}
+
+void power_network::serialize( JsonOut &json ) const
+{
+    json.start_object();
+    json.member( "id", id );
+    json.member( "last_resolved", last_resolved );
+    json.member( "root_pos", root_position );
+    json.member( "nodes", nodes );
+    json.end_object();
+}
+
+void power_network::deserialize( const JsonObject &data )
+{
+    data.read( "id", id );
+    data.read( "last_resolved", last_resolved );
+    data.read( "root_pos", root_position );
+    data.read( "nodes", nodes );
+}
+
+void power_network_manager::serialize( JsonOut &json ) const
+{
+    json.start_object();
+    json.member( "next_id", next_id_ );
+    json.member( "networks" );
+    json.start_array();
+    for( const auto &[net_id, net] : networks_ ) {
+        net.serialize( json );
+    }
+    json.end_array();
+    json.end_object();
+}
+
+void power_network_manager::deserialize( const JsonObject &data )
+{
+    clear();
+    data.read( "next_id", next_id_ );
+    for( JsonObject net_json : data.get_array( "networks" ) ) {
+        power_network net;
+        net.deserialize( net_json );
+        networks_[net.id] = std::move( net );
+    }
+}
+
+void power_network_manager::clear()
+{
+    networks_.clear();
+    next_id_ = 1;
+}
+
+static power_network_node make_node_from_vehicle( const vehicle &veh )
+{
+    power_network_node node;
+    node.position = veh.pos_abs();
+    node.rated_solar = veh.rated_solar_epower();
+    node.rated_wind = veh.rated_wind_epower();
+    node.rated_water = veh.rated_water_epower();
+    node.rated_consumption = veh.total_accessory_epower();
+    auto [remaining, capacity] = veh.battery_power_level();
+    node.battery_capacity_kJ = capacity;
+
+    return node;
+}
+
+void power_network_manager::begin_rebuild()
+{
+    // Build position-to-old-network-id lookup from current networks
+    old_pos_to_id_.clear();
+    for( const auto &[net_id, net] : networks_ ) {
+        for( const power_network_node &nd : net.nodes ) {
+            old_pos_to_id_[nd.position] = net_id;
+        }
+    }
+    claimed_ids_.clear();
+    pending_networks_.clear();
+    rebuild_next_id_ = next_id_;
+}
+
+void power_network_manager::add_grid( vehicle *root,
+                                      const std::map<vehicle *, float> &grid )
+{
+    power_network net;
+    net.root_position = root->pos_abs();
+    net.last_resolved = calendar::turn;
+
+    // Count overlaps with old networks to find best match for id stability
+    std::unordered_map<int, int> overlap_counts;
+    for( const auto &[grid_veh, loss] : grid ) {
+        net.nodes.push_back( make_node_from_vehicle( *grid_veh ) );
+
+        auto it = old_pos_to_id_.find( grid_veh->pos_abs() );
+        if( it != old_pos_to_id_.end() ) {
+            overlap_counts[it->second]++;
+        }
+    }
+
+    // Find the old id with the most overlap that hasn't been claimed yet
+    int best_old_id = 0;
+    int best_count = 0;
+    for( const auto &[prev_id, count] : overlap_counts ) {
+        if( count > best_count && !claimed_ids_.count( prev_id ) ) {
+            best_count = count;
+            best_old_id = prev_id;
+        }
+    }
+
+    if( best_old_id != 0 ) {
+        net.id = best_old_id;
+        claimed_ids_.insert( best_old_id );
+    } else {
+        net.id = rebuild_next_id_++;
+    }
+
+    pending_networks_[net.id] = std::move( net );
+}
+
+void power_network_manager::finish_rebuild()
+{
+    networks_ = std::move( pending_networks_ );
+    next_id_ = rebuild_next_id_;
+
+    // Clean up temporary state
+    old_pos_to_id_.clear();
+    claimed_ids_.clear();
+    pending_networks_.clear();
+}
+
+const power_network *power_network_manager::find_network_at(
+    const tripoint_abs_ms &pos ) const
+{
+    for( const auto &[net_id, net] : networks_ ) {
+        for( const power_network_node &node : net.nodes ) {
+            if( node.position == pos ) {
+                return &net;
+            }
+        }
+    }
+    return nullptr;
+}

--- a/src/power_network.h
+++ b/src/power_network.h
@@ -1,0 +1,81 @@
+#pragma once
+#ifndef CATA_SRC_POWER_NETWORK_H
+#define CATA_SRC_POWER_NETWORK_H
+
+#include <map>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "calendar.h"
+#include "coordinates.h"
+#include "point.h"
+#include "units.h"
+
+class JsonObject;
+class JsonOut;
+class vehicle;
+
+// Snapshot of a single vehicle's rated renewable output and battery capacity
+// within a power network. Write-only infrastructure for phase 3 --
+// not used for runtime generation decisions yet.
+struct power_network_node {
+    tripoint_abs_ms position;
+    units::power rated_solar = 0_W;
+    units::power rated_wind = 0_W;
+    units::power rated_water = 0_W;
+    units::power rated_consumption = 0_W;
+    int battery_capacity_kJ = 0;
+
+    void serialize( JsonOut &json ) const;
+    void deserialize( const JsonObject &data );
+};
+
+// A group of cable-connected vehicles forming one power grid.
+// Rebuilt from live BFS every turn; persisted for phase 3 use.
+struct power_network {
+    int id = 0;
+    time_point last_resolved = calendar::before_time_starts;
+    tripoint_abs_ms root_position;
+    std::vector<power_network_node> nodes;
+
+    void serialize( JsonOut &json ) const;
+    void deserialize( const JsonObject &data );
+};
+
+// Owns all power networks. Rebuilt every turn from search_connected_vehicles(),
+// carrying forward id from predecessor networks matched by position overlap.
+// last_resolved is set to calendar::turn on each rebuild.
+class power_network_manager
+{
+    public:
+        // Call begin_rebuild() before adding grids each turn.
+        // Call add_grid() for each BFS-discovered grid.
+        // Call finish_rebuild() after all grids have been added.
+        void begin_rebuild();
+        void add_grid( vehicle *root, const std::map<vehicle *, float> &grid );
+        void finish_rebuild();
+
+        const power_network *find_network_at( const tripoint_abs_ms &pos ) const;
+
+        void serialize( JsonOut &json ) const;
+        void deserialize( const JsonObject &data );
+
+        void clear();
+
+        const std::map<int, power_network> &all_networks() const {
+            return networks_;
+        }
+
+    private:
+        std::map<int, power_network> networks_;
+        int next_id_ = 1;
+
+        // Temporary state for the begin/add/finish rebuild cycle.
+        std::unordered_map<tripoint_abs_ms, int> old_pos_to_id_; // NOLINT(cata-serialize)
+        std::unordered_set<int> claimed_ids_; // NOLINT(cata-serialize)
+        std::map<int, power_network> pending_networks_; // NOLINT(cata-serialize)
+        int rebuild_next_id_ = 1; // NOLINT(cata-serialize)
+};
+
+#endif // CATA_SRC_POWER_NETWORK_H

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -41,6 +41,7 @@
 #include "overmap_types.h"
 #include "overmap_map_data_cache.h"
 #include "path_info.h"
+#include "power_network.h"
 #include "regional_settings.h"
 #include "scent_map.h"
 #include "stats_tracker.h"
@@ -1707,6 +1708,7 @@ void game::unserialize_dimension_data( const cata_path &file_name, std::istream 
 
 void game::unserialize_dimension_data( const JsonValue &jv )
 {
+    power_networks().clear();
     JsonObject game_json = jv;
     for( JsonMember jsin : game_json ) {
         std::string name = jsin.name();
@@ -1718,6 +1720,8 @@ void game::unserialize_dimension_data( const JsonValue &jv )
             overmap_buffer.deserialize_placed_unique_specials( jsin );
         } else if( name == "region_type" ) {
             jsin.read( overmap_buffer.current_region_type );
+        } else if( name == "power_networks" ) {
+            power_networks().deserialize( jsin );
         }
     }
 }
@@ -1906,6 +1910,10 @@ void game::serialize_dimension_data( std::ostream &fout )
         weather_manager::serialize_all( json );
 
         json.member( "region_type", overmap_buffer.current_region_type );
+
+        json.member( "power_networks" );
+        power_networks().serialize( json );
+
         json.end_object();
     } catch( const JsonError &e ) {
         debugmsg( "error saving to %s: %s", SAVE_DIMENSION_DATA, e.c_str() );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -5597,6 +5597,42 @@ units::power vehicle::total_water_wheel_epower( map &here ) const
     return epower;
 }
 
+units::power vehicle::rated_solar_epower() const
+{
+    units::power epower = 0_W;
+    for( const int p : solar_panels ) {
+        const vehicle_part &vp = parts[p];
+        if( !vp.is_unavailable() ) {
+            epower += part_epower( vp );
+        }
+    }
+    return epower;
+}
+
+units::power vehicle::rated_wind_epower() const
+{
+    units::power epower = 0_W;
+    for( const int p : wind_turbines ) {
+        const vehicle_part &vp = parts[p];
+        if( !vp.is_unavailable() ) {
+            epower += part_epower( vp );
+        }
+    }
+    return epower;
+}
+
+units::power vehicle::rated_water_epower() const
+{
+    units::power epower = 0_W;
+    for( const int p : water_wheels ) {
+        const vehicle_part &vp = parts[p];
+        if( !vp.is_unavailable() ) {
+            epower += part_epower( vp );
+        }
+    }
+    return epower;
+}
+
 units::power vehicle::net_battery_charge_rate( map &here, bool include_reactors ) const
 {
     return total_engine_epower() + total_alternator_epower( here ) + total_accessory_epower() +

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -8568,6 +8568,98 @@ void vehicle::update_time( map &here, const time_point &update_to )
     }
 }
 
+int vehicle::catchup_off_map_renewables( const time_point &now )
+{
+    const time_point update_from = last_update;
+    if( now <= update_from || update_from == time_point( 0 ) ) {
+        last_update = now;
+        return 0;
+    }
+
+    if( sm_pos.z() < 0 ) {
+        last_update = now;
+        return 0;
+    }
+
+    if( now - update_from < 1_minutes ) {
+        return 0;
+    }
+
+    if( solar_panels.empty() && wind_turbines.empty() && water_wheels.empty() ) {
+        return 0;
+    }
+
+    const time_duration elapsed = now - update_from;
+    last_update = now;
+
+    int total_energy = 0;
+    const weather_sum accum_weather = sum_conditions( update_from, now, pos_abs() );
+
+    if( !solar_panels.empty() ) {
+        units::power epower = 0_W;
+        for( const int p : solar_panels ) {
+            const vehicle_part &vp = parts[p];
+            if( vp.is_unavailable() || !is_sm_tile_outside( abs_part_pos( vp ) ) ) {
+                continue;
+            }
+            epower += part_epower( vp );
+        }
+        double intensity = accum_weather.radiant_exposure / max_sun_irradiance() /
+                           to_seconds<float>( elapsed );
+        int energy_bat = power_to_energy_bat( epower * intensity, elapsed );
+        if( energy_bat > 0 ) {
+            add_msg_debug( debugmode::DF_VEHICLE,
+                           "%s off-map got %d kJ from solar panels", name, energy_bat );
+            total_energy += energy_bat;
+        }
+    }
+
+    if( !wind_turbines.empty() ) {
+        // Same TODO as update_time: uses current wind, not weather backfill
+        const oter_id &cur_om_ter = overmap_buffer.ter( pos_abs_omt() );
+        weather_manager &weather = get_weather();
+        units::power epower = 0_W;
+        for( const int p : wind_turbines ) {
+            const vehicle_part &vp = parts[p];
+            if( vp.is_unavailable() || !is_sm_tile_outside( abs_part_pos( vp ) ) ) {
+                continue;
+            }
+            int windpower = get_local_windpower( weather.windspeed, cur_om_ter,
+                                                 abs_part_pos( vp ),
+                                                 weather.winddirection, false );
+            if( windpower <= ( weather.windspeed / 10.0 ) ) {
+                continue;
+            }
+            epower += part_epower( vp ) * windpower;
+        }
+        int energy_bat = power_to_energy_bat( epower, elapsed );
+        if( energy_bat > 0 ) {
+            add_msg_debug( debugmode::DF_VEHICLE,
+                           "%s off-map got %d kJ from wind turbines", name, energy_bat );
+            total_energy += energy_bat;
+        }
+    }
+
+    if( !water_wheels.empty() ) {
+        units::power epower = 0_W;
+        for( const int p : water_wheels ) {
+            const vehicle_part &vp = parts[p];
+            if( vp.is_unavailable() || !is_sm_tile_over_water( abs_part_pos( vp ) ) ) {
+                continue;
+            }
+            epower += part_epower( vp );
+        }
+        int energy_bat = power_to_energy_bat( epower, elapsed );
+        if( energy_bat > 0 ) {
+            add_msg_debug( debugmode::DF_VEHICLE,
+                           "%s off-map got %d kJ from water wheels", name, energy_bat );
+            total_energy += energy_bat;
+        }
+    }
+
+    return total_energy;
+}
+
 void vehicle::invalidate_mass()
 {
     mass_dirty = true;

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -2260,6 +2260,9 @@ class vehicle
         // Retroactively pass time spent outside bubble
         // Funnels, solar panels
         void update_time( map &here, const time_point &update_to );
+        // Catch up renewable generation for off-map vehicles using absolute positions.
+        // Returns energy generated in kJ. Updates last_update to prevent double-charge.
+        int catchup_off_map_renewables( const time_point &now );
 
         // The faction that owns this vehicle.
         faction_id owner = faction_id::NULL_ID();

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1582,6 +1582,12 @@ class vehicle
         units::power total_wind_epower( map &here ) const;
         // Total power currently being produced by all water wheels.
         units::power total_water_wheel_epower( map &here ) const;
+        // Rated (max) power from solar panels, ignoring weather and position.
+        units::power rated_solar_epower() const;
+        // Rated (max) power from wind turbines, ignoring weather and position.
+        units::power rated_wind_epower() const;
+        // Rated (max) power from water wheels, ignoring position.
+        units::power rated_water_epower() const;
         // Total power drain across all vehicle accessories.
         units::power total_accessory_epower() const;
         // Total power draw from all cable-connected devices. Is cleared every turn during idle().

--- a/tests/vehicle_power_test.cpp
+++ b/tests/vehicle_power_test.cpp
@@ -1,5 +1,9 @@
 #include <cstdlib>
+#include <map>
+#include <memory>
 #include <optional>
+#include <set>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -10,17 +14,24 @@
 #include "coordinates.h"
 #include "debug.h"
 #include "enums.h"
+#include "flexbuffer_json.h"
+#include "game.h"
 #include "item.h"
+#include "json.h"
+#include "json_loader.h"
+#include "level_cache.h"
 #include "map.h"
 #include "map_helpers.h"
 #include "map_scale_constants.h"
 #include "options_helpers.h"
 #include "player_helpers.h"
 #include "point.h"
+#include "power_network.h"
 #include "ret_val.h"
 #include "safe_reference.h"
 #include "type_id.h"
 #include "units.h"
+#include "weather.h"
 #include "veh_appliance.h"
 #include "veh_type.h"
 #include "vehicle.h"
@@ -31,12 +42,14 @@
 static const efftype_id effect_blind( "blind" );
 
 static const itype_id fuel_type_battery( "battery" );
+static const itype_id itype_ground_solar_panel( "ground_solar_panel" );
 static const itype_id itype_test_high_drain_lamp( "test_high_drain_lamp" );
 static const itype_id itype_test_power_cord( "test_power_cord" );
 static const itype_id itype_test_power_cord_25_loss( "test_power_cord_25_loss" );
 static const itype_id itype_test_standing_lamp( "test_standing_lamp" );
 static const itype_id itype_test_storage_battery( "test_storage_battery" );
 
+static const vpart_id vpart_ap_ground_solar_panel( "ap_ground_solar_panel" );
 static const vpart_id vpart_ap_test_high_drain_lamp( "ap_test_high_drain_lamp" );
 static const vpart_id vpart_ap_test_standing_lamp( "ap_test_standing_lamp" );
 static const vpart_id vpart_ap_test_storage_battery( "ap_test_storage_battery" );
@@ -47,6 +60,8 @@ static const vproto_id vehicle_prototype_none( "none" );
 static const vproto_id vehicle_prototype_scooter_electric_test( "scooter_electric_test" );
 static const vproto_id vehicle_prototype_scooter_test( "scooter_test" );
 static const vproto_id vehicle_prototype_solar_panel_test( "solar_panel_test" );
+static const vproto_id vehicle_prototype_water_wheel_test( "water_wheel_test" );
+static const vproto_id vehicle_prototype_wind_turbine_test( "wind_turbine_test" );
 
 // TODO: Move this into player_helpers to avoid character include.
 static void reset_player()
@@ -738,6 +753,23 @@ TEST_CASE( "off_map_solar_catchup_generates_energy", "[vehicle][power][grid]" )
         int offmap_energy = veh_ptr->catchup_off_map_renewables( future );
         CHECK( offmap_energy == 0 );
     }
+
+    SECTION( "indoor solar panels do not generate" ) {
+        // Rebuild map with indoor terrain (has TFLAG_INDOORS)
+        clear_vehicles();
+        build_test_map( ter_id( "t_thconc_floor" ) );
+        vehicle *indoor_veh = here.add_vehicle( vehicle_prototype_solar_panel_test,
+                                                solar_origin, 0_degrees, 0, 0 );
+        REQUIRE( indoor_veh != nullptr );
+        REQUIRE_FALSE( indoor_veh->solar_panels.empty() );
+
+        calendar::turn = calendar::turn_zero + calendar::season_length() + 1_days + 12_hours;
+        indoor_veh->update_time( here, calendar::turn );
+
+        time_point future = calendar::turn + 30_minutes;
+        int offmap_energy = indoor_veh->catchup_off_map_renewables( future );
+        CHECK( offmap_energy == 0 );
+    }
 }
 
 TEST_CASE( "off_map_catchup_prevents_double_charge", "[vehicle][power][grid]" )
@@ -789,4 +821,542 @@ TEST_CASE( "off_map_catchup_skips_short_intervals", "[vehicle][power][grid]" )
     // Less than 1 minute should return 0
     int energy = veh_ptr->catchup_off_map_renewables( calendar::turn + 30_seconds );
     CHECK( energy == 0 );
+}
+
+TEST_CASE( "power_network_rebuild_matches_grid", "[vehicle][power][grid]" )
+{
+    clear_map_without_vision();
+    clear_avatar();
+    map &here = get_map();
+    Character &player_character = get_player_character();
+
+    const tripoint_bub_ms battery_pos( HALF_MAPSIZE_X + 2, HALF_MAPSIZE_Y + 2, 0 );
+    const tripoint_bub_ms lamp_pos( HALF_MAPSIZE_X + 4, HALF_MAPSIZE_Y + 2, 0 );
+
+    std::optional<item> battery_item( itype_test_storage_battery );
+    std::optional<item> lamp_item( itype_test_standing_lamp );
+    place_appliance( here, battery_pos, vpart_ap_test_storage_battery, player_character, battery_item );
+    place_appliance( here, lamp_pos, vpart_ap_test_standing_lamp, player_character, lamp_item );
+
+    connect_power_cord( battery_pos, lamp_pos );
+
+    vehicle &bat_veh = here.veh_at( battery_pos )->vehicle();
+
+    // BFS from battery should find both vehicles
+    std::map<vehicle *, float> grid = bat_veh.search_connected_vehicles( here );
+    REQUIRE( grid.size() == 2 );
+
+    // Rebuild power networks via vehmove
+    calendar::turn += 1_turns;
+    here.vehmove();
+
+    power_network_manager &pnm = g->power_networks();
+    const auto &networks = pnm.all_networks();
+    REQUIRE( networks.size() == 1 );
+
+    const power_network &net = networks.begin()->second;
+    CHECK( net.nodes.size() == grid.size() );
+    CHECK( net.last_resolved == calendar::turn );
+
+    // Every vehicle in the BFS should appear as a node
+    for( const auto &[veh, loss] : grid ) {
+        const power_network *found = pnm.find_network_at( veh->pos_abs() );
+        CHECK( found != nullptr );
+        CHECK( found->id == net.id );
+    }
+}
+
+TEST_CASE( "power_network_serialization_round_trip", "[vehicle][power][grid]" )
+{
+    // Load a hand-crafted network state from raw JSON
+    power_network_manager original;
+    {
+        std::string raw = R"({
+            "next_id": 5,
+            "networks": [{
+                "id": 3,
+                "last_resolved": 604800,
+                "root_pos": [100, 200, 0],
+                "nodes": [{
+                    "pos": [100, 200, 0],
+                    "solar": "400 W",
+                    "wind": "0 W",
+                    "water": "0 W",
+                    "consumption": "-50 W",
+                    "battery_cap": 5000
+                }]
+            }]
+        })";
+        JsonValue jv = json_loader::from_string( raw );
+        JsonObject jo = jv;
+        original.deserialize( jo );
+    }
+
+    // Serialize via the manager's own method
+    std::ostringstream os;
+    JsonOut jsout( os );
+    original.serialize( jsout );
+
+    // Deserialize into a new manager
+    power_network_manager loaded;
+    JsonValue jv = json_loader::from_string( os.str() );
+    JsonObject jo = jv;
+    loaded.deserialize( jo );
+
+    const auto &orig_nets = original.all_networks();
+    const auto &load_nets = loaded.all_networks();
+    REQUIRE( orig_nets.size() == load_nets.size() );
+
+    const power_network &orig_net = orig_nets.begin()->second;
+    const power_network &load_net = load_nets.begin()->second;
+    CHECK( orig_net.id == load_net.id );
+    CHECK( orig_net.last_resolved == load_net.last_resolved );
+    CHECK( orig_net.root_position == load_net.root_position );
+    REQUIRE( orig_net.nodes.size() == load_net.nodes.size() );
+    CHECK( orig_net.nodes[0].position == load_net.nodes[0].position );
+    CHECK( orig_net.nodes[0].rated_solar == load_net.nodes[0].rated_solar );
+    CHECK( orig_net.nodes[0].rated_consumption == load_net.nodes[0].rated_consumption );
+    CHECK( orig_net.nodes[0].battery_capacity_kJ == load_net.nodes[0].battery_capacity_kJ );
+}
+
+TEST_CASE( "power_network_old_save_migration", "[vehicle][power][grid]" )
+{
+    // An empty manager (simulating an old save with no power_networks key)
+    // should work fine -- first vehmove builds the networks from scratch.
+    power_network_manager pnm;
+    CHECK( pnm.all_networks().empty() );
+
+    // A rebuild on empty state should assign fresh IDs starting from 1
+    g->power_networks().clear();
+    clear_map_without_vision();
+    clear_avatar();
+    map &here = get_map();
+    Character &player_character = get_player_character();
+
+    const tripoint_bub_ms battery_pos( HALF_MAPSIZE_X + 2, HALF_MAPSIZE_Y + 2, 0 );
+    std::optional<item> battery_item( itype_test_storage_battery );
+    place_appliance( here, battery_pos, vpart_ap_test_storage_battery, player_character, battery_item );
+
+    calendar::turn += 1_turns;
+    here.vehmove();
+
+    const auto &networks = g->power_networks().all_networks();
+    CHECK_FALSE( networks.empty() );
+    // First network assigned should have id=1
+    CHECK( networks.begin()->second.id == 1 );
+}
+
+TEST_CASE( "power_network_id_stability_across_rebuilds", "[vehicle][power][grid]" )
+{
+    clear_map_without_vision();
+    clear_avatar();
+    map &here = get_map();
+    Character &player_character = get_player_character();
+
+    const tripoint_bub_ms battery_pos( HALF_MAPSIZE_X + 2, HALF_MAPSIZE_Y + 2, 0 );
+    const tripoint_bub_ms lamp_pos( HALF_MAPSIZE_X + 4, HALF_MAPSIZE_Y + 2, 0 );
+
+    std::optional<item> battery_item( itype_test_storage_battery );
+    std::optional<item> lamp_item( itype_test_standing_lamp );
+    place_appliance( here, battery_pos, vpart_ap_test_storage_battery, player_character, battery_item );
+    place_appliance( here, lamp_pos, vpart_ap_test_standing_lamp, player_character, lamp_item );
+
+    connect_power_cord( battery_pos, lamp_pos );
+
+    // First rebuild
+    calendar::turn += 1_turns;
+    here.vehmove();
+
+    power_network_manager &pnm = g->power_networks();
+    REQUIRE( pnm.all_networks().size() == 1 );
+    int first_id = pnm.all_networks().begin()->second.id;
+
+    // Second rebuild -- same grid, should keep the same id
+    calendar::turn += 1_turns;
+    here.vehmove();
+
+    REQUIRE( pnm.all_networks().size() == 1 );
+    int second_id = pnm.all_networks().begin()->second.id;
+    CHECK( first_id == second_id );
+
+    // Third rebuild -- still stable
+    calendar::turn += 1_turns;
+    here.vehmove();
+    REQUIRE( pnm.all_networks().size() == 1 );
+    CHECK( pnm.all_networks().begin()->second.id == first_id );
+}
+
+TEST_CASE( "power_network_topology_mutation", "[vehicle][power][grid]" )
+{
+    clear_map_without_vision();
+    clear_avatar();
+    map &here = get_map();
+    Character &player_character = get_player_character();
+
+    const tripoint_bub_ms bat_pos( HALF_MAPSIZE_X + 2, HALF_MAPSIZE_Y + 2, 0 );
+    const tripoint_bub_ms lamp1_pos( HALF_MAPSIZE_X + 4, HALF_MAPSIZE_Y + 2, 0 );
+    const tripoint_bub_ms lamp2_pos( HALF_MAPSIZE_X + 6, HALF_MAPSIZE_Y + 2, 0 );
+
+    std::optional<item> battery_item( itype_test_storage_battery );
+    std::optional<item> lamp1_item( itype_test_standing_lamp );
+    std::optional<item> lamp2_item( itype_test_standing_lamp );
+    place_appliance( here, bat_pos, vpart_ap_test_storage_battery, player_character, battery_item );
+    place_appliance( here, lamp1_pos, vpart_ap_test_standing_lamp, player_character, lamp1_item );
+    place_appliance( here, lamp2_pos, vpart_ap_test_standing_lamp, player_character, lamp2_item );
+
+    // Connect battery to lamp1 only
+    connect_power_cord( bat_pos, lamp1_pos );
+
+    calendar::turn += 1_turns;
+    here.vehmove();
+
+    power_network_manager &pnm = g->power_networks();
+    // lamp2 is disconnected -- should be its own network or not in the battery's network
+    const power_network *bat_net = pnm.find_network_at(
+                                       here.get_abs( bat_pos ) );
+    REQUIRE( bat_net != nullptr );
+    CHECK( bat_net->nodes.size() == 2 );
+
+    const power_network *lamp2_net = pnm.find_network_at(
+                                         here.get_abs( lamp2_pos ) );
+    REQUIRE( lamp2_net != nullptr );
+    // lamp2 should NOT be in the battery's network
+    CHECK( lamp2_net->id != bat_net->id );
+
+    SECTION( "connecting lamp2 adds it to the network" ) {
+        connect_power_cord( lamp1_pos, lamp2_pos );
+
+        calendar::turn += 1_turns;
+        here.vehmove();
+
+        const power_network *updated_net = pnm.find_network_at(
+                                               here.get_abs( bat_pos ) );
+        REQUIRE( updated_net != nullptr );
+        CHECK( updated_net->nodes.size() == 3 );
+
+        // lamp2 should now be in the same network
+        const power_network *lamp2_updated = pnm.find_network_at(
+                here.get_abs( lamp2_pos ) );
+        REQUIRE( lamp2_updated != nullptr );
+        CHECK( lamp2_updated->id == updated_net->id );
+    }
+
+    SECTION( "removing a vehicle splits the network" ) {
+        // Connect all three: bat -> lamp1 -> lamp2
+        connect_power_cord( lamp1_pos, lamp2_pos );
+
+        calendar::turn += 1_turns;
+        here.vehmove();
+
+        const power_network *full_net = pnm.find_network_at(
+                                            here.get_abs( bat_pos ) );
+        REQUIRE( full_net != nullptr );
+        REQUIRE( full_net->nodes.size() == 3 );
+        int original_id = full_net->id;
+
+        // Remove lamp2 from the map
+        here.destroy_vehicle( &here.veh_at( lamp2_pos )->vehicle() );
+
+        calendar::turn += 1_turns;
+        here.vehmove();
+
+        // bat + lamp1 should remain as a network keeping the original id
+        const power_network *remaining = pnm.find_network_at(
+                                             here.get_abs( bat_pos ) );
+        REQUIRE( remaining != nullptr );
+        CHECK( remaining->nodes.size() == 2 );
+        CHECK( remaining->id == original_id );
+
+        // lamp2 is gone -- no network at that position
+        CHECK( pnm.find_network_at( here.get_abs( lamp2_pos ) ) == nullptr );
+    }
+}
+
+TEST_CASE( "power_network_rated_values_populated", "[vehicle][power][grid]" )
+{
+    clear_vehicles();
+    reset_player();
+    build_test_map( ter_id( "t_pavement" ) );
+    map &here = get_map();
+
+    const tripoint_bub_ms solar_origin{ 5, 5, 0 };
+    vehicle *veh_ptr = here.add_vehicle( vehicle_prototype_solar_panel_test, solar_origin,
+                                         0_degrees, 0, 0 );
+    REQUIRE( veh_ptr != nullptr );
+    REQUIRE_FALSE( veh_ptr->solar_panels.empty() );
+
+    calendar::turn += 1_turns;
+    here.vehmove();
+
+    power_network_manager &pnm = g->power_networks();
+    const power_network *net = pnm.find_network_at( veh_ptr->pos_abs() );
+    REQUIRE( net != nullptr );
+    REQUIRE( net->nodes.size() == 1 );
+
+    // The solar panel test vehicle has solar panels, so rated_solar should be > 0
+    CHECK( net->nodes[0].rated_solar > 0_W );
+    // And it should match the vehicle's rated helper
+    CHECK( net->nodes[0].rated_solar == veh_ptr->rated_solar_epower() );
+}
+
+TEST_CASE( "off_map_solar_charges_remote_battery_through_cable", "[vehicle][power][grid]" )
+{
+    clear_map_without_vision();
+    clear_avatar();
+    map &here = get_map();
+    Character &player_character = get_player_character();
+    scoped_weather_override clear_weather( WEATHER_CLEAR );
+
+    // Place battery appliance, lamp appliance, and solar panel appliance
+    const tripoint_bub_ms battery_pos( HALF_MAPSIZE_X + 2, HALF_MAPSIZE_Y + 2, 0 );
+    const tripoint_bub_ms lamp_pos( HALF_MAPSIZE_X + 4, HALF_MAPSIZE_Y + 2, 0 );
+    // test_power_cord has max_charges: 3, so max 3-tile range between endpoints
+    const tripoint_bub_ms solar_pos( HALF_MAPSIZE_X + 5, HALF_MAPSIZE_Y + 2, 0 );
+
+    std::optional<item> battery_item( itype_test_storage_battery );
+    std::optional<item> lamp_item( itype_test_standing_lamp );
+    // ground_solar_panel has 4.8x epower of a basic solar panel
+    std::optional<item> solar_item( itype_ground_solar_panel );
+    place_appliance( here, battery_pos, vpart_ap_test_storage_battery, player_character, battery_item );
+    place_appliance( here, lamp_pos, vpart_ap_test_standing_lamp, player_character, lamp_item );
+    place_appliance( here, solar_pos, vpart_ap_ground_solar_panel, player_character,
+                     solar_item );
+
+    vehicle *solar_veh = veh_pointer_or_null( here.veh_at( solar_pos ) );
+    REQUIRE( solar_veh != nullptr );
+    REQUIRE_FALSE( solar_veh->solar_panels.empty() );
+
+    // Connect: battery <-> lamp, battery <-> solar
+    connect_power_cord( battery_pos, lamp_pos );
+    connect_power_cord( battery_pos, solar_pos );
+
+    // Set time to summer noon for maximum solar
+    calendar::turn = calendar::turn_zero + calendar::season_length() + 1_days + 12_hours;
+    solar_veh->update_time( here, calendar::turn );
+
+    // Drain all batteries
+    vehicle &bat_veh = here.veh_at( battery_pos )->vehicle();
+    bat_veh.discharge_battery( here, 100000000 );
+    solar_veh->discharge_battery( here, 100000000 );
+    REQUIRE( bat_veh.fuel_left( here, fuel_type_battery ) == 0 );
+    REQUIRE( solar_veh->fuel_left( here, fuel_type_battery ) == 0 );
+
+    // Set up deficit-disabled lamp for ordering test
+    vehicle &lamp_veh = here.veh_at( lamp_pos )->vehicle();
+    for( const vpart_reference &vpr : lamp_veh.get_all_parts() ) {
+        if( vpr.info().has_flag( VPFLAG_ENABLED_DRAINS_EPOWER ) ) {
+            lamp_veh.part( vpr.part_index() ).enabled = false;
+            lamp_veh.part( vpr.part_index() ).power_disabled = true;
+        }
+    }
+
+    // Advance time by 30 minutes for catchup to produce energy
+    calendar::turn += 30_minutes;
+
+    // Fake the solar vehicle as off-map by removing it from level_cache
+    level_cache &cache = here.access_cache( 0 );
+    cache.vehicle_list.erase( solar_veh );
+
+    SECTION( "off-map solar charges grid battery" ) {
+        here.vehmove();
+        CHECK( bat_veh.fuel_left( here, fuel_type_battery ) > 0 );
+    }
+
+    SECTION( "ordering: off-map charge enables deficit-disabled appliance" ) {
+        // vehmove runs resolve_off_map_grid_generation before resolve_appliance_grid_power.
+        // If ordering were reversed, battery would still be 0 when recovery checks,
+        // so the lamp would stay disabled.
+        here.vehmove();
+
+        bool any_reenabled = false;
+        for( const vpart_reference &vpr : lamp_veh.get_all_parts() ) {
+            if( vpr.info().has_flag( VPFLAG_ENABLED_DRAINS_EPOWER ) ) {
+                if( lamp_veh.part( vpr.part_index() ).enabled &&
+                    !lamp_veh.part( vpr.part_index() ).power_disabled ) {
+                    any_reenabled = true;
+                }
+            }
+        }
+        CHECK( any_reenabled );
+    }
+
+    SECTION( "cable loss applied to off-map charge" ) {
+        // Get energy that the solar vehicle would produce with no cable loss
+        time_point future = calendar::turn;
+        vehicle *fresh_solar = here.add_vehicle( vehicle_prototype_solar_panel_test,
+                               tripoint_bub_ms( HALF_MAPSIZE_X + 10, HALF_MAPSIZE_Y + 10, 0 ),
+                               0_degrees, 0, 0 );
+        REQUIRE( fresh_solar != nullptr );
+        fresh_solar->update_time( here, calendar::turn - 30_minutes );
+        int raw_energy = fresh_solar->catchup_off_map_renewables( future );
+        REQUIRE( raw_energy > 0 );
+
+        // Now run the grid path -- battery gets charged through cable (with loss)
+        here.vehmove();
+        int grid_charge = bat_veh.fuel_left( here, fuel_type_battery );
+
+        // The grid charge should be less than raw energy due to cable loss
+        // (test_power_cord has some loss factor)
+        CHECK( grid_charge > 0 );
+        CHECK( grid_charge <= raw_energy );
+    }
+}
+
+TEST_CASE( "off_map_wind_turbine_catchup", "[vehicle][power][grid]" )
+{
+    clear_vehicles();
+    reset_player();
+    build_test_map( ter_id( "t_pavement" ) );
+    map &here = get_map();
+    scoped_weather_override clear_weather( WEATHER_CLEAR );
+
+    const tripoint_bub_ms origin{ 5, 5, 0 };
+    vehicle *veh_ptr = here.add_vehicle( vehicle_prototype_wind_turbine_test, origin,
+                                         0_degrees, 0, 0 );
+    REQUIRE( veh_ptr != nullptr );
+    REQUIRE_FALSE( veh_ptr->wind_turbines.empty() );
+
+    calendar::turn = calendar::turn_zero + calendar::season_length() + 1_days + 12_hours;
+    veh_ptr->update_time( here, calendar::turn );
+
+    // Set wind speed high enough to generate
+    get_weather().windspeed = 30;
+    get_weather().winddirection = 0;
+
+    veh_ptr->discharge_battery( here, 100000000 );
+    REQUIRE( veh_ptr->fuel_left( here, fuel_type_battery ) == 0 );
+
+    time_point future = calendar::turn + 30_minutes;
+    int energy = veh_ptr->catchup_off_map_renewables( future );
+    CHECK( energy > 0 );
+}
+
+TEST_CASE( "off_map_water_wheel_catchup", "[vehicle][power][grid]" )
+{
+    clear_vehicles();
+    reset_player();
+    // Start with pavement, then place flowing water under the wheel
+    build_test_map( ter_id( "t_pavement" ) );
+    map &here = get_map();
+
+    const tripoint_bub_ms origin{ 5, 5, 0 };
+    vehicle *veh_ptr = here.add_vehicle( vehicle_prototype_water_wheel_test, origin,
+                                         0_degrees, 0, 0 );
+    REQUIRE( veh_ptr != nullptr );
+    REQUIRE_FALSE( veh_ptr->water_wheels.empty() );
+
+    // Set terrain under each water wheel part to flowing water (has CURRENT flag)
+    for( const int idx : veh_ptr->water_wheels ) {
+        const tripoint_bub_ms wpos = veh_ptr->bub_part_pos( here, veh_ptr->part( idx ) );
+        here.ter_set( wpos, ter_id( "t_water_moving_sh" ) );
+    }
+
+    calendar::turn = calendar::turn_zero + calendar::season_length() + 1_days + 12_hours;
+    veh_ptr->update_time( here, calendar::turn );
+
+    veh_ptr->discharge_battery( here, 100000000 );
+    REQUIRE( veh_ptr->fuel_left( here, fuel_type_battery ) == 0 );
+
+    time_point future = calendar::turn + 30_minutes;
+    int energy = veh_ptr->catchup_off_map_renewables( future );
+    CHECK( energy > 0 );
+}
+
+TEST_CASE( "power_network_id_assignment_on_split", "[vehicle][power][grid]" )
+{
+    clear_map_without_vision();
+    clear_avatar();
+    map &here = get_map();
+    Character &player_character = get_player_character();
+
+    // Place 3 appliances in a chain: A -- B -- C
+    const tripoint_bub_ms pos_a( HALF_MAPSIZE_X + 2, HALF_MAPSIZE_Y + 2, 0 );
+    const tripoint_bub_ms pos_b( HALF_MAPSIZE_X + 4, HALF_MAPSIZE_Y + 2, 0 );
+    const tripoint_bub_ms pos_c( HALF_MAPSIZE_X + 6, HALF_MAPSIZE_Y + 2, 0 );
+
+    std::optional<item> item_a( itype_test_storage_battery );
+    std::optional<item> item_b( itype_test_standing_lamp );
+    std::optional<item> item_c( itype_test_standing_lamp );
+    place_appliance( here, pos_a, vpart_ap_test_storage_battery, player_character, item_a );
+    place_appliance( here, pos_b, vpart_ap_test_standing_lamp, player_character, item_b );
+    place_appliance( here, pos_c, vpart_ap_test_standing_lamp, player_character, item_c );
+
+    connect_power_cord( pos_a, pos_b );
+    connect_power_cord( pos_b, pos_c );
+
+    // First rebuild: all 3 in one network
+    calendar::turn += 1_turns;
+    here.vehmove();
+
+    power_network_manager &pnm = g->power_networks();
+    const power_network *full = pnm.find_network_at( here.get_abs( pos_a ) );
+    REQUIRE( full != nullptr );
+    REQUIRE( full->nodes.size() == 3 );
+    int original_id = full->id;
+
+    // Remove the middle node B -- splits into A (alone) and C (alone)
+    here.destroy_vehicle( &here.veh_at( pos_b )->vehicle() );
+
+    calendar::turn += 1_turns;
+    here.vehmove();
+
+    // Should now have at least 2 networks (A and C are disconnected)
+    const power_network *net_a = pnm.find_network_at( here.get_abs( pos_a ) );
+    const power_network *net_c = pnm.find_network_at( here.get_abs( pos_c ) );
+    REQUIRE( net_a != nullptr );
+    REQUIRE( net_c != nullptr );
+    CHECK( net_a->id != net_c->id );
+
+    // One of them should have inherited the original ID (whichever was processed first
+    // with 1 overlap node claims the old ID; the other gets a new one)
+    CHECK( ( net_a->id == original_id || net_c->id == original_id ) );
+}
+
+TEST_CASE( "power_network_multiple_independent_grids", "[vehicle][power][grid]" )
+{
+    clear_map_without_vision();
+    clear_avatar();
+    map &here = get_map();
+    Character &player_character = get_player_character();
+
+    // Grid 1: battery + lamp connected
+    const tripoint_bub_ms bat1_pos( HALF_MAPSIZE_X + 2, HALF_MAPSIZE_Y + 2, 0 );
+    const tripoint_bub_ms lamp1_pos( HALF_MAPSIZE_X + 4, HALF_MAPSIZE_Y + 2, 0 );
+    // Grid 2: battery + lamp connected, far away from grid 1
+    const tripoint_bub_ms bat2_pos( HALF_MAPSIZE_X + 12, HALF_MAPSIZE_Y + 2, 0 );
+    const tripoint_bub_ms lamp2_pos( HALF_MAPSIZE_X + 14, HALF_MAPSIZE_Y + 2, 0 );
+
+    std::optional<item> bat1_item( itype_test_storage_battery );
+    std::optional<item> lamp1_item( itype_test_standing_lamp );
+    std::optional<item> bat2_item( itype_test_storage_battery );
+    std::optional<item> lamp2_item( itype_test_standing_lamp );
+    place_appliance( here, bat1_pos, vpart_ap_test_storage_battery, player_character, bat1_item );
+    place_appliance( here, lamp1_pos, vpart_ap_test_standing_lamp, player_character, lamp1_item );
+    place_appliance( here, bat2_pos, vpart_ap_test_storage_battery, player_character, bat2_item );
+    place_appliance( here, lamp2_pos, vpart_ap_test_standing_lamp, player_character, lamp2_item );
+
+    connect_power_cord( bat1_pos, lamp1_pos );
+    connect_power_cord( bat2_pos, lamp2_pos );
+
+    calendar::turn += 1_turns;
+    here.vehmove();
+
+    power_network_manager &pnm = g->power_networks();
+
+    // Each connected pair should be in its own network
+    const power_network *net1 = pnm.find_network_at( here.get_abs( bat1_pos ) );
+    const power_network *net2 = pnm.find_network_at( here.get_abs( bat2_pos ) );
+    REQUIRE( net1 != nullptr );
+    REQUIRE( net2 != nullptr );
+    CHECK( net1->id != net2->id );
+    CHECK( net1->nodes.size() == 2 );
+    CHECK( net2->nodes.size() == 2 );
+
+    // Members of each grid should be in the correct network
+    const power_network *lamp1_net = pnm.find_network_at( here.get_abs( lamp1_pos ) );
+    const power_network *lamp2_net = pnm.find_network_at( here.get_abs( lamp2_pos ) );
+    REQUIRE( lamp1_net != nullptr );
+    REQUIRE( lamp2_net != nullptr );
+    CHECK( lamp1_net->id == net1->id );
+    CHECK( lamp2_net->id == net2->id );
 }

--- a/tests/vehicle_power_test.cpp
+++ b/tests/vehicle_power_test.cpp
@@ -697,3 +697,96 @@ TEST_CASE( "cable_survives_target_outside_reality_bubble", "[vehicle][power][gri
         CHECK( map_cord.link().target == link_state::vehicle_port );
     }
 }
+
+TEST_CASE( "off_map_solar_catchup_generates_energy", "[vehicle][power][grid]" )
+{
+    clear_vehicles();
+    reset_player();
+    build_test_map( ter_id( "t_pavement" ) );
+    map &here = get_map();
+
+    const tripoint_bub_ms solar_origin{ 5, 5, 0 };
+    vehicle *veh_ptr = here.add_vehicle( vehicle_prototype_solar_panel_test, solar_origin,
+                                         0_degrees, 0, 0 );
+    REQUIRE( veh_ptr != nullptr );
+    REQUIRE_FALSE( veh_ptr->solar_panels.empty() );
+    scoped_weather_override clear_weather( WEATHER_CLEAR );
+
+    // Set time to summer noon for maximum solar
+    calendar::turn = calendar::turn_zero + calendar::season_length() + 1_days + 12_hours;
+    veh_ptr->update_time( here, calendar::turn );
+
+    // Drain battery fully
+    veh_ptr->discharge_battery( here, 100000000 );
+    REQUIRE( veh_ptr->fuel_left( here, fuel_type_battery ) == 0 );
+
+    SECTION( "30 minutes of off-map solar matches on-map update_time" ) {
+        // Run catchup for 30 minutes
+        time_point future = calendar::turn + 30_minutes;
+        int offmap_energy = veh_ptr->catchup_off_map_renewables( future );
+        CHECK( offmap_energy > 0 );
+        // Should produce roughly the same as update_time for the same interval.
+        // The exact value may differ slightly because update_time uses
+        // bub_part_pos while catchup uses abs_part_pos, but for outdoor tiles
+        // on a flat map the outside check should agree.
+        CHECK( offmap_energy == Approx( 425 ).margin( 10 ) );
+    }
+
+    SECTION( "underground vehicle produces no solar" ) {
+        veh_ptr->sm_pos = tripoint_abs_sm( veh_ptr->sm_pos.xy(), -1 );
+        time_point future = calendar::turn + 30_minutes;
+        int offmap_energy = veh_ptr->catchup_off_map_renewables( future );
+        CHECK( offmap_energy == 0 );
+    }
+}
+
+TEST_CASE( "off_map_catchup_prevents_double_charge", "[vehicle][power][grid]" )
+{
+    clear_vehicles();
+    reset_player();
+    build_test_map( ter_id( "t_pavement" ) );
+    map &here = get_map();
+
+    const tripoint_bub_ms solar_origin{ 5, 5, 0 };
+    vehicle *veh_ptr = here.add_vehicle( vehicle_prototype_solar_panel_test, solar_origin,
+                                         0_degrees, 0, 0 );
+    REQUIRE( veh_ptr != nullptr );
+    scoped_weather_override clear_weather( WEATHER_CLEAR );
+
+    calendar::turn = calendar::turn_zero + calendar::season_length() + 1_days + 12_hours;
+    veh_ptr->update_time( here, calendar::turn );
+    veh_ptr->discharge_battery( here, 100000000 );
+    REQUIRE( veh_ptr->fuel_left( here, fuel_type_battery ) == 0 );
+
+    // Simulate off-map catchup advancing last_update
+    time_point future = calendar::turn + 30_minutes;
+    int offmap_energy = veh_ptr->catchup_off_map_renewables( future );
+    REQUIRE( offmap_energy > 0 );
+
+    // Now simulate on-map re-entry: update_time should produce nothing
+    // because last_update was already advanced by catchup
+    veh_ptr->update_time( here, future );
+    // Battery should still be zero (catchup returned energy but didn't charge)
+    CHECK( veh_ptr->fuel_left( here, fuel_type_battery ) == 0 );
+}
+
+TEST_CASE( "off_map_catchup_skips_short_intervals", "[vehicle][power][grid]" )
+{
+    clear_vehicles();
+    reset_player();
+    build_test_map( ter_id( "t_pavement" ) );
+    map &here = get_map();
+
+    const tripoint_bub_ms solar_origin{ 5, 5, 0 };
+    vehicle *veh_ptr = here.add_vehicle( vehicle_prototype_solar_panel_test, solar_origin,
+                                         0_degrees, 0, 0 );
+    REQUIRE( veh_ptr != nullptr );
+    scoped_weather_override clear_weather( WEATHER_CLEAR );
+
+    calendar::turn = calendar::turn_zero + calendar::season_length() + 1_days + 12_hours;
+    veh_ptr->update_time( here, calendar::turn );
+
+    // Less than 1 minute should return 0
+    int energy = veh_ptr->catchup_off_map_renewables( calendar::turn + 30_seconds );
+    CHECK( energy == 0 );
+}


### PR DESCRIPTION
#### Summary
Features "Off-map renewable generation and persistent power network tracking"

#### Purpose of change

Follow-up to & depends on #85628 (appliance re-enable resolution pass).

Two problems addressed here:

1. Off-map solar/wind/water vehicles connected to in-bubble grids via cables never generate power. `vehicle::idle()` returns early for off-map vehicles before `update_time()` runs. Off-map vehicles still drain batteries via `power_parts()` but never produce. Net result: grid batteries drain even with ample solar, as long as the panels are outside the bubble.

2. No persistent representation of power networks. The current system recomputes topology from scratch every turn via Dijkstra walks, with no way to track grid identity, rated capacity, or resolution timestamps across turns or save/load cycles. Future work (persistent topology, event-driven updates) needs this foundation.

Related: #83514, #84611 (loading order desync), #83712 (cable disconnect on bubble transitions).

#### Describe the solution

Two commits, independent but complementary.

**Off-map renewable generation catchup**

Adds `vehicle::catchup_off_map_renewables()` -- similar to `update_time()` but uses `abs_part_pos()` instead of `bub_part_pos()` so it works for vehicles outside the reality bubble via MAPBUFFER. Computes elapsed solar/wind/water generation using `sum_conditions()` weather backfill, same as the existing in-bubble path. Updates `last_update` to prevent double-charge when the vehicle re-enters the bubble.

`map::resolve_off_map_grid_generation()` runs before the appliance resolution pass from #85628. For each in-bubble vehicle, walks `search_connected_vehicles()` to find the full grid, then runs catchup on any off-map members. Each off-map vehicle calls `charge_battery()` on itself so that `search_connected_batteries()` computes the correct Dijkstra loss from that source. Aggregating and charging from a proxy would apply wrong loss factors.

Ordering in `vehmove()`:
```
... idle loop ...
resolve_off_map_grid_generation();   // this PR
resolve_appliance_grid_power();      // #85628
```

**Persistent power_network class**

Infrastructure for future topology work -- built and persisted each turn but not used for generation decisions at runtime. The live-vehicle approach handles all actual generation.

`power_network_manager` uses a begin/add/finish rebuild pattern. Each turn it builds fresh networks from the same `search_connected_vehicles()` BFS that's already running. Network IDs are stabilized across rebuilds by position overlap matching (the old network with the most member positions in common gets its ID carried forward). `last_resolved` is set to `calendar::turn` on each rebuild.

Persisted to `dimension_data.gsav`. Backward-compatible: old saves start with an empty manager, first rebuild populates it.

Key design decisions:
- Per-source charging -- each off-map vehicle charges its own batteries through the correct loss path, not through a proxy
- Network ID stability via overlap matching, not root identity -- handles grid splits/merges gracefully
- Rebuild scratch state (position lookup, claimed IDs, pending networks) lives on the manager as private members, not file-scope statics
- `power_networks().clear()` at the start of `unserialize_dimension_data()` prevents stale state from old saves without the key

#### Describe alternatives you've considered

For off-map generation, the obvious alternative is to not force-load off-map vehicles at all and instead use persisted rated values to estimate generation. This would avoid the MAPBUFFER access but requires solving loss composition first -- pre-applying source-to-root loss then letting `charge_battery()` apply root-to-battery loss gives multiplicative `(1-a)*(1-b)` instead of the correct additive `1-(a+b)`. Force-loading via MAPBUFFER is transparent and gives exact results, so there's no reason to approximate until there's a concrete performance need.

For network persistence, considered not persisting at all and just doing off-map generation with live vehicles. Works fine for the generation use case, but network identity and rated value tracking have to exist somewhere eventually, and bolting persistence onto a generation system after the fact is more painful than building the ~150-line skeleton now.

For ID stability, considered matching networks by vehicle ID instead of position overlap. Positions are more stable -- vehicle IDs can shift across save/load or on vehicle split/merge, but a solar panel at (120, 340, 0) tends to stay put.

#### Testing

14 new tests tagged `[vehicle][power][grid]` (20 total with the 6 from #85628):

Off-map renewable catchup:
  - Off-map solar charges grid batteries through cable (integration: faked off-map via level_cache removal, charges remote battery through `resolve_off_map_grid_generation` + `charge_battery`)
  - Cable loss applied to off-map charge (grid charge <= raw energy)
  - Ordering: off-map charge before appliance re-enable in same turn (deficit-disabled lamp re-enabled after off-map solar charges battery)
  - 30 minutes of off-map solar matches expected output
  - Indoor solar panels do not generate (TFLAG_INDOORS terrain)
  - Underground (z < 0) no solar
  - No double-charge on bubble re-entry (`last_update` advanced by catchup)
  - Short intervals (< 1 min) skipped
  - Wind turbine catchup generates energy
  - Water wheel catchup generates energy (flowing water terrain)

Power network manager:
  - Network rebuild matches `search_connected_vehicles()` BFS output, `last_resolved` set correctly
  - Serialization round-trip (hand-crafted JSON -> serialize -> deserialize -> compare)
  - Old save migration (empty manager, first rebuild assigns IDs from 1)
  - Network ID stability across 3 consecutive rebuilds
  - Cable connect adds vehicle to network / removing vehicle splits the network
  - ID assignment on grid split (middle node removed, surviving fragments get correct IDs via overlap matching)
  - Multiple independent grids produce distinct networks with correct membership
  - Rated values (solar/wind/water/consumption/battery) populated from vehicle helpers

New test data: `wind_turbine_test` and `water_wheel_test` vehicle prototypes.

Full vehicle power test suite passes (20 test cases, 233 assertions).

#### Additional context

Planned follow-up: persistent topology with cable edges stored in network graph, event-driven topology updates on place/remove/connect/disconnect, removing per-turn Dijkstra.

Open bugs not addressed here: cable disconnection on bubble entry/exit (#83712), extension cord traversal failures (#84588, #82836), `charge_linked_batteries()` rounding issues.