### PR TITLE
Fix flaky hunger test: sync stored_kcal after height reset

### DIFF
--- a/tests/player_helpers.cpp
+++ b/tests/player_helpers.cpp
@@ -109,12 +109,6 @@ void clear_character( Character &dummy, bool skip_nutrition )
         dummy.consume( food );
     }
 
-    // This sets HP to max, clears addictions and morale,
-    // and sets hunger, thirst, sleepiness and such to zero
-    dummy.environmental_revert_effect();
-    // However, the above does not set stored kcal
-    dummy.set_stored_kcal( dummy.get_healthy_kcal() );
-
     dummy.prof = profession::generic();
     dummy.hobbies.clear();
     dummy._skills->clear();
@@ -122,7 +116,12 @@ void clear_character( Character &dummy, bool skip_nutrition )
     dummy.clear_morale();
     dummy.activity.set_to_null();
     dummy.backlog.clear();
+    // Reset age/height before stored kcal since get_healthy_kcal()
+    // depends on height.
     dummy.reset_chargen_attributes();
+    dummy.environmental_revert_effect();
+    dummy.set_stored_kcal( dummy.get_healthy_kcal() );
+
     dummy.set_pain( 0 );
     dummy.reset_bonuses();
     dummy.set_speed_base( 100 );
@@ -166,6 +165,9 @@ void clear_character( Character &dummy, bool skip_nutrition )
     dummy.magic = pimpl<known_magic>();
     dummy.forget_all_recipes();
     dummy.set_focus( dummy.calc_focus_equilibrium() );
+
+    // Final stored_kcal sync after all attribute resets.
+    dummy.set_stored_kcal( dummy.get_healthy_kcal() );
 }
 
 void arm_shooter( Character &shooter, const itype_id &gun_type,

--- a/tests/stomach_contents_test.cpp
+++ b/tests/stomach_contents_test.cpp
@@ -409,6 +409,7 @@ TEST_CASE( "hunger" )
     reset_time();
     clear_stomach( dummy );
     dummy.initialize_stomach_contents();
+    dummy.set_stored_kcal( dummy.get_healthy_kcal() );
     dummy.clear_effects();
 
     if( print_tests ) {


### PR DESCRIPTION
#### Summary
Bugfixes "Fix flaky hunger test caused by stored_kcal/height desync in clear_character"

#### Purpose of change

Observed in https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/22574844179/job/65391426400.

`clear_character()` computes `stored_kcal` from `get_healthy_kcal()` before `reset_chargen_attributes()` resets height to 175. Since `get_healthy_kcal()` depends on height, seeds that produce short characters end up with `stored_kcal < healthy_kcal`, which makes `update_stomach()` force hunger to 100 immediately when the stomach empties.

#### Describe the solution

- Move `reset_chargen_attributes()` before the `set_stored_kcal()` call.
- Add a defensive final `set_stored_kcal()` at the end of `clear_character()`.
- Explicitly set `stored_kcal` in the hunger test for self-containment.

#### Describe alternatives you've considered

Fixing only the test, but that leaves the same issue for anything else relying on `clear_character()`.

#### Testing

Passes with the previously failing seed (1772452946) and several others.

#### Additional context

None