### PR TITLE
Don't strip the entire binary, only strip debug symbols and locals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1111,7 +1111,7 @@ ifeq ($(RELEASE), 1)
   ifndef DEBUG_SYMBOLS
     ifneq ($(BACKTRACE),1)
       ifneq ($(NATIVE), emscripten)
-	$(STRIP) $(TARGET)
+	$(STRIP) -Sx $(TARGET)
       endif
     endif
   endif


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #85620. Macos builds from CI were crashing because the allocator override symbols were stripped and dynamically loaded libraries were using system default allocators. This led to asserts and aborts.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Pass `-Sx` to `strip` so it only strips debug symbols and local functions. Globals, like the allocators, are preserved.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I repro'd the crash before and then not after.

Before:
```
akrieger-mac:Cataclysm-DDA akrieger$ nm -C cataclysm-tiles  | grep new
                 U std::__1::__match_any_but_newline<char>::__exec(std::__1::__state<char>&) const
                 U std::get_new_handler()
                 U _newlocale
```

After:
```
akrieger-mac:Cataclysm-DDA akrieger$ nm -C cataclysm-tiles  | grep new
...
0000000100207d54 T operator new[](unsigned long)
000000010020804c T operator new[](unsigned long, std::nothrow_t const&)
0000000100208580 T operator new[](unsigned long, std::align_val_t)
00000001002088d0 T operator new[](unsigned long, std::align_val_t, std::nothrow_t const&)
0000000100207bd8 T operator new(unsigned long)
0000000100207ed0 T operator new(unsigned long, std::nothrow_t const&)
00000001002083d8 T operator new(unsigned long, std::align_val_t)
0000000100208728 T operator new(unsigned long, std::align_val_t, std::nothrow_t const&)
                 U _newlocale
```

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
This slightly increases the size of the binary, like 3mb from 64mb -> 67mb, but like, that's fine. Idk, can probably figure out some better options to `strip` but this is the fastest least incorrect fix.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
