### PR TITLE
Use -fvisibility=hidden to shrink binary size further than bare `strip`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1111,7 +1111,7 @@ ifeq ($(RELEASE), 1)
   ifndef DEBUG_SYMBOLS
     ifneq ($(BACKTRACE),1)
       ifneq ($(NATIVE), emscripten)
-	$(STRIP) $(TARGET)
+	$(STRIP) -Sx $(TARGET)
       endif
     endif
   endif

--- a/Makefile
+++ b/Makefile
@@ -976,8 +976,8 @@ ifeq ($(MSYS2),1)
   DEFINES += -DMSYS2 -D_GLIBCXX_USE_C99_MATH_TR1
 endif
 
-CFLAGS += $(C_STD) $(WARNINGS)
-CXXFLAGS += $(CXX_STD) $(CXX_WARNINGS)
+CFLAGS += $(C_STD) $(WARNINGS) -fvisibility=hidden
+CXXFLAGS += $(CXX_STD) $(CXX_WARNINGS) -fvisibility=hidden
 
 # Enumerations of all the source files and headers.
 ifeq ($(HEADERPOPULARITY), 1)

--- a/src/cata_allocator.cpp
+++ b/src/cata_allocator.cpp
@@ -18,6 +18,9 @@
 #ifdef __ANDROID__
 #define MALLOC_USABLE_SIZE_QUALIFIER const
 #endif
+#if defined(__clang__) || defined(__GNUC__)
+#define SNMALLOC_EXPORT __attribute__((visibility("default")))
+#endif
 #include <snmalloc/override/new.cc> // NOLINT(bugprone-suspicious-include)
 #endif
 

--- a/src/math_parser.cpp
+++ b/src/math_parser.cpp
@@ -64,13 +64,14 @@ std::optional<double> get_number( std::string_view token )
     // FIXME: port to std::from_chars once double conversion is supported
     std::istringstream conv( std::string{ token } );
     conv.imbue( std::locale::classic() );
-    double val{};
+    std::optional<double> ret;
+    double val = 0;
     conv >> val;
     if( conv && conv.eof() ) {
-        return val;
+        ret.emplace( val );
     }
 
-    return {};
+    return ret;
 }
 
 constexpr std::optional<pmath_func> get_function( std::string_view token )

--- a/src/third-party/snmalloc/override/new.cc
+++ b/src/third-party/snmalloc/override/new.cc
@@ -1,3 +1,4 @@
+#include "override.h"
 #include "snmalloc/snmalloc.h"
 
 #include <new>
@@ -96,99 +97,102 @@ namespace snmalloc
   }
 } // namespace snmalloc
 
-void* operator new(size_t size)
+SNMALLOC_EXPORT void* operator new(size_t size)
 {
   return snmalloc::alloc<snmalloc::handler::Throw>(size);
 }
 
-void* operator new[](size_t size)
+SNMALLOC_EXPORT void* operator new[](size_t size)
 {
   return snmalloc::alloc<snmalloc::handler::Throw>(size);
 }
 
-void* operator new(size_t size, const std::nothrow_t&) noexcept
+SNMALLOC_EXPORT void* operator new(size_t size, const std::nothrow_t&) noexcept
 {
   return snmalloc::alloc<snmalloc::handler::NoThrow>(size);
 }
 
-void* operator new[](size_t size, const std::nothrow_t&) noexcept
+SNMALLOC_EXPORT void*
+operator new[](size_t size, const std::nothrow_t&) noexcept
 {
   return snmalloc::alloc<snmalloc::handler::NoThrow>(size);
 }
 
-void operator delete(void* p) EXCEPTSPEC
+SNMALLOC_EXPORT void operator delete(void* p) EXCEPTSPEC
 {
   snmalloc::libc::free(p);
 }
 
-void operator delete(void* p, size_t size) EXCEPTSPEC
+SNMALLOC_EXPORT void operator delete(void* p, size_t size) EXCEPTSPEC
 {
   snmalloc::libc::free_sized(p, size);
 }
 
-void operator delete(void* p, const std::nothrow_t&) noexcept
+SNMALLOC_EXPORT void operator delete(void* p, const std::nothrow_t&) noexcept
 {
   snmalloc::libc::free(p);
 }
 
-void operator delete[](void* p) EXCEPTSPEC
+SNMALLOC_EXPORT void operator delete[](void* p) EXCEPTSPEC
 {
   snmalloc::libc::free(p);
 }
 
-void operator delete[](void* p, size_t size) EXCEPTSPEC
+SNMALLOC_EXPORT void operator delete[](void* p, size_t size) EXCEPTSPEC
 {
   snmalloc::libc::free_sized(p, size);
 }
 
-void operator delete[](void* p, const std::nothrow_t&) noexcept
+SNMALLOC_EXPORT void operator delete[](void* p, const std::nothrow_t&) noexcept
 {
   snmalloc::libc::free(p);
 }
 
-void* operator new(size_t size, std::align_val_t val)
+SNMALLOC_EXPORT void* operator new(size_t size, std::align_val_t val)
 {
   size = snmalloc::aligned_size(size_t(val), size);
   return snmalloc::alloc<snmalloc::handler::Throw>(size);
 }
 
-void* operator new[](size_t size, std::align_val_t val)
+SNMALLOC_EXPORT void* operator new[](size_t size, std::align_val_t val)
 {
   size = snmalloc::aligned_size(size_t(val), size);
   return snmalloc::alloc<snmalloc::handler::Throw>(size);
 }
 
-void* operator new(
+SNMALLOC_EXPORT void*
+operator new(size_t size, std::align_val_t val, const std::nothrow_t&) noexcept
+{
+  size = snmalloc::aligned_size(size_t(val), size);
+  return snmalloc::alloc<snmalloc::handler::NoThrow>(size);
+}
+
+SNMALLOC_EXPORT void* operator new[](
   size_t size, std::align_val_t val, const std::nothrow_t&) noexcept
 {
   size = snmalloc::aligned_size(size_t(val), size);
   return snmalloc::alloc<snmalloc::handler::NoThrow>(size);
 }
 
-void* operator new[](
-  size_t size, std::align_val_t val, const std::nothrow_t&) noexcept
-{
-  size = snmalloc::aligned_size(size_t(val), size);
-  return snmalloc::alloc<snmalloc::handler::NoThrow>(size);
-}
-
-void operator delete(void* p, std::align_val_t) EXCEPTSPEC
+SNMALLOC_EXPORT void operator delete(void* p, std::align_val_t) EXCEPTSPEC
 {
   snmalloc::libc::free(p);
 }
 
-void operator delete[](void* p, std::align_val_t) EXCEPTSPEC
+SNMALLOC_EXPORT void operator delete[](void* p, std::align_val_t) EXCEPTSPEC
 {
   snmalloc::libc::free(p);
 }
 
-void operator delete(void* p, size_t size, std::align_val_t val) EXCEPTSPEC
+SNMALLOC_EXPORT void
+operator delete(void* p, size_t size, std::align_val_t val) EXCEPTSPEC
 {
   size = snmalloc::aligned_size(size_t(val), size);
   snmalloc::libc::free_sized(p, size);
 }
 
-void operator delete[](void* p, size_t size, std::align_val_t val) EXCEPTSPEC
+SNMALLOC_EXPORT void
+operator delete[](void* p, size_t size, std::align_val_t val) EXCEPTSPEC
 {
   size = snmalloc::aligned_size(size_t(val), size);
   snmalloc::libc::free_sized(p, size);


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
After #85637, there is a binary size regression due to unnecessarily preserving binary-only symbols which are like, most of them except the allocator functions. But we can instead tell the compiler that all symbols are private by default, and manually annotate the allocator overrides to being visible. Then the final stripped binary becomes even smaller!
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add `-fvisibility=hidden` to the Makefile default flags set. Add `__attribute__((visibility("default")))` to the allocator overrides.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Binary was ~64M before this stack of changes. Now it is 59, and an unqualified `strip` call does not remove more of the binary.
```
akrieger-mac:Cataclysm-DDA akrieger$ du -sh cataclysm-tiles
 59M	cataclysm-tiles
akrieger-mac:Cataclysm-DDA akrieger$ strip cataclysm-tiles
akrieger-mac:Cataclysm-DDA akrieger$ du -sh cataclysm-tiles
 59M	cataclysm-tiles
 ```
 
 Linux with clang-18:
 ```
 # Unstripped
akrieger@Bones:~/Cataclysm-DDA$ ls -la cataclysm-tiles
 -rwxr-xr-x 1 akrieger akrieger 55509512 Mar  2 18:28 cataclysm-tiles
 
 # Stripped just debug symbols and locals w/o -fvisibility=hidden
akrieger@Bones:~/Cataclysm-DDA$ strip -Sx cataclysm-tiles
akrieger@Bones:~/Cataclysm-DDA$ ls -la cataclysm-tiles
-rwxr-xr-x 1 akrieger akrieger 49877640 Mar  2 18:29 cataclysm-tiles

# Stripped w/ -fvisibility=hidden
akrieger@Bones:~/Cataclysm-DDA$ ls -la cataclysm-tiles
-rwxr-xr-x 1 akrieger akrieger 45279376 Mar  2 18:33 cataclysm-tiles
 ```
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
