### PR TITLE
Grab-aware pathfinding: danger checks, strength gating, auto-move integration

### DIFF
--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -2,14 +2,12 @@
 #include "activity_item_handling.h" // IWYU pragma: associated
 
 #include <algorithm>
-#include <array>
 #include <climits>
 #include <cmath>
 #include <cstdlib>
 #include <list>
 #include <memory>
 #include <optional>
-#include <queue>
 #include <set>
 #include <string>
 #include <tuple>
@@ -770,86 +768,6 @@ static void move_item( Character &you, item &it, const int quantity, const tripo
 namespace zone_sorting
 {
 
-// Number of grab direction slots: 3x3 grid encoding (x+1)*3 + (y+1), index 4 = center = unused.
-static constexpr int GRAB_DIRS = 9;
-
-static int grab_to_idx( const tripoint_rel_ms &g )
-{
-    return ( g.x() + 1 ) * 3 + ( g.y() + 1 );
-}
-
-static tripoint_rel_ms idx_to_grab( int idx )
-{
-    return tripoint_rel_ms( idx / 3 - 1, idx % 3 - 1, 0 );
-}
-
-static int grab_state_index( const point_bub_ms &pos, int grab_idx )
-{
-    return ( pos.x() * MAPSIZE_Y + pos.y() ) * GRAB_DIRS + grab_idx;
-}
-
-static point_bub_ms state_to_pos( int state_idx )
-{
-    int pos_idx = state_idx / GRAB_DIRS;
-    return point_bub_ms( pos_idx / MAPSIZE_Y, pos_idx % MAPSIZE_Y );
-}
-
-// Estimate vehicle drag difficulty using FLAT/ROAD terrain flags (matching
-// wheel terrain_modifiers): non-FLAT +4, FLAT non-ROAD +3, FLAT+ROAD +0.
-static int veh_drag_cost( const map &here, const tripoint_bub_ms &pos )
-{
-    const int base = here.move_cost_ter_furn( pos );
-    if( base <= 0 ) {
-        return 0;
-    }
-    if( !here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_FLAT, pos ) ) {
-        return base + 4;
-    }
-    if( !here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_ROAD, pos ) ) {
-        return base + 3;
-    }
-    return base;
-}
-
-// Check if a tile would cause a vehicle collision, matching part_collision
-// logic: impassable tiles block, bashable non-flat terrain/furniture blocks.
-// allow_doors: pull moves pass true (vehicle follows player through opened
-// doors); push/zigzag pass false (vehicle goes to unvisited tiles).
-static bool tile_blocks_vehicle( const map &here, const tripoint_bub_ms &pos,
-                                 bool allow_doors = true )
-{
-    const int ter_furn_cost = here.move_cost_ter_furn( pos );
-
-    // Impassable terrain (walls, closed windows, locked doors).
-    if( ter_furn_cost == 0 ) {
-        if( allow_doors ) {
-            // Openable doors: player opens them during auto-move, vehicle follows.
-            const bool is_door = ( here.ter( pos ).obj().open &&
-                                   here.ter( pos ).obj().has_flag( ter_furn_flag::TFLAG_DOOR ) ) ||
-                                 ( here.has_furn( pos ) && here.furn( pos ).obj().open &&
-                                   here.furn( pos ).obj().has_flag( ter_furn_flag::TFLAG_DOOR ) );
-            if( is_door ) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    // Flat ground (move_cost 2) never causes collision.
-    if( ter_furn_cost == 2 ) {
-        return false;
-    }
-
-    // Bashable non-flat terrain/furniture causes collision (bushes, open
-    // windows, fences). NOCOLLIDE excluded (e.g. railroad tracks).
-    if( here.is_bashable_ter_furn( pos, false ) &&
-        !here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_NOCOLLIDE, pos ) ) {
-        return true;
-    }
-
-    return false;
-}
-
 // Cache routes computed by route_length() for reuse by route_to_destination().
 // Avoids recomputing the same A* when the sorter probes route distance and
 // then immediately routes to the same destination.
@@ -859,6 +777,8 @@ struct zone_route_cache {
     tripoint_bub_ms start;
     object_type grab_type = object_type::NONE;
     tripoint_rel_ms grab_point;
+    int arm_str = 0;
+    units::mass veh_mass = 0_gram;
     // (destination center, route). Empty route means unreachable.
     std::vector<std::pair<tripoint_bub_ms, std::vector<tripoint_bub_ms>>> entries;
     bool initialized = false;
@@ -866,14 +786,28 @@ struct zone_route_cache {
     void ensure_valid( const Character &who ) {
         object_type gt = object_type::NONE;
         tripoint_rel_ms gp;
+        int cur_arm_str = 0;
+        units::mass cur_veh_mass = 0_gram;
         if( who.is_avatar() ) {
             gt = who.as_avatar()->get_grab_type();
             gp = who.as_avatar()->grab_point;
+            if( gt == object_type::VEHICLE ) {
+                map &here = get_map();
+                const tripoint_bub_ms veh_pos = who.pos_bub() + gp;
+                const optional_vpart_position ovp = here.veh_at( veh_pos );
+                if( ovp && ovp->vehicle().get_points().size() == 1 ) {
+                    cur_arm_str = who.get_arm_str();
+                    cur_veh_mass = ovp->vehicle().total_mass( here );
+                }
+            }
         }
-        if( !initialized || start != who.pos_bub() || grab_type != gt || grab_point != gp ) {
+        if( !initialized || start != who.pos_bub() || grab_type != gt ||
+            grab_point != gp || arm_str != cur_arm_str || veh_mass != cur_veh_mass ) {
             start = who.pos_bub();
             grab_type = gt;
             grab_point = gp;
+            arm_str = cur_arm_str;
+            veh_mass = cur_veh_mass;
             entries.clear();
             initialized = true;
         }
@@ -896,350 +830,10 @@ struct zone_route_cache {
 zone_route_cache g_route_cache;
 } // namespace
 
-// Check if a straight push or pull path works, skipping the full A*.
-// Only applies when grab direction is aligned with travel direction
-// (push) or opposite (pull), and every tile on the line is passable
-// for both the player and the dragged vehicle.
-static std::vector<tripoint_bub_ms> try_straight_grab_path(
-    const map &here, const tripoint_bub_ms &start, const pathfinding_target &target,
-    const tripoint_rel_ms &cur_grab, vehicle &grabbed_veh )
-{
-    const tripoint_bub_ms &dest = target.center;
-    const point d( dest.x() - start.x(), dest.y() - start.y() );
-    const point ad( std::abs( d.x ), std::abs( d.y ) );
-
-    // Must be a pure cardinal or diagonal direction
-    if( ( ad.x != ad.y && ad.x > 0 && ad.y > 0 ) || ( ad.x == 0 && ad.y == 0 ) ) {
-        return {};
-    }
-
-    const point s( d.x > 0 ? 1 : ( d.x < 0 ? -1 : 0 ), d.y > 0 ? 1 : ( d.y < 0 ? -1 : 0 ) );
-    const tripoint_rel_ms dir( s.x, s.y, 0 );
-
-    const bool is_push = cur_grab == dir;
-    const bool is_pull = cur_grab == -dir;
-    if( !is_push && !is_pull ) {
-        return {};
-    }
-
-    const int num_steps = std::max( ad.x, ad.y );
-    std::vector<tripoint_bub_ms> route;
-    route.reserve( num_steps );
-
-    tripoint_bub_ms player = start;
-    tripoint_bub_ms vehicle_pos = start + cur_grab;
-
-    for( int step = 0; step < num_steps; step++ ) {
-        const tripoint_bub_ms next_player = player + dir;
-        tripoint_bub_ms next_vehicle;
-        if( is_push ) {
-            next_vehicle = vehicle_pos + dir;
-        } else {
-            // Pull: vehicle follows to player's old position
-            next_vehicle = player;
-        }
-
-        // Player passability (exclude grabbed vehicle - it vacates on push)
-        if( here.move_cost( next_player, &grabbed_veh ) == 0 ) {
-            return {};
-        }
-
-        // Vehicle passability
-        if( tile_blocks_vehicle( here, next_vehicle, is_pull ) ) {
-            return {};
-        }
-        const optional_vpart_position ovp_check = here.veh_at( next_vehicle );
-        if( ovp_check && &ovp_check->vehicle() != &grabbed_veh ) {
-            return {};
-        }
-
-        route.push_back( next_player );
-        if( target.contains( next_player ) ) {
-            return route;
-        }
-
-        player = next_player;
-        vehicle_pos = next_vehicle;
-    }
-
-    return {};
-}
-
-// State is (player_position, grab_direction), so it finds routes where
-// both the player and the dragged vehicle can physically move.
-// Returns an empty vector if no path exists or if the player isn't
-// dragging a single-tile vehicle.
-static std::vector<tripoint_bub_ms> route_with_grab(
-    const map &here, const Character &you, const pathfinding_target &target )
-{
-    std::vector<tripoint_bub_ms> ret;
-
-    if( !you.is_avatar() || you.as_avatar()->get_grab_type() != object_type::VEHICLE ) {
-        return ret;
-    }
-
-    const tripoint_bub_ms start = you.pos_bub();
-    const tripoint_rel_ms start_grab = you.as_avatar()->grab_point;
-    const tripoint_bub_ms veh_pos = start + start_grab;
-    const optional_vpart_position ovp = here.veh_at( veh_pos );
-    if( !ovp ) {
-        add_msg_debug( debugmode::DF_ACTIVITY,
-                       "route_with_grab: no vehicle at grab point (%d,%d,%d)+(%d,%d,%d)",
-                       start.x(), start.y(), start.z(),
-                       start_grab.x(), start_grab.y(), start_grab.z() );
-        return ret;
-    }
-    vehicle &grabbed_veh = ovp->vehicle();
-    if( grabbed_veh.get_points().size() > 1 ) {
-        add_msg_debug( debugmode::DF_ACTIVITY,
-                       "route_with_grab: multi-tile vehicle (%zu parts), skipping",
-                       grabbed_veh.get_points().size() );
-        return ret;
-    }
-
-    add_msg_debug( debugmode::DF_ACTIVITY,
-                   "route_with_grab: start=(%d,%d) grab=(%d,%d) target=(%d,%d) r=%d",
-                   start.x(), start.y(), start_grab.x(), start_grab.y(),
-                   target.center.x(), target.center.y(), target.r );
-
-    // Fast path: if grab is aligned with travel direction, check the
-    // straight line before spinning up the full A* with its 157K-state arrays.
-    ret = try_straight_grab_path( here, start, target, start_grab, grabbed_veh );
-    if( !ret.empty() ) {
-        add_msg_debug( debugmode::DF_ACTIVITY,
-                       "route_with_grab: straight line path len=%zu", ret.size() );
-        return ret;
-    }
-
-    const int max_length = you.get_pathfinding_settings().max_length;
-    const int pad = 16;
-    const tripoint_bub_ms &t = target.center;
-
-    point_bub_ms min_bound( std::min( start.x(), t.x() ) - pad,
-                            std::min( start.y(), t.y() ) - pad );
-    point_bub_ms max_bound( std::max( start.x(), t.x() ) + pad,
-                            std::max( start.y(), t.y() ) + pad );
-    min_bound.x() = std::max( min_bound.x(), 0 );
-    min_bound.y() = std::max( min_bound.y(), 0 );
-    max_bound.x() = std::min( max_bound.x(), MAPSIZE_X );
-    max_bound.y() = std::min( max_bound.y(), MAPSIZE_Y );
-
-    const int total_states = MAPSIZE_X * MAPSIZE_Y * GRAB_DIRS;
-
-    // Reuse heap-allocated arrays across calls
-    static std::vector<bool> closed;
-    static std::vector<bool> open;
-    static std::vector<int> gscore;
-    static std::vector<int> parent;
-
-    if( static_cast<int>( closed.size() ) != total_states ) {
-        closed.resize( total_states );
-        open.resize( total_states );
-        gscore.resize( total_states );
-        parent.resize( total_states );
-    }
-
-    // Only closed and open need clearing. gscore and parent retain stale data
-    // but are never read for states where open[state] is false, which is reset
-    // above. This invariant must be maintained if the A* logic is modified.
-    std::fill( closed.begin(), closed.end(), false );
-    std::fill( open.begin(), open.end(), false );
-
-    // Priority queue: (f-score, state_index), smallest f-score first
-    using pq_entry = std::pair<int, int>;
-    std::priority_queue<pq_entry, std::vector<pq_entry>, std::greater<>> pq;
-
-    const int start_grab_idx = grab_to_idx( start_grab );
-    const int start_state = grab_state_index( start.xy(), start_grab_idx );
-    gscore[start_state] = 0;
-    open[start_state] = true;
-    parent[start_state] = start_state;
-    // Tighter heuristic: minimum cost per tile is 4 (player move_cost=2 +
-    // vehicle drag=2 on flat road), minus 2 for one possible sideways move
-    // (vehicle stays put, cost=2). Uses square_dist (Chebyshev = min steps)
-    // instead of rl_dist to stay admissible regardless of trigdist setting.
-    pq.emplace( std::max( 0, 4 * square_dist( start, t ) - 2 ), start_state );
-
-    // Movement offsets: W, E, N, S, NE, SW, NW, SE
-    constexpr std::array<int, 8> x_off{ { -1,  1,  0,  0,  1, -1, -1, 1 } };
-    constexpr std::array<int, 8> y_off{ {  0,  0, -1,  1, -1,  1, -1, 1 } };
-
-    bool done = false;
-    int found_state = -1;
-    int states_explored = 0;
-
-    while( !pq.empty() ) {
-        const auto [cur_score, cur_state] = pq.top();
-        pq.pop();
-
-        if( closed[cur_state] ) {
-            continue;
-        }
-
-        states_explored++;
-        const int cur_g = gscore[cur_state];
-        if( cur_g > max_length ) {
-            add_msg_debug( debugmode::DF_ACTIVITY,
-                           "route_with_grab: ABORTED max_length=%d explored=%d grab=(%d,%d)",
-                           max_length, states_explored, start_grab.x(), start_grab.y() );
-            return ret;
-        }
-
-        const point_bub_ms cur_pos = state_to_pos( cur_state );
-        const int cur_grab_idx = cur_state % GRAB_DIRS;
-        const tripoint_rel_ms cur_grab = idx_to_grab( cur_grab_idx );
-        const tripoint_bub_ms cur3d( cur_pos, start.z() );
-
-        if( target.contains( cur3d ) ) {
-            done = true;
-            found_state = cur_state;
-            break;
-        }
-
-        closed[cur_state] = true;
-
-        for( size_t i = 0; i < 8; i++ ) {
-            const point_bub_ms next_pos( cur_pos.x() + x_off[i], cur_pos.y() + y_off[i] );
-
-            if( next_pos.x() < min_bound.x() || next_pos.x() >= max_bound.x() ||
-                next_pos.y() < min_bound.y() || next_pos.y() >= max_bound.y() ) {
-                continue;
-            }
-
-            const tripoint_bub_ms next3d( next_pos, start.z() );
-
-            // Player passability (ignore grabbed vehicle - it vacates the tile on push)
-            int tile_cost = here.move_cost( next3d, &grabbed_veh );
-            if( tile_cost == 0 ) {
-                // Allow closed doors (cost 4, matching main pathfinder).
-                // Exclude windows - multi-step open, vehicle can't follow through.
-                const bool is_door = ( here.ter( next3d ).obj().open &&
-                                       here.ter( next3d ).obj().has_flag( ter_furn_flag::TFLAG_DOOR ) ) ||
-                                     ( here.furn( next3d ).obj().open &&
-                                       here.furn( next3d ).obj().has_flag( ter_furn_flag::TFLAG_DOOR ) );
-                if( is_door ) {
-                    tile_cost = 4;
-                } else {
-                    continue;
-                }
-            }
-
-            const tripoint_rel_ms dp( x_off[i], y_off[i], 0 );
-            tripoint_rel_ms dp_veh = -cur_grab;
-            tripoint_rel_ms next_grab = cur_grab;
-            bool vehicle_moves = true;
-            bool is_zigzag = false;
-            bool is_push = false;
-
-            if( dp == cur_grab ) {
-                // PUSH: vehicle moves in same direction as player
-                dp_veh = dp;
-                is_push = true;
-            } else if( std::abs( dp.x() + dp_veh.x() ) != 2 &&
-                       std::abs( dp.y() + dp_veh.y() ) != 2 ) {
-                // SIDEWAYS: vehicle stays put, grab rotates
-                next_grab = -( dp + dp_veh );
-                vehicle_moves = false;
-            } else if( ( dp.x() == cur_grab.x() || dp.y() == cur_grab.y() ) &&
-                       cur_grab.x() != 0 && cur_grab.y() != 0 ) {
-                // ZIGZAG: player is diagonal to vehicle, moves partially away
-                dp_veh.x() = dp.x() == -dp_veh.x() ? 0 : dp_veh.x();
-                dp_veh.y() = dp.y() == -dp_veh.y() ? 0 : dp_veh.y();
-                next_grab = -dp_veh;
-                is_zigzag = true;
-            } else {
-                // PULL: vehicle moves to player's old position
-                next_grab = -dp;
-                // dp_veh stays as -cur_grab (initialized above)
-            }
-
-            // Vehicle terrain cost: FLAT/ROAD flag penalties for dragging.
-            int veh_terrain_cost = 0;
-
-            if( vehicle_moves ) {
-                const tripoint_bub_ms veh_new( cur_pos + cur_grab.xy() + dp_veh.xy(), start.z() );
-                // Use veh_at() for other-vehicle check - multi-tile vehicles have
-                // passable parts (aisles) where move_cost > 0 but collision still occurs.
-                const optional_vpart_position ovp_new = here.veh_at( veh_new );
-                const bool other_veh = ovp_new && &ovp_new->vehicle() != &grabbed_veh;
-                // Push/zigzag: vehicle goes to unvisited tiles, doors stay closed.
-                const bool allow_doors = !( is_push || is_zigzag );
-                const bool veh_blocked = other_veh || tile_blocks_vehicle( here, veh_new, allow_doors );
-                if( veh_blocked ) {
-                    // Zigzag recovery: fall back to pull when vehicle move collides.
-                    // Only for zigzag - game doesn't recover push collisions.
-                    if( is_zigzag ) {
-                        dp_veh = -cur_grab;
-                        next_grab = -dp;
-                        const tripoint_bub_ms veh_recover( cur_pos + cur_grab.xy() + dp_veh.xy(),
-                                                           start.z() );
-                        const optional_vpart_position ovp_rec = here.veh_at( veh_recover );
-                        const bool rec_other_veh = ovp_rec && &ovp_rec->vehicle() != &grabbed_veh;
-                        if( rec_other_veh || tile_blocks_vehicle( here, veh_recover ) ) {
-                            continue;
-                        }
-                        veh_terrain_cost = veh_drag_cost( here, veh_recover );
-                    } else {
-                        continue;
-                    }
-                } else {
-                    veh_terrain_cost = veh_drag_cost( here, veh_new );
-                }
-            }
-
-            const int next_grab_idx = grab_to_idx( next_grab );
-            const int next_state = grab_state_index( next_pos, next_grab_idx );
-
-            if( closed[next_state] ) {
-                continue;
-            }
-
-            // Diagonal penalty (same as main A*)
-            const bool diagonal = cur_pos.x() != next_pos.x() && cur_pos.y() != next_pos.y();
-            const int newg = cur_g + tile_cost + veh_terrain_cost + ( diagonal ? 1 : 0 );
-
-            if( open[next_state] && newg >= gscore[next_state] ) {
-                continue;
-            }
-
-            open[next_state] = true;
-            gscore[next_state] = newg;
-            parent[next_state] = cur_state;
-            const int h = std::max( 0, 4 * square_dist( next3d, t ) - 2 );
-            pq.emplace( newg + h, next_state );
-        }
-    }
-
-    if( !done ) {
-        add_msg_debug( debugmode::DF_ACTIVITY,
-                       "route_with_grab: NO PATH FOUND (%d,%d) grab=(%d,%d) to (%d,%d) explored=%d bounds=(%d,%d)-(%d,%d)",
-                       start.x(), start.y(), start_grab.x(), start_grab.y(),
-                       target.center.x(), target.center.y(), states_explored,
-                       min_bound.x(), min_bound.y(), max_bound.x(), max_bound.y() );
-        return ret;
-    }
-
-    // Reconstruct path: collect player positions from found_state back to start
-    int trace = found_state;
-    while( trace != start_state ) {
-        const point_bub_ms pos = state_to_pos( trace );
-        ret.emplace_back( pos, start.z() );
-        trace = parent[trace];
-    }
-    std::reverse( ret.begin(), ret.end() );
-
-    add_msg_debug( debugmode::DF_ACTIVITY,
-                   "route_with_grab: found path len=%zu from (%d,%d) to (%d,%d) first_step=(%d,%d)",
-                   ret.size(), start.x(), start.y(),
-                   target.center.x(), target.center.y(),
-                   ret.empty() ? -1 : ret.front().x(), ret.empty() ? -1 : ret.front().y() );
-    return ret;
-}
-
 bool route_to_destination( Character &you, player_activity &act,
                            const tripoint_bub_ms &dest, zone_activity_stage &stage )
 {
-    const map &here = get_map();
+    map &here = get_map();
     std::vector<tripoint_bub_ms> route;
 
     // Check if route_length() already computed a path for this destination.
@@ -1258,20 +852,12 @@ bool route_to_destination( Character &you, player_activity &act,
     if( route.empty() && !from_cache ) {
         // Use grab-aware A* when dragging a single-tile vehicle - searches over
         // (position, grab_direction) state so both player and cart can move.
-        if( you.is_avatar() && you.as_avatar()->get_grab_type() == object_type::VEHICLE ) {
-            const tripoint_bub_ms veh_pos = you.pos_bub() + you.as_avatar()->grab_point;
-            const optional_vpart_position ovp = here.veh_at( veh_pos );
-            if( ovp && ovp->vehicle().get_points().size() == 1 ) {
-                // Single-tile vehicle: use grab-aware A*. If no path found,
-                // treat as unreachable (don't fall back to player-only routing
-                // which would cause cart collisions).
-                used_grab_routing = true;
-                route = route_with_grab( here, you, pathfinding_target::adjacent( dest ) );
-            } else {
-                // Multi-tile vehicle or no vehicle at grab point: use normal
-                // pathfinding (grab-aware A* doesn't support multi-tile).
-                route = here.route( you, pathfinding_target::adjacent( dest ) );
-            }
+        if( has_grabbed_single_tile_vehicle( you, here ) ) {
+            // Single-tile vehicle: use grab-aware A*. If no path found,
+            // treat as unreachable (don't fall back to player-only routing
+            // which would cause cart collisions).
+            used_grab_routing = true;
+            route = route_with_grab( here, you, pathfinding_target::adjacent( dest ) );
         } else {
             route = here.route( you, pathfinding_target::adjacent( dest ) );
         }
@@ -1752,17 +1338,11 @@ int route_length( const Character &you, const tripoint_bub_ms &dest )
         return cached->empty() ? INT_MAX : static_cast<int>( cached->size() );
     }
 
-    const map &here = get_map();
+    map &here = get_map();
     std::vector<tripoint_bub_ms> route;
 
-    if( you.is_avatar() && you.as_avatar()->get_grab_type() == object_type::VEHICLE ) {
-        const tripoint_bub_ms veh_pos = you.pos_bub() + you.as_avatar()->grab_point;
-        const optional_vpart_position ovp = here.veh_at( veh_pos );
-        if( ovp && ovp->vehicle().get_points().size() == 1 ) {
-            route = route_with_grab( here, you, pathfinding_target::adjacent( dest ) );
-        } else {
-            route = here.route( you, pathfinding_target::adjacent( dest ) );
-        }
+    if( has_grabbed_single_tile_vehicle( you, here ) ) {
+        route = route_with_grab( here, you, pathfinding_target::adjacent( dest ) );
     } else {
         route = here.route( you, pathfinding_target::adjacent( dest ) );
     }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5842,15 +5842,25 @@ std::optional<std::vector<tripoint_bub_ms>> game::safe_route_to( Character &who,
             return dist_a < dist_b ? a : b;
         }
     };
+    const bool use_grab_routing = has_grabbed_single_tile_vehicle( who, here );
+
     route_t shortest_route;
     for( const tripoint_bub_ms &p : here.points_in_radius( target, threshold, 0 ) ) {
         if( is_dangerous_tile( p ) ) {
             continue;
         }
-        const route_t route = here.route( who.pos_bub(), pathfinding_target::point( p ),
-        who.get_pathfinding_settings(), [this]( const tripoint_bub_ms & p ) {
-            return is_dangerous_tile( p );
-        } );
+        route_t route;
+        if( use_grab_routing ) {
+            route = route_with_grab( here, who, pathfinding_target::point( p ),
+            [this]( const tripoint_bub_ms & p ) {
+                return is_dangerous_tile( p );
+            } );
+        } else {
+            route = here.route( who.pos_bub(), pathfinding_target::point( p ),
+            who.get_pathfinding_settings(), [this]( const tripoint_bub_ms & p ) {
+                return is_dangerous_tile( p );
+            } );
+        }
         if( route.empty() ) {
             continue; // no route
         }

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2373,11 +2373,19 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             } else {
                 point_rel_ms dest_delta = get_delta_from_movement_action( act, iso_rotate::yes );
                 if( auto_travel_mode && !player_character.is_auto_moving() ) {
+                    const bool use_grab_routing =
+                        has_grabbed_single_tile_vehicle( player_character, here );
                     for( int i = 0; i < SEEX; i++ ) {
                         tripoint_bub_ms auto_travel_destination =
                             player_character.pos_bub() + dest_delta * ( SEEX - i );
-                        destination_preview =
-                            here.route( player_character, pathfinding_target::point( auto_travel_destination ) );
+                        if( use_grab_routing ) {
+                            destination_preview = route_with_grab( here, player_character,
+                                                                   pathfinding_target::point( auto_travel_destination ),
+                                                                   player_character.get_path_avoid() );
+                        } else {
+                            destination_preview =
+                                here.route( player_character, pathfinding_target::point( auto_travel_destination ) );
+                        }
                         if( !destination_preview.empty() ) {
                             destination_preview.erase(
                                 destination_preview.begin() + 1, destination_preview.end() );

--- a/src/pathfinding.cpp
+++ b/src/pathfinding.cpp
@@ -9,19 +9,25 @@
 #include <numeric>
 #include <optional>
 #include <queue>
+#include <set>
+#include <string>
 #include <utility>
 #include <vector>
 
+#include "avatar.h"
 #include "cata_utility.h"
+#include "character.h"
 #include "coordinates.h"
 #include "creature.h"
 #include "damage.h"
 #include "debug.h"
+#include "enums.h"
 #include "game.h"
 #include "line.h"
 #include "map.h"
 #include "map_scale_constants.h"
 #include "mapdata.h"
+#include "messages.h"
 #include "maptile_fwd.h"
 #include "point.h"
 #include "submap.h"
@@ -668,6 +674,528 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f,
         std::reverse( ret.begin(), ret.end() );
     }
 
+    return ret;
+}
+
+// --- Grab-aware pathfinding helpers ---
+
+// Number of grab direction slots: 3x3 grid encoding (x+1)*3 + (y+1), index 4 = center = unused.
+static constexpr int GRAB_DIRS = 9;
+
+static int grab_to_idx( const tripoint_rel_ms &g )
+{
+    return ( g.x() + 1 ) * 3 + ( g.y() + 1 );
+}
+
+static tripoint_rel_ms idx_to_grab( int idx )
+{
+    return tripoint_rel_ms( idx / 3 - 1, idx % 3 - 1, 0 );
+}
+
+static int grab_state_index( const point_bub_ms &pos, int grab_idx )
+{
+    return ( pos.x() * MAPSIZE_Y + pos.y() ) * GRAB_DIRS + grab_idx;
+}
+
+static point_bub_ms state_to_pos( int state_idx )
+{
+    int pos_idx = state_idx / GRAB_DIRS;
+    return point_bub_ms( pos_idx / MAPSIZE_Y, pos_idx % MAPSIZE_Y );
+}
+
+// Estimate vehicle drag difficulty using FLAT/ROAD terrain flags (matching
+// wheel terrain_modifiers): non-FLAT +4, FLAT non-ROAD +3, FLAT+ROAD +0.
+static int veh_drag_cost( const map &here, const tripoint_bub_ms &pos )
+{
+    const int base = here.move_cost_ter_furn( pos );
+    if( base <= 0 ) {
+        return 0;
+    }
+    if( !here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_FLAT, pos ) ) {
+        return base + 4;
+    }
+    if( !here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_ROAD, pos ) ) {
+        return base + 3;
+    }
+    return base;
+}
+
+// Check if a tile would cause a vehicle collision, matching part_collision
+// logic: impassable tiles block, bashable non-flat terrain/furniture blocks.
+// allow_doors: pull moves pass true (vehicle follows player through opened
+// doors); push/zigzag pass false (vehicle goes to unvisited tiles).
+static bool tile_blocks_vehicle( const map &here, const tripoint_bub_ms &pos,
+                                 bool allow_doors = true )
+{
+    const int ter_furn_cost = here.move_cost_ter_furn( pos );
+
+    // Impassable terrain (walls, closed windows, locked doors).
+    if( ter_furn_cost == 0 ) {
+        if( allow_doors ) {
+            // Openable doors: player opens them during auto-move, vehicle follows.
+            const bool is_door = ( here.ter( pos ).obj().open &&
+                                   here.ter( pos ).obj().has_flag( ter_furn_flag::TFLAG_DOOR ) ) ||
+                                 ( here.has_furn( pos ) && here.furn( pos ).obj().open &&
+                                   here.furn( pos ).obj().has_flag( ter_furn_flag::TFLAG_DOOR ) );
+            if( is_door ) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // No-floor tiles (open air) -- vehicle would fall
+    if( here.has_flag( ter_furn_flag::TFLAG_NO_FLOOR, pos ) ) {
+        return true;
+    }
+
+    // Flat ground (move_cost 2) never causes collision.
+    if( ter_furn_cost == 2 ) {
+        return false;
+    }
+
+    // Bashable non-flat terrain/furniture causes collision (bushes, open
+    // windows, fences). NOCOLLIDE excluded (e.g. railroad tracks).
+    if( here.is_bashable_ter_furn( pos, false ) &&
+        !here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_NOCOLLIDE, pos ) ) {
+        return true;
+    }
+
+    return false;
+}
+
+// Returns the danger cost for a tile based on pathfinding flags and settings.
+// 0 = safe, 500 = dangerous (trap or field), PF_IMPASSABLE = sharp.
+static int tile_danger_cost( const pathfinding_settings &settings,
+                             PathfindingFlags p_special )
+{
+    if( settings.avoid_sharp && ( p_special & PathfindingFlag::Sharp ) ) {
+        return PF_IMPASSABLE;
+    }
+
+    if( settings.avoid_traps && ( p_special & PathfindingFlag::DangerousTrap ) ) {
+        return 500;
+    }
+
+    if( settings.avoid_dangerous_fields && ( p_special & PathfindingFlag::DangerousField ) ) {
+        return 500;
+    }
+
+    return 0;
+}
+
+// Check if a straight push or pull path works, skipping the full A*.
+// Only applies when grab direction is aligned with travel direction
+// (push) or opposite (pull), and every tile on the line is passable
+// for both the player and the dragged vehicle.
+// Assumes a single-tile vehicle (caller gates on this).
+static std::vector<tripoint_bub_ms> try_straight_grab_path(
+    map &here, const tripoint_bub_ms &start, const pathfinding_target &target,
+    const tripoint_rel_ms &cur_grab, vehicle &grabbed_veh,
+    const pathfinding_settings &settings, const pathfinding_cache &pf_cache,
+    int cached_arm_str,
+    const std::function<bool( const tripoint_bub_ms & )> &avoid )
+{
+    const tripoint_bub_ms &dest = target.center;
+    const point d( dest.x() - start.x(), dest.y() - start.y() );
+    const point ad( std::abs( d.x ), std::abs( d.y ) );
+
+    // Must be a pure cardinal or diagonal direction
+    if( ( ad.x != ad.y && ad.x > 0 && ad.y > 0 ) || ( ad.x == 0 && ad.y == 0 ) ) {
+        return {};
+    }
+
+    const point s( d.x > 0 ? 1 : ( d.x < 0 ? -1 : 0 ), d.y > 0 ? 1 : ( d.y < 0 ? -1 : 0 ) );
+    const tripoint_rel_ms dir( s.x, s.y, 0 );
+
+    const bool is_push = cur_grab == dir;
+    const bool is_pull = cur_grab == -dir;
+    if( !is_push && !is_pull ) {
+        return {};
+    }
+
+    const int num_steps = std::max( ad.x, ad.y );
+    std::vector<tripoint_bub_ms> route;
+    route.reserve( num_steps );
+
+    tripoint_bub_ms player = start;
+    tripoint_bub_ms vehicle_pos = start + cur_grab;
+
+    for( int step = 0; step < num_steps; step++ ) {
+        const tripoint_bub_ms next_player = player + dir;
+        // Push: vehicle advances one step in travel direction.
+        // Pull: vehicle follows to player's old position, which is
+        // also vehicle_pos + dir (vehicle is one step behind player).
+        const tripoint_bub_ms next_vehicle = vehicle_pos + dir;
+
+        // Player passability (grabbed vehicle vacates the tile on push)
+        if( here.move_cost( next_player, &grabbed_veh ) == 0 ) {
+            return {};
+        }
+        if( here.has_flag( ter_furn_flag::TFLAG_NO_FLOOR, next_player ) ) {
+            return {};
+        }
+
+        // Danger check on player tile
+        const PathfindingFlags p_special =
+            pf_cache.special[next_player.x()][next_player.y()];
+        if( tile_danger_cost( settings, p_special ) != 0 ) {
+            return {};
+        }
+
+        // Avoid callback (matching map::route semantics)
+        if( !target.contains( next_player ) && avoid && avoid( next_player ) ) {
+            return {};
+        }
+
+        // Vehicle passability
+        if( tile_blocks_vehicle( here, next_vehicle, is_pull ) ) {
+            return {};
+        }
+        // The grabbed vehicle is always at vehicle_pos (its current position),
+        // so any vehicle found at next_vehicle is necessarily a different one.
+        if( here.veh_at( next_vehicle ) ) {
+            return {};
+        }
+
+        // Strength check: vehicle moves for both push and pull
+        const int req_cur = grabbed_veh.drag_str_req_at( here, vehicle_pos );
+        const int req_new = grabbed_veh.drag_str_req_at( here, next_vehicle );
+        if( req_cur > cached_arm_str || req_new > cached_arm_str ) {
+            return {};
+        }
+
+        route.push_back( next_player );
+        if( target.contains( next_player ) ) {
+            return route;
+        }
+
+        player = next_player;
+        vehicle_pos = next_vehicle;
+    }
+
+    return {};
+}
+
+bool has_grabbed_single_tile_vehicle( const Character &you, const map &here )
+{
+    if( !you.is_avatar() || you.as_avatar()->get_grab_type() != object_type::VEHICLE ) {
+        return false;
+    }
+    const tripoint_bub_ms veh_pos = you.pos_bub() + you.as_avatar()->grab_point;
+    const optional_vpart_position ovp = here.veh_at( veh_pos );
+    return ovp && ovp->vehicle().get_points().size() == 1;
+}
+
+// State is (player_position, grab_direction), so it finds routes where
+// both the player and the dragged vehicle can physically move.
+// Returns an empty vector if no path exists or if the player isn't
+// dragging a single-tile vehicle.
+// TODO: XY-only -- no ramp/stair support.
+std::vector<tripoint_bub_ms> route_with_grab(
+    map &here, const Character &you, const pathfinding_target &target,
+    const std::function<bool( const tripoint_bub_ms & )> &avoid )
+{
+    std::vector<tripoint_bub_ms> ret;
+
+    if( !you.is_avatar() || you.as_avatar()->get_grab_type() != object_type::VEHICLE ) {
+        return ret;
+    }
+
+    const tripoint_bub_ms start = you.pos_bub();
+    const tripoint_rel_ms start_grab = you.as_avatar()->grab_point;
+    const tripoint_bub_ms veh_pos = start + start_grab;
+    const optional_vpart_position ovp = here.veh_at( veh_pos );
+    if( !ovp ) {
+        add_msg_debug( debugmode::DF_ACTIVITY,
+                       "route_with_grab: no vehicle at grab point %s+%s",
+                       start.to_string_writable(), start_grab.to_string_writable() );
+        return ret;
+    }
+    vehicle &grabbed_veh = ovp->vehicle();
+    if( grabbed_veh.get_points().size() > 1 ) {
+        add_msg_debug( debugmode::DF_ACTIVITY,
+                       "route_with_grab: multi-tile vehicle (%zu parts), skipping",
+                       grabbed_veh.get_points().size() );
+        return ret;
+    }
+
+    add_msg_debug( debugmode::DF_ACTIVITY,
+                   "route_with_grab: start=%s grab=%s target=%s r=%d",
+                   start.to_string_writable(), start_grab.to_string_writable(),
+                   target.center.to_string_writable(), target.r );
+
+    pathfinding_settings settings = you.get_pathfinding_settings();
+    // Always avoid dangerous fields when dragging a vehicle -- there is
+    // no scenario where routing through fire with a cart is desirable.
+    settings.avoid_dangerous_fields = true;
+    const pathfinding_cache &pf_cache = here.get_pathfinding_cache_ref( start.z() );
+
+    // Cache arm strength for strength checks
+    const int cached_arm_str = you.get_arm_str();
+
+    // Fast path: if grab is aligned with travel direction, check the
+    // straight line before spinning up the full A* with its 157K-state arrays.
+    ret = try_straight_grab_path( here, start, target, start_grab, grabbed_veh,
+                                  settings, pf_cache, cached_arm_str, avoid );
+    if( !ret.empty() ) {
+        add_msg_debug( debugmode::DF_ACTIVITY,
+                       "route_with_grab: straight line path len=%zu", ret.size() );
+        return ret;
+    }
+
+    const int max_length = settings.max_length;
+    const int pad = 16;
+    const tripoint_bub_ms &t = target.center;
+
+    point_bub_ms min_bound( std::min( start.x(), t.x() ) - pad,
+                            std::min( start.y(), t.y() ) - pad );
+    point_bub_ms max_bound( std::max( start.x(), t.x() ) + pad,
+                            std::max( start.y(), t.y() ) + pad );
+    min_bound.x() = std::max( min_bound.x(), 0 );
+    min_bound.y() = std::max( min_bound.y(), 0 );
+    max_bound.x() = std::min( max_bound.x(), MAPSIZE_X );
+    max_bound.y() = std::min( max_bound.y(), MAPSIZE_Y );
+
+    const int total_states = MAPSIZE_X * MAPSIZE_Y * GRAB_DIRS;
+
+    // Reuse heap-allocated arrays across calls
+    static std::vector<bool> closed;
+    static std::vector<bool> open;
+    static std::vector<int> gscore;
+    static std::vector<int> parent;
+
+    if( static_cast<int>( closed.size() ) != total_states ) {
+        closed.resize( total_states );
+        open.resize( total_states );
+        gscore.resize( total_states );
+        parent.resize( total_states );
+    }
+
+    // Only closed and open need clearing; gscore and parent are only read
+    // for states where open[state] is true.
+    std::fill( closed.begin(), closed.end(), false );
+    std::fill( open.begin(), open.end(), false );
+
+    // Priority queue: (f-score, state_index), smallest f-score first
+    using pq_entry = std::pair<int, int>;
+    std::priority_queue<pq_entry, std::vector<pq_entry>, std::greater<>> pq;
+
+    const int start_grab_idx = grab_to_idx( start_grab );
+    const int start_state = grab_state_index( start.xy(), start_grab_idx );
+    gscore[start_state] = 0;
+    open[start_state] = true;
+    parent[start_state] = start_state;
+    // Heuristic: 4 * chebyshev - 2 (one sideways move costs only 2).
+    // Uses square_dist to stay admissible regardless of trigdist setting.
+    pq.emplace( std::max( 0, 4 * square_dist( start, t ) - 2 ), start_state );
+
+    // Movement offsets: W, E, N, S, NE, SW, NW, SE
+    constexpr std::array<int, 8> x_off{ { -1,  1,  0,  0,  1, -1, -1, 1 } };
+    constexpr std::array<int, 8> y_off{ {  0,  0, -1,  1, -1,  1, -1, 1 } };
+
+    bool done = false;
+    int found_state = -1;
+    int states_explored = 0;
+
+    while( !pq.empty() ) {
+        const auto [cur_score, cur_state] = pq.top();
+        pq.pop();
+
+        if( closed[cur_state] ) {
+            continue;
+        }
+
+        states_explored++;
+        const int cur_g = gscore[cur_state];
+        if( cur_g > max_length ) {
+            add_msg_debug( debugmode::DF_ACTIVITY,
+                           "route_with_grab: ABORTED max_length=%d explored=%d grab=%s",
+                           max_length, states_explored, start_grab.to_string_writable() );
+            return ret;
+        }
+
+        const point_bub_ms cur_pos = state_to_pos( cur_state );
+        const int cur_grab_idx = cur_state % GRAB_DIRS;
+        const tripoint_rel_ms cur_grab = idx_to_grab( cur_grab_idx );
+        const tripoint_bub_ms cur3d( cur_pos, start.z() );
+
+        if( target.contains( cur3d ) ) {
+            done = true;
+            found_state = cur_state;
+            break;
+        }
+
+        closed[cur_state] = true;
+
+        for( size_t i = 0; i < 8; i++ ) {
+            const point_bub_ms next_pos( cur_pos.x() + x_off[i], cur_pos.y() + y_off[i] );
+
+            if( next_pos.x() < min_bound.x() || next_pos.x() >= max_bound.x() ||
+                next_pos.y() < min_bound.y() || next_pos.y() >= max_bound.y() ) {
+                continue;
+            }
+
+            const tripoint_bub_ms next3d( next_pos, start.z() );
+
+            // Avoid callback (matching map::route semantics)
+            if( !target.contains( next3d ) && avoid && avoid( next3d ) ) {
+                continue;
+            }
+
+            // Danger check on player's next position
+            const PathfindingFlags p_special = pf_cache.special[next_pos.x()][next_pos.y()];
+            const int danger = tile_danger_cost( settings, p_special );
+            if( danger == PF_IMPASSABLE ) {
+                continue;
+            }
+
+            // Player passability (grabbed vehicle vacates the tile on push)
+            if( here.has_flag( ter_furn_flag::TFLAG_NO_FLOOR, next3d ) ) {
+                continue;
+            }
+            int tile_cost = here.move_cost( next3d, &grabbed_veh );
+            if( tile_cost == 0 ) {
+                // Closed doors cost 4 (auto-move opens them).
+                // Windows excluded - multi-step open, vehicle can't follow.
+                const bool is_door = ( here.ter( next3d ).obj().open &&
+                                       here.ter( next3d ).obj().has_flag( ter_furn_flag::TFLAG_DOOR ) ) ||
+                                     ( here.furn( next3d ).obj().open &&
+                                       here.furn( next3d ).obj().has_flag( ter_furn_flag::TFLAG_DOOR ) );
+                if( is_door ) {
+                    tile_cost = 4;
+                } else {
+                    continue;
+                }
+            }
+
+            if( danger > 0 ) {
+                tile_cost += danger;
+            }
+
+            const tripoint_rel_ms dp( x_off[i], y_off[i], 0 );
+            tripoint_rel_ms dp_veh = -cur_grab;
+            tripoint_rel_ms next_grab = cur_grab;
+            bool vehicle_moves = true;
+            bool is_zigzag = false;
+            bool is_push = false;
+
+            if( dp == cur_grab ) {
+                // PUSH: vehicle moves in same direction as player
+                dp_veh = dp;
+                is_push = true;
+            } else if( std::abs( dp.x() + dp_veh.x() ) != 2 &&
+                       std::abs( dp.y() + dp_veh.y() ) != 2 ) {
+                // SIDEWAYS: vehicle stays put, grab rotates
+                next_grab = -( dp + dp_veh );
+                vehicle_moves = false;
+            } else if( ( dp.x() == cur_grab.x() || dp.y() == cur_grab.y() ) &&
+                       cur_grab.x() != 0 && cur_grab.y() != 0 ) {
+                // ZIGZAG: player is diagonal to vehicle, moves partially away
+                dp_veh.x() = dp.x() == -dp_veh.x() ? 0 : dp_veh.x();
+                dp_veh.y() = dp.y() == -dp_veh.y() ? 0 : dp_veh.y();
+                next_grab = -dp_veh;
+                is_zigzag = true;
+            } else {
+                // PULL: vehicle moves to player's old position
+                next_grab = -dp;
+                // dp_veh stays as -cur_grab (initialized above)
+            }
+
+            // FLAT/ROAD drag penalty for vehicle terrain
+            int veh_terrain_cost = 0;
+
+            if( vehicle_moves ) {
+                const tripoint_bub_ms veh_new( cur_pos + cur_grab.xy() + dp_veh.xy(), start.z() );
+                // veh_at() needed because other vehicles (e.g. ambulance aisles)
+                // have passable move_cost but still block placement. dp_veh is
+                // always non-zero here, so veh_new != current vehicle position.
+                const bool other_veh = static_cast<bool>( here.veh_at( veh_new ) );
+                // Push/zigzag: doors stay closed (vehicle goes to unvisited tiles)
+                const bool allow_doors = !( is_push || is_zigzag );
+                const bool veh_blocked = other_veh || tile_blocks_vehicle( here, veh_new, allow_doors );
+                if( veh_blocked ) {
+                    // Zigzag recovery: fall back to pull when vehicle collides
+                    if( is_zigzag ) {
+                        dp_veh = -cur_grab;
+                        next_grab = -dp;
+                        const tripoint_bub_ms veh_recover( cur_pos + cur_grab.xy() + dp_veh.xy(),
+                                                           start.z() );
+                        if( here.veh_at( veh_recover ) || tile_blocks_vehicle( here, veh_recover ) ) {
+                            continue;
+                        }
+                        // Strength check on recovery position
+                        {
+                            const tripoint_bub_ms veh_cur( cur_pos + cur_grab.xy(), start.z() );
+                            const int req_cur = grabbed_veh.drag_str_req_at( here, veh_cur );
+                            const int req_rec = grabbed_veh.drag_str_req_at( here, veh_recover );
+                            if( req_cur > cached_arm_str || req_rec > cached_arm_str ) {
+                                continue;
+                            }
+                        }
+                        veh_terrain_cost = veh_drag_cost( here, veh_recover );
+                    } else {
+                        continue;
+                    }
+                } else {
+                    // Strength check: both current and new vehicle positions
+                    {
+                        const tripoint_bub_ms veh_cur( cur_pos + cur_grab.xy(), start.z() );
+                        const int req_cur = grabbed_veh.drag_str_req_at( here, veh_cur );
+                        const int req_new = grabbed_veh.drag_str_req_at( here, veh_new );
+                        if( req_cur > cached_arm_str || req_new > cached_arm_str ) {
+                            continue;
+                        }
+                    }
+                    veh_terrain_cost = veh_drag_cost( here, veh_new );
+                }
+            }
+
+            const int next_grab_idx = grab_to_idx( next_grab );
+            const int next_state = grab_state_index( next_pos, next_grab_idx );
+
+            if( closed[next_state] ) {
+                continue;
+            }
+
+            // Diagonal penalty
+            const bool diagonal = cur_pos.x() != next_pos.x() && cur_pos.y() != next_pos.y();
+            const int newg = cur_g + tile_cost + veh_terrain_cost + ( diagonal ? 1 : 0 );
+
+            if( open[next_state] && newg >= gscore[next_state] ) {
+                continue;
+            }
+
+            open[next_state] = true;
+            gscore[next_state] = newg;
+            parent[next_state] = cur_state;
+            const int h = std::max( 0, 4 * square_dist( next3d, t ) - 2 );
+            pq.emplace( newg + h, next_state );
+        }
+    }
+
+    if( !done ) {
+        add_msg_debug( debugmode::DF_ACTIVITY,
+                       "route_with_grab: NO PATH FOUND %s grab=%s to %s explored=%d bounds=%s-%s",
+                       start.to_string_writable(), start_grab.to_string_writable(),
+                       target.center.to_string_writable(), states_explored,
+                       min_bound.to_string_writable(), max_bound.to_string_writable() );
+        return ret;
+    }
+
+    // Reconstruct path
+    int trace = found_state;
+    while( trace != start_state ) {
+        const point_bub_ms pos = state_to_pos( trace );
+        ret.emplace_back( pos, start.z() );
+        trace = parent[trace];
+    }
+    std::reverse( ret.begin(), ret.end() );
+
+    add_msg_debug( debugmode::DF_ACTIVITY,
+                   "route_with_grab: found path len=%zu from %s to %s first_step=%s",
+                   ret.size(), start.to_string_writable(), target.center.to_string_writable(),
+                   ret.empty() ? std::string( "none" ) : ret.front().to_string_writable() );
     return ret;
 }
 

--- a/src/pathfinding.h
+++ b/src/pathfinding.h
@@ -3,15 +3,19 @@
 #define CATA_SRC_PATHFINDING_H
 
 #include <cstdint>
+#include <functional>
 #include <map>
 #include <optional>
 #include <unordered_set>
+#include <vector>
 
 #include "coordinates.h"
 #include "mdarray.h"
 #include "point.h"
 #include "type_id.h"
 
+class Character;
+class map;
 enum class creature_size : int;
 
 // An attribute of a particular map square that is of interest in pathfinding.
@@ -189,5 +193,21 @@ struct pathfinding_target {
         return { p, radius };
     }
 };
+
+// Returns true when the character is an avatar dragging a single-tile
+// vehicle, meaning grab-aware pathfinding (route_with_grab) should be used.
+bool has_grabbed_single_tile_vehicle( const Character &you, const map &here );
+
+// Grab-aware A* pathfinding for a player dragging a single-tile vehicle.
+// State is (player_position, grab_direction), so it finds routes where both
+// the player and the dragged vehicle can physically move.
+// Returns an empty vector if no path exists, or if the character is not an
+// avatar, not grabbing a vehicle, or dragging a multi-tile vehicle.
+// The optional |avoid| callback rejects player tiles matching map::route
+// semantics: if( !target.contains(pos) && avoid && avoid(pos) ) skip tile.
+std::vector<tripoint_bub_ms> route_with_grab(
+    map &here, const Character &you,
+    const pathfinding_target &target,
+    const std::function<bool( const tripoint_bub_ms & )> &avoid = {} );
 
 #endif // CATA_SRC_PATHFINDING_H

--- a/tests/clzones_test.cpp
+++ b/tests/clzones_test.cpp
@@ -1,3 +1,4 @@
+#include <climits>
 #include <functional>
 #include <initializer_list>
 #include <optional>
@@ -2071,3 +2072,140 @@ TEST_CASE( "zone_sorting_drag_weight_gate",
     CHECK( in_cart + carried + at_source == num_boulders );
     CHECK( at_source > 0 );
 }
+
+static void build_open_area( map &here, const tripoint_bub_ms &center, int radius = 15 )
+{
+    for( int x = center.x() - radius; x <= center.x() + radius; x++ ) {
+        for( int y = center.y() - radius; y <= center.y() + radius; y++ ) {
+            here.ter_set( tripoint_bub_ms( x, y, 0 ), ter_t_floor );
+        }
+    }
+}
+
+static vehicle *setup_grabbed_cart( avatar &dummy, map &here,
+                                    const tripoint_bub_ms &player_pos,
+                                    const tripoint_rel_ms &grab_dir )
+{
+    dummy.setpos( here, player_pos );
+    dummy.clear_destination();
+
+    const tripoint_bub_ms cart_pos = player_pos + grab_dir;
+    vehicle *cart = here.add_vehicle( vehicle_prototype_test_shopping_cart,
+                                      cart_pos, 0_degrees, 0, 0 );
+    REQUIRE( cart != nullptr );
+    cart->set_owner( dummy );
+    dummy.grab( object_type::VEHICLE, grab_dir );
+    REQUIRE( dummy.get_grab_type() == object_type::VEHICLE );
+    REQUIRE( cart->get_points().size() == 1 );
+    return cart;
+}
+
+TEST_CASE( "route_with_grab_strength_gating",
+           "[zones][pathfinding][vehicle]" )
+{
+    avatar &dummy = get_avatar();
+    map &here = get_map();
+
+    clear_avatar();
+    clear_map_without_vision();
+    zone_manager::get_manager().clear();
+
+    const tripoint_bub_ms start_pos( 60, 60, 0 );
+    const tripoint_bub_ms dest_pos( 60, 70, 0 );
+
+    build_open_area( here, tripoint_bub_ms( 60, 65, 0 ) );
+
+    vehicle *cart = setup_grabbed_cart( dummy, here, start_pos, tripoint_rel_ms::south );
+
+    const tripoint_abs_ms start_abs = here.get_abs( start_pos );
+    const tripoint_abs_ms dest_abs = here.get_abs( dest_pos );
+    create_tile_zone( "Unsorted", zone_type_LOOT_UNSORTED, start_abs );
+    create_tile_zone( "Food", zone_type_LOOT_FOOD, dest_abs );
+    here.add_item_or_charges( start_pos, item( itype_test_apple ) );
+
+    const int low_str = 4;
+    dummy.set_str_base( low_str );
+    dummy.set_str_bonus( 0 );
+
+    const tripoint_bub_ms cart_pos = start_pos + tripoint::south;
+    std::optional<vpart_reference> cargo = here.veh_at( cart_pos ).cargo();
+    REQUIRE( cargo.has_value() );
+    for( int i = 0; i < 200; i++ ) {
+        if( !cargo->vehicle().add_item( here, cargo->part(),
+                                        item( itype_test_heavy_boulder ) ) ) {
+            break;
+        }
+    }
+
+    here.invalidate_map_cache( 0 );
+    here.build_map_cache( 0, true );
+
+    const int drag_req = cart->drag_str_req_at( here, start_pos + tripoint::south );
+    CAPTURE( drag_req );
+    CAPTURE( dummy.get_arm_str() );
+    REQUIRE( drag_req > dummy.get_arm_str() );
+
+    dummy.setpos( here, start_pos + tripoint::north );
+    dummy.setpos( here, start_pos );
+    CHECK( zone_sorting::route_length( dummy, dest_pos ) == INT_MAX );
+
+    dummy.set_str_base( 20 );
+    dummy.set_str_bonus( 0 );
+    REQUIRE( dummy.get_arm_str() >= drag_req );
+
+    dummy.setpos( here, start_pos + tripoint::north );
+    dummy.setpos( here, start_pos );
+    CHECK( zone_sorting::route_length( dummy, dest_pos ) != INT_MAX );
+}
+
+TEST_CASE( "route_cache_invalidation_on_mass_change",
+           "[zones][pathfinding][vehicle]" )
+{
+    avatar &dummy = get_avatar();
+    map &here = get_map();
+
+    clear_avatar();
+    clear_map_without_vision();
+    zone_manager::get_manager().clear();
+
+    const tripoint_bub_ms start_pos( 60, 60, 0 );
+    const tripoint_bub_ms dest_pos( 60, 70, 0 );
+
+    build_open_area( here, tripoint_bub_ms( 60, 65, 0 ) );
+
+    vehicle *cart = setup_grabbed_cart( dummy, here, start_pos, tripoint_rel_ms::south );
+
+    const tripoint_abs_ms start_abs = here.get_abs( start_pos );
+    const tripoint_abs_ms dest_abs = here.get_abs( dest_pos );
+    create_tile_zone( "Unsorted", zone_type_LOOT_UNSORTED, start_abs );
+    create_tile_zone( "Food", zone_type_LOOT_FOOD, dest_abs );
+    here.add_item_or_charges( start_pos, item( itype_test_apple ) );
+
+    here.invalidate_map_cache( 0 );
+    here.build_map_cache( 0, true );
+
+    const int len_before = zone_sorting::route_length( dummy, dest_pos );
+    CHECK( len_before != INT_MAX );
+
+    const tripoint_bub_ms cart_pos = start_pos + tripoint::south;
+    std::optional<vpart_reference> cargo = here.veh_at( cart_pos ).cargo();
+    REQUIRE( cargo.has_value() );
+    for( int i = 0; i < 200; i++ ) {
+        if( !cargo->vehicle().add_item( here, cargo->part(),
+                                        item( itype_test_heavy_boulder ) ) ) {
+            break;
+        }
+    }
+
+    dummy.set_str_base( 4 );
+    dummy.set_str_bonus( 0 );
+
+    const int drag_req = cart->drag_str_req_at( here, cart_pos );
+    CAPTURE( drag_req );
+    CAPTURE( dummy.get_arm_str() );
+    REQUIRE( drag_req > dummy.get_arm_str() );
+
+    const int len_after = zone_sorting::route_length( dummy, dest_pos );
+    CHECK( len_after == INT_MAX );
+}
+

--- a/tests/pathfinding_test.cpp
+++ b/tests/pathfinding_test.cpp
@@ -1,0 +1,392 @@
+#include <algorithm>
+#include <functional>
+#include <optional>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "avatar.h"
+#include "calendar.h"
+#include "cata_catch.h"
+#include "coordinates.h"
+#include "enums.h"
+#include "field_type.h"
+#include "item.h"
+#include "map.h"
+#include "map_helpers.h"
+#include "map_scale_constants.h"
+#include "pathfinding.h"
+#include "player_helpers.h"
+#include "point.h"
+#include "type_id.h"
+#include "units.h"
+#include "vehicle.h"
+#include "vpart_position.h"
+
+static const itype_id itype_test_heavy_boulder( "test_heavy_boulder" );
+
+static const ter_str_id ter_t_fence_barbed( "t_fence_barbed" );
+static const ter_str_id ter_t_floor( "t_floor" );
+static const ter_str_id ter_t_open_air( "t_open_air" );
+static const ter_str_id ter_t_pit( "t_pit" );
+static const ter_str_id ter_t_reinforced_glass_shutter( "t_reinforced_glass_shutter" );
+static const ter_str_id ter_t_wall( "t_wall" );
+
+static const vproto_id vehicle_prototype_test_shopping_cart( "test_shopping_cart" );
+
+static void build_open_area( map &here, const tripoint_bub_ms &center, int radius = 15 )
+{
+    for( int x = center.x() - radius; x <= center.x() + radius; x++ ) {
+        for( int y = center.y() - radius; y <= center.y() + radius; y++ ) {
+            here.ter_set( tripoint_bub_ms( x, y, 0 ), ter_t_floor );
+        }
+    }
+}
+
+static void build_wall_barrier( map &here, int y, int min_x, int max_x,
+                                int gap_x = -1 )
+{
+    for( int x = min_x; x <= max_x; x++ ) {
+        if( x != gap_x ) {
+            here.ter_set( tripoint_bub_ms( x, y, 0 ), ter_t_wall );
+        }
+    }
+}
+
+static vehicle *setup_grabbed_cart( avatar &dummy, map &here,
+                                    const tripoint_bub_ms &player_pos,
+                                    const tripoint_rel_ms &grab_dir )
+{
+    dummy.setpos( here, player_pos );
+    dummy.clear_destination();
+
+    const tripoint_bub_ms cart_pos = player_pos + grab_dir;
+    vehicle *cart = here.add_vehicle( vehicle_prototype_test_shopping_cart,
+                                      cart_pos, 0_degrees, 0, 0 );
+    REQUIRE( cart != nullptr );
+    cart->set_owner( dummy );
+    dummy.grab( object_type::VEHICLE, grab_dir );
+    REQUIRE( dummy.get_grab_type() == object_type::VEHICLE );
+    REQUIRE( cart->get_points().size() == 1 );
+    return cart;
+}
+
+TEST_CASE( "route_with_grab_avoids_sharp_terrain",
+           "[pathfinding][vehicle]" )
+{
+    avatar &dummy = get_avatar();
+    map &here = get_map();
+
+    clear_avatar();
+    clear_map_without_vision();
+
+    const tripoint_bub_ms start_pos( 60, 60, 0 );
+    const tripoint_bub_ms dest_pos( 60, 70, 0 );
+    const tripoint_bub_ms sharp_pos( 60, 65, 0 );
+
+    build_open_area( here, tripoint_bub_ms( 60, 65, 0 ) );
+    build_wall_barrier( here, 65, 0, MAPSIZE_X - 1, 60 );
+    here.ter_set( sharp_pos, ter_t_fence_barbed );
+
+    setup_grabbed_cart( dummy, here, start_pos, tripoint_rel_ms::south );
+
+    here.invalidate_map_cache( 0 );
+    here.build_map_cache( 0, true );
+
+    auto blocked_route = route_with_grab( here, dummy,
+                                          pathfinding_target::adjacent( dest_pos ) );
+    CHECK( blocked_route.empty() );
+
+    here.ter_set( sharp_pos, ter_t_floor );
+    here.invalidate_map_cache( 0 );
+    here.build_map_cache( 0, true );
+
+    auto open_route = route_with_grab( here, dummy,
+                                       pathfinding_target::adjacent( dest_pos ) );
+    CHECK( !open_route.empty() );
+}
+
+TEST_CASE( "route_with_grab_fast_path_fallback",
+           "[pathfinding][vehicle]" )
+{
+    avatar &dummy = get_avatar();
+    map &here = get_map();
+
+    clear_avatar();
+    clear_map_without_vision();
+
+    const tripoint_bub_ms start_pos( 60, 60, 0 );
+    const tripoint_bub_ms dest_pos( 60, 70, 0 );
+    const tripoint_bub_ms sharp_pos( 60, 65, 0 );
+
+    build_open_area( here, tripoint_bub_ms( 60, 65, 0 ) );
+
+    setup_grabbed_cart( dummy, here, start_pos, tripoint_rel_ms::south );
+    here.ter_set( sharp_pos, ter_t_fence_barbed );
+
+    here.invalidate_map_cache( 0 );
+    here.build_map_cache( 0, true );
+
+    auto route = route_with_grab( here, dummy,
+                                  pathfinding_target::adjacent( dest_pos ) );
+    CHECK( !route.empty() );
+}
+
+TEST_CASE( "grab_aware_routing_integration",
+           "[pathfinding][vehicle]" )
+{
+    avatar &dummy = get_avatar();
+    map &here = get_map();
+
+    clear_avatar();
+    clear_map_without_vision();
+
+    const tripoint_bub_ms start_pos( 60, 60, 0 );
+    const tripoint_bub_ms dest_pos( 60, 70, 0 );
+
+    build_open_area( here, tripoint_bub_ms( 60, 65, 0 ) );
+
+    here.invalidate_map_cache( 0 );
+    here.build_map_cache( 0, true );
+
+    SECTION( "with grabbed single-tile vehicle" ) {
+        setup_grabbed_cart( dummy, here, start_pos, tripoint_rel_ms::south );
+
+        here.invalidate_map_cache( 0 );
+        here.build_map_cache( 0, true );
+
+        auto result = route_with_grab( here, dummy,
+                                       pathfinding_target::point( dest_pos ) );
+        CHECK( !result.empty() );
+    }
+
+    SECTION( "without grab, normal routing" ) {
+        dummy.setpos( here, start_pos );
+        dummy.clear_destination();
+        dummy.grab( object_type::NONE );
+
+        auto result = here.route( dummy.pos_bub(),
+                                  pathfinding_target::point( dest_pos ),
+                                  dummy.get_pathfinding_settings() );
+        CHECK( !result.empty() );
+    }
+}
+
+TEST_CASE( "route_with_grab_penalizes_dangerous_traps",
+           "[pathfinding][vehicle]" )
+{
+    avatar &dummy = get_avatar();
+    map &here = get_map();
+
+    clear_avatar();
+    clear_map_without_vision();
+
+    const tripoint_bub_ms start_pos( 60, 60, 0 );
+    const tripoint_bub_ms dest_pos( 60, 70, 0 );
+
+    build_open_area( here, tripoint_bub_ms( 60, 65, 0 ) );
+
+    const tripoint_bub_ms pit_pos( 60, 65, 0 );
+    here.ter_set( pit_pos, ter_t_pit );
+
+    setup_grabbed_cart( dummy, here, start_pos, tripoint_rel_ms::south );
+
+    here.invalidate_map_cache( 0 );
+    here.build_map_cache( 0, true );
+
+    auto route = route_with_grab( here, dummy,
+                                  pathfinding_target::adjacent( dest_pos ) );
+    REQUIRE( !route.empty() );
+
+    const bool route_hits_pit = std::find( route.begin(), route.end(),
+                                           pit_pos ) != route.end();
+    CHECK_FALSE( route_hits_pit );
+
+    here.ter_set( pit_pos, ter_t_floor );
+    here.invalidate_map_cache( 0 );
+    here.build_map_cache( 0, true );
+
+    dummy.setpos( here, start_pos + tripoint::north );
+    dummy.setpos( here, start_pos );
+    dummy.grab( object_type::VEHICLE, tripoint_rel_ms::south );
+
+    auto direct_route = route_with_grab( here, dummy,
+                                         pathfinding_target::adjacent( dest_pos ) );
+    REQUIRE( !direct_route.empty() );
+    CHECK( direct_route.size() <= route.size() );
+}
+
+TEST_CASE( "route_with_grab_rejects_open_air",
+           "[pathfinding][vehicle]" )
+{
+    avatar &dummy = get_avatar();
+    map &here = get_map();
+
+    clear_avatar();
+    clear_map_without_vision();
+
+    const tripoint_bub_ms start_pos( 60, 60, 0 );
+    const tripoint_bub_ms dest_pos( 60, 70, 0 );
+
+    build_open_area( here, tripoint_bub_ms( 60, 65, 0 ) );
+    build_wall_barrier( here, 65, 0, MAPSIZE_X - 1, 60 );
+    here.ter_set( tripoint_bub_ms( 60, 65, 0 ), ter_t_open_air );
+
+    setup_grabbed_cart( dummy, here, start_pos, tripoint_rel_ms::south );
+
+    here.invalidate_map_cache( 0 );
+    here.build_map_cache( 0, true );
+
+    auto route = route_with_grab( here, dummy,
+                                  pathfinding_target::adjacent( dest_pos ) );
+    CHECK( route.empty() );
+}
+
+TEST_CASE( "route_with_grab_rejects_reinforced_glass_shutters",
+           "[pathfinding][vehicle]" )
+{
+    avatar &dummy = get_avatar();
+    map &here = get_map();
+
+    clear_avatar();
+    clear_map_without_vision();
+
+    const tripoint_bub_ms start_pos( 60, 60, 0 );
+    const tripoint_bub_ms dest_pos( 60, 70, 0 );
+
+    build_open_area( here, tripoint_bub_ms( 60, 65, 0 ) );
+    build_wall_barrier( here, 65, 0, MAPSIZE_X - 1, 60 );
+    here.ter_set( tripoint_bub_ms( 60, 65, 0 ), ter_t_reinforced_glass_shutter );
+
+    setup_grabbed_cart( dummy, here, start_pos, tripoint_rel_ms::south );
+
+    here.invalidate_map_cache( 0 );
+    here.build_map_cache( 0, true );
+
+    auto route = route_with_grab( here, dummy,
+                                  pathfinding_target::adjacent( dest_pos ) );
+    CHECK( route.empty() );
+}
+
+TEST_CASE( "route_with_grab_avoids_dangerous_fields",
+           "[pathfinding][vehicle]" )
+{
+    avatar &dummy = get_avatar();
+    map &here = get_map();
+
+    clear_avatar();
+    clear_map_without_vision();
+
+    const tripoint_bub_ms start_pos( 60, 60, 0 );
+    const tripoint_bub_ms dest_pos( 60, 70, 0 );
+    const tripoint_bub_ms fire_pos( 60, 65, 0 );
+
+    build_open_area( here, tripoint_bub_ms( 60, 65, 0 ) );
+    here.add_field( fire_pos, fd_fire, 1, 10_minutes );
+    REQUIRE( here.get_field( fire_pos, fd_fire ) );
+
+    setup_grabbed_cart( dummy, here, start_pos, tripoint_rel_ms::south );
+
+    here.invalidate_map_cache( 0 );
+    here.build_map_cache( 0, true );
+
+    auto route = route_with_grab( here, dummy,
+                                  pathfinding_target::adjacent( dest_pos ) );
+    REQUIRE( !route.empty() );
+
+    const bool route_hits_fire = std::find( route.begin(), route.end(),
+                                            fire_pos ) != route.end();
+    CHECK_FALSE( route_hits_fire );
+}
+
+TEST_CASE( "route_with_grab_respects_avoid_callback",
+           "[pathfinding][vehicle]" )
+{
+    avatar &dummy = get_avatar();
+    map &here = get_map();
+
+    clear_avatar();
+    clear_map_without_vision();
+
+    const tripoint_bub_ms start_pos( 60, 60, 0 );
+    const tripoint_bub_ms dest_pos( 60, 70, 0 );
+    const tripoint_bub_ms blocked_pos( 60, 65, 0 );
+
+    build_open_area( here, tripoint_bub_ms( 60, 65, 0 ) );
+    build_wall_barrier( here, 65, 0, MAPSIZE_X - 1, 60 );
+    here.ter_set( blocked_pos, ter_t_floor );
+
+    setup_grabbed_cart( dummy, here, start_pos, tripoint_rel_ms::south );
+
+    here.invalidate_map_cache( 0 );
+    here.build_map_cache( 0, true );
+
+    // Avoid callback that rejects the only gap in the wall
+    auto avoid = [&blocked_pos]( const tripoint_bub_ms & p ) {
+        return p == blocked_pos;
+    };
+
+    auto route = route_with_grab( here, dummy,
+                                  pathfinding_target::adjacent( dest_pos ), avoid );
+    CHECK( route.empty() );
+
+    // Without the avoid callback, route should succeed
+    auto route_no_avoid = route_with_grab( here, dummy,
+                                           pathfinding_target::adjacent( dest_pos ) );
+    CHECK( !route_no_avoid.empty() );
+}
+
+TEST_CASE( "route_with_grab_accounts_for_broken_wheels",
+           "[pathfinding][vehicle]" )
+{
+    avatar &dummy = get_avatar();
+    map &here = get_map();
+
+    clear_avatar();
+    clear_map_without_vision();
+
+    const tripoint_bub_ms start_pos( 60, 60, 0 );
+    const tripoint_bub_ms dest_pos( 60, 70, 0 );
+
+    build_open_area( here, tripoint_bub_ms( 60, 65, 0 ) );
+
+    vehicle *cart = setup_grabbed_cart( dummy, here, start_pos, tripoint_rel_ms::south );
+
+    // Add heavy cargo so mass-based drag cap is meaningful
+    const tripoint_bub_ms cart_pos = start_pos + tripoint::south;
+    std::optional<vpart_reference> cargo = here.veh_at( cart_pos ).cargo();
+    REQUIRE( cargo.has_value() );
+    for( int i = 0; i < 200; i++ ) {
+        if( !cargo->vehicle().add_item( here, cargo->part(),
+                                        item( itype_test_heavy_boulder ) ) ) {
+            break;
+        }
+    }
+
+    here.invalidate_map_cache( 0 );
+    here.build_map_cache( 0, true );
+
+    const int healthy_req = cart->drag_str_req_at( here, cart_pos );
+
+    // Remove the wheel -- simulates complete wheel destruction from collision.
+    // Without wheels, drag_str_req_at returns the mass-based maximum.
+    std::vector<int> wheels = cart->wheelcache;
+    for( const int idx : wheels ) {
+        cart->remove_part( cart->part( idx ) );
+    }
+    cart->part_removal_cleanup( here );
+    REQUIRE( cart->wheelcache.empty() );
+
+    const int broken_req = cart->drag_str_req_at( here, cart_pos );
+    REQUIRE( broken_req > healthy_req );
+
+    // Set strength between healthy and broken requirements
+    dummy.set_str_base( healthy_req + 1 );
+    dummy.set_str_bonus( 0 );
+    REQUIRE( dummy.get_arm_str() >= healthy_req );
+    REQUIRE( dummy.get_arm_str() < broken_req );
+
+    auto route = route_with_grab( here, dummy,
+                                  pathfinding_target::adjacent( dest_pos ) );
+    CHECK( route.empty() );
+}


### PR DESCRIPTION
#### Summary
Bugfixes "Fix zone sorting and auto-move hangs when dragging a shopping cart"

#### Purpose of change

Closes #85639. The grab-aware A* (`route_with_grab`) was missing several safety checks that caused hangs and dangerous pathing:

- No strength check against `drag_str_req_at` -- heavy carts on grass could produce routes the player physically couldn't follow, causing infinite retry loops
- No danger avoidance -- sharp terrain (broken windows/barbed wire), dangerous traps, dangerous fields (fire/acid) were all ignored
- Open air tiles (TFLAG_NO_FLOOR, move_cost=2) were treated as walkable
- Reinforced glass shutters were opened then immediately blocked the cart
- Manual auto-move (mouse click, keyboard travel-to) used the regular A* and ignored the grabbed vehicle entirely

#### Describe the solution

Moved `route_with_grab` to `src/pathfinding.cpp` so it can be used by all routing entry points, not just zone sorting.

Added safety checks to `route_with_grab`'s A* expansion:
- `tile_danger_cost()` helper penalizes dangerous traps/fields (+500 cost) and treats sharp terrain as impassable. `avoid_dangerous_fields` is forced true regardless of character settings.
- `tile_blocks_vehicle()` helper rejects impassable terrain, bashable non-flat terrain, and TFLAG_NO_FLOOR tiles. Handles door asymmetry (pull through opened doors, but push/zigzag don't open doors for vehicle).
- `drag_str_req_at` checked against `get_arm_str()` at both current and new vehicle positions.
- Player positions also reject TFLAG_NO_FLOOR.

Integrated with all manual auto-move paths:
- `game::safe_route_to` (mouse click, travel-to from look-around)
- `handle_action.cpp` auto-travel (keyboard)
- Both dispatch to `route_with_grab` when the avatar is dragging a single-tile vehicle, passing the `get_path_avoid()` callback.

**Zone sorting cache** (`zone_route_cache`) now tracks `arm_str` and `veh_mass`, invalidating cached routes when these change.

#### Describe alternatives you've considered

Extending the main A* with grab state would bloat all pathfinding (157K extra states per z-level). Separate function is cleaner.

#### Testing

Unit tests in `tests/pathfinding_test.cpp`:
- Sharp terrain blocks route; removing sharp opens it
- Fast path falls back to full A* when sharp is on the straight line
- Dangerous traps: route avoids pit tile, shorter without trap
- Open air: route empty when only gap is TFLAG_NO_FLOOR
- Reinforced glass shutters: route empty (impassable, no TFLAG_DOOR)
- Dangerous fields: route avoids fire tile
- Avoid callback: custom callback blocks the only gap; without it, works
- Broken wheels: removing wheel increases drag_str_req, route empty when strength is between healthy and broken requirements

Zone-level tests in `tests/clzones_test.cpp`:
- Strength gating via `route_length` with heavy cargo
- Cache invalidation on mass change
- Integration: grabbed single-tile vs no-grab routing

#### Additional context

Issues from #85639 and comments addressed:
- OP: hang from strength/grass -- strength gating
- OP: hang from unreachable locations behind vehicle -- existing `unreachable_sources` from prior PR
- Comment: broken windows/tetanus -- sharp terrain rejection
- Comment: reinforced glass shutters -- `tile_blocks_vehicle` rejects impassable non-door terrain
- Comment: open air pathfinding -- TFLAG_NO_FLOOR checks
- Comment: broken cart wheels -- `drag_str_req_at` increases without wheels, strength check blocks route