### PR TITLE
calculate additional_pocket_encumbrance correctly

### DIFF
--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -2242,6 +2242,7 @@ std::vector<const item *> item_contents::get_added_pockets() const
 void item_contents::add_pocket( const item &pocket_item )
 {
     units::volume total_nonrigid_volume = 0_ml;
+    units::volume effective_nonrigid_volume = 0_ml;
     for( const item_pocket *i_pocket : pocket_item.get_container_pockets() ) {
 
         // need to insert before the end since the final pocket is the migration pocket
@@ -2250,8 +2251,11 @@ void item_contents::add_pocket( const item &pocket_item )
         // need to update it once it's stored in the contents list
         ( ++contents.rbegin() )->name_as_description = true;
         total_nonrigid_volume += i_pocket->volume_capacity();
+        effective_nonrigid_volume += i_pocket->volume_capacity() *
+                                     i_pocket->get_pocket_data()->volume_encumber_modifier;
     }
     additional_pockets_volume += total_nonrigid_volume;
+    additional_pockets_effective_volume += effective_nonrigid_volume;
     additional_pockets_space_used += pocket_item.get_pocket_size();
     additional_pockets.push_back( pocket_item );
     additional_pockets.back().clear_items();
@@ -2272,8 +2276,11 @@ item item_contents::remove_pocket( int index )
     // at this point reversed past the pockets we want to get rid of so now start going forward
     auto it = std::next( rit ).base();
     units::volume total_nonrigid_volume = 0_ml;
+    units::volume effective_nonrigid_volume = 0_ml;
     for( item_pocket *i_pocket : additional_pockets[index].get_container_pockets() ) {
         total_nonrigid_volume += i_pocket->volume_capacity();
+        effective_nonrigid_volume += i_pocket->volume_capacity() *
+                                     i_pocket->get_pocket_data()->volume_encumber_modifier;
 
         // move items from the consolidated pockets to the item that will be returned
         for( const item *item_to_move : it->all_items_top() ) {
@@ -2284,6 +2291,7 @@ item item_contents::remove_pocket( int index )
         contents.erase( it++ );
     }
     additional_pockets_volume -= total_nonrigid_volume;
+    additional_pockets_effective_volume -= effective_nonrigid_volume;
     additional_pockets_space_used -= additional_pockets[index].get_pocket_size();
 
     // create a copy of the item to return and delete the old items entry
@@ -2322,7 +2330,7 @@ bool item_contents::has_additional_pockets() const
 
 int item_contents::get_additional_pocket_encumbrance( float mod ) const
 {
-    return additional_pockets_volume * mod / 250_ml;
+    return additional_pockets_effective_volume * mod / 250_ml;
 }
 
 int item_contents::get_additional_space_used() const

--- a/src/item_contents.h
+++ b/src/item_contents.h
@@ -462,6 +462,8 @@ class item_contents
         std::vector<item> additional_pockets;
         // TODO make this work with non torso items
         units::volume additional_pockets_volume = 0_ml; // NOLINT(cata-serialize)
+        // Similar to additional_pockets_volume but respect volume_encumber_modifier of the pocket
+        units::volume additional_pockets_effective_volume = 0_ml; // NOLINT(cata-serialize)
 
         /** An abstraction for how many 'spaces' of this item have been used attaching additional pockets. */
         int additional_pockets_space_used = 0; // NOLINT(cata-serialize)


### PR DESCRIPTION
#### Summary
Bugfixes "calculate the encumbrance of attached molle compatible pouch correctly"

#### Purpose of change
Fixes #85622 
Fixes #77452 

#### Describe the solution
Take volume_encumber_modifier of the pocket into account.

#### Describe alternatives you've considered
Calculate it in get_additional_pocket_encumbrance.
#### Testing
No more invisible "extra_encumbrance".
<img width="685" height="1019" alt="2026-03-03 190852" src="https://github.com/user-attachments/assets/b9a52a41-894d-407d-b32e-a74e0ec55a04" />

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
