### PR TITLE
Pat talks to you about POIs through dialogue, not `u_message`

### DIFF
--- a/data/json/effects_on_condition/item_eocs.json
+++ b/data/json/effects_on_condition/item_eocs.json
@@ -416,13 +416,7 @@
             { "npc_near_om_location": "radio_tower_reverberation_mp3", "range": 3 },
             { "npc_near_om_location": "string_dimension_crossroads", "range": 3 },
             { "npc_near_om_location": "mine_spiral_finale_s", "range": 3 },
-            { "npc_near_om_location": "void_spider_lair", "range": 3 },
-            { "math": [ "robofac_pat_lost_signal_highlands == 1" ] },
-            { "math": [ "robofac_pat_lost_signal_radiosphere == 1" ] },
-            { "math": [ "robofac_pat_lost_signal_cabin_reverb == 1" ] },
-            { "math": [ "robofac_pat_lost_signal_labyrinth == 1" ] },
-            { "math": [ "robofac_pat_lost_signal_string_dimension == 1" ] },
-            { "math": [ "robofac_pat_lost_signal_spider_dimension == 1" ] }
+            { "npc_near_om_location": "void_spider_lair", "range": 3 }
           ]
         }
       ]
@@ -436,10 +430,7 @@
           ]
         },
         "then": [
-          {
-            "u_message": "You hear a chirp in your earpiece and Pat's voice comes over the line: \"I'm pickin' up some radio disturbances in the area.  Mostly, shit keeps goin' dead.  There's not much around, but it's gettin' worse the closer you get to a nearby house.  Be careful.  Over.\"",
-            "popup": true
-          },
+          { "open_dialogue": { "topic": "TALK_ROBOFAC_MERC_PAT_POI_unvitrified_orchard" } },
           { "u_add_var": "robofac_pat_saw_vitrified", "value": "yes" }
         ]
       },
@@ -451,10 +442,7 @@
           ]
         },
         "then": [
-          {
-            "u_message": "You hear a chirp in your earpiece and Pat's voice comes over the line: \"Whatever that building is ain't on my maps.  You might be gettin' close to some government spook shit.  Watch out.  Over.\"",
-            "popup": true
-          },
+          { "open_dialogue": { "topic": "TALK_ROBOFAC_MERC_PAT_POI_LIXA_surface_1a" } },
           { "u_add_var": "robofac_pat_saw_lixa", "value": "yes" }
         ]
       },
@@ -466,10 +454,7 @@
           ]
         },
         "then": [
-          {
-            "u_message": "You hear a chirp in your earpiece, and Pat's voice comes over the line: \"The photos I'm gettin' are worse than usual.  Somethin's fuckin' with the transmission.  I don't see anythin' on my maps, so be on lookout.  Over.\"",
-            "popup": true
-          },
+          { "open_dialogue": { "topic": "TALK_ROBOFAC_MERC_PAT_POI_temple_stairs" } },
           { "u_add_var": "robofac_pat_saw_strange_temple", "value": "yes" }
         ]
       },
@@ -481,10 +466,7 @@
           ]
         },
         "then": [
-          {
-            "u_message": "You hear a chirp in your earpiece, and Pat's voice comes over the line: \"You heah that?  Sounded like someone chatterin' on our band.  It was fuckin' spooky, too.  I dunno what kinda' trouble you're getting into down there, but the signal's too weak and I'm not getting pictures.  Be careful.  Over.\"",
-            "popup": true
-          },
+          { "open_dialogue": { "topic": "TALK_ROBOFAC_MERC_PAT_POI_mine_amigara_finale_central" } },
           { "u_add_var": "robofac_pat_saw_amigara", "value": "yes" }
         ]
       },
@@ -496,7 +478,7 @@
           ]
         },
         "then": [
-          { "u_message": "Your earpiece is filled with static and your HUD glitches.", "popup": true },
+          { "u_message": "Your comm is filled with static and your HUD glitches.", "popup": true },
           { "u_add_var": "robofac_pat_saw_highlands", "value": "yes" },
           { "math": [ "robofac_pat_lost_signal_highlands = 1" ] }
         ]
@@ -509,10 +491,7 @@
           ]
         },
         "then": [
-          {
-            "u_message": "You hear a chirp in your earpiece and Pat's voice comes over the line: \"Is that a fuckin' CASTLE?  Holy shit.  What the fuck world are we livin' in?  Anyway, get in there and bring me back a sword!\"  Pat starts to cackle and then the line cuts off with a chirp.",
-            "popup": true
-          },
+          { "open_dialogue": { "topic": "TALK_ROBOFAC_MERC_PAT_POI_exodii_base_x0y0z0" } },
           { "u_add_var": "robofac_pat_saw_exodii", "value": "yes" }
         ]
       },
@@ -524,10 +503,7 @@
           ]
         },
         "then": [
-          {
-            "u_message": "You hear a chirp in your earpiece and Pat's voice comes over the line: \"I'm not gettin' a good--cshhh--signal.  Yo--cshhh--eep underground.  Somethin' bad--cshhh--.  Over.\"",
-            "popup": true
-          },
+          { "open_dialogue": { "topic": "TALK_ROBOFAC_MERC_PAT_POI_microlab_portal_security1" } },
           { "u_add_var": "robofac_pat_saw_physics_lab", "value": "yes" }
         ]
       },
@@ -539,7 +515,7 @@
           ]
         },
         "then": [
-          { "u_message": "Your earpiece is filled with static and your HUD glitches.", "popup": true },
+          { "u_message": "Your comm is filled with static and your HUD glitches.", "popup": true },
           { "u_add_var": "robofac_pat_saw_labyrinth", "value": "yes" },
           { "math": [ "robofac_pat_lost_signal_labyrinth = 1" ] }
         ]
@@ -552,10 +528,7 @@
           ]
         },
         "then": [
-          {
-            "u_message": "You hear a chirp in your earpiece and Pat's voice comes over the line: \"I'm looking at some topological maps I got from a merc, and whatever that thing is up ahead stickin' out of the ground, it isn't the only one heah.  I don't think that's a cave, pal.  Over.\"",
-            "popup": true
-          },
+          { "open_dialogue": { "topic": "TALK_ROBOFAC_MERC_PAT_POI_corpse_surface" } },
           { "u_add_var": "robofac_pat_saw_monster_corpse", "value": "yes" }
         ]
       },
@@ -567,10 +540,7 @@
           ]
         },
         "then": [
-          {
-            "u_message": "You hear a chirp in your earpiece and Pat's voice comes over the line: \"Am I seeing those pictures right?  Is that thing glowin' over theah?  I checked my maps, and it should be a church.  No data on my old downloads, so I'd bet a beer it's one'a those culty ones.  Steer clear, bud.  No knowin' how crazy they got after everything that's happened.  Over.\"",
-            "popup": true
-          },
+          { "open_dialogue": { "topic": "TALK_ROBOFAC_MERC_PAT_POI_xedra_rural_church" } },
           { "u_add_var": "robofac_pat_saw_rural_church", "value": "yes" }
         ]
       },
@@ -582,10 +552,7 @@
           ]
         },
         "then": [
-          {
-            "u_message": "You hear a chirp in your earpiece and Pat's voice comes over the line: \"Bud, I've been watchin' for a while, and you're heading somewhere you don't wanna be.  You're close to Morgantown.  That place is fuckin' hauwnted - my uncle told me all about it.  They say it's full of ghosts and shit like that.  Wicked scary.  Over.\"",
-            "popup": true
-          },
+          { "open_dialogue": { "topic": "TALK_ROBOFAC_MERC_PAT_POI_morgantown_2b_far" } },
           { "u_add_var": "robofac_pat_saw_morgantown", "value": "yes" }
         ]
       },
@@ -597,10 +564,7 @@
           ]
         },
         "then": [
-          {
-            "u_message": "You hear a chirp in your earpiece and Pat's voice comes over the line in a faint whisper: \"I've just got a picture come through and I see them THINGS over theah.  Those freaky little SHITS look just like the parabolic dishes I used'ta'use to pickup sat signals.  If this ain't some tabletop RPG dumbass nerd shit I don't know what is, but I'd bet they use them to hear.  Be quiet or get the fuck outta' there.\"",
-            "popup": true
-          },
+          { "open_dialogue": { "topic": "TALK_ROBOFAC_MERC_PAT_POI_morgantown_2b_close" } },
           { "u_add_var": "robofac_pat_saw_morgantown_2", "value": "yes" }
         ]
       },
@@ -612,7 +576,7 @@
           ]
         },
         "then": [
-          { "u_message": "Your earpiece is filled with static and your HUD glitches.", "popup": true },
+          { "u_message": "Your comm is filled with static and your HUD glitches.", "popup": true },
           { "u_add_var": "robofac_pat_saw_cabin_reverb", "value": "yes" },
           { "math": [ "robofac_pat_lost_signal_cabin_reverb = 1" ] }
         ]
@@ -625,10 +589,7 @@
           ]
         },
         "then": [
-          {
-            "u_message": "Your earpiece is filled with static and your HUD glitches.  Suddenly, the sound of soft, slightly distorted smooth jazz starts to play in your earpiece - it continues for a moment before you hear a chirp and Pat's voice: \"What was that bullshit?  Pal, someone might be nearby with a transmitter.  There's not much but a radio tower nearby, so maybe there.  Lock and load.  Over.\"  A moment later, something, or someone, whispers an indiscernible word through the earpiece.  It then falls silent.",
-            "popup": true
-          },
+          { "open_dialogue": { "topic": "TALK_ROBOFAC_MERC_PAT_POI_radio_tower_reverberation_mp3" } },
           { "u_add_var": "robofac_pat_saw_radio_tower_reverberation_mp3", "value": "yes" }
         ]
       },
@@ -640,10 +601,7 @@
           ]
         },
         "then": [
-          {
-            "u_message": "Your earpiece is filled with static for a long moment before the faint sound of Pat's voice interrupts: \"I dunno what the fuck you're into down there, but I'm recordin'.  Keep goin'!",
-            "popup": true
-          },
+          { "open_dialogue": { "topic": "TALK_ROBOFAC_MERC_PAT_POI_mine_spiral_finale_s" } },
           { "u_add_var": "robofac_pat_saw_spiral_mine", "value": "yes" }
         ]
       },
@@ -655,10 +613,7 @@
           ]
         },
         "then": [
-          {
-            "u_message": "You hear a chirp in your earpiece and Pat's voice comes over the line:  \"Some'a your recent images are wicked twisted with errors and noise.  Not sure what's nearby, but it's messin' with the signal.  Over.\"",
-            "popup": true
-          },
+          { "open_dialogue": { "topic": "TALK_ROBOFAC_MERC_PAT_POI_cabin_3_reverberation_hint" } },
           { "u_add_var": "robofac_pat_saw_cabin_reverb_hint", "value": "yes" }
         ]
       },
@@ -670,7 +625,7 @@
           ]
         },
         "then": [
-          { "u_message": "Your earpiece is filled with static and your HUD glitches.", "popup": true },
+          { "u_message": "Your comm is filled with static and your HUD glitches.", "popup": true },
           { "u_add_var": "robofac_pat_saw_radiosphere", "value": "yes" },
           { "math": [ "robofac_pat_lost_signal_radiosphere = 1" ] }
         ]
@@ -683,7 +638,7 @@
           ]
         },
         "then": [
-          { "u_message": "Your earpiece is filled with static and your HUD glitches.", "popup": true },
+          { "u_message": "Your comm is filled with static and your HUD glitches.", "popup": true },
           { "u_add_var": "robofac_pat_saw_string_dimension", "value": "yes" },
           { "math": [ "robofac_pat_lost_signal_string_dimension = 1" ] }
         ]
@@ -696,81 +651,9 @@
           ]
         },
         "then": [
-          { "u_message": "Your earpiece is filled with static and your HUD glitches.", "popup": true },
+          { "u_message": "Your comm is filled with static and your HUD glitches.", "popup": true },
           { "u_add_var": "robofac_pat_saw_spider_dimension", "value": "yes" },
           { "math": [ "robofac_pat_lost_signal_spider_dimension = 1" ] }
-        ]
-      },
-      {
-        "if": {
-          "and": [ { "npc_near_om_location": "field", "range": 10 }, { "math": [ "robofac_pat_lost_signal_highlands == 1" ] } ]
-        },
-        "then": [
-          {
-            "u_message": "You hear a chirp in your earpiece and Pat's voice comes over the line: \"Holy shit, I'm slowly gettin' pictures now.  What the fuck happened to you?  One second you're walking through that water like a moron, and the next second, you're gone!  I'll look over the images as they come through.  You take it easy.  Over.\"",
-            "popup": true
-          },
-          { "math": [ "robofac_pat_lost_signal_highlands = 0" ] }
-        ]
-      },
-      {
-        "if": {
-          "and": [ { "npc_near_om_location": "field", "range": 10 }, { "math": [ "robofac_pat_lost_signal_radiosphere == 1" ] } ]
-        },
-        "then": [
-          {
-            "u_message": "You hear a chirp in your earpiece and Pat's voice comes over the line: \"What the hell, pal, I thought you fell off that radio tower.  What happened?  Wait, wait, wait image coming through now.  It looks broken?  Where the hell were you?  Over.\"",
-            "popup": true
-          },
-          { "math": [ "robofac_pat_lost_signal_radiosphere = 0" ] }
-        ]
-      },
-      {
-        "if": {
-          "and": [ { "npc_near_om_location": "field", "range": 10 }, { "math": [ "robofac_pat_lost_signal_labyrinth == 1" ] } ]
-        },
-        "then": [
-          {
-            "u_message": "You hear a chirp in your earpiece and Pat's voice comes over the line: \"Well, welcome back.  I guess that robot wasn't kidding.  Your radio signal vanished.  I'll record all the data as it comes through.\"",
-            "popup": true
-          },
-          { "math": [ "robofac_pat_lost_signal_labyrinth = 0" ] }
-        ]
-      },
-      {
-        "if": {
-          "and": [ { "npc_near_om_location": "field", "range": 10 }, { "math": [ "robofac_pat_lost_signal_cabin_reverb == 1" ] } ]
-        },
-        "then": [
-          {
-            "u_message": "You hear a chirp in your earpiece and Pat's voice comes over the line: \"I thought maybe you fell off that roof.  You alright?  I'm getting a backed up stream of shitty images now.  I'll record whatever the hell happened, I guess.  Over.\"",
-            "popup": true
-          },
-          { "math": [ "robofac_pat_lost_signal_cabin_reverb = 0" ] }
-        ]
-      },
-      {
-        "if": {
-          "and": [ { "npc_near_om_location": "field", "range": 10 }, { "math": [ "robofac_pat_lost_signal_string_dimension == 1" ] } ]
-        },
-        "then": [
-          {
-            "u_message": "You hear a chirp in your earpiece and Pat's voice comes over the line: \"There ya' are - once that last storm stahrted, I lost ya'.  I'll catch up as images come through, and we can talk latah.  Over.\"",
-            "popup": true
-          },
-          { "math": [ "robofac_pat_lost_signal_string_dimension = 0" ] }
-        ]
-      },
-      {
-        "if": {
-          "and": [ { "npc_near_om_location": "field", "range": 10 }, { "math": [ "robofac_pat_lost_signal_spider_dimension == 1" ] } ]
-        },
-        "then": [
-          {
-            "u_message": "You hear a chirp in your earpiece and Pat's voice comes over the line: \"Theah ya' go.  Got ya' back.  Lost the signal a while back, but she's strong now, and I got some images comin' in…  what in the livin' fuck?  Holy shit, looks like I should catch up.  We can talk latah.  Glad ya' back.  Ovah.\"",
-            "popup": true
-          },
-          { "math": [ "robofac_pat_lost_signal_spider_dimension = 0" ] }
         ]
       }
     ]

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/PAT/NPC_Pat.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/PAT/NPC_Pat.json
@@ -644,7 +644,7 @@
         "condition": { "math": [ "robofac_pat_lost_signal_radiosphere == 1" ] }
       },
       {
-        "text": "Honestly, Pat, I don't even known what to say about this place, yet. [ALPHA TEST LABYRINTH]",
+        "text": "Honestly, Pat, I don't even known what to say about this place, yet.  [ALPHA TEST LABYRINTH]",
         "topic": "TALK_ROBOFAC_MERC_PAT_POI_lost_signal_labyrinth",
         "condition": { "math": [ "robofac_pat_lost_signal_labyrinth == 1" ] }
       },

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/PAT/NPC_Pat.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/PAT/NPC_Pat.json
@@ -429,6 +429,20 @@
         "condition": { "compare_string": [ "yes", { "u_val": "robofac_pat_gave_gear" } ] }
       },
       {
+        "text": "Let's talk about when we lost contact earlier…",
+        "topic": "TALK_ROBOFAC_MERC_PAT_LOST_SIGNAL",
+        "condition": {
+          "or": [
+            { "math": [ "robofac_pat_lost_signal_highlands == 1" ] },
+            { "math": [ "robofac_pat_lost_signal_string_dimension == 1" ] },
+            { "math": [ "robofac_pat_lost_signal_radiosphere == 1" ] },
+            { "math": [ "robofac_pat_lost_signal_spider_dimension == 1" ] },
+            { "math": [ "robofac_pat_lost_signal_cabin_reverb == 1" ] },
+            { "math": [ "robofac_pat_lost_signal_labyrinth == 1" ] }
+          ]
+        }
+      },
+      {
         "text": "Just came by to chat.",
         "topic": "TALK_ROBOFAC_MERC_PAT_MORALE_CHAT",
         "condition": {
@@ -603,6 +617,44 @@
     ],
     "speaker_effect": { "effect": [ "morale_chat_activity", { "npc_add_effect": "asked_to_socialize", "duration": 7000 } ] },
     "responses": [ { "text": "[Have a chat then say goodbye]", "topic": "TALK_DONE" } ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_LOST_SIGNAL",
+    "type": "talk_topic",
+    "dynamic_line": "Yeah, I was tryin' to ping ya' for a while.  What happened?",
+    "responses": [
+      {
+        "text": "I was standing in a bit of water during a portal storm, and next thing I know, I found myself in some sort of field?  Stretched as far as the eye could see.",
+        "topic": "TALK_ROBOFAC_MERC_PAT_POI_lost_signal_highlands",
+        "condition": { "math": [ "robofac_pat_lost_signal_highlands == 1" ] }
+      },
+      {
+        "text": "I got tangled up in these webs, and then all of a sudden I'm in some sort of cavern, with the biggest spider I've ever seen.",
+        "topic": "TALK_ROBOFAC_MERC_PAT_POI_lost_signal_spider_dimension",
+        "condition": { "math": [ "robofac_pat_lost_signal_spider_dimension == 1" ] }
+      },
+      {
+        "text": "I was standing on the roof of that cabin in a portal storm, when everything just…  it's like I was in a world of just, cabins.  Forever.  Repeating themselves.",
+        "topic": "TALK_ROBOFAC_MERC_PAT_POI_lost_signal_cabin_reverb",
+        "condition": { "math": [ "robofac_pat_lost_signal_cabin_reverb == 1" ] }
+      },
+      {
+        "text": "I was standing up on a radio tower during a portal storm, when everything just…  I don't really know, it's like I fell.  But then there were radio towers.  Forever.  Repeating themselves.",
+        "topic": "TALK_ROBOFAC_MERC_PAT_POI_lost_signal_radiosphere",
+        "condition": { "math": [ "robofac_pat_lost_signal_radiosphere == 1" ] }
+      },
+      {
+        "text": "Honestly, Pat, I don't even known what to say about this place, yet. [ALPHA TEST LABYRINTH]",
+        "topic": "TALK_ROBOFAC_MERC_PAT_POI_lost_signal_labyrinth",
+        "condition": { "math": [ "robofac_pat_lost_signal_labyrinth == 1" ] }
+      },
+      {
+        "text": "You know that glowing string I was carrying around?  It started moving in the portal storm, and then I was in this…  place.  It's hard to describe.",
+        "topic": "TALK_ROBOFAC_MERC_PAT_POI_lost_signal_string_dimension",
+        "condition": { "math": [ "robofac_pat_lost_signal_string_dimension == 1" ] }
+      },
+      { "text": "Actually, maybe another time.", "topic": "TALK_ROBOFAC_MERC_PAT" }
+    ]
   },
   {
     "id": "TALK_ROBOFAC_MERC_PAT_GEAR_MENU",

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/PAT/NPC_Pat_POIs.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/PAT/NPC_Pat_POIs.json
@@ -151,8 +151,8 @@
     "type": "talk_topic",
     "dynamic_line": {
       "compare_string": [ "yes", { "u_val": "robofac_pat_knows_u_cyborg" } ],
-      "yes": "&You hear a chirp in your comm and Pat's voice comes over the line: \"Pat ta' <pat_robo_nickname>.  Is that a fahkin' CASTLE? Holy shit.  What the fahk kinda' world are we livin' in?  Anyway, get in there and bring me back a sword!  Ovah.\"",
-      "no": "&You hear a chirp in your comm and Pat's voice comes over the line: \"Pat heah.  Is that a fahkin' CASTLE?  What the fahk kinda' world are we livin' in?  Anyway, get in there and bring me back a sword!  Ovah.\""
+      "yes": "&You hear a chirp in your comm and Pat's voice comes over the line: \"Pat ta' <pat_robo_nickname>.  Is that a fahkin' CASTLE?  Holy shit.  What the fahk kinda' world are we livin' in?  Anyway, get in there and bring me back a sword!  Ovah.\"",
+      "no": "&You hear a chirp in your comm and Pat's voice comes over the line: \"Pat heah.  Is that a fahkin' CASTLE?  Holy shit.  What the fahk kinda' world are we livin' in?  Anyway, get in there and bring me back a sword!  Ovah.\""
     },
     "responses": [
       {

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/PAT/NPC_Pat_POIs.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/PAT/NPC_Pat_POIs.json
@@ -1,0 +1,480 @@
+[
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_POI_unvitrified_orchard",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "compare_string": [ "yes", { "u_val": "robofac_pat_knows_u_cyborg" } ],
+      "yes": "&You hear a chirp in your comm and Pat's voice comes over the line: \"Pat ta' <pat_robo_nickname>.  I'm pickin' up some radio disturbances.  Ovah.\"",
+      "no": "&You hear a chirp in your comm and Pat's voice comes over the line: \"Pat heah.  I'm pickin' up some radio disturbances.  Ovah.\""
+    },
+    "responses": [
+      {
+        "text": "I'm getting close to that farmstead the merc told us about.  Pick up any more recon?  Over.",
+        "topic": "TALK_ROBOFAC_MERC_PAT_POI_unvitrified_orchard_recon",
+        "condition": { "u_has_mission": "MISSION_ROBOFAC_PAT_RECON_1" }
+      },
+      { "text": "What kind of disturbances?  Over.", "topic": "TALK_ROBOFAC_MERC_PAT_POI_unvitrified_orchard_1" },
+      {
+        "text": "Not now, Pat.  We'll talk about this later.  Over and out.",
+        "topic": "TALK_DONE",
+        "effect": { "u_add_var": "robofac_pat_talk_unvitrified_orchard_later", "value": "yes" }
+      },
+      {
+        "text": "[Quickly Chirp the radio twice and stay silent]",
+        "topic": "TALK_DONE",
+        "effect": { "u_add_var": "robofac_pat_talk_unvitrified_orchard_later", "value": "yes" }
+      }
+    ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_POI_unvitrified_orchard_recon",
+    "type": "talk_topic",
+    "dynamic_line": "Ah, yeah, actually, I did.  Listen.  I'm not sure it's a good idea.  Talked to a buddy of that same fahkin' merc.  Turns out the merc was goin' to explore that house, but nevah came back.  On top'a that, now that you're close, the fahkin' feed keeps goin dead.  Don't bode well.  If ya' go, be prepared for somethin' real bad to happen.  Go get a snack, some smokes, and some watah.  Ovah.",
+    "responses": [ { "text": "Got it.  Thanks, Pat.  Over and out.", "topic": "TALK_DONE" } ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_POI_unvitrified_orchard_1",
+    "type": "talk_topic",
+    "dynamic_line": "Mostly the fahkin' feed keeps goin' dead.  I've been checkin the maps, and it seems worse the closer you get to that house ovah there.  Go check it out, yeah?  Ovah'n'out.",
+    "responses": [ { "text": "Over and out.", "topic": "TALK_DONE" } ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_POI_LIXA_surface_1a",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "compare_string": [ "yes", { "u_val": "robofac_pat_knows_u_cyborg" } ],
+      "yes": "&You hear a chirp in your comm and Pat's voice comes over the line: \"Pat ta' <pat_robo_nickname>.  Hang on.  Need to confirm ya' location.  Ovah.\"",
+      "no": "&You hear a chirp in your comm and Pat's voice comes over the line: \"Pat heah.  Hang on.  Need to confirm ya' location.  Ovah.\""
+    },
+    "responses": [
+      {
+        "text": "I'm getting close to that Department of Energy facility we talked about.  What's up?  Over.",
+        "topic": "TALK_ROBOFAC_MERC_PAT_POI_LIXA_surface_1a_recon",
+        "condition": { "u_has_mission": "MISSION_ROBOFAC_PAT_RECON_2" }
+      },
+      { "text": "What's going on?  Over.", "topic": "TALK_ROBOFAC_MERC_PAT_POI_LIXA_surface_1a_1" },
+      {
+        "text": "Not now, Pat.  We'll talk about this later.  Over and out.",
+        "topic": "TALK_DONE",
+        "effect": { "u_add_var": "robofac_pat_talk_LIXA_surface_1a_later", "value": "yes" }
+      },
+      {
+        "text": "[Chirp Pat twice and stay silent]",
+        "topic": "TALK_DONE",
+        "effect": { "u_add_var": "robofac_pat_talk_LIXA_surface_1a_later", "value": "yes" }
+      }
+    ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_POI_LIXA_surface_recon",
+    "type": "talk_topic",
+    "dynamic_line": "That's what I thought.  Turns out theah's some chattah about this place around the Hub with the mercs.  If you're there for a scan, set up the HEW, scan from outside, and get the fahk outta theah.",
+    "responses": [ { "text": "Got it.  Over and out.", "topic": "TALK_DONE" } ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_POI_LIXA_surface_1a_1",
+    "type": "talk_topic",
+    "dynamic_line": "&The line is silent a moment before Pat chirps back: \"Well, nothin'.  It's just that this buildin' isn' on my maps.  If I had to guess, it's some sort of government spook shit.  Ovah\"",
+    "responses": [
+      {
+        "text": "It's that LIXA place - that contract I accepted from the intercom.  Over.",
+        "topic": "TALK_ROBOFAC_MERC_PAT_POI_LIXA_surface_1a_2",
+        "condition": { "u_has_mission": "MISSION_ROBOFAC_INTERCOM_LIXA_SM_1" }
+      },
+      { "text": "I'll be careful.  Over and out.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_POI_LIXA_surface_1a_2",
+    "type": "talk_topic",
+    "dynamic_line": "Right, right.  Without the intahnet I couldn't find shit about this, but I did ask around when I heard about it.  Some of the othah mercs have been avoidin' the job.  Nothin' concrete, but they just don't like the sound of it.  Doesn't bode well for us, I think.  Ovah'n'out.",
+    "responses": [ { "text": "Over and out.", "topic": "TALK_DONE" } ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_POI_temple_stairs",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "compare_string": [ "yes", { "u_val": "robofac_pat_knows_u_cyborg" } ],
+      "yes": "&You hear a chirp in your comm and Pat's voice comes over the line: \"Pat ta' <pat_robo_nickname>.  The photos I'm gettin' are worse than usual.  Somethin's fahkin' with the transmission.  Just be careful, yeah?  Ovah.\"",
+      "no": "&You hear a chirp in your comm and Pat's voice comes over the line: \"Pat heah.  The photos I'm gettin' are worse than usual.  Somethin's fahkin' with the transmission.  Just be careful, yeah?  Ovah.\""
+    },
+    "responses": [
+      {
+        "text": "I'm near the point from that treasure map you bought.  Think it's that?  Over.",
+        "topic": "TALK_ROBOFAC_MERC_PAT_POI_temple_stairs_recon",
+        "condition": { "u_has_mission": "MISSION_ROBOFAC_PAT_RECON_3" }
+      },
+      { "text": "Alright.  Over and out.", "topic": "TALK_DONE" },
+      { "text": "[Chirp Pat twice and stay silent]", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_POI_temple_stairs_recon",
+    "type": "talk_topic",
+    "dynamic_line": "Might be.  Remembah, it's some sort of grate in the ground.  Might be tough'ta spot.  Keep an eye out.",
+    "responses": [ { "text": "Right.  Over and out.", "topic": "TALK_DONE" } ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_POI_mine_amigara_finale_central",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "compare_string": [ "yes", { "u_val": "robofac_pat_knows_u_cyborg" } ],
+      "yes": "&You hear a chirp in your comm and Pat's voice comes over the line, broken up by static: \"Pat ta' <pat_robo_nickname>. You heah tha-- sound?  Ovah.\"",
+      "no": "&You hear a chirp in your comm and Pat's voice comes over the line, broken up by static: \"Pat heah.  You heah tha-- sound?  Ovah.\""
+    },
+    "responses": [
+      {
+        "text": "Hear what?  Over.",
+        "topic": "TALK_ROBOFAC_MERC_PAT_POI_mine_amigara_finale_central_1",
+        "effect": { "u_add_var": "robofac_pat_talk_mine_amigara_finale_central_later", "value": "yes" }
+      },
+      {
+        "text": "Not now, Pat.  We'll talk about this later.  Over and out.",
+        "topic": "TALK_DONE",
+        "effect": { "u_add_var": "robofac_pat_talk_mine_amigara_finale_central_later", "value": "yes" }
+      },
+      {
+        "text": "[Chirp Pat twice and stay silent]",
+        "topic": "TALK_DONE",
+        "effect": { "u_add_var": "robofac_pat_talk_mine_amigara_finale_central_later", "value": "yes" }
+      }
+    ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_POI_mine_amigara_finale_central_1",
+    "type": "talk_topic",
+    "dynamic_line": "Sounded like someone--omething, chattin' on -- frequency.  It's gone-\"… the signal becomes dead static.",
+    "responses": [ { "text": "…", "topic": "TALK_DONE" } ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_POI_exodii_base_x0y0z0",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "compare_string": [ "yes", { "u_val": "robofac_pat_knows_u_cyborg" } ],
+      "yes": "&You hear a chirp in your comm and Pat's voice comes over the line: \"Pat ta' <pat_robo_nickname>.  Is that a fahkin' CASTLE? Holy shit.  What the fahk kinda' world are we livin' in?  Anyway, get in there and bring me back a sword!  Ovah.\"",
+      "no": "&You hear a chirp in your comm and Pat's voice comes over the line: \"Pat heah.  Is that a fahkin' CASTLE?  What the fahk kinda' world are we livin' in?  Anyway, get in there and bring me back a sword!  Ovah.\""
+    },
+    "responses": [
+      {
+        "text": "It's gotta be that castle that crazy guy said \"blipped\" into existence, right?  Over.",
+        "topic": "TALK_ROBOFAC_MERC_PAT_POI_exodii_base_x0y0z0_recon",
+        "condition": { "u_has_mission": "MISSION_ROBOFAC_PAT_RECON_5" }
+      },
+      {
+        "text": "It's that place the teamster told me about.  Over.",
+        "topic": "TALK_ROBOFAC_MERC_PAT_POI_exodii_base_x0y0z0_1",
+        "condition": { "u_has_mission": "directions_exodii" }
+      },
+      {
+        "text": "It's that place from that sign I found.  Over.",
+        "topic": "TALK_ROBOFAC_MERC_PAT_POI_exodii_base_x0y0z0_1",
+        "condition": { "u_has_mission": "directions_exodii_signpost" }
+      },
+      {
+        "text": "From here it looks like a pile of scrap metal, but I can't really tell.  That mean anything to you?  Over.",
+        "topic": "TALK_ROBOFAC_MERC_PAT_POI_exodii_base_x0y0z0_1"
+      },
+      { "text": "I'll see what I can do.  Over and out.", "topic": "TALK_DONE" },
+      {
+        "text": "Not now, Pat.  We'll talk about this later.  Over and out.",
+        "topic": "TALK_DONE",
+        "effect": { "u_add_var": "robofac_pat_talk_exodii_base_x0y0z0_later", "value": "yes" }
+      },
+      {
+        "text": "[Chirp Pat twice and stay silent]",
+        "topic": "TALK_DONE",
+        "effect": { "u_add_var": "robofac_pat_talk_exodii_base_x0y0z0_later", "value": "yes" }
+      }
+    ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_POI_exodii_base_x0y0z0_recon",
+    "type": "talk_topic",
+    "dynamic_line": "Gotta fahkin' be.  Listen, I got an update.  While ya' was gone, I met some merc hangin' around with a strange gun - it's relevant, I sweah.  Anyway.  Asked'em where he got it, and he told me to mind my own fahkin' business, so I told him to fahk off, and anyway, long story short, he says he got it off some killah robot he found out in the wildahness, near some kind of fahkin' scrap-metal pod with a sign.  I dunno.  Seems relevant.  If it's killah-fahkin' robots, set the HEW up, get a scan, and bounce.  Ovah'n'out.",
+    "responses": [ { "text": "Thanks, Pat.  Over and out.", "topic": "TALK_DONE" } ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_POI_exodii_base_x0y0z0_1",
+    "type": "talk_topic",
+    "dynamic_line": "Ah, right.  Now that ya mention it, I saw some merc hangin' around with a strange gun - it's relevant, I sweah.  Anyway.  Asked'em where he got it, and he told me to mind my own fahkin' business, so I told him to fahk off, and anyway, long story short, he says he got it off some killah robot he found out in the wildahness, near some kind of fahkin' scrap-metal pod with a sign.  I dunno.  Seems relevant.  Ovah'n'out.",
+    "responses": [ { "text": "Thanks, Pat.  Over and out.", "topic": "TALK_DONE" } ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_POI_microlab_portal_security1",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "compare_string": [ "yes", { "u_val": "robofac_pat_knows_u_cyborg" } ],
+      "yes": "&You hear a chirp in your comm and Pat's voice comes over the line, broken up by static: \"Pat ta' <pat_robo_nickname>.  I'm not gettin' a good--cshhh--signal.  Yo--cshhh--eep underground.  Somethin' bad--cshhh--\"…  the line is then filled with dead static.",
+      "no": "&You hear a chirp in your comm and Pat's voice comes over the line, broken up by static: \"Pat heah.  I'm not gettin' a good--cshhh--signal.  Yo--cshhh--eep underground.  Somethin' bad--cshhh--\"…  the line is then filled with dead static."
+    },
+    "responses": [
+      {
+        "text": "…",
+        "topic": "TALK_DONE",
+        "effect": { "u_add_var": "robofac_pat_talk_microlab_portal_security1_later", "value": "yes" }
+      }
+    ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_POI_corpse_surface",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "compare_string": [ "yes", { "u_val": "robofac_pat_knows_u_cyborg" } ],
+      "yes": "&You hear a chirp in your comm and Pat's voice comes over the line: \"Pat ta' <pat_robo_nickname>.  Ovah.\"",
+      "no": "&You hear a chirp in your comm and Pat's voice comes over the line: \"Pat heah.  Ovah.\""
+    },
+    "responses": [
+      {
+        "text": "I'm close to that place the hunk of meat came from.  See anything?  Over.",
+        "topic": "TALK_ROBOFAC_MERC_PAT_POI_corpse_surface_2",
+        "condition": { "u_has_mission": "MISSION_ROBOFAC_PAT_RECON_7" }
+      },
+      {
+        "text": "Hey, Pat.  I'm getting close to that… thing I'm supposed to go into for the Hub.  Over.",
+        "topic": "TALK_ROBOFAC_MERC_PAT_POI_corpse_surface_1",
+        "condition": { "u_has_mission": "MISSION_ROBOFAC_INTERCOM_MWS_MONSTER_CORPSE" }
+      },
+      { "text": "Go ahead, Pat.  Over.", "topic": "TALK_ROBOFAC_MERC_PAT_POI_corpse_surface_2" },
+      {
+        "text": "Not now, Pat.  We'll talk about this later.  Over and out.",
+        "topic": "TALK_DONE",
+        "effect": { "u_add_var": "robofac_pat_talk_corpse_surface_later", "value": "yes" }
+      },
+      {
+        "text": "[Chirp Pat twice and stay silent]",
+        "topic": "TALK_DONE",
+        "effect": { "u_add_var": "robofac_pat_talk_corpse_surface_later", "value": "yes" }
+      }
+    ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_POI_corpse_surface_1",
+    "type": "talk_topic",
+    "dynamic_line": "Ah, right.  Yeah, that ain't no fahkin' cave.  I looked ovah my old maps, and couldn't find anythin' theah before <the_cataclysm>.  Whatever it is is supahnatahral, ya' undahstand?",
+    "responses": [ { "text": "Thanks, Pat.  Over and out.", "topic": "TALK_DONE" } ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_POI_corpse_surface_2",
+    "type": "talk_topic",
+    "dynamic_line": "You see that fahkin'… thing, nearby?  In the distance?  Looks like a cave, but it isn't no fahkin' cave.  I looked ovah my old maps, and couldn't find anythin' theah before <the_cataclysm>.  Whatever it is is supahnatahral, ya' undahstand?",
+    "responses": [ { "text": "Thanks, Pat.  Over and out.", "topic": "TALK_DONE" } ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_POI_xedra_rural_church",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "compare_string": [ "yes", { "u_val": "robofac_pat_knows_u_cyborg" } ],
+      "yes": "&You hear a chirp in your comm and Pat's voice comes over the line: \"Pat ta' <pat_robo_nickname>.  You see that?  Ovah.\"",
+      "no": "&You hear a chirp in your comm and Pat's voice comes over the line: \"Pat heah.  You see that?  Ovah.\""
+    },
+    "responses": [
+      {
+        "text": "Yeah, that purple glow in the distance?  I'm getting close to the location that photo was taken.  Over.",
+        "topic": "TALK_ROBOFAC_MERC_PAT_POI_xedra_rural_church_recon",
+        "condition": { "u_has_mission": "MISSION_ROBOFAC_PAT_RECON_8" }
+      },
+      {
+        "text": "Yeah, that faint purple glow in the distance, I think I do.  I've got an address from some \"XEDRA\" notebook.  Know anything about it?  Over.",
+        "topic": "TALK_ROBOFAC_MERC_PAT_POI_xedra_rural_church_1",
+        "condition": { "u_has_mission": "MISSION_XEDRA_FIELD_STATION_1" }
+      },
+      { "text": "See what?  Over.", "topic": "TALK_ROBOFAC_MERC_PAT_POI_xedra_rural_church_2" },
+      {
+        "text": "Not now, Pat.  We'll talk about this later.  Over and out.",
+        "topic": "TALK_DONE",
+        "effect": { "u_add_var": "robofac_pat_talk_xedra_rural_church_later", "value": "yes" }
+      },
+      {
+        "text": "[Chirp Pat twice and stay silent]",
+        "topic": "TALK_DONE",
+        "effect": { "u_add_var": "robofac_pat_talk_xedra_rural_church_later", "value": "yes" }
+      }
+    ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_POI_xedra_rural_church_recon",
+    "type": "talk_topic",
+    "dynamic_line": "Yeah, check this out.  Aftah we talked I tracked down the merc that sold me the photo.  Turns out she went back.  She opened the door, crawled through a fahkin' blocked-up hallway, and got inside.  She tells me she opens the next door an' BAM - somethin' grabs her.  She said it didn' fahkin' hurt, but it was STRONG.  Wicked strong.  Said she couldn' even describe it, just, like, some kinda' fahkin' THING.  So whatevah it is, if ya' get close, make sure ya' got an escape, yeah?  Don't just fahkin' bumble in there like an idiot.  Pat ovah'n'out.",
+    "responses": [ { "text": "Thanks, Pat.  Over and out.", "topic": "TALK_DONE" } ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_POI_xedra_rural_church_1",
+    "type": "talk_topic",
+    "dynamic_line": "&The comm is silent a moment before Pat chirps back.  \"Dunno if it's helpful, but my old map cache says there's a church theah.  Go slow, quiet, and careful, yeah?",
+    "responses": [ { "text": "Thanks, Pat.  Over and out.", "topic": "TALK_DONE" } ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_POI_xedra_rural_church_2",
+    "type": "talk_topic",
+    "dynamic_line": "Look closah, theah, in the distance.  Caught it on one'a the pics that came through.  Look's like it's glowin' purple.  Checked my maps, and it's definitely that church theah in the distance.  Somethin' goin' on.  Go slow, quiet, careful, yeah?",
+    "responses": [ { "text": "Thanks, Pat.  Over and out.", "topic": "TALK_DONE" } ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_POI_morgantown_2b_far",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "compare_string": [ "yes", { "u_val": "robofac_pat_knows_u_cyborg" } ],
+      "yes": "&You hear a chirp in your comm and Pat's voice comes over the line: \"Pat ta' <pat_robo_nickname>.  Gettin' a bit too close to Morgantown for my likin'.  Ovah.\"",
+      "no": "&You hear a chirp in your comm and Pat's voice comes over the line: \"Pat heah.  Gettin' a bit too close to Morgantown for my likin'.  Ovah.\""
+    },
+    "responses": [
+      {
+        "text": "Morgantown?  Look, I'm close to the place that merc said they saw a creature in the woods.  Must be there, yeah?  What do you know about Morgantown?  Over.",
+        "topic": "TALK_ROBOFAC_MERC_PAT_POI_morgantown_2b_far_1",
+        "condition": { "u_has_mission": "MISSION_ROBOFAC_PAT_RECON_9" }
+      },
+      {
+        "text": "Morgantown?  I've got an address from some \"XEDRA\" notebook leading me that direction.  Over.",
+        "topic": "TALK_ROBOFAC_MERC_PAT_POI_morgantown_2b_far_1",
+        "condition": { "u_has_mission": "MISSION_XEDRA_FIELD_STATION_2" }
+      },
+      { "text": "Morgantown?  Never heard of it.  Over.", "topic": "TALK_ROBOFAC_MERC_PAT_POI_morgantown_2b_far_1" },
+      {
+        "text": "Not now, Pat.  We'll talk about this later.  Over and out.",
+        "topic": "TALK_DONE",
+        "effect": { "u_add_var": "robofac_pat_talk_morgantown_2b_later", "value": "yes" }
+      },
+      {
+        "text": "[Chirp Pat twice and stay silent]",
+        "topic": "TALK_DONE",
+        "effect": { "u_add_var": "robofac_pat_talk_morgantown_2b_later", "value": "yes" }
+      }
+    ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_POI_morgantown_2b_far_1",
+    "type": "talk_topic",
+    "dynamic_line": "Yeah, some old place in the woods, all fenced off.  That place is fahkin' hauwnted - my uncle told me all about it.  They say it's full of ghosts and shit like that.  Wicked scary.  I don't believe in ghosts, don't get me wrong, but I didn't believe in zombies either before <the_cataclysm>, so, ya' know, put that in ya' pipe and smoke it.",
+    "responses": [ { "text": "I'll be careful.  Over and out.", "topic": "TALK_DONE" } ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_POI_morgantown_2b_close",
+    "type": "talk_topic",
+    "dynamic_line": "&You hear a chirp in your comm and Pat's hushed voice comes over the line: \"Listen', don' respond.  I've just got a picture come through and I see them THINGS over theah.  Those freaky little SHITS look just like the parabolic dishes I used'ta'use to pickup sat signals.  If this ain't some tabletop RPG dumbass nerd shit I don't know what is, but I'd bet they use them to hear.  Be quiet or get the fahk outta' there.  Bettah' yeah, go around back and fiah off a few shots, yeah?  Maybe they'll scramble over there n' you can poke around in safety.\"",
+    "responses": [ { "text": "[Chirp Pat once and stay silent]", "topic": "TALK_DONE" } ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_POI_radio_tower_reverberation_mp3",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "u_has_mission": "MISSION_ROBOFAC_PAT_RECON_11",
+      "yes": "&Your comm is filled with static and your HUD glitches.  Suddenly, the sound of soft, slightly distorted smooth jazz starts to play in your earpiece - it continues for a moment before you hear a chirp and Pat's voice:\n\n\"That's it!  That's the fahkin' sound I hear!  Pal, someone might be nearby with a transmittah, fahkin' with ya'.  There's not much but that radio towah we talked about, so maybe there.  Lock and load.  Ovah.\"",
+      "no": "&Your comm is filled with static and your HUD glitches.  Suddenly, the sound of soft, slightly distorted smooth jazz starts to play in your earpiece - it continues for a moment before you hear a chirp and Pat's voice:\n\n\"What was that bullshit?  Pal, someone might be nearby with a transmittah, fahkin' with ya'.  There's not much but a radio towah nearby, so maybe there.  Lock and load.  Ovah.\""
+    },
+    "responses": [
+      { "text": "I'll check it out.  Over and out.", "topic": "TALK_ROBOFAC_MERC_PAT_POI_radio_tower_reverberation_mp3_1" }
+    ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_POI_radio_tower_reverberation_mp3_1",
+    "type": "talk_topic",
+    "dynamic_line": "&Your comm is filled with static again and your HUD glitches.  Something, or someone, whispers an indiscernible word through the earpiece.  It then falls silent.",
+    "responses": [ { "text": "…", "topic": "TALK_DONE" } ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_POI_mine_spiral_finale_s",
+    "type": "talk_topic",
+    "dynamic_line": "Your comm is filled with static for a long moment before the faint sound of Pat's voice interrupts: \"I dunno what the fahk you're into down theah, but I'm recordin'.  Keep goin'!\"",
+    "responses": [ { "text": "…", "topic": "TALK_DONE" } ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_POI_cabin_3_reverberation_hint",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "compare_string": [ "yes", { "u_val": "robofac_pat_knows_u_cyborg" } ],
+      "yes": "&You hear a chirp in your comm and Pat's voice comes over the line: \"Pat ta' <pat_robo_nickname>.  Some'a your recent images are wicked twisted with errors and noise.  Not sure what's nearby, but it's messin' with the signal.  Ovah.\"",
+      "no": "&You hear a chirp in your comm and Pat's voice comes over the line: \"Pat heah.  Some'a your recent images are wicked twisted with errors and noise.  Not sure what's nearby, but it's messin' with the signal.  Ovah.\""
+    },
+    "responses": [
+      {
+        "text": "I'm close to the cabin we talked about.  Think that's it?  Over.",
+        "topic": "TALK_ROBOFAC_MERC_PAT_POI_cabin_3_reverberation_hint_1",
+        "condition": { "u_has_mission": "MISSION_ROBOFAC_PAT_RECON_10" }
+      },
+      { "text": "I'll be careful.  Thanks, Pat.  Over and out.", "topic": "TALK_DONE" },
+      { "text": "[Chirp Pat twice and stay silent]", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_POI_cabin_3_reverberation_hint_1",
+    "type": "talk_topic",
+    "dynamic_line": "Gotta be.  I asked around aftah we talked, and nobody has talked to that lonah in days, turns out.  They haven't been around.  They're either theah in the cabin, or gone.  Fahkin' lock'n'load and be ready.  Ovah'n'out.",
+    "responses": [ { "text": "Thanks, Pat.  Over and out.", "topic": "TALK_DONE" } ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_POI_lost_signal_string_dimension",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "compare_string": [ "yes", { "u_val": "robofac_pat_saw_exodii" } ],
+      "yes": "That's fahkin' insane.  Look, I've been pourin' over the data the system collected while ya' was there, and the weathah is out of control.  Cold.  Real low preshah.  But also, when I'm checkin' temps and the rangefindah, I'm seein' little blops of heat in the distance, with some sorta structahs.  Lots'a little ones, and one big one.  Anothah thing.  I picked up some fahkin' radio signals, but I can't understand'em.  It's the EXACT same shit those robots from the scrap castle are kickin' out.  Odd, right?  If I had a dollah to bet, I bet if you looked around you'd find more'a them robots.  Dunno if it's anything you saw, but if ya' can get back, and wanna go back, may be worth explorin'.",
+      "no": "That's fahkin' insane.  Look, I've been pourin' over the data the system collected while ya' was there, and the weathah is out of control.  Cold.  Real low preshah.  But also, when I'm checkin' temps and the rangefindah, I'm seein' little blops of heat in the distance, with some sorta structahs.  Lots'a little ones, and one big one.  Anothah thing.  I picked up some fahkin' radio signals, but I can't understand'em.  But it's somethin' I've picked up heah now and again, too.  Somethin' is alive theah.  Dunno if it's anything you saw, but if ya' can get back, and wanna go back, may be worth explorin'."
+    },
+    "responses": [
+      {
+        "text": "I'll remember that, Pat.",
+        "topic": "TALK_ROBOFAC_MERC_PAT",
+        "effect": { "math": [ "robofac_pat_lost_signal_string_dimension = 0" ] }
+      }
+    ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_POI_lost_signal_labyrinth",
+    "type": "talk_topic",
+    "dynamic_line": "Me neithah.",
+    "responses": [
+      {
+        "text": "[shrug at Pat]",
+        "topic": "TALK_ROBOFAC_MERC_PAT",
+        "effect": { "math": [ "robofac_pat_lost_signal_labyrinth = 0" ] }
+      }
+    ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_POI_lost_signal_radiosphere",
+    "type": "talk_topic",
+    "dynamic_line": "Ya' fahkin' kiddin' me.  I don't even know what to say.",
+    "responses": [
+      {
+        "text": "[shrug at Pat]",
+        "topic": "TALK_ROBOFAC_MERC_PAT",
+        "effect": { "math": [ "robofac_pat_lost_signal_radiosphere = 0" ] }
+      }
+    ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_POI_lost_signal_cabin_reverb",
+    "type": "talk_topic",
+    "dynamic_line": "Ya' fahkin' kiddin' me.  I don't even know what to say.",
+    "responses": [
+      {
+        "text": "[shrug at Pat]",
+        "topic": "TALK_ROBOFAC_MERC_PAT",
+        "effect": { "math": [ "robofac_pat_lost_signal_cabin_reverb = 0" ] }
+      }
+    ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_POI_lost_signal_spider_dimension",
+    "type": "talk_topic",
+    "dynamic_line": "Ya' fahkin' kiddin' me.  I don't even know what to say.",
+    "responses": [
+      {
+        "text": "[shrug at Pat]",
+        "topic": "TALK_ROBOFAC_MERC_PAT",
+        "effect": { "math": [ "robofac_pat_lost_signal_spider_dimension = 0" ] }
+      }
+    ]
+  },
+  {
+    "id": "TALK_ROBOFAC_MERC_PAT_POI_lost_signal_highlands",
+    "type": "talk_topic",
+    "dynamic_line": "That's straight freakin' nuts.  But.  You were theah long enough for me to get some good data from ya' rangefindah and othah instruments.  Theah's definitely some man-made shit theah, but I didn't pick up a single other radio signal or anythin' of the sort.  Dunno what to make'a that.",
+    "responses": [
+      {
+        "text": "Not sure, Pat.  But I'll let you know if I learn anything.",
+        "topic": "TALK_ROBOFAC_MERC_PAT",
+        "effect": { "math": [ "robofac_pat_lost_signal_highlands = 0" ] }
+      }
+    ]
+  }
+]

--- a/data/json/npcs/snippets/talk_tags.json
+++ b/data/json/npcs/snippets/talk_tags.json
@@ -304,5 +304,29 @@
     "type": "snippet",
     "category": "<granny_name_g>",
     "text": [ { "text": { "ctxt": "<granny_name_g>", "str": "child" } }, "my child", "dear", "my dear", "friend", "survivor" ]
+  },
+  {
+    "type": "snippet",
+    "category": "<pat_robo_nuckname>",
+    "text": [
+      "Tin Tony",
+      "Wi-Fi",
+      "Bluetooth",
+      "Robocawp",
+      "Beep-Boop",
+      "Toastah",
+      "Clankah",
+      "Skinjob",
+      "HAL",
+      "WALL-E",
+      "3PO",
+      "Sparky",
+      "Transformah",
+      "Terminatah",
+      "Circuit Breakah",
+      "Tinfoil",
+      "Nuts'n'bolts",
+      "Neo"
+    ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Features "Pat uses dialogue instead of pop-up messages"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Pat would communicate through various communication devices while traveling the world.  When near POIs, you'd get a `u_message` from Pat.  This was less than ideal, because it was sort of like Pat just yelling at you, and you couldn't really talk about what they say.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

I've switched these all of the dialogue to actual dialogue, so that you can have a brief back and forth with Pat instead of just reading a popup.  This allows for branching conversations, which is nice if you have relevant missions or information about the place Pat is telling you about.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Different dialogue

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Loaded up one of Pat's headsets and visited all the locations.  Dialogue opens up as expected.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I also added a few variables in the style of `robofac_pat_talk_LOCATION_later`.  This way you can cut Pat off when they call, but continue the conversation later.  Dialogue for continuing the conversation will be added in a followup PR, so that this doesn't get too big.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
