### PR TITLE
Update Rubik's mission dialogue to allow easier mission branching

### DIFF
--- a/data/json/npcs/exodii/exodii_merchant_missions.json
+++ b/data/json/npcs/exodii/exodii_merchant_missions.json
@@ -122,7 +122,7 @@
     "type": "talk_topic",
     "dynamic_line": {
       "//~": "Just because you asked, I think we can work something out.  Yes, the Scythean has been bugging me about something.  It's not something a cyborg like me can do, but a mercenary would probably fit the bill.",
-      "str": "Them as offer as can, an it be so.  Aye, there's summat the old Scythy been larkin' up Rubik's tailpipe.  B'ain't tass right for a clanker like this'n, but a pop-an-work like you'n, maybe well and suited."
+      "str": "Them as offer as can, an it be so.  How'd ye be twigged by a quick an' round, a nice escoltin' out to a place sommat of curiosity?  Aye, there's summat the old Scythy been larkin' up Rubik's tailpipe.  B'ain't tass right for a clanker like this'n, but a pop-an-work like you'n, maybe well and suited."
     },
     "responses": [
       { "text": "What's \"the ol' Scythy\"?", "topic": "TALK_EXODII_MERCHANT_Scythean" },
@@ -340,23 +340,23 @@
       "math": [ "time_since('cataclysm', 'unit':'days') >= 28" ],
       "yes": {
         "//~": "We are unable to locate one of our warehouses since the last jump.  We would need you to go find it and reactivate its locator",
-        "str": "Well an surely, fruit gum!  Aye, ye kennit well.  'Tis a store-cabin, mayhap the likes you've seen.  This'n be older'n most, clade o' iron and crete-stone.  Abreast the ceil, high atop, there be a steely jut, piercin' the heavens.  In times ordinary, Great Grey could call out and screed the jut, kennit, and send aloft an escolt to razz 'er.  Oft times, the jut is wibbled on the wobble, an' it be coals'n coke.  Ol' Rubik can give you'n a dandy to pop 'er back aloft, and that's a fig and a fiddle."
+        "str": "Well an surely, fruit gum!  How'd ye be twigged by a pop-an-squeak?  Or as y'r tassed, a treasure hunt?  'Tis a store-cabin, mayhap the likes you've seen.  This'n be older'n most, clade o' iron and crete-stone.  Abreast the ceil, high atop, there be a steely jut, piercin' the heavens.  In times ordinary, Great Grey could call out and screed the jut, kennit, and send aloft an escolt to razz 'er.  Oft times, the jut is wibbled on the wobble, an' it be coals'n coke.  Ol' Rubik can give you'n a dandy to pop 'er back aloft, and that's a fig and a fiddle."
       },
       "no": {
         "math": [ "talked_to_hub == 1" ],
         "yes": {
           "//~": "We are unable to locate one of our warehouses since the last jump.  We would need you to go find it and reactivate its locator",
-          "str": "Well an surely, fruit gum!  Mayhap this be a chance to show y'self a true, for Rubik's got sommat to ask yet again.  The way o' the Exode is t'shimmy an' wobble, an' on thislike wobble, a few bits wobbled off, kennit?  'Tis rightful common, alack.  One such is hidden for our escolts an' our screeds.  Mayhap as y'know the lands, ye'd have a see of it?  Aye, ye kennit well.  'Tis a store-cabin, mayhap the likes you've seen.  This'n be older'n most, clade o' iron and crete-stone.  Abreast the ceil, high atop, there be a steely jut, piercin' the heavens.  In times ordinary, Great Grey could call out and screed the jut, kennit, and send aloft an escolt to razz 'er.  Oft times, the jut is wibbled on the wobble, an' it be coals'n coke.  Ol' Rubik can give you'n a dandy to pop 'er back aloft, and that's a fig and a fiddle."
+          "str": "Well an surely, fruit gum!  How'd ye be twigged by a pop-an-squeak?  Or as y'r tassed, a treasure hunt?  Mayhap this be a chance to show y'self a true, for Rubik's got sommat to ask yet again.  The way o' the Exode is t'shimmy an' wobble, an' on thislike wobble, a few bits wobbled off, kennit?  'Tis rightful common, alack.  One such is hidden for our escolts an' our screeds.  Mayhap as y'know the lands, ye'd have a see of it?  Aye, ye kennit well.  'Tis a store-cabin, mayhap the likes you've seen.  This'n be older'n most, clade o' iron and crete-stone.  Abreast the ceil, high atop, there be a steely jut, piercin' the heavens.  In times ordinary, Great Grey could call out and screed the jut, kennit, and send aloft an escolt to razz 'er.  Oft times, the jut is wibbled on the wobble, an' it be coals'n coke.  Ol' Rubik can give you'n a dandy to pop 'er back aloft, and that's a fig and a fiddle."
         },
         "no": {
           "math": [ "exodii_knows_hub01 == 1" ],
           "yes": {
             "//~": "We are unable to locate one of our warehouses since the last jump.  We would need you to go find it and reactivate its locator",
-            "str": "Well an surely, fruit gum!  For an' such as ye've done us a good.  Aye, ye kennit well.  'Tis a store-cabin, mayhap the likes you've seen.  This'n be older'n most, clade o' iron and crete-stone.  Abreast the ceil, high atop, there be a steely jut, piercin' the heavens.  In times ordinary, Great Grey could call out and screed the jut, kennit, and send aloft an escolt to razz 'er.  Oft times, the jut is wibbled on the wobble, an' it be coals'n coke.  Ol' Rubik can give you'n a dandy to pop 'er back aloft, and that's a fig and a fiddle."
+            "str": "Well an surely, fruit gum!  For an' such as ye've done us a good.  How'd ye be twigged by a pop-an-squeak?  Or as y'r tassed, a treasure hunt?  'Tis a store-cabin, mayhap the likes you've seen.  This'n be older'n most, clade o' iron and crete-stone.  Abreast the ceil, high atop, there be a steely jut, piercin' the heavens.  In times ordinary, Great Grey could call out and screed the jut, kennit, and send aloft an escolt to razz 'er.  Oft times, the jut is wibbled on the wobble, an' it be coals'n coke.  Ol' Rubik can give you'n a dandy to pop 'er back aloft, and that's a fig and a fiddle."
           },
           "no": {
             "//~": "We are unable to locate one of our warehouses since the last jump.  We would need you to go find it and reactivate its locator",
-            "str": "Well an surely, fruit gum!  Aye, ye kennit well.  'Tis a store-cabin, mayhap the likes you've seen.  This'n be older'n most, clade o' iron and crete-stone.  Abreast the ceil, high atop, there be a steely jut, piercin' the heavens.  In times ordinary, Great Grey could call out and screed the jut, kennit, and send aloft an escolt to razz 'er.  Oft times, the jut is wibbled on the wobble, an' it be coals'n coke.  Ol' Rubik can give you'n a dandy to pop 'er back aloft, and that's a fig and a fiddle."
+            "str": "Well an surely, fruit gum!  How'd ye be twigged by a pop-an-squeak?  Or as y'r tassed, a treasure hunt?  'Tis a store-cabin, mayhap the likes you've seen.  This'n be older'n most, clade o' iron and crete-stone.  Abreast the ceil, high atop, there be a steely jut, piercin' the heavens.  In times ordinary, Great Grey could call out and screed the jut, kennit, and send aloft an escolt to razz 'er.  Oft times, the jut is wibbled on the wobble, an' it be coals'n coke.  Ol' Rubik can give you'n a dandy to pop 'er back aloft, and that's a fig and a fiddle."
           }
         }
       }

--- a/data/json/npcs/exodii/exodii_merchant_talk.json
+++ b/data/json/npcs/exodii/exodii_merchant_talk.json
@@ -1180,34 +1180,12 @@
     "id": "TALK_EXODII_MERCHANT_Jobs",
     "type": "talk_topic",
     "dynamic_line": {
-      "concatenate": [
-        {
-          "//": "mod_update_script_compact",
-          "//~": "Yeah, we're always in need of some help around here.  Here's the list I've got for stuff like this.",
-          "str": "*pulls out a sheaf of mismatched papers, and leafs through the pages for a second.  Their broad metallic fingers look surprisingly deft and delicate, and incongruous on the otherwise unremarkable looseleaf.  \"Aye, an' there's room for a pop-an-work roun' here.  Rubik's got tassed a lissy, right and clean"
-        },
-        {
-          "u_has_mission": "EXODII_MISSION_CONTACT_HUB",
-          "yes": ".  Right and so, mayhap ye should first see about that escoltin'.\"",
-          "no": [
-            {
-              "math": [ "exodii_knows_hub01 == 1" ],
-              "yes": [
-                {
-                  "math": [ "warehouse_was_found == 1" ],
-                  "yes": ", but for the right-an-quick, this'n has nothin' t'be tassed for ye.\"",
-                  "no": ".  How'd ye be twigged by a pop-an-squeak?  Or as y'r tassed, a treasure hunt?\""
-                }
-              ],
-              "no": ".  How'd ye be twigged by a quick an' round, a nice escoltin' out to a place sommat of curiosity?\""
-            }
-          ]
-        }
-      ]
+      "//~": "Yeah, we're always in need of some help around here.  Here's the list I've got for stuff like this.",
+      "str": "*pulls out a sheaf of mismatched papers, and leafs through the pages for a second.  Their broad metallic fingers look surprisingly deft and delicate, and incongruous on the otherwise unremarkable looseleaf.  \"Aye, an' there's room for a pop-an-work roun' here.  Rubik's got tassed a lissy, right and clean."
     },
     "responses": [
       {
-        "text": "Sounds like you're saying a job?  That's what I'm looking for.  Tell me more.",
+        "text": "[Pop-an-Work: Escoltin' sommat of curiosity]",
         "condition": {
           "and": [
             { "not": { "u_has_mission": "EXODII_MISSION_CONTACT_HUB" } },
@@ -1218,7 +1196,7 @@
         "topic": "TALK_EXODII_MERCHANT_mission_1_intro"
       },
       {
-        "text": "Sounds like you're saying a job?  That's what I'm looking for.  Tell me more.",
+        "text": "[Pop-an-Work: A pop-an-squeak]",
         "condition": {
           "and": [
             { "not": { "u_has_mission": "EXODII_MISSION_WAREHOUSE" } },
@@ -1230,7 +1208,7 @@
         "topic": "TALK_EXODII_MERCHANT_mission_2_intro"
       },
       {
-        "text": "Sounds like you're saying a job?  That's what I'm looking for.  Tell me more.",
+        "text": "[Pop-an-Work: Escolt, held fast]",
         "condition": {
           "and": [
             { "not": { "u_has_mission": "EXODII_MISSION_CHOP_SHOP" } },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Features "Simplified Rubik's mission option dialogue"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Rubik had some very charming dialogue for getting jobs, which used string concatenation to give custom dialogue at each stage of his original 2 missions.  Now that the Chop Shop mission exists (#85309), and now that I'm preparing to address their mission to make a deal with the Free Merchants (#59911), the mission lines will start to branch, so the linear yes/no string concatenation won't work, at least not easily for me.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Changed the dialogue about missions.  Instead of the player now always responding with `"Sounds like you're saying a job?  That's what I'm looking for.  Tell me more."`, Rubik now offers the jobs, and you can pick from dialogue options with a name for the mission, each with Exodii flavor from the original dialogue.  The current options are  `[Pop-an-Work: Escoltin' sommat of curiosity]`, `[Pop-an-Work: A pop-an-squeak]`, and `[Pop-an-Work: Escolt, held fast]`.

I didn't want to lose the nice dialogue that was cut from this menu, so all of it was moved to the intro dialogue for each of the missions.  In the end, things are clearer, missions can branch easier, and the dialogue was maintained elsewhere.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Really digging into the string concatenation and seeing if I can make it work with branching, but that's gonna get really old, really really fast.

Yeeting the old dialogue, but it's great.  I think it should stay, just downstream of where it was.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Tested the dialogue.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
