### PR TITLE
[Bombastic Paths] Require minimum 5 walls for Closetland/Closetland Paths

### DIFF
--- a/data/mods/BombasticPerks/perkdata/closetland.json
+++ b/data/mods/BombasticPerks/perkdata/closetland.json
@@ -85,11 +85,12 @@
           ]
         }
       },
+      { "if": "u_is_outside", "then": { "math": [ "u_closetland_perk_nearby_walls = 0" ] } },
       {
         "if": {
           "and": [
             { "math": [ "u_closetland_perk_nearby_walls >= 5" ] },
-            { "math": [ "(u_closetland_perk_nearby_walls + u_closetland_perk_nearby_furniture)  == 5" ] },
+            { "math": [ "(u_closetland_perk_nearby_walls + u_closetland_perk_nearby_furniture)  == 7" ] },
             { "math": [ "u_closetland_perk_nearby_doors == 1" ] }
           ]
         },

--- a/data/mods/BombasticPerks/perkdata/closetland.json
+++ b/data/mods/BombasticPerks/perkdata/closetland.json
@@ -36,6 +36,7 @@
     "effect": [
       { "dimension_name": { "global_val": "closetland_last_dimension" } },
       { "math": [ "u_closetland_perk_nearby_walls = 0" ] },
+      { "math": [ "u_closetland_perk_nearby_furniture = 0" ] },
       { "math": [ "u_closetland_perk_nearby_doors = 0" ] },
       {
         "u_map_run_eocs": [
@@ -47,10 +48,21 @@
         "range": 1,
         "store_coordinates_in": { "context_val": "closetland_terrain_check" },
         "stop_at_first": false,
+        "condition": { "map_terrain_with_flag": "WALL", "loc": { "context_val": "closetland_terrain_check" } }
+      },
+      {
+        "u_map_run_eocs": [
+          {
+            "id": "EOC_BOMBASTIC_PERKS_CLOSET_STORAGE_TRAVEL_TO_CLOSETLAND_FURNITURE_CHECK",
+            "effect": [ { "math": [ "u_closetland_perk_nearby_furniture += 1" ] } ]
+          }
+        ],
+        "range": 1,
+        "store_coordinates_in": { "context_val": "closetland_terrain_check" },
+        "stop_at_first": false,
         "condition": {
           "or": [
             { "map_furniture_with_flag": "BLOCKSDOOR", "loc": { "context_val": "closetland_terrain_check" } },
-            { "map_terrain_with_flag": "WALL", "loc": { "context_val": "closetland_terrain_check" } },
             { "map_furniture_id": "f_safe_l", "loc": { "context_val": "closetland_terrain_check" } },
             { "map_furniture_id": "f_safe_c", "loc": { "context_val": "closetland_terrain_check" } }
           ]
@@ -75,7 +87,11 @@
       },
       {
         "if": {
-          "and": [ { "math": [ "u_closetland_perk_nearby_walls == 7" ] }, { "math": [ "u_closetland_perk_nearby_doors == 1" ] } ]
+          "and": [
+            { "math": [ "u_closetland_perk_nearby_walls >= 5" ] },
+            { "math": [ "(u_closetland_perk_nearby_walls + u_closetland_perk_nearby_furniture)  == 5" ] },
+            { "math": [ "u_closetland_perk_nearby_doors == 1" ] }
+          ]
         },
         "then": [
           {

--- a/data/mods/BombasticPerks/perkdata/closetland_paths.json
+++ b/data/mods/BombasticPerks/perkdata/closetland_paths.json
@@ -23,7 +23,7 @@
       {
         "u_map_run_eocs": [
           {
-            "id": "EOC_BOMBASTIC_PERKS_CLOSET_STORAGE_TRAVEL_TO_CLOSETLAND_FURNITURE_CHECK",
+            "id": "EOC_BOMBASTIC_PERKS_CLOSET_STORAGE_DIFFERENT_PATHS_OF_CLOSETLAND_FURNITURE_CHECK",
             "effect": [ { "math": [ "u_closetland_perk_nearby_furniture += 1" ] } ]
           }
         ],
@@ -55,29 +55,12 @@
           ]
         }
       },
-      {
-        "u_map_run_eocs": [
-          {
-            "id": "EOC_BOMBASTIC_PERKS_CLOSET_STORAGE_TRAVEL_TO_CLOSETLAND_FURNITURE_CHECK",
-            "effect": [ { "math": [ "u_closetland_perk_nearby_furniture += 1" ] } ]
-          }
-        ],
-        "range": 1,
-        "store_coordinates_in": { "context_val": "closetland_terrain_check" },
-        "stop_at_first": false,
-        "condition": {
-          "or": [
-            { "map_furniture_with_flag": "BLOCKSDOOR", "loc": { "context_val": "closetland_terrain_check" } },
-            { "map_furniture_id": "f_safe_l", "loc": { "context_val": "closetland_terrain_check" } },
-            { "map_furniture_id": "f_safe_c", "loc": { "context_val": "closetland_terrain_check" } }
-          ]
-        }
-      },
+      { "if": "u_is_outside", "then": { "math": [ "u_closetland_perk_nearby_walls = 0" ] } },
       {
         "if": {
           "and": [
             { "math": [ "u_closetland_perk_nearby_walls >= 5" ] },
-            { "math": [ "(u_closetland_perk_nearby_walls + u_closetland_perk_nearby_furniture)  == 5" ] },
+            { "math": [ "(u_closetland_perk_nearby_walls + u_closetland_perk_nearby_furniture)  == 7" ] },
             { "math": [ "u_closetland_perk_nearby_doors == 1" ] }
           ]
         },

--- a/data/mods/BombasticPerks/perkdata/closetland_paths.json
+++ b/data/mods/BombasticPerks/perkdata/closetland_paths.json
@@ -6,6 +6,7 @@
     "effect": [
       { "dimension_name": { "context_val": "closetland_paths_last_dimension" } },
       { "math": [ "u_closetland_perk_nearby_walls = 0" ] },
+      { "math": [ "u_closetland_perk_nearby_furniture = 0" ] },
       { "math": [ "u_closetland_perk_nearby_doors = 0" ] },
       {
         "u_map_run_eocs": [
@@ -17,12 +18,23 @@
         "range": 1,
         "store_coordinates_in": { "context_val": "closetland_terrain_check" },
         "stop_at_first": false,
+        "condition": { "map_terrain_with_flag": "WALL", "loc": { "context_val": "closetland_terrain_check" } }
+      },
+      {
+        "u_map_run_eocs": [
+          {
+            "id": "EOC_BOMBASTIC_PERKS_CLOSET_STORAGE_TRAVEL_TO_CLOSETLAND_FURNITURE_CHECK",
+            "effect": [ { "math": [ "u_closetland_perk_nearby_furniture += 1" ] } ]
+          }
+        ],
+        "range": 1,
+        "store_coordinates_in": { "context_val": "closetland_terrain_check" },
+        "stop_at_first": false,
         "condition": {
           "or": [
             { "map_furniture_with_flag": "BLOCKSDOOR", "loc": { "context_val": "closetland_terrain_check" } },
             { "map_furniture_id": "f_safe_l", "loc": { "context_val": "closetland_terrain_check" } },
-            { "map_furniture_id": "f_safe_c", "loc": { "context_val": "closetland_terrain_check" } },
-            { "map_terrain_with_flag": "WALL", "loc": { "context_val": "closetland_terrain_check" } }
+            { "map_furniture_id": "f_safe_c", "loc": { "context_val": "closetland_terrain_check" } }
           ]
         }
       },
@@ -44,8 +56,30 @@
         }
       },
       {
+        "u_map_run_eocs": [
+          {
+            "id": "EOC_BOMBASTIC_PERKS_CLOSET_STORAGE_TRAVEL_TO_CLOSETLAND_FURNITURE_CHECK",
+            "effect": [ { "math": [ "u_closetland_perk_nearby_furniture += 1" ] } ]
+          }
+        ],
+        "range": 1,
+        "store_coordinates_in": { "context_val": "closetland_terrain_check" },
+        "stop_at_first": false,
+        "condition": {
+          "or": [
+            { "map_furniture_with_flag": "BLOCKSDOOR", "loc": { "context_val": "closetland_terrain_check" } },
+            { "map_furniture_id": "f_safe_l", "loc": { "context_val": "closetland_terrain_check" } },
+            { "map_furniture_id": "f_safe_c", "loc": { "context_val": "closetland_terrain_check" } }
+          ]
+        }
+      },
+      {
         "if": {
-          "and": [ { "math": [ "u_closetland_perk_nearby_walls == 7" ] }, { "math": [ "u_closetland_perk_nearby_doors == 1" ] } ]
+          "and": [
+            { "math": [ "u_closetland_perk_nearby_walls >= 5" ] },
+            { "math": [ "(u_closetland_perk_nearby_walls + u_closetland_perk_nearby_furniture)  == 5" ] },
+            { "math": [ "u_closetland_perk_nearby_doors == 1" ] }
+          ]
         },
         "then": [
           {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "[Bombastic Paths] Require minimum 5 walls for Closetland/Closetland Paths"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

It was possible to drag 7 items of furniture near a door to make it into a "closet" and apparently _some people_ couldn't control themselves.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Require at least 5 walls that are actual walls (with the `WALL` flag) to count as a closet. That way you can have up to a 3x1 space (with two units of shelving) that's a closet, but you can't drag 7 bookcases or even just drag three items of furniture into a corner.

Now, this isn't perfect--you can still turn a 1-wide hallway into a "closet", but banning that would mean that an actual closet with a unit of shelving wouldn't count as a closet. Barring some mapgen way of marking closets there's no way around this, but this does make it so you at least need an actual building and can't drag bookcases into a field somewhere and then build a door into them.

Also add a check that you're inside, just in case.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Went out into a field with bookcases, it wasn't a closet.

Went into an actual closet, it was a closet.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
