### PR TITLE
Bombastic Perks: Yeoman perk

### DIFF
--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -1868,6 +1868,22 @@
         "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
       },
       {
+        "condition": { "not": { "u_has_trait": "perk_yeoman" } },
+        "text": "Gain [<trait_name:perk_yeoman>]",
+        "effect": [
+          { "set_string_var": "<trait_name:perk_yeoman>", "target_var": { "context_val": "trait_name" } },
+          { "set_string_var": "<trait_description:perk_yeoman>", "target_var": { "context_val": "trait_description" } },
+          { "set_string_var": "perk_yeoman", "target_var": { "context_val": "trait_id" } },
+          {
+            "set_string_var": "Requires archery 8",
+            "target_var": { "context_val": "trait_requirement_description" },
+            "i18n": true
+          },
+          { "set_condition": "perk_condition", "condition": { "math": [ "u_skill('archery') >= 8" ] } }
+        ],
+        "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
+      },
+      {
         "condition": { "not": { "u_has_trait": "perk_empath" } },
         "text": "Gain [<trait_name:perk_empath>]",
         "effect": [

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -1872,7 +1872,10 @@
         "text": "Gain [<trait_name:perk_yeoman>]",
         "effect": [
           { "set_string_var": "<trait_name:perk_yeoman>", "target_var": { "context_val": "trait_name" } },
-          { "set_string_var": "<trait_description:perk_yeoman>", "target_var": { "context_val": "trait_description" } },
+          {
+            "set_string_var": "<trait_description:perk_yeoman>",
+            "target_var": { "context_val": "trait_description" }
+          },
           { "set_string_var": "perk_yeoman", "target_var": { "context_val": "trait_id" } },
           {
             "set_string_var": "Requires archery 8",

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -1516,7 +1516,7 @@
     "valid": false,
     "enchantments": [
       {
-        "condition": { "u_has_wielded_with_ammotype": "arrow" },
+        "condition": { "u_has_wielded_with_flag": "SHEATH_BOW" },
         "values": [
           { "value": "RANGED_ARMOR_PENETRATION", "add": 4 },
           { "value": "WEAKPOINT_ACCURACY", "multiply": 1 },

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -1508,6 +1508,27 @@
   },
   {
     "type": "mutation",
+    "id": "perk_yeoman",
+    "name": { "str": "Yeoman" },
+    "description": "In a world of guns, you were born to string a bow.  With such weapons you draw back further, increasing damage and range, and your arrows strike true with unerring accuracy.",
+    "points": 0,
+    "purifiable": false,
+    "valid": false,
+    "enchantments": [
+      {
+        "condition": { "u_has_wielded_with_ammotype": "arrow" },
+        "values": [
+          { "value": "RANGED_ARMOR_PENETRATION", "add": 4 },
+          { "value": "WEAKPOINT_ACCURACY", "multiply": 1 },
+          { "value": "WEAPON_DISPERSION", "multiply": -0.25 },
+          { "value": "RANGED_DAMAGE", "multiply": 0.25 },
+          { "value": "RANGE", "add": 6 }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "mutation",
     "id": "perk_secret_closet_storage",
     "name": { "str": "Closetland" },
     "description": "When you were little you remember thinking that your closet was a portal to a secret realm and if you just knew the way to open the path, you could find your way through to another world.  Well, you've found the way.\n\nWhen in a closet (walls on all sides except for one closed door), activate this perk to transport you to a secret realm.  Deactivate this perk to transport you back to your entrance point.",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "Master archer playstyle perk for Bombastic Perks"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
There was a playstyle perk for old fashioned guns, a playstyle perk for .22s, a playstyle perk for revolvers, but no playstyle perk for bows. Bows are cool, so 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
New playstyle perk "Yeoman". Playstyle perk, req. 8 archery.
With bows you get:
+25% damage
-25% dispersion
+6 range
+4 arpen
2x weakpoint hit rate
This is a lot stronger than the equivalent gun perks, but you can often stack the gun perks together, and guns are often very strong, so they need less help. You'd still be way better off using the old fashioned guns perk with an M2 Browning or something similar.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Yeoman is slightly gendered so maybe a different word would be good for the lady and enby survivors. But also yeomen are cool, so, idk.
It could be too powerful as is.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded in game, took the perk, good to go.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
