### PR TITLE
Traits can control skill display

### DIFF
--- a/doc/JSON/JSON_INFO.md
+++ b/doc/JSON/JSON_INFO.md
@@ -2565,8 +2565,10 @@ it is present to help catch errors.
 | `companion_combat_rank_factor`   | _(int)_ Affects an NPC's rank when determining the success rate for combat missions. |
 | `companion_survival_rank_factor` | _(int)_ Affects an NPC's rank when determining the success rate for survival missions. |
 | `companion_industry_rank_factor` | _(int)_ Affects an NPC's rank when determining the success rate for industry missions. |
-| `required_traits` | Traits that the player is required to have to display the skill in the character tab. All traits are required |
-| `allowed_traits` | Traits that the player needs at least one of to display the skill in the character tab. At least one trait is required |
+| `requires_all_traits` | Traits that the player is required to have to display the skill in the character tab. All traits are required |
+| `requires_any_traits` | Traits that the player needs at least one of to display the skill in the character tab. At least one trait is required |
+
+If neither `requires_all_traits` or `requires_any_traits` are defined, the skill will always display in the character tab
 
 ### Speed Description
 

--- a/doc/JSON/JSON_INFO.md
+++ b/doc/JSON/JSON_INFO.md
@@ -2535,15 +2535,17 @@ it is present to help catch errors.
     { "level": 2, "description": "foo" },
     { "level": 3, "description": "bar" },
     { "level": 4, "description": "xyz" }
-],
-"level_descriptions_practice": [
-    { "level": 0, "description": "You don't know how to operate the computer whatsoever" },
-    { "level": 1, "description": "You know how to open browser and search images.  Were able to, at least." },
-    { "level": 2, "description": "foo" },
-    { "level": 3, "description": "bar" },
-    { "level": 4, "description": "xyz" }
-],
-  "companion_skill_practice": [ { "skill": "hunting", "weight": 25 } ]
+  ],
+  "level_descriptions_practice": [
+      { "level": 0, "description": "You don't know how to operate the computer whatsoever" },
+      { "level": 1, "description": "You know how to open browser and search images.  Were able to, at least." },
+      { "level": 2, "description": "foo" },
+      { "level": 3, "description": "bar" },
+      { "level": 4, "description": "xyz" }
+  ],
+  "companion_skill_practice": [ { "skill": "hunting", "weight": 25 } ],
+  "required_traits": [ "THINSKIN", "HORNS" ],
+  "allowed_traits": [ "PAWS", "SKIN_DARK" ]
 }
 ```
 
@@ -2563,6 +2565,8 @@ it is present to help catch errors.
 | `companion_combat_rank_factor`   | _(int)_ Affects an NPC's rank when determining the success rate for combat missions. |
 | `companion_survival_rank_factor` | _(int)_ Affects an NPC's rank when determining the success rate for survival missions. |
 | `companion_industry_rank_factor` | _(int)_ Affects an NPC's rank when determining the success rate for industry missions. |
+| `required_traits` | Traits that the player is required to have to display the skill in the character tab. All traits are required |
+| `allowed_traits` | Traits that the player needs at least one of to display the skill in the character tab. At least one trait is required |
 
 ### Speed Description
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1036,7 +1036,8 @@ void DynamicDataLoader::check_consistency()
             { _( "Wounds" ), &wound_type::check_consistency },
             { _( "Wound fixes" ), &wound_fix::check_consistency },
             { _( "Faction missions" ), &faction_mission::check_consistency },
-            { _( "Relic Procedural Generations" ), &relic_procgen_data::check_consistency }
+            { _( "Relic Procedural Generations" ), &relic_procgen_data::check_consistency },
+            { _( "Skills" ), &Skill::check_consistency }
         }
     };
 

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -1641,7 +1641,7 @@ void Character::disp_info( bool customize_character )
     }
     const unsigned int bionics_win_size_y_max = 2 + bionicslist.size();
 
-    const std::vector<const Skill *> player_skill = Skill::get_skills_sorted_by(
+    const std::vector<const Skill *> player_skill = Skill::get_skills_for_chr_display( *this,
     [&]( const Skill & a, const Skill & b ) {
         return a.get_sort_rank() < b.get_sort_rank();
     } );

--- a/src/skill.cpp
+++ b/src/skill.cpp
@@ -137,21 +137,21 @@ void Skill::reset()
 void Skill::check_consistency()
 {
     for( Skill &skill : skills )  {
-        auto rt = skill._required_traits.begin();
-        while( rt != skill._required_traits.end() ) {
+        auto rt = skill._requires_all_traits.begin();
+        while( rt != skill._requires_all_traits.end() ) {
             auto current = rt++;
             if( !trait_id( *current ).is_valid() ) {
                 debugmsg( "trait %s does not exist", current->c_str() );
-                rt = skill._required_traits.erase( current );
+                rt = skill._requires_all_traits.erase( current );
             }
         }
 
-        rt = skill._allowed_traits.begin();
-        while( rt != skill._allowed_traits.end() ) {
+        rt = skill._requires_any_traits.begin();
+        while( rt != skill._requires_any_traits.end() ) {
             auto current = rt++;
             if( !trait_id( *current ).is_valid() ) {
                 debugmsg( "trait %s does not exist", current->c_str() );
-                rt = skill._allowed_traits.erase( current );
+                rt = skill._requires_any_traits.erase( current );
             }
         }
     }
@@ -213,8 +213,8 @@ void Skill::load_skill( const JsonObject &jsobj )
     sk._level_descriptions_practice = level_descriptions_practice;
     sk._obsolete = jsobj.get_bool( "obsolete", false );
     sk._teachable = jsobj.get_bool( "teachable", true );
-    sk._required_traits = jsobj.get_tags( "required_traits" );
-    sk._allowed_traits = jsobj.get_tags( "allowed_traits" );
+    sk._requires_all_traits = jsobj.get_tags( "requires_all_traits" );
+    sk._requires_any_traits = jsobj.get_tags( "requires_any_traits" );
 
     if( sk.is_contextual_skill() ) {
         contextual_skills[sk.ident()] = sk;
@@ -297,14 +297,14 @@ skill_id Skill::random_skill()
 
 bool Skill::can_chr_use( Character &chr ) const
 {
-    for( std::string tid : _required_traits ) {
+    for( std::string tid : _requires_all_traits ) {
         if( !chr.has_trait( trait_id( tid ) ) ) {
             return false;
         }
     }
 
-    if( !_allowed_traits.empty() ) {
-        for( std::string tid : _allowed_traits ) {
+    if( !_requires_any_traits.empty() ) {
+        for( std::string tid : _requires_any_traits ) {
             if( chr.has_trait( trait_id( tid ) ) ) {
                 return true;
             }

--- a/src/skill.cpp
+++ b/src/skill.cpp
@@ -136,7 +136,7 @@ void Skill::reset()
 
 void Skill::check_consistency()
 {
-    for( auto &skill : skills )  {
+    for( Skill &skill : skills )  {
         auto rt = skill._required_traits.begin();
         while( rt != skill._required_traits.end() ) {
             auto current = rt++;
@@ -297,14 +297,14 @@ skill_id Skill::random_skill()
 
 bool Skill::can_chr_use( Character &chr ) const
 {
-    for( auto tid : _required_traits ) {
+    for( std::string tid : _required_traits ) {
         if( !chr.has_trait( trait_id( tid ) ) ) {
             return false;
         }
     }
 
-    if( _allowed_traits.size() > 0 ) {
-        for( auto tid : _allowed_traits ) {
+    if( !_allowed_traits.empty() ) {
+        for( std::string tid : _allowed_traits ) {
             if( chr.has_trait( trait_id( tid ) ) ) {
                 return true;
             }

--- a/src/skill.cpp
+++ b/src/skill.cpp
@@ -8,6 +8,7 @@
 #include <iterator>
 #include <utility>
 
+#include "character.h"
 #include "debug.h"
 #include "flexbuffer_json.h"
 #include "game_constants.h"
@@ -89,6 +90,25 @@ Skill::Skill( const skill_id &ident, const translation &name, const translation 
 {
 }
 
+std::vector<const Skill *> Skill::get_skills_for_chr_display(
+    Character &chr, std::function<bool ( const Skill &, const Skill & )> pred )
+{
+    std::vector<const Skill *> result;
+    result.reserve( skills.size() );
+
+    for( const Skill &sk : skills ) {
+        if( !sk.obsolete() && sk.can_chr_use( chr ) ) {
+            result.push_back( &sk );
+        }
+    }
+
+    std::sort( begin( result ), end( result ), [&]( const Skill * lhs, const Skill * rhs ) {
+        return pred( *lhs, *rhs );
+    } );
+
+    return result;
+}
+
 std::vector<const Skill *> Skill::get_skills_sorted_by(
     std::function<bool ( const Skill &, const Skill & )> pred )
 {
@@ -112,6 +132,29 @@ void Skill::reset()
 {
     skills.clear();
     contextual_skills.clear();
+}
+
+void Skill::check_consistency()
+{
+    for( auto &skill : skills )  {
+        auto rt = skill._required_traits.begin();
+        while( rt != skill._required_traits.end() ) {
+            auto current = rt++;
+            if( !trait_id( *current ).is_valid() ) {
+                debugmsg( "trait %s does not exist", current->c_str() );
+                rt = skill._required_traits.erase( current );
+            }
+        }
+
+        rt = skill._allowed_traits.begin();
+        while( rt != skill._allowed_traits.end() ) {
+            auto current = rt++;
+            if( !trait_id( *current ).is_valid() ) {
+                debugmsg( "trait %s does not exist", current->c_str() );
+                rt = skill._allowed_traits.erase( current );
+            }
+        }
+    }
 }
 
 void Skill::load_skill( const JsonObject &jsobj )
@@ -170,6 +213,8 @@ void Skill::load_skill( const JsonObject &jsobj )
     sk._level_descriptions_practice = level_descriptions_practice;
     sk._obsolete = jsobj.get_bool( "obsolete", false );
     sk._teachable = jsobj.get_bool( "teachable", true );
+    sk._required_traits = jsobj.get_tags( "required_traits" );
+    sk._allowed_traits = jsobj.get_tags( "allowed_traits" );
 
     if( sk.is_contextual_skill() ) {
         contextual_skills[sk.ident()] = sk;
@@ -248,6 +293,26 @@ skill_id Skill::from_legacy_int( const int legacy_id )
 skill_id Skill::random_skill()
 {
     return random_entry_ref( skills ).ident();
+}
+
+bool Skill::can_chr_use( Character &chr ) const
+{
+    for( auto tid : _required_traits ) {
+        if( !chr.has_trait( trait_id( tid ) ) ) {
+            return false;
+        }
+    }
+
+    if( _allowed_traits.size() > 0 ) {
+        for( auto tid : _allowed_traits ) {
+            if( chr.has_trait( trait_id( tid ) ) ) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    return true;
 }
 
 // used for the pacifist trait

--- a/src/skill.h
+++ b/src/skill.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "calendar.h"
+#include "character.h"
 #include "game_constants.h"
 #include "translation.h"
 #include "type_id.h"

--- a/src/skill.h
+++ b/src/skill.h
@@ -11,7 +11,6 @@
 #include <vector>
 
 #include "calendar.h"
-#include "character.h"
 #include "game_constants.h"
 #include "translation.h"
 #include "type_id.h"

--- a/src/skill.h
+++ b/src/skill.h
@@ -52,8 +52,8 @@ class Skill
         bool _teachable = true;
         bool _obsolete = false;
         bool consumes_focus = true;
-        std::set<std::string> _required_traits;
-        std::set<std::string> _allowed_traits;
+        std::set<std::string> _requires_all_traits;
+        std::set<std::string> _requires_any_traits;
     public:
         static std::vector<Skill> skills;
         static void load_skill( const JsonObject &jsobj );

--- a/src/skill.h
+++ b/src/skill.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "calendar.h"
+#include "character.h"
 #include "game_constants.h"
 #include "translation.h"
 #include "type_id.h"
@@ -51,6 +52,8 @@ class Skill
         bool _teachable = true;
         bool _obsolete = false;
         bool consumes_focus = true;
+        std::set<std::string> _required_traits;
+        std::set<std::string> _allowed_traits;
     public:
         static std::vector<Skill> skills;
         static void load_skill( const JsonObject &jsobj );
@@ -60,6 +63,10 @@ class Skill
 
         // clear skill vector, every skill pointer becomes invalid!
         static void reset();
+        static void check_consistency();
+
+        static std::vector<const Skill *> get_skills_for_chr_display(
+            Character &chr, std::function<bool ( const Skill &, const Skill & )> pred );
 
         static std::vector<const Skill *> get_skills_sorted_by(
             std::function<bool ( const Skill &, const Skill & )> pred );
@@ -122,6 +129,7 @@ class Skill
             return consumes_focus;
         }
 
+        bool can_chr_use( Character &chr ) const;
         bool is_combat_skill() const;
         bool is_contextual_skill() const;
         std::string get_level_description( int skill_lvl, bool practical ) const;

--- a/src/skill.h
+++ b/src/skill.h
@@ -11,11 +11,11 @@
 #include <vector>
 
 #include "calendar.h"
-#include "character.h"
 #include "game_constants.h"
 #include "translation.h"
 #include "type_id.h"
 
+class Character;
 class JsonObject;
 class JsonOut;
 class item;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Infrastructure "Traits can control skill display"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Allows traits to control display of skills in the @ menu
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add two new optional fields to the `skill` object
- `requires_all_traits` - array of trait IDs
  - the player is required to have all of these traits so the skill is displayed
- `requires_any_traits` - array of trait IDs
  - the player is required to have at least one of these traits so the skill is displayed

If the skill has neither of these properties, the skill will always display

Docs are updated with this information

A new consistency check was added for skills to validate these two fields have valid trait IDs in them. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Something like adding a boolean property to the skill to tell the game to not display the skill at 0 exp and then require the mod maker to control exp for the skill to control display. I went with traits so a) the xp doesn't have to be lost and b) this has a better natural setup for the use case
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Consistency check will drop all invalid trait IDs, tested with many invalid strings.
Toggled traits that were assigned in both fields for a debug skill properly controlled the display of the skill
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
As requested by @Maleclypse [here](https://discord.com/channels/598523535169945603/598529538015887372/1478248277102301338) 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
