### PR TITLE
Temporarily disable riot damage

### DIFF
--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -552,6 +552,9 @@ static void GENERATOR_pre_burn( map &md,
 
 static void GENERATOR_riot_damage( map &md, const tripoint_abs_omt &p, bool is_a_road )
 {
+    // Currently, do nothing, until riot damage is made more robust.
+    return;
+
     std::list<tripoint_bub_ms> all_points_in_map;
 
 
@@ -891,12 +894,10 @@ void map::generate( const tripoint_abs_omt &p, const time_point &when, bool save
                 const tripoint_abs_omt omt_point = { p.x(), p.y(), gridz };
                 oter_id omt = overmap_buffer.ter( omt_point );
                 if( omt->has_flag( oter_flags::pp_generate_riot_damage ) && !omt->has_flag( oter_flags::road ) ) {
-                    // Currently, do nothing, until riot damage is made more robust.
-                    // GENERATOR_riot_damage( *this, omt_point, false );
+                    GENERATOR_riot_damage( *this, omt_point, false );
                 } else if( omt->has_flag( oter_flags::road ) && overmap_buffer.is_in_city( omt_point ) ) {
                     // HACK: Hardcode running only certain sub-generators on roads
-                    // Currently, do nothing, until riot damage is made more robust.
-                    // GENERATOR_riot_damage( *this, omt_point, true );
+                    GENERATOR_riot_damage( *this, omt_point, true );
                 }
                 if( omt->has_flag( oter_flags::pp_generate_ruined ) && !omt->has_flag( oter_flags::road ) ) {
                     GENERATOR_aftershock_ruin( *this, omt_point );

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -891,10 +891,12 @@ void map::generate( const tripoint_abs_omt &p, const time_point &when, bool save
                 const tripoint_abs_omt omt_point = { p.x(), p.y(), gridz };
                 oter_id omt = overmap_buffer.ter( omt_point );
                 if( omt->has_flag( oter_flags::pp_generate_riot_damage ) && !omt->has_flag( oter_flags::road ) ) {
-                    GENERATOR_riot_damage( *this, omt_point, false );
+                    // Currently, do nothing, until riot damage is made more robust.
+                    // GENERATOR_riot_damage( *this, omt_point, false );
                 } else if( omt->has_flag( oter_flags::road ) && overmap_buffer.is_in_city( omt_point ) ) {
                     // HACK: Hardcode running only certain sub-generators on roads
-                    GENERATOR_riot_damage( *this, omt_point, true );
+                    // Currently, do nothing, until riot damage is made more robust.
+                    // GENERATOR_riot_damage( *this, omt_point, true );
                 }
                 if( omt->has_flag( oter_flags::pp_generate_ruined ) && !omt->has_flag( oter_flags::road ) ) {
                     GENERATOR_aftershock_ruin( *this, omt_point );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
balance "temporarily disable riot damage"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Riot damage is currently a really broken and underbaked mechanic that causes all kinds of problems. Prominent devs like @GuardianDll have tried to fix it and have been unsuccessful at making it any less broken. Some reasons it does not work:
- Riot damage does not respect Z-levels. Any building with riot damage usually has a wholly pristine and intact roof. Any two story building has a ruined first or second floor. Skyscrapers have ruined first floors supporting upper floors even though structurally that makes no sense, and it causes tons of holes in the upper floors.
- Riot damage is isolated to single OMT squares. Any multi OMT building has nonsensical squares burnt to a crisp perfectly along grid lines. Again with the skyscraper example, you'll randomly have a single section completely burnt up while all the other ones are untouched.
- Riot damage does not affect vehicles. You'll find burnt down houses and grocery stores with perfectly intact cars or shopping carts inside.
- Riot damage fucks with quest or otherwise important locations creating lots of extra JSON overhead to corral its effects. See #85451 #85007. You'll get a quest from an NPC to get software off their home computer or rescue their dog and it'll take place in a burnt down house.
- Riot damage burns down obviously non flammable locations made of concrete with no regard for structural components. It's also not as easy as simply "removing it from all the concrete ones" because many buildings have parameterized walls that are assigned randomly different materials like wood, brick, concrete, and there's no easy way to tell in advance what it is. You very often see it in subways where there's literally just nothing to burn.
- Riot damage discourages going into cities. It doesn't apply to anywhere in the countryside like mansions. We have made a concerted effort to fix an old stale gameplay loop of "travel endlessly around the countryside going only to safe locations and never go to a city because that's dangerous" and undermine that by randomly destroying 25% of all city buildings.
- Riot damage makes tons of noise when the zombies destroy the flimsy burnt walls and floors. If they're that fragile, they should have already been broken by just attrition. This can make you go deaf, or otherwise just cause lots of noise in the city to be isolated to your reality bubble because zombies can't smash the buildings unless you are nearby.
- Riot damage sometimes burns down your starter building if you spawn in a city. This just means you have to re roll until you get a starting building that isn't completely ruined. It doesn't make sense that if you were hiding out in the city you'd do so in a completely burned down ruin with no visual coverage.


<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
In the C++ check to apply riot damage, comment out the code. This means no need to do a bunch of JSON flag work and those flags will still be there once the c++ function actually, well, functions.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Comprehensively attempt to fix riot damage myself when other, more experienced devs have tried before and failed, which isn't encouraging.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Need to compile.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
