### PR TITLE
Use suggestion blocks for IWYU review comments

### DIFF
--- a/.github/workflows/iwyu-linter.yml
+++ b/.github/workflows/iwyu-linter.yml
@@ -30,8 +30,10 @@ jobs:
         ref: '${{ github.event.pull_request.head.sha }}'
         persist-credentials: false
 
-    - name: install LLVM 19
-      run: sudo apt install llvm-19-dev clang-19 libclang-19-dev cmake
+    - name: install dependencies
+      run: |
+        sudo apt install llvm-19-dev clang-19 libclang-19-dev cmake
+        pip install PyGithub
 
     - name: checkout IWYU repository
       id: iwyu-checkout
@@ -84,13 +86,12 @@ jobs:
           .
         make includes -j4 --silent TILES=${TILES:-0} SOUND=${SOUND:-0} LOCALIZE=${LOCALIZE:-0}
 
-    - name: run IWYU and apply fixes
+    - name: run IWYU and post suggestions
+      if: ${{ always() }}
+      env:
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+        GH_TOKEN: ${{ github.token }}
       run: |
         export PATH="${PWD}/iwyu-build/bin:${PWD}/include-what-you-use-src:${PATH}"
         python build-scripts/ci-iwyu-suggest.py
-
-    - name: 'suggester / IWYU'
-      uses: reviewdog/action-suggester@aa38384ceb608d00f84b4690cacc83a5aba307ff # v1
-      if: ${{ always() }}
-      with:
-        tool_name: 'IWYU'

--- a/build-scripts/ci-iwyu-suggest.py
+++ b/build-scripts/ci-iwyu-suggest.py
@@ -1,9 +1,16 @@
 # Companion to ci-iwyu-run.py for the IWYU suggester workflow.
 # Runs IWYU and pipes the output through fix_includes.py to apply
-# fixes in-place. reviewdog/action-suggester then diffs against
-# the original and posts suggested changes on the PR.
+# fixes in-place, then posts review comments with suggestion blocks
+# for each diff hunk.
+#
+# Requires environment variables (set by the workflow):
+#   GITHUB_REPOSITORY  - e.g. "CleverRaven/Cataclysm-DDA"
+#   PR_NUMBER          - pull request number
+#   COMMIT_SHA         - head commit SHA of the PR
+#   GH_TOKEN           - GitHub token for API access
 
 import os
+import re
 import subprocess
 import sys
 
@@ -12,6 +19,7 @@ from pathlib import Path
 CHANGED_FILES_INDEX = "files_changed"
 GET_AFFECTED_FILES_SCRIPT = "build-scripts/get_affected_files.py"
 BLACKLIST_PATH = "tools/iwyu/bad_files.txt"
+COMMENT_MARKER = "<!-- iwyu-suggest -->"
 
 
 def main():
@@ -34,7 +42,22 @@ def main():
         print("Nothing to analyze!")
         return
 
-    run_iwyu_and_fix(files_to_analyze)
+    try:
+        run_iwyu_and_fix(files_to_analyze)
+    except Exception as e:
+        # Don't let IWYU/fix_includes failures prevent posting
+        # whatever partial changes were applied.
+        print("IWYU run failed: %s" % e, file=sys.stderr)
+
+    diff_text = get_diff()
+    if not diff_text:
+        print("No changes after IWYU -- nothing to suggest.")
+        return
+
+    file_hunks = parse_hunks(diff_text)
+    print("Files with IWYU changes: %s" % ", ".join(file_hunks.keys()))
+
+    post_suggestions(file_hunks)
 
 
 def get_changed_files() -> list[Path]:
@@ -157,6 +180,116 @@ def run_iwyu_and_fix(files: list[Path]):
     print("::endgroup::")
     print("IWYU exit code: %d, fix_includes exit code: %d"
           % (iwyu_proc.returncode, fix_proc.returncode))
+
+
+def get_diff() -> str:
+    result = subprocess.run(
+        ["git", "diff", "--no-color"],
+        capture_output=True, encoding="utf-8")
+    return result.stdout.strip()
+
+
+def parse_hunks(diff_text: str) -> dict[str, list[dict]]:
+    """Parse a unified diff into per-file lists of hunks.
+
+    Each hunk has old_start, old_count (the original line range)
+    and new_lines (the replacement content for a suggestion block).
+    """
+    files = {}
+    current_file = None
+    in_hunk = False
+
+    for line in diff_text.split("\n"):
+        m = re.match(r"^diff --git a/.+ b/(.+)$", line)
+        if m:
+            current_file = m.group(1)
+            files.setdefault(current_file, [])
+            in_hunk = False
+            continue
+
+        m = re.match(r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@", line)
+        if m and current_file is not None:
+            old_start = int(m.group(1))
+            old_count = int(m.group(2)) if m.group(2) is not None else 1
+            files[current_file].append({
+                "old_start": old_start,
+                "old_count": old_count,
+                "new_lines": [],
+            })
+            in_hunk = True
+            continue
+
+        if in_hunk and current_file is not None and files[current_file]:
+            hunk = files[current_file][-1]
+            if line.startswith("+"):
+                hunk["new_lines"].append(line[1:])
+            elif line.startswith(" "):
+                hunk["new_lines"].append(line[1:])
+            # '-' lines are already counted in old_count;
+            # '\' (no newline) lines are ignored.
+
+    return files
+
+
+def post_suggestions(file_hunks: dict[str, list[dict]]):
+    """Post review comments with suggestion blocks for each hunk."""
+    from github import Github, GithubException
+
+    token = os.environ.get("GH_TOKEN", "")
+    repo_name = os.environ.get("GITHUB_REPOSITORY", "")
+    pr_number = os.environ.get("PR_NUMBER", "")
+    commit_sha = os.environ.get("COMMIT_SHA", "")
+
+    if not all([token, repo_name, pr_number, commit_sha]):
+        print("Missing environment variables -- skipping comment posting.",
+              file=sys.stderr)
+        return
+
+    print("::group::Posting IWYU suggestions")
+
+    gh = Github(token)
+    repo = gh.get_repo(repo_name)
+    pr = repo.get_pull(int(pr_number))
+    commit = repo.get_commit(commit_sha)
+
+    # Delete stale IWYU comments from previous runs.
+    for comment in pr.get_review_comments():
+        if COMMENT_MARKER in comment.body:
+            print("Deleting stale IWYU comment %d on %s"
+                  % (comment.id, comment.path))
+            comment.delete()
+
+    # Post one suggestion per hunk.
+    for path, hunks in file_hunks.items():
+        for hunk in hunks:
+            old_start = hunk["old_start"]
+            old_count = hunk["old_count"]
+            new_content = "\n".join(hunk["new_lines"])
+
+            if old_count < 1:
+                continue
+
+            body = "%s\n```suggestion\n%s\n```" % (
+                COMMENT_MARKER, new_content)
+            end_line = old_start + old_count - 1
+
+            try:
+                print("Posting suggestion on %s lines %d-%d"
+                      % (path, old_start, end_line))
+                if old_count > 1:
+                    pr.create_review_comment(
+                        body=body, commit=commit, path=path,
+                        line=end_line, start_line=old_start,
+                        side="RIGHT")
+                else:
+                    pr.create_review_comment(
+                        body=body, commit=commit, path=path,
+                        line=old_start, side="RIGHT")
+            except GithubException as e:
+                print("Failed to post on %s:%d - %s"
+                      % (path, old_start, e), file=sys.stderr)
+
+    print("::endgroup::")
 
 
 def print_list(things: list):


### PR DESCRIPTION
#### Summary
Infrastructure "Use suggestion blocks for IWYU review comments"

#### Purpose of change

Fixes #85660. The IWYU suggester used `reviewdog/action-suggester` which filters suggestions by the PR diff context -- changes outside that context (like a forward declaration at line 1 when the PR only touched line 14) were silently dropped. Also each diff hunk was a separate comment without a clickable "Apply suggestion" button.

#### Describe the solution

Replace `reviewdog/action-suggester` with direct review comments via PyGithub. Each diff hunk gets a `suggestion` block, so the "Apply suggestion" button works. The script:

1. Runs IWYU + fix_includes.py as before
2. Parses `git diff` into per-file hunks
3. Deletes stale IWYU comments from previous runs (identified by HTML marker)
4. Posts one suggestion comment per hunk via `PullRequest.create_review_comment`

#### Describe alternatives you've considered

- `filter_mode: file` on action-suggester -- docs say GitHub suggestions only support `added` and `diff_context`
- File-level comments (`subject_type: file`) with diff blocks -- works but loses the "Apply suggestion" button

#### Testing

Verified in https://github.com/dumb-kevin/Cataclysm-DDA/pull/4

#### Additional context