### PR TITLE
Add --rng-seed-fuzz to test runner

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -208,6 +208,11 @@ bool debug_has_error_been_observed()
     return error_observed;
 }
 
+void debug_reset_error_observed()
+{
+    error_observed = false;
+}
+
 // saved in game::serialize
 bool debug_mode = false;
 

--- a/src/debug.h
+++ b/src/debug.h
@@ -210,6 +210,11 @@ void limitDebugClass( int );
 bool debug_has_error_been_observed();
 
 /**
+ * Reset the error observation flag (for seed-fuzz test reruns).
+ */
+void debug_reset_error_observed();
+
+/**
  * Capturing debug messages during func execution,
  * used to test debugmsg calls in the unit tests
  * @return std::string debugmsg

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -11,6 +11,7 @@
 #include <functional>
 #include <memory>
 #include <ostream>
+#include <random>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -63,6 +64,7 @@ static std::string user_dir;
 static bool dont_save{ false };
 static option_overrides_t option_overrides_for_test_suite;
 static std::string error_fmt = "human-readable";
+static int rng_seed_fuzz_iterations = 0;
 
 static std::chrono::system_clock::time_point start_time;
 static std::chrono::system_clock::time_point end_time;
@@ -203,7 +205,8 @@ struct CataListener : Catch::TestEventListenerBase {
     using TestEventListenerBase::TestEventListenerBase;
 
     void testRunStarting( Catch::TestRunInfo const & ) override {
-        if( needs_game ) {
+        static bool game_initialized = false;
+        if( needs_game && !game_initialized ) {
             try {
                 init_global_game_state( mods, option_overrides_for_test_suite, user_dir );
             } catch( ... ) {
@@ -212,14 +215,18 @@ struct CataListener : Catch::TestEventListenerBase {
                 fail_to_init_game_state = true;
                 throw;
             }
+            game_initialized = true;
             // NOLINTNEXTLINE(cata-tests-must-restore-global-state)
             error_during_initialization = debug_has_error_been_observed();
 
             DebugLog( D_INFO, DC_ALL ) << "Game data loaded, running Catch2 session:" << std::endl;
-        } else {
+        } else if( !needs_game ) {
             DebugLog( D_INFO, DC_ALL ) << "Running Catch2 session:" << std::endl;
         }
-        end_time = start_time = std::chrono::system_clock::now();
+        if( start_time == std::chrono::system_clock::time_point{} ) {
+            start_time = std::chrono::system_clock::now();
+        }
+        end_time = start_time;
     }
 
     void testRunEnded( Catch::TestRunStats const & ) override {
@@ -302,6 +309,7 @@ TEST_CASE( "noop_test", "[.]" )
     CHECK( true );
 }
 
+
 int main( int argc, const char *argv[] )
 {
     cata::init_allocator();
@@ -354,6 +362,10 @@ int main( int argc, const char *argv[] )
                  | Opt( limit_debug_level, "number" )
                  ["--set-debug-level-mask"]
                  ( "[CataclysmDDA] Set debug level bitmask - see `enum DebugLevel` in src/debug.h for individual bits definition" )
+                 | Opt( rng_seed_fuzz_iterations, "N" )
+                 ["--rng-seed-fuzz"]
+                 // NOLINTNEXTLINE(cata-text-style)
+                 ( "[CataclysmDDA] Run tests N times with varying RNG seeds, reusing loaded game data. With --rng-seed X: uses X, X+1, ... Without: random seeds." )
                  ;
     session.cli( cli );
 
@@ -419,12 +431,15 @@ int main( int argc, const char *argv[] )
     const unsigned int seed = session.config().rngSeed();
     if( seed ) {
         rng_set_engine_seed( seed );
-
+    }
+    if( rng_seed_fuzz_iterations <= 1 ) {
         // If the run is terminated due to a crash during initialization, we won't
         // see the seed unless it's printed out in advance, so do that here.
-        DebugLog( D_INFO, DC_ALL ) << "Randomness seeded to: " << seed << std::endl;
-    } else {
-        DebugLog( D_INFO, DC_ALL ) << "Default randomness seeded to: " << rng_get_first_seed() << std::endl;
+        if( seed ) {
+            DebugLog( D_INFO, DC_ALL ) << "Randomness seeded to: " << seed << std::endl;
+        } else {
+            DebugLog( D_INFO, DC_ALL ) << "Default randomness seeded to: " << rng_get_first_seed() << std::endl;
+        }
     }
 
     // Tests not requiring the global game initialized are tagged with [nogame]
@@ -453,7 +468,30 @@ int main( int argc, const char *argv[] )
     }
 
     try {
-        result = session.run();
+        if( rng_seed_fuzz_iterations > 1 ) {
+            // NOLINTNEXTLINE(cata-determinism)
+            std::minstd_rand0 fuzz_rng(
+                std::chrono::high_resolution_clock::now().time_since_epoch().count() );
+            for( int i = 0; i < rng_seed_fuzz_iterations; i++ ) {
+                unsigned int fuzz_seed = seed ? seed + static_cast<unsigned int>( i ) : fuzz_rng();
+                Catch::ConfigData cd = session.configData();
+                cd.rngSeed = fuzz_seed;
+                session.useConfigData( cd );
+                debug_reset_error_observed();
+                DebugLog( D_INFO, DC_ALL ) << "RNG seed fuzz " << ( i + 1 ) << "/"
+                                           << rng_seed_fuzz_iterations << ", seed: " << fuzz_seed
+                                           << std::endl;
+                result = session.run();
+                if( result != 0 || debug_has_error_been_observed() ) {
+                    DebugLog( D_ERROR, DC_ALL ) << "RNG seed fuzz failed on seed " << fuzz_seed
+                                                << " (iteration " << ( i + 1 ) << ")"
+                                                << std::endl;
+                    break;
+                }
+            }
+        } else {
+            result = session.run();
+        }
     } catch( const std::exception &err ) {
         DebugLog( D_ERROR, DC_ALL ) << "Terminated:\n" << err.what();
         DebugLog( D_INFO, DC_ALL ) <<
@@ -478,11 +516,13 @@ int main( int argc, const char *argv[] )
     std::chrono::duration<double> elapsed_seconds = end_time - start_time;
     DebugLog( D_INFO, DC_ALL ) << "Finished in " << elapsed_seconds.count() << " seconds";
 
-    if( seed ) {
+    if( rng_seed_fuzz_iterations <= 1 ) {
         // Also print the seed at the end so it can be easily found
-        DebugLog( D_INFO, DC_ALL ) << "Randomness seeded to: " << seed << std::endl;
-    } else {
-        DebugLog( D_INFO, DC_ALL ) << "Default randomness seeded to: " << rng_get_first_seed() << std::endl;
+        if( seed ) {
+            DebugLog( D_INFO, DC_ALL ) << "Randomness seeded to: " << seed << std::endl;
+        } else {
+            DebugLog( D_INFO, DC_ALL ) << "Default randomness seeded to: " << rng_get_first_seed() << std::endl;
+        }
     }
 
     if( error_during_initialization ) {


### PR DESCRIPTION
#### Summary
Infrastructure "Add --rng-seed-fuzz flag to rerun tests with varying RNG seeds"

#### Purpose of change

Finding seed-dependent test failures currently means relaunching the binary in a shell loop, paying ~30s of game data init each time. Or waiting for CI to eventually catch one. Or instrumenting every specific inspected test locally. This makes RNG fuzzing painfully slow.

#### Describe the solution

New `--rng-seed-fuzz N` flag that loops `session.run()` N times inside a single process, changing the RNG seed each iteration while reusing already-loaded game data.

- `--rng-seed-fuzz 10` -- 10 iterations with random seeds
- `--rng-seed 42 --rng-seed-fuzz 10` -- seeds 42, 43, ..., 51

Game init is guarded to run only once. The debug error flag (`error_observed`) gets a reset function so it doesn't accumulate across iterations.

Stops on first failure and prints the offending seed.

#### Describe alternatives you've considered

Shell loop with `for i in $(seq ...); do ./cata_test --rng-seed $i ...; done` -- works but eats the init cost every time, which is the whole problem.

Could also create new `Catch::Session` instances per iteration, but Catch2 enforces a one-instance-per-process limit via a static flag.

#### Testing

```
# Random seeds, 3 iterations
./tests/cata_test --rng-seed-fuzz 3 "nested_items_tname"

# Sequential seeds from base
./tests/cata_test --rng-seed 100 --rng-seed-fuzz 3 "nested_items_tname"

# Normal mode unchanged
./tests/cata_test --rng-seed 42 "nested_items_tname"
```

Verified seeds actually change between iterations by printing `rng(0,999)` values from a throwaway test -- each iteration produced different output.

#### Additional context

None