### PR TITLE
Fix test labeler failing on nonexistent label removal

### DIFF
--- a/.github/workflows/test_labeler.yml
+++ b/.github/workflows/test_labeler.yml
@@ -79,15 +79,21 @@ jobs:
             if ('${{ steps.set-pr-id.outputs.pr-id }}'.trim().length == 0) {
               console.log("The PR ID artifact does not contain a pull request number.")
             } else {
-              try {
-                github.rest.issues.removeLabel({
+              const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+                issue_number: ${{ steps.set-pr-id.outputs.pr-id }},
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              });
+              const labelName = '${{ steps.setLabel.outputs.label }}';
+              if (labels.some(l => l.name === labelName)) {
+                await github.rest.issues.removeLabel({
                   issue_number: ${{ steps.set-pr-id.outputs.pr-id }},
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  name: '${{ steps.setLabel.outputs.label }}'
-                })
-              } catch (e) {
-                console.log(e)
+                  name: labelName
+                });
+              } else {
+                console.log(`Label "${labelName}" not present on PR, skipping removal.`);
               }
             }
             


### PR DESCRIPTION
#### Summary
Infrastructure "Fix test labeler failing on nonexistent label removal"

#### Purpose of change

The `remove-label` step crashes when it tries to remove a label that was never added. The `try/catch` didn't work because `removeLabel()` was never `await`ed. Also reduces notification noise from workflow failures.

#### Describe the solution

Pre-check the PR's labels before calling `removeLabel`.

#### Describe alternatives you've considered

Could have just added `await` to the existing try/catch but a pre-check is cleaner.

#### Testing

#### Additional context

None