### PR TITLE
Reject mapgen vehicle placement with out-of-bounds parts

### DIFF
--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -6600,6 +6600,26 @@ std::unique_ptr<vehicle> map::add_vehicle_to_map(
     //When hitting a wall, only smash the vehicle once (but walls many times)
     bool needs_smashing = false;
 
+    // Reject vehicles with parts extending beyond map bounds.
+    // add_vehicle() only checks the pivot; large vehicles near tinymap edges
+    // can have parts past the 24-tile boundary, causing issues in remove_part/smash.
+    for( int i = 0, cnt = veh_to_add->part_count(); i < cnt; ++i ) {
+        if( veh_to_add->part( i ).is_fake || veh_to_add->part( i ).removed ) {
+            continue;
+        }
+        if( !inbounds( veh_to_add->bub_part_pos( *this, i ) ) ) {
+            dbg( D_WARNING ) << string_format(
+                                 "%.120s (%s) part '%s' at mount %s extends to %s, "
+                                 "%.0fx%.0f map bounds exceeded; skipping placement",
+                                 veh_to_add->name, veh_to_add->type.str(),
+                                 veh_to_add->part( i ).info().id.str(),
+                                 veh_to_add->part( i ).mount.to_string(),
+                                 veh_to_add->bub_part_pos( *this, i ).to_string(),
+                                 getmapsize() * SEEX, getmapsize() * SEEY );
+            return nullptr;
+        }
+    }
+
     for( std::vector<int>::const_iterator part = frame_indices.begin();
          part != frame_indices.end(); part++ ) {
         const tripoint_bub_ms p = veh_to_add->bub_part_pos( *this, *part );


### PR DESCRIPTION
#### Summary
Bugfixes "Reject mapgen vehicle placement when parts extend beyond map bounds"

#### Purpose of change

`map::add_vehicle()` validates the vehicle's pivot point against map bounds, but not individual parts. During mapgen on a tinymap (24x24 tiles), large vehicles placed near the edge can have parts extending past the boundary. When those parts are later processed by `remove_part`/`smash` during wreck merging, it triggers a debugmsg about out-of-bounds positions.

Found via RNG seed fuzzing, also observed in CI multiple times.

#### Describe the solution

Add a bounds check for all vehicle parts in `add_vehicle_to_map()` before the existing structural-parts loop. If any non-fake, non-removed part is out of bounds, skip the placement (return nullptr). This is consistent with other rejection paths in the same function (deep water, shopping cart obstacles, impassable terrain).

#### Describe alternatives you've considered

Could clamp or shift the vehicle position inward, but that risks weird partial-vehicle placements. Skipping is simpler and already how the function handles other invalid placements.

#### Testing

Previously failing seed now passes clean. All `[vehicle]` and `[mapgen]` tests keep passing.

#### Additional context

The `MapgenRemovePartHandler` already handles out-of-bounds item drops by clipping to valid positions, so the game wouldn't crash - but the logged error can mask real issues and trips automated test harnesses that treat debugmsg as failure.