### PR TITLE
Fix flaky liquid_projectiles_applies_effect test

### DIFF
--- a/tests/projectile_test.cpp
+++ b/tests/projectile_test.cpp
@@ -30,6 +30,7 @@ static const itype_id itype_308( "308" );
 static const itype_id itype_boomer_head( "boomer_head" );
 static const itype_id itype_hazmat_suit( "hazmat_suit" );
 static const itype_id itype_m1a( "m1a" );
+static const itype_id itype_mask_gas( "mask_gas" );
 
 
 static tripoint_bub_ms projectile_end_point( const std::vector<tripoint_bub_ms> &range,
@@ -124,9 +125,10 @@ TEST_CASE( "liquid_projectiles_applies_effect", "[projectile_effect]" )
 
     dummy.clear_effects();
 
-    //Fire on NPC with hazmat suit and check that it didn't get the effect
+    //Fire on NPC with hazmat suit + gas mask and check that it didn't get the effect
     SECTION( "Hazmat NPC doesn't get the effect" ) {
         dummy.wear_item( hazmat );
+        dummy.wear_item( item( itype_mask_gas ) );
         player.fire_gun( here, dummy.pos_bub(), 100, *player.get_wielded_item() );
         CHECK( !dummy.has_effect( effect_bile_stink ) );
     }


### PR DESCRIPTION
#### Summary
Bugfixes "Fix flaky liquid_projectiles_applies_effect test"

#### Purpose of change

The `liquid_projectiles_applies_effect` test ("Hazmat NPC doesn't get the effect") fails intermittently. Observed in https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/22681699021/job/65753700185?pr=85671

#### Describe the solution

The hazmat suit covers `head` but not `eyes` or `mouth` as separate body parts. When a liquid projectile hits those parts, `clothing_wetness_mult` finds no covering item, returns full permeability, and `bile_stink` gets applied despite the suit.

Add a gas mask to the test dummy alongside the hazmat suit. The gas mask covers `eyes` and `mouth`, so all body parts are now protected against liquid permeation.

#### Describe alternatives you've considered

Adding `eyes`/`mouth` coverage to the hazmat suit JSON, but that's a balance change rather than a test fix.

#### Testing

The test should now pass consistently regardless of which body part the projectile hits.

#### Additional context

None