### PR TITLE
Fix smoker/mill finalization on save off bubble

### DIFF
--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -6452,9 +6452,8 @@ bool iexamine::smoker_fire( Character &you, const tripoint_bub_ms &examp )
     return true;
 }
 
-void iexamine::mill_finalize( Character &, const tripoint_bub_ms &examp )
+void iexamine::mill_finalize( Character &, map &here, const tripoint_bub_ms &examp )
 {
-    map &here = get_map();
     const furn_id &cur_mill_type = here.furn( examp );
     furn_id next_mill_type = furn_str_id::NULL_ID();
     if( cur_mill_type == furn_f_wind_mill_active ) {
@@ -6568,10 +6567,9 @@ void iexamine::mill_finalize( Character &, const tripoint_bub_ms &examp )
     here.furn_set( examp, next_mill_type );
 }
 
-static void smoker_finalize( Character &, const tripoint_bub_ms &examp,
+static void smoker_finalize( map &here, Character &, const tripoint_bub_ms &examp,
                              const time_point &start_time )
 {
-    map &here = get_map();
     const furn_id &cur_smoker_type = here.furn( examp );
     furn_id next_smoker_type = furn_str_id::NULL_ID();
     if( cur_smoker_type == furn_f_smoking_rack_active ) {
@@ -6805,12 +6803,12 @@ static void mill_load_food( Character &you, const tripoint_bub_ms &examp,
     you.invalidate_crafting_inventory();
 }
 
-void iexamine::on_smoke_out( const tripoint_bub_ms &examp, const time_point &start_time )
+void iexamine::on_smoke_out( map &here, const tripoint_bub_ms &examp, const time_point &start_time )
 {
-    const furn_id &f = get_map().furn( examp );
+    const furn_id &f = here.furn( examp );
     if( f == furn_f_smoking_rack_active ||
         f == furn_f_metal_smoking_rack_active ) {
-        smoker_finalize( get_avatar(), examp, start_time );
+        smoker_finalize( here, get_avatar(), examp, start_time );
     }
 }
 

--- a/src/iexamine.h
+++ b/src/iexamine.h
@@ -18,6 +18,7 @@ class Character;
 class JsonObject;
 class item;
 class item_location;
+class map;
 class time_point;
 class vpart_reference;
 struct itype;
@@ -138,9 +139,9 @@ void ledge( Character &you, const tripoint_bub_ms &examp );
 void autodoc( Character &you, const tripoint_bub_ms &examp );
 void attunement_altar( Character &you, const tripoint_bub_ms &examp );
 void translocator( Character &you, const tripoint_bub_ms &examp );
-void on_smoke_out( const tripoint_bub_ms &examp,
+void on_smoke_out( map &here, const tripoint_bub_ms &examp,
                    const time_point &start_time ); //activates end of smoking effects
-void mill_finalize( Character &, const tripoint_bub_ms &examp );
+void mill_finalize( Character &, map &here, const tripoint_bub_ms &examp );
 void quern_examine( Character &you, const tripoint_bub_ms &examp );
 void smoker_options( Character &you, const tripoint_bub_ms &examp );
 bool smoker_prep( Character &you, const tripoint_bub_ms &examp );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4130,7 +4130,7 @@ bool item::process_fake_mill( map &here, Character * /*carrier*/, const tripoint
         return true; //destroy fake mill
     }
     if( age() >= 6_hours || item_counter == 0 ) {
-        iexamine::mill_finalize( get_avatar(), pos ); //activate effects when timers goes to zero
+        iexamine::mill_finalize( get_avatar(), here, pos ); //activate effects when timers goes to zero
         return true; //destroy fake mill item
     }
 
@@ -4147,7 +4147,7 @@ bool item::process_fake_smoke( map &here, Character * /*carrier*/, const tripoin
     }
 
     if( age() >= 6_hours || item_counter == 0 ) {
-        iexamine::on_smoke_out( pos, birthday() ); //activate effects when timers goes to zero
+        iexamine::on_smoke_out( here, pos, birthday() ); //activate effects when timers goes to zero
         return true; //destroy fake smoke when it 'burns out'
     }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #85668, i.e. smoking racks and wind mills not getting processed properly when saved off reality bubble after their processing has finished.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Carry the map processed down to the finalization rather than using the supplied bubble coordinates with the reality bubble.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Use the same framework as explosion handling uses to ensure the current map (fetched by get_map()) is set to be the one actually being processed for the duration of the special processing and then restore the reality bubble as the "current" map when serializing saves.
It has the advantage that it would redirect other usages of get_map() to use the map actually processd for the various calls made transitively during loading and actualization of maps, but has the disadvantage of only covering game saving specifically, rather than other (future?) off bubble map processing.
It can also be noted that it is possible to implement both. These two specific cases are only called via map loading, and so should refer the map actually loaded, rather than the "current" map.
Based on the call stack ultimately calling the finalization, it looks like the point for a "current" map redirection would be in visitable.cpp operation map_cursor::visit_items() before the here.load() call.
Edit: Redirecting the current map in visit_item() could be risky, because you don't have the map you're loading yet. The good thing here is that it's a tinymap, but a tinymap is still loaded as 4 submaps, so any referencing may point to parts not yet loaded, and it would also mess with the map::load() check against the reality bubble. We yet again have the problem that map loading transitively calls a lot of stuff that's not safe to call during map loading (although post load processing is a bit safer), as well as stuff that treats coordinates as reality bubble coordinates despite being called by map methods that SHOULD only refer to itself unless other maps are referenced explicitly.
- Change map::load() to redirect the "current" map to itself. That would probably result in the exposure of lots of interesting bugs where reality bubble coordinates are mixed with the loaded map's coordinates as interchangeable, which works mostly fine when dealing with loading of new parts of the reality bubble, but can blow up when loading other stuff (explosions, saving the game, remote map location editing (kept mostly safe for now due to restricted set of operations used for "mapgen" updates)).

Edit 2:
There's probably nobody who's going to read this, but anyway:
I tested to swap out the map in map_cursor::visit_items() before the "here.load()" call (on my master, which hasn't yet been updated to include this PR), and it caused things to work properly as well, i.e. the products in the mill and the smoker were produced correctly in the bug report reproduction scenario.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Repeated the tests procedure of the bug report (after replicating the original bugged effects) and found the smoker contained dehydrated corn kernels and the mill contained flour. Both "furnitures" were inactive (though I didn't check whether they were actually active in the bugged save).
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
This should cover water mills as well, as it is the same code as the wind mill one, but that path hasn't been tested.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
