### PR TITLE
Fix flaky melee damage type effectiveness test

### DIFF
--- a/tests/melee_test.cpp
+++ b/tests/melee_test.cpp
@@ -358,7 +358,7 @@ static void check_damage_from_test_fire( const std::string &mon_id, int expected
     int total_dmg = 0;
     int total_hits = 0;
     int set_on_fire = 0;
-    for( int i = 0; i < 1000; i++ ) {
+    for( int i = 0; i < 1500; i++ ) {
         clear_creatures();
         standard_npc dude( "TestCharacter", dude_pos, {}, 8, 10, 10, 10, 10 );
         monster &mon = spawn_test_monster( mon_id, dude.pos_bub() + tripoint::east );
@@ -380,9 +380,9 @@ static void check_damage_from_test_fire( const std::string &mon_id, int expected
         }
     }
     Messages::clear_messages();
-    CHECK( total_hits == Approx( 1000 ).margin( 50 ) );
+    CHECK( total_hits == Approx( 1500 ).margin( 75 ) );
     CHECK( set_on_fire == total_hits );
-    CHECK( total_dmg / static_cast<float>( total_hits ) == Approx( expected_avg_dmg ).epsilon( 0.05 ) );
+    CHECK( total_dmg / static_cast<float>( total_hits ) == Approx( expected_avg_dmg ).epsilon( 0.06 ) );
 }
 
 static void check_eocs_from_test_fire( const std::string &mon_id )


### PR DESCRIPTION
#### Summary
Infrastructure "Fix flaky Damage_type_effectiveness_vs_monster_resistance test"

#### Purpose of change

The test flakes on CI (seed 1772741052): avg damage 8.40454 vs expected 8.0, barely exceeding the 5% epsilon cap of 8.4. Observed in https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/22734285473/job/65931396803?pr=85675

#### Describe the solution

Increase iterations (1000 -> 1500) and epsilon (0.05 -> 0.06) for the monster-targeting `check_damage_from_test_fire`.

The NPC has a ~37% crit rate against zero-dodge monsters, making per-hit variance high (SD ~4.6). This moves P(fail) from ~1/350 to ~1/42000.

#### Describe alternatives you've considered

Going bigger (e.g. epsilon 0.10) but 0.06 at n=1500 is already safe enough.

#### Testing

Failing seed now passes locally.

#### Additional context

The NPC-targeting overload already uses wider margins (epsilon 0.075) so it wasn't affected.