### PR TITLE
Fix flaky vehicle_ramp_test by clearing items on non-zero z-levels

### DIFF
--- a/tests/vehicle_ramp_test.cpp
+++ b/tests/vehicle_ramp_test.cpp
@@ -42,6 +42,10 @@ static void clear_game_and_set_ramp( const int transit_x, bool use_ramp, bool up
 
     map &here = get_map();
     build_test_map( ter_id( "t_pavement" ) );
+    // build_test_map only clears items on z=0; clear the z-levels
+    // the ramp setup touches so stray items don't blow out tires.
+    clear_items( -1 );
+    clear_items( 1 );
     if( use_ramp ) {
         const int upper_zlevel = up ? 1 : 0;
         const int lower_zlevel = up - 1;


### PR DESCRIPTION
#### Summary
Bugfixes "Fix flaky vehicle ramp test"

#### Purpose of change

The `vehicle_ramp_test_59` / "angled ramp up" section flakes in CI -- the motorcycle's tires blow out on stray items left on z=1, tanking velocity from 400 to 150.

Observed in https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/22735946808/job/65937234097?pr=85671

Log messages from the failing run:
```
You hear a loud pop from below, and your vehicle suddenly start to wobble like crazy!
With a jolt, hitting something has blown out your tire!
The weight of the Motorcycle destroys several items!
```

#### Describe the solution

`build_test_map` only clears items on z=0. The ramp setup in `clear_game_and_set_ramp` places terrain on z=-1 and z=1 but never clears whatever items are already sitting there. Added `clear_items(-1)` and `clear_items(1)` after `build_test_map`.

#### Describe alternatives you've considered

Could also clear items inline in the terrain-setting loops, but `clear_items` is simpler and already exists for exactly this purpose.

#### Testing

Checked that no other test files share this pattern (`build_test_map` + non-zero z-level terrain for vehicle movement).

#### Additional context

None