### PR TITLE
Fix main pathfinder routing through open air on upper floors

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -11086,6 +11086,10 @@ void map::update_pathfinding_cache( const tripoint_bub_ms &p ) const
         cur_value |= PathfindingFlag::DangerousTrap;
     }
 
+    if( terrain.has_flag( ter_furn_flag::TFLAG_NO_FLOOR ) && !this->has_vehicle_floor( p ) ) {
+        cur_value |= PathfindingFlag::Air;
+    }
+
     if( terrain.has_flag( ter_furn_flag::TFLAG_GOES_UP ) ) {
         cur_value |= PathfindingFlag::GoesUp;
     }

--- a/src/pathfinding.cpp
+++ b/src/pathfinding.cpp
@@ -556,6 +556,21 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f,
                 }
             }
 
+            // Bare NO_FLOOR tiles without a trap: try to climb down, then close.
+            if( settings.avoid_traps && ( p_special & PathfindingFlag::Air ) ) {
+                tripoint_bub_ms below( p + tripoint::below );
+                if( valid_move( p, below, false, true ) ) {
+                    if( !has_flag( ter_furn_flag::TFLAG_NO_FLOOR, below ) ) {
+                        path_data_layer &layer_below = pf.get_layer( p.z() - 1 );
+                        pf.add_point( layer_below.gscore[parent_index] + 10,
+                                      layer_below.score[parent_index] + 10 + 2 * rl_dist( below, t ),
+                                      cur, below );
+                    }
+                }
+                layer.closed[index] = true;
+                continue;
+            }
+
             pf.add_point( newg, newg + 2 * rl_dist( p, t ), cur, p );
         }
 

--- a/tests/clzones_test.cpp
+++ b/tests/clzones_test.cpp
@@ -2156,6 +2156,9 @@ TEST_CASE( "route_with_grab_strength_gating",
     dummy.setpos( here, start_pos + tripoint::north );
     dummy.setpos( here, start_pos );
     CHECK( zone_sorting::route_length( dummy, dest_pos ) != INT_MAX );
+
+    dummy.grab( object_type::NONE );
+    clear_map_without_vision();
 }
 
 TEST_CASE( "route_cache_invalidation_on_mass_change",
@@ -2207,5 +2210,9 @@ TEST_CASE( "route_cache_invalidation_on_mass_change",
 
     const int len_after = zone_sorting::route_length( dummy, dest_pos );
     CHECK( len_after == INT_MAX );
+
+    dummy.grab( object_type::NONE );
+    zone_manager::get_manager().clear();
+    clear_map_without_vision();
 }
 

--- a/tests/map_path_test.cpp
+++ b/tests/map_path_test.cpp
@@ -492,6 +492,8 @@ TEST_CASE( "map_route_player_up_down_stairs", "[map][pathfinding]" )
          */
         m.ter_set( tripoint_bub_ms{ 67, 65, 0 }, t_stairs_up );
         m.ter_set( tripoint_bub_ms{ 67, 65, 1 }, t_stairs_down );
+        m.ter_set( tripoint_bub_ms{ 68, 65, 1 }, t_floor );
+        m.ter_set( tripoint_bub_ms{ 69, 65, 1 }, t_floor );
         clear_map_caches( m );
         WHEN( "map::route does pathfinding" ) {
             const pathfinding_target t = pathfinding_target::point(


### PR DESCRIPTION
#### Summary
Bugfixes "Fix main pathfinder routing through open air on upper floors"

#### Purpose of change

On upper floors the player auto-travel happily routes through windows into open air. PR #85642 fixed this for `route_with_grab` but the main `map::route` pathfinder was never touched.

Root cause: `PathfindingFlag::Air` existed in the enum but was never set or checked. The main A*'s NO_FLOOR handling is gated on `DangerousTrap`, which only fires when a real trap exists. `t_open_air` has no trap, so the pathfinder treats it as normal walkable ground.

#### Describe the solution

- Set `PathfindingFlag::Air` in `update_pathfinding_cache` for tiles with `TFLAG_NO_FLOOR` (and no vehicle floor).
- Handle the Air flag in `map::route` the same way the existing `DangerousTrap + NO_FLOOR` block works: try to route down if there's solid ground below, otherwise close the tile.
- Fix two tests in clzones_test.cpp that left stale grab state contaminating later pathfinding tests.
- Add floor tiles to the stairs-up pathfinding test that was relying on the open-air-as-walkable bug.

#### Describe alternatives you've considered

Could have added a built-in trap to `t_open_air` so the existing `DangerousTrap` path would catch it, but that felt like a hack -- the Air flag already exists for exactly this purpose, it just wasn't wired up.

#### Testing

- All [pathfinding] tests pass
- Tested in-game on a two-story house: auto-sort no longer routes through windows on the second floor.

#### Additional context

None