### PR TITLE
If Rubik sees you with Hub 01 cybernetics, no more Exodii for you

### DIFF
--- a/data/json/npcs/exodii/exodii_merchant_talk.json
+++ b/data/json/npcs/exodii/exodii_merchant_talk.json
@@ -130,20 +130,32 @@
     "id": "TALK_EXODII_MERCHANT",
     "type": "talk_topic",
     "dynamic_line": {
-      "u_has_effect": "u_exodii_interaction_timer_short",
-      "yes": [
-        "Back in a blink and a whiff, eh?",
-        { "gendered_line": "Forgot sommat?", "relevant_genders": [ "u" ] },
-        "Ah, a returnin', an I'm ken."
-      ],
+      "u_has_bionics": "bio_robofac_xmarm",
+      "yes": "&The towering mass of metal rests its hands on its exotic rifle, albeit rather naturally and calmly.  After a brief pause, a hefty finger gently toggles a safety switch on the side of the firearm: *click*.",
       "no": {
-        "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Rubik" } ],
-        "yes": [
-          "&\"And a fine return, matey.\"  Rubik puts a hand on the countertop, and gestures you closer with the other.",
-          "Fine and you still ain't dead.\"  Their gravelly voice is cheerful.  \"What brings ye roun' Rubik's neckawoods?",
-          "Bright and sunny, you're back!\"  There's a bit of a friendly chuckle in Rubik's gravelly voice.  \"Rubik's got goods for ye, if you got goods for Rubik."
-        ],
-        "no": "&Before you stands a towering mass of metal, at least seven feet high, with a large reflective glass plate in the center of its torso.  It turns as you enter the room, and raises its hand in a surprisingly natural motion of greeting.  A gravelly voice resonates from unseen speakers in the steel frame.  Its tone is bizarrely normal, in complete contrast with everything else around you.  \"Oy, you ain't dead.  Lookin' t'trade?\"  The accent sounds vaguely British, but not familiar; like a terrible imitation of Cockney."
+        "u_has_bionics": "bio_robofac_xmleg",
+        "yes": "&The towering mass of metal rests its hands on its exotic rifle, albeit rather naturally and calmly.  After a brief pause, a hefty finger gently toggles a safety switch on the side of the firearm: *click*.",
+        "no": {
+          "u_has_bionics": "bio_robofac_xmback",
+          "yes": "&The towering mass of metal rests its hands on its exotic rifle, albeit rather naturally and calmly.  After a brief pause, a hefty finger gently toggles a safety switch on the side of the firearm: *click*.",
+          "no": {
+            "u_has_effect": "u_exodii_interaction_timer_short",
+            "yes": [
+              "Back in a blink and a whiff, eh?",
+              { "gendered_line": "Forgot sommat?", "relevant_genders": [ "u" ] },
+              "Ah, a returnin', an I'm ken."
+            ],
+            "no": {
+              "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Rubik" } ],
+              "yes": [
+                "&\"And a fine return, matey.\"  Rubik puts a hand on the countertop, and gestures you closer with the other.",
+                "Fine and you still ain't dead.\"  Their gravelly voice is cheerful.  \"What brings ye roun' Rubik's neckawoods?",
+                "Bright and sunny, you're back!\"  There's a bit of a friendly chuckle in Rubik's gravelly voice.  \"Rubik's got goods for ye, if you got goods for Rubik."
+              ],
+              "no": "&Before you stands a towering mass of metal, at least seven feet high, with a large reflective glass plate in the center of its torso.  It turns as you enter the room, and raises its hand in a surprisingly natural motion of greeting.  A gravelly voice resonates from unseen speakers in the steel frame.  Its tone is bizarrely normal, in complete contrast with everything else around you.  \"Oy, you ain't dead.  Lookin' t'trade?\"  The accent sounds vaguely British, but not familiar; like a terrible imitation of Cockney."
+            }
+          }
+        }
       }
     },
     "speaker_effect": [
@@ -170,40 +182,100 @@
     ],
     "responses": [
       {
+        "text": "What's going on?",
+        "topic": "TALK_EXODII_MERCHANT_Hates_Hub_Cyborgs",
+        "condition": {
+          "or": [
+            { "u_has_bionics": "bio_robofac_xmarm" },
+            { "u_has_bionics": "bio_robofac_xmleg" },
+            { "u_has_bionics": "bio_robofac_xmback" }
+          ]
+        }
+      },
+      {
         "text": "Who are you?  What is this place?",
         "topic": "TALK_EXODII_MERCHANT_New",
-        "condition": { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Rubik" } ] } },
+        "condition": {
+          "and": [
+            { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Rubik" } ] } },
+            { "not": { "u_has_bionics": "bio_robofac_xmarm" } },
+            { "not": { "u_has_bionics": "bio_robofac_xmleg" } },
+            { "not": { "u_has_bionics": "bio_robofac_xmback" } }
+          ]
+        },
         "effect": { "u_add_var": "general_meeting_u_met_Rubik", "value": "yes" }
       },
       {
         "text": "What've you got for trade?",
         "effect": "start_trade",
         "topic": "TALK_EXODII_MERCHANT_DoneTrade",
-        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Rubik" } ] }
+        "condition": {
+          "and": [
+            { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Rubik" } ] },
+            { "not": { "u_has_bionics": "bio_robofac_xmarm" } },
+            { "not": { "u_has_bionics": "bio_robofac_xmleg" } },
+            { "not": { "u_has_bionics": "bio_robofac_xmback" } }
+          ]
+        }
       },
       {
         "text": "Actually, I wanted to talk.",
         "topic": "TALK_EXODII_MERCHANT_Talk",
-        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Rubik" } ] }
+        "condition": {
+          "and": [
+            { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Rubik" } ] },
+            { "not": { "u_has_bionics": "bio_robofac_xmarm" } },
+            { "not": { "u_has_bionics": "bio_robofac_xmleg" } },
+            { "not": { "u_has_bionics": "bio_robofac_xmback" } }
+          ]
+        }
       },
       {
         "text": "Can you do something for me?",
         "topic": "TALK_EXODII_MERCHANT_DoSomething",
-        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Rubik" } ] }
+        "condition": {
+          "and": [
+            { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Rubik" } ] },
+            { "not": { "u_has_bionics": "bio_robofac_xmarm" } },
+            { "not": { "u_has_bionics": "bio_robofac_xmleg" } },
+            { "not": { "u_has_bionics": "bio_robofac_xmback" } }
+          ]
+        }
       },
       {
         "text": "I'm here to talk about a job.",
         "topic": "TALK_EXODII_MERCHANT_TalkJob",
-        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Rubik" } ] }
+        "condition": {
+          "and": [
+            { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Rubik" } ] },
+            { "not": { "u_has_bionics": "bio_robofac_xmarm" } },
+            { "not": { "u_has_bionics": "bio_robofac_xmleg" } },
+            { "not": { "u_has_bionics": "bio_robofac_xmback" } }
+          ]
+        }
       },
       {
         "text": "Hell no, I'm out of here.",
-        "condition": { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Rubik" } ] } },
+        "condition": {
+          "and": [
+            { "not": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Rubik" } ] } },
+            { "not": { "u_has_bionics": "bio_robofac_xmarm" } },
+            { "not": { "u_has_bionics": "bio_robofac_xmleg" } },
+            { "not": { "u_has_bionics": "bio_robofac_xmback" } }
+          ]
+        },
         "topic": "TALK_DONE"
       },
       {
         "text": "Just popping in to say hi.  See you later, alligator.",
-        "condition": { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Rubik" } ] },
+        "condition": {
+          "and": [
+            { "compare_string": [ "yes", { "u_val": "general_meeting_u_met_Rubik" } ] },
+            { "not": { "u_has_bionics": "bio_robofac_xmarm" } },
+            { "not": { "u_has_bionics": "bio_robofac_xmleg" } },
+            { "not": { "u_has_bionics": "bio_robofac_xmback" } }
+          ]
+        },
         "topic": "TALK_DONE"
       },
       {
@@ -211,7 +283,10 @@
         "condition": {
           "and": [
             { "math": [ "time_since(u_timer_exodii_cybor_rescue_operating) < time('1 d')" ] },
-            { "compare_string": [ "yes", { "u_val": "dialogue_exodii_cybor_rescue_ongoing" } ] }
+            { "compare_string": [ "yes", { "u_val": "dialogue_exodii_cybor_rescue_ongoing" } ] },
+            { "not": { "u_has_bionics": "bio_robofac_xmarm" } },
+            { "not": { "u_has_bionics": "bio_robofac_xmleg" } },
+            { "not": { "u_has_bionics": "bio_robofac_xmback" } }
           ]
         },
         "topic": "TALK_EXODII_MERCHANT_Experiment_Cyborg_Rescue_Ongoing"
@@ -221,7 +296,10 @@
         "condition": {
           "and": [
             { "math": [ "time_since(u_timer_exodii_cybor_rescue_operating) > time('1 d')" ] },
-            { "compare_string": [ "yes", { "u_val": "dialogue_exodii_cybor_rescue_ongoing" } ] }
+            { "compare_string": [ "yes", { "u_val": "dialogue_exodii_cybor_rescue_ongoing" } ] },
+            { "not": { "u_has_bionics": "bio_robofac_xmarm" } },
+            { "not": { "u_has_bionics": "bio_robofac_xmleg" } },
+            { "not": { "u_has_bionics": "bio_robofac_xmback" } }
           ]
         },
         "topic": "TALK_EXODII_MERCHANT_Experiment_Cyborg_Rescue_Complete"
@@ -237,7 +315,10 @@
                 { "u_has_items": { "item": "bot_broken_cyborg", "count": 1 } },
                 { "u_has_items": { "item": "bot_prototype_cyborg", "count": 1 } }
               ]
-            }
+            },
+            { "not": { "u_has_bionics": "bio_robofac_xmarm" } },
+            { "not": { "u_has_bionics": "bio_robofac_xmleg" } },
+            { "not": { "u_has_bionics": "bio_robofac_xmback" } }
           ]
         },
         "topic": "TALK_EXODII_MERCHANT_Experiment_Cyborg_Rescue"
@@ -1769,6 +1850,21 @@
       },
       { "text": "<done_conversation_section>", "topic": "TALK_EXODII_MERCHANT_Talk" },
       { "text": "<end_talking_leave>  See you later, Rubik.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "TALK_EXODII_MERCHANT_Hates_Hub_Cyborgs",
+    "type": "talk_topic",
+    "dynamic_line": {
+      "//~": "We've had some tech and some workers go missing, and we've heard from a few trade partners that a certain bunker is offering stolen cybernetics.  Your bionics.  You didn't get them from around here.  You've got two minutes to get out of here.  You are not welcome here.  Got it?",
+      "str": "Shinies an' stompers missin', an' escoltin' a bunker offerin' stolen steelies.  Thine steelies.  Ne.  Ye ain't tassed from around here.  Ye've two minutes to traipse out o'here.  Ken it."
+    },
+    "responses": [
+      {
+        "text": "Two minutes to get out of here?  Ah, shit.",
+        "topic": "TALK_DONE",
+        "effect": { "run_eocs": "EOC_EXODII_HATES_YOU", "time_in_future": [ "100 seconds", "140 seconds" ] }
+      }
     ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Features "Hub 01 cyborgs are not welcome at the Exodii castle"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

The Exodii are already very cautious of Hub 01, and would be catching on to their games as the Hub 01 autodoc goes live.  The probably wouldn't deal with Hub 01 cyborgs, once they meet them.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

If the player shows up with Hub 01 cybernetics (the new external ones) and talks to Rubik, they'll tell the player to leave and turn hostile (with a 2 minute warning).

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Letting the player cover the cybernetics.
No warning.
Some kind of trait or variable on CBM install to make the checks in the dialogue file a little less cumbersome (only necessary later if visible Hub cybernetics get greatly expanded)

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Talked to Rubik with and without cybernetics.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
