### PR TITLE
Filter item info body part display by viewer anatomy

### DIFF
--- a/data/mods/TEST_DATA/body_parts.json
+++ b/data/mods/TEST_DATA/body_parts.json
@@ -313,6 +313,133 @@
     "modified_bodyparts": [ { "gain": "test_lizard_tail" } ]
   },
   {
+    "id": "test_alt_arm_l",
+    "type": "body_part",
+    "copy-from": "arm_l",
+    "name": "alt arm",
+    "name_multiple": "alt arms",
+    "heading": "L. Alt Arm",
+    "heading_multiple": "Alt Arms",
+    "main_part": "test_alt_arm_l",
+    "opposite_part": "test_alt_arm_r",
+    "side": "left",
+    "similar_bodypart": "arm_l",
+    "sub_parts": [ "test_alt_arm_shoulder_l", "test_alt_arm_upper_l", "test_alt_arm_elbow_l", "test_alt_arm_lower_l" ]
+  },
+  {
+    "id": "test_alt_arm_r",
+    "type": "body_part",
+    "copy-from": "arm_r",
+    "name": "alt arm",
+    "name_multiple": "alt arms",
+    "heading": "R. Alt Arm",
+    "heading_multiple": "Alt Arms",
+    "main_part": "test_alt_arm_r",
+    "opposite_part": "test_alt_arm_l",
+    "side": "right",
+    "similar_bodypart": "arm_r",
+    "sub_parts": [ "test_alt_arm_shoulder_r", "test_alt_arm_upper_r", "test_alt_arm_elbow_r", "test_alt_arm_lower_r" ]
+  },
+  {
+    "id": "test_alt_arm_shoulder_l",
+    "type": "sub_body_part",
+    "max_coverage": 20,
+    "parent": "test_alt_arm_l",
+    "side": "left",
+    "similar_bodypart": "arm_shoulder_l",
+    "opposite": "test_alt_arm_shoulder_r",
+    "name": "left alt shoulder",
+    "name_multiple": "alt shoulders"
+  },
+  {
+    "id": "test_alt_arm_upper_l",
+    "type": "sub_body_part",
+    "max_coverage": 40,
+    "parent": "test_alt_arm_l",
+    "side": "left",
+    "similar_bodypart": "arm_upper_l",
+    "opposite": "test_alt_arm_upper_r",
+    "name": "left alt upper arm",
+    "name_multiple": "alt upper arms"
+  },
+  {
+    "id": "test_alt_arm_elbow_l",
+    "type": "sub_body_part",
+    "max_coverage": 5,
+    "parent": "test_alt_arm_l",
+    "side": "left",
+    "similar_bodypart": "arm_elbow_l",
+    "opposite": "test_alt_arm_elbow_r",
+    "name": "left alt elbow",
+    "name_multiple": "alt elbows"
+  },
+  {
+    "id": "test_alt_arm_lower_l",
+    "type": "sub_body_part",
+    "max_coverage": 35,
+    "parent": "test_alt_arm_l",
+    "side": "left",
+    "similar_bodypart": "arm_lower_l",
+    "opposite": "test_alt_arm_lower_r",
+    "name": "left alt forearm",
+    "name_multiple": "alt forearms"
+  },
+  {
+    "id": "test_alt_arm_shoulder_r",
+    "type": "sub_body_part",
+    "max_coverage": 20,
+    "parent": "test_alt_arm_r",
+    "side": "right",
+    "similar_bodypart": "arm_shoulder_r",
+    "opposite": "test_alt_arm_shoulder_l",
+    "name": "right alt shoulder",
+    "name_multiple": "alt shoulders"
+  },
+  {
+    "id": "test_alt_arm_upper_r",
+    "type": "sub_body_part",
+    "max_coverage": 40,
+    "parent": "test_alt_arm_r",
+    "side": "right",
+    "similar_bodypart": "arm_upper_r",
+    "opposite": "test_alt_arm_upper_l",
+    "name": "right alt upper arm",
+    "name_multiple": "alt upper arms"
+  },
+  {
+    "id": "test_alt_arm_elbow_r",
+    "type": "sub_body_part",
+    "max_coverage": 5,
+    "parent": "test_alt_arm_r",
+    "side": "right",
+    "similar_bodypart": "arm_elbow_r",
+    "opposite": "test_alt_arm_elbow_l",
+    "name": "right alt elbow",
+    "name_multiple": "alt elbows"
+  },
+  {
+    "id": "test_alt_arm_lower_r",
+    "type": "sub_body_part",
+    "max_coverage": 35,
+    "parent": "test_alt_arm_r",
+    "side": "right",
+    "similar_bodypart": "arm_lower_r",
+    "opposite": "test_alt_arm_lower_l",
+    "name": "right alt forearm",
+    "name_multiple": "alt forearms"
+  },
+  {
+    "type": "enchantment",
+    "id": "ENCH_TEST_ALT_ARMS",
+    "condition": "ALWAYS",
+    "modified_bodyparts": [
+      { "lose": "arm_l" },
+      { "gain": "test_alt_arm_l" },
+      { "lose": "arm_r" },
+      { "gain": "test_alt_arm_r" }
+    ]
+  },
+  {
     "type": "enchantment",
     "id": "ENCH_TEST_BIRD_PARTS",
     "condition": "ALWAYS",

--- a/data/mods/TEST_DATA/body_parts.json
+++ b/data/mods/TEST_DATA/body_parts.json
@@ -432,12 +432,7 @@
     "type": "enchantment",
     "id": "ENCH_TEST_ALT_ARMS",
     "condition": "ALWAYS",
-    "modified_bodyparts": [
-      { "lose": "arm_l" },
-      { "gain": "test_alt_arm_l" },
-      { "lose": "arm_r" },
-      { "gain": "test_alt_arm_r" }
-    ]
+    "modified_bodyparts": [ { "lose": "arm_l" }, { "gain": "test_alt_arm_l" }, { "lose": "arm_r" }, { "gain": "test_alt_arm_r" } ]
   },
   {
     "type": "enchantment",

--- a/src/item_info.cpp
+++ b/src/item_info.cpp
@@ -1658,6 +1658,10 @@ bool item::armor_full_protection_info( std::vector<iteminfo> &info,
             return ret;
         }
 
+        const Character &viewer = get_player_character();
+        body_part_set viewer_parts;
+        viewer_parts.fill( viewer.get_all_body_parts() );
+
         for( const armor_portion_data &p : t->sub_data ) {
             if( divider_needed ) {
                 insert_separation_line( info );
@@ -1668,17 +1672,23 @@ bool item::armor_full_protection_info( std::vector<iteminfo> &info,
             covered.begin(), []( sub_bodypart_str_id a ) {
                 return a.id();
             } );
+            erase_if( covered, [&viewer_parts]( const sub_bodypart_id & sbp ) {
+                return !viewer_parts.test( sbp->parent );
+            } );
+            if( covered.empty() ) {
+                continue;
+            }
+            // pick representative before consolidate() which mutates the vector
+            sub_bodypart_id representative = covered.front();
             std::set<translation, localized_comparator> to_print = body_part_type::consolidate( covered );
             std::string coverage = _( "<bold>Protection for</bold>:" );
             for( const translation &entry : to_print ) {
                 coverage += string_format( _( " The <info>%s</info>." ), entry );
             }
             info.emplace_back( "DESCRIPTION", coverage );
-
-            // the following function need one representative sub limb from which to query data
-            armor_material_info( info, parts, 0, false, *p.sub_coverage.begin() );
-            armor_attribute_info( info, parts, 0, false, *p.sub_coverage.begin() );
-            armor_protection_info( info, parts, 0, false, *p.sub_coverage.begin() );
+            armor_material_info( info, parts, 0, false, representative );
+            armor_attribute_info( info, parts, 0, false, representative );
+            armor_protection_info( info, parts, 0, false, representative );
             ret = true;
             divider_needed = true;
         }
@@ -2003,12 +2013,31 @@ void item::armor_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
     const bool show_bodygraph = get_option<bool>( "ITEM_BODYGRAPH" ) &&
                                 parts->test( iteminfo_parts::ARMOR_BODYGRAPH );
 
+    // Filter displayed body parts to the viewing character's actual anatomy.
+    // A human sees "arms", a feathered-arm mutant sees "feathered arms", etc.
+    const Character &viewer = get_player_character();
+    body_part_set viewer_parts;
+    viewer_parts.fill( viewer.get_all_body_parts() );
+    body_part_set display_parts = covered_parts.make_intersection( viewer_parts );
+    bool has_display_parts = display_parts.any();
+
     if( parts->test( iteminfo_parts::ARMOR_BODYPARTS ) ) {
         insert_separation_line( info );
         std::vector<sub_bodypart_id> covered = get_covered_sub_body_parts();
+        erase_if( covered, [&viewer_parts]( const sub_bodypart_id & sbp ) {
+            return !viewer_parts.test( sbp->parent );
+        } );
         std::string coverage = _( "<bold>Covers</bold>:" );
 
-        if( !covered.empty() ) {
+        if( covered.empty() && covers_anything ) {
+            // Viewer has none of the covered parts -- show unfiltered with annotation
+            covered = get_covered_sub_body_parts();
+            std::set<translation, localized_comparator> to_print = body_part_type::consolidate( covered );
+            for( const translation &entry : to_print ) {
+                coverage += string_format( _( " The <info>%s</info>." ), entry );
+            }
+            coverage += _( " <color_c_light_gray>(not for your anatomy)</color>" );
+        } else if( !covered.empty() ) {
             std::set<translation, localized_comparator> to_print = body_part_type::consolidate( covered );
             for( const translation &entry : to_print ) {
                 coverage += string_format( _( " The <info>%s</info>." ), entry );
@@ -2061,11 +2090,16 @@ void item::armor_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
 
                 if( !covered.empty() ) {
                     std::vector<sub_bodypart_id> covered_vec( covered.begin(), covered.end() );
-                    std::set<translation, localized_comparator> to_print = body_part_type::consolidate( covered_vec );
-                    for( const translation &entry : to_print ) {
-                        coverage += string_format( _( " The <info>%s</info>." ), entry );
+                    erase_if( covered_vec, [&viewer_parts]( const sub_bodypart_id & sbp ) {
+                        return !viewer_parts.test( sbp->parent );
+                    } );
+                    if( !covered_vec.empty() ) {
+                        std::set<translation, localized_comparator> to_print = body_part_type::consolidate( covered_vec );
+                        for( const translation &entry : to_print ) {
+                            coverage += string_format( _( " The <info>%s</info>." ), entry );
+                        }
+                        info.emplace_back( "ARMOR", coverage );
                     }
-                    info.emplace_back( "ARMOR", coverage );
                 }
             }
         }
@@ -2089,6 +2123,9 @@ void item::armor_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
                         }
                     }
                 }
+                erase_if( covered, [&viewer_parts]( const sub_bodypart_id & sbp ) {
+                    return !viewer_parts.test( sbp->parent );
+                } );
                 if( !covered.empty() ) {
                     std::set<translation, localized_comparator> to_print = body_part_type::consolidate( covered );
                     for( const translation &entry : to_print ) {
@@ -2100,9 +2137,9 @@ void item::armor_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
         }
     }
 
-    if( parts->test( iteminfo_parts::ARMOR_COVERAGE ) && covers_anything ) {
+    if( parts->test( iteminfo_parts::ARMOR_COVERAGE ) && has_display_parts ) {
         std::map<int, std::vector<bodypart_id>> limb_groups;
-        for( const bodypart_str_id &bp : get_covered_body_parts() ) {
+        for( const bodypart_str_id &bp : display_parts ) {
             const armor_portion_data *portion = portion_for_bodypart( bp );
             if( portion ) {
                 limb_groups[portion->coverage].emplace_back( bp );
@@ -2126,14 +2163,14 @@ void item::armor_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
         }
     }
 
-    if( parts->test( iteminfo_parts::ARMOR_ENCUMBRANCE ) && covers_anything ) {
+    if( parts->test( iteminfo_parts::ARMOR_ENCUMBRANCE ) && has_display_parts ) {
         std::map<armor_encumb_data, std::vector<bodypart_id>> limb_groups;
-        const Character &c = get_player_character();
 
         armor_encumb_header_info( *this, info );
-        for( const bodypart_str_id &bp : get_covered_body_parts() ) {
-            armor_encumb_data encumbrance( get_encumber( c, bp, item::encumber_flags::assume_empty ),
-                                           get_encumber( c, bp ), get_encumber( c, bp, item::encumber_flags::assume_full ) );
+        for( const bodypart_str_id &bp : display_parts ) {
+            armor_encumb_data encumbrance( get_encumber( viewer, bp, item::encumber_flags::assume_empty ),
+                                           get_encumber( viewer, bp ),
+                                           get_encumber( viewer, bp, item::encumber_flags::assume_full ) );
 
             limb_groups[encumbrance].emplace_back( bp );
         }
@@ -2174,10 +2211,9 @@ void item::armor_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
         }
     }
 
-    if( parts->test( iteminfo_parts::ARMOR_WARMTH ) && covers_anything ) {
-        // TODO: Make this less inflexible on anatomy
+    if( parts->test( iteminfo_parts::ARMOR_WARMTH ) && has_display_parts ) {
         std::map<int, std::vector<bodypart_id>> limb_groups;
-        for( const bodypart_str_id &bp : get_covered_body_parts() ) {
+        for( const bodypart_str_id &bp : display_parts ) {
             limb_groups[get_warmth( bp )].emplace_back( bp );
         }
         // keep on one line if only 1 entry
@@ -2197,10 +2233,9 @@ void item::armor_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
         }
     }
 
-    if( parts->test( iteminfo_parts::ARMOR_BREATHABILITY ) && covers_anything ) {
-
+    if( parts->test( iteminfo_parts::ARMOR_BREATHABILITY ) && has_display_parts ) {
         std::map<int, std::vector<bodypart_id>> limb_groups;
-        for( const bodypart_str_id &bp : get_covered_body_parts() ) {
+        for( const bodypart_str_id &bp : display_parts ) {
             const armor_portion_data *portion = portion_for_bodypart( bp );
             if( portion ) {
                 limb_groups[portion->breathability].emplace_back( bp );

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -11,6 +11,7 @@
 #include <utility>
 
 #include "ammo.h"
+#include "body_part_set.h"
 #include "bodypart.h"
 #include "calendar.h"
 #include "cata_path.h"
@@ -1157,13 +1158,23 @@ void item_pocket::general_info( std::vector<iteminfo> &info, int pocket_number,
     }
     if( !no_rigid.empty() ) {
         std::vector<sub_bodypart_id> no_rigid_vec( no_rigid.begin(), no_rigid.end() );
-        std::set<translation, localized_comparator> to_print = body_part_type::consolidate( no_rigid_vec );
-        std::string bps = enumerate_as_string( to_print.begin(),
-        to_print.end(), []( const translation & t ) {
-            return t.translated();
+        // Filter to the viewing character's actual anatomy
+        const Character &viewer = get_player_character();
+        body_part_set viewer_parts;
+        viewer_parts.fill( viewer.get_all_body_parts() );
+        erase_if( no_rigid_vec, [&viewer_parts]( const sub_bodypart_id & sbp ) {
+            return !viewer_parts.test( sbp->parent );
         } );
-        info.emplace_back( "DESCRIPTION", string_format( _( "<bold>Can't put hard armor on: %s</bold>:" ),
-                           bps ) );
+        if( !no_rigid_vec.empty() ) {
+            std::set<translation, localized_comparator> to_print = body_part_type::consolidate(
+                        no_rigid_vec );
+            std::string bps = enumerate_as_string( to_print.begin(),
+            to_print.end(), []( const translation & t ) {
+                return t.translated();
+            } );
+            info.emplace_back( "DESCRIPTION", string_format( _( "<bold>Can't put hard armor on: %s</bold>:" ),
+                               bps ) );
+        }
     }
 }
 

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -17,9 +17,11 @@
 #include "item.h"
 #include "item_location.h"
 #include "iteminfo_query.h"
+#include "magic_enchantment.h"
 #include "itype.h"
 #include "options_helpers.h"
 #include "output.h"
+#include "pimpl.h"
 #include "player_helpers.h"
 #include "pocket_type.h"
 #include "recipe.h"
@@ -31,12 +33,16 @@
 #include "units.h"
 #include "value_ptr.h"
 
+static const bodypart_str_id body_part_test_alt_arm_l( "test_alt_arm_l" );
+
 static const damage_type_id damage_acid( "acid" );
 static const damage_type_id damage_bash( "bash" );
 static const damage_type_id damage_bullet( "bullet" );
 static const damage_type_id damage_cut( "cut" );
 static const damage_type_id damage_heat( "heat" );
 static const damage_type_id damage_stab( "stab" );
+
+static const enchantment_id enchantment_ENCH_TEST_ALT_ARMS( "ENCH_TEST_ALT_ARMS" );
 
 static const itype_id itype_attachable_ear_muffs( "attachable_ear_muffs" );
 static const itype_id itype_backpack( "backpack" );
@@ -110,6 +116,7 @@ static const itype_id itype_test_socks( "test_socks" );
 static const itype_id itype_test_soldering_iron( "test_soldering_iron" );
 static const itype_id itype_test_sonic_screwdriver( "test_sonic_screwdriver" );
 static const itype_id itype_test_swat_armor( "test_swat_armor" );
+static const itype_id itype_test_tail_encumber( "test_tail_encumber" );
 static const itype_id itype_test_thumb( "test_thumb" );
 static const itype_id itype_test_tool_belt_pocket_mix( "test_tool_belt_pocket_mix" );
 static const itype_id itype_test_waterskin( "test_waterskin" );
@@ -3265,4 +3272,94 @@ TEST_CASE( "Armor_values_preserved_after_copy-from", "[iteminfo][armor][protecti
 
     relative_test( a_copy_rel_str );
     relative_test( a_copy_w_armor_rel_str );
+}
+
+// Character-aware body part display filtering for armor info.
+// When similar_bodypart expands item coverage at load time (e.g. arm_l -> alt_arm_l),
+// the display should only show body parts the viewing character actually has.
+TEST_CASE( "armor_info_character_aware_body_parts", "[iteminfo][armor][limbs]" )
+{
+    // Exact color-tagged fragments with trailing punctuation to avoid partial matches.
+    // "arms" could match inside "alt arms" without the color tags.
+    const std::string arms_frag = "<color_c_cyan>arms</color>.";
+    const std::string alt_arms_frag = "<color_c_cyan>Alt Arms</color>.";
+    const std::string torso_frag = "<color_c_cyan>torso</color>.";
+
+    auto make_alt_arm_viewer = []() {
+        Character &viewer = get_player_character();
+        clear_character( viewer, true );
+        viewer.enchantment_cache->force_add( *enchantment_ENCH_TEST_ALT_ARMS, viewer );
+        viewer.recalculate_bodyparts();
+        REQUIRE( viewer.has_part( body_part_test_alt_arm_l ) );
+    };
+
+    SECTION( "default human sees standard limb names" ) {
+        clear_avatar();
+        item longshirt( itype_test_longshirt );
+        std::string info = item_info_str( longshirt, { iteminfo_parts::ARMOR_BODYPARTS } );
+        CHECK( info.find( arms_frag ) != std::string::npos );
+        CHECK( info.find( alt_arms_frag ) == std::string::npos );
+        CHECK( info.find( torso_frag ) != std::string::npos );
+    }
+
+    SECTION( "alt-arm character sees alt limb names" ) {
+        make_alt_arm_viewer();
+        item longshirt( itype_test_longshirt );
+        std::string info = item_info_str( longshirt, { iteminfo_parts::ARMOR_BODYPARTS } );
+        CHECK( info.find( alt_arms_frag ) != std::string::npos );
+        CHECK( info.find( arms_frag ) == std::string::npos );
+        CHECK( info.find( torso_frag ) != std::string::npos );
+    }
+
+    SECTION( "coverage section filtered by viewer anatomy" ) {
+        make_alt_arm_viewer();
+        item longshirt( itype_test_longshirt );
+        std::string info = item_info_str( longshirt, { iteminfo_parts::ARMOR_COVERAGE } );
+        CHECK( info.find( alt_arms_frag ) != std::string::npos );
+        CHECK( info.find( arms_frag ) == std::string::npos );
+    }
+
+    SECTION( "warmth section filtered by viewer anatomy" ) {
+        make_alt_arm_viewer();
+        item longshirt( itype_test_longshirt );
+        std::string info = item_info_str( longshirt, { iteminfo_parts::ARMOR_WARMTH } );
+        CHECK( info.find( alt_arms_frag ) != std::string::npos );
+        CHECK( info.find( arms_frag ) == std::string::npos );
+    }
+
+    SECTION( "encumbrance section filtered by viewer anatomy" ) {
+        make_alt_arm_viewer();
+        item longshirt( itype_test_longshirt );
+        std::string info = item_info_str( longshirt, { iteminfo_parts::ARMOR_ENCUMBRANCE } );
+        CHECK( info.find( alt_arms_frag ) != std::string::npos );
+        CHECK( info.find( arms_frag ) == std::string::npos );
+    }
+
+    SECTION( "breathability section filtered by viewer anatomy" ) {
+        make_alt_arm_viewer();
+        item longshirt( itype_test_longshirt );
+        std::string info = item_info_str( longshirt, { iteminfo_parts::ARMOR_BREATHABILITY } );
+        CHECK( info.find( alt_arms_frag ) != std::string::npos );
+        CHECK( info.find( arms_frag ) == std::string::npos );
+    }
+
+    SECTION( "fallback annotation for anatomy-incompatible items" ) {
+        clear_avatar();
+        item tail_item( itype_test_tail_encumber );
+        std::string info = item_info_str( tail_item, { iteminfo_parts::ARMOR_BODYPARTS } );
+        CHECK( info.find( "not for your anatomy" ) != std::string::npos );
+    }
+
+    SECTION( "no empty section headers for anatomy-incompatible items" ) {
+        clear_avatar();
+        item tail_item( itype_test_tail_encumber );
+        std::string cov = item_info_str( tail_item, { iteminfo_parts::ARMOR_COVERAGE } );
+        std::string enc = item_info_str( tail_item, { iteminfo_parts::ARMOR_ENCUMBRANCE } );
+        std::string wrm = item_info_str( tail_item, { iteminfo_parts::ARMOR_WARMTH } );
+        std::string brt = item_info_str( tail_item, { iteminfo_parts::ARMOR_BREATHABILITY } );
+        CHECK( cov.find( "Total Coverage" ) == std::string::npos );
+        CHECK( enc.find( "Encumbrance" ) == std::string::npos );
+        CHECK( wrm.find( "Warmth" ) == std::string::npos );
+        CHECK( brt.find( "Breathability" ) == std::string::npos );
+    }
 }


### PR DESCRIPTION
#### Summary
Interface "Filter item info body part display by viewing character's anatomy"

#### Purpose of change

The `similar_bodypart` mechanism in `finalize_post_armor()` permanently expands every arm-covering item's coverage to include alternate limb variants (feathered arms, bionic arms, etc). This is needed for damage calculations but causes the item info screen to list both "arms" AND the alternate limb name for every arm-covering item - confusing output and broken iteminfo tests.

Unblocks #85613 and any future `similar_bodypart` limbs moving to mainline.

#### Describe the solution

Intersect item coverage with the viewing character's actual body parts (`get_all_body_parts()`). A human sees "arms", a feathered-arm mutant sees "feathered arms", etc.

Display filtering applied to:
- `armor_info()`: Covers, Coverage %, Encumbrance, Warmth, Breathability, Rigid Locations, Comfortable Locations
- `armor_full_protection_info()`: per-portion Protection display
- `item_pocket::general_info()`: "Can't put hard armor on" display

When the intersection is empty (item covers none of the viewer's body parts), the Covers section shows all parts with a "(not for your anatomy)" annotation, and per-limb sections are suppressed to avoid empty headers.

Precedent: `armor_info()` already calls `get_player_character()` for encumbrance display - making body part display character-aware is consistent.

#### Describe alternatives you've considered

Filtering at the `finalize_post_armor` level (hiding derived parts when the base is present) - this is a band-aid that shows wrong names to mutated characters and doesn't generalize.

#### Testing

- All `[iteminfo]` and `[limbs]` tests pass
- New test case `armor_info_character_aware_body_parts` covers:
  - Default human sees standard limb names
  - Alt-arm character sees alt limb names only
  - Coverage/Warmth/Encumbrance/Breathability sections filtered
  - Fallback annotation for anatomy-incompatible items
  - No empty section headers for anatomy-incompatible items

#### Additional context

Test data adds `test_alt_arm_l/r` body parts with `similar_bodypart: "arm_l"/"arm_r"` and an `ENCH_TEST_ALT_ARMS` enchantment, reproducing exactly what #85613 triggers with real feathered arm body parts.