### PR TITLE
Fix battery spawns in the evac shelter

### DIFF
--- a/data/json/itemgroups/SUS/evac_shelter.json
+++ b/data/json/itemgroups/SUS/evac_shelter.json
@@ -11,7 +11,7 @@
       { "item": "emer_blanket", "prob": 75 },
       { "group": "gasmask_bag_full", "prob": 2 },
       { "item": "flashlight", "prob": 50 },
-      { "item": "medium_battery_cell", "charges": 56, "prob": 10 }
+      { "item": "medium_battery_cell", "charges": 56, "prob": 10 },
       { "item": "lighter", "prob": 20, "charges": [ 60, 100 ] },
       { "item": "whistle", "prob": 70 },
       { "item": "water_clean", "count": [ 1, 2 ], "prob": 80 },

--- a/data/json/itemgroups/SUS/evac_shelter.json
+++ b/data/json/itemgroups/SUS/evac_shelter.json
@@ -11,7 +11,7 @@
       { "item": "emer_blanket", "prob": 75 },
       { "group": "gasmask_bag_full", "prob": 2 },
       { "item": "flashlight", "prob": 50 },
-      { "item": "light_battery_cell", "prob": 10 },
+      { "item": "medium_battery_cell", "charges": 56, "prob": 10 }
       { "item": "lighter", "prob": 20, "charges": [ 60, 100 ] },
       { "item": "whistle", "prob": 70 },
       { "item": "water_clean", "count": [ 1, 2 ], "prob": 80 },

--- a/data/json/itemgroups/SUS/evac_shelter.json
+++ b/data/json/itemgroups/SUS/evac_shelter.json
@@ -11,7 +11,7 @@
       { "item": "emer_blanket", "prob": 75 },
       { "group": "gasmask_bag_full", "prob": 2 },
       { "item": "flashlight", "prob": 50 },
-      { "item": "medium_battery_cell", "charges": 56, "prob": 10 }
+      { "item": "medium_battery_cell_disposable", "charges": 56, "prob": 10 },
       { "item": "lighter", "prob": 20, "charges": [ 60, 100 ] },
       { "item": "whistle", "prob": 70 },
       { "item": "water_clean", "count": [ 1, 2 ], "prob": 80 },

--- a/data/json/itemgroups/SUS/evac_shelter.json
+++ b/data/json/itemgroups/SUS/evac_shelter.json
@@ -11,7 +11,7 @@
       { "item": "emer_blanket", "prob": 75 },
       { "group": "gasmask_bag_full", "prob": 2 },
       { "item": "flashlight", "prob": 50 },
-      { "item": "medium_battery_cell_disposable", "charges": 56, "prob": 10 },
+      { "item": "medium_battery_cell", "charges": 56, "prob": 10 }
       { "item": "lighter", "prob": 20, "charges": [ 60, 100 ] },
       { "item": "whistle", "prob": 70 },
       { "item": "water_clean", "count": [ 1, 2 ], "prob": 80 },


### PR DESCRIPTION


<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Fixes the battery spawns in the evac shelter and makes them useful again."

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #82413 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Replace the uncharged light_battery_cell in the item group with charged medium_battery_cell at the same rarity.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
<img width="524" height="623" alt="image" src="https://github.com/user-attachments/assets/dcd283f2-9787-4e30-a26a-e379158a75b5" />
Tested item groups once I loaded into the game

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
