### PR TITLE
Fix test labeler skipping PRs from fork master branches

### DIFF
--- a/.github/workflows/test_labeler.yml
+++ b/.github/workflows/test_labeler.yml
@@ -4,8 +4,6 @@ on:
   workflow_run:
     workflows: ["astyle", "JSON Validation", "General build matrix"]
     types: [completed]
-    branches-ignore:
-      - master
 
 jobs:
   labeling:
@@ -43,9 +41,15 @@ jobs:
         run_id: ${{ github.event.workflow_run.id }}
         name: basic-build
         allow_forks: false
+        if_no_artifact_found: warn
     - name: set-basic-build-success
       id: set-basic-build-success
-      run: echo "basic-build-success=$( cat basic-build )" >> $GITHUB_OUTPUT
+      run: |
+        if [[ -f basic-build ]]; then
+          echo "basic-build-success=$( cat basic-build )" >> $GITHUB_OUTPUT
+        else
+          echo "basic-build-success=false" >> $GITHUB_OUTPUT
+        fi
     - name: Download pr id artifact
       uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe # v3.1.4
       with:
@@ -53,9 +57,15 @@ jobs:
         run_id: ${{ github.event.workflow_run.id }}
         name: pull_request_id
         allow_forks: false
+        if_no_artifact_found: warn
     - name: set-pr-id
       id: set-pr-id
-      run: echo "pr-id=$( cat pull_request_id )" >> $GITHUB_OUTPUT
+      run: |
+        if [[ -f pull_request_id ]]; then
+          echo "pr-id=$( cat pull_request_id )" >> $GITHUB_OUTPUT
+        else
+          echo "pr-id=" >> $GITHUB_OUTPUT
+        fi
     - name: set-label
       if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.conclusion != 'skipped' || steps.set-basic-build-success.outputs.basic-build-success == 'true' }}
       uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
@@ -96,4 +106,3 @@ jobs:
                 console.log(`Label "${labelName}" not present on PR, skipping removal.`);
               }
             }
-            


### PR DESCRIPTION
#### Summary
Infrastructure "Fix test labeler skipping PRs from fork master branches"

#### Purpose of change

PRs from forks where the head branch is `master` never get CI labels (astyled, json-styled, BasicBuildPassed). See #85689 for an example.

#### Describe the solution

Remove `branches-ignore: master` from the workflow_run trigger - it was filtering out these PRs. The existing `event == 'pull_request'` job guard already handles push-to-master filtering.

Also add `if_no_artifact_found: warn` and file existence checks so the labeler doesn't crash on missing artifacts.

#### Describe alternatives you've considered

None worth considering, the branch filter was just redundant with the existing if-guard.

#### Testing

N/A

#### Additional context

N/A