### PR TITLE
Fix segfault after failed out-of-bounds teleport

### DIFF
--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -208,9 +208,15 @@ bool teleport::teleport_to_point( Creature &critter, tripoint_bub_ms target, boo
     map tm;
     map *dest = &here;
     tripoint_bub_ms dest_target = target;
+    // Track whether we reloaded the map for the avatar so we can restore it
+    // if the teleport fails (otherwise pos_bub() goes out of bounds).
+    bool map_reloaded_for_avatar = false;
+    tripoint_abs_omt original_omt;
     if( !here.inbounds( target ) ) {
         if( c_is_u ) {
+            original_omt = project_to<coords::omt>( critter.pos_abs() );
             g->place_player_overmap( project_to<coords::omt>( abs_ms ), false );
+            map_reloaded_for_avatar = true;
         } else {
             dest = &tm;
             dest->load( project_to<coords::sm>( abs_ms ), false );
@@ -218,6 +224,13 @@ bool teleport::teleport_to_point( Creature &critter, tripoint_bub_ms target, boo
         }
         dest_target = dest->get_bub( abs_ms );
     }
+
+    const auto restore_map_on_failure = [&]() {
+        if( map_reloaded_for_avatar ) {
+            g->place_player_overmap( original_omt, false );
+        }
+    };
+
     //handles teleporting into solids.
     if( dest->impassable( dest_target ) ) {
         if( force || force_safe ) {
@@ -237,6 +250,7 @@ bool teleport::teleport_to_point( Creature &critter, tripoint_bub_ms target, boo
                 if( c_is_u && display_message ) {
                     add_msg( m_bad, _( "You cannot teleport safely." ) );
                 }
+                restore_map_on_failure();
                 return false;
             }
             critter.apply_damage( nullptr, bodypart_id( "torso" ), 9999 );
@@ -285,6 +299,7 @@ bool teleport::teleport_to_point( Creature &critter, tripoint_bub_ms target, boo
                 } else if( !c_is_u && p != nullptr ) {
                     add_msg( m_bad, _( "%s flickers but remains exactly where they are." ), p->get_name() );
                 }
+                restore_map_on_failure();
                 return false;
             }
         }
@@ -297,6 +312,7 @@ bool teleport::teleport_to_point( Creature &critter, tripoint_bub_ms target, boo
                 } else if( get_player_view().sees( here, critter ) && display_message ) {
                     add_msg( _( "%1$s flickers." ), critter.disp_name() );
                 }
+                restore_map_on_failure();
                 return false;
             }
             //if the thing that was going to be teleported into has a dimensional anchor, break out early and don't teleport.
@@ -304,6 +320,7 @@ bool teleport::teleport_to_point( Creature &critter, tripoint_bub_ms target, boo
                 ( poor_soul->as_character()->worn_with_flag( json_flag_DIMENSIONAL_ANCHOR ) ||
                   poor_soul->as_character()->has_effect_with_flag( json_flag_DIMENSIONAL_ANCHOR ) ) ) {
                 poor_soul->as_character()->add_msg_if_player( m_warning, _( "You feel disjointed." ) );
+                restore_map_on_failure();
                 return false;
             }
             if( force ) {
@@ -314,6 +331,7 @@ bool teleport::teleport_to_point( Creature &critter, tripoint_bub_ms target, boo
                 if( c_is_u && display_message ) {
                     add_msg( m_bad, _( "You cannot teleport safely." ) );
                 }
+                restore_map_on_failure();
                 return false;
             } else if( !collision ) {
                 //we passed all the conditions needed for a teleport accident, so handle messages for teleport accidents here


### PR DESCRIPTION
#### Summary
Bugfixes "Fix segfault in scent_map::update after failed out-of-bounds teleport"

#### Purpose of change
Fixes #76718

#### Describe the solution
When `teleport_to_point` targets a tile outside the current map, it calls `place_player_overmap` to reload the map around the destination. If the teleport then fails (impassable tile, occupied tile, dimensional anchor, etc.), the function returned without restoring the map. This left the map centered on the distant target while the player's absolute position was still at their origin, so `pos_bub()` returned wildly out-of-bounds coordinates. The next `do_turn` call to `scent_map::update` used those as array indices -- segfault.

The fix saves the player's original overmap position before reloading and restores it at every early-return path after the reload.

#### Describe alternatives you've considered
Could restructure to defer the map reload until after all safety checks pass, but that would need a bigger rewrite of the function and the checks themselves need the reloaded map to inspect the destination terrain.

#### Testing
Read through all return paths in `teleport_to_point` to confirm the five affected ones are covered. The fix is a no-op when the map wasn't reloaded (target inbounds or creature isn't the avatar).

#### Additional context
Any mod spell using `u_teleport` to a distant impassable/occupied tile with `safe: true` (the default) can trigger this. The original report involves Mind Over Matter's Gateway power targeting a closed door or NPC-occupied tile at the Exodii.