### PR TITLE
string dimension ziggurats v3

### DIFF
--- a/data/json/effects_on_condition/nether_eocs/string_dimension.json
+++ b/data/json/effects_on_condition/nether_eocs/string_dimension.json
@@ -60,7 +60,7 @@
         }
       }
     ],
-    "false_effect": { "u_message": "Your glowing string rattles in its container." }
+    "false_effect": { "u_message": "Your glowing string rattles in its container.  There is almost a futile sadness to its struggle." }
   },
   {
     "type": "effect_on_condition",
@@ -120,21 +120,28 @@
         },
         "else": [
           {
-            "u_message": "You pull the hypercube free and space around you violently bends before snapping back in place!",
+            "u_message": "You pull the hypercube free and space around you violently bends before snapping back in place!  The hypercube now sits in your palm, but its original housing has violently imploded into a ball of scrap.",
             "popup": true
           },
-          { "u_spawn_item": "string_dimension_hypercube", "count": 1 }
+          { "u_spawn_item": "string_dimension_hypercube", "count": 1 },
+          { "u_transform_radius": 10, "ter_furn_transform": "string_dimension_ziggurat_transform" },
+          {
+            "mapgen_update": "string_dimension_small_ziggurat_0_inert",
+            "om_terrain": "string_dimension_small_ziggurat_0"
+          },
+          { "math": [ "u_string_dimension_ziggurat_exit += 1" ] }
         ]
       },
-      { "u_transform_radius": 5, "ter_furn_transform": "string_dimension_ziggurat_transform" },
-      { "math": [ "u_string_dimension_ziggurat_exit += 1" ] },
       { "run_eocs": "EOC_PORTAL_STRING_DIMENSION_RETURN" }
     ]
   },
   {
     "type": "ter_furn_transform",
     "id": "string_dimension_ziggurat_transform",
-    "furniture": [ { "result": [ "f_string_dimension_housing_imploded" ], "valid_furniture": [ "f_string_dimension_housing" ] } ]
+    "furniture": [
+      { "result": [ "f_string_dimension_housing_imploded" ], "valid_furniture": [ "f_string_dimension_housing" ] },
+      { "result": [ "f_string_dimension_pylon_inert" ], "valid_furniture": [ "f_string_dimension_pylon" ] }
+    ]
   },
   {
     "type": "effect_on_condition",

--- a/data/json/furniture_and_terrain/furniture-alien.json
+++ b/data/json/furniture_and_terrain/furniture-alien.json
@@ -915,6 +915,42 @@
   },
   {
     "type": "furniture",
+    "id": "f_string_dimension_pylon_inert",
+    "name": "inert column",
+    "description": "A floor-to-ceiling cylinder wrapped neatly and tightly in thick copper wire.  It has no markings, but the cables connected to the base suggest that it generates or receives some kind of power.  Perhaps it once worked, but it is now still and silent.",
+    "symbol": "O",
+    "color": "red",
+    "move_cost_mod": -1,
+    "coverage": 50,
+    "required_str": -1,
+    "flags": [ "NOITEM", "BLOCKSDOOR" ],
+    "bash": {
+      "str_min": 60,
+      "str_max": 400,
+      "sound": "metal screeching!",
+      "sound_fail": "clang!",
+      "items": [
+        { "item": "scrap", "count": [ 4, 16 ] },
+        { "item": "ch_steel_chunk", "count": [ 1, 6 ] },
+        { "item": "plutonium", "count": [ 0, 3 ] },
+        { "item": "lead", "charges": [ 12, 18 ] },
+        { "item": "sheet_metal_small", "count": [ 10, 30 ] },
+        { "item": "scrap_copper", "count": [ 12, 37 ] },
+        { "item": "e_scrap", "count": [ 10, 20 ] },
+        { "item": "string_dimension_computer", "count": [ 0, 1 ] }
+      ]
+    }
+  },
+  {
+    "type": "furniture",
+    "id": "f_vent_inert",
+    "description": "A metal vent on the floor.",
+    "copy-from": "f_vent_cold_air2_stream",
+    "symbol": "~",
+    "color": "light_gray"
+  },
+  {
+    "type": "furniture",
     "id": "f_string_dimension_housing",
     "name": "metal container",
     "looks_like": "f_safe_c",

--- a/data/json/furniture_and_terrain/terrain-string-dimension.json
+++ b/data/json/furniture_and_terrain/terrain-string-dimension.json
@@ -158,6 +158,25 @@
     }
   },
   {
+    "type": "terrain",
+    "id": "t_string_gates_mech_control_inert",
+    "name": "rotary lever",
+    "description": "A heavy-duty metal lever with two settings, each marked by an alien symbol.  Toggling it back and forth does nothing.",
+    "symbol": "6",
+    "color": "cyan_red",
+    "move_cost": 0,
+    "connect_groups": "INDOORFLOOR",
+    "flags": [ "TRANSPARENT", "NOITEM", "INDOORS", "PERMEABLE", "THIN_OBSTACLE" ],
+    "bash": {
+      "str_min": 18,
+      "str_max": 80,
+      "sound": "metal screeching!",
+      "sound_fail": "clang!",
+      "ter_set": "t_metal_floor",
+      "items": [ { "item": "mc_steel_chunk", "count": [ 1, 4 ] }, { "item": "scrap", "count": [ 3, 6 ] } ]
+    }
+  },
+  {
     "type": "gate",
     "id": "t_string_gates_mech_control",
     "door": "t_door_metal_locked",

--- a/data/json/items/relics/extradimensional_artifacts.json
+++ b/data/json/items/relics/extradimensional_artifacts.json
@@ -56,6 +56,7 @@
     "material": [ "anomaly" ],
     "symbol": "[",
     "volume": "500 ml",
+    "longest_side": "8 cm",
     "weight": "0 g",
     "pocket_data": [
       {
@@ -63,6 +64,8 @@
         "max_contains_volume": "10000 ml",
         "max_contains_weight": "10000 g",
         "max_item_length": "50 cm",
+        "weight_multiplier": 0.5,
+        "volume_multiplier": 0.5,
         "rigid": true
       }
     ],

--- a/data/json/items/relics/extradimensional_artifacts.json
+++ b/data/json/items/relics/extradimensional_artifacts.json
@@ -60,8 +60,8 @@
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
-        "max_contains_volume": "20000 ml",
-        "max_contains_weight": "20000 g",
+        "max_contains_volume": "10000 ml",
+        "max_contains_weight": "10000 g",
         "max_item_length": "50 cm",
         "rigid": true
       }

--- a/data/json/items/relics/extradimensional_artifacts.json
+++ b/data/json/items/relics/extradimensional_artifacts.json
@@ -52,12 +52,21 @@
     "subtypes": [ "ARTIFACT" ],
     "category": "artifacts",
     "name": { "str": "transparent hypercube" },
-    "description": "A transparent cube within a cube.  It seems to be made of clear plastic or glass, but it feels quite solid, despite also seeming weightless.  It's full of stars.",
+    "description": "A transparent cube within a cube.  It seems to be made of clear plastic or glass, but it feels quite solid, despite also seeming weightless.  Impossibly, the inside seems larger than the outside.  It's full of stars.",
     "material": [ "anomaly" ],
     "symbol": "[",
     "volume": "500 ml",
     "weight": "0 g",
-    "flags": [ "ZERO_WEIGHT" ],
-    "passive_effects": [ { "has": "HELD", "condition": "ALWAYS", "values": [ { "value": "ARTIFACT_RESONANCE", "add": 2000 } ] } ]
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "20000 ml",
+        "max_contains_weight": "20000 g",
+        "max_item_length": "50 cm",
+        "rigid": true
+      }
+    ],
+    "flags": [ "ZERO_WEIGHT", "TARDIS" ],
+    "passive_effects": [ { "has": "HELD", "condition": "ALWAYS", "values": [ { "value": "ARTIFACT_RESONANCE", "add": 1200 } ] } ]
   }
 ]

--- a/data/json/items/relics/extradimensional_artifacts.json
+++ b/data/json/items/relics/extradimensional_artifacts.json
@@ -52,7 +52,7 @@
     "subtypes": [ "ARTIFACT" ],
     "category": "artifacts",
     "name": { "str": "transparent hypercube" },
-    "description": "A transparent cube within a cube.  It seems to be made of clear plastic or glass, but it feels quite solid, despite also seeming weightless.  Impossibly, the inside seems larger than the outside.  It's full of stars.",
+    "description": "A transparent cube within a cube.  It seems to be made of clear plastic or glass, but it feels quite solid, despite also seeming weightless.  Impossibly, the inside seems larger than the outside - as you tilt it here and there, you can peer into its depths.  It's full of stars.",
     "material": [ "anomaly" ],
     "symbol": "[",
     "volume": "500 ml",
@@ -61,8 +61,8 @@
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
-        "max_contains_volume": "10000 ml",
-        "max_contains_weight": "10000 g",
+        "max_contains_volume": "125000 ml",
+        "max_contains_weight": "125000 g",
         "max_item_length": "50 cm",
         "weight_multiplier": 0.5,
         "volume_multiplier": 0.5,
@@ -70,6 +70,6 @@
       }
     ],
     "flags": [ "ZERO_WEIGHT", "TARDIS" ],
-    "passive_effects": [ { "has": "HELD", "condition": "ALWAYS", "values": [ { "value": "ARTIFACT_RESONANCE", "add": 1200 } ] } ]
+    "passive_effects": [ { "has": "HELD", "condition": "ALWAYS", "values": [ { "value": "ARTIFACT_RESONANCE", "add": 2000 } ] } ]
   }
 ]

--- a/data/json/mapgen/string_dimension/string_dimension_small_ziggurat.json
+++ b/data/json/mapgen/string_dimension/string_dimension_small_ziggurat.json
@@ -184,5 +184,41 @@
       "terrain": { "E": "t_metal_floor", "O": "t_metal_floor" },
       "furniture": { "O": "f_string_dimension_pylon", "E": "f_string_dimension_housing" }
     }
+  },
+  {
+    "type": "mapgen",
+    "update_mapgen_id": "string_dimension_small_ziggurat_0_inert",
+    "object": {
+      "rows": [
+        ",,,,,,,,,,,,,,,,,,,,,,,,",
+        ",,,,,,,,,,,,,,,,,,,,,,,,",
+        ",,                    ,,",
+        ",,                    ,,",
+        ",,  v              v  ,,",
+        ",,                    ,,",
+        ",,                    ,,",
+        ",,         @          ,,",
+        ",,                    ,,",
+        ",,                    ,,",
+        ",,                    ,,",
+        ",,                    ,,",
+        ",,                    ,,",
+        ",,                    ,,",
+        ",,                    ,,",
+        ",,                    ,,",
+        ",,                    ,,",
+        ",,                    ,,",
+        ",,                    ,,",
+        ",,  v              v  ,,",
+        ",,                    ,,",
+        ",,                    ,,",
+        ",,,,,,,,,,,,,a,,,,,,,,,,",
+        ",,,,,,,,,,,,,,,,,,,,,,,,"
+      ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "terrain": { ",": "t_rock_floor_no_roof", "a": "t_string_gates_mech_control_inert", "v": "t_metal_floor", "@": "t_metal_floor" },
+      "monster": { "@": { "monster": "mon_tindalos" } },
+      "furniture": { "v": "f_vent_inert" }
+    }
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Just continuing to develop the ziggurats in the string dimension (following #84826 and #85116)

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

1. Moved the exit counter into the check for actually removing the hypercube from its housing. As before, do this 4 times and the string dimension is closed to you (oh no, what have you done?).  Touching the cube without an anchor is a freebie exit.
2. Mapgen/transform the rest of the ziggurat so that: the hypercube housing implodes, the humming columns stop humming, the vents stop kicking out air, the door toggle doesn't work (hope you didn't close it, somehow), and the strange planar space is converted to real rock (uh oh, did you stabilize or _destabilize_ this place?).
3. Gave the hypercube some internal space, to make it a storage container with rather punishing resonance.
4. Your hubris attracts a Star-Crowned Hound (how dare you do what you did).

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

not continuing to develop these

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Visited, took the cube, touched the cube, checked all the furniture/terrain, got killed by a hound.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Thanks to anid & others for playtesting and suggestions (hypercube storage suggested by anid)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
