### PR TITLE
Add map::is_roofed() with vertical walk-up for precipitation checks

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -83,6 +83,11 @@ disp_overmap_cache::disp_overmap_cache()
     _width = 0;
 }
 
+void display::invalidate_overmap_cache()
+{
+    disp_om_cache.invalidate();
+}
+
 disp_bodygraph_cache::disp_bodygraph_cache( bodygraph_var var )
 {
     _var = var;

--- a/src/display.h
+++ b/src/display.h
@@ -64,6 +64,11 @@ struct disp_overmap_cache {
         const std::string &get_val() const {
             return _om_wgt_str;
         }
+
+        // Mark the cache as stale so it will be rebuilt on next access.
+        void invalidate() {
+            _center = tripoint_abs_omt::invalid;
+        }
 };
 
 struct disp_bodygraph_cache {
@@ -207,6 +212,9 @@ std::string weight_string( const Character &u );
 // Functions returning colorized string
 // gets the string that describes your health
 std::string health_string( const Character &u );
+
+// Force the overmap widget cache to rebuild on next access.
+void invalidate_overmap_cache();
 } // namespace display
 
 #endif // CATA_SRC_DISPLAY_H

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3478,52 +3478,65 @@ bool map::is_roofed( const tripoint_bub_ms &p ) const
     if( !inbounds( p ) ) {
         return false;
     }
-    if( p.z() < 0 ) {
-        return true;
-    }
-    if( p.z() + 1 > OVERMAP_HEIGHT ) {
-        return false;
-    }
 
-    const tripoint_bub_ms p_above = p + tripoint::above;
-    const level_cache *cache_above = get_cache_lazy( p_above.z() );
+    // Walk upward through z-levels looking for any surface that blocks
+    // precipitation. The first blocking surface found means this tile is roofed.
+    for( int z = p.z() + 1; z <= OVERMAP_HEIGHT; ++z ) {
+        const tripoint_bub_ms check_pos( p.x(), p.y(), z );
+        const level_cache *cache = get_cache_lazy( z );
 
-    // Fast path: use floor_cache at z+1 when it exists and is clean
-    if( cache_above && !cache_above->floor_cache_dirty ) {
-        if( cache_above->floor_cache[p_above.x()][p_above.y()] ) {
+        // Fast path: use floor_cache when it exists and is clean
+        if( cache && !cache->floor_cache_dirty ) {
+            if( cache->floor_cache[p.x()][p.y()] ) {
+                return true;
+            }
+            // Transparent floors (glass, ramps, grates) are marked as "no floor"
+            // in floor_cache but are physical surfaces that block precipitation
+            if( has_flag_ter( ter_furn_flag::TFLAG_TRANSPARENT_FLOOR, check_pos ) ) {
+                return true;
+            }
+            // Water surfaces absorb precipitation before it reaches tiles below
+            if( has_flag_ter( ter_furn_flag::TFLAG_NO_FLOOR_WATER, check_pos ) ) {
+                return true;
+            }
+            continue;
+        }
+
+        // Fallback: direct terrain/furniture/vehicle checks when cache is
+        // missing or dirty. Mirrors build_floor_cache semantics.
+
+        // TRANSPARENT_FLOOR checked first: blocks precipitation even when
+        // combined with vertical-transition flags like GOES_DOWN
+        if( has_flag_ter( ter_furn_flag::TFLAG_TRANSPARENT_FLOOR, check_pos ) ) {
             return true;
         }
-        // Glass floors are marked as "no floor" in floor_cache but block precipitation
-        if( has_flag_ter( ter_furn_flag::TFLAG_TRANSPARENT_FLOOR, p_above ) ) {
+
+        const bool no_floor = has_flag_ter( ter_furn_flag::TFLAG_NO_FLOOR, check_pos );
+        const bool goes_down = has_flag_ter( ter_furn_flag::TFLAG_GOES_DOWN, check_pos );
+
+        if( !no_floor && !goes_down ) {
             return true;
         }
-        return false;
-    }
 
-    // Fallback: direct terrain/furniture/vehicle checks when cache is missing or dirty.
-    // Mirrors build_floor_cache semantics (map.cpp:10038-10050).
-    const bool no_floor = has_flag_ter( ter_furn_flag::TFLAG_NO_FLOOR, p_above );
-    const bool no_floor_water = has_flag_ter( ter_furn_flag::TFLAG_NO_FLOOR_WATER, p_above );
-    const bool goes_down = has_flag_ter( ter_furn_flag::TFLAG_GOES_DOWN, p_above );
-
-    if( !no_floor && !no_floor_water && !goes_down ) {
-        // Solid floor or glass floor above - roofed. Glass (TRANSPARENT_FLOOR) is
-        // marked as no-floor in floor_cache, but it blocks precipitation.
-        return true;
-    }
-
-    // SUN_ROOF_ABOVE on furniture at current z overrides no-floor above
-    // (matching build_floor_cache which checks below_submap furniture)
-    if( has_flag_furn( ter_furn_flag::TFLAG_SUN_ROOF_ABOVE, p ) ) {
-        return true;
-    }
-
-    // Check for vehicle roof/opaque parts above
-    const optional_vpart_position vp = veh_at( p_above );
-    if( vp ) {
-        if( vp->part_with_feature( VPFLAG_ROOF, false ) ||
-            vp->part_with_feature( VPFLAG_OPAQUE, false ) ) {
+        if( has_flag_ter( ter_furn_flag::TFLAG_NO_FLOOR_WATER, check_pos ) ) {
             return true;
+        }
+
+        // SUN_ROOF_ABOVE on furniture at z-1 overrides no-floor at z
+        // (matching build_floor_cache which checks below_submap furniture)
+        const tripoint_bub_ms below_pos( p.x(), p.y(), z - 1 );
+        if( inbounds( below_pos ) &&
+            has_flag_furn( ter_furn_flag::TFLAG_SUN_ROOF_ABOVE, below_pos ) ) {
+            return true;
+        }
+
+        // Check for vehicle roof/opaque parts at this level
+        const optional_vpart_position vp = veh_at( check_pos );
+        if( vp ) {
+            if( vp->part_with_feature( VPFLAG_ROOF, false ) ||
+                vp->part_with_feature( VPFLAG_OPAQUE, false ) ) {
+                return true;
+            }
         }
     }
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3473,6 +3473,63 @@ bool map::is_outside( const tripoint_bub_ms &p ) const
     return outside_cache[p.x()][p.y()];
 }
 
+bool map::is_roofed( const tripoint_bub_ms &p ) const
+{
+    if( !inbounds( p ) ) {
+        return false;
+    }
+    if( p.z() < 0 ) {
+        return true;
+    }
+    if( p.z() + 1 > OVERMAP_HEIGHT ) {
+        return false;
+    }
+
+    const tripoint_bub_ms p_above = p + tripoint::above;
+    const level_cache *cache_above = get_cache_lazy( p_above.z() );
+
+    // Fast path: use floor_cache at z+1 when it exists and is clean
+    if( cache_above && !cache_above->floor_cache_dirty ) {
+        if( cache_above->floor_cache[p_above.x()][p_above.y()] ) {
+            return true;
+        }
+        // Glass floors are marked as "no floor" in floor_cache but block precipitation
+        if( has_flag_ter( ter_furn_flag::TFLAG_TRANSPARENT_FLOOR, p_above ) ) {
+            return true;
+        }
+        return false;
+    }
+
+    // Fallback: direct terrain/furniture/vehicle checks when cache is missing or dirty.
+    // Mirrors build_floor_cache semantics (map.cpp:10038-10050).
+    const bool no_floor = has_flag_ter( ter_furn_flag::TFLAG_NO_FLOOR, p_above );
+    const bool no_floor_water = has_flag_ter( ter_furn_flag::TFLAG_NO_FLOOR_WATER, p_above );
+    const bool goes_down = has_flag_ter( ter_furn_flag::TFLAG_GOES_DOWN, p_above );
+
+    if( !no_floor && !no_floor_water && !goes_down ) {
+        // Solid floor or glass floor above - roofed. Glass (TRANSPARENT_FLOOR) is
+        // marked as no-floor in floor_cache, but it blocks precipitation.
+        return true;
+    }
+
+    // SUN_ROOF_ABOVE on furniture at current z overrides no-floor above
+    // (matching build_floor_cache which checks below_submap furniture)
+    if( has_flag_furn( ter_furn_flag::TFLAG_SUN_ROOF_ABOVE, p ) ) {
+        return true;
+    }
+
+    // Check for vehicle roof/opaque parts above
+    const optional_vpart_position vp = veh_at( p_above );
+    if( vp ) {
+        if( vp->part_with_feature( VPFLAG_ROOF, false ) ||
+            vp->part_with_feature( VPFLAG_OPAQUE, false ) ) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 bool map::is_last_ter_wall( const bool no_furn, const point_bub_ms &p,
                             const point_bub_ms &max, const direction dir ) const
 {

--- a/src/map.h
+++ b/src/map.h
@@ -1084,6 +1084,10 @@ class map
         }
 
         bool is_outside( const tripoint_bub_ms &p ) const;
+        // Returns true if precipitation cannot reach this tile (roof, floor, or
+        // vehicle with ROOF/OPAQUE above). Uses floor_cache at z+1 when valid,
+        // falls back to direct terrain/furniture/vehicle checks otherwise.
+        bool is_roofed( const tripoint_bub_ms &p ) const;
         /**
          * Returns whether or not the terrain at the given location can be dived into
          * (by monsters that can swim or are aquatic or non-breathing).
@@ -2532,6 +2536,9 @@ class tinymap : private map
         };
         bool is_outside( const tripoint_omt_ms &p ) const {
             return map::is_outside( rebase_bub( p ) );
+        }
+        bool is_roofed( const tripoint_omt_ms &p ) const {
+            return map::is_roofed( rebase_bub( p ) );
         }
         int get_radiation( const tripoint_omt_ms &p ) const {
             return map::get_radiation( rebase_bub( p ) );

--- a/src/map.h
+++ b/src/map.h
@@ -1084,8 +1084,10 @@ class map
         }
 
         bool is_outside( const tripoint_bub_ms &p ) const;
-        // Returns true if precipitation cannot reach this tile (roof, floor, or
-        // vehicle with ROOF/OPAQUE above). Uses floor_cache at z+1 when valid,
+        // Returns true if precipitation cannot reach this tile. Walks upward
+        // through z-levels looking for any blocking surface: solid floor,
+        // TRANSPARENT_FLOOR (glass/ramps/grates), NO_FLOOR_WATER, SUN_ROOF_ABOVE
+        // furniture, or vehicle with ROOF/OPAQUE. Uses floor_cache when valid,
         // falls back to direct terrain/furniture/vehicle checks otherwise.
         bool is_roofed( const tripoint_bub_ms &p ) const;
         /**

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -469,8 +469,9 @@ void handle_weather_effects( const weather_type_id &w )
         }
         here.decay_fields_and_scent( decay_time );
         // Coarse correction to get us back to previously intended soaking rate.
-        if( calendar::once_every( 6_seconds ) && is_creature_outside( target ) &&
-            !here.is_roofed( target.pos_bub() ) ) {
+        // Precipitation is vertical - only roofs/floors block it, not walls.
+        // is_roofed() walks upward through all z-levels for a complete check.
+        if( calendar::once_every( 6_seconds ) && !here.is_roofed( target.pos_bub() ) ) {
             wet_character( target, wetness );
         }
     }

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -469,9 +469,8 @@ void handle_weather_effects( const weather_type_id &w )
         }
         here.decay_fields_and_scent( decay_time );
         // Coarse correction to get us back to previously intended soaking rate.
-        const bool no_roof_above = here.has_flag( ter_furn_flag::TFLAG_NO_FLOOR,
-                                   target.pos_bub() + tripoint::above );
-        if( calendar::once_every( 6_seconds ) && is_creature_outside( target ) && no_roof_above ) {
+        if( calendar::once_every( 6_seconds ) && is_creature_outside( target ) &&
+            !here.is_roofed( target.pos_bub() ) ) {
             wet_character( target, wetness );
         }
     }

--- a/tests/roof_test.cpp
+++ b/tests/roof_test.cpp
@@ -1,0 +1,79 @@
+#include <string>
+
+#include "cata_catch.h"
+#include "coordinates.h"
+#include "map.h"
+#include "map_helpers.h"
+#include "map_scale_constants.h"
+#include "point.h"
+#include "type_id.h"
+
+static const furn_str_id furn_f_canvas_wall( "f_canvas_wall" );
+static const ter_str_id ter_t_floor( "t_floor" );
+static const ter_str_id ter_t_open_air( "t_open_air" );
+static const ter_str_id ter_t_ramp_down_high( "t_ramp_down_high" );
+
+TEST_CASE( "is_roofed", "[map]" )
+{
+    clear_map();
+    map &here = get_map();
+
+    // Test point at z=0, roof checks z=1
+    const tripoint_bub_ms test_pos( 60, 60, 0 );
+    const tripoint_bub_ms above_pos = test_pos + tripoint::above;
+
+    SECTION( "out of bounds returns false" ) {
+        const tripoint_bub_ms oob( -1, -1, 0 );
+        CHECK_FALSE( here.is_roofed( oob ) );
+    }
+
+    SECTION( "underground is always roofed" ) {
+        const tripoint_bub_ms underground( 60, 60, -1 );
+        CHECK( here.is_roofed( underground ) );
+    }
+
+    SECTION( "top of world is never roofed" ) {
+        const tripoint_bub_ms top( 60, 60, OVERMAP_HEIGHT );
+        CHECK_FALSE( here.is_roofed( top ) );
+    }
+
+    SECTION( "solid floor above means roofed" ) {
+        here.ter_set( above_pos, ter_t_floor );
+        here.build_map_cache( 0 );
+        here.build_map_cache( 1 );
+        CHECK( here.is_roofed( test_pos ) );
+    }
+
+    SECTION( "open air above means not roofed" ) {
+        here.ter_set( above_pos, ter_t_open_air );
+        here.build_map_cache( 0 );
+        here.build_map_cache( 1 );
+        CHECK_FALSE( here.is_roofed( test_pos ) );
+    }
+
+    SECTION( "transparent floor (ramp) above is roofed" ) {
+        // TRANSPARENT_FLOOR is marked no-floor in floor_cache but blocks precipitation
+        here.ter_set( above_pos, ter_t_ramp_down_high );
+        here.build_map_cache( 0 );
+        here.build_map_cache( 1 );
+        CHECK( here.is_roofed( test_pos ) );
+    }
+
+    SECTION( "SUN_ROOF_ABOVE furniture overrides no-floor above" ) {
+        here.ter_set( above_pos, ter_t_open_air );
+        here.furn_set( test_pos, furn_f_canvas_wall );
+        here.build_map_cache( 0 );
+        here.build_map_cache( 1 );
+        CHECK( here.is_roofed( test_pos ) );
+    }
+
+    SECTION( "fallback path works when cache is dirty" ) {
+        // Build cache with floor above, then dirty it without rebuilding
+        here.ter_set( above_pos, ter_t_floor );
+        here.build_map_cache( 0 );
+        here.build_map_cache( 1 );
+        // Manually dirty the z+1 floor cache to force fallback path
+        here.set_floor_cache_dirty( above_pos.z() );
+        CHECK( here.is_roofed( test_pos ) );
+    }
+}

--- a/tests/roof_test.cpp
+++ b/tests/roof_test.cpp
@@ -1,19 +1,30 @@
+#include <algorithm>
 #include <string>
+#include <vector>
 
+#include "avatar.h"
+#include "bodypart.h"
+#include "calendar.h"
 #include "cata_catch.h"
 #include "coordinates.h"
+#include "item.h"
 #include "map.h"
 #include "map_helpers.h"
 #include "map_scale_constants.h"
+#include "options_helpers.h"
+#include "player_helpers.h"
 #include "point.h"
 #include "type_id.h"
+#include "weather.h"
 
 static const furn_str_id furn_f_canvas_wall( "f_canvas_wall" );
 static const ter_str_id ter_t_floor( "t_floor" );
 static const ter_str_id ter_t_open_air( "t_open_air" );
 static const ter_str_id ter_t_ramp_down_high( "t_ramp_down_high" );
+static const ter_str_id ter_t_water_sh( "t_water_sh" );
+static const weather_type_id weather_drizzle( "drizzle" );
 
-TEST_CASE( "is_roofed", "[map]" )
+TEST_CASE( "is_roofed", "[map][roof]" )
 {
     clear_map();
     map &here = get_map();
@@ -27,8 +38,10 @@ TEST_CASE( "is_roofed", "[map]" )
         CHECK_FALSE( here.is_roofed( oob ) );
     }
 
-    SECTION( "underground is always roofed" ) {
+    SECTION( "underground with solid floor above is roofed" ) {
         const tripoint_bub_ms underground( 60, 60, -1 );
+        here.build_map_cache( -1 );
+        here.build_map_cache( 0 );
         CHECK( here.is_roofed( underground ) );
     }
 
@@ -75,5 +88,132 @@ TEST_CASE( "is_roofed", "[map]" )
         // Manually dirty the z+1 floor cache to force fallback path
         here.set_floor_cache_dirty( above_pos.z() );
         CHECK( here.is_roofed( test_pos ) );
+    }
+
+    SECTION( "multi-level walk-up finds roof at z+2" ) {
+        // Open air at z=1 but solid floor at z=2 still roofs the tile
+        here.ter_set( above_pos, ter_t_open_air );
+        const tripoint_bub_ms z2_pos( 60, 60, 2 );
+        here.ter_set( z2_pos, ter_t_floor );
+        here.build_map_cache( 0 );
+        here.build_map_cache( 1 );
+        here.build_map_cache( 2 );
+        CHECK( here.is_roofed( test_pos ) );
+    }
+
+    SECTION( "underground open to sky is not roofed" ) {
+        const tripoint_bub_ms underground( 60, 60, -1 );
+        // Clear the column from z=0 upward to open air
+        for( int z = 0; z <= OVERMAP_HEIGHT; ++z ) {
+            here.ter_set( tripoint_bub_ms( 60, 60, z ), ter_t_open_air );
+        }
+        for( int z = -1; z <= std::min( 2, static_cast<int>( OVERMAP_HEIGHT ) ); ++z ) {
+            here.build_map_cache( z );
+        }
+        CHECK_FALSE( here.is_roofed( underground ) );
+        // Restore ground floor so gravity check in later tests doesn't
+        // drop the avatar through open air at the default spawn point
+        here.ter_set( tripoint_bub_ms( 60, 60, 0 ), ter_t_floor );
+    }
+
+    SECTION( "water surface above blocks precipitation" ) {
+        here.ter_set( above_pos, ter_t_water_sh );
+        here.build_map_cache( 0 );
+        here.build_map_cache( 1 );
+        CHECK( here.is_roofed( test_pos ) );
+    }
+
+    SECTION( "transparent floor blocks on fallback path" ) {
+        // Validates the explicit TRANSPARENT_FLOOR check in the fallback path
+        here.ter_set( above_pos, ter_t_ramp_down_high );
+        here.build_map_cache( 0 );
+        here.build_map_cache( 1 );
+        here.set_floor_cache_dirty( above_pos.z() );
+        CHECK( here.is_roofed( test_pos ) );
+    }
+}
+
+TEST_CASE( "weather_wetting_respects_roof", "[roof]" )
+{
+    clear_map();
+    clear_avatar();
+    map &here = get_map();
+    avatar &you = get_avatar();
+
+    scoped_weather_override weather_override( weather_drizzle );
+
+    // Reset turn to a known baseline aligned with once_every(6_seconds)
+    calendar::turn = calendar::turn_zero;
+
+    // Ensure avatar has no rain protection
+    you.clear_worn();
+    you.set_wielded_item( item() );
+
+    const tripoint_bub_ms surface_pos( 60, 60, 0 );
+
+    auto run_weather = [&]( int iterations ) {
+        for( int i = 0; i < iterations; ++i ) {
+            calendar::turn += 6_seconds;
+            handle_weather_effects( weather_drizzle );
+        }
+    };
+
+    auto reset_wetness = [&]() {
+        for( const bodypart_id &bp : you.get_all_body_parts() ) {
+            you.set_part_wetness( bp, 0 );
+        }
+    };
+
+    SECTION( "roofed tile stays dry" ) {
+        you.setpos( here, surface_pos );
+        here.ter_set( surface_pos + tripoint::above, ter_t_floor );
+        here.build_map_cache( 0 );
+        here.build_map_cache( 1 );
+        reset_wetness();
+
+        run_weather( 60 );
+        CHECK( you.get_part_wetness( body_part_torso ) == 0 );
+    }
+
+    SECTION( "unroofed tile gets wet" ) {
+        you.setpos( here, surface_pos );
+        here.ter_set( surface_pos + tripoint::above, ter_t_open_air );
+        here.build_map_cache( 0 );
+        here.build_map_cache( 1 );
+        reset_wetness();
+
+        run_weather( 60 );
+        CHECK( you.get_part_wetness( body_part_torso ) > 0 );
+    }
+
+    SECTION( "underground roofed tile stays dry" ) {
+        const tripoint_bub_ms underground( 60, 60, -1 );
+        you.setpos( here, underground, false );
+        // z=0 has default solid floor from clear_map
+        here.build_map_cache( -1 );
+        here.build_map_cache( 0 );
+        reset_wetness();
+
+        run_weather( 60 );
+        CHECK( you.get_part_wetness( body_part_torso ) == 0 );
+    }
+
+    SECTION( "underground open to sky gets wet" ) {
+        const tripoint_bub_ms underground( 60, 60, -1 );
+        you.setpos( here, underground, false );
+        // Clear column from z=0 upward
+        for( int z = 0; z <= OVERMAP_HEIGHT; ++z ) {
+            here.ter_set( tripoint_bub_ms( 60, 60, z ), ter_t_open_air );
+        }
+        for( int z = -1; z <= std::min( 2, static_cast<int>( OVERMAP_HEIGHT ) ); ++z ) {
+            here.build_map_cache( z );
+        }
+        reset_wetness();
+
+        run_weather( 60 );
+        CHECK( you.get_part_wetness( body_part_torso ) > 0 );
+        // Restore ground floor so gravity check in later tests doesn't
+        // drop the avatar through open air at the default spawn point
+        here.ter_set( tripoint_bub_ms( 60, 60, 0 ), ter_t_floor );
     }
 }

--- a/tests/widget_test.cpp
+++ b/tests/widget_test.cpp
@@ -19,6 +19,7 @@
 #include "cata_utility.h"
 #include "character_attire.h"
 #include "coordinates.h"
+#include "display.h"
 #include "effect.h"
 #include "game.h"
 #include "game_constants.h"
@@ -1812,6 +1813,8 @@ static void fill_overmap_area( const avatar &ava, const oter_id &oter )
             overmap_buffer.set_seen( ava_pos + offset, om_vision_level::full );
         }
     }
+    // Terrain changed, so the overmap widget cache is stale.
+    display::invalidate_overmap_cache();
 }
 
 TEST_CASE( "multi-line_overmap_text_widget", "[widget][overmap]" )


### PR DESCRIPTION
#### Summary
Infrastructure "Add map::is_roofed() API with vertical walk-up for precipitation checks"

#### Purpose of change

The weather wetting code in `weather.cpp` used an inline `has_flag(TFLAG_NO_FLOOR, pos + above)` check to determine if rain reaches a character. This only checked one z-level, didn't account for glass floors, SUN_ROOF_ABOVE furniture, vehicle roofs, or multi-level openings (craters, mine shafts), and wasn't reusable by other systems that need to know "does precipitation hit this tile?"

This is groundwork for future weather realism features (snow depth tracking, etc.) that need a reliable roof query. See #46354, #46559, #28227 for prior snow attempts that all needed this kind of API.

#### Describe the solution

New `map::is_roofed(tripoint_bub_ms)` const method that walks upward through all z-levels from `p.z()+1` to `OVERMAP_HEIGHT`, looking for any surface that blocks precipitation:

- **Fast path**: When floor_cache at a given z is valid and clean, reads it directly. Also checks TRANSPARENT_FLOOR (glass/ramps/grates block rain even though floor_cache marks them as no-floor) and NO_FLOOR_WATER (water surfaces absorb precipitation).
- **Fallback path**: When cache is dirty or missing, does direct terrain flag checks. TRANSPARENT_FLOOR is checked explicitly before NO_FLOOR/GOES_DOWN to prevent divergence with the fast path when flags combine. Checks SUN_ROOF_ABOVE furniture at z-1 (matching `build_floor_cache` semantics). Checks vehicle parts for VPFLAG_ROOF/VPFLAG_OPAQUE.
- First blocking surface found at any z-level means the tile is roofed. No blocking surface all the way to OVERMAP_HEIGHT means not roofed.
- No special-casing for z < 0 -- underground tiles with open air above them all the way to the sky correctly report as not roofed.

The weather wetting condition is simplified from `is_creature_outside(target) && !is_roofed(pos)` to just `!is_roofed(pos)`. Precipitation is vertical -- only roofs and floors block it, not walls. This also removes the hardcoded `z >= 0` gate in `is_creature_outside()` from the precipitation path, so underground tiles exposed to sky (craters, shafts) can now receive rain.

#### Describe alternatives you've considered

Could have modified `game::is_sheltered()` to include a roof check, but `is_sheltered` feeds sunlight, wind, fire/gas, bionics, and UI systems -- too much blast radius for what should be a pure precipitation query.

Could have fixed `build_outside_cache()` for z < 0 (currently fills everything underground with not-outside), but that has ~64 callers and would change behavior for sunlight, sound propagation, NPC conditions, and more. Using `!is_roofed()` alone for precipitation avoids that blast radius entirely.

Could have made `is_roofed` non-const and called `build_floor_cache` when dirty, but that would change the call-site contract and prevent use in const contexts. The fallback path produces correct results without the cache.

#### Testing

`tests/roof_test.cpp` with 16 assertions across 2 test cases:

**is_roofed unit tests** (10 assertions):
- Out-of-bounds, top-of-world edge cases
- Underground with solid floor above (roofed), underground open to sky (not roofed)
- Solid floor, open air, transparent floor (ramp), SUN_ROOF_ABOVE furniture
- Water surface above blocks precipitation
- Multi-level walk-up finds roof at z+2
- Transparent floor on dirty-cache fallback path
- Dirty cache fallback

**End-to-end weather wetting** (6 assertions):
- Avatar under roof stays dry, avatar under open air gets wet
- Underground roofed stays dry, underground open to sky gets wet
- Uses `get_part_wetness(body_part_torso)` with 60 iterations at 6-second intervals to overcome per-tick RNG

All pass: `./tests/cata_test "[roof]"`

#### Additional context

Part 1 of the snow series. Part 2 is #85724 (per-OMT snow depth tracking).

Behavior changes beyond the original inline check:
- Glass floors, SUN_ROOF_ABOVE furniture, and vehicle roofs now correctly block rain (the old inline check missed all of these)
- NO_FLOOR_WATER (deep water surfaces) now blocks precipitation for tiles below
- Underground tiles exposed to sky through craters/shafts are no longer unconditionally roofed
- Roofless buildings on the surface now receive rain (previously blocked by `is_outside()=false` from INDOORS flag, but walls don't block vertical precipitation)