### PR TITLE
Fix spell checker compatibility with pyspellchecker 0.9.0

### DIFF
--- a/tools/spell_checker/__init__.py
+++ b/tools/spell_checker/__init__.py
@@ -50,7 +50,7 @@ KnownWords = set()
 def init_known_words(DefaultKnownWords, KnownWords):
     default_dict = {
         unicodedata.normalize('NFC', word) for word in
-        SpellChecker(case_sensitive=True).word_frequency
+        SpellChecker(case_sensitive=False).word_frequency
     }
 
     custom_dict = set()


### PR DESCRIPTION
#### Summary
Infrastructure "Fix spell checker compatibility with pyspellchecker 0.9.0"

#### Purpose of change

pyspellchecker 0.9.0 (released today) made `case_sensitive` and `language` mutually exclusive parameters. Since `language` defaults to `'en'`, passing `case_sensitive=True` now raises `ValueError`. This breaks the spell check CI test even when no text was changed.

#### Describe the solution

Changed `case_sensitive=True` to `case_sensitive=False` (which is the default). The built-in English dictionary is all lowercase, so this produces the same word list either way.

#### Describe alternatives you've considered

Could also just remove the parameter entirely since `False` is the default, but keeping it explicit makes the intent clearer.

Could pin pyspellchecker<0.9.0, but that's just kicking the can down the road.

#### Testing

The spell checker test should pass again with the latest pyspellchecker.

#### Additional context

https://github.com/barrust/pyspellchecker/releases/tag/v0.9.0