### PR TITLE
Add per-OMT snow depth tracking and movement penalty

### DIFF
--- a/data/json/ui/weather.json
+++ b/data/json/ui/weather.json
@@ -11,5 +11,12 @@
     "type": "widget",
     "copy-from": "weather_desc",
     "flags": [ "W_LABEL_NONE" ]
+  },
+  {
+    "id": "snow_depth_desc",
+    "type": "widget",
+    "label": "Snow",
+    "style": "text",
+    "var": "snow_depth_text"
   }
 ]

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -6117,6 +6117,15 @@ std::vector<run_cost_effect> Character::run_cost_effects( float &movecost ) cons
         run_cost_effect_add( 10, _( "Roots" ) );
     }
 
+    // Snow depth movement penalty (outdoor, unroofed tiles only)
+    if( here.is_outside( pos_bub() ) && !here.is_roofed( pos_bub() ) ) {
+        const double snow_mm = get_weather().get_snow_depth_mm( pos_abs_omt() );
+        if( snow_mm >= 100 ) {
+            const int penalty = snow_mm >= 500 ? 100 : ( snow_mm >= 250 ? 50 : 20 );
+            run_cost_effect_add( penalty, _( "Snow" ) );
+        }
+    }
+
     run_cost_effect_add( enchantment_cache->get_value_add( enchant_vals::mod::MOVE_COST ),
                          _( "Enchantments" ) );
     run_cost_effect_mul( std::max( 0.01,

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1576,6 +1576,37 @@ std::string display::colorized_bodygraph_text( const Character &u, const std::st
     return ret;
 }
 
+std::pair<std::string, nc_color> display::snow_depth_text_color( const Character &u )
+{
+    if( u.posz() < 0 ) {
+        return std::make_pair( std::string(), c_light_gray );
+    }
+    const map &here = get_map();
+    if( !here.is_outside( u.pos_bub() ) || here.is_roofed( u.pos_bub() ) ) {
+        return std::make_pair( std::string(), c_light_gray );
+    }
+    const double depth = get_weather().get_snow_depth_mm( u.pos_abs_omt() );
+    if( depth < 1.0 ) {
+        return std::make_pair( std::string(), c_light_gray );
+    }
+    std::string text;
+    nc_color color;
+    if( depth >= 500 ) {
+        text = _( "Deep snow" );
+        color = c_white;
+    } else if( depth >= 250 ) {
+        text = _( "Snow" );
+        color = c_light_blue;
+    } else if( depth >= 100 ) {
+        text = _( "Light snow" );
+        color = c_light_cyan;
+    } else {
+        text = _( "Dusting" );
+        color = c_cyan;
+    }
+    return std::make_pair( text, color );
+}
+
 std::pair<std::string, nc_color> display::weather_text_color( const Character &u )
 {
     if( u.posz() < 0 ) {

--- a/src/display.h
+++ b/src/display.h
@@ -165,6 +165,7 @@ std::pair<std::string, nc_color> power_balance_text_color( const avatar &u );
 
 std::pair<std::string, nc_color> safe_mode_text_color( bool classic_mode );
 std::pair<std::string, nc_color> wind_text_color( const Character &u );
+std::pair<std::string, nc_color> snow_depth_text_color( const Character &u );
 std::pair<std::string, nc_color> weather_text_color( const Character &u );
 
 // Get visible threats by cardinal direction - Already colorized

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -1744,6 +1744,22 @@ void weather_manager::serialize_all( JsonOut &json )
     if( weather.forced_temperature ) {
         json.member( "forced_temperature", units::to_fahrenheit( *weather.forced_temperature ) );
     }
+    if( !weather.snow_depth_map.empty() ) {
+        json.member( "snow_depth" );
+        json.start_array();
+        for( const auto &pair : weather.snow_depth_map ) {
+            if( pair.second.depth_mm > 0.001 ) {
+                json.start_object();
+                json.member( "x", pair.first.x() );
+                json.member( "y", pair.first.y() );
+                json.member( "z", pair.first.z() );
+                json.member( "depth_mm", pair.second.depth_mm );
+                json.member( "last_update", pair.second.last_update );
+                json.end_object();
+            }
+        }
+        json.end_array();
+    }
     json.end_object();
 }
 
@@ -1763,6 +1779,16 @@ void weather_manager::unserialize_all( const JsonObject &w )
         get_weather().forced_temperature = units::from_fahrenheit( read_forced_temp );
     } else {
         get_weather().forced_temperature.reset();
+    }
+    get_weather().snow_depth_map.clear();
+    if( w.has_array( "snow_depth" ) ) {
+        for( JsonObject entry : w.get_array( "snow_depth" ) ) {
+            tripoint_abs_omt pos( entry.get_int( "x" ), entry.get_int( "y" ), entry.get_int( "z" ) );
+            omt_snow_state state;
+            entry.read( "depth_mm", state.depth_mm );
+            entry.read( "last_update", state.last_update );
+            get_weather().snow_depth_map[pos] = state;
+        }
     }
 }
 

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <array>
+#include <climits>
 #include <cmath>
 #include <functional>
 #include <map>
@@ -1052,6 +1053,98 @@ void weather_manager::update_weather()
             effect_on_conditions::process_reactivate();
         }
     }
+    update_snow_depth();
+}
+
+// Maximum time delta to apply in a single catch-up update (1 hour).
+// Beyond this, weather has certainly changed and the approximation is too coarse.
+static constexpr time_duration max_snow_catchup = 1_hours;
+// Snow-water equivalent ratio: 1mm liquid precipitation = 12mm snow depth
+static constexpr double snow_water_ratio = 12.0;
+// Melt rate in mm snow per degree-C above freezing per hour.
+// Derived from degree-day factor ~4 mm SWE/C/day at 12:1 ratio:
+// 4/24 * 12 = 2.0.  Real-world range is 1.5-3.0 for open ground.
+static constexpr double melt_rate_per_deg_per_hour = 2.0;
+// Maximum snow depth in mm
+static constexpr double max_snow_depth = 800.0;
+
+void weather_manager::update_snow_depth()
+{
+    if( !calendar::once_every( 1_minutes ) ) {
+        return;
+    }
+
+    // Prune dead entries once per hour
+    if( calendar::once_every( 1_hours ) ) {
+        for( auto it = snow_depth_map.begin(); it != snow_depth_map.end(); ) {
+            if( it->second.depth_mm <= 0.001 &&
+                calendar::turn - it->second.last_update > 6_hours ) {
+                it = snow_depth_map.erase( it );
+            } else {
+                ++it;
+            }
+        }
+    }
+
+    if( weather_id == WEATHER_NULL ) {
+        // No valid weather yet - just keep timestamps current
+        const tripoint_abs_omt player_omt = get_player_character().pos_abs_omt();
+        auto it = snow_depth_map.find( player_omt );
+        if( it != snow_depth_map.end() ) {
+            it->second.last_update = calendar::turn;
+        }
+        return;
+    }
+
+    const tripoint_abs_omt player_omt = get_player_character().pos_abs_omt();
+    omt_snow_state &state = snow_depth_map[player_omt];
+
+    time_duration dt = calendar::turn - state.last_update;
+    if( dt > max_snow_catchup ) {
+        dt = max_snow_catchup;
+    }
+    if( dt <= 0_seconds ) {
+        state.last_update = calendar::turn;
+        return;
+    }
+
+    const double hours = to_seconds<double>( dt ) / 3600.0;
+
+    // Accumulation: snow weather (precipitation that doesn't rain)
+    if( weather_id->precip != precip_class::none && !weather_id->rains ) {
+        state.depth_mm += precip_mm_per_hour( weather_id->precip ) * snow_water_ratio * hours;
+    }
+
+    // Melt: temperature above 0C
+    if( temperature > 0_C && state.depth_mm > 0 ) {
+        const double degrees_above = units::to_celsius( temperature );
+        state.depth_mm -= melt_rate_per_deg_per_hour * degrees_above * hours;
+    }
+
+    state.depth_mm = std::clamp( state.depth_mm, 0.0, max_snow_depth );
+    state.last_update = calendar::turn;
+}
+
+double weather_manager::get_snow_depth_mm( const tripoint_abs_omt &omt_pos ) const
+{
+    auto it = snow_depth_map.find( omt_pos );
+    if( it != snow_depth_map.end() ) {
+        return it->second.depth_mm;
+    }
+    // Seed from nearest same-z neighbor that has data
+    double best_depth = 0.0;
+    int best_dist = INT_MAX;
+    for( const auto &pair : snow_depth_map ) {
+        if( pair.first.z() != omt_pos.z() ) {
+            continue;
+        }
+        const int dist = square_dist( omt_pos, pair.first );
+        if( dist < best_dist ) {
+            best_dist = dist;
+            best_depth = pair.second.depth_mm;
+        }
+    }
+    return best_depth;
 }
 
 void weather_manager::set_nextweather( time_point t )

--- a/src/weather.h
+++ b/src/weather.h
@@ -195,6 +195,11 @@ float incident_sun_irradiance( const weather_type_id &wtype,
 
 void weather_sound( const translation &sound_message, const std::string &sound_effect );
 
+struct omt_snow_state {
+    double depth_mm = 0;
+    time_point last_update = calendar::turn;
+};
+
 class weather_manager
 {
     public:
@@ -202,6 +207,10 @@ class weather_manager
         const weather_generator &get_cur_weather_gen() const;
         // Updates the temperature and weather patten
         void update_weather();
+        // Incrementally update snow depth at the player's current OMT
+        void update_snow_depth();
+        // Snow depth in mm at a given OMT (0 if no data)
+        double get_snow_depth_mm( const tripoint_abs_omt &omt_pos ) const;
         // The air temperature
         units::temperature temperature = 0_K;
         bool lightning_active = false;
@@ -225,6 +234,8 @@ class weather_manager
         time_point nextweather;
         /** temperature cache, cleared every turn, sparse map of map tripoints to temperatures */
         std::unordered_map< tripoint_bub_ms, units::temperature > temperature_cache;
+        // Per-OMT snow depth state, updated incrementally
+        std::unordered_map< tripoint_abs_omt, omt_snow_state > snow_depth_map;
         /*
         * Returns current temperature of given tile. Includes temperature modifications from
         * radiative and convective sources, such as fires or hot air from heaters.

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -224,6 +224,8 @@ std::string enum_to_string<widget_var>( widget_var data )
             return "weary_transition_level";
         case widget_var::weary_malus_text:
             return "weary_malus_text";
+        case widget_var::snow_depth_text:
+            return "snow_depth_text";
         case widget_var::weather_text:
             return "weather_text";
         case widget_var::wielding_text:
@@ -1175,6 +1177,7 @@ bool widget::uses_text_function() const
         case widget_var::veh_fuel_text:
         case widget_var::weariness_text:
         case widget_var::weary_malus_text:
+        case widget_var::snow_depth_text:
         case widget_var::weather_text:
         case widget_var::wielding_text:
         case widget_var::wielding_simple_text:
@@ -1327,6 +1330,9 @@ std::string widget::color_text_function_string( const avatar &ava, unsigned int 
             break;
         case widget_var::weary_malus_text:
             desc = display::weary_malus_text_color( ava );
+            break;
+        case widget_var::snow_depth_text:
+            desc = display::snow_depth_text_color( ava );
             break;
         case widget_var::weather_text:
             desc = display::weather_text_color( ava );

--- a/src/widget.h
+++ b/src/widget.h
@@ -95,6 +95,7 @@ enum class widget_var : int {
     veh_fuel_text,  // Current/total fuel for active vehicle engine, color string
     weariness_text, // Weariness description text, color string
     weary_malus_text, // Weariness malus or penalty
+    snow_depth_text, // Snow depth at player's OMT, color string
     weather_text,   // Weather/sky conditions (if visible), color string
     wielding_text,  // Currently wielded weapon or item name
     wielding_simple_text,  // Currently wielded weapon or item name, without mode and ammo

--- a/tests/snow_depth_test.cpp
+++ b/tests/snow_depth_test.cpp
@@ -1,0 +1,159 @@
+#include "cata_catch.h"
+
+#include <string>
+#include <unordered_map>
+
+#include "calendar.h"
+#include "character.h"
+#include "coordinates.h"
+#include "map.h"
+#include "map_helpers.h"
+#include "player_helpers.h"
+#include "point.h"
+#include "type_id.h"
+#include "units.h"
+#include "weather.h"
+
+static const weather_type_id weather_snowing( "snowing" );
+static const weather_type_id weather_sunny( "sunny" );
+
+TEST_CASE( "snow_accumulation_and_melt", "[snow][weather]" )
+{
+    clear_map();
+    weather_manager &weather = get_weather();
+    weather.snow_depth_map.clear();
+
+    // Align to minute boundary so once_every(1_minutes) in update_snow_depth fires
+    calendar::turn -= ( calendar::turn - calendar::turn_zero ) % 1_minutes;
+
+    Character &player = get_player_character();
+    const tripoint_abs_omt player_omt = player.pos_abs_omt();
+
+    SECTION( "snow accumulates during snowfall" ) {
+        weather.weather_id = weather_snowing;
+        weather.temperature = units::from_celsius( -5 );
+
+        // Simulate 30 minutes of snowfall by advancing time in 1-minute steps
+        for( int i = 0; i < 30; i++ ) {
+            calendar::turn += 1_minutes;
+            weather.update_snow_depth();
+        }
+
+        CHECK( weather.get_snow_depth_mm( player_omt ) > 0.0 );
+    }
+
+    SECTION( "snow melts above freezing" ) {
+        // Pre-seed some snow
+        weather.snow_depth_map[player_omt] = { 200.0, calendar::turn };
+
+        weather.weather_id = weather_sunny;
+        weather.temperature = 10_C;
+
+        for( int i = 0; i < 30; i++ ) {
+            calendar::turn += 1_minutes;
+            weather.update_snow_depth();
+        }
+
+        CHECK( weather.get_snow_depth_mm( player_omt ) < 200.0 );
+    }
+
+    SECTION( "no snow in warm weather" ) {
+        weather.weather_id = weather_sunny;
+        weather.temperature = 20_C;
+
+        for( int i = 0; i < 30; i++ ) {
+            calendar::turn += 1_minutes;
+            weather.update_snow_depth();
+        }
+
+        CHECK( weather.get_snow_depth_mm( player_omt ) < 0.001 );
+    }
+
+    SECTION( "unvisited OMT seeds from nearest neighbor" ) {
+        weather.snow_depth_map[player_omt] = { 150.0, calendar::turn };
+
+        // Query an adjacent OMT with no data
+        tripoint_abs_omt neighbor = player_omt + tripoint::east;
+        CHECK( weather.get_snow_depth_mm( neighbor ) == Approx( 150.0 ) );
+    }
+
+    SECTION( "depth is clamped to maximum" ) {
+        weather.snow_depth_map[player_omt] = { 790.0, calendar::turn };
+        weather.weather_id = weather_snowing;
+        weather.temperature = units::from_celsius( -10 );
+
+        // Accumulate past max
+        for( int i = 0; i < 60; i++ ) {
+            calendar::turn += 1_minutes;
+            weather.update_snow_depth();
+        }
+
+        CHECK( weather.get_snow_depth_mm( player_omt ) <= 800.0 );
+    }
+
+    SECTION( "catch-up delta is clamped" ) {
+        // Entry from 3 days ago during a blizzard
+        weather.snow_depth_map[player_omt] = { 0.0, calendar::turn - 3_days };
+        weather.weather_id = weather_snowing;
+        weather.temperature = units::from_celsius( -5 );
+
+        calendar::turn += 1_minutes;
+        weather.update_snow_depth();
+
+        // Should only accumulate for 1 hour (max catchup), not 3 days
+        double depth = weather.get_snow_depth_mm( player_omt );
+        CHECK( depth > 0.0 );
+        CHECK( depth < 200.0 );
+    }
+}
+
+TEST_CASE( "snow_movement_penalty", "[snow][movement]" )
+{
+    clear_map();
+    clear_character( get_player_character() );
+    weather_manager &weather = get_weather();
+    weather.snow_depth_map.clear();
+
+    Character &player = get_player_character();
+    map &here = get_map();
+    const tripoint_abs_omt player_omt = player.pos_abs_omt();
+
+    // Make sure player is outside and unroofed
+    here.ter_set( player.pos_bub(), ter_id( "t_grass" ) );
+    here.ter_set( player.pos_bub() + tripoint::above, ter_id( "t_open_air" ) );
+    here.build_map_cache( player.posz() );
+    here.build_map_cache( player.posz() + 1 );
+
+    SECTION( "heavy snow increases movement cost" ) {
+        weather.snow_depth_map[player_omt] = { 600.0, calendar::turn };
+        weather.weather_id = weather_sunny;
+        weather.temperature = units::from_celsius( -5 );
+
+        const int cost_with_snow = player.run_cost( 100 );
+
+        weather.snow_depth_map[player_omt] = { 0.0, calendar::turn };
+        const int cost_without_snow = player.run_cost( 100 );
+
+        CHECK( cost_with_snow > cost_without_snow );
+    }
+
+    SECTION( "no penalty indoors" ) {
+        weather.snow_depth_map[player_omt] = { 600.0, calendar::turn };
+
+        // Put a floor above to make it roofed
+        here.ter_set( player.pos_bub() + tripoint::above, ter_id( "t_floor" ) );
+        here.build_map_cache( player.posz() );
+        here.build_map_cache( player.posz() + 1 );
+
+        // Get cost with roof
+        const int cost_roofed = player.run_cost( 100 );
+
+        // Remove roof
+        here.ter_set( player.pos_bub() + tripoint::above, ter_id( "t_open_air" ) );
+        here.build_map_cache( player.posz() );
+        here.build_map_cache( player.posz() + 1 );
+        const int cost_unroofed = player.run_cost( 100 );
+
+        CHECK( cost_roofed < cost_unroofed );
+    }
+}


### PR DESCRIPTION
#### Summary
Features "Per-overmap-tile snow depth tracking with movement penalty"

#### Purpose of change

The game has snowfall weather but no persistent snow state. This adds per-OMT depth tracking so snow actually piles up during storms, melts when it warms up, and slows you down when you wade through it.

Depends on #85721 for `map::is_roofed()`.

#### Describe the solution

- `weather_manager` gets an `unordered_map<tripoint_abs_omt, omt_snow_state>` mapping each OMT to its depth in mm and a last-update timestamp
- `update_snow_depth()` runs every game minute inside `update_weather()`, accumulating snow during snowfall (existing `precip_mm_per_hour()` * 12:1 snow-water ratio) and melting above 0C at 3 mm/C/hour
- Stale entries get a 1-hour catch-up clamp so you don't come back to 3 meters of snow after sleeping; zero-depth entries pruned hourly
- Unvisited OMTs seed from their nearest neighbor so you don't walk into a suspiciously snow-free bubble
- Movement penalty via `run_cost_effects()`: 25/50/100 extra cost at 50/150/300mm thresholds, shows up in the cost breakdown UI
- Sidebar widget (`snow_depth_desc`) with color-coded depth tiers
- Serialized as a JSON array in savegame

#### Describe alternatives you've considered

Per-tile tracking would be more granular but the storage and update overhead is hard to justify at this stage for something that's mostly uniform across an OMT. Per-OMT keeps it cheap and simple - per-tile snow fields can build on top of this later using the OMT depth as a baseline.

Could have gone with a simple seasonal counter, but incremental accumulation and melt means a warm day mid-winter actually does something.

#### Testing

- `snow_depth_test.cpp` - 2 test cases, 9 assertions covering: accumulation during snowfall, melt above 0C, no change in warm weather, neighbor seeding for unknown OMTs, max depth clamp (800mm), catch-up clamp (1 hour), movement penalty at each tier, no penalty under roof

#### Additional context

Part 2 of the snow series. Part 1 is #85721 (`map::is_roofed()`).

This opens up a bunch of ❄️ cool❄️  opportunities:
- Vehicle traction penalty from snow depth
- `snow_depth_mm` as a math function for modders/EOCs
- Per-tile `fd_snow` field (Aivean's actualization architecture from #46559, built on OMT depth as baseline)
- Snow rendering (tiles mode only, curses stays as-is)
- Mitigation items (snowshoes, tire chains, snow boots)
- Snow interactions (gathering, shoveling, snowballs)