### PR TITLE
[Xedra Evolved] Move changelings to the `gramarye` skill for their powers

### DIFF
--- a/data/mods/Xedra_Evolved/eocs/misc_eoc.json
+++ b/data/mods/Xedra_Evolved/eocs/misc_eoc.json
@@ -7,7 +7,7 @@
     "condition": {
       "and": [
         {
-          "u_has_any_trait": [ "EATER", "DREAMER", "DREAMSMITH", "INVENTOR", "IERDE", "HOMULLUS", "SALAMANDER", "UNDINE", "SYLPH", "VAMPIRE" ]
+          "u_has_any_trait": [ "EATER", "DREAMER", "DREAMSMITH", "INVENTOR", "IERDE", "HOMULLUS", "SALAMANDER", "UNDINE", "SYLPH" ]
         },
         {
           "or": [

--- a/data/mods/Xedra_Evolved/eocs/misc_eoc.json
+++ b/data/mods/Xedra_Evolved/eocs/misc_eoc.json
@@ -7,19 +7,7 @@
     "condition": {
       "and": [
         {
-          "u_has_any_trait": [
-            "EATER",
-            "DREAMER",
-            "DREAMSMITH",
-            "INVENTOR",
-            "CHANGELING_MAGIC",
-            "IERDE",
-            "HOMULLUS",
-            "SALAMANDER",
-            "UNDINE",
-            "SYLPH",
-            "VAMPIRE"
-          ]
+          "u_has_any_trait": [ "EATER", "DREAMER", "DREAMSMITH", "INVENTOR", "IERDE", "HOMULLUS", "SALAMANDER", "UNDINE", "SYLPH", "VAMPIRE" ]
         },
         {
           "or": [
@@ -27,11 +15,6 @@
             { "compare_string": [ "DREAMER", { "context_val": "school" } ] },
             { "compare_string": [ "DREAMSMITH", { "context_val": "school" } ] },
             { "compare_string": [ "INVENTOR", { "context_val": "school" } ] },
-            { "compare_string": [ "CHANGELING_MAGIC", { "context_val": "school" } ] },
-            { "compare_string": [ "CHANGELING_SEASONAL_MAGIC_SPRING", { "context_val": "school" } ] },
-            { "compare_string": [ "CHANGELING_SEASONAL_MAGIC_SUMMER", { "context_val": "school" } ] },
-            { "compare_string": [ "CHANGELING_SEASONAL_MAGIC_AUTUMN", { "context_val": "school" } ] },
-            { "compare_string": [ "CHANGELING_SEASONAL_MAGIC_WINTER", { "context_val": "school" } ] },
             { "compare_string": [ "IERDE", { "context_val": "school" } ] },
             { "compare_string": [ "HOMULLUS", { "context_val": "school" } ] },
             { "compare_string": [ "SALAMANDER", { "context_val": "school" } ] },

--- a/data/mods/Xedra_Evolved/jmath.json
+++ b/data/mods/Xedra_Evolved/jmath.json
@@ -77,7 +77,7 @@
     "id": "xe_fey_seasonal_magick_spring_failure_chance_actual",
     "//": "This and below separations are necessary to keep the 'You cannot go below 5% chance to fail in the opposite season' logic",
     "num_args": 0,
-    "return": "(0.15 + (global_what_is_the_season == 2 ? 0.15 : 0 ) + (global_what_is_the_season == 3 ? 0.35 : 0 ) + (global_what_is_the_season == 4 ? 0.15 : 0 ) + (u_spell_difficulty(_spell_id) * 0.09 ) + xe_fey_magick_mana_penalty() ) - ( (u_skill('deduction') * 0.06) + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 0.04) )"
+    "return": "(0.15 + (global_what_is_the_season == 2 ? 0.15 : 0 ) + (global_what_is_the_season == 3 ? 0.35 : 0 ) + (global_what_is_the_season == 4 ? 0.15 : 0 ) + (u_spell_difficulty(_spell_id) * 0.09 ) + xe_fey_magick_mana_penalty() ) - ( (u_skill('gramarye') * 0.06) + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 0.04) )"
   },
   {
     "type": "jmath_function",
@@ -89,7 +89,7 @@
     "type": "jmath_function",
     "id": "xe_fey_seasonal_magick_summer_failure_chance_actual",
     "num_args": 0,
-    "return": "(0.15 + (global_what_is_the_season == 1 ? 0.15 : 0 ) + (global_what_is_the_season == 3 ? 0.15 : 0 ) + (global_what_is_the_season == 4 ? 0.35 : 0 ) + (u_spell_difficulty(_spell_id) * 0.09 ) + xe_fey_magick_mana_penalty() ) - ( (u_skill('deduction') * 0.06) + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 0.04) )"
+    "return": "(0.15 + (global_what_is_the_season == 1 ? 0.15 : 0 ) + (global_what_is_the_season == 3 ? 0.15 : 0 ) + (global_what_is_the_season == 4 ? 0.35 : 0 ) + (u_spell_difficulty(_spell_id) * 0.09 ) + xe_fey_magick_mana_penalty() ) - ( (u_skill('gramarye') * 0.06) + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 0.04) )"
   },
   {
     "type": "jmath_function",
@@ -101,7 +101,7 @@
     "type": "jmath_function",
     "id": "xe_fey_seasonal_magick_autumn_failure_chance_actual",
     "num_args": 0,
-    "return": "(0.15 + (global_what_is_the_season == 1 ? 0.35 : 0 ) + (global_what_is_the_season == 2 ? 0.15 : 0 ) + (global_what_is_the_season == 4 ? 0.15 : 0 ) + (u_spell_difficulty(_spell_id) * 0.09 ) + xe_fey_magick_mana_penalty() ) - ( (u_skill('deduction') * 0.06) + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 0.04) )"
+    "return": "(0.15 + (global_what_is_the_season == 1 ? 0.35 : 0 ) + (global_what_is_the_season == 2 ? 0.15 : 0 ) + (global_what_is_the_season == 4 ? 0.15 : 0 ) + (u_spell_difficulty(_spell_id) * 0.09 ) + xe_fey_magick_mana_penalty() ) - ( (u_skill('gramarye') * 0.06) + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 0.04) )"
   },
   {
     "type": "jmath_function",
@@ -113,7 +113,7 @@
     "type": "jmath_function",
     "id": "xe_fey_seasonal_magick_winter_failure_chance_actual",
     "num_args": 0,
-    "return": "(0.15 + (global_what_is_the_season == 1 ? 0.15 : 0 ) + (global_what_is_the_season == 2 ? 0.35 : 0 ) + (global_what_is_the_season == 3 ? 0.15 : 0 ) + (u_spell_difficulty(_spell_id) * 0.09 ) + xe_fey_magick_mana_penalty() ) - ( (u_skill('deduction') * 0.06) + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 0.04) )"
+    "return": "(0.15 + (global_what_is_the_season == 1 ? 0.15 : 0 ) + (global_what_is_the_season == 2 ? 0.35 : 0 ) + (global_what_is_the_season == 3 ? 0.15 : 0 ) + (u_spell_difficulty(_spell_id) * 0.09 ) + xe_fey_magick_mana_penalty() ) - ( (u_skill('gramarye') * 0.06) + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 0.04) )"
   },
   {
     "type": "jmath_function",
@@ -131,7 +131,7 @@
     "type": "jmath_function",
     "id": "xe_fey_elemental_magick_arvore_failure_chance",
     "num_args": 0,
-    "return": "clamp( ( ( ( (global_what_is_the_season == 4 ? 0.15 : 0 ) + (u_spell_difficulty(_spell_id) * 0.09 ) + xe_fey_magick_mana_penalty() ) + (u_skill('deduction') * -0.03) + (u_spell_level(_spell_id) * -0.06 ) ) * (u_effect_intensity('effect_arvore_is_day_in_the_sun_not_winter') > -1 ? 0.5 : 1 ) ), 0, 1)"
+    "return": "clamp( ( ( ( (global_what_is_the_season == 4 ? 0.15 : 0 ) + (u_spell_difficulty(_spell_id) * 0.09 ) + xe_fey_magick_mana_penalty() ) + (u_skill('gramarye') * -0.03) + (u_spell_level(_spell_id) * -0.06 ) ) * (u_effect_intensity('effect_arvore_is_day_in_the_sun_not_winter') > -1 ? 0.5 : 1 ) ), 0, 1)"
   },
   {
     "type": "jmath_function",

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_eocs.json
@@ -18,7 +18,16 @@
             "BLOODTHORNE_DRUID_SYMBIOTIC_PLANT"
           ]
         },
-        { "or": [ { "compare_string": [ "ARVORE", { "context_val": "school" } ] } ] }
+        {
+          "or": [
+            { "compare_string": [ "CHANGELING_MAGIC", { "context_val": "school" } ] },
+            { "compare_string": [ "CHANGELING_SEASONAL_MAGIC_SPRING", { "context_val": "school" } ] },
+            { "compare_string": [ "CHANGELING_SEASONAL_MAGIC_SUMMER", { "context_val": "school" } ] },
+            { "compare_string": [ "CHANGELING_SEASONAL_MAGIC_AUTUMN", { "context_val": "school" } ] },
+            { "compare_string": [ "CHANGELING_SEASONAL_MAGIC_WINTER", { "context_val": "school" } ] },
+            { "compare_string": [ "ARVORE", { "context_val": "school" } ] }
+          ]
+        }
       ]
     },
     "effect": [

--- a/data/mods/Xedra_Evolved/skills.json
+++ b/data/mods/Xedra_Evolved/skills.json
@@ -44,6 +44,6 @@
     "time_to_attack": { "min_time": 60, "base_time": 200, "time_reduction_per_level": 14 },
     "display_category": "display_interaction",
     "sort_rank": 26750,
-    "requires_any_traits": [ "ARVORE" ]
+    "requires_any_traits": [ "ARVORE", "CHANGELING_MAGIC" ]
   }
 ]

--- a/data/mods/Xedra_Evolved/spells/changeling_seasonal_magic_autumn.json
+++ b/data/mods/Xedra_Evolved/spells/changeling_seasonal_magic_autumn.json
@@ -22,7 +22,7 @@
     "spell_class": "CHANGELING_SEASONAL_MAGIC_AUTUMN",
     "valid_targets": [ "ally", "hostile" ],
     "teachable": false,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "shape": "blast",
     "difficulty": 1,
@@ -31,16 +31,16 @@
     "min_range": 1,
     "min_duration": {
       "math": [
-        "( ( 562 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 185) + (u_skill('deduction') * 253) ) ) * (global_what_is_the_season == 3 ? 3 : 1)"
+        "( ( 562 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 185) + (u_skill('gramarye') * 253) ) ) * (global_what_is_the_season == 3 ? 3 : 1)"
       ]
     },
     "max_duration": {
       "math": [
-        "( ( 1235 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 385) + (u_skill('deduction') * 498) ) ) * (global_what_is_the_season == 3 ? 3 : 1)"
+        "( ( 1235 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 385) + (u_skill('gramarye') * 498) ) ) * (global_what_is_the_season == 3 ? 3 : 1)"
       ]
     },
     "base_energy_cost": {
-      "math": [ "max( ( 100 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 1) - (u_skill('deduction') * 3)), 40)" ]
+      "math": [ "max( ( 100 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 1) - (u_skill('gramarye') * 3)), 40)" ]
     },
     "base_casting_time": 50
   },
@@ -54,7 +54,7 @@
     "spell_class": "CHANGELING_SEASONAL_MAGIC_AUTUMN",
     "valid_targets": [ "ally", "hostile" ],
     "teachable": false,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "shape": "blast",
     "difficulty": 2,
@@ -62,16 +62,16 @@
     "effect_str": "EOC_CHANGELING_AUTUMN_SCARE_ANIMALS",
     "min_range": {
       "math": [
-        "min( ( 2 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 0.4) + (u_skill('deduction') * 0.6) ), 10)"
+        "min( ( 2 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 0.4) + (u_skill('gramarye') * 0.6) ), 10)"
       ]
     },
     "max_range": {
       "math": [
-        "min( ( 2 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 0.4) + (u_skill('deduction') * 0.6) ), 10)"
+        "min( ( 2 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 0.4) + (u_skill('gramarye') * 0.6) ), 10)"
       ]
     },
     "base_energy_cost": {
-      "math": [ "max( ( 150 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 3) - (u_skill('deduction') * 6)), 50)" ]
+      "math": [ "max( ( 150 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 3) - (u_skill('gramarye') * 6)), 50)" ]
     },
     "base_casting_time": 50
   },
@@ -86,7 +86,7 @@
     "spell_class": "CHANGELING_SEASONAL_MAGIC_AUTUMN",
     "valid_targets": [ "self" ],
     "teachable": false,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "shape": "blast",
     "difficulty": 2,
@@ -94,16 +94,16 @@
     "effect_str": "effect_changeling_autumn_detect_magic_user",
     "min_duration": {
       "math": [
-        "( ( 19085 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 9185) + (u_skill('deduction') * 19485) ) )"
+        "( ( 19085 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 9185) + (u_skill('gramarye') * 19485) ) )"
       ]
     },
     "max_duration": {
       "math": [
-        "( ( 51385 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 16712) + (u_skill('deduction') * 31085) ) )"
+        "( ( 51385 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 16712) + (u_skill('gramarye') * 31085) ) )"
       ]
     },
     "base_energy_cost": {
-      "math": [ "max( ( 250 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 3) - (u_skill('deduction') * 8)), 125)" ]
+      "math": [ "max( ( 250 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 3) - (u_skill('gramarye') * 8)), 125)" ]
     },
     "base_casting_time": 500
   },
@@ -118,7 +118,7 @@
     "spell_class": "CHANGELING_SEASONAL_MAGIC_AUTUMN",
     "valid_targets": [ "ally", "hostile", "ground" ],
     "teachable": false,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "shape": "blast",
     "difficulty": 3,
@@ -129,7 +129,7 @@
     "min_range": 15,
     "max_range": 15,
     "base_energy_cost": {
-      "math": [ "max( ( 200 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 3) - (u_skill('deduction') * 7)), 100)" ]
+      "math": [ "max( ( 200 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 3) - (u_skill('gramarye') * 7)), 100)" ]
     },
     "base_casting_time": 25
   },
@@ -144,7 +144,7 @@
     "spell_class": "CHANGELING_SEASONAL_MAGIC_AUTUMN",
     "valid_targets": [ "ally", "hostile", "ground" ],
     "teachable": false,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "shape": "blast",
     "difficulty": 3,
@@ -152,12 +152,12 @@
     "damage_type": "biological",
     "min_damage": {
       "math": [
-        "( ( 15 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 1.6) + (u_skill('deduction') * 3) ) ) * (global_what_is_the_season == 1 ? 0.6 : 1)"
+        "( ( 15 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 1.6) + (u_skill('gramarye') * 3) ) ) * (global_what_is_the_season == 1 ? 0.6 : 1)"
       ]
     },
     "max_damage": {
       "math": [
-        "( ( 40 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 3.2) + (u_skill('deduction') * 7.5) ) ) * (global_what_is_the_season == 1 ? 0.4 : 1)"
+        "( ( 40 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 3.2) + (u_skill('gramarye') * 7.5) ) ) * (global_what_is_the_season == 1 ? 0.4 : 1)"
       ]
     },
     "min_range": 15,
@@ -175,7 +175,7 @@
     "spell_class": "CHANGELING_SEASONAL_MAGIC_AUTUMN",
     "valid_targets": [ "self" ],
     "teachable": false,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "shape": "blast",
     "difficulty": 4,
@@ -183,22 +183,22 @@
     "effect_str": "EOC_CHANGELING_AUTUMN_CHANGE_WEATHER_DENSE_FOG",
     "min_duration": {
       "math": [
-        "( ( 45812 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 7952) + (u_skill('deduction') * 15371) ) ) * (global_what_is_the_season == 1 ? 0.6 : 1)"
+        "( ( 45812 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 7952) + (u_skill('gramarye') * 15371) ) ) * (global_what_is_the_season == 1 ? 0.6 : 1)"
       ]
     },
     "max_duration": {
       "math": [
-        "( ( 91527 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 21685) + (u_skill('deduction') * 39852) ) ) * (global_what_is_the_season == 1 ? 0.4 : 1)"
+        "( ( 91527 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 21685) + (u_skill('gramarye') * 39852) ) ) * (global_what_is_the_season == 1 ? 0.4 : 1)"
       ]
     },
     "base_energy_cost": {
       "math": [
-        "u_effect_intensity('effect_controlling_weather_fog') > -1 ? 50 : max( ( 400 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 6) - (u_skill('deduction') * 10)), 150)"
+        "u_effect_intensity('effect_controlling_weather_fog') > -1 ? 50 : max( ( 400 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 6) - (u_skill('gramarye') * 10)), 150)"
       ]
     },
     "base_casting_time": {
       "math": [
-        "u_effect_intensity('effect_controlling_weather_fog') > -1 ? 50 : max( ( 6000 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 56) - (u_skill('deduction') * 125)), 400)"
+        "u_effect_intensity('effect_controlling_weather_fog') > -1 ? 50 : max( ( 6000 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 56) - (u_skill('gramarye') * 125)), 400)"
       ]
     }
   },
@@ -213,20 +213,20 @@
     "spell_class": "CHANGELING_SEASONAL_MAGIC_AUTUMN",
     "valid_targets": [ "self" ],
     "teachable": false,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "shape": "blast",
     "difficulty": 5,
     "effect": "attack",
     "effect_str": "effect_changeling_autumn_scare_humans",
     "min_duration": {
-      "math": [ "( ( 235 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 52) + (u_skill('deduction') * 185) ) )" ]
+      "math": [ "( ( 235 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 52) + (u_skill('gramarye') * 185) ) )" ]
     },
     "max_duration": {
-      "math": [ "( ( 812 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 125) + (u_skill('deduction') * 322) ) )" ]
+      "math": [ "( ( 812 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 125) + (u_skill('gramarye') * 322) ) )" ]
     },
     "base_energy_cost": {
-      "math": [ "max( ( 300 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 4) - (u_skill('deduction') * 7)), 150)" ]
+      "math": [ "max( ( 300 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 4) - (u_skill('gramarye') * 7)), 150)" ]
     },
     "base_casting_time": 50
   },
@@ -241,7 +241,7 @@
     "spell_class": "CHANGELING_SEASONAL_MAGIC_AUTUMN",
     "valid_targets": [ "self" ],
     "teachable": false,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "shape": "blast",
     "difficulty": 6,
@@ -249,21 +249,19 @@
     "effect_str": "effect_changeling_autumn_protection_from_ranged",
     "min_duration": {
       "math": [
-        "( ( 19852 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 5852) + (u_skill('deduction') * 11512) ) )"
+        "( ( 19852 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 5852) + (u_skill('gramarye') * 11512) ) )"
       ]
     },
     "max_duration": {
       "math": [
-        "( ( 40851 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 16815) + (u_skill('deduction') * 32945) ) )"
+        "( ( 40851 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 16815) + (u_skill('gramarye') * 32945) ) )"
       ]
     },
     "base_energy_cost": {
-      "math": [ "max( ( 450 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 5) - (u_skill('deduction') * 8)), 250)" ]
+      "math": [ "max( ( 450 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 5) - (u_skill('gramarye') * 8)), 250)" ]
     },
     "base_casting_time": {
-      "math": [
-        "max( ( 500 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 8) - (u_skill('deduction') * 15)), 150)"
-      ]
+      "math": [ "max( ( 500 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 8) - (u_skill('gramarye') * 15)), 150)" ]
     }
   },
   {
@@ -276,7 +274,7 @@
     "spell_class": "CHANGELING_SEASONAL_MAGIC_AUTUMN",
     "valid_targets": [ "ground" ],
     "teachable": false,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "shape": "blast",
     "difficulty": 7,
@@ -285,23 +283,17 @@
     "components": "spell_components_changeling_dreamsparks_3",
     "min_range": 1,
     "min_aoe": {
-      "math": [
-        "min( ( 0 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 0.05) - (u_skill('deduction') * 0.1)), 3)"
-      ]
+      "math": [ "min( ( 0 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 0.05) - (u_skill('gramarye') * 0.1)), 3)" ]
     },
     "max_aoe": {
-      "math": [
-        "min( ( 0 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 0.05) - (u_skill('deduction') * 0.1)), 3)"
-      ]
+      "math": [ "min( ( 0 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 0.05) - (u_skill('gramarye') * 0.1)), 3)" ]
     },
     "base_energy_cost": {
-      "math": [
-        "max( ( 800 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 8) - (u_skill('deduction') * 15)), 300)"
-      ]
+      "math": [ "max( ( 800 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 8) - (u_skill('gramarye') * 15)), 300)" ]
     },
     "base_casting_time": {
       "math": [
-        "max( ( 30000 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 250) - (u_skill('deduction') * 500)), 6000)"
+        "max( ( 30000 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 250) - (u_skill('gramarye') * 500)), 6000)"
       ]
     }
   },
@@ -315,7 +307,7 @@
     "spell_class": "CHANGELING_SEASONAL_MAGIC_AUTUMN",
     "valid_targets": [ "hostile" ],
     "teachable": false,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "shape": "blast",
     "difficulty": 8,
@@ -324,9 +316,7 @@
     "components": "spell_components_changeling_dreamsparks",
     "min_range": 8,
     "base_energy_cost": {
-      "math": [
-        "max( ( 600 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 7) - (u_skill('deduction') * 12)), 250)"
-      ]
+      "math": [ "max( ( 600 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 7) - (u_skill('gramarye') * 12)), 250)" ]
     },
     "base_casting_time": 25
   },
@@ -340,7 +330,7 @@
     "spell_class": "CHANGELING_SEASONAL_MAGIC_AUTUMN",
     "valid_targets": [ "hostile", "ally", "ground" ],
     "teachable": false,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "shape": "blast",
     "difficulty": 8,
@@ -359,7 +349,7 @@
     "spell_class": "CHANGELING_SEASONAL_MAGIC_AUTUMN",
     "valid_targets": [ "hostile", "ally", "ground", "self" ],
     "teachable": false,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "shape": "blast",
     "difficulty": 8,
@@ -370,31 +360,29 @@
     "max_duration": 600,
     "min_range": {
       "math": [
-        "min( ( 4 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 0.4) + (u_skill('deduction') * 1) ), 25 ) * (global_what_is_the_season == 1 ? 0.5 : 1)"
+        "min( ( 4 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 0.4) + (u_skill('gramarye') * 1) ), 25 ) * (global_what_is_the_season == 1 ? 0.5 : 1)"
       ]
     },
     "max_range": {
       "math": [
-        "min( ( 4 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 0.4) + (u_skill('deduction') * 1) ), 25 ) * (global_what_is_the_season == 1 ? 0.5 : 1)"
+        "min( ( 4 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 0.4) + (u_skill('gramarye') * 1) ), 25 ) * (global_what_is_the_season == 1 ? 0.5 : 1)"
       ]
     },
     "min_aoe": {
       "math": [
-        "min( ( 2 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 0.4) + (u_skill('deduction') * 1) ), 20 ) * (global_what_is_the_season == 1 ? 0.5 : 1)"
+        "min( ( 2 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 0.4) + (u_skill('gramarye') * 1) ), 20 ) * (global_what_is_the_season == 1 ? 0.5 : 1)"
       ]
     },
     "max_aoe": {
       "math": [
-        "min( ( 2 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 0.4) + (u_skill('deduction') * 1) ), 20 ) * (global_what_is_the_season == 1 ? 0.5 : 1)"
+        "min( ( 2 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 0.4) + (u_skill('gramarye') * 1) ), 20 ) * (global_what_is_the_season == 1 ? 0.5 : 1)"
       ]
     },
     "base_energy_cost": {
-      "math": [ "max( ( 750 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 4) - (u_skill('deduction') * 8)), 500)" ]
+      "math": [ "max( ( 750 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 4) - (u_skill('gramarye') * 8)), 500)" ]
     },
     "base_casting_time": {
-      "math": [
-        "max( ( 250 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 5) - (u_skill('deduction') * 10)), 100)"
-      ]
+      "math": [ "max( ( 250 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 5) - (u_skill('gramarye') * 10)), 100)" ]
     },
     "field_id": "fd_autumn_lost_fog",
     "field_chance": 1,

--- a/data/mods/Xedra_Evolved/spells/changeling_seasonal_magic_autumn_eocs.json
+++ b/data/mods/Xedra_Evolved/spells/changeling_seasonal_magic_autumn_eocs.json
@@ -5,12 +5,12 @@
     "effect": [
       {
         "math": [
-          "u_spell_low_duration = ( ( ( 5.62 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 1.85) + (u_skill('deduction') * 2.53) ) ) * (global_what_is_the_season == 3 ? 3 : 1) )"
+          "u_spell_low_duration = ( ( ( 5.62 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 1.85) + (u_skill('gramarye') * 2.53) ) ) * (global_what_is_the_season == 3 ? 3 : 1) )"
         ]
       },
       {
         "math": [
-          "u_spell_high_duration = ( ( ( 12.35 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 3.85) + (u_skill('deduction') * 4.98) ) ) * (global_what_is_the_season == 3 ? 3 : 1) )"
+          "u_spell_high_duration = ( ( ( 12.35 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 3.85) + (u_skill('gramarye') * 4.98) ) ) * (global_what_is_the_season == 3 ? 3 : 1) )"
         ]
       },
       {
@@ -72,7 +72,7 @@
             "math": [
               "u_val('morale')",
               "-=",
-              "(25 + ( (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 2) + (u_skill('deduction') * 4) ) ) * global_what_is_the_season == 1 ? 0.5 : 1"
+              "(25 + ( (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 2) + (u_skill('gramarye') * 4) ) ) * global_what_is_the_season == 1 ? 0.5 : 1"
             ]
           },
           { "u_add_effect": "effect_changeling_autumn_scare_animals", "duration": "5 minutes" }
@@ -94,12 +94,12 @@
         "time_in_future": [
           {
             "math": [
-              "( ( 458.12 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 79.52) + (u_skill('deduction') * 153.71) ) ) * (global_what_is_the_season == 1 ? 0.6 : 1)"
+              "( ( 458.12 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 79.52) + (u_skill('gramarye') * 153.71) ) ) * (global_what_is_the_season == 1 ? 0.6 : 1)"
             ]
           },
           {
             "math": [
-              "( ( 915.27 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 216.85) + (u_skill('deduction') * 398.52) ) ) * (global_what_is_the_season == 1 ? 0.4 : 1)"
+              "( ( 915.27 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_AUTUMN') * 216.85) + (u_skill('gramarye') * 398.52) ) ) * (global_what_is_the_season == 1 ? 0.4 : 1)"
             ]
           }
         ]

--- a/data/mods/Xedra_Evolved/spells/changeling_seasonal_magic_spring.json
+++ b/data/mods/Xedra_Evolved/spells/changeling_seasonal_magic_spring.json
@@ -23,30 +23,30 @@
     "magic_type": "xe_fey_seasonal_magick_spring",
     "spell_class": "CHANGELING_SEASONAL_MAGIC_SPRING",
     "max_level": 1,
-    "skill": "deduction",
+    "skill": "gramarye",
     "difficulty": 1,
     "effect": "ter_transform",
     "effect_str": "ter_changeling_spring_command_grasses",
     "shape": "blast",
     "min_range": {
-      "math": [ "min( ( 3 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 0.8) + u_skill('deduction')), 30)" ]
+      "math": [ "min( ( 3 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 0.8) + u_skill('gramarye')), 30)" ]
     },
     "max_range": {
-      "math": [ "min( ( 3 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 0.8) + u_skill('deduction')), 30)" ]
+      "math": [ "min( ( 3 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 0.8) + u_skill('gramarye')), 30)" ]
     },
     "min_aoe": {
       "math": [
-        "min( ( 2 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 0.25) + (u_skill('deduction') * 0.5)), 15) * (global_what_is_the_season == 3 ? 0.5 : 1)"
+        "min( ( 2 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 0.25) + (u_skill('gramarye') * 0.5)), 15) * (global_what_is_the_season == 3 ? 0.5 : 1)"
       ]
     },
     "max_aoe": {
       "math": [
-        "min( ( 2 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 0.25) + (u_skill('deduction') * 0.5)), 15) * (global_what_is_the_season == 3 ? 0.5 : 1)"
+        "min( ( 2 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 0.25) + (u_skill('gramarye') * 0.5)), 15) * (global_what_is_the_season == 3 ? 0.5 : 1)"
       ]
     },
     "base_energy_cost": {
       "math": [
-        "max( ( 150 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 3) - (u_skill('deduction') * 4)), 50) * (global_what_is_the_season == 3 ? 4 : 1)"
+        "max( ( 150 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 3) - (u_skill('gramarye') * 4)), 50) * (global_what_is_the_season == 3 ? 4 : 1)"
       ]
     },
     "base_casting_time": 100
@@ -62,7 +62,7 @@
     "spell_class": "CHANGELING_SEASONAL_MAGIC_SPRING",
     "valid_targets": [ "self" ],
     "teachable": false,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "shape": "blast",
     "difficulty": 2,
@@ -70,16 +70,16 @@
     "effect_str": "effect_changeling_spring_reduce_scent",
     "min_duration": {
       "math": [
-        "( ( 27095 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 4521) + (u_skill('deduction') * 6241) ) )"
+        "( ( 27095 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 4521) + (u_skill('gramarye') * 6241) ) )"
       ]
     },
     "max_duration": {
       "math": [
-        "( ( 70912 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 8491) + (u_skill('deduction') * 18405) ) )"
+        "( ( 70912 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 8491) + (u_skill('gramarye') * 18405) ) )"
       ]
     },
     "base_energy_cost": {
-      "math": [ "max( ( 200 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 2) - (u_skill('deduction') * 6)), 75)" ]
+      "math": [ "max( ( 200 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 2) - (u_skill('gramarye') * 6)), 75)" ]
     },
     "base_casting_time": 250
   },
@@ -94,7 +94,7 @@
     "spell_class": "CHANGELING_SEASONAL_MAGIC_SPRING",
     "valid_targets": [ "self" ],
     "teachable": false,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "shape": "blast",
     "difficulty": 2,
@@ -102,11 +102,11 @@
     "effect_str": "EOC_CHANGELING_SPRING_MINOR_RESTORE_STAMINA_AND_PAIN",
     "min_range": 1,
     "base_energy_cost": {
-      "math": [ "max( ( 200 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 8) - (u_skill('deduction') * 10)), 75)" ]
+      "math": [ "max( ( 200 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 8) - (u_skill('gramarye') * 10)), 75)" ]
     },
     "base_casting_time": {
       "math": [
-        "max( ( 1500 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 25) - (u_skill('deduction') * 50)), 150)"
+        "max( ( 1500 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 25) - (u_skill('gramarye') * 50)), 150)"
       ]
     }
   },
@@ -120,7 +120,7 @@
     "spell_class": "CHANGELING_SEASONAL_MAGIC_SPRING",
     "valid_targets": [ "ground" ],
     "teachable": false,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "shape": "blast",
     "difficulty": 3,
@@ -129,12 +129,12 @@
     "min_range": 1,
     "base_energy_cost": {
       "math": [
-        "max( ( 1000 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 8) - (u_skill('deduction') * 10)), 500) * (global_what_is_the_season == 4 ? 10000 : 1)"
+        "max( ( 1000 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 8) - (u_skill('gramarye') * 10)), 500) * (global_what_is_the_season == 4 ? 10000 : 1)"
       ]
     },
     "base_casting_time": {
       "math": [
-        "max( ( 6000 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 150) - (u_skill('deduction') * 75)), 1500)"
+        "max( ( 6000 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 150) - (u_skill('gramarye') * 75)), 1500)"
       ]
     }
   },
@@ -149,7 +149,7 @@
     "spell_class": "CHANGELING_SEASONAL_MAGIC_SPRING",
     "valid_targets": [ "self", "ally" ],
     "teachable": false,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "shape": "blast",
     "difficulty": 4,
@@ -159,20 +159,20 @@
     "max_range": 1,
     "min_duration": {
       "math": [
-        "( ( 90854 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 18625) + (u_skill('deduction') * 38543) ) ) * (global_what_is_the_season == 3 ? 0.3 : 1)"
+        "( ( 90854 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 18625) + (u_skill('gramarye') * 38543) ) ) * (global_what_is_the_season == 3 ? 0.3 : 1)"
       ]
     },
     "max_duration": {
       "math": [
-        "( ( 244800 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 41835) + (u_skill('deduction') * 98515) ) )  * (global_what_is_the_season == 3 ? 0.2 : 1)"
+        "( ( 244800 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 41835) + (u_skill('gramarye') * 98515) ) )  * (global_what_is_the_season == 3 ? 0.2 : 1)"
       ]
     },
     "base_energy_cost": {
-      "math": [ "max( ( 500 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 4) - (u_skill('deduction') * 8)), 350)" ]
+      "math": [ "max( ( 500 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 4) - (u_skill('gramarye') * 8)), 350)" ]
     },
     "base_casting_time": {
       "math": [
-        "max( ( 6000 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 50) - (u_skill('deduction') * 120)), 2000)"
+        "max( ( 6000 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 50) - (u_skill('gramarye') * 120)), 2000)"
       ]
     }
   },
@@ -186,24 +186,20 @@
     "spell_class": "CHANGELING_SEASONAL_MAGIC_SPRING",
     "valid_targets": [ "self" ],
     "teachable": false,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "shape": "blast",
     "difficulty": 4,
     "effect": "effect_on_condition",
     "effect_str": "EOC_CHANGELING_SPRING_SUMMON_FLOWER_WARRIORS",
     "min_duration": {
-      "math": [ "( ( 3051 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 510) + (u_skill('deduction') * 952) ) )" ]
+      "math": [ "( ( 3051 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 510) + (u_skill('gramarye') * 952) ) )" ]
     },
     "max_duration": {
-      "math": [
-        "( ( 7512 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 1204) + (u_skill('deduction') * 2185) ) )"
-      ]
+      "math": [ "( ( 7512 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 1204) + (u_skill('gramarye') * 2185) ) )" ]
     },
     "base_energy_cost": {
-      "math": [
-        "max( ( 500 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 6) - (u_skill('deduction') * 10)), 200)"
-      ]
+      "math": [ "max( ( 500 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 6) - (u_skill('gramarye') * 10)), 200)" ]
     },
     "base_casting_time": 300
   },
@@ -217,7 +213,7 @@
     "spell_class": "CHANGELING_SEASONAL_MAGIC_SPRING",
     "valid_targets": [ "self", "ally" ],
     "teachable": false,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "shape": "blast",
     "difficulty": 5,
@@ -226,22 +222,20 @@
     "min_range": 1,
     "min_duration": {
       "math": [
-        "( ( 20864 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 7534) + (u_skill('deduction') * 9852) ) )"
+        "( ( 20864 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 7534) + (u_skill('gramarye') * 9852) ) )"
       ]
     },
     "max_duration": {
       "math": [
-        "( ( 85346 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 17854) + (u_skill('deduction') * 21852) ) )"
+        "( ( 85346 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 17854) + (u_skill('gramarye') * 21852) ) )"
       ]
     },
     "base_energy_cost": {
-      "math": [
-        "max( ( 500 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 6) - (u_skill('deduction') * 10)), 300)"
-      ]
+      "math": [ "max( ( 500 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 6) - (u_skill('gramarye') * 10)), 300)" ]
     },
     "base_casting_time": {
       "math": [
-        "max( ( 3000 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 75) - (u_skill('deduction') * 100)), 500)"
+        "max( ( 3000 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 75) - (u_skill('gramarye') * 100)), 500)"
       ]
     }
   },
@@ -256,7 +250,7 @@
     "spell_class": "CHANGELING_SEASONAL_MAGIC_SPRING",
     "valid_targets": [ "self" ],
     "teachable": false,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "shape": "blast",
     "difficulty": 5,
@@ -264,13 +258,11 @@
     "effect": "effect_on_condition",
     "effect_str": "EOC_CHANGELING_SPRING_REMOVE_FATIGUE_AND_SLEEP_DEPRIVATION_INITIATE",
     "base_energy_cost": {
-      "math": [
-        "max( ( 550 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 6) - (u_skill('deduction') * 12)), 250)"
-      ]
+      "math": [ "max( ( 550 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 6) - (u_skill('gramarye') * 12)), 250)" ]
     },
     "base_casting_time": {
       "math": [
-        "max( ( 6000 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 75) - (u_skill('deduction') * 125)), 500)"
+        "max( ( 6000 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 75) - (u_skill('gramarye') * 125)), 500)"
       ]
     }
   },
@@ -285,7 +277,7 @@
     "spell_class": "CHANGELING_SEASONAL_MAGIC_SPRING",
     "valid_targets": [ "self" ],
     "teachable": false,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "shape": "blast",
     "difficulty": 5,
@@ -294,22 +286,22 @@
     "effect_str": "EOC_CHANGELING_SPRING_SUMMON_RAIN_SHOWER",
     "min_duration": {
       "math": [
-        "( ( 55653 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 14677) + (u_skill('deduction') * 26749) ) )"
+        "( ( 55653 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 14677) + (u_skill('gramarye') * 26749) ) )"
       ]
     },
     "max_duration": {
       "math": [
-        "( ( 125650 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 20548) + (u_skill('deduction') * 68740) ) )"
+        "( ( 125650 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 20548) + (u_skill('gramarye') * 68740) ) )"
       ]
     },
     "base_energy_cost": {
       "math": [
-        "u_effect_intensity('effect_controlling_weather_rains') > -1 ? 0 : max( ( 500 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 4) - (u_skill('deduction') * 8)), 250)"
+        "u_effect_intensity('effect_controlling_weather_rains') > -1 ? 0 : max( ( 500 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 4) - (u_skill('gramarye') * 8)), 250)"
       ]
     },
     "base_casting_time": {
       "math": [
-        "u_effect_intensity('effect_controlling_weather_rains') > -1 ? 0 : max( ( 45000 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 75) - (u_skill('deduction') * 1000)), 6000)"
+        "u_effect_intensity('effect_controlling_weather_rains') > -1 ? 0 : max( ( 45000 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 75) - (u_skill('gramarye') * 1000)), 6000)"
       ]
     }
   },
@@ -325,7 +317,7 @@
     "valid_targets": [ "hostile", "ally" ],
     "caster_condition": { "and": [ "npc_is_outside", { "npc_is_on_terrain_with_flag": "DIGGABLE" } ] },
     "teachable": false,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "shape": "blast",
     "difficulty": 7,
@@ -333,19 +325,19 @@
     "effect": "noise",
     "extra_effects": [ { "id": "changeling_spring_summon_smashing_plants_actual_summon_spell" } ],
     "min_damage": {
-      "math": [ "( ( 1 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 0.05) + (u_skill('deduction') * 0.25) ) )" ]
+      "math": [ "( ( 1 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 0.05) + (u_skill('gramarye') * 0.25) ) )" ]
     },
     "max_damage": {
-      "math": [ "( ( 1 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 0.12) + (u_skill('deduction') * 0.5) ) )" ]
+      "math": [ "( ( 1 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 0.12) + (u_skill('gramarye') * 0.5) ) )" ]
     },
     "min_duration": {
       "math": [
-        "( ( 90854 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 18625) + (u_skill('deduction') * 38543) ) ) * (global_what_is_the_season == 3 ? 0.3 : 1)"
+        "( ( 90854 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 18625) + (u_skill('gramarye') * 38543) ) ) * (global_what_is_the_season == 3 ? 0.3 : 1)"
       ]
     },
     "max_duration": {
       "math": [
-        "( ( 244800 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 41835) + (u_skill('deduction') * 98515) ) )  * (global_what_is_the_season == 3 ? 0.2 : 1)"
+        "( ( 244800 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 41835) + (u_skill('gramarye') * 98515) ) )  * (global_what_is_the_season == 3 ? 0.2 : 1)"
       ]
     },
     "min_range": 20,
@@ -353,9 +345,7 @@
     "min_aoe": 3,
     "max_aoe": 3,
     "base_energy_cost": {
-      "math": [
-        "max( ( 750 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 6) - (u_skill('deduction') * 12)), 450)"
-      ]
+      "math": [ "max( ( 750 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 6) - (u_skill('gramarye') * 12)), 450)" ]
     },
     "base_casting_time": 150
   },
@@ -383,7 +373,7 @@
     "spell_class": "CHANGELING_SEASONAL_MAGIC_SPRING",
     "valid_targets": [ "self", "ally" ],
     "teachable": false,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "shape": "blast",
     "difficulty": 8,
@@ -393,22 +383,20 @@
     "min_range": 10,
     "min_duration": {
       "math": [
-        "( ( 84612 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 12952) + (u_skill('deduction') * 18542) ) )"
+        "( ( 84612 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 12952) + (u_skill('gramarye') * 18542) ) )"
       ]
     },
     "max_duration": {
       "math": [
-        "( ( 168524 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 34815) + (u_skill('deduction') * 49851) ) )"
+        "( ( 168524 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 34815) + (u_skill('gramarye') * 49851) ) )"
       ]
     },
     "base_energy_cost": {
-      "math": [
-        "max( ( 800 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 8) - (u_skill('deduction') * 15)), 450)"
-      ]
+      "math": [ "max( ( 800 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 8) - (u_skill('gramarye') * 15)), 450)" ]
     },
     "base_casting_time": {
       "math": [
-        "max( ( 2000 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 50) - (u_skill('deduction') * 75)), 250)"
+        "max( ( 2000 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 50) - (u_skill('gramarye') * 75)), 250)"
       ]
     }
   },
@@ -423,7 +411,7 @@
     "spell_class": "CHANGELING_SEASONAL_MAGIC_SPRING",
     "valid_targets": [ "ground", "hostile", "ally" ],
     "teachable": false,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "shape": "blast",
     "difficulty": 9,
@@ -433,33 +421,29 @@
     "min_range": 15,
     "min_damage": {
       "math": [
-        "( ( 42 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 1) + (u_skill('deduction') * 4) ) ) * (global_what_is_the_season == 3 ? 0.6 : 1)"
+        "( ( 42 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 1) + (u_skill('gramarye') * 4) ) ) * (global_what_is_the_season == 3 ? 0.6 : 1)"
       ]
     },
     "max_damage": {
       "math": [
-        "( ( 78 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 2.5) + (u_skill('deduction') * 12) ) ) * (global_what_is_the_season == 3 ? 0.4 : 1)"
+        "( ( 78 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 2.5) + (u_skill('gramarye') * 12) ) ) * (global_what_is_the_season == 3 ? 0.4 : 1)"
       ]
     },
     "min_duration": {
-      "math": [ "( ( 1385 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 254) + (u_skill('deduction') * 544) ) )" ]
+      "math": [ "( ( 1385 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 254) + (u_skill('gramarye') * 544) ) )" ]
     },
     "max_duration": {
-      "math": [ "( ( 3482 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 518) + (u_skill('deduction') * 815) ) )" ]
+      "math": [ "( ( 3482 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 518) + (u_skill('gramarye') * 815) ) )" ]
     },
     "min_aoe": {
-      "math": [
-        "min( ( 0 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 0.1) + (u_skill('deduction') * 0.25)), 4)"
-      ]
+      "math": [ "min( ( 0 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 0.1) + (u_skill('gramarye') * 0.25)), 4)" ]
     },
     "max_aoe": {
-      "math": [
-        "min( ( 0 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 0.1) + (u_skill('deduction') * 0.25)), 4)"
-      ]
+      "math": [ "min( ( 0 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 0.1) + (u_skill('gramarye') * 0.25)), 4)" ]
     },
     "base_energy_cost": {
       "math": [
-        "max( ( 1100 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 12) - (u_skill('deduction') * 25)), 650)"
+        "max( ( 1100 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 12) - (u_skill('gramarye') * 25)), 650)"
       ]
     },
     "base_casting_time": 75,
@@ -475,26 +459,22 @@
     "spell_class": "CHANGELING_SEASONAL_MAGIC_SPRING",
     "valid_targets": [ "ally" ],
     "teachable": false,
-    "skill": "deduction",
+    "skill": "gramarye",
     "shape": "blast",
     "effect": "attack",
     "effect_str": "effect_changeling_spring_charm_control_target",
     "min_range": 15,
     "min_duration": {
-      "math": [ "( ( 1385 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 254) + (u_skill('deduction') * 544) ) )" ]
+      "math": [ "( ( 1385 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 254) + (u_skill('gramarye') * 544) ) )" ]
     },
     "max_duration": {
-      "math": [ "( ( 3482 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 518) + (u_skill('deduction') * 815) ) )" ]
+      "math": [ "( ( 3482 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 518) + (u_skill('gramarye') * 815) ) )" ]
     },
     "min_aoe": {
-      "math": [
-        "min( ( 0 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 0.1) + (u_skill('deduction') * 0.25)), 4)"
-      ]
+      "math": [ "min( ( 0 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 0.1) + (u_skill('gramarye') * 0.25)), 4)" ]
     },
     "max_aoe": {
-      "math": [
-        "min( ( 0 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 0.1) + (u_skill('deduction') * 0.25)), 4)"
-      ]
+      "math": [ "min( ( 0 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 0.1) + (u_skill('gramarye') * 0.25)), 4)" ]
     },
     "targeted_monster_species": [ "FERAL", "HUMAN", "CHANGELING", "ARVORE", "HOMULLUS", "IERDE", "SALAMANDER", "SYLPH", "UNDINE" ]
   }

--- a/data/mods/Xedra_Evolved/spells/changeling_seasonal_magic_spring_eocs.json
+++ b/data/mods/Xedra_Evolved/spells/changeling_seasonal_magic_spring_eocs.json
@@ -9,7 +9,7 @@
         "math": [
           "u_val('stamina')",
           "+=",
-          "1000 + ( (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 30) - (u_skill('deduction') * 25))"
+          "1000 + ( (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 30) - (u_skill('gramarye') * 25))"
         ]
       },
       { "u_transform_radius": 0, "ter_furn_transform": "ter_changeling_spring_verdant_vitality" }
@@ -22,12 +22,12 @@
     "effect": [
       {
         "math": [
-          "u_spell_low_duration = ( ( 30.51 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 5.10) + (u_skill('deduction') * 9.52) ) )"
+          "u_spell_low_duration = ( ( 30.51 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 5.10) + (u_skill('gramarye') * 9.52) ) )"
         ]
       },
       {
         "math": [
-          "u_spell_high_duration = ( ( 75.12 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 12.04) + (u_skill('deduction') * 21.85) ) )"
+          "u_spell_high_duration = ( ( 75.12 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 12.04) + (u_skill('gramarye') * 21.85) ) )"
         ]
       },
       {
@@ -35,7 +35,7 @@
         "target_var": { "context_val": "changeling_spring_summon_flower_warriors_location" },
         "range": {
           "math": [
-            "min( ( ( 2 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 0.35) + (u_skill('deduction') * 0.65) ) ), 12)"
+            "min( ( ( 2 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 0.35) + (u_skill('gramarye') * 0.65) ) ), 12)"
           ]
         },
         "z_level": true,
@@ -66,7 +66,7 @@
               "u_spawn_monster": "mon_fetch_daffodil_warrior_player",
               "real_count": {
                 "math": [
-                  "min( ( ( 1 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 0.1) + (u_skill('deduction') * 0.3) ) ), 16)"
+                  "min( ( ( 1 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 0.1) + (u_skill('gramarye') * 0.3) ) ), 16)"
                 ]
               },
               "min_radius": 1,
@@ -89,12 +89,12 @@
     "effect": [
       {
         "math": [
-          "u_spell_low_duration = ( ( 846.12 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 129.52) + (u_skill('deduction') * 185.42) ) )"
+          "u_spell_low_duration = ( ( 846.12 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 129.52) + (u_skill('gramarye') * 185.42) ) )"
         ]
       },
       {
         "math": [
-          "u_spell_high_duration = ( ( 1685.24 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 348.15) + (u_skill('deduction') * 498.51) ) )"
+          "u_spell_high_duration = ( ( 1685.24 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 348.15) + (u_skill('gramarye') * 498.51) ) )"
         ]
       },
       {
@@ -117,15 +117,15 @@
     ],
     "false_effect": [
       { "math": [ "u_spring_magic_spell_count = n_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING')" ] },
-      { "math": [ "u_spring_magic_deduction_level = n_skill('deduction')" ] },
+      { "math": [ "u_spring_magic_deduction_level = n_skill('gramarye')" ] },
       {
         "math": [
-          "u_spell_low_duration = ( ( 846.12 + (n_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 129.52) + (n_skill('deduction') * 185.42) ) )"
+          "u_spell_low_duration = ( ( 846.12 + (n_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 129.52) + (n_skill('gramarye') * 185.42) ) )"
         ]
       },
       {
         "math": [
-          "u_spell_high_duration = ( ( 1685.24 + (n_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 348.15) + (n_skill('deduction') * 498.51) ) )"
+          "u_spell_high_duration = ( ( 1685.24 + (n_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 348.15) + (n_skill('gramarye') * 498.51) ) )"
         ]
       },
       { "run_eocs": "EOC_CHANGELING_SPRING_HEALING_INCREASE_WHILE_OUTSIDE_APPLY_EFFECT" }
@@ -206,12 +206,12 @@
           { "u_add_effect": "effect_controlling_weather_rains", "duration": "6 hours" },
           {
             "math": [
-              "u_spell_low_duration = ( ( 556.53 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 146.77) + (u_skill('deduction') * 267.49) ) ) * selkie_has_weather_mastery()"
+              "u_spell_low_duration = ( ( 556.53 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 146.77) + (u_skill('gramarye') * 267.49) ) ) * selkie_has_weather_mastery()"
             ]
           },
           {
             "math": [
-              "u_spell_high_duration = ( ( 1256.50 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 205.48) + (u_skill('deduction') * 687.40) ) ) * selkie_has_weather_mastery()"
+              "u_spell_high_duration = ( ( 1256.50 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SPRING') * 205.48) + (u_skill('gramarye') * 687.40) ) ) * selkie_has_weather_mastery()"
             ]
           },
           {

--- a/data/mods/Xedra_Evolved/spells/changeling_seasonal_magic_summer.json
+++ b/data/mods/Xedra_Evolved/spells/changeling_seasonal_magic_summer.json
@@ -23,7 +23,7 @@
     "spell_class": "CHANGELING_SEASONAL_MAGIC_SUMMER",
     "valid_targets": [ "self" ],
     "teachable": false,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "shape": "blast",
     "difficulty": 1,
@@ -31,17 +31,17 @@
     "effect_str": "EOC_CHANGELING_SUMMER_LIGHT_INITIATE",
     "min_duration": {
       "math": [
-        "( ( 38697 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 9791) + (u_skill('deduction') * 16250) ) ) * (global_what_is_the_season == 4 ? 0.6 : 1)"
+        "( ( 38697 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 9791) + (u_skill('gramarye') * 16250) ) ) * (global_what_is_the_season == 4 ? 0.6 : 1)"
       ]
     },
     "max_duration": {
       "math": [
-        "( ( 91527 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 26531) + (u_skill('deduction') * 48615) ) ) * (global_what_is_the_season == 4 ? 0.4 : 1)"
+        "( ( 91527 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 26531) + (u_skill('gramarye') * 48615) ) ) * (global_what_is_the_season == 4 ? 0.4 : 1)"
       ]
     },
     "base_energy_cost": {
       "math": [
-        "u_effect_intensity('effect_changeling_summer_light') > -1 ? 0 : max( ( 100 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 3) - (u_skill('deduction') * 3)), 25)"
+        "u_effect_intensity('effect_changeling_summer_light') > -1 ? 0 : max( ( 100 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 3) - (u_skill('gramarye') * 3)), 25)"
       ]
     },
     "base_casting_time": 50
@@ -64,7 +64,7 @@
     "effect": "effect_on_condition",
     "effect_str": "EOC_CHANGELING_SUMMER_LIGHT_FIRE_INITIATE",
     "base_energy_cost": {
-      "math": [ "max( ( 75 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 2) - (u_skill('deduction') * 2)), 25)" ]
+      "math": [ "max( ( 75 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 2) - (u_skill('gramarye') * 2)), 25)" ]
     },
     "base_casting_time": 50
   },
@@ -86,13 +86,13 @@
     "effect": "effect_on_condition",
     "effect_str": "EOC_CHANGELING_SUMMER_SUN_GLASSES_INITIATE",
     "min_duration": {
-      "math": [ "58052 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 10982) + (u_skill('deduction') * 22365)" ]
+      "math": [ "58052 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 10982) + (u_skill('gramarye') * 22365)" ]
     },
     "max_duration": {
-      "math": [ "118521 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 31825) + (u_skill('deduction') * 81682)" ]
+      "math": [ "118521 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 31825) + (u_skill('gramarye') * 81682)" ]
     },
     "base_energy_cost": {
-      "math": [ "max( ( 100 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 3) - (u_skill('deduction') * 3)), 25)" ]
+      "math": [ "max( ( 100 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 3) - (u_skill('gramarye') * 3)), 25)" ]
     },
     "base_casting_time": 100
   },
@@ -115,13 +115,13 @@
     "effect_str": "EOC_CHANGELING_SUMMER_PROTECT_FROM_HOT_WEATHER",
     "min_range": 10,
     "min_duration": {
-      "math": [ "76628 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 14496) + (u_skill('deduction') * 29521)" ]
+      "math": [ "76628 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 14496) + (u_skill('gramarye') * 29521)" ]
     },
     "max_duration": {
-      "math": [ "169485 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 45508) + (u_skill('deduction') * 116805)" ]
+      "math": [ "169485 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 45508) + (u_skill('gramarye') * 116805)" ]
     },
     "base_energy_cost": {
-      "math": [ "max( ( 250 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 2) - (u_skill('deduction') * 2)), 100)" ]
+      "math": [ "max( ( 250 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 2) - (u_skill('gramarye') * 2)), 100)" ]
     },
     "base_casting_time": 50
   },
@@ -147,16 +147,16 @@
     "damage_type": "bash",
     "min_range": {
       "math": [
-        "min( ( ( 2 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 0.25) + (u_skill('deduction') * 0.5) ) ), 12) * (global_what_is_the_season == 2 ? 1.35 : 1)"
+        "min( ( ( 2 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 0.25) + (u_skill('gramarye') * 0.5) ) ), 12) * (global_what_is_the_season == 2 ? 1.35 : 1)"
       ]
     },
     "max_range": {
       "math": [
-        "min( ( ( 2 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 0.25) + (u_skill('deduction') * 0.5) ) ), 12) * (global_what_is_the_season == 2 ? 1.35 : 1)"
+        "min( ( ( 2 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 0.25) + (u_skill('gramarye') * 0.5) ) ), 12) * (global_what_is_the_season == 2 ? 1.35 : 1)"
       ]
     },
     "base_energy_cost": {
-      "math": [ "max( ( 150 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 2) - (u_skill('deduction') * 4)), 50)" ]
+      "math": [ "max( ( 150 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 2) - (u_skill('gramarye') * 4)), 50)" ]
     },
     "base_casting_time": 50
   },
@@ -179,16 +179,16 @@
     "effect_str": "effect_changeling_fire_melee_damage",
     "min_duration": {
       "math": [
-        "( ( 2285 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 915) + (u_skill('deduction') * 3045) ) ) * (global_what_is_the_season == 4 ? 0.6 : 1)"
+        "( ( 2285 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 915) + (u_skill('gramarye') * 3045) ) ) * (global_what_is_the_season == 4 ? 0.6 : 1)"
       ]
     },
     "max_duration": {
       "math": [
-        "( ( 6185 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 2025) + (u_skill('deduction') * 7185) ) ) * (global_what_is_the_season == 4 ? 0.4 : 1)"
+        "( ( 6185 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 2025) + (u_skill('gramarye') * 7185) ) ) * (global_what_is_the_season == 4 ? 0.4 : 1)"
       ]
     },
     "base_energy_cost": {
-      "math": [ "max( ( 300 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 5) - (u_skill('deduction') * 4)), 120)" ]
+      "math": [ "max( ( 300 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 5) - (u_skill('gramarye') * 4)), 120)" ]
     },
     "base_casting_time": 150
   },
@@ -210,31 +210,27 @@
     "effect": "attack",
     "effect_str": "effect_changeling_summer_slow_and_sweat_debuff",
     "min_duration": {
-      "math": [
-        "( ( 5438 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 2381) + (u_skill('deduction') * 3815) ) )"
-      ]
+      "math": [ "( ( 5438 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 2381) + (u_skill('gramarye') * 3815) ) )" ]
     },
     "max_duration": {
       "math": [
-        "( ( 18513 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 5731) + (u_skill('deduction') * 9885) ) )"
+        "( ( 18513 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 5731) + (u_skill('gramarye') * 9885) ) )"
       ]
     },
     "min_range": {
       "math": [
-        "min( ( ( 2 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 0.5) + (u_skill('deduction') * 1) ) ), 25)"
+        "min( ( ( 2 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 0.5) + (u_skill('gramarye') * 1) ) ), 25)"
       ]
     },
     "max_range": 25,
     "min_aoe": {
       "math": [
-        "min( ( 1 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 0.2) + (u_skill('deduction') * 0.5) ), 20)"
+        "min( ( 1 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 0.2) + (u_skill('gramarye') * 0.5) ), 20)"
       ]
     },
     "max_aoe": 20,
     "base_energy_cost": {
-      "math": [
-        "max( ( 400 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 5) - (u_skill('deduction') * 11)), 150)"
-      ]
+      "math": [ "max( ( 400 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 5) - (u_skill('gramarye') * 11)), 150)" ]
     },
     "base_casting_time": 75
   },
@@ -256,7 +252,7 @@
     "effect": "effect_on_condition",
     "effect_str": "EOC_CHANGELING_SUMMER_RUN_FOR_LONG_PERIODS",
     "base_energy_cost": {
-      "math": [ "max( ( 450 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 5) - (u_skill('deduction') * 7)), 250)" ]
+      "math": [ "max( ( 450 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 5) - (u_skill('gramarye') * 7)), 250)" ]
     },
     "base_casting_time": 100
   },
@@ -299,10 +295,10 @@
     ],
     "damage_type": "electric",
     "min_damage": {
-      "math": [ "( ( 40 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 2) + (u_skill('deduction') * 4.5) ) )" ]
+      "math": [ "( ( 40 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 2) + (u_skill('gramarye') * 4.5) ) )" ]
     },
     "max_damage": {
-      "math": [ "( ( 85 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 4.5) + (u_skill('deduction') * 8) ) )" ]
+      "math": [ "( ( 85 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 4.5) + (u_skill('gramarye') * 8) ) )" ]
     },
     "min_range": 25,
     "max_range": 25,
@@ -312,7 +308,7 @@
     "max_duration": 300,
     "base_energy_cost": {
       "math": [
-        "max( ( 800 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 8) - (u_skill('deduction') * 15) ), 400)"
+        "max( ( 800 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 8) - (u_skill('gramarye') * 15) ), 400)"
       ]
     },
     "base_casting_time": 200,
@@ -411,19 +407,13 @@
     "effect": "attack",
     "effect_str": "effect_changeling_summer_bonus_stamina_near_enemies",
     "min_duration": {
-      "math": [
-        "( ( 3825 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 1152) + (u_skill('deduction') * 4852) ) )"
-      ]
+      "math": [ "( ( 3825 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 1152) + (u_skill('gramarye') * 4852) ) )" ]
     },
     "max_duration": {
-      "math": [
-        "( ( 8642 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 2852) + (u_skill('deduction') * 9852) ) )"
-      ]
+      "math": [ "( ( 8642 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 2852) + (u_skill('gramarye') * 9852) ) )" ]
     },
     "base_energy_cost": {
-      "math": [
-        "max( ( 550 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 5) - (u_skill('deduction') * 10)), 200)"
-      ]
+      "math": [ "max( ( 550 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 5) - (u_skill('gramarye') * 10)), 200)" ]
     },
     "base_casting_time": 75
   },
@@ -447,20 +437,20 @@
     "effect_str": "EOC_CHANGELING_SUMMER_CREATE_THUNDERSTORM_INITIATE",
     "min_duration": {
       "math": [
-        "( ( 42810 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 11290) + (u_skill('deduction') * 20576) ) )"
+        "( ( 42810 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 11290) + (u_skill('gramarye') * 20576) ) )"
       ]
     },
     "max_duration": {
       "math": [
-        "( ( 89750 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 24916) + (u_skill('deduction') * 49107) ) )"
+        "( ( 89750 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 24916) + (u_skill('gramarye') * 49107) ) )"
       ]
     },
     "base_energy_cost": {
-      "math": [ "max( ( 700 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 4) - (u_skill('deduction') * 8)), 400)" ]
+      "math": [ "max( ( 700 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 4) - (u_skill('gramarye') * 8)), 400)" ]
     },
     "base_casting_time": {
       "math": [
-        "max( ( 30000 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 50) - (u_skill('deduction') * 750)), 6000)"
+        "max( ( 30000 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 50) - (u_skill('gramarye') * 750)), 6000)"
       ]
     }
   },
@@ -486,7 +476,7 @@
     "max_range": 3,
     "base_energy_cost": {
       "math": [
-        "u_effect_intensity('effect_changeling_summer_ring_of_flames') > -1 ? 0 : max( ( 750 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 4) - (u_skill('deduction') * 10) ), 500)"
+        "u_effect_intensity('effect_changeling_summer_ring_of_flames') > -1 ? 0 : max( ( 750 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 4) - (u_skill('gramarye') * 10) ), 500)"
       ]
     },
     "base_casting_time": 50
@@ -552,15 +542,13 @@
     "effect": "effect_on_condition",
     "effect_str": "EOC_CHANGELING_SUMMER_POWERFUL_SUNLIGHT_INITIATE",
     "min_duration": {
-      "math": [ "( ( 595 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 152) + (u_skill('deduction') * 251) ) )" ]
+      "math": [ "( ( 595 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 152) + (u_skill('gramarye') * 251) ) )" ]
     },
     "max_duration": {
-      "math": [ "( ( 1520 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 382) + (u_skill('deduction') * 601) ) )" ]
+      "math": [ "( ( 1520 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 382) + (u_skill('gramarye') * 601) ) )" ]
     },
     "base_energy_cost": {
-      "math": [
-        "max( ( 900 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 5) - (u_skill('deduction') * 10)), 600)"
-      ]
+      "math": [ "max( ( 900 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 5) - (u_skill('gramarye') * 10)), 600)" ]
     },
     "base_casting_time": 50
   },

--- a/data/mods/Xedra_Evolved/spells/changeling_seasonal_magic_summer_eocs.json
+++ b/data/mods/Xedra_Evolved/spells/changeling_seasonal_magic_summer_eocs.json
@@ -6,12 +6,12 @@
     "effect": [
       {
         "math": [
-          "u_spell_low_duration = ( ( ( 256.97 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 67.91) + (u_skill('deduction') * 162.50) ) ) * (global_what_is_the_season == 4 ? 0.6 : 1) )"
+          "u_spell_low_duration = ( ( ( 256.97 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 67.91) + (u_skill('gramarye') * 162.50) ) ) * (global_what_is_the_season == 4 ? 0.6 : 1) )"
         ]
       },
       {
         "math": [
-          "u_spell_high_duration = ( ( ( 615.27 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 165.31) + (u_skill('deduction') * 486.15) ) ) * (global_what_is_the_season == 4 ? 0.4 : 1) ) "
+          "u_spell_high_duration = ( ( ( 615.27 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 165.31) + (u_skill('gramarye') * 486.15) ) ) * (global_what_is_the_season == 4 ? 0.4 : 1) ) "
         ]
       },
       {
@@ -49,12 +49,12 @@
     "effect": [
       {
         "math": [
-          "u_spell_low_duration = ( 580.52 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 109.82) + (u_skill('deduction') * 223.65) )"
+          "u_spell_low_duration = ( 580.52 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 109.82) + (u_skill('gramarye') * 223.65) )"
         ]
       },
       {
         "math": [
-          "u_spell_high_duration = ( 1185.21 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 318.25) + (u_skill('deduction') * 816.82) ) "
+          "u_spell_high_duration = ( 1185.21 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 318.25) + (u_skill('gramarye') * 816.82) ) "
         ]
       },
       {
@@ -71,12 +71,12 @@
     "effect": [
       {
         "math": [
-          "u_spell_low_duration = (766.28 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 144.96) + (u_skill('deduction') * 295.21) )"
+          "u_spell_low_duration = (766.28 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 144.96) + (u_skill('gramarye') * 295.21) )"
         ]
       },
       {
         "math": [
-          "u_spell_high_duration = ( 1694.85 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 455.08) + (u_skill('deduction') * 1168.05) )"
+          "u_spell_high_duration = ( 1694.85 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 455.08) + (u_skill('gramarye') * 1168.05) )"
         ]
       },
       {
@@ -137,12 +137,12 @@
           { "u_add_effect": "effect_controlling_weather_lightningstorm", "duration": "6 hours" },
           {
             "math": [
-              "u_spell_low_duration = ( ( 428.10 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 112.90) + (u_skill('deduction') * 205.76) ) ) * selkie_has_weather_mastery()"
+              "u_spell_low_duration = ( ( 428.10 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 112.90) + (u_skill('gramarye') * 205.76) ) ) * selkie_has_weather_mastery()"
             ]
           },
           {
             "math": [
-              "u_spell_high_duration = ( ( 897.50 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 249.16) + (u_skill('deduction') * 491.07) ) ) * selkie_has_weather_mastery()"
+              "u_spell_high_duration = ( ( 897.50 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 249.16) + (u_skill('gramarye') * 491.07) ) ) * selkie_has_weather_mastery()"
             ]
           },
           {
@@ -295,12 +295,12 @@
     "effect": [
       {
         "math": [
-          "u_spell_low_duration = ( 5.95 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 1.52) + (u_skill('deduction') * 2.51) )"
+          "u_spell_low_duration = ( 5.95 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 1.52) + (u_skill('gramarye') * 2.51) )"
         ]
       },
       {
         "math": [
-          "u_spell_high_duration = ( 15.20 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 3.82) + (u_skill('deduction') * 6.01) )"
+          "u_spell_high_duration = ( 15.20 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_SUMMER') * 3.82) + (u_skill('gramarye') * 6.01) )"
         ]
       },
       {

--- a/data/mods/Xedra_Evolved/spells/changeling_seasonal_magic_winter.json
+++ b/data/mods/Xedra_Evolved/spells/changeling_seasonal_magic_winter.json
@@ -22,7 +22,7 @@
     "spell_class": "CHANGELING_SEASONAL_MAGIC_WINTER",
     "valid_targets": [ "self", "ally" ],
     "teachable": false,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "shape": "blast",
     "difficulty": 1,
@@ -30,21 +30,21 @@
     "effect_str": "effect_changeling_winter_walk_in_silence",
     "min_aoe": {
       "math": [
-        "min( ( 1 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 0.1) + (u_skill('deduction') * 0.2) ), 10)"
+        "min( ( 1 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 0.1) + (u_skill('gramarye') * 0.2) ), 10)"
       ]
     },
     "min_duration": {
       "math": [
-        "( ( 5831 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 2882) + (u_skill('deduction') * 15385) ) ) * (global_what_is_the_season == 2 ? 0.6 : 1)"
+        "( ( 5831 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 2882) + (u_skill('gramarye') * 15385) ) ) * (global_what_is_the_season == 2 ? 0.6 : 1)"
       ]
     },
     "max_duration": {
       "math": [
-        "( ( 19850 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 9850) + (u_skill('deduction') * 35482) ) ) * (global_what_is_the_season == 2 ? 0.4 : 1)"
+        "( ( 19850 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 9850) + (u_skill('gramarye') * 35482) ) ) * (global_what_is_the_season == 2 ? 0.4 : 1)"
       ]
     },
     "base_energy_cost": {
-      "math": [ "max( ( 150 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 4) - (u_skill('deduction') * 6)), 50)" ]
+      "math": [ "max( ( 150 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 4) - (u_skill('gramarye') * 6)), 50)" ]
     },
     "base_casting_time": 75
   },
@@ -58,7 +58,7 @@
     "spell_class": "CHANGELING_SEASONAL_MAGIC_WINTER",
     "valid_targets": [ "ally", "hostile" ],
     "teachable": false,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "shape": "blast",
     "difficulty": 2,
@@ -66,26 +66,26 @@
     "effect_str": "EOC_CHANGELING_WINTER_FREEZE_TARGET_IN_PLACE",
     "min_range": {
       "math": [
-        "min( ( 2 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 0.5) + (u_skill('deduction') * 0.75) ), 15)"
+        "min( ( 2 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 0.5) + (u_skill('gramarye') * 0.75) ), 15)"
       ]
     },
     "max_range": {
       "math": [
-        "min( ( 2 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 0.5) + (u_skill('deduction') * 0.75) ), 15)"
+        "min( ( 2 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 0.5) + (u_skill('gramarye') * 0.75) ), 15)"
       ]
     },
     "min_duration": {
       "math": [
-        "( ( 251 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 245) + (u_skill('deduction') * 350) ) )  * (global_what_is_the_season == 2 ? 0.6 : 1)"
+        "( ( 251 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 245) + (u_skill('gramarye') * 350) ) )  * (global_what_is_the_season == 2 ? 0.6 : 1)"
       ]
     },
     "max_duration": {
       "math": [
-        "( ( 652 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 555) + (u_skill('deduction') * 791) ) )  * (global_what_is_the_season == 2 ? 0.4 : 1)"
+        "( ( 652 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 555) + (u_skill('gramarye') * 791) ) )  * (global_what_is_the_season == 2 ? 0.4 : 1)"
       ]
     },
     "base_energy_cost": {
-      "math": [ "max( ( 200 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 4) - (u_skill('deduction') * 6)), 75)" ]
+      "math": [ "max( ( 200 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 4) - (u_skill('gramarye') * 6)), 75)" ]
     },
     "base_casting_time": 100
   },
@@ -99,7 +99,7 @@
     "spell_class": "CHANGELING_SEASONAL_MAGIC_WINTER",
     "valid_targets": [ "self" ],
     "teachable": false,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "shape": "blast",
     "difficulty": 2,
@@ -107,16 +107,16 @@
     "effect_str": "effect_changeling_winter_walk_on_water",
     "min_duration": {
       "math": [
-        "( ( 2413 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 912) + (u_skill('deduction') * 3758) ) ) * (global_what_is_the_season == 2 ? 0.6 : 1)"
+        "( ( 2413 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 912) + (u_skill('gramarye') * 3758) ) ) * (global_what_is_the_season == 2 ? 0.6 : 1)"
       ]
     },
     "max_duration": {
       "math": [
-        "( ( 5682 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 2782) + (u_skill('deduction') * 8372) ) ) * (global_what_is_the_season == 2 ? 0.4 : 1)"
+        "( ( 5682 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 2782) + (u_skill('gramarye') * 8372) ) ) * (global_what_is_the_season == 2 ? 0.4 : 1)"
       ]
     },
     "base_energy_cost": {
-      "math": [ "max( ( 200 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 4) - (u_skill('deduction') * 6)), 75)" ]
+      "math": [ "max( ( 200 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 4) - (u_skill('gramarye') * 6)), 75)" ]
     },
     "base_casting_time": 75
   },
@@ -131,14 +131,14 @@
     "spell_class": "CHANGELING_SEASONAL_MAGIC_WINTER",
     "valid_targets": [ "self" ],
     "teachable": false,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "shape": "blast",
     "difficulty": 3,
     "effect": "effect_on_condition",
     "effect_str": "EOC_CHANGELING_WINTER_FEIGN_DEATH",
     "base_energy_cost": {
-      "math": [ "max( ( 100 - u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') - (u_skill('deduction') * 2)), 40)" ]
+      "math": [ "max( ( 100 - u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') - (u_skill('gramarye') * 2)), 40)" ]
     },
     "base_casting_time": 25
   },
@@ -153,7 +153,7 @@
     "spell_class": "CHANGELING_SEASONAL_MAGIC_WINTER",
     "valid_targets": [ "hostile" ],
     "teachable": false,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "shape": "blast",
     "difficulty": 3,
@@ -163,16 +163,16 @@
     "max_range": 20,
     "min_duration": {
       "math": [
-        "( ( 788 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 253) + (u_skill('deduction') * 672) ) ) * (global_what_is_the_season == 4 ? 2.4 : 1)"
+        "( ( 788 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 253) + (u_skill('gramarye') * 672) ) ) * (global_what_is_the_season == 4 ? 2.4 : 1)"
       ]
     },
     "max_duration": {
       "math": [
-        "( ( 1531 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 585) + (u_skill('deduction') * 1585) ) ) * (global_what_is_the_season == 4 ? 5.9 : 1)"
+        "( ( 1531 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 585) + (u_skill('gramarye') * 1585) ) ) * (global_what_is_the_season == 4 ? 5.9 : 1)"
       ]
     },
     "base_energy_cost": {
-      "math": [ "max( ( 150 - u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') - (u_skill('deduction') * 2)), 75)" ]
+      "math": [ "max( ( 150 - u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') - (u_skill('gramarye') * 2)), 75)" ]
     },
     "base_casting_time": 25
   },
@@ -188,7 +188,7 @@
     "valid_targets": [ "hostile", "ally" ],
     "target_condition": { "and": [ "npc_is_outside", "is_day" ] },
     "teachable": false,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "shape": "blast",
     "difficulty": 4,
@@ -198,16 +198,16 @@
     "max_range": 20,
     "min_duration": {
       "math": [
-        "( ( 1733 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 557) + (u_skill('deduction') * 1680) ) ) * (global_what_is_the_season == 2 ? 0.6 : 1)"
+        "( ( 1733 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 557) + (u_skill('gramarye') * 1680) ) ) * (global_what_is_the_season == 2 ? 0.6 : 1)"
       ]
     },
     "max_duration": {
       "math": [
-        "( ( 3368 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 1345) + (u_skill('deduction') * 3963) ) ) * (global_what_is_the_season == 2 ? 0.4 : 1)"
+        "( ( 3368 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 1345) + (u_skill('gramarye') * 3963) ) ) * (global_what_is_the_season == 2 ? 0.4 : 1)"
       ]
     },
     "base_energy_cost": {
-      "math": [ "max( ( 250 - u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') - (u_skill('deduction') * 2)), 120)" ]
+      "math": [ "max( ( 250 - u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') - (u_skill('gramarye') * 2)), 120)" ]
     },
     "base_casting_time": 50
   },
@@ -222,7 +222,7 @@
     "spell_class": "CHANGELING_SEASONAL_MAGIC_WINTER",
     "valid_targets": [ "ally", "hostile", "ground" ],
     "teachable": false,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "shape": "cone",
     "difficulty": 4,
@@ -230,35 +230,35 @@
     "effect_str": "effect_changeling_winter_frozen_breath",
     "damage_type": "cold",
     "min_damage": {
-      "math": [ "( ( 4 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 0.25) + (u_skill('deduction') * 1.25) ) )" ]
+      "math": [ "( ( 4 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 0.25) + (u_skill('gramarye') * 1.25) ) )" ]
     },
     "max_damage": {
-      "math": [ "( ( 10 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 0.8) + (u_skill('deduction') * 3) ) )" ]
+      "math": [ "( ( 10 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 0.8) + (u_skill('gramarye') * 3) ) )" ]
     },
     "min_duration": {
       "math": [
-        "( ( 282 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 34) + (u_skill('deduction') * 56) ) ) * (global_what_is_the_season == 2 ? 0.6 : 1)"
+        "( ( 282 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 34) + (u_skill('gramarye') * 56) ) ) * (global_what_is_the_season == 2 ? 0.6 : 1)"
       ]
     },
     "max_duration": {
       "math": [
-        "( ( 642 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 82) + (u_skill('deduction') * 132) ) ) * (global_what_is_the_season == 2 ? 0.4 : 1)"
+        "( ( 642 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 82) + (u_skill('gramarye') * 132) ) ) * (global_what_is_the_season == 2 ? 0.4 : 1)"
       ]
     },
     "min_range": {
       "math": [
-        "min( ( ( 2 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 0.1) + (u_skill('deduction') * 0.2) ) ), 7)"
+        "min( ( ( 2 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 0.1) + (u_skill('gramarye') * 0.2) ) ), 7)"
       ]
     },
     "max_range": 20,
     "min_aoe": {
       "math": [
-        "min( ( ( 30 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 1) + (u_skill('deduction') * 2) ) ) , 80)"
+        "min( ( ( 30 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 1) + (u_skill('gramarye') * 2) ) ) , 80)"
       ]
     },
     "max_aoe": 75,
     "base_energy_cost": {
-      "math": [ "max( ( 200 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 3) - (u_skill('deduction') * 5)), 100)" ]
+      "math": [ "max( ( 200 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 3) - (u_skill('gramarye') * 5)), 100)" ]
     },
     "base_casting_time": 100
   },
@@ -273,7 +273,7 @@
     "spell_class": "CHANGELING_SEASONAL_MAGIC_WINTER",
     "valid_targets": [ "self" ],
     "teachable": false,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "shape": "blast",
     "difficulty": 5,
@@ -281,18 +281,16 @@
     "effect_str": "EOC_CHANGELING_WINTER_NEUTRALIZE_MORALE",
     "min_duration": {
       "math": [
-        "( ( 2912 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 1582) + (u_skill('deduction') * 3184) ) ) * (global_what_is_the_season == 2 ? 0 : 1)"
+        "( ( 2912 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 1582) + (u_skill('gramarye') * 3184) ) ) * (global_what_is_the_season == 2 ? 0 : 1)"
       ]
     },
     "max_duration": {
       "math": [
-        "( ( 6952 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 4185) + (u_skill('deduction') * 9052) ) ) * (global_what_is_the_season == 2 ? 0 : 1)"
+        "( ( 6952 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 4185) + (u_skill('gramarye') * 9052) ) ) * (global_what_is_the_season == 2 ? 0 : 1)"
       ]
     },
     "base_energy_cost": {
-      "math": [
-        "max( ( 500 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 2 ) - (u_skill('deduction') * 4)), 350)"
-      ]
+      "math": [ "max( ( 500 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 2 ) - (u_skill('gramarye') * 4)), 350)" ]
     },
     "base_casting_time": 500
   },
@@ -308,7 +306,7 @@
     "spell_class": "CHANGELING_SEASONAL_MAGIC_WINTER",
     "valid_targets": [ "self" ],
     "teachable": false,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "shape": "blast",
     "difficulty": 6,
@@ -316,18 +314,16 @@
     "effect_str": "effect_changeling_winter_see_craft_darkness",
     "min_duration": {
       "math": [
-        "( ( 48462 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 6451) + (u_skill('deduction') * 11715) ) )"
+        "( ( 48462 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 6451) + (u_skill('gramarye') * 11715) ) )"
       ]
     },
     "max_duration": {
       "math": [
-        "( ( 108164 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 15985) + (u_skill('deduction') * 27054) ) )"
+        "( ( 108164 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 15985) + (u_skill('gramarye') * 27054) ) )"
       ]
     },
     "base_energy_cost": {
-      "math": [
-        "max( ( 450 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 2 ) - (u_skill('deduction') * 4)), 300)"
-      ]
+      "math": [ "max( ( 450 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 2 ) - (u_skill('gramarye') * 4)), 300)" ]
     },
     "base_casting_time": 250
   },
@@ -342,7 +338,7 @@
     "spell_class": "CHANGELING_SEASONAL_MAGIC_WINTER",
     "valid_targets": [ "self" ],
     "teachable": false,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "shape": "blast",
     "difficulty": 7,
@@ -350,12 +346,12 @@
     "effect_str": "EOC_CHANGELING_WINTER_HAIL_ATTACK",
     "min_aoe": {
       "math": [
-        "min( ( ( 2 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 0.2) + (u_skill('deduction') * 0.4) ) ), 10)"
+        "min( ( ( 2 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 0.2) + (u_skill('gramarye') * 0.4) ) ), 10)"
       ]
     },
     "max_aoe": 10,
     "base_energy_cost": {
-      "math": [ "max( ( 650 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 3) - (u_skill('deduction') * 5)), 350)" ]
+      "math": [ "max( ( 650 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 3) - (u_skill('gramarye') * 5)), 350)" ]
     },
     "base_casting_time": 250
   },
@@ -370,7 +366,7 @@
     "spell_class": "CHANGELING_SEASONAL_MAGIC_WINTER",
     "valid_targets": [ "ally", "hostile", "ground" ],
     "teachable": false,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "shape": "blast",
     "difficulty": 7,
@@ -378,20 +374,20 @@
     "damage_type": "bash",
     "affected_body_parts": [ "head", "torso", "mouth", "eyes", "arm_l", "arm_r", "hand_r", "hand_l" ],
     "min_damage": {
-      "math": [ "( ( 10 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 1.5) + (u_skill('deduction') * 2) ) )" ]
+      "math": [ "( ( 10 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 1.5) + (u_skill('gramarye') * 2) ) )" ]
     },
     "max_damage": {
-      "math": [ "( ( 25 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 4) + (u_skill('deduction') * 6) ) )" ]
+      "math": [ "( ( 25 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 4) + (u_skill('gramarye') * 6) ) )" ]
     },
     "min_range": {
       "math": [
-        "min( ( ( 2 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 0.35) + (u_skill('deduction') * 0.65) ) ), 15)"
+        "min( ( ( 2 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 0.35) + (u_skill('gramarye') * 0.65) ) ), 15)"
       ]
     },
     "max_range": 15,
     "min_aoe": {
       "math": [
-        "min( ( ( 2 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 0.2) + (u_skill('deduction') * 0.4) ) ) , 10)"
+        "min( ( ( 2 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 0.2) + (u_skill('gramarye') * 0.4) ) ) , 10)"
       ]
     },
     "max_aoe": 10
@@ -407,27 +403,27 @@
     "spell_class": "CHANGELING_SEASONAL_MAGIC_WINTER",
     "valid_targets": [ "ally", "hostile", "ground" ],
     "teachable": false,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "shape": "blast",
     "difficulty": 7,
     "effect": "attack",
     "damage_type": "cold",
     "min_damage": {
-      "math": [ "( ( 8 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 1) + (u_skill('deduction') * 1.8) ) )" ]
+      "math": [ "( ( 8 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 1) + (u_skill('gramarye') * 1.8) ) )" ]
     },
     "max_damage": {
-      "math": [ "( ( 20 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 3) + (u_skill('deduction') * 4) ) )" ]
+      "math": [ "( ( 20 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 3) + (u_skill('gramarye') * 4) ) )" ]
     },
     "min_range": {
       "math": [
-        "min( ( ( 2 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 0.35) + (u_skill('deduction') * 0.65) ) ), 15)"
+        "min( ( ( 2 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 0.35) + (u_skill('gramarye') * 0.65) ) ), 15)"
       ]
     },
     "max_range": 15,
     "min_aoe": {
       "math": [
-        "min( ( ( 2 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 0.2) + (u_skill('deduction') * 0.4) ) ) , 10)"
+        "min( ( ( 2 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 0.2) + (u_skill('gramarye') * 0.4) ) ) , 10)"
       ]
     },
     "max_aoe": 10
@@ -443,20 +439,20 @@
     "spell_class": "CHANGELING_SEASONAL_MAGIC_WINTER",
     "valid_targets": [ "ally", "hostile", "ground" ],
     "teachable": false,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "shape": "blast",
     "difficulty": 7,
     "effect": "attack",
     "min_range": {
       "math": [
-        "min( ( ( 2 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 0.35) + (u_skill('deduction') * 0.65) ) ), 15)"
+        "min( ( ( 2 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 0.35) + (u_skill('gramarye') * 0.65) ) ), 15)"
       ]
     },
     "max_range": 20,
     "min_aoe": {
       "math": [
-        "min( ( ( 2 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 0.2) + (u_skill('deduction') * 0.4) ) ), 10)"
+        "min( ( ( 2 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 0.2) + (u_skill('gramarye') * 0.4) ) ), 10)"
       ]
     },
     "max_aoe": 10,
@@ -477,7 +473,7 @@
     "spell_class": "CHANGELING_SEASONAL_MAGIC_WINTER",
     "valid_targets": [ "self" ],
     "teachable": false,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "shape": "blast",
     "difficulty": 9,
@@ -486,22 +482,22 @@
     "components": "spell_components_changeling_dreamsparks_3",
     "min_duration": {
       "math": [
-        "( ( 5978 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 2684) + (u_skill('deduction') * 8225) ) ) * (global_what_is_the_season == 4 ? 1.4 : 1)"
+        "( ( 5978 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 2684) + (u_skill('gramarye') * 8225) ) ) * (global_what_is_the_season == 4 ? 1.4 : 1)"
       ]
     },
     "max_duration": {
       "math": [
-        "( ( 28028 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 13630) + (u_skill('deduction') * 30212) ) ) * (global_what_is_the_season == 4 ? 1.4 : 1)"
+        "( ( 28028 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 13630) + (u_skill('gramarye') * 30212) ) ) * (global_what_is_the_season == 4 ? 1.4 : 1)"
       ]
     },
     "base_energy_cost": {
       "math": [
-        "max( ( 600 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 5 ) - (u_skill('deduction') * 10)), 400)"
+        "max( ( 600 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 5 ) - (u_skill('gramarye') * 10)), 400)"
       ]
     },
     "base_casting_time": {
       "math": [
-        "max( ( 2000 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 10 ) - (u_skill('deduction') * 50)), 500)"
+        "max( ( 2000 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 10 ) - (u_skill('gramarye') * 50)), 500)"
       ]
     }
   },
@@ -516,7 +512,7 @@
     "spell_class": "CHANGELING_SEASONAL_MAGIC_WINTER",
     "valid_targets": [ "self" ],
     "teachable": false,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "shape": "blast",
     "difficulty": 10,
@@ -525,22 +521,22 @@
     "components": "spell_components_changeling_dreamsparks_5",
     "min_duration": {
       "math": [
-        "( ( 3985 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 1678) + (u_skill('deduction') * 4985) ) ) * (global_what_is_the_season == 2 ? 0.3 : 1)"
+        "( ( 3985 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 1678) + (u_skill('gramarye') * 4985) ) ) * (global_what_is_the_season == 2 ? 0.3 : 1)"
       ]
     },
     "max_duration": {
       "math": [
-        "( ( 13347 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 6815) + (u_skill('deduction') * 12085) ) ) * (global_what_is_the_season == 2 ? 0.2 : 1)"
+        "( ( 13347 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 6815) + (u_skill('gramarye') * 12085) ) ) * (global_what_is_the_season == 2 ? 0.2 : 1)"
       ]
     },
     "base_energy_cost": {
       "math": [
-        "max( ( 1300 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 8 ) - (u_skill('deduction') * 20)), 700)"
+        "max( ( 1300 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 8 ) - (u_skill('gramarye') * 20)), 700)"
       ]
     },
     "base_casting_time": {
       "math": [
-        "max( ( 2000 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 10 ) - (u_skill('deduction') * 50)), 500)"
+        "max( ( 2000 - (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 10 ) - (u_skill('gramarye') * 50)), 500)"
       ]
     }
   }

--- a/data/mods/Xedra_Evolved/spells/changeling_seasonal_magic_winter_eocs.json
+++ b/data/mods/Xedra_Evolved/spells/changeling_seasonal_magic_winter_eocs.json
@@ -5,12 +5,12 @@
     "effect": [
       {
         "math": [
-          "u_spell_low_duration = ( ( 2.51 + (n_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 2.45) + (n_skill('deduction') * 3.50) ) )"
+          "u_spell_low_duration = ( ( 2.51 + (n_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 2.45) + (n_skill('gramarye') * 3.50) ) )"
         ]
       },
       {
         "math": [
-          "u_spell_high_duration = ( ( 6.52 + (n_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 5.55) + (n_skill('deduction') * 7.91) ) )"
+          "u_spell_high_duration = ( ( 6.52 + (n_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 5.55) + (n_skill('gramarye') * 7.91) ) )"
         ]
       },
       {
@@ -210,12 +210,12 @@
         "then": [
           {
             "math": [
-              "u_spell_low_duration = ( ( 29.12 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 15.82) + (u_skill('deduction') * 31.84) ) )"
+              "u_spell_low_duration = ( ( 29.12 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 15.82) + (u_skill('gramarye') * 31.84) ) )"
             ]
           },
           {
             "math": [
-              "u_spell_high_duration = ( ( 69.52 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 41.85) + (u_skill('deduction') * 90.52) ) )"
+              "u_spell_high_duration = ( ( 69.52 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 41.85) + (u_skill('gramarye') * 90.52) ) )"
             ]
           },
           {
@@ -245,7 +245,7 @@
         "target_var": { "context_val": "changeling_winter_hail_attack_location" },
         "range": {
           "math": [
-            "min( ( ( 2 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 0.35) + (u_skill('deduction') * 0.65) ) ), 7)"
+            "min( ( ( 2 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 0.35) + (u_skill('gramarye') * 0.65) ) ), 7)"
           ]
         },
         "z_level": true,
@@ -289,12 +289,12 @@
         "length": [
           {
             "math": [
-              "( ( 39.85 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 16.78) + (u_skill('deduction') * 49.85) ) ) * (global_what_is_the_season == 2 ? 0.3 : 1)"
+              "( ( 39.85 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 16.78) + (u_skill('gramarye') * 49.85) ) ) * (global_what_is_the_season == 2 ? 0.3 : 1)"
             ]
           },
           {
             "math": [
-              "( ( 133.47 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 68.15) + (u_skill('deduction') * 120.85) ) ) * (global_what_is_the_season == 2 ? 0.2 : 1)"
+              "( ( 133.47 + (u_spell_count('school': 'CHANGELING_SEASONAL_MAGIC_WINTER') * 68.15) + (u_skill('gramarye') * 120.85) ) ) * (global_what_is_the_season == 2 ? 0.2 : 1)"
             ]
           }
         ]

--- a/data/mods/Xedra_Evolved/spells/changeling_spells.json
+++ b/data/mods/Xedra_Evolved/spells/changeling_spells.json
@@ -9,7 +9,7 @@
     "valid_targets": [ "self" ],
     "spell_class": "CHANGELING_MAGIC",
     "difficulty": 6,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "effect": "effect_on_condition",
     "effect_str": "EOC_CHANGELING_USE_DREAMDROSS_TO_RESEARCH_NEW_SPELLS",
@@ -28,7 +28,7 @@
     "valid_targets": [ "self" ],
     "spell_class": "CHANGELING_MAGIC",
     "difficulty": 9,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "effect": "effect_on_condition",
     "effect_str": "EOC_CHANGELING_TURN_DREAMDROSS_INTO_DREAMSPARKS",
@@ -47,16 +47,16 @@
     "valid_targets": [ "self" ],
     "spell_class": "CHANGELING_MAGIC",
     "difficulty": 2,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "effect": "effect_on_condition",
     "effect_str": "EOC_CHANGELING_DISGUISE_AS_NATURE",
     "shape": "blast",
-    "min_duration": { "math": [ "(changeling_common_traits() * 2250) + (u_skill('deduction') * 23400) + 35100" ] },
-    "max_duration": { "math": [ "(changeling_common_traits() * 5750) + (u_skill('deduction') * 56300) + 78900" ] },
+    "min_duration": { "math": [ "(changeling_common_traits() * 2250) + (u_skill('gramarye') * 23400) + 35100" ] },
+    "max_duration": { "math": [ "(changeling_common_traits() * 5750) + (u_skill('gramarye') * 56300) + 78900" ] },
     "magic_type": "xe_fey_magick",
-    "base_energy_cost": { "math": [ "max(( 150 - (changeling_common_traits() * 2) - (u_skill('deduction') * 3)), 50)" ] },
-    "base_casting_time": { "math": [ "max(( 100 - changeling_common_traits() - (u_skill('deduction') * 3)), 30)" ] }
+    "base_energy_cost": { "math": [ "max(( 150 - (changeling_common_traits() * 2) - (u_skill('gramarye') * 3)), 50)" ] },
+    "base_casting_time": { "math": [ "max(( 100 - changeling_common_traits() - (u_skill('gramarye') * 3)), 30)" ] }
   },
   {
     "id": "changeling_invisibility_spell",
@@ -68,16 +68,16 @@
     "valid_targets": [ "self" ],
     "spell_class": "CHANGELING_MAGIC",
     "difficulty": 6,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "effect": "attack",
     "effect_str": "effect_changeling_invisibility",
     "shape": "blast",
-    "min_duration": { "math": [ "(changeling_common_traits() * 50) + (u_skill('deduction') * 500) + 2600" ] },
-    "max_duration": { "math": [ "(changeling_common_traits() * 163) + (u_skill('deduction') * 1200) + 13900" ] },
+    "min_duration": { "math": [ "(changeling_common_traits() * 50) + (u_skill('gramarye') * 500) + 2600" ] },
+    "max_duration": { "math": [ "(changeling_common_traits() * 163) + (u_skill('gramarye') * 1200) + 13900" ] },
     "magic_type": "xe_fey_magick",
-    "base_energy_cost": { "math": [ "max(( 750 - (changeling_common_traits() * 5) - (u_skill('deduction') * 20)), 350)" ] },
-    "base_casting_time": { "math": [ "max(( 250 - (changeling_common_traits() * 3) - (u_skill('deduction') * 8)), 50)" ] }
+    "base_energy_cost": { "math": [ "max(( 750 - (changeling_common_traits() * 5) - (u_skill('gramarye') * 20)), 350)" ] },
+    "base_casting_time": { "math": [ "max(( 250 - (changeling_common_traits() * 3) - (u_skill('gramarye') * 8)), 50)" ] }
   },
   {
     "id": "changeling_summon_will_o_the_wisps_spell",
@@ -89,22 +89,22 @@
     "valid_targets": [ "ground", "self", "ally", "hostile" ],
     "spell_class": "CHANGELING_MAGIC",
     "difficulty": 3,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "effect": "summon",
     "effect_str": "mon_changeling_wisp",
     "shape": "blast",
     "min_damage": 2,
     "max_damage": 4,
-    "min_duration": { "math": [ "(changeling_common_traits() * 190) + (u_skill('deduction') * 3980) + 16500" ] },
-    "max_duration": { "math": [ "(changeling_common_traits() * 608) + (u_skill('deduction') * 9750) + 39800" ] },
+    "min_duration": { "math": [ "(changeling_common_traits() * 190) + (u_skill('gramarye') * 3980) + 16500" ] },
+    "max_duration": { "math": [ "(changeling_common_traits() * 608) + (u_skill('gramarye') * 9750) + 39800" ] },
     "min_range": 25,
     "max_range": 25,
     "min_aoe": 3,
     "max_aoe": 3,
     "magic_type": "xe_fey_magick",
-    "base_energy_cost": { "math": [ "max(( 300 - (changeling_common_traits() * 3) - (u_skill('deduction') * 10)), 100)" ] },
-    "base_casting_time": { "math": [ "max(( 100 - changeling_common_traits() - (u_skill('deduction') * 3)), 50)" ] }
+    "base_energy_cost": { "math": [ "max(( 300 - (changeling_common_traits() * 3) - (u_skill('gramarye') * 10)), 100)" ] },
+    "base_casting_time": { "math": [ "max(( 100 - changeling_common_traits() - (u_skill('gramarye') * 3)), 50)" ] }
   },
   {
     "id": "changeling_noble_cure_bad_conditions_spell",
@@ -116,7 +116,7 @@
     "valid_targets": [ "self", "ally" ],
     "spell_class": "CHANGELING_MAGIC",
     "difficulty": 5,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "effect": "effect_on_condition",
     "effect_str": "EOC_NOBLE_CURE_BAD_CONDITIONS",
@@ -125,10 +125,10 @@
     "max_range": 1,
     "magic_type": "xe_fey_magick",
     "base_energy_cost": {
-      "math": [ "max(( 600 - (u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 5) - (u_skill('deduction') * 35)), 200)" ]
+      "math": [ "max(( 600 - (u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 5) - (u_skill('gramarye') * 35)), 200)" ]
     },
     "base_casting_time": {
-      "math": [ "max(( 250 - (u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 2) - (u_skill('deduction') * 5)), 150)" ]
+      "math": [ "max(( 250 - (u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 2) - (u_skill('gramarye') * 5)), 150)" ]
     }
   },
   {
@@ -141,18 +141,18 @@
     "valid_targets": [ "self" ],
     "spell_class": "CHANGELING_MAGIC",
     "difficulty": 4,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "effect": "effect_on_condition",
     "effect_str": "EOC_CHANGELING_NOBLE_BURNING_WEAPON",
     "shape": "blast",
-    "min_duration": { "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 240) + (u_skill('deduction') * 2600) + 27800" ] },
-    "max_duration": { "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 880) + (u_skill('deduction') * 17500) + 91500" ] },
+    "min_duration": { "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 240) + (u_skill('gramarye') * 2600) + 27800" ] },
+    "max_duration": { "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 880) + (u_skill('gramarye') * 17500) + 91500" ] },
     "magic_type": "xe_fey_magick",
     "base_energy_cost": {
-      "math": [ "max(( 400 - (u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 3) - (u_skill('deduction') * 20)), 200)" ]
+      "math": [ "max(( 400 - (u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 3) - (u_skill('gramarye') * 20)), 200)" ]
     },
-    "base_casting_time": { "math": [ "max(( 250 - u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') - (u_skill('deduction') * 5)), 150)" ] }
+    "base_casting_time": { "math": [ "max(( 250 - u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') - (u_skill('gramarye') * 5)), 150)" ] }
   },
   {
     "id": "changeling_noble_burning_weapon_fire_damage",
@@ -194,21 +194,21 @@
     "valid_targets": [ "self", "ally" ],
     "spell_class": "CHANGELING_MAGIC",
     "difficulty": 5,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "effect": "effect_on_condition",
     "effect_str": "EOC_CHANGELING_NOBLE_MOVEMENT_BUFFS",
     "shape": "blast",
     "min_range": 1,
     "max_range": 1,
-    "min_duration": { "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 550) + (u_skill('deduction') * 3900) + 22500" ] },
-    "max_duration": { "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 1230) + (u_skill('deduction') * 8900) + 69100" ] },
+    "min_duration": { "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 550) + (u_skill('gramarye') * 3900) + 22500" ] },
+    "max_duration": { "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 1230) + (u_skill('gramarye') * 8900) + 69100" ] },
     "magic_type": "xe_fey_magick",
     "base_energy_cost": {
-      "math": [ "max(( 300 - (u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 2) - (u_skill('deduction') * 25)), 100)" ]
+      "math": [ "max(( 300 - (u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 2) - (u_skill('gramarye') * 25)), 100)" ]
     },
     "base_casting_time": {
-      "math": [ "max(( 200 - (u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 2) - (u_skill('deduction') * 10)), 50)" ]
+      "math": [ "max(( 200 - (u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 2) - (u_skill('gramarye') * 10)), 50)" ]
     }
   },
   {
@@ -221,25 +221,25 @@
     "valid_targets": [ "self", "ally", "ground", "hostile" ],
     "spell_class": "CHANGELING_MAGIC",
     "difficulty": 8,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "effect": "summon",
     "effect_str": "GROUP_HOSTS_OF_SAMHAIN",
     "shape": "blast",
-    "min_damage": { "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 0.04) + (u_skill('deduction') * 0.1) + 1" ] },
-    "max_damage": { "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 0.12) + (u_skill('deduction') * 0.25) + 2" ] },
+    "min_damage": { "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 0.04) + (u_skill('gramarye') * 0.1) + 1" ] },
+    "max_damage": { "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 0.12) + (u_skill('gramarye') * 0.25) + 2" ] },
     "min_range": 20,
     "max_range": 20,
     "min_aoe": 3,
     "max_aoe": 3,
-    "min_duration": { "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 340) + (u_skill('deduction') * 2700) + 14200" ] },
-    "max_duration": { "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 620) + (u_skill('deduction') * 11300) + 52300" ] },
+    "min_duration": { "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 340) + (u_skill('gramarye') * 2700) + 14200" ] },
+    "max_duration": { "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 620) + (u_skill('gramarye') * 11300) + 52300" ] },
     "magic_type": "xe_fey_magick",
     "base_energy_cost": {
-      "math": [ "max(( 1200 - (u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 15) - (u_skill('deduction') * 40)), 550)" ]
+      "math": [ "max(( 1200 - (u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 15) - (u_skill('gramarye') * 40)), 550)" ]
     },
     "base_casting_time": {
-      "math": [ "max(( 400 - (u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 8) - (u_skill('deduction') * 15)), 150)" ]
+      "math": [ "max(( 400 - (u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 8) - (u_skill('gramarye') * 15)), 150)" ]
     }
   },
   {
@@ -254,20 +254,20 @@
     "shape": "blast",
     "spell_class": "CHANGELING_MAGIC",
     "difficulty": 5,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
-    "min_damage": { "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 4.5) + (u_skill('deduction') * 20) + 10" ] },
-    "max_damage": { "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 9) + (u_skill('deduction') * 30) + 30" ] },
-    "min_duration": { "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 691) + (u_skill('deduction') * 3246) + 8259" ] },
-    "max_duration": { "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 1685) + (u_skill('deduction') * 8388) + 26221" ] },
+    "min_damage": { "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 4.5) + (u_skill('gramarye') * 20) + 10" ] },
+    "max_damage": { "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 9) + (u_skill('gramarye') * 30) + 30" ] },
+    "min_duration": { "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 691) + (u_skill('gramarye') * 3246) + 8259" ] },
+    "max_duration": { "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 1685) + (u_skill('gramarye') * 8388) + 26221" ] },
     "min_range": 15,
     "max_range": 15,
     "magic_type": "xe_fey_magick",
     "base_energy_cost": {
-      "math": [ "max(( 450 - (u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 5) - (u_skill('deduction') * 15)), 150)" ]
+      "math": [ "max(( 450 - (u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 5) - (u_skill('gramarye') * 15)), 150)" ]
     },
     "base_casting_time": {
-      "math": [ "max(( 150 - (u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 3) - (u_skill('deduction') * 8)), 50)" ]
+      "math": [ "max(( 150 - (u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 3) - (u_skill('gramarye') * 8)), 50)" ]
     },
     "targeted_monster_species": [ "CHANGELING" ],
     "ignored_monster_species": [ "CHANGELING_NOBLE" ]
@@ -284,20 +284,20 @@
     "shape": "blast",
     "spell_class": "CHANGELING_MAGIC",
     "difficulty": 7,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
-    "min_damage": { "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 3) + (u_skill('deduction') * 20) + 10" ] },
-    "max_damage": { "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 7) + (u_skill('deduction') * 30) + 30" ] },
-    "min_duration": { "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 286) + (u_skill('deduction') * 2455) + 5824" ] },
-    "max_duration": { "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 773) + (u_skill('deduction') * 6250) + 19375" ] },
+    "min_damage": { "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 3) + (u_skill('gramarye') * 20) + 10" ] },
+    "max_damage": { "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 7) + (u_skill('gramarye') * 30) + 30" ] },
+    "min_duration": { "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 286) + (u_skill('gramarye') * 2455) + 5824" ] },
+    "max_duration": { "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 773) + (u_skill('gramarye') * 6250) + 19375" ] },
     "min_range": 10,
     "max_range": 10,
     "magic_type": "xe_fey_magick",
     "base_energy_cost": {
-      "math": [ "max(( 700 - (u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 9) - (u_skill('deduction') * 25)), 300)" ]
+      "math": [ "max(( 700 - (u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 9) - (u_skill('gramarye') * 25)), 300)" ]
     },
     "base_casting_time": {
-      "math": [ "max(( 150 - (u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 3) - (u_skill('deduction') * 8)), 50)" ]
+      "math": [ "max(( 150 - (u_sum_traits_of_category_char_has('FAIR_FOLK_NOBLE') * 3) - (u_skill('gramarye') * 8)), 50)" ]
     },
     "targeted_monster_species": [ "FERAL", "HUMAN" ]
   },
@@ -311,7 +311,7 @@
     "valid_targets": [ "self" ],
     "spell_class": "CHANGELING_MAGIC",
     "difficulty": 7,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "effect": "effect_on_condition",
     "effect_str": "EOC_BROWNIE_INDOOR_BLINK",
@@ -319,12 +319,12 @@
     "magic_type": "xe_fey_magick",
     "base_energy_cost": {
       "math": [
-        "max(( 500 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_BROWNIE') * 3) - (u_skill('deduction') * 15)), 250)"
+        "max(( 500 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_BROWNIE') * 3) - (u_skill('gramarye') * 15)), 250)"
       ]
     },
     "base_casting_time": {
       "math": [
-        "max(( 150 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_BROWNIE') * 1) - (u_skill('deduction') * 4)), 50)"
+        "max(( 150 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_BROWNIE') * 1) - (u_skill('gramarye') * 4)), 50)"
       ]
     }
   },
@@ -337,7 +337,7 @@
     "valid_targets": [ "self" ],
     "spell_class": "CHANGELING_MAGIC",
     "difficulty": 9,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "effect": "effect_on_condition",
     "effect_str": "EOC_BROWNIE_HOME_TELEPORT_ACTUAL_TELEPORT",
@@ -345,12 +345,12 @@
     "magic_type": "xe_fey_magick",
     "base_energy_cost": {
       "math": [
-        "max(( 800 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_BROWNIE') * 10) - (u_skill('deduction') * 25)), 400)"
+        "max(( 800 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_BROWNIE') * 10) - (u_skill('gramarye') * 25)), 400)"
       ]
     },
     "base_casting_time": {
       "math": [
-        "max(( 100 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_BROWNIE') * 3) - (u_skill('deduction') * 5)), 25)"
+        "max(( 100 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_BROWNIE') * 3) - (u_skill('gramarye') * 5)), 25)"
       ]
     }
   },
@@ -366,26 +366,26 @@
     "shape": "blast",
     "spell_class": "CHANGELING_MAGIC",
     "difficulty": 6,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
-    "min_damage": { "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_POOKA') * 3) + (u_skill('deduction') * 10) + 15" ] },
-    "max_damage": { "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_POOKA') * 7) + (u_skill('deduction') * 25) + 60" ] },
+    "min_damage": { "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_POOKA') * 3) + (u_skill('gramarye') * 10) + 15" ] },
+    "max_damage": { "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_POOKA') * 7) + (u_skill('gramarye') * 25) + 60" ] },
     "min_duration": {
-      "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_POOKA') * 286) + (u_skill('deduction') * 3455) + 9450" ]
+      "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_POOKA') * 286) + (u_skill('gramarye') * 3455) + 9450" ]
     },
     "max_duration": {
-      "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_POOKA') * 850) + (u_skill('deduction') * 8641) + 33145" ]
+      "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_POOKA') * 850) + (u_skill('gramarye') * 8641) + 33145" ]
     },
     "min_range": 10,
     "max_range": 10,
     "magic_type": "xe_fey_magick",
     "base_energy_cost": {
       "math": [
-        "max(( 600 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_POOKA') * 8) - (u_skill('deduction') * 25)), 250)"
+        "max(( 600 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_POOKA') * 8) - (u_skill('gramarye') * 25)), 250)"
       ]
     },
     "base_casting_time": {
-      "math": [ "max(( 200 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_POOKA') * 4) - (u_skill('deduction') * 8)), 50)" ]
+      "math": [ "max(( 200 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_POOKA') * 4) - (u_skill('gramarye') * 8)), 50)" ]
     },
     "targeted_monster_species": [ "MAMMAL", "BIRD" ]
   },
@@ -401,32 +401,26 @@
     "shape": "blast",
     "spell_class": "CHANGELING_MAGIC",
     "difficulty": 7,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
-    "min_damage": {
-      "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 3) + (u_skill('deduction') * 10) + 10" ]
-    },
-    "max_damage": {
-      "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 7) + (u_skill('deduction') * 20) + 30" ]
-    },
+    "min_damage": { "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 3) + (u_skill('gramarye') * 10) + 10" ] },
+    "max_damage": { "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 7) + (u_skill('gramarye') * 20) + 30" ] },
     "min_duration": {
-      "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 286) + (u_skill('deduction') * 2455) + 5824" ]
+      "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 286) + (u_skill('gramarye') * 2455) + 5824" ]
     },
     "max_duration": {
-      "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 773) + (u_skill('deduction') * 6250) + 19375" ]
+      "math": [ "(u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 773) + (u_skill('gramarye') * 6250) + 19375" ]
     },
     "min_range": 10,
     "max_range": 10,
     "magic_type": "xe_fey_magick",
     "base_energy_cost": {
       "math": [
-        "max(( 750 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 9) - (u_skill('deduction') * 25)), 350)"
+        "max(( 750 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 9) - (u_skill('gramarye') * 25)), 350)"
       ]
     },
     "base_casting_time": {
-      "math": [
-        "max(( 200 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 4) - (u_skill('deduction') * 8)), 50)"
-      ]
+      "math": [ "max(( 200 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 4) - (u_skill('gramarye') * 8)), 50)" ]
     },
     "targeted_monster_species": [ "FERAL", "HUMAN" ]
   },
@@ -443,26 +437,26 @@
     "shape": "blast",
     "spell_class": "CHANGELING_MAGIC",
     "difficulty": 3,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "min_duration": {
       "math": [
-        "((u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 560) + (u_skill('deduction') * 5120) + 13540) * selkie_has_weather_mastery()"
+        "((u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 560) + (u_skill('gramarye') * 5120) + 13540) * selkie_has_weather_mastery()"
       ]
     },
     "max_duration": {
       "math": [
-        "((u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 1380) + (u_skill('deduction') * 12305) + 49850) * selkie_has_weather_mastery()"
+        "((u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 1380) + (u_skill('gramarye') * 12305) + 49850) * selkie_has_weather_mastery()"
       ]
     },
     "magic_type": "xe_fey_magick",
     "base_energy_cost": {
       "math": [
-        "u_effect_intensity('effect_selkie_fog_cloak') > -1 ? 0 : max(( 450 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 5) - (u_skill('deduction') * 15)), 100)"
+        "u_effect_intensity('effect_selkie_fog_cloak') > -1 ? 0 : max(( 450 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 5) - (u_skill('gramarye') * 15)), 100)"
       ]
     },
     "base_casting_time": {
-      "math": [ "max(( 100 - u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') - (u_skill('deduction') * 3)), 40)" ]
+      "math": [ "max(( 100 - u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') - (u_skill('gramarye') * 3)), 40)" ]
     }
   },
   {
@@ -478,27 +472,27 @@
     "shape": "blast",
     "spell_class": "CHANGELING_MAGIC",
     "difficulty": 5,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "min_duration": {
       "math": [
-        "((u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 980) + (u_skill('deduction') * 3453) + 20310) * selkie_has_weather_mastery()"
+        "((u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 980) + (u_skill('gramarye') * 3453) + 20310) * selkie_has_weather_mastery()"
       ]
     },
     "max_duration": {
       "math": [
-        "((u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 2415) + (u_skill('deduction') * 10275) + 74775) * selkie_has_weather_mastery()"
+        "((u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 2415) + (u_skill('gramarye') * 10275) + 74775) * selkie_has_weather_mastery()"
       ]
     },
     "magic_type": "xe_fey_magick",
     "base_energy_cost": {
       "math": [
-        "u_effect_intensity('effect_controlling_weather_fog') > -1 ? 50 : max(( 750 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 3) - (u_skill('deduction') * 25)), 400)"
+        "u_effect_intensity('effect_controlling_weather_fog') > -1 ? 50 : max(( 750 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 3) - (u_skill('gramarye') * 25)), 400)"
       ]
     },
     "base_casting_time": {
       "math": [
-        "max(( 30000 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 25) - (u_skill('deduction') * 500)), 6000)"
+        "max(( 30000 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 25) - (u_skill('gramarye') * 500)), 6000)"
       ]
     }
   },
@@ -515,27 +509,27 @@
     "shape": "blast",
     "spell_class": "CHANGELING_MAGIC",
     "difficulty": 6,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "min_duration": {
       "math": [
-        "((u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 1715) + (u_skill('deduction') * 6043) + 35543) * selkie_has_weather_mastery()"
+        "((u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 1715) + (u_skill('gramarye') * 6043) + 35543) * selkie_has_weather_mastery()"
       ]
     },
     "max_duration": {
       "math": [
-        "((u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 4226) + (u_skill('deduction') * 17981) + 123379) * selkie_has_weather_mastery()"
+        "((u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 4226) + (u_skill('gramarye') * 17981) + 123379) * selkie_has_weather_mastery()"
       ]
     },
     "magic_type": "xe_fey_magick",
     "base_energy_cost": {
       "math": [
-        "u_effect_intensity('effect_controlling_weather_rains') > -1 ? 0 : max(( 950 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 3) - (u_skill('deduction') * 25)), 450)"
+        "u_effect_intensity('effect_controlling_weather_rains') > -1 ? 0 : max(( 950 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 3) - (u_skill('gramarye') * 25)), 450)"
       ]
     },
     "base_casting_time": {
       "math": [
-        "max(( 60000 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 45) - (u_skill('deduction') * 1000)), 6000)"
+        "max(( 60000 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 45) - (u_skill('gramarye') * 1000)), 6000)"
       ]
     }
   },
@@ -552,27 +546,27 @@
     "shape": "blast",
     "spell_class": "CHANGELING_MAGIC",
     "difficulty": 7,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "min_duration": {
       "math": [
-        "((u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 1715) + (u_skill('deduction') * 6043) + 35543) * selkie_has_weather_mastery()"
+        "((u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 1715) + (u_skill('gramarye') * 6043) + 35543) * selkie_has_weather_mastery()"
       ]
     },
     "max_duration": {
       "math": [
-        "((u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 4226) + (u_skill('deduction') * 17981) + 123379) * selkie_has_weather_mastery()"
+        "((u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 4226) + (u_skill('gramarye') * 17981) + 123379) * selkie_has_weather_mastery()"
       ]
     },
     "magic_type": "xe_fey_magick",
     "base_energy_cost": {
       "math": [
-        "u_effect_intensity('effect_controlling_weather_rainstorm') > -1 ? 0 : max(( 1200 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 4) - (u_skill('deduction') * 25)), 600)"
+        "u_effect_intensity('effect_controlling_weather_rainstorm') > -1 ? 0 : max(( 1200 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 4) - (u_skill('gramarye') * 25)), 600)"
       ]
     },
     "base_casting_time": {
       "math": [
-        "max(( 90000 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 45) - (u_skill('deduction') * 1000)), 9000)"
+        "max(( 90000 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 45) - (u_skill('gramarye') * 1000)), 9000)"
       ]
     }
   },
@@ -589,17 +583,17 @@
     "shape": "blast",
     "spell_class": "CHANGELING_MAGIC",
     "difficulty": 9,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "magic_type": "xe_fey_magick",
     "base_energy_cost": {
       "math": [
-        "u_effect_intensity('effect_controlling_weather_lightningstorm') > -1 ? 50 : max(( 500 - u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') - (u_skill('deduction') * 15)), 200)"
+        "u_effect_intensity('effect_controlling_weather_lightningstorm') > -1 ? 50 : max(( 500 - u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') - (u_skill('gramarye') * 15)), 200)"
       ]
     },
     "base_casting_time": {
       "math": [
-        "max(( 9000 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 10) - (u_skill('deduction') * 250)), 1000)"
+        "max(( 9000 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_SELKIE') * 10) - (u_skill('gramarye') * 250)), 1000)"
       ]
     }
   },
@@ -613,7 +607,7 @@
     "valid_targets": [ "ground", "self", "ally", "hostile" ],
     "spell_class": "CHANGELING_MAGIC",
     "difficulty": 2,
-    "skill": "deduction",
+    "skill": "gramarye",
     "max_level": 1,
     "effect": "noise",
     "shape": "blast",
@@ -625,10 +619,10 @@
     "max_aoe": 1,
     "magic_type": "xe_fey_magick",
     "base_energy_cost": {
-      "math": [ "max(( 200 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_TROW') * 2) - (u_skill('deduction') * 5)), 35)" ]
+      "math": [ "max(( 200 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_TROW') * 2) - (u_skill('gramarye') * 5)), 35)" ]
     },
     "base_casting_time": {
-      "math": [ "max(( 150 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_TROW') * 3) - (u_skill('deduction') * 6)), 50)" ]
+      "math": [ "max(( 150 - (u_sum_traits_of_category_char_has('FAIR_FOLK_COMMONER_TROW') * 3) - (u_skill('gramarye') * 6)), 50)" ]
     },
     "sound_description": "a loud thump"
   },
@@ -638,7 +632,7 @@
     "name": "Cultivate Goblin Fruit",
     "description": "You may spin a bit of fae magic into water, bringing forth a goblin fruit.  Goblin fruit have a variety of effects, never predictable but always at least somewhat beneficial.  This spell may only be cast near water or under the rain.",
     "valid_targets": [ "self" ],
-    "skill": "deduction",
+    "skill": "gramarye",
     "effect": "effect_on_condition",
     "effect_str": "EOC_SELKIE_GOBLIN_FRUIT",
     "shape": "blast",
@@ -661,7 +655,7 @@
     "name": "Cultivate Goblin Fruit",
     "description": "You may spin a bit of fae magic into the air, bringing forth a goblin fruit.  Goblin fruit have a variety of effects, never predictable but always at least somewhat beneficial.  This spell may only be cast indoors, when nobody is watching.",
     "valid_targets": [ "self" ],
-    "skill": "deduction",
+    "skill": "gramarye",
     "effect": "effect_on_condition",
     "effect_str": "EOC_BROWNIE_GOBLIN_FRUIT",
     "shape": "blast",
@@ -684,7 +678,7 @@
     "name": "Cultivate Goblin Fruit",
     "description": "You may spin a bit of fae magic into the air, bringing forth a goblin fruit.  Goblin fruit have a variety of effects, never predictable but always at least somewhat beneficial.  This spell may only be cast near an animal.",
     "valid_targets": [ "self" ],
-    "skill": "deduction",
+    "skill": "gramarye",
     "effect": "effect_on_condition",
     "effect_str": "EOC_POOKA_GOBLIN_FRUIT",
     "shape": "blast",
@@ -707,7 +701,7 @@
     "name": "Cultivate Goblin Fruit",
     "description": "You may spin a bit of fae magic into the earth, bringing forth a goblin fruit.  Goblin fruit have a variety of effects, never predictable but always at least somewhat beneficial.  This spell may only be cast underground or at night.",
     "valid_targets": [ "self" ],
-    "skill": "deduction",
+    "skill": "gramarye",
     "effect": "effect_on_condition",
     "effect_str": "EOC_TROW_GOBLIN_FRUIT",
     "shape": "blast",
@@ -730,7 +724,7 @@
     "name": "Cultivate Goblin Fruit",
     "description": "You may spin a bit of fae magic into the air, bringing forth a goblin fruit.  Goblin fruit have a variety of effects, never predictable but always at least somewhat beneficial.  This spell may only be cast near a human or a Fae.",
     "valid_targets": [ "self" ],
-    "skill": "deduction",
+    "skill": "gramarye",
     "effect": "effect_on_condition",
     "effect_str": "EOC_NOBLE_GOBLIN_FRUIT",
     "shape": "blast",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Xedra Evolved] Move changelings to the `gramarye` skill for their powers"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

More moving supernatural beings over.  Also since Vampire's spells are no_fail they shouldn't train deduction.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Move changelings over to the `gramarye` skill for their powers. This includes both seasonal glamours and their innate magick. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Loaded the game, assigned self some glamours, raised `gramarye` and saw their effects got stronger.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
