### PR TITLE
[Sky Island] Portal storms only happen in the raid dimension

### DIFF
--- a/data/mods/Sky_Island/effectoncondition/portal_storms.json
+++ b/data/mods/Sky_Island/effectoncondition/portal_storms.json
@@ -1,0 +1,24 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PORTAL_STORM_WARN_OR_CAUSE_RECURRING",
+    "recurrence": [ { "global_val": "ps_min_woc", "default": "5 days" }, { "global_val": "ps_max_woc", "default": "18 days" } ],
+    "global": true,
+    "condition": { "current_dimension": "" },
+    "effect": [ { "math": [ "saved_portal_storms++" ] } ],
+    "false_effect": [ { "if": { "math": [ "saved_portal_storms > 0" ] }, "then": { "run_eocs": "EOC_SI_START_PORTAL_STORM" } } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_SI_START_PORTAL_STORM",
+    "condition": { "not": { "current_dimension": "" } },
+    "effect": [ { "run_eocs": "EOC_CAUSE_EARLY_PORTAL_STORM" }, { "math": [ "saved_portal_storms--" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_SI_SETUP_RAID_PORTAL_STORM",
+    "effect": [
+      { "run_eocs": "EOC_SI_START_PORTAL_STORM", "time_in_future": { "global_val": "currentpulselength", "default": "15 m" } }
+    ]
+  }
+]

--- a/data/mods/Sky_Island/effectoncondition/teleport.json
+++ b/data/mods/Sky_Island/effectoncondition/teleport.json
@@ -90,7 +90,8 @@
         "fail_message": "It seems the portal couldn't find a valid location.",
         "force": true
       },
-      { "run_eocs": [ "EOC_safely_landed" ] }
+      { "run_eocs": [ "EOC_safely_landed" ] },
+      { "if": { "math": [ "saved_portal_storms > 0" ] }, "then": { "run_eocs": "EOC_SI_SETUP_RAID_PORTAL_STORM" } }
     ]
   },
   {
@@ -98,6 +99,7 @@
     "id": "EOC_return_OM_teleport",
     "//": "This is the EOC which actually returns you home.  It brings you home and removes all warp-related effects including warp sickness.  It heals you enough to fix broken limbs.  It also resets the awayfromhome counter to 0 so warp sickness can be tracked properly next time you're out.",
     "effect": [
+      { "run_eocs": "EOC_CANCEL_PORTAL_STORM" },
       {
         "u_run_npc_eocs": [
           {

--- a/data/mods/Sky_Island/region_settings.json
+++ b/data/mods/Sky_Island/region_settings.json
@@ -13,6 +13,12 @@
     "feature_flag_settings": { "extend": { "blacklist": [ "SKY_ISLAND", "SKY_ISLAND_NO_RAID_SPAWN" ] } }
   },
   {
+    "type": "weather_generator",
+    "id": "sky_island_weather",
+    "copy-from": "default",
+    "weather_black_list": [ "early_portal_storm", "portal_storm", "distant_portal_storm", "close_portal_storm" ]
+  },
+  {
     "type": "region_settings",
     "id": "default_skyisland",
     "rivers": null,
@@ -27,7 +33,7 @@
     "map_extras": "no_map_extras",
     "place_roads": false,
     "place_specials": true,
-    "weather": "default",
+    "weather": "sky_island_weather",
     "default_oter": [
       "open_air",
       "open_air",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Sky Island] Portal storms only happen in the raid dimension"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Portal Storms on the island are pointless and cheesable since you can't actually die there.
THis makes it so they remain the threat they are by only happening while on a raid.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Disable all portal storm weather in the home dimension.
- This covers an edge case where the portal storm EOC can trigger one of its intermediary steps if the player teleports home before it triggers while in the raid dimension. The player would have to portal home within 30-60 seconds after the portal storm starts.
  - The only way around this would be to overwrite the intermediary EOC as well but this has effects with other mods that interact with these EOCs. All the player sees is the portal storm messages in the log if this happens. I considered it a minor edge case to not have to account for other EOC edits when this is highly unlikely to happen.

Overwrite the recurring EOC that triggers the spawning of portal storms. 
- Change it so that it checks where the player is. If at home it builds up a saved storm count. If they're on a raid it will trigger a storm as normal.

Edit the raid start and raid return EOCs
- Force portal storms to end when returning home, no matter how the player gets home
- When a raid starts, if the player has any saved storms, one is triggered one pulse length after the raid start. 
  - Defaults to 15m pulse length
  - If the player goes home before the storm starts, the storm remains in the saved count
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
With some test messages in placee, checked that the storm count builds, storms trigger in the raids after the first pulse, storm count decrements when a storm starts, storm count remains the same if the player makes it out fast enough, and no storms happen at home.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
