### PR TITLE
Fix display_fridge furniture weight

### DIFF
--- a/data/json/furniture_and_terrain/furniture_refrigeration.json
+++ b/data/json/furniture_and_terrain/furniture_refrigeration.json
@@ -129,7 +129,7 @@
     "move_cost_mod": -1,
     "coverage": 90,
     "required_str": 10,
-    "mass": "60 kg",
+    "mass": "102 kg",
     "examine_action": { "type": "appliance_convert", "furn_set": "f_null", "item": "display_fridge" },
     "flags": [ "PLACE_ITEM", "BLOCKSDOOR", "NO_SELF_CONNECT", "EASY_DECONSTRUCT", "SMALL_HIDE" ],
     "item": "display_fridge",


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
https://github.com/CleverRaven/Cataclysm-DDA/pull/85344#issuecomment-4017411383
#### Describe the solution
make display_fridge weight 102 kg, on par with it's item weight