### PR TITLE
Fix non-deterministic hp_max in clear_character()

### DIFF
--- a/tests/player_helpers.cpp
+++ b/tests/player_helpers.cpp
@@ -94,6 +94,7 @@ void clear_character( Character &dummy, bool skip_nutrition )
     // clear_mutations() removes traits but does not rebuild bodypart topology.
     // Rebuild anatomy now so tests see baseline human limbs (e.g. feet, not talons).
     dummy.set_body();
+    dummy.tally_organic_size();
     dummy.mutation_category_level.clear();
     dummy.clear_bionics();
 
@@ -168,6 +169,8 @@ void clear_character( Character &dummy, bool skip_nutrition )
 
     // Final stored_kcal sync after all attribute resets.
     dummy.set_stored_kcal( dummy.get_healthy_kcal() );
+    // Recompute hp_max now that stats, body, and kcal are all finalized.
+    dummy.recalc_hp();
 }
 
 void arm_shooter( Character &shooter, const itype_id &gun_type,


### PR DESCRIPTION
#### Summary
Bugfixes "Fix non-deterministic hp_max in test helper clear_character()"

#### Purpose of change

`clear_character()` produces hp_max of either 85 or 86 depending on prior test state. This causes flaky failures in widget tests (`W_NO_PADDING_widget_flag`) where the HP bar graph renders one symbol off.

#### Describe the solution

Two issues in `clear_character()`:

1. `set_body()` does not call `tally_organic_size()`, so `cached_organic_size` stays at whatever the previous test left it (could be 1.0 instead of the correct 0.99 for standard human anatomy). This feeds into `get_bmi_fat()` and `get_healthy_kcal()`, affecting `get_fat_to_hp()`.

2. `set_stored_kcal(get_healthy_kcal())` triggers `recalc_hp()` as a side effect, but this happens before stats are set to their baseline of 8, and before effects are cleared (so stale enchantments may still modify hp_mod/hp_adjustment). The second `set_stored_kcal()` at the end is a no-op because the calorie value hasn't changed, so the stale hp_max sticks.

Fix: add `tally_organic_size()` after `set_body()`, and add an explicit `recalc_hp()` at the very end after all attributes are finalized.

#### Describe alternatives you've considered

Could reorder `clear_character()` so stats are set before `set_stored_kcal()`, but that is a bigger change with more risk of subtle side effects. The explicit `recalc_hp()` at the end is safer -- it just makes the final state correct regardless of intermediate computation order.

#### Testing

Verified with a standalone C++ test at all optimization levels (-O0 through -O3, plus -ffast-math) that with the finalized inputs (str=8, cached_organic_size=0.99, height=175), hp_max is deterministically 85:
- `healthy_kcal = floor(7716.17 * 0.99 * 5.0 * 3.0625) = 116972`
- `bmi_fat = 4.9999866...` (always < 5.0 because of the floor)
- `fat_to_hp = int(4.9999866 - 3.0) = 1`
- `hp_max = (60 + 8*3.0 + 1) * 1.0 = 85`

#### Additional context

None.