### PR TITLE
new special for string dimension, electronic things with odd monitors

### DIFF
--- a/data/json/effects_on_condition/nether_eocs/string_dimension.json
+++ b/data/json/effects_on_condition/nether_eocs/string_dimension.json
@@ -193,5 +193,10 @@
         }
       }
     ]
+  },
+  {
+    "id": "EOC_SD_Computer",
+    "type": "effect_on_condition",
+    "effect": [ "open_dialogue" ]
   }
 ]

--- a/data/json/furniture_and_terrain/terrain-string-dimension.json
+++ b/data/json/furniture_and_terrain/terrain-string-dimension.json
@@ -202,5 +202,25 @@
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "DIGGABLE", "FLAT", "PLOWABLE" ],
     "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 40, "str_max": 100, "str_min_supported": 100, "bash_below": true }
+  },
+  {
+    "type": "terrain",
+    "id": "t_string_distress_beacon",
+    "name": "scrap metal thing",
+    "looks_like": "t_scrap_wall",
+    "description": "Part of a structure that almost looks like a small version of Earth's lunar lander.  It has exposed electronics and deployed stabilizers made of cobbled together scrap metal.  The ground at its feet appears to have been scorched long ago.",
+    "symbol": "-",
+    "color": "dark_gray",
+    "move_cost": 0,
+    "coverage": 100,
+    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "REDUCE_SCENT", "AUTO_WALL_SYMBOL", "BLOCK_WIND" ],
+    "bash": {
+      "str_min": 80,
+      "str_max": 200,
+      "sound": "metal crying!",
+      "sound_fail": "clang!",
+      "ter_set": "t_rock_floor",
+      "items": [ { "item": "steel_chunk", "count": [ 10, 22 ] } ]
+    }
   }
 ]

--- a/data/json/mapgen/string_dimension/string_dimension_exodii_dome.json
+++ b/data/json/mapgen/string_dimension/string_dimension_exodii_dome.json
@@ -657,5 +657,81 @@
       "terrain": { ".": "t_metal_roof_sloped", ">": "t_stairs_down", " ": "t_open_air", "*": "t_string_z" },
       "furniture": { ".": [ [ "f_null", 198 ], [ "f_scrap_antenna", 1 ], [ "f_exodii_scanner", 1 ] ] }
     }
+  },
+  {
+    "type": "mapgen",
+    "om_terrain": "string_dimension_dome_distress_beacon",
+    "object": {
+      "predecessor_mapgen": "string_dimension_crossroads",
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "rows": [
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "          ##            ",
+        "         #++#           ",
+        "        #+..+#          ",
+        "       #+....+#         ",
+        "      #+..%%..+#        ",
+        "      #+..%t..+#        ",
+        "       #+....+#         ",
+        "        #+..+#          ",
+        "         #++#           ",
+        "          ##            ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        "
+      ],
+      "terrain": {
+        ".": [ [ "t_rock_floor", 90 ], [ "t_railroad_rubble", 10 ] ],
+        "%": "t_string_distress_beacon",
+        "t": "t_rock_floor",
+        "+": [ [ "t_rock_floor", 70 ], [ "t_string_xy", 20 ], [ "t_railroad_rubble", 10 ] ],
+        "#": "t_string_xy"
+      },
+      "computers": { "t": { "name": "odd monitor", "eocs": [ "EOC_SD_Computer" ], "chat_topics": [ "COMP_SD_EXODII_DISTRESS_BEACON" ] } }
+    }
+  },
+  {
+    "type": "mapgen",
+    "om_terrain": "string_dimension_dome_distress_beacon_1",
+    "object": {
+      "rows": [
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "          %%            ",
+        "          %%            ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        "
+      ],
+      "terrain": { "%": "t_scrap_floor", " ": "t_open_air" },
+      "furniture": { "%": "f_exodii_scanner" }
+    }
   }
 ]

--- a/data/json/npcs/exodii/string_dimension/string_dimension_distress_beacon_computer.json
+++ b/data/json/npcs/exodii/string_dimension/string_dimension_distress_beacon_computer.json
@@ -1,0 +1,142 @@
+[
+  {
+    "type": "talk_topic",
+    "id": "COMP_SD_EXODII_DISTRESS_BEACON",
+    "dynamic_line": "&You see a bulbous, black computer screen.  It would almost be mundane on Earth's early 1990s.  Next to it is a large, clear plastic toggle switch, yellowed and brittle with age.",
+    "responses": [
+      {
+        "text": "[Flip the switch]",
+        "topic": "COMP_SD_EXODII_DISTRESS_BEACON_1",
+        "condition": { "not": { "math": [ "string_dimension_flipped_switched >= 1" ] } },
+        "effect": [
+          { "math": [ "string_dimension_flipped_switched = 1" ] },
+          { "u_transform_radius": 2, "ter_furn_transform": "ter_local_sd_distress_beacon_1" }
+        ]
+      },
+      {
+        "text": "[Flip the switch]",
+        "topic": "COMP_SD_EXODII_DISTRESS_BEACON_2",
+        "condition": { "math": [ "string_dimension_flipped_switched == 1" ] },
+        "effect": [
+          { "math": [ "string_dimension_flipped_switched = 2" ] },
+          { "u_transform_radius": 2, "ter_furn_transform": "ter_local_sd_distress_beacon_2" }
+        ]
+      },
+      {
+        "text": "[Flip the switch]",
+        "topic": "COMP_SD_EXODII_DISTRESS_BEACON_3",
+        "condition": { "math": [ "string_dimension_flipped_switched == 2" ] },
+        "effect": [
+          { "math": [ "string_dimension_flipped_switched = 3" ] },
+          { "u_transform_radius": 2, "ter_furn_transform": "ter_local_sd_distress_beacon_3" },
+          { "assign_mission": "MISSION_STRING_DIMENSION_EXODII_DOME" }
+        ]
+      },
+      {
+        "text": "[Flip the switch]",
+        "topic": "COMP_SD_EXODII_DISTRESS_BEACON_4",
+        "condition": { "math": [ "string_dimension_flipped_switched == 3" ] },
+        "effect": { "u_transform_radius": 2, "ter_furn_transform": "ter_local_sd_distress_beacon_3" }
+      },
+      { "text": "[Step away]", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "COMP_SD_EXODII_DISTRESS_BEACON_1",
+    "dynamic_line": "&There is an electronic whirr, following by a click and a high-pitched ringing that slowly fades.  The screen turns on and garbled text and images cover the screen.  It is either some language you do not understand, or a series of confounding errors.  Three circle dominate the top of the screen - after just a few seconds, one circle lights up orange.",
+    "responses": [ { "text": "[Step away]", "topic": "TALK_DONE" } ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "COMP_SD_EXODII_DISTRESS_BEACON_2",
+    "dynamic_line": "&There is an electronic whirr, following by a click and a high-pitched ringing that slowly fades.  The screen turns on and garbled text and images cover the screen.  It is either some language you do not understand, or a series of confounding errors.  Three circle dominate the top of the screen - after just a few seconds, two circles light up orange.",
+    "responses": [ { "text": "[Step away]", "topic": "TALK_DONE" } ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "COMP_SD_EXODII_DISTRESS_BEACON_3",
+    "dynamic_line": "&There is an electronic whirr, following by a click and a high-pitched ringing that slowly fades.  The screen turns on and garbled text and images cover the screen.  It is either some language you do not understand, or a series of confounding errors.  Three circle dominate the top of the screen - after just a few seconds, all three circles light up orange.\n\nImmediately, three similar dots appear on the garbled image, and after a few punctuated corrections, the image morphs into a highly pixelated topological map.  A fourth, blinking light appears.  You make note if its location in reference to the three terminals you've visited.",
+    "responses": [ { "text": "[Step away]", "topic": "TALK_DONE" } ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "COMP_SD_EXODII_DISTRESS_BEACON_4",
+    "dynamic_line": "&There is an electronic whirr, following by a click and a high-pitched ringing that slowly fades.  A familiar topological map forms.  You glean no new information from it.",
+    "responses": [ { "text": "[Step away]", "topic": "TALK_DONE" } ]
+  },
+  {
+    "type": "ter_furn_transform",
+    "id": "ter_local_sd_distress_beacon_1",
+    "furniture": [ { "result": "f_string_dimension_distress_beacon_1", "valid_furniture": [ "f_console" ] } ]
+  },
+  {
+    "type": "ter_furn_transform",
+    "id": "ter_local_sd_distress_beacon_2",
+    "furniture": [ { "result": "f_string_dimension_distress_beacon_2", "valid_furniture": [ "f_console" ] } ]
+  },
+  {
+    "type": "ter_furn_transform",
+    "id": "ter_local_sd_distress_beacon_3",
+    "furniture": [ { "result": "f_string_dimension_distress_beacon_3", "valid_furniture": [ "f_console" ] } ]
+  },
+  {
+    "type": "furniture",
+    "id": "f_string_dimension_distress_beacon_1",
+    "copy-from": "f_console_broken",
+    "name": "powered odd monitor",
+    "looks_like": "t_console_broken",
+    "description": "A bulbous monitor.  It displays a garbled image and one glowing circle.",
+    "symbol": "6",
+    "color": "light_gray"
+  },
+  {
+    "type": "furniture",
+    "id": "f_string_dimension_distress_beacon_2",
+    "copy-from": "f_console_broken",
+    "name": "powered odd monitor",
+    "looks_like": "t_console_broken",
+    "description": "A bulbous monitor.  It displays a garbled image and two glowing circles.",
+    "symbol": "6",
+    "color": "light_gray"
+  },
+  {
+    "type": "furniture",
+    "id": "f_string_dimension_distress_beacon_3",
+    "copy-from": "f_console_broken",
+    "name": "powered odd monitor",
+    "looks_like": "t_console_broken",
+    "description": "A bulbous monitor.  It displays a topological map.  There's nothing new or interesting on it.",
+    "symbol": "6",
+    "color": "light_gray"
+  },
+  {
+    "id": "MISSION_STRING_DIMENSION_EXODII_DOME",
+    "type": "mission_definition",
+    "name": { "str": "Investigate the Blinking Dot" },
+    "goal": "MGOAL_GO_TO_TYPE",
+    "destination": "string_dimension_dome_x1y2z0",
+    "start": {
+      "assign_mission_target": {
+        "om_terrain": "string_dimension_dome_x1y2z0",
+        "om_special": "string_dimension_dome",
+        "reveal_radius": 0,
+        "random": false
+      }
+    },
+    "difficulty": 2,
+    "value": 0,
+    "origins": [ "ORIGIN_SECONDARY" ],
+    "dialogue": {
+      "describe": "-",
+      "offer": "-",
+      "accepted": "-",
+      "rejected": "-",
+      "advice": "-",
+      "inquire": "-",
+      "success": "-",
+      "success_lie": "-",
+      "failure": "-"
+    }
+  }
+]

--- a/data/json/overmap/overmap_special/string_dimension.json
+++ b/data/json/overmap/overmap_special/string_dimension.json
@@ -126,5 +126,17 @@
     "rotate": false,
     "locations": [ "string_dimension_field_core" ],
     "flags": [ "MAN_MADE", "EXTRADIMENSIONAL", "STRING_DIMENSION", "GLOBALLY_UNIQUE" ]
+  },
+  {
+    "type": "overmap_special",
+    "id": "string_dimension_dome_distress_beacon",
+    "overmaps": [
+      { "point": [ 0, 0, 1 ], "overmap": "string_dimension_dome_distress_beacon_1_north" },
+      { "point": [ 0, 0, 0 ], "overmap": "string_dimension_dome_distress_beacon_north" }
+    ],
+    "locations": [ "string_dimension_crossroads" ],
+    "city_distance": [ 0, -1 ],
+    "occurrences": [ 0, 5 ],
+    "flags": [ "MAN_MADE", "EXTRADIMENSIONAL", "STRING_DIMENSION" ]
   }
 ]

--- a/data/json/overmap/overmap_terrain/overmap_terrain_string_dimension.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_string_dimension.json
@@ -173,5 +173,14 @@
     "color": "light_gray",
     "see_cost": "full_high",
     "flags": [ "NO_ROTATE" ]
+  },
+  {
+    "type": "overmap_terrain",
+    "id": [ "string_dimension_dome_distress_beacon", "string_dimension_dome_distress_beacon_1" ],
+    "vision_levels": "isolated_tower",
+    "name": "big electronic thing",
+    "sym": "E",
+    "color": "light_green",
+    "see_cost": "high"
   }
 ]

--- a/data/mods/TEST_DATA/overmap_terrain_coverage_test/overmap_terrain_coverage_whitelist.json
+++ b/data/mods/TEST_DATA/overmap_terrain_coverage_test/overmap_terrain_coverage_whitelist.json
@@ -95,6 +95,8 @@
       "string_dimension_plane_z_stack_0",
       "string_dimension_plane_z_stack_1",
       "string_dimension_plane_z_stack_-1",
+      "string_dimension_dome_distress_beacon",
+      "string_dimension_dome_distress_beacon_1",
       "labyrinth_hall",
       "labyrinth_entrance",
       "netherum_labyrinth_sparkling_chasm",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Small Exodii specials in the string dimension"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Adding more content to string dimension

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Added "big electronic things," that are supposed to sort of resemble small moonlanders (abstractly, I'm no artist).  If you activate the terminals on 3 of them, they triangulate the failed Exodii node dungeon for you (otherwise it's extremely difficult to find).

Headcanon is these are distress beacons the Exodii fired off before they jumped-ship/died/ran away/whatever they did, but there's no real in game info on that.  Their functions and origins are left mysterious.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

n/a

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Visited specials, activated several.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
