### PR TITLE
Aftershock: Fix minor vahagn errors

### DIFF
--- a/data/mods/aftershock_exoplanet/items/magazine/7.50mm.json
+++ b/data/mods/aftershock_exoplanet/items/magazine/7.50mm.json
@@ -88,7 +88,7 @@
     "material": [ "qt_steel" ],
     "symbol": "#",
     "color": "light_gray",
-    "ammo_type": [ "afs_7.50mm" ],
+    "ammo_type": [ "afs_7.50mm_smart" ],
     "flags": [ "MAG_BULKY" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "afs_7.50mm_smart": 80 } } ]
   }

--- a/data/mods/aftershock_exoplanet/spells/spells.json
+++ b/data/mods/aftershock_exoplanet/spells/spells.json
@@ -227,7 +227,7 @@
     "effect_str": "smart_targeted",
     "valid_targets": [ "hostile", "ground" ],
     "extra_effects": [ { "id": "vahagn_extra_shots", "hit_self": true } ],
-    "flags": [ "NO_EXPLOSION_SFX" ],
+    "flags": [ "NO_EXPLOSION_SFX", "SILENT" ],
     "min_damage": 0,
     "max_damage": 0,
     "min_bash_scaling": 1,
@@ -247,7 +247,7 @@
     "description": { "str": "Fires at up to 10 tagged targets", "//~": "NO_I18N" },
     "valid_targets": [ "self" ],
     "message": "Casted",
-    "flags": [ "NO_EXPLOSION_SFX" ],
+    "flags": [ "NO_EXPLOSION_SFX", "SILENT" ],
     "effect": "effect_on_condition",
     "effect_str": "EOC_vahagn_check_shootfoes",
     "shape": "blast"


### PR DESCRIPTION
#### Summary
Mods "Aftershock: Fix minor vahagn errors"

#### Purpose of change
Remove spell noises from shooting the vahagn.
Let magazines be reloaded in case you find more ammo.

#### Describe the solution
Very simple json stuff.

#### Testing
Spawned reloaded and shot the gun.