### PR TITLE
Remove reach attacks across z-levels

### DIFF
--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -754,6 +754,9 @@ void avatar_action::autoattack( avatar &you, map &m )
         if( reach == 1 && !you.is_adjacent( c, true ) ) {
             return true;
         }
+        if( !you.can_reach_attack( *c ) ) { // target on different z-level
+            return true;
+        }
         if( !c->is_npc() ) {
             return false;
         }

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -746,7 +746,7 @@ void avatar_action::autoattack( avatar &you, map &m )
         return;
     }
     const item_location weapon = you.get_wielded_item();
-    int reach = weapon ? weapon->reach_range( you ) : std::max( 1,
+    int reach = weapon ? weapon->reach_range( you ).first : std::max( 1,
                 static_cast<int>( you.calculate_by_enchantment( 1, enchant_vals::mod::MELEE_RANGE_MODIFIER ) ) );
     std::vector<Creature *> critters = you.get_targetable_creatures( reach, true );
     critters.erase( std::remove_if( critters.begin(), critters.end(), [&you,

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -6260,6 +6260,10 @@ std::vector<Creature *> Character::get_targetable_creatures( const int range, bo
             }
         }
         bool in_range = std::round( rl_dist_exact( pos_abs(), critter.pos_abs() ) ) <= range;
+        if( melee && !can_reach_attack( critter ) )
+        {
+            in_range = false;
+        }
         bool valid_target = this != &critter && pos_abs() != critter.pos_abs() && attitude_to( critter ) != Creature::Attitude::FRIENDLY;
         return valid_target && in_range && can_see;
     } );

--- a/src/character.h
+++ b/src/character.h
@@ -1156,6 +1156,7 @@ class Character : public Creature, public visitable
                                     bool allow_unarmed = true, int forced_movecost = -1 );
 
         /** Handles reach melee attacks */
+        bool can_reach_attack( const Creature &target ) const;
         void reach_attack( const tripoint_bub_ms &p, int forced_movecost = -1 );
 
         /**

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1783,7 +1783,7 @@ static void fire()
 
     const item_location weapon = you.get_wielded_item();
     // try reach weapon
-    if( weapon && !weapon->is_gun() && weapon->current_reach_range( you ) > 1 ) {
+    if( weapon && !weapon->is_gun() && weapon->current_reach_range( you ).first > 1 ) {
         reach_attack( you );
         return;
     }

--- a/src/item.h
+++ b/src/item.h
@@ -798,17 +798,19 @@ class item : public visitable
 
         /*
          * Max range of melee attack this weapon can be used for.
+         * First value is horizontal range, latter is vertical range
          * Accounts for character's abilities and installed gun mods.
          * Guaranteed to be at least 1
          */
-        int reach_range( const Character &guy ) const;
+        std::pair<int, int> reach_range( const Character &guy ) const;
 
         /*
          * Max range of melee attack this weapon can be used for in its current state.
+         * First value is horizontal range, latter is vertical range
          * Accounts for character's abilities and installed gun mods.
          * Guaranteed to be at least 1
          */
-        int current_reach_range( const Character &guy ) const;
+        std::pair<int, int> current_reach_range( const Character &guy ) const;
 
         /**
          * Sets time until activation for an item that will self-activate in the future.

--- a/src/item_gun_tool_ammo.cpp
+++ b/src/item_gun_tool_ammo.cpp
@@ -50,6 +50,7 @@
 #include "itype.h"
 #include "iuse.h"
 #include "iuse_actor.h"
+#include "line.h"
 #include "magic_enchantment.h"
 #include "map.h"
 #include "map_scale_constants.h"
@@ -688,7 +689,22 @@ damage_instance item::base_damage_thrown() const
     return type->thrown_damage;
 }
 
-int item::reach_range( const Character &guy ) const
+static int vert_reach_range( int horizontal_range )
+{
+    // Some future proofing. If you're debugging this fatal I hope you're the one that changed it!
+    const int vertical_tile_math = trig_dist( tripoint::zero, tripoint::above );
+    if( vertical_tile_math > 1 ) {
+        cata_fatal( "function expects vertical range of one due to hardcoded modifier" );
+    }
+
+    // Future vertical distance.
+    const int that_hardcoded_modifier = 4;
+    // Purposeful integer math, remainder is discarded. e.g. 3 / 4 = 0, not 0.75. Only integers are kept.
+    const int vert_res = horizontal_range / that_hardcoded_modifier;
+    return vert_res;
+}
+
+std::pair<int, int> item::reach_range( const Character &guy ) const
 {
     int res = 1;
     int reach_attack_add = has_flag( flag_REACH_ATTACK ) ? has_flag( flag_REACH3 ) ? 2 : 1 : 0;
@@ -714,10 +730,12 @@ int item::reach_range( const Character &guy ) const
         }
     }
 
-    return res;
+    const int vert_res = vert_reach_range( res );
+
+    return std::pair<int, int>( res, vert_res );
 }
 
-int item::current_reach_range( const Character &guy ) const
+std::pair<int, int> item::current_reach_range( const Character &guy ) const
 {
     int res = 1;
 
@@ -739,7 +757,9 @@ int item::current_reach_range( const Character &guy ) const
         }
     }
 
-    return res;
+    const int vert_res = vert_reach_range( res );
+
+    return std::pair<int, int>( res, vert_res );
 }
 
 bool item::has_technique( const matec_id &tech ) const

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -577,7 +577,7 @@ bool Character::melee_attack( Creature &t, bool allow_special, const matec_id &f
         add_msg_if_player( m_info, _( "You lack the substance to affect anything." ) );
         return false;
     }
-    if( !is_adjacent( &t, true ) ) {
+    if( !is_adjacent( &t, false ) ) {
         return false;
     }
 
@@ -1027,8 +1027,20 @@ int Character::get_total_melee_stamina_cost( const item *weap ) const
     return std::min<int>( -50, proficiency_multiplier * ( mod_sta + melee - stance_malus ) );
 }
 
+bool Character::can_reach_attack( const Creature &target ) const
+{
+    if( pos_bub().z() != target.pos_bub().z() ) {
+        return false;
+    }
+    return true;
+}
+
 void Character::reach_attack( const tripoint_bub_ms &p, int forced_movecost )
 {
+    if( this->pos_bub().z() != p.z() ) {
+        debugmsg( "%s tried to reach attack across z-level", disp_name() );
+        return;
+    }
     static const matec_id no_technique_id( "" );
     matec_id force_technique = no_technique_id;
     /** @EFFECT_MELEE >5 allows WHIP_DISARM technique */

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -815,7 +815,7 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
         // lacks the room to build up momentum on a slash.
         // In the case of a pike, the mass of the pole behind the wielder
         // should they choose to employ it up close will unbalance them.
-        if( cur_weap.reach_range( *this ) > 1 && !reach_attacking &&
+        if( cur_weap.reach_range( *this ).first > 1 && !reach_attacking &&
             cur_weap.has_flag( flag_POLEARM ) ) {
             d.mult_damage( 0.7 );
         }
@@ -1029,7 +1029,13 @@ int Character::get_total_melee_stamina_cost( const item *weap ) const
 
 bool Character::can_reach_attack( const Creature &target ) const
 {
-    if( pos_bub().z() != target.pos_bub().z() ) {
+    item_location maybe_weapon = get_wielded_item();
+    int vert_reach = 0;
+    if( maybe_weapon ) {
+        vert_reach = maybe_weapon->current_reach_range( *this ).second;
+    }
+
+    if( std::abs( pos_bub().z() - target.pos_bub().z() ) > vert_reach ) {
         return false;
     }
     return true;
@@ -1037,10 +1043,6 @@ bool Character::can_reach_attack( const Creature &target ) const
 
 void Character::reach_attack( const tripoint_bub_ms &p, int forced_movecost )
 {
-    if( this->pos_bub().z() != p.z() ) {
-        debugmsg( "%s tried to reach attack across z-level", disp_name() );
-        return;
-    }
     static const matec_id no_technique_id( "" );
     matec_id force_technique = no_technique_id;
     /** @EFFECT_MELEE >5 allows WHIP_DISARM technique */
@@ -2853,7 +2855,7 @@ double Character::melee_value( const item &weap ) const
     // start with average effective dps against a range of enemies
     double my_value = weap.average_dps( *this );
 
-    float reach = weap.reach_range( *this );
+    float reach = weap.reach_range( *this ).first;
     // value reach weapons more
     if( reach > 1.0f ) {
         my_value *= 1.0f + 0.5f * ( std::sqrt( reach ) - 1.0f );

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1159,7 +1159,14 @@ void monster::move()
         // in both circular and roguelike distance modes.
         const float distance_to_target = trig_dist( pos_bub(), destination );
         tripoint_bub_ms loc = pos_bub();
-        for( tripoint_bub_ms &candidate : squares_closer_to( loc, destination ) ) {
+        std::vector<tripoint_bub_ms> options = squares_closer_to( loc, destination );
+        if( destination.z() < loc.z() )  {
+            // HACK: Consider moving straight downward (because we might be flying!)
+            tripoint_bub_ms directly_below( loc.x(), loc.y(), loc.z() - 1 );
+            // EXTRA SUPER DUPER HACK: Put it at the front so it's checked first.
+            options.insert( options.begin(), directly_below );
+        }
+        for( tripoint_bub_ms &candidate : options ) {
             // rare scenario when monster is on the border of the map and it's goal is outside of the map
             if( !here.inbounds( candidate ) ) {
                 continue;
@@ -1178,7 +1185,8 @@ void monster::move()
             }
             const tripoint_abs_ms candidate_abs = here.get_abs( candidate );
 
-            if( candidate.z() != pos_abs().z() ) {
+            const bool is_z_move = candidate.z() != pos_abs().z();
+            if( is_z_move ) {
                 bool can_z_move = true;
                 if( !here.valid_move( pos_bub(), candidate, false, true, via_ramp ) ) {
                     // Can't phase through floor
@@ -1225,7 +1233,7 @@ void monster::move()
                     continue;
                 }
                 const Attitude att = attitude_to( *target );
-                if( att == Attitude::HOSTILE ) {
+                if( att == Attitude::HOSTILE && !is_z_move ) {
                     // When attacking an adjacent enemy, we're direct.
                     moved = true;
                     next_step = candidate_abs;
@@ -1911,7 +1919,7 @@ bool monster::attack_at( const tripoint_bub_ms &p )
     Character &player_character = get_player_character();
     const bool sees_player = sees( here, player_character );
     // Targeting player location
-    if( p == player_character.pos_bub() ) {
+    if( p == player_character.pos_bub() && p.z() == pos_bub().z() ) {
         if( sees_player ) {
             return melee_attack( player_character );
         } else {

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1632,7 +1632,7 @@ void npc::invalidate_range_cache()
         confident_range_cache = confident_shoot_range( *weapon,
                                 most_accurate_aiming_method_limit( *weapon ) );
     } else {
-        confident_range_cache = weapon->reach_range( *this );
+        confident_range_cache = weapon->reach_range( *this ).first;
     }
 }
 

--- a/src/npc_attack.cpp
+++ b/src/npc_attack.cpp
@@ -6,6 +6,7 @@
 #include <memory>
 #include <set>
 #include <string>
+#include <utility>
 
 #include "cata_utility.h"
 #include "character.h"
@@ -262,7 +263,7 @@ void npc_attack_melee::use( npc &source, const tripoint_bub_ms &location ) const
     }
     int target_distance = rl_dist( source.pos_bub(), location );
     if( !source.is_adjacent( critter, true ) ) {
-        if( target_distance <= weapon.reach_range( source ) ) {
+        if( target_distance <= weapon.reach_range( source ).first ) {
             add_msg_debug( debugmode::debug_filter::DF_NPC, "%s is attempting a reach attack",
                            source.disp_name() );
             // check for friendlies in the line of fire
@@ -419,7 +420,7 @@ npc_attack_rating npc_attack_melee::evaluate_critter( const npc &source,
     // rating against armored targets
     double damage{ weapon.base_damage_melee().total_damage() };
     damage *= 100.0 / weapon.attack_time( source );
-    const int reach_range{ weapon.reach_range( source ) };
+    const int reach_range{ weapon.reach_range( source ).first };
     const int distance_to_me = clamp( rl_dist( source.pos_bub(), critter->pos_bub() ) - reach_range, 0,
                                       10 );
     // Multiplier of 0.5f to 1.5f based on distance

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -512,7 +512,7 @@ target_handler::trajectory target_handler::mode_reach( avatar &you, item_locatio
     ui.you = &you;
     ui.mode = target_ui::TargetMode::Reach;
     ui.relevant = weapon.get_item();
-    ui.range = weapon ? weapon->current_reach_range( you ) : 1;
+    ui.range = weapon ? weapon->current_reach_range( you ).first : 1;
 
     restore_on_out_of_scope view_offset_prev( you.view_offset );
     return ui.run();
@@ -3635,7 +3635,7 @@ void target_ui::update_ammo_range_from_gun_mode()
         }
     } else {
         if( relevant->gun_current_mode().melee() ) {
-            range = relevant->current_reach_range( *you );
+            range = relevant->current_reach_range( *you ).first;
         } else {
             ammo = activity->reload_loc ? activity->reload_loc.get_item()->type :
                    relevant->gun_current_mode().target->ammo_data();
@@ -3736,7 +3736,7 @@ bool target_ui::action_switch_mode()
     } else {
         if( relevant->gun_current_mode().melee() ) {
             refresh = true;
-            range = relevant->current_reach_range( *you );
+            range = relevant->current_reach_range( *you ).first;
         } else {
             ammo = activity->reload_loc ? activity->reload_loc.get_item()->type :
                    relevant->gun_current_mode().target->ammo_data();

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -3136,6 +3136,10 @@ bool target_ui::set_cursor_pos( const tripoint_bub_ms &new_pos )
         valid_pos.z() = clamp( valid_pos.z(), -OVERMAP_DEPTH, OVERMAP_HEIGHT );
         // Or current view range
         valid_pos.z() = clamp( valid_pos.z() - src.z(), -fov_3d_z_range, fov_3d_z_range ) + src.z();
+        // Or across z-levels (in melee)
+        if( mode == TargetMode::Reach && src.z() != new_pos.z() ) {
+            return false;
+        }
 
         new_traj = here.find_clear_path( src, valid_pos );
         if( range == 1 ) {
@@ -3387,6 +3391,8 @@ void target_ui::update_status()
         // We're out of range. This can happen if we switch from long-ranged
         // gun mode to short-ranged. We can, of course, move the cursor into range automatically,
         // but that would be rude. Instead, wait for directional keys/etc. and *then* move the cursor.
+        status = Status::OutOfRange;
+    } else if( mode == TargetMode::Reach && src.z() != dst.z() ) {
         status = Status::OutOfRange;
     } else {
         status = Status::Good;

--- a/tests/monster_attack_test.cpp
+++ b/tests/monster_attack_test.cpp
@@ -109,13 +109,15 @@ static void test_monster_attack( const tripoint &target_offset, bool expect_atta
     reset_caches( a_zlev, t_zlev );
     CHECK( you.sees( here, target_monster ) == expect_vision );
     if( special_attack == nullptr ) {
+        // FIXME: This should be a reach attack!
         CHECK( you.melee_attack( target_monster, false ) == expect_attack );
     }
 }
 
 static void monster_attack_zlevel( const std::string &title, const tripoint &offset,
                                    const std::string &monster_ter, const std::string &target_ter,
-                                   const bool ledge, const bool expected_vertical, const bool expected_adjacent )
+                                   const bool ledge, const bool expected_vertical, const bool expected_adjacent,
+                                   const bool on_stairs = false )
 {
     clear_map_without_vision();
     map &here = get_map();
@@ -133,7 +135,11 @@ static void monster_attack_zlevel( const std::string &title, const tripoint &off
                 here.ter_set( target_location + more_offset, target_ledge );
             }
         }
-        test_monster_attack( offset, expected_vertical, expected_vertical );
+        if( on_stairs ) {
+            test_monster_attack( offset, false, expected_adjacent );
+        } else {
+            test_monster_attack( offset, expected_vertical, expected_vertical );
+        }
         if( ledge ) {
             here.ter_set( target_location, target_ledge );
         }
@@ -177,9 +183,9 @@ TEST_CASE( "monster_attack", "[vision][reachability]" )
     }
 
     monster_attack_zlevel( "attack_up_stairs", tripoint::above, "t_stairs_up", "t_stairs_down",
-                           false, true, true );
+                           false, false, true, true );
     monster_attack_zlevel( "attack_down_stairs", tripoint::below, "t_stairs_down", "t_stairs_up",
-                           false, true, true );
+                           false, false, true, true );
     monster_attack_zlevel( "attack through ceiling", tripoint::above, "t_floor", "t_floor",
                            false, false, false );
     monster_attack_zlevel( "attack through floor", tripoint::below, "t_floor", "t_floor",


### PR DESCRIPTION
#### Summary
Balance "Remove reach attacks across z-levels"

#### Purpose of change
First, a visual representation from our finest artists on Discord (@kevingranade ):
<img width="1080" height="1527" alt="image" src="https://github.com/user-attachments/assets/f0b27dd0-6e6c-40ff-9257-bf2ae4a32941" />

More to the point, reach attacking across z-levels is an essentially risk-free cheese. It's very simple to get onto a roof and poke an endless amount of zombies with cheap spears.

#### Describe the solution
Remove all ability for reach attacks to reach across z-levels.

Just in case I missed something, add a loud guard to the reach_attack() function.

#### Describe alternatives you've considered
~~Stop slacking on writing tests?~~

Changing the distance functions to return the extra z distance. Entirely possible, but changing fundamental distance calculations is a lot more invasive. This is the targeted approach.

Weapons getting stuck/dropped: No. Doesn't resolve the problem and was already removed for a reason.

Stumble and fall: As funny as letting people shoot themselves in the foot is, it's bad design. So again, no.

#### Testing
Tried various reach attack scenarios on the side of a rooftop with a pike. Could not reach attack with auto attacks or manually-aimed attacks. 'f'ire UI did not allow me to aim up/down levels with a melee weapon.

#### Additional context
