### PR TITLE
Reset calendar and weather between test cases

### DIFF
--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -10,6 +10,7 @@
 #include <exception>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <ostream>
 #include <random>
 #include <string>
@@ -52,6 +53,7 @@
 #include "string_formatter.h"
 #include "type_id.h"
 #include "weather.h"
+#include "weather_type.h"
 #include "worldfactory.h"
 
 static const mod_id MOD_INFORMATION_dda( "dda" );
@@ -265,6 +267,21 @@ struct CataListener : Catch::TestEventListenerBase {
             }
             Messages::clear_messages();
         }
+    }
+
+    void testCaseEnded( Catch::TestCaseStats const &testCaseStats ) override {
+        TestEventListenerBase::testCaseEnded( testCaseStats );
+        if( !needs_game ) {
+            return;
+        }
+        // Reset lightweight global state that tests commonly modify without
+        // restoring.  Expensive operations like clear_map() stay manual.
+        calendar::turn = calendar::turn_zero;
+        weather_manager &weather = get_weather();
+        weather.weather_override = WEATHER_NULL;
+        weather.windspeed_override.reset();
+        weather.set_nextweather( calendar::turn );
+        weather.clear_temp_cache();
     }
 
     bool assertionEnded( Catch::AssertionStats const &assertionStats ) override {

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -278,7 +278,7 @@ struct CataListener : Catch::TestEventListenerBase {
         // restoring.  Expensive operations like clear_map() stay manual.
         calendar::turn = calendar::turn_zero;
         weather_manager &weather = get_weather();
-        weather.weather_override = WEATHER_NULL;
+        weather.weather_override = WEATHER_NULL; // NOLINT(cata-tests-must-restore-global-state)
         weather.windspeed_override.reset();
         weather.set_nextweather( calendar::turn );
         weather.clear_temp_cache();


### PR DESCRIPTION
#### Summary
Infrastructure "Reset calendar and weather between test cases"

#### Purpose of change

`calendar::turn`, weather overrides, and temperature cache leak between test cases. Tests modify them without restoring, causing order-dependent flakiness. Ran into this while working on #85721 where a new test left the spawn point as open air, and the next test's `clear_avatar()` gravity-dropped the avatar underground.

#### Describe the solution

Adds a `testCaseEnded` hook to the existing Catch2 listener (`CataListener` in test_main.cpp) that resets lightweight global state after every test case:

- `calendar::turn` back to `turn_zero`
- `weather_override` back to `WEATHER_NULL`
- `windspeed_override` cleared
- weather nextweather trigger reset
- temperature cache cleared

Expensive operations like `clear_map()` stay manual and per-test.

Skipped entirely when running `[nogame]` tests (via existing `needs_game` flag).

#### Describe alternatives you've considered

RAII wrappers for each global (like the existing `scoped_weather_override`) -- works well but requires modifying every test that touches calendar or weather. The listener approach is automatic and catches forgotten cleanups without touching any test code.

#### Testing

All tests passed in CI.

#### Additional context