### PR TITLE
Remove redundant pull_request trigger from IWYU Suggester

### DIFF
--- a/.github/workflows/iwyu-linter.yml
+++ b/.github/workflows/iwyu-linter.yml
@@ -7,20 +7,13 @@ on:
       - '**.cpp'
       - '**.h'
       - '**.c'
-  pull_request:
-    types: ['opened', 'reopened', 'synchronize', 'ready_for_review']
-    paths:
-      - '**.cpp'
-      - '**.h'
-      - '**.c'
 
 concurrency:
-  group: iwyu-linter-${{ github.event.pull_request.number }}-${{ github.event_name }}
+  group: iwyu-linter-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   iwyu-suggest:
-    if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.draft == false }}
     runs-on: ubuntu-24.04
     env:
       COMPILER: clang++-19


### PR DESCRIPTION
#### Summary
Infrastructure "Remove redundant pull_request trigger from IWYU Suggester workflow"

#### Purpose of change

The IWYU Suggester workflow was triggering on both `pull_request` and `pull_request_target` events, but the job's `if` condition only allowed `pull_request_target` runs through. Every `pull_request` event created a workflow run that immediately skipped, cluttering the Actions tab.

Also removed the draft PR gate so the suggester runs on drafts too, matching the main IWYU workflow.

#### Describe the solution

- Removed the `pull_request` trigger entirely since the job needs `pull_request_target` for write permissions anyway
- Simplified the concurrency group (no longer need to disambiguate by event name)
- Dropped the `draft == false` condition from the job

#### Describe alternatives you've considered

Could have added `skip-duplicate-actions` like `matrix.yml` uses, but the root cause was simpler - just a trigger that could never actually run.

#### Testing

N/A

#### Additional context

None