### PR TITLE
Register active items in merge_submaps

### DIFF
--- a/src/submap.cpp
+++ b/src/submap.cpp
@@ -405,7 +405,8 @@ void submap::merge_submaps( submap *copy_from, bool copy_from_is_overlay )
             this->m->lum[x][y] += copy_from->m->lum[x][y];
 
             for( const item &itm : copy_from->m->itm[x][y] ) {
-                this->m->itm[x][y].emplace( itm );
+                const auto iter = this->m->itm[x][y].emplace( itm );
+                this->active_items.add( *iter, point_sm_ms( x, y ) );
             }
 
             for( std::map<field_type_id, field_entry>::iterator it = copy_from->m->fld[x][y].begin();
@@ -454,10 +455,7 @@ void submap::merge_submaps( submap *copy_from, bool copy_from_is_overlay )
         }
     }
 
-    // TODO: Copy the active item cache
-    if( !copy_from->active_items.empty() ) {
-        debugmsg( "Active items found on copied submap which is not supported." );
-    }
+    // Active items from copy_from are re-registered during item copy above.
 
     if( copy_from->last_touched > this->last_touched ) {
         this->last_touched = copy_from->last_touched;


### PR DESCRIPTION
#### Summary
Bugfixes "Fix random 'Active items found on copied submap' debugmsg during mapgen"

#### Purpose of change

`merge_submaps` copies items from overlay submaps but never registered them with the destination's `active_items` cache. This was a known TODO left behind in #74169 (3D mapgen), with a `debugmsg` canary that fires when cross-z-level mapgen places corpses or perishable food on lower floors. Since those items are RNG-dependent, it causes random CI failures.

#### Describe the solution

Call `active_items.add()` on each item right after emplacing it into the destination submap -- same pattern `revert_submap` already uses a few lines above.

#### Describe alternatives you've considered

Not really any, this is just a missing line.

#### Testing

- Compiled clean
- Mirrors the existing pattern in `revert_submap`

#### Additional context

The original TODO and debugmsg were added in commit 6efe406c32 ("Barely enough to get it to work") as part of #74169. The PR description notes: "The submap merging code has some fields that aren't merged due to a lack of knowledge on how to do it."