### PR TITLE
Add event_statistic() dialogue function to math parser

### DIFF
--- a/src/math_parser_diag.cpp
+++ b/src/math_parser_diag.cpp
@@ -14,6 +14,7 @@
 
 #include "bodypart.h"
 #include "calendar.h"
+#include "cata_variant.h"
 #include "cata_compiler_support.h"
 #include "cata_utility.h"
 #include "character.h"
@@ -47,6 +48,7 @@
 #include "pimpl.h"
 #include "point.h"
 #include "proficiency.h"
+#include "stats_tracker.h"
 #include "stomach.h"
 #include "talker.h"
 #include "translations.h"
@@ -56,6 +58,8 @@
 #include "weather_gen.h"
 #include "weather_type.h"
 #include "worldfactory.h"
+
+class event_statistic;
 
 /*
 General guidelines for writing dialogue functions
@@ -128,6 +132,18 @@ double option_eval( const_dialogue const &d, char /* scope */,
                     std::vector<diag_value> const &params, diag_kwargs const & /* kwargs */ )
 {
     return get_option<float>( params[0].str( d ), true );
+}
+
+double event_statistic_eval( const_dialogue const &d, char /* scope */,
+                             std::vector<diag_value> const &params,
+                             diag_kwargs const & /* kwargs */ )
+{
+    string_id<event_statistic> stat_id( params[0].str( d ) );
+    if( !stat_id.is_valid() ) {
+        throw math::runtime_error( R"(Unknown event_statistic "%s")", stat_id.str() );
+    }
+    cata_variant val = get_stats().value_of( stat_id );
+    return diag_value( val ).dbl( d );
 }
 
 double addiction_intensity_eval( const_dialogue const &d, char scope,
@@ -1735,6 +1751,7 @@ std::map<std::string_view, dialogue_func> const dialogue_funcs{
     { "health", { "un", 0, health_eval, health_ass } },
     { "encumbrance", { "un", 1, encumbrance_eval } },
     { "energy", { "g", 1, energy_eval } },
+    { "event_statistic", { "g", 1, event_statistic_eval } },
     { "faction_like", { "g", 1, faction_like_eval, faction_like_ass } },
     { "faction_respect", { "g", 1, faction_respect_eval, faction_respect_ass } },
     { "faction_trust", { "g", 1, faction_trust_eval, faction_trust_ass } },

--- a/tests/math_parser_test.cpp
+++ b/tests/math_parser_test.cpp
@@ -434,4 +434,12 @@ TEST_CASE( "math_parser_dialogue_integration", "[math_parser]" )
     testexp.eval( d );
     CHECK( get_avatar().get_stamina() == 459 );
 
+    // event_statistic lookup
+    CHECK( testexp.parse( "event_statistic('num_avatar_wake_ups')" ) );
+    CHECK( testexp.eval( d ) == 0 );
+
+    // invalid event_statistic should throw
+    CHECK( testexp.parse( "event_statistic('nonexistent_stat_blorg')" ) );
+    CHECK_THROWS_AS( testexp.eval( d ), math::exception );
+
 }


### PR DESCRIPTION
#### Summary
Features "Add event_statistic() dialogue function to math parser"

#### Purpose of change

Let EOC math expressions read event_statistic values (kill counts, damage taken, etc.).

#### Describe the solution

Global-scope dialogue function `event_statistic('stat_id')` - looks up the stat via `stats_tracker::value_of()`, returns it as a number. Throws on unknown IDs. Non-numeric stats (strings, tripoints) hit the same `math::runtime_error` as every other type mismatch in the math parser.

#### Describe alternatives you've considered

N/A

#### Testing

Tests in `math_parser_test.cpp` for valid lookup and unknown stat error. All math_parser tests pass.

#### Additional context

N/A