### PR TITLE
Disable upgrades for pseudo-dormant monsters

### DIFF
--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -531,6 +531,12 @@ mtype MonsterGenerator::generate_fake_pseudo_dormant_monster( const mtype &mon )
     fake_mon.zombify_into = mon.id;
     // looks like "corpse" + original mon
     fake_mon.looks_like = "corpse_" + mon.id.str();
+    // disable upgrades - pseudo-dormant monsters exist briefly and must not
+    // change type before they fire their dormant trap setup attack
+    fake_mon.upgrades = false;
+    // just in case, clear the upgrade targets too
+    fake_mon.upgrade_into = mtype_id::NULL_ID();
+    fake_mon.upgrade_group = mongroup_id::NULL_ID();
     // set the hp to 5
     fake_mon.hp = 5;
     // set the speed to 1


### PR DESCRIPTION
#### Summary
Bugfixes "Prevent pseudo-dormant monsters from upgrading before going dormant"

#### Purpose of change

Was investigating a flaky CI failure in `dormant_monsters_materialize_correctly`:
https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/22867725314/job/66338936835

Didn't find the root cause of that particular failure, but noticed a latent bug: pseudo-dormant monsters inherit the `upgrades` field from their base zombie type. In a real game, `on_load()` calls `try_upgrade()` which can change the monster's type before it fires its dormant trap setup attack. If a `pseudo_dormant_mon_zombie_fat` upgrades into, say, `mon_zombie_brute`, it loses its `pseudo_dormant_trap_setup` special attack entirely and just walks around as a regular brute - the dormant corpse mechanic silently breaks for that spawn.

Doesn't manifest in tests because calendar starts at `turn_zero` so upgrades never trigger. But in a real game with actual calendar progression, a monster with `half_life: 128` has a reasonable chance of upgrading on materialization.

#### Describe the solution

Set `upgrades = false` on the generated pseudo-dormant mtype, same pattern as the generator already uses for dodge, regen, armor, etc.

#### Describe alternatives you've considered

Could set it in JSON per-monster, but since the generator already programmatically strips a bunch of stuff, this fits right in.

#### Testing

Code inspection. The generator already handles similar fields the same way.

#### Additional context

None