### PR TITLE
Fix missing faction ownership in bulk trade/donate

### DIFF
--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -5126,6 +5126,7 @@ talk_effect_fun_t::func f_bulk_trade_accept( const JsonObject &jo, std::string_v
             // Now let's actually transfer the items!
             for( item *transferred : items_to_transfer ) {
                 item transfer_copy( *transferred );
+                transfer_copy.set_owner( *buyer->get_character() );
                 buyer->i_add_or_drop( transfer_copy );
 
                 auto remove_items_filter = [&]( const item & it ) {
@@ -5141,6 +5142,7 @@ talk_effect_fun_t::func f_bulk_trade_accept( const JsonObject &jo, std::string_v
             int number_transferred = 0;
             for( item *transferred : items_to_transfer ) {
                 item transfer_copy( *transferred );
+                transfer_copy.set_owner( *buyer->get_character() );
                 buyer->i_add_or_drop( transfer_copy );
 
                 // Count now, while the item still exists


### PR DESCRIPTION
#### Summary
Bugfixes "Fix infinite trade exploit from missing faction ownership in bulk trade"

#### Purpose of change

Closes #85760

`u_bulk_trade_accept` and `u_bulk_donate` never set faction ownership on transferred items. When an NPC's inventory overflows and items get dropped, they keep the player's faction ownership, so you can pick them up and sell them again for free.

#### Describe the solution

Call `set_owner()` on the item copy before `i_add_or_drop`, same as the regular trade UI already does in `npc_trading::transfer_items`.

#### Describe alternatives you've considered

Could also expand NPC faction zones to cover their whole area, but that's a band-aid - the ownership should be set regardless.

#### Testing

Read the code. The regular trade path in `npctrade.cpp` does the same `set_owner(receiver)` call - this just brings `bulk_trade_accept` in line with it.

#### Additional context

None