### PR TITLE
Fix NPC wield_better_weapon selecting items inside wielded container

### DIFF
--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1575,23 +1575,56 @@ static void choose_best_MA_style( npc *you )
 
 bool npc::wield( item &it )
 {
-    // dont unwield if you already wield the item
     if( is_wielding( it ) ) {
         return true;
     }
-    // instead of unwield(), call stow_item, allowing to wear it and check it is not inside wielded item
-    if( has_wield_conflicts( it ) && !get_wielded_item()->has_item( it ) ) {
-        stow_item( *get_wielded_item() );
-    }
-    if( !Character::wield( it ) ) {
-        return false;
-    }
-    if( get_wielded_item() ) {
-        // add_msg_if_player_sees does no internal npc name replacement
-        add_msg_if_player_sees( *this, m_info, replace_with_npc_name( _( "<npcname> wields a %s." ) ),
-                                get_wielded_item()->tname() );
+
+    item extracted;
+
+    item_location wielded = get_wielded_item();
+    if( has_wield_conflicts( it ) ) {
+        if( wielded && wielded->has_item( it ) ) {
+            // Item is inside the wielded container. Check wieldability
+            // before extracting - once extracted, reinsertion is not
+            // guaranteed (container may be stowed into a different pocket).
+            if( !can_wield( it ).success() ) {
+                return false;
+            }
+            // Compute retrieval cost while we still have the container
+            // reference. Uses item_retrieve_cost for skill-scaled draw
+            // speed, matching wield_contents semantics.
+            int retrieve_mv = item_retrieve_cost( it, *wielded );
+            extracted = it;
+            wielded->remove_item( it );
+            stow_item( *get_wielded_item() );
+            if( !Character::wield( extracted, retrieve_mv ) ) {
+                // can_wield passed above, so this should not happen.
+                // If it does, put the item into inventory or drop it.
+                map &here = get_map();
+                if( can_stash( extracted ) ) {
+                    i_add( extracted, true, nullptr, nullptr, true, false );
+                } else {
+                    here.add_item_or_charges( pos_bub( here ), extracted );
+                }
+                return false;
+            }
+        } else {
+            stow_item( *get_wielded_item() );
+            if( !Character::wield( it ) ) {
+                return false;
+            }
+        }
+    } else {
+        if( !Character::wield( it ) ) {
+            return false;
+        }
     }
 
+    if( get_wielded_item() ) {
+        add_msg_if_player_sees( *this, m_info,
+                                replace_with_npc_name( _( "<npcname> wields a %s." ) ),
+                                get_wielded_item()->tname() );
+    }
     choose_best_MA_style( this );
     invalidate_range_cache();
     return true;

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -4198,6 +4198,13 @@ item *npc::evaluate_best_weapon() const
 
     //Now check through the NPC's inventory for melee weapons, guns, or holstered items
     visit_items( [this, &weap, &best_value, &best]( item * node, item * ) {
+        // The wielded weapon is already evaluated above. Skip it and its
+        // contents here - we can't extract items from inside it without
+        // stowing it first, and npc::wield() has no logic for that.
+        // TODO: teach npc::wield() to stow the weapon first, then remove this
+        if( node == &weap ) {
+            return VisitResponse::SKIP;
+        }
         if( can_wield( *node ).success() ) {
             double weapon_value = 0.0;
             bool using_same_type_bionic_weapon = is_using_bionic_weapon()

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -4198,12 +4198,12 @@ item *npc::evaluate_best_weapon() const
 
     //Now check through the NPC's inventory for melee weapons, guns, or holstered items
     visit_items( [this, &weap, &best_value, &best]( item * node, item * ) {
-        // The wielded weapon is already evaluated above. Skip it and its
-        // contents here - we can't extract items from inside it without
-        // stowing it first, and npc::wield() has no logic for that.
-        // TODO: teach npc::wield() to stow the weapon first, then remove this
         if( node == &weap ) {
-            return VisitResponse::SKIP;
+            // Weapon is already evaluated above with danger multiplier.
+            // Return NEXT to visit its contents (items inside containers
+            // that might be better weapons). CONTAINER pockets only -
+            // gun mags/mods are in non-CONTAINER pockets, not visited.
+            return VisitResponse::NEXT;
         }
         if( can_wield( *node ).success() ) {
             double weapon_value = 0.0;

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -695,7 +695,7 @@ TEST_CASE( "npc_prefers_guns", "[npc_ai]" )
     REQUIRE( hostile.get_wielded_item().get_item()->is_gun() );
 }
 
-TEST_CASE( "npc_ignores_weapons_inside_wielded_item", "[npc_ai]" )
+TEST_CASE( "npc_extracts_weapon_from_wielded_container", "[npc_ai]" )
 {
     g->faction_manager_ptr->create_if_needed();
 
@@ -731,13 +731,17 @@ TEST_CASE( "npc_ignores_weapons_inside_wielded_item", "[npc_ai]" )
     hostile.regen_ai_cache();
     CHECK( hostile.danger_assessment() > 1.0f );
 
-    // The NPC should NOT select the bat from inside the wielded backpack.
-    // evaluate_best_weapon returns &weap (the weapon itself) when nothing
-    // better is found, so check that best IS the weapon, not something inside it
+    // evaluate_best_weapon should find the bat inside the backpack
     item *best = hostile.evaluate_best_weapon();
     item_location wielded = hostile.get_wielded_item();
-    CHECK( best == wielded.get_item() );
+    CHECK( best != wielded.get_item() );
+    CHECK( best->typeId() == itype_bat );
 
-    // wield_better_weapon should not trigger a debugmsg
+    // wield_better_weapon should extract the bat and wield it
     hostile.wield_better_weapon();
+    REQUIRE( hostile.get_wielded_item() );
+    CHECK( hostile.get_wielded_item()->typeId() == itype_bat );
+
+    // The backpack should no longer be wielded
+    CHECK( hostile.get_wielded_item()->typeId() != itype_debug_backpack );
 }

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -34,6 +34,7 @@
 #include "output.h"
 #include "overmapbuffer.h"
 #include "pathfinding.h"
+#include "pocket_type.h"
 #include "pimpl.h"
 #include "player_helpers.h"
 #include "point.h"
@@ -692,4 +693,51 @@ TEST_CASE( "npc_prefers_guns", "[npc_ai]" )
 
     CAPTURE( hostile.get_wielded_item().get_item()->tname() );
     REQUIRE( hostile.get_wielded_item().get_item()->is_gun() );
+}
+
+TEST_CASE( "npc_ignores_weapons_inside_wielded_item", "[npc_ai]" )
+{
+    g->faction_manager_ptr->create_if_needed();
+
+    clear_map_without_vision();
+    clear_avatar();
+    set_time_to_day();
+
+    Character &player_character = get_player_character();
+    point five_tiles_south = {0, 5};
+    npc &hostile = spawn_npc( player_character.pos_bub().xy() + five_tiles_south, "thug" );
+    hostile.clear_worn();
+    hostile.invalidate_crafting_inventory();
+    hostile.inv->clear();
+    hostile.remove_weapon();
+    hostile.clear_mutations();
+    hostile.set_body();
+    hostile.mutation_category_level.clear();
+    hostile.clear_bionics();
+    REQUIRE( rl_dist( player_character.pos_bub(), hostile.pos_bub() ) >= 4 );
+    hostile.set_attitude( NPCATT_KILL );
+    hostile.name = "Enemy NPC";
+
+    // Wield a non-melee container with a melee weapon inside
+    item backpack( itype_debug_backpack );
+    backpack.force_insert_item( item( itype_bat ), pocket_type::CONTAINER );
+    REQUIRE( !backpack.empty() );
+    hostile.set_wielded_item( backpack );
+    REQUIRE( hostile.get_wielded_item() );
+    REQUIRE( !hostile.get_wielded_item()->is_melee() );
+
+    // Trigger danger awareness so the NPC considers switching weapons
+    arm_shooter( player_character, itype_M24 );
+    hostile.regen_ai_cache();
+    CHECK( hostile.danger_assessment() > 1.0f );
+
+    // The NPC should NOT select the bat from inside the wielded backpack.
+    // evaluate_best_weapon returns &weap (the weapon itself) when nothing
+    // better is found, so check that best IS the weapon, not something inside it
+    item *best = hostile.evaluate_best_weapon();
+    item_location wielded = hostile.get_wielded_item();
+    CHECK( best == wielded.get_item() );
+
+    // wield_better_weapon should not trigger a debugmsg
+    hostile.wield_better_weapon();
 }

--- a/tests/wield_test.cpp
+++ b/tests/wield_test.cpp
@@ -316,7 +316,12 @@ TEST_CASE( "Wield_test", "[wield]" )
                 }
 
                 AND_WHEN( "trying to wield contained item" ) {
-                    REQUIRE_FALSE( guy.wield( *knife_loc ) );
+                    REQUIRE( guy.wield( *knife_loc ) );
+
+                    THEN( "you wield the knife, not the sheath" ) {
+                        REQUIRE( guy.get_wielded_item() );
+                        CHECK( guy.get_wielded_item()->typeId() == itype_knife_combat );
+                    }
                 }
 
                 AND_WHEN( "trying to wield contained item_location" ) {


### PR DESCRIPTION
#### Summary
Bugfixes "Fix NPC failing to wield weapons from inside wielded container"

#### Purpose of change

Fixes #85728

Also observed in https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/22884533483/job/66395613310?pr=85759

When an NPC wields a non-weapon container (e.g. a backpack) that has a weapon inside, `evaluate_best_weapon()` finds that weapon but `npc::wield()` can't extract it - `Character::wield()` rejects items from inside the wielded container, producing a debugmsg.

#### Describe the solution

1. `npc::wield(item&)`: when the target is inside the wielded container, copy it out, remove from container, stow via `stow_item()`, wield the copy. Pre-checks `can_wield` before extracting. Uses `item_retrieve_cost` for skill-scaled draw speed.

2. `evaluate_best_weapon()`: return NEXT instead of SKIP on the wielded weapon node so the visitor enters container contents. The weapon itself is already evaluated at the top with the danger multiplier, so re-encountering it is harmless.

#### Describe alternatives you've considered

Could use `Character::wield_contents()` directly, but it goes through `unwield()` -> `dispose_item()` which shows a UI menu and returns false in test_mode. `stow_item()` avoids that.

#### Testing

Created test `npc_extracts_weapon_from_wielded_container`: wields a debug_backpack with a bat inside, verifies `evaluate_best_weapon` finds the bat, `wield_better_weapon` extracts and wields it, and the backpack is no longer wielded.

Updated `Wield_test` in wield_test.cpp (from #80448, which was written to catch regressions from the wield refactor in #79719): the "trying to wield contained item" case for NPCs previously expected `wield(*knife_loc)` to fail (`REQUIRE_FALSE`), since that was the old behavior. Now that `npc::wield()` handles extraction, it succeeds and the test verifies the knife ends up wielded.

The `item_location` overload test (`guy.wield(knife_loc)`) still correctly expects failure - `npc::wield(item_location)` goes through `Character::wield(item_location)` which doesn't have the extraction logic.

All `[npc_ai]` and `Wield_test` tests pass (275 assertions, 4 test cases).

#### Additional context

First commit added a SKIP workaround preventing NPCs from seeing weapons inside wielded containers. Second commit replaces it with the proper extract-stow-wield logic.