### PR TITLE
Prioritize hostile targets over neutral when firing

### DIFF
--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -3300,8 +3300,17 @@ void target_ui::update_target_list()
             targets.push_back( target->pos_bub() );
         }
     }
+    // Sort hostile creatures first, then by distance within each group.
+    creature_tracker &creatures = get_creature_tracker();
     std::sort( targets.begin(), targets.end(), [&]( const tripoint_bub_ms lhs,
     const tripoint_bub_ms rhs ) {
+        const Creature *cl = creatures.creature_at( lhs, true );
+        const Creature *cr = creatures.creature_at( rhs, true );
+        const bool lhs_hostile = cl && cl->attitude_to( *you ) == Creature::Attitude::HOSTILE;
+        const bool rhs_hostile = cr && cr->attitude_to( *you ) == Creature::Attitude::HOSTILE;
+        if( lhs_hostile != rhs_hostile ) {
+            return lhs_hostile;
+        }
         return rl_dist_exact( lhs, you->pos_bub() ) < rl_dist_exact( rhs, you->pos_bub() );
     } );
 }


### PR DESCRIPTION
#### Summary
Interface "Prioritize hostile targets over neutral when firing"

#### Purpose of change

When pressing 'f' to fire near neutral NPCs (like during "Clear Back Bay"), the auto-target picks the closest targetable creature regardless of hostility. Friendly creatures are already filtered out, but neutral ones aren't - so a neutral NPC standing closer than an actual enemy gets auto-targeted instead.

#### Describe the solution

The target list sort now uses a two-level key: hostility first, distance second. Hostile creatures always sort before neutral ones, and within each group they're still ordered by distance. Tab-cycling also benefits from this ordering.

#### Describe alternatives you've considered

Accidentally wiping out all refugee center guards every time you press 'f'.

#### Testing

Built and verified no compile errors. The change is a comparator-only modification to an existing `std::sort` call, no new control flow.

#### Additional context

None