### PR TITLE
Properly show materials for repair, not material type

### DIFF
--- a/src/item_info.cpp
+++ b/src/item_info.cpp
@@ -3172,7 +3172,7 @@ void item::repair_info( std::vector<iteminfo> &info, const iteminfo_query *parts
 
         const std::string repairs_with = enumerate_as_string( type->repairs_with,
         []( const material_id & e ) {
-            return string_format( "<info>%s</info>", e->name() );
+            return string_format( "<info>%s</info>", e->repaired_with()->nname( 1 ) );
         } );
         if( !repairs_with.empty() ) {
             info.emplace_back( "DESCRIPTION", string_format( _( "<bold>With</bold> %s." ), repairs_with ) );

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -2674,14 +2674,14 @@ TEST_CASE( "repairable_and_with_what_tools", "[iteminfo][repair]" )
     CHECK( item_info_str( halligan, repaired ) ==
            "--\n"
            "<color_c_white>Repair</color> using integrated welder, arc welder, makeshift arc welder, or high-temperature welding kit.\n"
-           "<color_c_white>With</color> <color_c_cyan>Steel</color>.\n"
+           "<color_c_white>With</color> <color_c_cyan>chunk of steel</color>.\n"
          );
 
     // FIXME: Use an item that can only be repaired by test tools
     CHECK( item_info_str( hazmat, repaired ) ==
            "--\n"
            "<color_c_white>Repair</color> using integrated soldering iron, integrated welder, gunsmith repair kit, firearm repair kit, soldering iron, portable soldering iron, or TEST soldering iron.\n"
-           "<color_c_white>With</color> <color_c_cyan>Plastic</color>.\n" );
+           "<color_c_white>With</color> <color_c_cyan>plastic chunk</color>.\n" );
 
     CHECK( item_info_str( rock, repaired ) ==
            "--\n"


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
A while back the repair iteminfo changed to showing material name instead of item name. This is troublesome because frankly nobody knows what "Low Carbon Steel" is. Well the item it actually needs is "chunk of mild steel".

#### Describe the solution
So, just show that.

<img width="803" height="60" alt="image" src="https://github.com/user-attachments/assets/00554100-c173-434c-99f8-f11b21b18cd8" />

--->

<img width="802" height="53" alt="image" src="https://github.com/user-attachments/assets/84ae0019-2eb7-4242-90e2-b7625311393b" />


I wasn't able to immediately git blame when/why we started using material names, but it's a simple mistake to make.

#### Describe alternatives you've considered
Continue procrastinating in the hopes we will move to a fully fault-based damage system?

#### Testing
Images

#### Additional context
