### PR TITLE
Fix character generation with custom XP scaling

### DIFF
--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -714,18 +714,6 @@ void Character::add_random_hobby( std::vector<profession_id> &choices )
     }
 }
 
-static int calculate_cumulative_experience( int level )
-{
-    int sum = 0;
-
-    while( level > 0 ) {
-        sum += 10000 * level * level;
-        level--;
-    }
-
-    return sum;
-}
-
 bool avatar::create( character_type type, const std::string &tempname )
 {
     loading_ui::done();
@@ -852,20 +840,14 @@ bool avatar::create( character_type type, const std::string &tempname )
 
 void Character::set_skills_from_hobbies( bool no_override )
 {
-    // 2 for an average person
-    float catchup_modifier = 1.0f + ( 2.0f * get_int() + get_per() ) / 24.0f;
-    // 1.2 for an average person, always a bit higher than base amount
-    float knowledge_modifier = 1.0f + get_int() / 40.0f;
-    // Grab skills from hobbies and train
     for( const profession *profession : hobbies ) {
         for( const profession::StartingSkill &e : profession->skills() ) {
-            if( no_override && get_skill_level( e.first ) != 0 ) {
+            if( no_override ) {
                 continue;
             }
-            // Train our skill
-            const int skill_xp_bonus = calculate_cumulative_experience( e.second );
-            get_skill_level_object( e.first ).train( skill_xp_bonus, catchup_modifier,
-                    knowledge_modifier, true );
+            if( get_skill_level( e.first ) < e.second ) {
+                set_skill_level( e.first, e.second );
+            }
         }
     }
 }
@@ -3105,6 +3087,14 @@ void set_skills( tab_manager &tabs, avatar &u, pool_type pool )
                         break;
                     }
                 }
+                for( const profession *hobby : u.hobbies ) {
+                    for( auto &hobby_skill : hobby->skills() ) {
+                        if( hobby_skill.first == thisSkill->ident() ) {
+                            prof_skill_level = std::max( prof_skill_level, hobby_skill.second );
+                            break;
+                        }
+                    }
+                }
             }
             const point opt_pos( 1, y );
             std::string skill_text;
@@ -4000,50 +3990,33 @@ void set_description( tab_manager &tabs, avatar &you, const bool allow_reroll,
 
             int line = 1;
             bool has_skills = false;
-            profession::StartingSkillList list_skills = you.prof->skills();
 
             for( const Skill *&elem : skillslist ) {
                 int level = you.get_skill_level( elem->ident() );
 
                 // Handle skills from professions
                 if( pool != pool_type::TRANSFER ) {
-                    profession::StartingSkillList::iterator i = list_skills.begin();
-                    while( i != list_skills.end() ) {
-                        if( i->first == elem->ident() ) {
-                            level += i->second;
+                    for( auto &prof_skill : you.prof->skills() ) {
+                        if( prof_skill.first == elem->ident() ) {
+                            level += prof_skill.second;
                             break;
                         }
-                        ++i;
                     }
                 }
 
                 // Handle skills from hobbies
-                int leftover_exp = 0;
-                int exp_to_level = 10000 * ( level + 1 ) * ( level + 1 );
-                for( const profession *profession : you.hobbies ) {
-                    profession::StartingSkillList hobby_skills = profession->skills();
-                    profession::StartingSkillList::iterator i = hobby_skills.begin();
-                    while( i != hobby_skills.end() ) {
-                        if( i->first == elem->ident() ) {
-                            int skill_exp_bonus = leftover_exp + calculate_cumulative_experience( i->second );
-                            // Calculate Level up to find final level and remaining exp
-                            while( skill_exp_bonus >= exp_to_level ) {
-                                level++;
-                                skill_exp_bonus -= exp_to_level;
-                                exp_to_level = 10000 * ( level + 1 ) * ( level + 1 );
-                            }
-                            leftover_exp = skill_exp_bonus;
+                for( const profession *hobby : you.hobbies ) {
+                    for( auto &hobby_skill : hobby->skills() ) {
+                        if( hobby_skill.first == elem->ident() ) {
+                            level = std::max( level, hobby_skill.second );
                             break;
                         }
-                        ++i;
                     }
                 }
 
                 if( level > 0 ) {
-                    const int exp_percent = 100 * leftover_exp / exp_to_level;
-                    mvwprintz( w_skills, point( 0, line ), c_light_gray,
-                               elem->name() + ":" );
-                    right_print( w_skills, line, 1, c_light_gray, string_format( "%d(%2d%%)", level, exp_percent ) );
+                    mvwprintz( w_skills, point( 0, line ), c_light_gray, elem->name() + ":" );
+                    right_print( w_skills, line, 1, c_light_gray, string_format( "%d", level ) );
                     line++;
                     has_skills = true;
                 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Fix character generation with custom XP scaling"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

For new characters, skills granted by hobbies are added as XP instead of direct levels. When playing with custom `SKILL_TRAINING_SPEED`, this XP is "trained" and affected by this amount. For example, I started a run with 0.25 as value, that means all skills that should with `1` from default hobbies are now at 25% instead.  The world option is for slowing the skill progression during a run, but chargen should be what you see is what you get. 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Bit of hack, but the simplest thing that could work, is before training a new char with XP from hobbies I multiply by the inverse of the variable. That will be correct downstream to become the right amount.

As part of this change, the presentation of the SKILL tab, when presented as X + Y where X is skill value from professions + bonus, apply the same logic used on summary so both skill tab and summary are consistent.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

The current behavior makes sense with old point buy system, where backgrounds would cost you points so you want some of the skills trained even as diminishing returns. I would rather have the skill simply set to the max value between profession and all backgrounds (plus added bonus from skill tab). Code is simpler / less duplicated and as a player is the behavior I initially expected TBH. Also, is future proof in case learning change, like the pooled XP idea from Erk.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

Generate a char on a world with 0.25 skill xp scaling, new char have expected level in all skills.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
