### PR TITLE
Filter get_avg_coverage() by viewer anatomy

### DIFF
--- a/data/mods/TEST_DATA/body_parts.json
+++ b/data/mods/TEST_DATA/body_parts.json
@@ -301,6 +301,36 @@
     "name": "right bird foot"
   },
   {
+    "id": "test_partial_wing_l",
+    "type": "body_part",
+    "copy-from": "test_bird_wing_l",
+    "name": "left partial wing",
+    "heading": "L. P.Wing",
+    "hp_bar_ui_text": "L P.WING",
+    "main_part": "test_partial_wing_l",
+    "opposite_part": "test_partial_wing_l",
+    "sub_parts": [ "sub_test_partial_wing_shoulder_l", "sub_test_partial_wing_lower_l" ]
+  },
+  {
+    "id": "sub_test_partial_wing_shoulder_l",
+    "type": "sub_body_part",
+    "parent": "test_partial_wing_l",
+    "name": "left partial wing shoulder",
+    "side": "left",
+    "opposite": "sub_test_partial_wing_shoulder_l",
+    "max_coverage": 25
+  },
+  {
+    "id": "sub_test_partial_wing_lower_l",
+    "type": "sub_body_part",
+    "parent": "test_partial_wing_l",
+    "name": "lower left partial wing",
+    "side": "left",
+    "opposite": "sub_test_partial_wing_lower_l",
+    "secondary": true,
+    "max_coverage": 75
+  },
+  {
     "type": "enchantment",
     "id": "ENCH_TEST_TAIL",
     "condition": "ALWAYS",

--- a/src/item.h
+++ b/src/item.h
@@ -2349,6 +2349,9 @@ class item : public visitable
          * Returns the average coverage of each piece of data this item
          */
         int get_avg_coverage( const cover_type &type = cover_type::COVER_DEFAULT ) const;
+        // Filtered overload: only counts body parts present in relevant_parts
+        int get_avg_coverage( const body_part_set &relevant_parts,
+                              const cover_type &type = cover_type::COVER_DEFAULT ) const;
         /**
          * Returns the highest coverage that any piece of data that this item has that covers the bodypart.
          * Values range from 0 (not covering anything) to 100 (covering the whole body part).

--- a/src/item_armor.cpp
+++ b/src/item_armor.cpp
@@ -764,6 +764,15 @@ item::cover_type item::get_cover_type( const damage_type_id &type )
 
 int item::get_avg_coverage( const cover_type &type ) const
 {
+    const Character &viewer = get_player_character();
+    body_part_set viewer_parts;
+    viewer_parts.fill( viewer.get_all_body_parts() );
+    return get_avg_coverage( viewer_parts, type );
+}
+
+int item::get_avg_coverage( const body_part_set &relevant_parts,
+                            const cover_type &type ) const
+{
     const islot_armor *t = find_armor_data();
     if( !t ) {
         return 0;
@@ -773,6 +782,9 @@ int item::get_avg_coverage( const cover_type &type ) const
     for( const armor_portion_data &entry : t->data ) {
         if( entry.covers.has_value() ) {
             for( const bodypart_str_id &limb : entry.covers.value() ) {
+                if( !relevant_parts.test( limb ) ) {
+                    continue;
+                }
                 int coverage = get_coverage( limb, type );
                 if( coverage ) {
                     avg_coverage += coverage;
@@ -781,12 +793,7 @@ int item::get_avg_coverage( const cover_type &type ) const
             }
         }
     }
-    if( avg_coverage == 0 ) {
-        return 0;
-    } else {
-        avg_coverage /= avg_ctr;
-        return avg_coverage;
-    }
+    return avg_ctr > 0 ? avg_coverage / avg_ctr : 0;
 }
 
 int item::get_coverage( const bodypart_id &bodypart, const cover_type &type ) const

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -3366,4 +3366,22 @@ TEST_CASE( "armor_info_character_aware_body_parts", "[iteminfo][armor][limbs]" )
         CHECK( wrm.find( "Warmth" ) == std::string::npos );
         CHECK( brt.find( "Breathability" ) == std::string::npos );
     }
+
+    SECTION( "coverage value correct for default human" ) {
+        clear_avatar();
+        item longshirt( itype_test_longshirt );
+        std::string info = item_info_str( longshirt, { iteminfo_parts::ARMOR_COVERAGE } );
+        CHECK( info.find( "<color_c_yellow>90</color>%" ) != std::string::npos );
+        CHECK( info.find( arms_frag ) != std::string::npos );
+        CHECK( info.find( torso_frag ) != std::string::npos );
+    }
+
+    SECTION( "coverage value correct for alt-arm character" ) {
+        make_alt_arm_viewer();
+        item longshirt( itype_test_longshirt );
+        std::string info = item_info_str( longshirt, { iteminfo_parts::ARMOR_COVERAGE } );
+        CHECK( info.find( "<color_c_yellow>90</color>%" ) != std::string::npos );
+        CHECK( info.find( alt_arms_frag ) != std::string::npos );
+        CHECK( info.find( torso_frag ) != std::string::npos );
+    }
 }

--- a/tests/limb_test.cpp
+++ b/tests/limb_test.cpp
@@ -27,12 +27,14 @@
 #include "weather_gen.h"
 #include "weather_type.h"
 
+static const bodypart_str_id body_part_test_alt_arm_l( "test_alt_arm_l" );
 static const bodypart_str_id body_part_test_bird_foot_l( "test_bird_foot_l" );
 static const bodypart_str_id body_part_test_bird_foot_r( "test_bird_foot_r" );
 static const bodypart_str_id body_part_test_bird_wing_l( "test_bird_wing_l" );
 static const bodypart_str_id body_part_test_bird_wing_r( "test_bird_wing_r" );
 static const bodypart_str_id body_part_test_corvid_beak( "test_corvid_beak" );
 static const bodypart_str_id body_part_test_lizard_tail( "test_lizard_tail" );
+static const bodypart_str_id body_part_test_partial_wing_l( "test_partial_wing_l" );
 
 static const character_modifier_id character_modifier_liquid_consume_mod( "liquid_consume_mod" );
 static const character_modifier_id character_modifier_solid_consume_mod( "solid_consume_mod" );
@@ -40,12 +42,14 @@ static const character_modifier_id character_modifier_solid_consume_mod( "solid_
 static const efftype_id effect_mending( "mending" );
 static const efftype_id effect_winded_arm_r( "winded_arm_r" );
 
+static const enchantment_id enchantment_ENCH_TEST_ALT_ARMS( "ENCH_TEST_ALT_ARMS" );
 static const enchantment_id enchantment_ENCH_TEST_BIRD_PARTS( "ENCH_TEST_BIRD_PARTS" );
 static const enchantment_id enchantment_ENCH_TEST_LIZARD_TAIL( "ENCH_TEST_LIZARD_TAIL" );
 
 static const itype_id itype_test_bird_boots( "test_bird_boots" );
 static const itype_id itype_test_jumpsuit_cotton( "test_jumpsuit_cotton" );
 static const itype_id itype_test_liquid( "test_liquid" );
+static const itype_id itype_test_longshirt( "test_longshirt" );
 static const itype_id itype_test_pine_nuts( "test_pine_nuts" );
 static const itype_id itype_test_shackles( "test_shackles" );
 static const itype_id itype_test_winglets( "test_winglets" );
@@ -307,4 +311,48 @@ TEST_CASE( "Limb_armor_coverage", "[character][limb][armor]" )
     // Backwards population of coverage works as well
     CHECK( bird_boots.covers( body_part_test_bird_foot_l ) );
     CHECK( bird_boots.covers( body_part_test_bird_foot_r ) );
+}
+
+TEST_CASE( "get_avg_coverage_filters_phantom_limbs", "[character][limb][armor]" )
+{
+    item test_shackles( itype_test_shackles );
+
+    SECTION( "fixture wiring" ) {
+        // Partial wing picked up via similar_bodypart with scaled coverage
+        REQUIRE( test_shackles.covers( body_part_test_partial_wing_l ) );
+        REQUIRE( test_shackles.portion_for_bodypart( body_part_test_partial_wing_l ) );
+        REQUIRE( test_shackles.portion_for_bodypart(
+                     body_part_test_partial_wing_l )->coverage == 25 );
+    }
+
+    SECTION( "default human sees only own body parts" ) {
+        clear_avatar();
+        // Default filters by player character (human) - only arm_l/r match
+        CHECK( test_shackles.get_avg_coverage() == 100 );
+
+        item longshirt( itype_test_longshirt );
+        CHECK( longshirt.get_avg_coverage() == 90 );
+    }
+
+    SECTION( "bird character with explicit body_part_set" ) {
+        standard_npc dude( "Test NPC" );
+        create_bird_char( dude );
+        body_part_set bird_parts;
+        bird_parts.fill( dude.get_all_body_parts() );
+
+        // Bird has arm_l/r(100) and test_bird_wing_l/r(100) from this item
+        CHECK( test_shackles.get_avg_coverage( bird_parts ) == 100 );
+    }
+
+    SECTION( "alt-arm character" ) {
+        clear_avatar();
+        Character &viewer = get_player_character();
+        viewer.enchantment_cache->force_add( *enchantment_ENCH_TEST_ALT_ARMS, viewer );
+        viewer.recalculate_bodyparts();
+        REQUIRE( viewer.has_part( body_part_test_alt_arm_l ) );
+
+        item longshirt( itype_test_longshirt );
+        // Default uses player character which now has alt arms
+        CHECK( longshirt.get_avg_coverage() == 90 );
+    }
 }


### PR DESCRIPTION
#### Summary
Bugfixes "Fix armor average coverage including phantom limbs from similar_bodypart expansion"

#### Purpose of change

`finalize_post_armor` expands every item's coverage set to include all similar limbs at the data level. `get_avg_coverage()` then averages over ALL entries including phantom limbs the viewer doesn't have, producing wrong values in the armor inventory menu, ablative pocket info, and anywhere else it's called.

Currently masked on master because all similar limbs have sub-parts summing to 100, so phantom coverage matches the original. #85730 (bird wings) breaks this - only the shoulder sub-part is linked, so the phantom wing coverage is much lower and drags down the average.

#### Describe the solution

Make the default `get_avg_coverage()` filter by `get_player_character()` anatomy. Add a `body_part_set` overload for when you need a specific anatomy (e.g. NPCs).

The two callers left on the default (`clothing_mod.cpp`, `gamemode_tutorial.cpp`) are fine with player-filtered values - arguably more correct.

#### Describe alternatives you've considered

Keeping the default unfiltered and adding an overload - but that means every caller has to opt in, and it's easy to forget. Since this is a display-oriented function, defaulting to the player character makes more sense.

#### Testing

All new tests pass.

#### Additional context

New test data: `test_partial_wing_l` body part with shoulder-only linkage (max_coverage=25) to exercise partial coverage scaling.