### PR TITLE
Turn woodpecker beak into a body part

### DIFF
--- a/data/json/mutations/limbs_body_parts.json
+++ b/data/json/mutations/limbs_body_parts.json
@@ -172,6 +172,25 @@
     "unarmed_damage": [ { "damage_type": "stab", "amount": 8 } ]
   },
   {
+    "id": "beak_woodpecker",
+    "copy-from": "mouth",
+    "type": "body_part",
+    "name": "beak",
+    "accusative": { "ctxt": "bodypart_accusative", "str": "beak" },
+    "heading": "beak",
+    "heading_multiple": "beaks",
+    "opposite_part": "beak_woodpecker",
+    "limb_type": "mouth",
+    "limb_scores": [ [ "breathing", 1.0 ], [ "manip", 0.03, 0.15 ], [ "consume_liquid", 1.0 ], [ "consume_solid", 1.0 ] ],
+    "side": "both",
+    "similar_bodypart": "beak",
+    "flags": [ "LIMB_UPPER" ],
+    "sub_parts": [ "beak_woodpecker_nares", "beak_woodpecker_top", "beak_woodpecker_tip", "beak_woodpecker_bottom" ],
+    "//": "Pecking is not a primary attack for birds but they'll do it if they have to",
+    "techniques": [ "TECH_BIRD_WOODPECKER_PECK", "TECH_BIRD_WOODPECKER_PECK_GRABBED" ],
+    "unarmed_damage": [ { "damage_type": "stab", "amount": 12 } ]
+  },
+  {
     "id": "crustacean_pincer_r",
     "copy-from": "hand_r",
     "type": "body_part",

--- a/data/json/mutations/limbs_sublimbs.json
+++ b/data/json/mutations/limbs_sublimbs.json
@@ -303,28 +303,28 @@
     "id": "beak_woodpecker_nares",
     "copy-from": "beak_nares",
     "type": "sub_body_part",
-    "parent": "beak_bird",
+    "parent": "beak_woodpecker",
     "similar_bodypart": "beak_nares"
   },
   {
     "id": "beak_woodpecker_top",
     "copy-from": "beak_top",
     "type": "sub_body_part",
-    "parent": "beak_bird",
+    "parent": "beak_woodpecker",
     "similar_bodypart": "beak_top"
   },
   {
     "id": "beak_woodpecker_tip",
     "copy-from": "beak_tip",
     "type": "sub_body_part",
-    "parent": "beak_bird",
+    "parent": "beak_woodpecker",
     "similar_bodypart": "beak_tip"
   },
   {
     "id": "beak_woodpecker_bottom",
     "copy-from": "beak_bottom",
     "type": "sub_body_part",
-    "parent": "beak_bird",
+    "parent": "beak_woodpecker",
     "similar_bodypart": "beak_bottom"
   },
   {

--- a/data/json/mutations/limbs_sublimbs.json
+++ b/data/json/mutations/limbs_sublimbs.json
@@ -300,6 +300,34 @@
     "similar_bodypart": "beak_bottom"
   },
   {
+    "id": "beak_woodpecker_nares",
+    "copy-from": "beak_nares",
+    "type": "sub_body_part",
+    "parent": "beak_bird",
+    "similar_bodypart": "beak_nares"
+  },
+  {
+    "id": "beak_woodpecker_top",
+    "copy-from": "beak_top",
+    "type": "sub_body_part",
+    "parent": "beak_bird",
+    "similar_bodypart": "beak_top"
+  },
+  {
+    "id": "beak_woodpecker_tip",
+    "copy-from": "beak_tip",
+    "type": "sub_body_part",
+    "parent": "beak_bird",
+    "similar_bodypart": "beak_tip"
+  },
+  {
+    "id": "beak_woodpecker_bottom",
+    "copy-from": "beak_bottom",
+    "type": "sub_body_part",
+    "parent": "beak_bird",
+    "similar_bodypart": "beak_bottom"
+  },
+  {
     "id": "crustacean_pincer_wrist_r",
     "type": "sub_body_part",
     "name": "crustacean pincer wrist",

--- a/data/json/mutations/mutation_attack_vectors.json
+++ b/data/json/mutations/mutation_attack_vectors.json
@@ -43,6 +43,13 @@
   },
   {
     "type": "attack_vector",
+    "id": "vector_bird_woodpecker_peck",
+    "limbs": [ "beak_woodpecker" ],
+    "contact_area": [ "beak_woodpecker_tip" ],
+    "encumbrance_limit": 1
+  },
+  {
+    "type": "attack_vector",
     "id": "vector_crab_pincer",
     "limbs": [ "crustacean_pincer_r" ],
     "contact_area": [ "crustacean_pincer_claws_r" ]

--- a/data/json/mutations/mutation_techs.json
+++ b/data/json/mutations/mutation_techs.json
@@ -399,7 +399,7 @@
     "weighting": -2,
     "messages": [ "You peck %s", "<npcname> pecks %s" ],
     "description": "A bird peck.",
-    "attack_vectors": [ "vector_bird_peck" ],
+    "attack_vectors": [ "vector_bird_woodpecker_peck" ],
     "flat_bonuses": [
       { "stat": "damage", "type": "stab", "scaling-stat": "unarmed", "scale": 0.75 },
       { "stat": "damage", "type": "stab", "scaling-stat": "str", "scale": 0.5625 },
@@ -417,7 +417,7 @@
     "melee_allowed": true,
     "messages": [ "You peck %s", "<npcname> pecks %s" ],
     "description": "A bird peck.",
-    "attack_vectors": [ "vector_bird_peck" ],
+    "attack_vectors": [ "vector_bird_woodpecker_peck" ],
     "condition": {
       "or": [
         { "u_has_effect": "grabbed", "bodypart": "arm_r" },

--- a/data/json/mutations/mutation_techs.json
+++ b/data/json/mutations/mutation_techs.json
@@ -349,7 +349,7 @@
   {
     "type": "technique",
     "id": "TECH_BIRD_PECK",
-    "name": "Bite",
+    "name": "Peck",
     "crit_ok": true,
     "unarmed_allowed": true,
     "weighting": -2,
@@ -367,7 +367,7 @@
   {
     "type": "technique",
     "id": "TECH_BIRD_PECK_GRABBED",
-    "name": "Bite",
+    "name": "Peck",
     "crit_ok": true,
     "unarmed_allowed": true,
     "melee_allowed": true,
@@ -388,6 +388,50 @@
       { "stat": "arpen", "type": "stab", "scaling-stat": "unarmed", "scale": 0.45 },
       { "stat": "movecost", "scaling-stat": "melee", "scale": -1.25 },
       { "stat": "movecost", "scaling-stat": "dex", "scale": -0.5 }
+    ]
+  },
+  {
+    "type": "technique",
+    "id": "TECH_BIRD_WOODPECKER_PECK",
+    "name": "Peck",
+    "crit_ok": true,
+    "unarmed_allowed": true,
+    "weighting": -2,
+    "messages": [ "You peck %s", "<npcname> pecks %s" ],
+    "description": "A bird peck.",
+    "attack_vectors": [ "vector_bird_peck" ],
+    "flat_bonuses": [
+      { "stat": "damage", "type": "stab", "scaling-stat": "unarmed", "scale": 0.75 },
+      { "stat": "damage", "type": "stab", "scaling-stat": "str", "scale": 0.5625 },
+      { "stat": "arpen", "type": "stab", "scaling-stat": "unarmed", "scale": 0.75 },
+      { "stat": "movecost", "scaling-stat": "melee", "scale": -2.5 },
+      { "stat": "movecost", "scaling-stat": "dex", "scale": -1 }
+    ]
+  },
+  {
+    "type": "technique",
+    "id": "TECH_BIRD_WOODPECKER_PECK_GRABBED",
+    "name": "Peck",
+    "crit_ok": true,
+    "unarmed_allowed": true,
+    "melee_allowed": true,
+    "messages": [ "You peck %s", "<npcname> pecks %s" ],
+    "description": "A bird peck.",
+    "attack_vectors": [ "vector_bird_peck" ],
+    "condition": {
+      "or": [
+        { "u_has_effect": "grabbed", "bodypart": "arm_r" },
+        { "u_has_effect": "grabbed", "bodypart": "arm_l" },
+        { "u_has_effect": "grabbed", "bodypart": "hand_r" },
+        { "u_has_effect": "grabbed", "bodypart": "hand_l" }
+      ]
+    },
+    "flat_bonuses": [
+      { "stat": "damage", "type": "stab", "scaling-stat": "unarmed", "scale": 0.75 },
+      { "stat": "damage", "type": "stab", "scaling-stat": "str", "scale": 0.5625 },
+      { "stat": "arpen", "type": "stab", "scaling-stat": "unarmed", "scale": 0.75 },
+      { "stat": "movecost", "scaling-stat": "melee", "scale": -2.5 },
+      { "stat": "movecost", "scaling-stat": "dex", "scale": -1 }
     ]
   },
   {

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -4854,7 +4854,8 @@
     "destroys_gear": true,
     "restricts_gear": [ "mouth" ],
     "wet_protection": [ { "part": "mouth", "ignored": 2 } ],
-    "enchantments": [ { "modified_bodyparts": [ { "lose": "mouth" }, { "gain": "beak_woodpecker" } ] } ]
+    "enchantments": [ { "modified_bodyparts": [ { "lose": "mouth" }, { "gain": "beak_woodpecker" } ] } ],
+    "armor": [ { "parts": [ "head", "beak" ], "bash": 3 } ]
   },
   {
     "type": "mutation",

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -4853,16 +4853,8 @@
     "ugliness": 5,
     "destroys_gear": true,
     "restricts_gear": [ "mouth" ],
-    "attacks": [
-      {
-        "attack_text_u": "You jackhammer into %s with your beak!",
-        "attack_text_npc": "%1$s jackhammer into %2$s with their beak!",
-        "body_part": "mouth",
-        "chance": 15,
-        "hardcoded_effect": true
-      }
-    ],
-    "wet_protection": [ { "part": "mouth", "ignored": 2 } ]
+    "wet_protection": [ { "part": "mouth", "ignored": 2 } ],
+    "enchantments": [ { "modified_bodyparts": [ { "lose": "mouth" }, { "gain": "beak_woodpecker" } ] } ]
   },
   {
     "type": "mutation",

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -162,7 +162,6 @@ static const skill_id skill_unarmed( "unarmed" );
 static const trait_id trait_ARM_TENTACLES( "ARM_TENTACLES" );
 static const trait_id trait_ARM_TENTACLES_4( "ARM_TENTACLES_4" );
 static const trait_id trait_ARM_TENTACLES_8( "ARM_TENTACLES_8" );
-static const trait_id trait_BEAK_PECK( "BEAK_PECK" );
 static const trait_id trait_CLAWS_TENTACLE( "CLAWS_TENTACLE" );
 static const trait_id trait_CLUMSY( "CLUMSY" );
 static const trait_id trait_DEBUG_NIGHTVISION( "DEBUG_NIGHTVISION" );

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -2380,19 +2380,6 @@ std::string Character::melee_special_effects( Creature &t, damage_instance &d, i
 
 static damage_instance hardcoded_mutation_attack( const Character &u, const trait_id &id )
 {
-    if( id == trait_BEAK_PECK ) {
-        // method open to improvement, please feel free to suggest
-        // a better way to simulate target's anti-peck efforts
-        /** @EFFECT_DEX increases number of hits with BEAK_PECK */
-
-        /** @EFFECT_UNARMED increases number of hits with BEAK_PECK */
-        int num_hits = std::max( 1, std::min<int>( 6,
-                                 u.get_dex() + u.get_skill_level( skill_unarmed ) - rng( 4, 10 ) ) );
-        damage_instance di = damage_instance();
-        di.add_damage( damage_stab, num_hits * 10 );
-        return di;
-    }
-
     if( id == trait_ARM_TENTACLES || id == trait_ARM_TENTACLES_4 || id == trait_ARM_TENTACLES_8 ) {
         int num_attacks = 1;
         if( id == trait_ARM_TENTACLES_4 ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Turn woodpecker beak into a body part"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Continued limbification

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Turn woodpecker limb into a body part, with subparts, techniques, etc.

It works basically the same as the generic bird peak except with higher stab damage. Also, I removed the hardcoded special attack bonuses where you get extra attacks. I get what it was going for--woodpeckers jackhammering into a tree therefore they get a bunch of attacks in a single second--but trees crucially 1) stand still and 2) are not trying to kill the woodpecker. In exchange, woodpeckers get higher armor penetration and better movecost reduction on their attack. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Mutated a woodpecker beak, pecked some zombies.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
