### PR TITLE
A tracker for Hub 01 CBM knowledge, and an NPC to "lead" it

### DIFF
--- a/data/json/mapgen/robofaq_locs/EOC_robofac_hq_updater.json
+++ b/data/json/mapgen/robofaq_locs/EOC_robofac_hq_updater.json
@@ -67,7 +67,26 @@
               "u_location_variable": { "global_val": "ancilla_autodoc_loc" },
               "target_params": { "om_terrain": "robofachq_subcc_a1" }
             },
-            { "math": [ "ancilla_autodoc_placed = 1" ] }
+            { "math": [ "ancilla_autodoc_placed = 1" ] },
+            { "math": [ "ancilla_autodoc_placed_when = time('now')" ] }
+          ]
+        },
+        {
+          "id": "EOC_ROBOFAC_HQ_PLACE_ANCILLA_BIONIC_GARAGE",
+          "condition": {
+            "and": [
+              { "math": [ "ancilla_autodoc_placed == 1" ] },
+              { "math": [ "ancilla_bionic_garage_placed != 1" ] },
+              { "math": [ "time_since('cataclysm', 'unit':'days') >= 87" ] }
+            ]
+          },
+          "effect": [
+            { "mapgen_update": "robofachq_ancilla_bionic_garage", "om_terrain": "robofachq_surface_car_entrance" },
+            {
+              "u_location_variable": { "global_val": "ancilla_bionic_garage_loc" },
+              "target_params": { "om_terrain": "robofachq_surface_car_entrance" }
+            },
+            { "math": [ "ancilla_bionic_garage_placed = 1" ] }
           ]
         }
       ]
@@ -83,7 +102,27 @@
         "u_location_variable": { "global_val": "ancilla_autodoc_loc" },
         "target_params": { "om_terrain": "robofachq_subcc_a1" }
       },
-      { "math": [ "ancilla_autodoc_placed = 1" ] }
+      { "math": [ "ancilla_autodoc_placed = 1" ] },
+      { "run_eocs": "EOC_ROBOFAC_HQ_FORCE_PLACE_ANCILLA_BIONIC_GARAGE", "time_in_future": "7 days" }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_ROBOFAC_HQ_FORCE_PLACE_ANCILLA_BIONIC_GARAGE",
+    "condition": { "current_dimension": "" },
+    "effect": [
+      {
+        "if": { "math": [ "ancilla_autodoc_placed != 1" ] },
+        "then": [
+          { "mapgen_update": "robofachq_ancilla_bionic_garage", "om_terrain": "robofachq_surface_car_entrance" },
+          {
+            "u_location_variable": { "global_val": "ancilla_bionic_garage_loc" },
+            "target_params": { "om_terrain": "robofachq_surface_car_entrance" }
+          },
+          { "math": [ "ancilla_bionic_garage_placed = 1" ] }
+        ]
+      }
+    ],
+    "false_effect": { "run_eocs": "EOC_ROBOFAC_HQ_FORCE_PLACE_ANCILLA_BIONIC_GARAGE", "time_in_future": "2 days" }
   }
 ]

--- a/data/json/mapgen/robofaq_locs/robofac_hq_chunks.json
+++ b/data/json/mapgen/robofaq_locs/robofac_hq_chunks.json
@@ -438,5 +438,73 @@
         { "class": "BEM_exodii_hunter", "x": 0, "y": 0 }
       ]
     }
+  },
+  {
+    "type": "mapgen",
+    "update_mapgen_id": "robofachq_ancilla_bionic_garage",
+    "object": {
+      "faction_owner": [ { "id": "robofac_auxiliaries", "x": [ 0, 23 ], "y": [ 0, 23 ] } ],
+      "rows": [
+        "|||||||||||%%%%%%%%___||",
+        "^ hY ||||||_______%___||",
+        " ddd |SSSSy___________||",
+        "     |    y___________||",
+        "(((([|    y____$$____D||",
+        "          y____WW____D||",
+        "          y____WW____D||",
+        "    Y Y   y__________S||",
+        "yyyyyyyyyyy__________w||",
+        "y    y   R|__________S||",
+        "yRRRRyRRRR|55555555555||",
+        "|||||||||||MMMMMMMMMMM||",
+        "|||||||||||mmmmmmmmmmm||",
+        ",,,,,,,,||||||||||||||||",
+        ",,,,,,,,||||||||||||||||",
+        ",,,,,,,,||||||||||||||||",
+        ",,,,,,,,,,,,,,,,,,,,,,,,",
+        "||||||||||||||||||||||||",
+        ",,,,,,,,,,,,,,,,,,,,,,,,",
+        ",,,,,,,,,,,,,,,,,,,,,,,,",
+        ",,,,,,,,,,,,,,,,,,,,,,,,",
+        ",,,,,,,,,,,,,,,,,,,,,,,,",
+        ",,,,,,,,,,,,,,,,,,,,,,,,",
+        ",,,,,,,,,,,,,,,,,,,,,,,,"
+      ],
+      "palettes": [ "robofachq" ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "terrain": {
+        "M": "t_ramp_down_high",
+        "m": "t_ramp_down_low",
+        "%": "t_pavement",
+        "S": "t_pavement",
+        "w": "t_pavement",
+        "W": "t_pavement",
+        "R": "t_pavement",
+        "D": "t_pavement",
+        "Y": "t_strconc_floor_olight",
+        "$": "t_strconc_floor_olight"
+      },
+      "furniture": {
+        "R": "f_warehouse_shelf",
+        "W": "f_workbench",
+        "$": "f_workbench",
+        "S": "f_utility_shelf",
+        "w": "f_mitresaw",
+        "%": "f_sandbag_wall",
+        "D": "f_standing_tank"
+      },
+      "place_vehicles": [
+        { "chance": 100, "fuel": 0, "rotation": 0, "status": 0, "vehicle": "engine_crane", "x": 12, "y": 3 },
+        { "chance": 100, "fuel": 0, "rotation": 0, "status": 0, "vehicle": "welding_cart", "x": 16, "y": 8 }
+      ],
+      "items": {
+        "R": [ { "item": "SUS_exodii_storage_lowvalue", "chance": 80 }, { "item": "SUS_exodii_botrack", "chance": 80 } ],
+        "S": [
+          { "item": "mechanics", "chance": 100, "repeat": [ 1, 6 ] },
+          { "item": "SUS_welding_gear", "chance": 80, "repeat": [ 1, 2 ] }
+        ]
+      },
+      "place_npcs": [ { "class": "robofac_garage_scientist_1", "x": 2, "y": 1 } ]
+    }
   }
 ]

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/NC_ROBOFAC_SCIENTIST_GARAGE.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/NC_ROBOFAC_SCIENTIST_GARAGE.json
@@ -1,0 +1,223 @@
+[
+  {
+    "type": "npc",
+    "id": "robofac_garage_scientist_1",
+    "name_unique": "Sebastian Smith",
+    "name_suffix": "Hub Scientist",
+    "class": "NC_ROBOFAC_SCIENTIST_GARAGE",
+    "attitude": 0,
+    "mission": 3,
+    "chat": "TALK_ROBOFAC_SCIENTIST_GARAGE",
+    "faction": "robofac_auxiliaries"
+  },
+  {
+    "type": "npc_class",
+    "id": "NC_ROBOFAC_SCIENTIST_GARAGE",
+    "name": { "str": "Hub Scientist" },
+    "job_description": "A Hub 01 scientist.",
+    "common": false,
+    "traits": [ { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ],
+    "bonus_str": { "rng": [ 0, 1 ] },
+    "bonus_dex": { "rng": [ 0, 2 ] },
+    "bonus_int": { "rng": [ -2, 0 ] },
+    "bonus_per": { "rng": [ 0, 2 ] },
+    "worn_override": "NC_ROBOFAC_SCIENTIST_GARAGE_worn",
+    "weapon_override": "NC_ROBOFAC_SCIENTIST_GARAGE_wield",
+    "skills": [ { "skill": "firstaid", "bonus": 8 }, { "skill": "electronics", "bonus": 8 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_ROBOFAC_SCIENTIST_GARAGE_worn",
+    "subtype": "collection",
+    "items": [
+      { "item": "under_armor" },
+      { "item": "under_armor_shorts" },
+      { "item": "socks" },
+      { "item": "robofac_enviro_suit" },
+      { "item": "welding_papr_helmet_raised", "contents-item": [ "diving_flashlight_small_hipower" ] },
+      { "item": "basic_papr_belt_off" },
+      { "item": "coat_lab" }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_ROBOFAC_SCIENTIST_GARAGE_wield",
+    "subtype": "collection",
+    "items": [ { "item": "red_pen" } ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_ROBOFAC_SCIENTIST_GARAGE",
+    "dynamic_line": {
+      "u_has_faction_trust": 10,
+      "yes": "Good to see you.  What can I do for you?",
+      "no": {
+        "compare_string": [ "yes", { "u_val": "dialogue_robofac_scientist_garage_first_meet" } ],
+        "yes": "Got something for me?",
+        "no": "Ah, good, another independent contractor, right?  I take it you've heard about the bounty?"
+      }
+    },
+    "responses": [
+      {
+        "text": "Bounty?",
+        "topic": "TALK_ROBOFAC_SCIENTIST_GARAGE_BOUNTY",
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "dialogue_robofac_scientist_garage_first_meet" } ] } },
+        "effect": [ { "u_add_var": "dialogue_robofac_scientist_garage_first_meet", "value": "yes" } ]
+      },
+      {
+        "text": "I'm here to collect on the bounty.",
+        "topic": "TALK_ROBOFAC_SCIENTIST_GARAGE_SELL_EXODII",
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_robofac_scientist_garage_first_meet" } ] }
+      },
+      {
+        "text": "How goes research?",
+        "topic": "TALK_ROBOFAC_SCIENTIST_GARAGE_RESEARCH_PROGRESS",
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_robofac_scientist_garage_first_meet" } ] }
+      },
+      { "text": "Nevermind.  Bye.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_ROBOFAC_SCIENTIST_GARAGE_BOUNTY",
+    "dynamic_line": "That's right, bounty.  No doubt you've heard of the aliens known as the \"Exodii\", right?  Big killer-robot-vibes, am I right?  Well, I've spun off an initiative adjacent to our Cybernetic Enhancements Program.  The basic strategy is simple: learn what we can, synergize with our strengths, and fight fire with fire.\n\nSo here's the play: I'm actively sourcing \"decommissioned\" Exodii hardware for teardown and reverse engineering.\n\nIt's simple: you bring inactivated Exodii here, and I'll pay you for each one.  Think of yourself as a citizen scientist, yeah?  A community R&D effort.\n\nSmall note, though.  None of those \"zomborg\" things - the walking corpses with devices jammed into them.  Another team is running that pipeline, and honestly, the signals out of that aren't so great.\n\nRight now, the highest value pickups are worker drones, the big four-legged robots, and turret platforms.  They're hard to come by, but trust me, I'll pay a good price.",
+    "responses": [ { "text": "I'll keep that in mind.  See you around.", "topic": "TALK_DONE" } ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_ROBOFAC_SCIENTIST_GARAGE_SELL_EXODII",
+    "dynamic_line": "Is that so?  What do you have?",
+    "responses": [
+      {
+        "text": "[1 HGC] I've brought you one of those workers.",
+        "topic": "TALK_ROBOFAC_SCIENTIST_GARAGE_SELL_EXODII_PAID",
+        "condition": { "u_has_items": { "item": "broken_exodii_worker", "count": 1 } },
+        "effect": [
+          { "u_consume_item": "broken_exodii_worker", "count": 1, "popup": true },
+          { "u_spawn_item": "RobofacCoin", "count": 1 },
+          { "math": [ "robofac_exodii_cbm_knowledge += 1" ] }
+        ]
+      },
+      {
+        "text": "[2 HGC] I've brought you one of those quadrapeds.",
+        "topic": "TALK_ROBOFAC_SCIENTIST_GARAGE_SELL_EXODII_PAID",
+        "condition": { "u_has_items": { "item": "broken_exodii_quad", "count": 1 } },
+        "effect": [
+          { "u_consume_item": "broken_exodii_quad", "count": 1, "popup": true },
+          { "u_spawn_item": "RobofacCoin", "count": 2 },
+          { "math": [ "robofac_exodii_cbm_knowledge += 1" ] }
+        ]
+      },
+      {
+        "text": "[2 HGC] I've brought you one of those turrets.",
+        "topic": "TALK_ROBOFAC_SCIENTIST_GARAGE_SELL_EXODII_PAID",
+        "condition": { "u_has_items": { "item": "broken_exodii_turret", "count": 1 } },
+        "effect": [
+          { "u_consume_item": "broken_exodii_turret", "count": 1, "popup": true },
+          { "u_spawn_item": "RobofacCoin", "count": 2 },
+          { "math": [ "robofac_exodii_cbm_knowledge += 1" ] }
+        ]
+      },
+      {
+        "text": "[4 HGC] I found this strange balloon robot.",
+        "topic": "TALK_ROBOFAC_SCIENTIST_GARAGE_SELL_EXODII_PAID",
+        "condition": { "u_has_items": { "item": "broken_exodii_sniper_drone", "count": 1 } },
+        "effect": [
+          { "u_consume_item": "broken_exodii_sniper_drone", "count": 1, "popup": true },
+          { "u_spawn_item": "RobofacCoin", "count": 4 },
+          { "math": [ "robofac_exodii_cbm_knowledge += 1" ] }
+        ]
+      },
+      { "text": "Nevermind.  Let's talk about something else.", "topic": "TALK_ROBOFAC_SCIENTIST_GARAGE" },
+      { "text": "Actually, I'd better be going.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_ROBOFAC_SCIENTIST_GARAGE_SELL_EXODII_PAID",
+    "dynamic_line": "Thanks, man.  Enjoy that.",
+    "responses": [
+      {
+        "text": "[1 HGC] I've also got one of those workers.",
+        "topic": "TALK_ROBOFAC_SCIENTIST_GARAGE_SELL_EXODII_PAID",
+        "condition": { "u_has_items": { "item": "broken_exodii_worker", "count": 1 } },
+        "effect": [
+          { "u_consume_item": "broken_exodii_worker", "count": 1, "popup": true },
+          { "u_spawn_item": "RobofacCoin", "count": 1 },
+          { "math": [ "robofac_exodii_cbm_knowledge += 1" ] }
+        ]
+      },
+      {
+        "text": "[2 HGC] I've also got one of those quadrapeds.",
+        "topic": "TALK_ROBOFAC_SCIENTIST_GARAGE_SELL_EXODII_PAID",
+        "condition": { "u_has_items": { "item": "broken_exodii_quad", "count": 1 } },
+        "effect": [
+          { "u_consume_item": "broken_exodii_quad", "count": 1, "popup": true },
+          { "u_spawn_item": "RobofacCoin", "count": 2 },
+          { "math": [ "robofac_exodii_cbm_knowledge += 1" ] }
+        ]
+      },
+      {
+        "text": "[2 HGC] I've also got one of those turrets.",
+        "topic": "TALK_ROBOFAC_SCIENTIST_GARAGE_SELL_EXODII_PAID",
+        "condition": { "u_has_items": { "item": "broken_exodii_turret", "count": 1 } },
+        "effect": [
+          { "u_consume_item": "broken_exodii_turret", "count": 1, "popup": true },
+          { "u_spawn_item": "RobofacCoin", "count": 2 },
+          { "math": [ "robofac_exodii_cbm_knowledge += 1" ] }
+        ]
+      },
+      {
+        "text": "[4 HGC] I also found this strange balloon robot.",
+        "topic": "TALK_ROBOFAC_SCIENTIST_GARAGE_SELL_EXODII_PAID",
+        "condition": { "u_has_items": { "item": "broken_exodii_sniper_drone", "count": 1 } },
+        "effect": [
+          { "u_consume_item": "broken_exodii_sniper_drone", "count": 1, "popup": true },
+          { "u_spawn_item": "RobofacCoin", "count": 4 },
+          { "math": [ "robofac_exodii_cbm_knowledge += 1" ] }
+        ]
+      },
+      { "text": "Let's talk about something else.", "topic": "TALK_ROBOFAC_SCIENTIST_GARAGE" },
+      { "text": "I'd better be going.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_ROBOFAC_SCIENTIST_GARAGE_RESEARCH_PROGRESS",
+    "dynamic_line": {
+      "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_3" } ],
+      "yes": {
+        "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_3" } ],
+        "yes": {
+          "math": [ "robofac_exodii_cbm_knowledge > 50" ],
+          "yes": "R&D is going well.  Maybe we'll have new products ready sometime soon.",
+          "no": "Research is ongoing.  Nothing new to report."
+        },
+        "no": "We've made some progress.  If you're keen to use our newest prototypes, I'd encourage you to see the Doc across the street.  Now we're looking for some cool military tech to synergize with the circuits I'm slapping together.  The intercome will have a relevant open contract, if they don't already."
+      },
+      "no": "Honestly?  I'm able to reverse engineer a lot of this tech, but I can't recreate it.  Our top engineers know what we need to fix the problem, and are looking for mercs to help us solve the problem.  Ask about contracts at the intercom."
+    },
+    "responses": [
+      { "text": "Let's talk about something else.", "topic": "TALK_ROBOFAC_SCIENTIST_GARAGE" },
+      { "text": "I'd better be going.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_ROBOFAC_SCIENTIST_GARAGE_ADVANCE_EXODII_CBM_KNOWLEDGE",
+    "//": "A counter that represents how much Hub 01 knows about CBMs.  It only starts once they have autodoc tech.  +1 if garage is spawned.  +1 if chop shop scientist is still alive.",
+    "recurrence": "48 hours",
+    "global": true,
+    "condition": { "and": [ { "math": [ "ancilla_autodoc_placed == 1" ] }, { "math": [ "robofac_exodii_cbm_knowledge <= 99" ] } ] },
+    "effect": [
+      {
+        "if": { "math": [ "robofac_chop_shop_scientist_1_is_dead != 1" ] },
+        "then": { "math": [ "robofac_exodii_cbm_knowledge += 1" ] }
+      },
+      {
+        "if": { "math": [ "ancilla_bionic_garage_placed == 1" ] },
+        "then": { "math": [ "robofac_exodii_cbm_knowledge += 1" ] }
+      }
+    ]
+  }
+]

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/NC_ROBOFAC_SCIENTIST_GARAGE.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/NC_ROBOFAC_SCIENTIST_GARAGE.json
@@ -99,7 +99,7 @@
         ]
       },
       {
-        "text": "[2 HGC] I've brought you one of those quadrapeds.",
+        "text": "[2 HGC] I've brought you one of those quadrupeds.",
         "topic": "TALK_ROBOFAC_SCIENTIST_GARAGE_SELL_EXODII_PAID",
         "condition": { "u_has_items": { "item": "broken_exodii_quad", "count": 1 } },
         "effect": [
@@ -148,7 +148,7 @@
         ]
       },
       {
-        "text": "[2 HGC] I've also got one of those quadrapeds.",
+        "text": "[2 HGC] I've also got one of those quadrupeds.",
         "topic": "TALK_ROBOFAC_SCIENTIST_GARAGE_SELL_EXODII_PAID",
         "condition": { "u_has_items": { "item": "broken_exodii_quad", "count": 1 } },
         "effect": [
@@ -193,7 +193,7 @@
           "yes": "R&D is going well.  Maybe we'll have new products ready sometime soon.",
           "no": "Research is ongoing.  Nothing new to report."
         },
-        "no": "We've made some progress.  If you're keen to use our newest prototypes, I'd encourage you to see the Doc across the street.  Now we're looking for some cool military tech to synergize with the circuits I'm slapping together.  The intercome will have a relevant open contract, if they don't already."
+        "no": "We've made some progress.  If you're keen to use our newest prototypes, I'd encourage you to see the Doc across the street.  Now we're looking for some cool military tech to synergize with the circuits I'm slapping together.  The intercom will have a relevant open contract, if they don't already."
       },
       "no": "Honestly?  I'm able to reverse engineer a lot of this tech, but I can't recreate it.  Our top engineers know what we need to fix the problem, and are looking for mercs to help us solve the problem.  Ask about contracts at the intercom."
     },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Hub/Ancilla CBM garage & progress tracker"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Implementing #85783 and other Hub CBMs will require tracking just how much the Hub knows about bionics.  This can be done with a simple meter.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Implements a var called `robofac_exodii_cbm_knowledge`

Also adds an NPC/workshop that spawns 7 days after the AutoDoc, in the unused Car entry of Hub 01.  It's sort of the "clean" version of the chop shop.  Whereas the chop shop is chopping up zomborgs and trying to sew stuff to humans, this place only shows up after AutoDoc tech is available, and only works on the robot-like Exodii drones. The corpo-enthusiastic-tech-bro Hub scientist running it is in charge of reverse-engineering bionics and other Exodii tech.  They are offering a bounty for "decommissioned" Exodii.

The knowledge meter only increases two ways (which can be added to later):
1. Time (+1 per 48/hours when the garage spawns.  +1 per 48/hours if the chop shop is still running after the AutoDoc is placed)
2. The player selling dead Exodii to the garage

Right now it doesn't do anything - just affects the new NPC's dialogue.  But it can be used to gate CBM and bionic limb availability.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Doing it all through the intercom.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Made sure the mapgen_update and NPC work.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Screenshot of the "garage":

<img width="1118" height="560" alt="GARAGE" src="https://github.com/user-attachments/assets/aa0fc73c-f0bc-4b44-a4ed-58347142431c" />


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
