### PR TITLE
Revise the bionic mana penalty

### DIFF
--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2544,12 +2544,14 @@ void known_magic::mod_mana( const Character &guy, int add_mana )
 int known_magic::max_mana( const Character &guy ) const
 {
     const float int_bonus = ( ( 0.2f + guy.get_int() * 0.1f ) - 1.0f ) * mana_base;
-    const float unaugmented_mana = guy.calculate_by_enchantment( ( mana_base + int_bonus ), enchant_vals::mod::MAX_MANA, true );
+    const float unaugmented_mana = guy.calculate_by_enchantment( ( mana_base + int_bonus ),
+                                   enchant_vals::mod::MAX_MANA, true );
 
     units::mass bionics_weight = guy.bionics_weight();
     units::mass bodyweight = guy.bodyweight();
     const float penalty_calc = std::sqrt( bionics_weight / ( bionics_weight + bodyweight ) );
-    const float bionic_penalty = guy.enchantment_cache->modify_value( enchant_vals::mod::BIONIC_MANA_PENALTY, unaugmented_mana * penalty_calc );
+    const float bionic_penalty = guy.enchantment_cache->modify_value(
+                                     enchant_vals::mod::BIONIC_MANA_PENALTY, unaugmented_mana * penalty_calc );
 
     return std::floor( unaugmented_mana - bionic_penalty );
 }

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2548,8 +2548,7 @@ int known_magic::max_mana( const Character &guy ) const
                                    enchant_vals::mod::MAX_MANA, true );
 
     units::mass bionics_weight = guy.bionics_weight();
-    units::mass bodyweight = guy.bodyweight();
-    const float penalty_calc = std::sqrt( bionics_weight / ( bionics_weight + bodyweight ) );
+    const float penalty_calc = bionics_weight / ( bionics_weight + 50_kilogram ) );
     const float bionic_penalty = guy.enchantment_cache->modify_value(
                                      enchant_vals::mod::BIONIC_MANA_PENALTY, unaugmented_mana * penalty_calc );
 

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2544,15 +2544,14 @@ void known_magic::mod_mana( const Character &guy, int add_mana )
 int known_magic::max_mana( const Character &guy ) const
 {
     const float int_bonus = ( ( 0.2f + guy.get_int() * 0.1f ) - 1.0f ) * mana_base;
-    int penalty_calc = std::round( std::max<int64_t>( 0,
-                                   units::to_kilojoule( guy.get_power_level() ) ) );
+    const float unaugmented_mana = guy.calculate_by_enchantment( ( mana_base + int_bonus ), enchant_vals::mod::MAX_MANA, true );
 
-    const int bionic_penalty = guy.enchantment_cache->modify_value(
-                                   enchant_vals::mod::BIONIC_MANA_PENALTY, penalty_calc );
+    units::mass bionics_weight = guy.bionics_weight();
+    units::mass bodyweight = guy.bodyweight();
+    const float penalty_calc = std::sqrt( bionics_weight / ( bionics_weight + bodyweight ) );
+    const float bionic_penalty = guy.enchantment_cache->modify_value( enchant_vals::mod::BIONIC_MANA_PENALTY, unaugmented_mana * penalty_calc );
 
-    const float unaugmented_mana = std::max( 0.0f,
-                                   ( mana_base + int_bonus ) - bionic_penalty );
-    return guy.calculate_by_enchantment( unaugmented_mana, enchant_vals::mod::MAX_MANA, true );
+    return std::floor( unaugmented_mana - bionic_penalty );
 }
 
 void known_magic::update_mana( const Character &guy, float turns )


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Balance "instead of current stored power level, total mass of bionics is what reduces max mana"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The penalty for bionic power and mana was very inconsequential. Not only did it do literally nothing if you just used passive bionics, but you can run your powergen to only charge below 10% and get an incredibly minor -10 mana penalty. It essentially only mattered when using bionics that needed enormous injections of power all at once, such as time dilation. Also, it led to your max mana fluctuating constantly, which was weird and bad for "OK this is how much mana I have" convenience. Especially with bionic limbs right around the corner, it needs improvement!
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
~Rather than your current stored power level, the total mass of your bionics is summed and compared against the combined total mass of your bionics and your organic body. Then, it takes the square root of the resulting percentage, and multiplies that value by your max mana to get the total penalty. Finally, if you have an enchantment that reduces this penalty, that is applied. Some metrics:~
- ~You are naturally 70 kilograms and you install Rubik's "starter package". While you're at it you add in a Calorie Tracker for the heck of it. Altogether that's 330 grams of bionics. Your penalty is about 7% of your maximum mana.~
- ~You naturally weigh 80 kilograms and install a total of 10 kilograms of bionics. Your total penalty is 35% of your maximum mana.~
- ~You have bionic legs and arms, but a human torso and head, and the total weight of your bionics and your organic body are exactly equal. Your total penalty is 71% of your maximum mana.~
- ~You are a total conversion cyborg like Rubik, and only 10% of your overall mass is organic. Your penalty is 99% of your maximum mana.~
- ~You are a total conversion cyborg, but you are a Biotek wizard. Your total penalty is 50% of your maximum mana.~

current change: mana penalty is the ratio of weight of installed bionics to a flat "50 kilograms". So:
10 kilograms of bionics is a 17% penalty.
20 kilograms of bionics is a 28% penalty.
30 kilograms of bionics is a 33% penalty.
50 kilograms of bionics is a 50% penalty.

This may yet again change. Not sure really...

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
This is a serious nerf to cyborg wizards, but I think it's fine because magic is really strong and cybernetics are really strong and I like that there can be incentive to not get literally all of the power buffs without hassle. Plus, you can still use "just a little bit" of cyberware and still magic just fine. The scaling on Biotek means it makes the "full cyborg wizard" viable, though still notably limited, but also you're a giant metal killing machine who can also do magic so maybe you shouldn't be complaining so much. Apprentices these days...

Different scaling factors might be in order. Originally I was thinking of not using a square root on the modifier, but I think it's too toothless without it.

~~This does mean that being very tall, or fat, give you the ability to get less penalty to the same bionics. Your magical leylines just care that there's a *path*, from my view, so like, maybe this is just ok?~~

I probably should write some lore snippets, or give you the ability to ask Rubik about how hard it is to cast spells like that.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
NOT COMPILED YET! 
Also, there are probably tests expecting the old system that will fail now that I need to fix! Making this public so it can get some discussion and loom over me to work on it.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
