### PR TITLE
`conceal-carry six-shooter` is actually six-shooter

### DIFF
--- a/data/json/itemgroups/Weapons_Mods_Ammo/gunstore_guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/gunstore_guns.json
@@ -560,7 +560,7 @@
     "subtype": "collection",
     "id": "boxed_ruger_lcr_38",
     "container-item": "box_pistol",
-    "items": [ { "item": "ruger_lcr_38" }, { "group": "firearm_box_extras" }, { "item": "38_speedloader5", "prob": 5 } ]
+    "items": [ { "item": "ruger_lcr_38" }, { "group": "firearm_box_extras" }, { "item": "38_speedloader6", "prob": 5 } ]
   },
   {
     "type": "item_group",

--- a/data/json/itemgroups/Weapons_Mods_Ammo/nested_guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/nested_guns.json
@@ -343,7 +343,7 @@
     "//": "this is a distribution for the gun, reasonable number of backup mags, and some ammo to repack",
     "subtype": "collection",
     "ammo": 100,
-    "entries": [ { "item": "ruger_lcr_38", "charges": [ 0, 5 ] }, { "group": "on_hand_38" } ]
+    "entries": [ { "item": "ruger_lcr_38", "charges": [ 0, 6 ] }, { "group": "on_hand_38" } ]
   },
   {
     "id": "nested_sw642",

--- a/data/json/items/gun/38.json
+++ b/data/json/items/gun/38.json
@@ -120,8 +120,8 @@
       {
         "pocket_type": "MAGAZINE",
         "rigid": true,
-        "ammo_restriction": { "38": 5 },
-        "allowed_speedloaders": [ "38_speedloader5" ]
+        "ammo_restriction": { "38": 6 },
+        "allowed_speedloaders": [ "38_speedloader6" ]
       }
     ]
   },


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Someone reported `conceal-carry six-shooter` has only 5 rounds
#### Describe the solution
Checked if there is a .38 ruger lcr with six rounds, found there is, made it 6 shooter
#### Describe alternatives you've considered
rename it to five-shooter