### PR TITLE
Remove mention of points pool in main menu

### DIFF
--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -480,7 +480,7 @@ void main_menu::init_strings()
     }
     vNewGameHints.clear();
     vNewGameHints.emplace_back(
-        _( "Allows you to fully customize points pool, scenario, and character's profession, stats, traits, skills and other parameters." ) );
+        _( "Allows you to fully customize scenario, character's profession, stats, traits, skills and other parameters." ) );
     vNewGameHints.emplace_back( _( "Select from one of previously created character templates." ) );
     vNewGameHints.emplace_back(
         _( "Creates random character, but lets you preview the generated character and the scenario and change character and/or scenario if needed." ) );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Points pool has been completely removed (#85528). This PR removes mention of points pool from one of the New Game hints.