### PR TITLE
Fix zone activity hangs, route cache perf, and pathfinder z-scoring

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -4763,6 +4763,12 @@ bool multi_zone_activity_actor::simulate_turn( player_activity &act, Character &
     for( const tripoint_abs_ms &src : src_sorted ) {
         const tripoint_bub_ms &src_bub = here.get_bub( src );
         if( !check_only ) {
+            // Budget: each source evaluation costs 1 move to prevent
+            // unbounded can_do/requirements/route work in a single frame.
+            you.mod_moves( -1 );
+            if( you.get_moves() <= 0 ) {
+                return true;
+            }
             if( !here.inbounds( src_bub ) ) {
                 if( zone_sorting::sorter_out_of_bounds( you, current_activity ) ) {
                     // activity cancelled
@@ -12872,6 +12878,19 @@ bool zone_sort_activity_actor::stage_think( player_activity &act, Character &you
             best_route = 0;
         } else {
             const int dist = zone_sorting::route_length( you, p_bub );
+            // Budget: each route probe costs 1 move to prevent unbounded
+            // A* work in a single frame. Charged before the INT_MAX check
+            // because unreachable probes explore the full search space.
+            you.mod_moves( -1 );
+            if( you.get_moves() <= 0 ) {
+                if( dist != INT_MAX ) {
+                    computed.emplace_back( dist, candidates[i].second );
+                } else {
+                    unreachable_sources.emplace( candidates[i].second );
+                }
+                cutoff = i + 1;
+                break;
+            }
             if( dist == INT_MAX ) {
                 unreachable_sources.emplace( candidates[i].second );
                 continue;
@@ -12904,6 +12923,12 @@ bool zone_sort_activity_actor::stage_think( player_activity &act, Character &you
 
     // iterate over zone positions and look for items to move
     for( const tripoint_abs_ms &src : src_sorted ) {
+        // Budget: each source evaluation costs 1 move (populate_items,
+        // has_items_to_sort, zone lookups). Yield before mutating state.
+        you.mod_moves( -1 );
+        if( you.get_moves() <= 0 ) {
+            return false;
+        }
         placement = src;
 
         const tripoint_bub_ms src_bub = here.get_bub( src );
@@ -13150,6 +13175,7 @@ void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
                 return_items_to_source( you, src_bub );
                 unreachable_sources.emplace( src );
                 stage = THINK;
+                you.mod_moves( -1 );
             }
             return;
         }
@@ -13170,6 +13196,7 @@ void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
                        "zone_sort DO: NOT adjacent to src (dist=%d), back to THINK",
                        square_dist( you.pos_bub(), src_bub ) );
         stage = THINK;
+        you.mod_moves( -1 );
         return;
     }
 
@@ -13502,6 +13529,7 @@ void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
             coord_set.erase( src );
         }
         stage = THINK;
+        you.mod_moves( -1 );
         dropoff_coords.clear();
     } else if( !dropoff_coords.empty() && !you.has_destination() )  {
         // Purge item_locations invalidated by inventory restacking.
@@ -13521,6 +13549,7 @@ void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
                            "zone_sort DO: all picked items lost (merged?), back to THINK" );
             coord_set.erase( src );
             stage = THINK;
+            you.mod_moves( -1 );
             dropoff_coords.clear();
             return;
         }
@@ -13537,8 +13566,8 @@ void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
                 }
             }
         }
+        int dest_dist = INT_MAX;
         if( picked_up_this_pass ) {
-            int dest_dist = INT_MAX;
             for( const tripoint_abs_ms &dest : dropoff_coords ) {
                 if( square_dist( abspos, dest ) <= 1 ) {
                     dest_dist = 0;
@@ -13552,6 +13581,14 @@ void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
                 dest_dist = std::min( dest_dist, rd );
             }
 
+            // Skip entire batch candidate scan when all destinations are
+            // unreachable -- the Chebyshev filter (cheb >= dest_dist) would
+            // pass everything through, causing O(N) unfiltered A* probes.
+            if( dest_dist == INT_MAX ) {
+                picked_up_this_pass = false;
+            }
+        }
+        if( picked_up_this_pass ) {
             // Pre-fetch cart cargo for per-item volume check
             std::optional<vpart_reference> batch_cart_vp;
             if( you.is_avatar() && you.as_avatar()->get_grab_type() == object_type::VEHICLE ) {
@@ -13769,6 +13806,7 @@ void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
             return_items_to_source( you, src_bub );
             unreachable_sources.emplace( src );
             stage = THINK;
+            you.mod_moves( -1 );
             return;
         }
 
@@ -13788,6 +13826,7 @@ void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
                            "zone_sort DO: route to dest FAILED, returning items, back to THINK" );
             return_items_to_source( you, src_bub );
             stage = THINK;
+            you.mod_moves( -1 );
         }
 
     } else if( !you.has_destination() ) {
@@ -13796,6 +13835,7 @@ void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
         return_items_to_source( you, src_bub );
         unreachable_sources.emplace( src );
         stage = THINK;
+        you.mod_moves( -1 );
     }
 }
 

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <climits>
 #include <cmath>
+#include <deque>
 #include <cstdlib>
 #include <list>
 #include <memory>
@@ -774,13 +775,17 @@ namespace zone_sorting
 namespace
 {
 struct zone_route_cache {
+    static constexpr size_t max_entries = 200;
+
     tripoint_bub_ms start;
     object_type grab_type = object_type::NONE;
     tripoint_rel_ms grab_point;
     int arm_str = 0;
     units::mass veh_mass = 0_gram;
-    // (destination center, route). Empty route means unreachable.
-    std::vector<std::pair<tripoint_bub_ms, std::vector<tripoint_bub_ms>>> entries;
+    // destination -> route. Empty route means unreachable.
+    std::unordered_map<tripoint_bub_ms, std::vector<tripoint_bub_ms>> entries;
+    // FIFO eviction order -- front is oldest.
+    std::deque<tripoint_bub_ms> insertion_order;
     bool initialized = false;
 
     void ensure_valid( const Character &who ) {
@@ -809,21 +814,31 @@ struct zone_route_cache {
             arm_str = cur_arm_str;
             veh_mass = cur_veh_mass;
             entries.clear();
+            insertion_order.clear();
             initialized = true;
         }
     }
 
     const std::vector<tripoint_bub_ms> *find( const tripoint_bub_ms &dest ) const {
-        for( const auto &e : entries ) {
-            if( e.first == dest ) {
-                return &e.second;
-            }
+        auto it = entries.find( dest );
+        if( it != entries.end() ) {
+            return &it->second;
         }
         return nullptr;
     }
 
     void store( const tripoint_bub_ms &dest, std::vector<tripoint_bub_ms> route ) {
-        entries.emplace_back( dest, std::move( route ) );
+        auto it = entries.find( dest );
+        if( it != entries.end() ) {
+            it->second = std::move( route );
+            return;
+        }
+        while( entries.size() >= max_entries && !insertion_order.empty() ) {
+            entries.erase( insertion_order.front() );
+            insertion_order.pop_front();
+        }
+        entries.emplace( dest, std::move( route ) );
+        insertion_order.push_back( dest );
     }
 };
 

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -1097,22 +1097,22 @@ std::unordered_set<tripoint_bub_ms> zone_manager::get_point_set_loot( const trip
 {
     std::unordered_set<tripoint_bub_ms> res;
     map &here = get_map();
-    for( const std::pair<std::string, std::unordered_set<tripoint_abs_ms>> cache : area_cache ) {
+    for( const auto &cache : area_cache ) {
         zone_type_id type = zone_data::unhash_type( cache.first );
         faction_id z_fac = zone_data::unhash_fac( cache.first );
         if( fac == z_fac && type.str().substr( 0, 4 ) == "LOOT" ) {
-            for( tripoint_abs_ms point : cache.second ) {
+            for( const tripoint_abs_ms &point : cache.second ) {
                 if( square_dist( where, point ) <= radius ) {
                     res.emplace( here.get_bub( point ) );
                 }
             }
         }
     }
-    for( const std::pair<std::string, std::unordered_set<tripoint_abs_ms>> cache : vzone_cache ) {
+    for( const auto &cache : vzone_cache ) {
         zone_type_id type = zone_data::unhash_type( cache.first );
         faction_id z_fac = zone_data::unhash_fac( cache.first );
         if( fac == z_fac && type.str().substr( 0, 4 ) == "LOOT" ) {
-            for( tripoint_abs_ms point : cache.second ) {
+            for( const tripoint_abs_ms &point : cache.second ) {
                 if( square_dist( where, point ) <= radius ) {
                     res.emplace( here.get_bub( point ) );
                 }
@@ -1121,10 +1121,10 @@ std::unordered_set<tripoint_bub_ms> zone_manager::get_point_set_loot( const trip
     }
 
     if( npc_search ) {
-        for( const std::pair<std::string, std::unordered_set<tripoint_abs_ms>> cache : vzone_cache ) {
+        for( const auto &cache : vzone_cache ) {
             zone_type_id type = zone_data::unhash_type( cache.first );
             if( type == zone_type_NO_NPC_PICKUP ) {
-                for( tripoint_abs_ms point : cache.second ) {
+                for( const tripoint_abs_ms &point : cache.second ) {
                     res.erase( here.get_bub( point ) );
                 }
             }

--- a/src/pathfinding.cpp
+++ b/src/pathfinding.cpp
@@ -541,15 +541,15 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f,
                     tripoint_bub_ms below( p + tripoint::below );
                     if( valid_move( p, below, false, true ) ) {
                         if( !has_flag( ter_furn_flag::TFLAG_NO_FLOOR, below ) ) {
-                            // Otherwise this would have been a huge fall
-                            path_data_layer &layer = pf.get_layer( p.z() - 1 );
-                            // From cur, not p, because we won't be walking on air
-                            pf.add_point( layer.gscore[parent_index] + 10,
-                                          layer.score[parent_index] + 10 + 2 * rl_dist( below, t ),
+                            // From cur, not p, because we won't be walking on air.
+                            // Use outer layer (cur.z()) for gscore -- the destination
+                            // layer may contain stale data at parent_index.
+                            int new_g = layer.gscore[parent_index] + 10;
+                            pf.add_point( new_g, new_g + 2 * rl_dist( below, t ),
                                           cur, below );
                         }
 
-                        // Close p, because we won't be walking on it
+                        // Close p on the current z-level -- we won't walk on air
                         layer.closed[index] = true;
                         continue;
                     }
@@ -561,9 +561,8 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f,
                 tripoint_bub_ms below( p + tripoint::below );
                 if( valid_move( p, below, false, true ) ) {
                     if( !has_flag( ter_furn_flag::TFLAG_NO_FLOOR, below ) ) {
-                        path_data_layer &layer_below = pf.get_layer( p.z() - 1 );
-                        pf.add_point( layer_below.gscore[parent_index] + 10,
-                                      layer_below.score[parent_index] + 10 + 2 * rl_dist( below, t ),
+                        int new_g = layer.gscore[parent_index] + 10;
+                        pf.add_point( new_g, new_g + 2 * rl_dist( below, t ),
                                       cur, below );
                     }
                 }
@@ -596,9 +595,10 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f,
                 if( !inbounds( dest ) ) {
                     continue;
                 }
-                path_data_layer &layer = pf.get_layer( dest.z() );
-                pf.add_point( layer.gscore[parent_index] + 2,
-                              layer.score[parent_index] + 2 * rl_dist( dest, t ),
+                // Use outer layer (cur.z()) for gscore -- the destination
+                // layer may contain stale data at parent_index.
+                int new_g = layer.gscore[parent_index] + 2;
+                pf.add_point( new_g, new_g + 2 * rl_dist( dest, t ),
                               cur, dest );
             }
         }
@@ -614,48 +614,44 @@ std::vector<tripoint_bub_ms> map::route( const tripoint_bub_ms &f,
                 if( !inbounds( dest ) ) {
                     continue;
                 }
-                path_data_layer &layer = pf.get_layer( dest.z() );
-                pf.add_point( layer.gscore[parent_index] + 2,
-                              layer.score[parent_index] + 2 * rl_dist( dest, t ),
+                int new_g = layer.gscore[parent_index] + 2;
+                pf.add_point( new_g, new_g + 2 * rl_dist( dest, t ),
                               cur, dest );
             }
         }
         if( cur.z() < max.z() && parent_terrain.has_flag( ter_furn_flag::TFLAG_RAMP ) &&
             valid_move( cur, cur + tripoint::above, false, true ) ) {
-            path_data_layer &layer = pf.get_layer( cur.z() + 1 );
             for( size_t it = 0; it < 8; it++ ) {
                 const tripoint_bub_ms above( cur.x() + x_offset[it], cur.y() + y_offset[it], cur.z() + 1 );
                 if( !inbounds( above ) ) {
                     continue;
                 }
-                pf.add_point( layer.gscore[parent_index] + 4,
-                              layer.score[parent_index] + 4 + 2 * rl_dist( above, t ),
+                int new_g = layer.gscore[parent_index] + 4;
+                pf.add_point( new_g, new_g + 2 * rl_dist( above, t ),
                               cur, above );
             }
         }
         if( cur.z() < max.z() && parent_terrain.has_flag( ter_furn_flag::TFLAG_RAMP_UP ) &&
             valid_move( cur, cur + tripoint::above, false, true, true ) ) {
-            path_data_layer &layer = pf.get_layer( cur.z() + 1 );
             for( size_t it = 0; it < 8; it++ ) {
                 const tripoint_bub_ms above( cur.x() + x_offset[it], cur.y() + y_offset[it], cur.z() + 1 );
                 if( !inbounds( above ) ) {
                     continue;
                 }
-                pf.add_point( layer.gscore[parent_index] + 4,
-                              layer.score[parent_index] + 4 + 2 * rl_dist( above, t ),
+                int new_g = layer.gscore[parent_index] + 4;
+                pf.add_point( new_g, new_g + 2 * rl_dist( above, t ),
                               cur, above );
             }
         }
         if( cur.z() > min.z() && parent_terrain.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN ) &&
             valid_move( cur, cur + tripoint::below, false, true, true ) ) {
-            path_data_layer &layer = pf.get_layer( cur.z() - 1 );
             for( size_t it = 0; it < 8; it++ ) {
                 const tripoint_bub_ms below( cur.x() + x_offset[it], cur.y() + y_offset[it], cur.z() - 1 );
                 if( !inbounds( below ) ) {
                     continue;
                 }
-                pf.add_point( layer.gscore[parent_index] + 4,
-                              layer.score[parent_index] + 4 + 2 * rl_dist( below, t ),
+                int new_g = layer.gscore[parent_index] + 4;
+                pf.add_point( new_g, new_g + 2 * rl_dist( below, t ),
                               cur, below );
             }
         }


### PR DESCRIPTION
#### Summary
Bugfixes "Fix zone activity hangs from unbounded single-frame work"

#### Purpose of change

Addresses #85827, related to #85826 and #85750.

Zone activities (sorting, farming, construction) can hang the game by doing unbounded work in a single frame. The game loop spins `while(moves > 0 && activity)`, but zone activities had code paths that scanned many sources, ran A* pathfinding, and transitioned stages without ever consuming moves. On bases with many zone tiles and items this meant seconds-to-minutes of blocking work in one frame, appearing as a freeze. Memory also grew from unbounded route cache accumulation.

#### Describe the solution

**Zone sort hang prevention:** added per-source move budgets in stage_think -- 1 move per route probe (charged right after `route_length`, covering unreachable probes that do full search space exploration) and 1 move per source in the validation loop (charged before mutating state, yields via `return false`). Added 1-move yield at all seven DO-to-THINK transitions in stage_do to prevent zero-move spinning. Added a guard that skips the batching scan entirely when all destinations are unreachable (dest_dist stays INT_MAX), preventing O(N) unfiltered A* probes.

**Multi-zone hang prevention:** added per-source move budget in simulate_turn, 1 move charged at the top of the source loop body before any continue paths, yields when exhausted.

**Route cache:** replaced the linear-scan vector with an unordered_map for O(1) lookup. Added FIFO eviction with a 200-entry cap to bound memory growth.

**Zone lookup perf:** fixed `get_point_set_loot` iterating area_cache/vzone_cache by value, copying entire unordered_sets on every loop iteration. Changed to const ref.

**Pathfinder z-level scoring:** all seven vertical transitions (DangerousTrap descent, Air descent, GoesDown/GoesUp stairs, Ramp, RampUp, RampDown) had the same bug -- reading gscore/score from the destination z-level's layer using parent_index, but parent_index indexes the current node on a different z-level, so this reads stale data. Fixed all of them to use the outer layer at cur.z() and compute f-score as g + h matching the horizontal move pattern. Also fixed DangerousTrap handler variable shadowing where an inner `layer` declaration prevented closing tiles on the correct z-level.

#### Describe alternatives you've considered

Flat upfront move charge per stage_think call instead of per-source -- rejected because it charges regardless of actual work and changes pacing when few sources exist. Full cache clear at size cap instead of FIFO eviction -- rejected because it causes churn. Returning const& from get_point_set/get_vzone_set -- rejected as too risky for API stability without full caller audit.

#### Testing

All 33 zone tests pass (405 assertions), all 21 pathfinding tests pass (215 assertions). 

#### Additional context

The pathfinder scoring bug affected all vertical transitions and has been present since the stair/ramp code was written. The zone hang is a regression surface from the multi-activity refactor and zone sort improvements landing in early 2026 -- more code paths doing more work per source evaluation, but the move-budget pattern was never added.