### PR TITLE
Remove chunk of graphite from recipe for clay crucible

### DIFF
--- a/data/json/recipes/recipe_others.json
+++ b/data/json/recipes/recipe_others.json
@@ -1326,7 +1326,7 @@
     "autolearn": true,
     "proficiencies": [ { "proficiency": "prof_pottery" } ],
     "using": [ [ "earthenware_firing", 90 ], [ "clay_refractory", 5 ] ],
-    "components": [ [ [ "any_water", 1, "LIST" ] ], [ [ "graphite", 12500 ], [ "chunk_graphite", 1 ] ], [ [ "material_sand", 10 ] ] ]
+    "components": [ [ [ "any_water", 1, "LIST" ] ], [ [ "graphite", 12500 ] ], [ [ "material_sand", 10 ] ] ]
   },
   {
     "type": "recipe",


### PR DESCRIPTION
#### Summary
Balance "Remove chunk of graphite from recipe for clay crucible"

#### Purpose of change

Crafting a "crucible_clay" in the mod innawoods is a significant challenge, because it needs 1 "chunk_graphite" or 12500 "graphite" and they are hard to come by.

The player can obtain 13750 "graphite" by grinding 1 "chunk_graphite".

So if the player starts with a chunk of graphite and crafts the crucible with the chunk of graphite, all graphite is gone.

If the player instead first grinds the chunk of graphite to graphite and then crafts the crucible with the graphite, the player still has 1250 graphite left over.

After crafting the crucible, having graphite is still a hard requirement to progressing, such as for obtaining the tool quality hammering 3 by crafting "hammer_bronze".

So there is a significant consequence for the player progressing if the chunk of graphite is first processed or directly used.

#### Describe the solution

It removes the ability to directly use the chunk of graphite. So the player will need to grind it first.

#### Describe alternatives you've considered

Modify the recipe for the clay crucible to always use the chunk of graphite and add 1250 graphite as byproduct.

#### Testing

It's a trivial pull request.

#### Additional context

None