### PR TITLE
Fix zone sort hang with liquid containers at UNLOAD zones

### DIFF
--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1227,6 +1227,7 @@ std::optional<bool> unload_item( Character &you, const tripoint_abs_ms &src,
                             continue;
                         }
                         unload_teleport_item( contained );
+                        moved_something = true;
                     }
                     if( you.get_moves() <= 0 ) {
                         return std::nullopt;
@@ -1243,6 +1244,7 @@ std::optional<bool> unload_item( Character &you, const tripoint_abs_ms &src,
                             }
                         }
                         unload_teleport_item( contained );
+                        moved_something = true;
                     }
 
                     // destroy fully unloaded magazines
@@ -1261,9 +1263,9 @@ std::optional<bool> unload_item( Character &you, const tripoint_abs_ms &src,
                 for( item *contained : it->all_items_top( pocket_type::MAGAZINE_WELL ) ) {
                     if( zone_sorting::can_unload( contained ) ) {
                         unload_teleport_item( contained );
+                        moved_something = true;
                     }
                 }
-                moved_something = true;
 
             }
 

--- a/tests/clzones_test.cpp
+++ b/tests/clzones_test.cpp
@@ -36,6 +36,8 @@ static const itype_id itype_556( "556" );
 static const itype_id itype_ammolink223( "ammolink223" );
 static const itype_id itype_backpack( "backpack" );
 static const itype_id itype_belt223( "belt223" );
+static const itype_id itype_bottle_glass( "bottle_glass" );
+static const itype_id itype_chem_washing_soda( "chem_washing_soda" );
 static const itype_id itype_test_apple( "test_apple" );
 static const itype_id itype_test_bitter_almond( "test_bitter_almond" );
 static const itype_id itype_test_heavy_boulder( "test_heavy_boulder" );
@@ -50,6 +52,7 @@ static const ter_str_id ter_t_wall( "t_wall" );
 static const vproto_id vehicle_prototype_test_shopping_cart( "test_shopping_cart" );
 static const vproto_id vehicle_prototype_test_turret_rig( "test_turret_rig" );
 
+static const zone_type_id zone_type_LOOT_CHEMICAL( "LOOT_CHEMICAL" );
 static const zone_type_id zone_type_LOOT_DRINK( "LOOT_DRINK" );
 static const zone_type_id zone_type_LOOT_FOOD( "LOOT_FOOD" );
 static const zone_type_id zone_type_LOOT_PDRINK( "LOOT_PDRINK" );
@@ -2214,6 +2217,44 @@ TEST_CASE( "route_cache_invalidation_on_mass_change",
     dummy.grab( object_type::NONE );
     zone_manager::get_manager().clear();
     clear_map_without_vision();
+}
+
+// #85827: bottle with liquid at UNSORTED+UNLOAD_ALL tile hangs sorting.
+// unload_item unconditionally sets moved_something=true after the pocket
+// unload loops even when nothing was actually unloaded (liquid fails
+// can_unload), causing infinite nullopt re-entry in stage_do.
+TEST_CASE( "zone_sort_unload_liquid_container_hang", "[zones][items][activities][sorting]" )
+{
+    avatar &dummy = get_avatar();
+    map &here = get_map();
+
+    clear_avatar();
+    clear_map_without_vision();
+
+    const tripoint_bub_ms start_pos = tripoint_bub_ms::zero + tripoint::east;
+    const tripoint_abs_ms start_abs = here.get_abs( start_pos );
+    dummy.set_pos_abs_only( start_abs );
+
+    const tripoint_bub_ms chem_pos = start_pos + tripoint( 3, 0, 0 );
+    here.ter_set( chem_pos, ter_t_floor );
+    create_tile_zone( "Unsorted", zone_type_LOOT_UNSORTED, start_abs );
+    create_tile_zone( "Unload All", zone_type_UNLOAD_ALL, start_abs );
+    create_tile_zone( "Chemical", zone_type_LOOT_CHEMICAL, here.get_abs( chem_pos ) );
+
+    // Bottle with liquid first -- no matching food zone, so zt_id is NULL_ID
+    // but unload_item still runs (UNLOAD_ALL + empty dest_set).
+    // Chemical after -- has a valid dest, makes has_items_to_sort return true.
+    item bottle( itype_bottle_glass );
+    item milk( itype_test_milk );
+    REQUIRE( milk.made_of( phase_id::LIQUID ) );
+    REQUIRE( bottle.put_in( milk, pocket_type::CONTAINER ).success() );
+    here.add_item_or_charges( start_pos, bottle );
+    here.add_item_or_charges( start_pos, item( itype_chem_washing_soda ) );
+
+    dummy.assign_activity( zone_sort_activity_actor() );
+    process_activity( dummy );
+
+    CHECK( !dummy.activity );
 }
 
 // Large UNSORTED zone with many empty tiles and one item adjacent to the


### PR DESCRIPTION
#### Summary
Bugfixes "Fix zone sort hang with liquid containers at unload zones"

#### Purpose of change

Fixes #85827.

Sorting hangs when a liquid-filled container (e.g. bottle of maple syrup) is on a tile with both UNSORTED and UNLOAD_ALL zones, and there is no matching destination zone for the container's contents. The game becomes unresponsive and memory usage climbs until the process is killed.

#### Describe the solution

`unload_item` in `activity_item_handling.cpp` unconditionally set `moved_something = true` after iterating the container/magazine/magazine-well unload loops, even when nothing was actually unloaded. Liquids fail `can_unload` (solid-only check), so the loops run without moving anything, but the flag still triggered a nullopt return for "re-assessment". `stage_do` then re-entered with `num_processed` reset to 0, hit the same bottle, got nullopt again, forever.

Fix: only set `moved_something` inside each loop body when `unload_teleport_item` actually fires, matching the existing `can_unload` guard.

Added a regression test that reproduces the exact scenario from the bug report: UNSORTED + UNLOAD_ALL tile, a bottle with liquid (no food zone), and a chemical item with a valid destination (so `has_items_to_sort` returns true and `stage_do` processes all items).

#### Describe alternatives you've considered

Guarding in `stage_do` (skip on nullopt without move consumption) -- works as defense-in-depth but doesn't fix the root cause in `unload_item`. The previous PR #85829 included this guard alongside other fixes; this PR addresses the actual bug.

#### Testing

Regression test `zone_sort_unload_liquid_container_hang` hangs without the fix, passes with it. All 34 zone tests pass (408 assertions). Verified with the save file from the issue report.

#### Additional context

The unconditional `moved_something = true` has been present since the original `move_loot` implementation. It didn't cause visible hangs until UNLOAD_ALL zones were commonly stacked with UNSORTED zones on tiles containing liquid-filled containers without matching destination zones.