### PR TITLE
Fix zone sort stalling on large zones with mostly empty tiles

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -4763,12 +4763,6 @@ bool multi_zone_activity_actor::simulate_turn( player_activity &act, Character &
     for( const tripoint_abs_ms &src : src_sorted ) {
         const tripoint_bub_ms &src_bub = here.get_bub( src );
         if( !check_only ) {
-            // Budget: each source evaluation costs 1 move to prevent
-            // unbounded can_do/requirements/route work in a single frame.
-            you.mod_moves( -1 );
-            if( you.get_moves() <= 0 ) {
-                return true;
-            }
             if( !here.inbounds( src_bub ) ) {
                 if( zone_sorting::sorter_out_of_bounds( you, current_activity ) ) {
                     // activity cancelled
@@ -12923,12 +12917,6 @@ bool zone_sort_activity_actor::stage_think( player_activity &act, Character &you
 
     // iterate over zone positions and look for items to move
     for( const tripoint_abs_ms &src : src_sorted ) {
-        // Budget: each source evaluation costs 1 move (populate_items,
-        // has_items_to_sort, zone lookups). Yield before mutating state.
-        you.mod_moves( -1 );
-        if( you.get_moves() <= 0 ) {
-            return false;
-        }
         placement = src;
 
         const tripoint_bub_ms src_bub = here.get_bub( src );
@@ -12946,6 +12934,7 @@ bool zone_sort_activity_actor::stage_think( player_activity &act, Character &you
         bool ignore_contents = zone_sorting::ignore_contents( you, src );
 
         if( zone_sorting::ignore_zone_position( you, src, ignore_contents ) ) {
+            coord_set.erase( src );
             continue;
         }
 
@@ -12968,12 +12957,11 @@ bool zone_sort_activity_actor::stage_think( player_activity &act, Character &you
         }
 
         if( !has_items_to_work_on ) {
+            coord_set.erase( src );
             continue;
         }
 
         bool is_adjacent_or_closer = square_dist( you.pos_bub(), src_bub ) <= 1;
-        // before we move any item, check if player is at or
-        // adjacent to the loot source tile
         if( !is_adjacent_or_closer ) {
             add_msg_debug( debugmode::DF_ACTIVITY,
                            "zone_sort THINK: routing to source (%d,%d,%d) from (%d,%d)",
@@ -12992,6 +12980,12 @@ bool zone_sort_activity_actor::stage_think( player_activity &act, Character &you
                        src.x(), src.y(), src.z() );
         stage = DO;
         break;
+    }
+    if( stage != DO && !coord_set.empty() ) {
+        // Remaining entries are filtered by unreachable_sources, have
+        // full destinations, or were past the route probe cutoff.
+        // Clear so the activity ends cleanly instead of re-scanning.
+        coord_set.clear();
     }
     return true;
 }

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -371,7 +371,13 @@ void player_activity::do_turn( Character &you )
     if( !*this ) {
         // Make sure data of previous activity is cleared
         you.activity = player_activity();
-        you.resume_backlog_activity();
+        // Don't resume backlog while auto-moving to a destination --
+        // the destination_activity will restore the right activity on
+        // arrival. Resuming now would re-trigger the same fetch/route
+        // cycle within the same frame.
+        if( !you.has_destination() ) {
+            you.resume_backlog_activity();
+        }
         // If whatever activity we were doing forced us to pick something up to
         // handle it, drop any overflow that may have caused
         you.drop_invalid_inventory();

--- a/tests/clzones_test.cpp
+++ b/tests/clzones_test.cpp
@@ -2216,3 +2216,40 @@ TEST_CASE( "route_cache_invalidation_on_mass_change",
     clear_map_without_vision();
 }
 
+// Large UNSORTED zone with many empty tiles and one item adjacent to the
+// player. stage_think should prune empty sources from coord_set so it
+// reaches the tile with the item instead of re-scanning empties forever.
+TEST_CASE( "zone_sort_think_prunes_empty_sources", "[zones][items][activities][sorting]" )
+{
+    avatar &dummy = get_avatar();
+    map &here = get_map();
+
+    clear_avatar();
+    clear_map_without_vision();
+
+    const tripoint_bub_ms start_pos( 60, 60, 0 );
+    dummy.setpos( here, start_pos );
+
+    // 20x20 UNSORTED zone -- 400 tiles, mostly empty
+    const tripoint_abs_ms zone_start = here.get_abs( start_pos - point( 10, 10 ) );
+    const tripoint_abs_ms zone_end = here.get_abs( start_pos + point( 9, 9 ) );
+    zone_manager &zm = zone_manager::get_manager();
+    zm.add( "Unsorted", zone_type_LOOT_UNSORTED, faction_your_followers,
+            false, true, zone_start, zone_end );
+
+    // Destination zone adjacent to player
+    const tripoint_bub_ms dest_pos = start_pos + tripoint::east;
+    here.ter_set( dest_pos, ter_t_floor );
+    create_tile_zone( "Food", zone_type_LOOT_FOOD, here.get_abs( dest_pos ) );
+
+    // Item at the player's tile (adjacent to dest) so process_activity
+    // can deliver it without auto-move
+    here.add_item_or_charges( start_pos, item( itype_test_apple ) );
+
+    dummy.assign_activity( zone_sort_activity_actor() );
+    process_activity( dummy );
+
+    CHECK( !dummy.activity );
+    // Apple should have been delivered to the food zone
+    CHECK( count_items_or_charges( dest_pos, itype_test_apple, std::nullopt ) == 1 );
+}


### PR DESCRIPTION
#### Summary
Bugfixes "Fix zone sort stalling on large zones with mostly empty tiles"

#### Purpose of change

Follow-up to #85829. Zone sorting on large UNSORTED zones (like a 20x20 area) with mostly empty tiles stalls -- character stands still, time passes, nothing gets sorted. Found while investigating #85826.

The route probe move budget from #85829 ate all available moves before the validation loop could run. Empty tiles stayed in coord_set forever, got re-probed every turn, same result.

Additionally, multi-zone activities (disassemble, construct) could loop infinitely when a fetch activity set a destination but `resume_backlog_activity` immediately restored the parent activity from the backlog, re-triggering the same fetch cycle within the same frame.

#### Describe the solution

Zone sort starvation:
- Erase sources from coord_set when `has_items_to_sort` returns false or `ignore_zone_position` skips them. Items don't appear spontaneously, so empty tiles don't need re-evaluation.
- Remove the validation loop move budget that caused starvation when the route probe consumed all moves first.
- Add a debugmsg safety net at the end of stage_think: if it finishes without finding work but coord_set is non-empty, clear and warn instead of looping.

Multi-zone backlog loop:
- Skip `resume_backlog_activity` in `player_activity::do_turn` when the player has a destination set. The destination_activity mechanism handles restoring the right activity on arrival -- resuming the backlog immediately causes the parent activity to re-trigger the same fetch/route cycle.

Also removed the multi-zone per-source move budget from simulate_turn. It caused mop/vehicle repair to stall by returning "continue next turn" after scanning only a subset of sources, even when none had work. Without it, simulate_turn scans all sources in one pass and returns false (activity ends) when nothing can be done.

#### Describe alternatives you've considered

Splitting moves between route probes and validation -- too fragile. Pruning empties is the actual fix. For the backlog loop, consuming moves in check_requirements was considered but doesn't address the root cause.

#### Testing

Regression test: 20x20 UNSORTED zone (400 tiles), one item, adjacent destination. Hangs without fix, passes with it. All 34 zone tests pass. Verified disassemble and mop zone activities with save files from #85826.

#### Additional context

The zone sort starvation: route probe evaluates ~100 candidates/turn, finds them reachable, uses all moves. Validation loop gets 0 moves, yields. Next turn: same candidates, same probe, no progress.

The backlog loop: fetch activity routes to a tool, do_turn clears the activity, player_activity::do_turn detects null activity, resume_backlog_activity restores the parent (disassemble), which immediately triggers another fetch for the same tool. All within one frame, no moves consumed.