### PR TITLE
A few extra ways to advance Hub 01 CBM knowledge

### DIFF
--- a/data/json/npcs/robofac/robofac_ancilla_npcs/NPC_ANCILLA_DOCTOR.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/NPC_ANCILLA_DOCTOR.json
@@ -263,7 +263,8 @@
             "then": [
               { "u_lose_trait": "CBM_Interface" },
               { "u_add_trait": "CBM_Interface_brain_lesion" },
-              { "math": [ "hub01_found_u_exodii_interface = 1" ] }
+              { "math": [ "hub01_found_u_exodii_interface = 1" ] },
+              { "math": [ "robofac_exodii_cbm_knowledge += 1" ] }
             ]
           },
           { "u_add_effect": "narcosis", "duration": "2 hours" },
@@ -294,7 +295,8 @@
             "then": [
               { "u_lose_trait": "CBM_Interface" },
               { "u_add_trait": "CBM_Interface_brain_lesion" },
-              { "math": [ "hub01_found_u_exodii_interface = 1" ] }
+              { "math": [ "hub01_found_u_exodii_interface = 1" ] },
+              { "math": [ "robofac_exodii_cbm_knowledge += 1" ] }
             ]
           },
           { "u_add_effect": "narcosis", "duration": "2 hours" },
@@ -320,6 +322,7 @@
         "text": "[Exchange your Exodii CBM interface for the Hub 01 CBM interface and 10 HGC]  Let's do it.",
         "effect": [
           { "math": [ "hub01_found_u_exodii_interface = 1" ] },
+          { "math": [ "robofac_exodii_cbm_knowledge += 1" ] },
           { "u_add_effect": "narcosis", "duration": "2 hours" },
           { "u_add_effect": "sleep", "duration": "2 hours" },
           { "u_assign_activity": "ACT_CBM_SURGERY", "duration": "2 hours" },

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
@@ -831,19 +831,19 @@
       {
         "text": "They are a race of inter-dimensional beings who call themselves the Exodii.  These guys are more metal than man in my opinion and use automated machinery to do their fighting and heavy lifting.  They do understand English to a certain extent and when talking they use a strange dialect they like to call Anglic.",
         "topic": "TALK_FINISH_ROBOFAC_EXODII_DISCUSSION",
-        "effect": { "u_add_faction_trust": 1 }
+        "effect": [ { "u_add_faction_trust": 1 }, { "math": [ "robofac_exodii_cbm_knowledge += 1" ] } ]
       },
       {
         "text": "They are a race of inter-dimensional beings who call themselves the Exodii and they use a mix of futuristic and ancient technology the latter being mostly due to their last landing place being an ancient battlefield of some sort.  These guys are more metal than man in my opinion and use automated machinery to do their fighting and heavy lifting.  While their choice for personal defense was more along the lines of ancient gear like spears and swords.  They do understand English to a certain extent and when talking they use a strange dialect they like to call Anglic.",
         "topic": "TALK_FINISH_ROBOFAC_EXODII_DISCUSSION",
         "condition": { "compare_string": [ "yes", { "u_val": "u_talk_exodii_about_medieval_stock" } ] },
-        "effect": { "u_add_faction_trust": 2 }
+        "effect": [ { "u_add_faction_trust": 2 }, { "math": [ "robofac_exodii_cbm_knowledge += 1" ] } ]
       },
       {
         "text": "They are a race of inter-dimensional beings who call themselves the Exodii.  These guys are more metal than man in my opinion and use automated machinery to do their fighting and heavy lifting.  They do understand English to a certain extent and when talking they use a strange dialect they like to call Anglic.  They are here to mine this place of any useful metal, gather any tech they deem worth saving and maybe even grab a couple of survivors to join their ranks before they move out.",
         "topic": "TALK_FINISH_ROBOFAC_EXODII_DISCUSSION",
         "condition": { "compare_string": [ "yes", { "u_val": "u_know_exodii_purpose2" } ] },
-        "effect": { "u_add_faction_trust": 2 }
+        "effect": [ { "u_add_faction_trust": 2 }, { "math": [ "robofac_exodii_cbm_knowledge += 1" ] } ]
       },
       {
         "text": "They are a race of inter-dimensional beings who call themselves the Exodii and they use a mix of futuristic and ancient technology the latter being mostly due to their last landing place being an ancient battlefield of some sort.  These guys are more metal than man in my opinion and use automated machinery to do their fighting and heavy lifting.  However their choice for personal defense was more along the lines of ancient gear like spears and swords.  They do understand English to a certain extent and when talking they use a strange dialect they like to call Anglic.  They are here to mine this place of any useful metal, gather any tech they deem worth saving and maybe even grab a couple of survivors to join their ranks before they move out.",
@@ -854,7 +854,7 @@
             { "compare_string": [ "yes", { "u_val": "u_talk_exodii_about_medieval_stock" } ] }
           ]
         },
-        "effect": { "u_add_faction_trust": 3 }
+        "effect": [ { "u_add_faction_trust": 3 }, { "math": [ "robofac_exodii_cbm_knowledge += 1" ] } ]
       }
     ]
   },
@@ -1218,19 +1218,31 @@
       {
         "text": "It's a warehouse owned by a race of inter-dimensional beings who call themselves the Exodii.  They're… robots?  Cyborgs?  More metal than man in my opinion.  They use automated machinery to do their fighting and heavy lifting.  They do understand English to a certain extent, but when talking they use a strange dialect they like to call Anglic.",
         "topic": "TALK_ROBOFAC_INTERCOM_BUY_EXODII_WAREHOUSE",
-        "effect": [ { "u_add_faction_trust": 1 }, { "math": [ "hub01_knows_exodii = 1" ] } ]
+        "effect": [
+          { "u_add_faction_trust": 1 },
+          { "math": [ "hub01_knows_exodii = 1" ] },
+          { "math": [ "robofac_exodii_cbm_knowledge += 1" ] }
+        ]
       },
       {
         "text": "It's a warehouse owned by a race of inter-dimensional beings who call themselves the Exodii.  They're… robots?  Cyborgs?  More metal than man in my opinion.  They use automated machinery to do their fighting and heavy lifting, and they seem to have a preference for large firearms, swords, and spears.  They do understand English to a certain extent, but when talking they use a strange dialect they like to call Anglic.",
         "topic": "TALK_ROBOFAC_INTERCOM_BUY_EXODII_WAREHOUSE",
         "condition": { "compare_string": [ "yes", { "u_val": "u_talk_exodii_about_medieval_stock" } ] },
-        "effect": [ { "u_add_faction_trust": 2 }, { "math": [ "hub01_knows_exodii = 1" ] } ]
+        "effect": [
+          { "u_add_faction_trust": 2 },
+          { "math": [ "hub01_knows_exodii = 1" ] },
+          { "math": [ "robofac_exodii_cbm_knowledge += 1" ] }
+        ]
       },
       {
         "text": "It's a warehouse owned by a race of inter-dimensional beings who call themselves the Exodii.  They're… robots?  Cyborgs?  More metal than man in my opinion.  They use automated machinery to do their fighting and heavy lifting.  They do understand English to a certain extent, but when talking they use a strange dialect they like to call Anglic.  From what I understand, they are here to mine this place of any useful metal, gather any tech they deem worth saving and maybe even grab a couple of survivors to join their ranks before they move out.",
         "topic": "TALK_ROBOFAC_INTERCOM_BUY_EXODII_WAREHOUSE",
         "condition": { "compare_string": [ "yes", { "u_val": "u_know_exodii_purpose2" } ] },
-        "effect": [ { "u_add_faction_trust": 2 }, { "math": [ "hub01_knows_exodii = 1" ] } ]
+        "effect": [
+          { "u_add_faction_trust": 2 },
+          { "math": [ "hub01_knows_exodii = 1" ] },
+          { "math": [ "robofac_exodii_cbm_knowledge += 1" ] }
+        ]
       },
       {
         "text": "It's a warehouse owned by a race of inter-dimensional beings who call themselves the Exodii.  They're… robots?  Cyborgs?  More metal than man in my opinion.  They use automated machinery to do their fighting and heavy lifting, and they seem to have a preference for large firearms, swords, and spears.  They do understand English to a certain extent, but when talking they use a strange dialect they like to call Anglic.  From what I understand, they are here to mine this place of any useful metal, gather any tech they deem worth saving and maybe even grab a couple of survivors to join their ranks before they move out.",
@@ -1241,7 +1253,11 @@
             { "compare_string": [ "yes", { "u_val": "u_talk_exodii_about_medieval_stock" } ] }
           ]
         },
-        "effect": [ { "u_add_faction_trust": 3 }, { "math": [ "hub01_knows_exodii = 1" ] } ]
+        "effect": [
+          { "u_add_faction_trust": 3 },
+          { "math": [ "hub01_knows_exodii = 1" ] },
+          { "math": [ "robofac_exodii_cbm_knowledge += 1" ] }
+        ]
       },
       { "text": "Actually, nevermind.", "topic": "TALK_ROBOFAC_INTERCOM_SERVICES" }
     ]
@@ -1390,6 +1406,7 @@
         "effect": [
           { "u_add_faction_trust": 1 },
           { "math": [ "hub01_stole_warehouse = 1" ] },
+          { "math": [ "robofac_exodii_cbm_knowledge += 1" ] },
           { "math": [ "u_timer_hub_waiting_on_warehouse = time('now')" ] },
           { "u_add_var": "dialogue_hub_u_waiting_on_warehouse", "value": "yes" },
           { "mapgen_update": "exo_warehouse_1_robofac_looted", "om_terrain": "exo_warehouse_1" }

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
@@ -141,6 +141,7 @@
           { "u_consume_item": "broken_exodii_worker", "count": 1, "popup": true },
           { "finish_mission": "MISSION_ROBOFAC_INTERCOM_CIRCUIT_SAFARI", "success": true },
           { "math": [ "u_timer_hub_waiting_on_autodoc = time('now')" ] },
+          { "math": [ "robofac_exodii_cbm_knowledge += 1" ] },
           { "u_add_var": "dialogue_hub_u_waiting_on_autodoc", "value": "yes" }
         ],
         "topic": "MISSION_ROBOFAC_INTERCOM_CIRCUIT_SAFARI_COMPLETE"
@@ -152,6 +153,7 @@
           { "u_consume_item": "exodii_chop_shop_head", "count": 1, "popup": true },
           { "finish_mission": "MISSION_ROBOFAC_INTERCOM_CIRCUIT_SAFARI", "success": true },
           { "math": [ "u_timer_hub_waiting_on_autodoc = time('now')" ] },
+          { "math": [ "robofac_exodii_cbm_knowledge += 1" ] },
           { "u_add_var": "dialogue_hub_u_waiting_on_autodoc", "value": "yes" }
         ],
         "topic": "MISSION_ROBOFAC_INTERCOM_CIRCUIT_SAFARI_COMPLETE_ALT"

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_trades.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_trades.json
@@ -489,6 +489,7 @@
         "effect": [
           { "u_consume_item": "HEW_printout_data_exodii", "count": 1, "popup": true },
           { "math": [ "HEW_exodii_data_sold++" ] },
+          { "math": [ "robofac_exodii_cbm_knowledge += 1" ] },
           { "u_spawn_item": "RobofacCoin", "count": 5 }
         ],
         "topic": "TALK_ROBOFAC_INTERCOM_SELL_HEW_DATA_EXODII"
@@ -561,6 +562,7 @@
         "effect": [
           { "u_consume_item": "HEW_printout_data_physics_lab", "count": 1, "popup": true },
           { "math": [ "HEW_physics_lab_data_sold++" ] },
+          { "math": [ "robofac_exodii_cbm_knowledge += 1" ] },
           { "u_spawn_item": "RobofacCoin", "count": 5 }
         ],
         "topic": "TALK_ROBOFAC_INTERCOM_SELL_HEW_DATA_PHYSICS_LAB"


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Features "Giving Hub 01 info on the Exodii advances their knowledge of them/CBMs"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

There are a few missions/dialogue options that would at least give the Hub some intellectual insight into CBMs and how they work.  They should add to the new counter that tracks their CBM/Exodii knowledge.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Adds 1 to the counter in the following events:

- Giving them extensive details on the Exodii during the Exodii scouting mission or when selling the warehouse to them.
- Helping them steal the Exodii warehouse
- Finishing Circuit Safari (thus giving them an inactive worker)
- Returning the Exodii HEW report
- Returning the Labyrinth HEW report
- If the Ancilla doc recovered your Exodii Neurobionic Interface while installing the Hub interface

This allows the player to advance the counter by a few days' worth of points, if they're rather judicious and on the Hub's side consistently.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

n/a

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

checked the tracker after doing the dialogue

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
