### PR TITLE
Changed both 'looks_like' for Wooden and Steel Tankards

### DIFF
--- a/data/json/items/containers/containers.json
+++ b/data/json/items/containers/containers.json
@@ -5064,7 +5064,7 @@
     "price": "15 USD",
     "price_postapoc": "50 cent",
     "material": [ "wood" ],
-    "looks_like": "clay_canister",
+    "looks_like": "ceramic_mug",
     "symbol": ")",
     "color": "brown",
     "pocket_data": [
@@ -5094,7 +5094,7 @@
     "price": "30 USD",
     "price_postapoc": "50 cent",
     "material": [ "steel" ],
-    "looks_like": "clay_canister",
+    "looks_like": "ceramic_mug",
     "symbol": ")",
     "color": "light_cyan",
     "pocket_data": [


### PR DESCRIPTION
#### Summary

Content "Changed both "looks_like" for Wooden and Steel Tankards"

#### Purpose of change

Wooden and Steel Tankards both had 'looks_like' of clay_cannister which looks kind of odd, so instead for immersion sake I changed it to look like the coffee mugs texture

#### Describe the solution

I just changed the 'looks_like', hopefully I did it right

#### Describe alternatives you've considered

suffer through my broken immersion when I have a wooden or steel tankard on a table

#### Testing

it was just a quick change, if I somehow broke it then that would be incredible

#### Additional context

I require IMMERSION RAAAAAAHHHHH
