### PR TITLE
Fix zone activities ignoring player cancel

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -5259,6 +5259,10 @@ void Character::cancel_activity()
     }
     if( activity && activity.can_resume() ) {
         activity.allow_distractions();
+        // Don't auto-resume after explicit cancellation.  The stamina
+        // "continue after a break" path uses assign_activity() (not
+        // cancel_activity) to push to backlog, so this is safe.
+        activity.auto_resume = false;
         backlog.push_front( activity );
     }
     sfx::end_activity_sounds(); // kill activity sounds when canceled

--- a/tests/clzones_test.cpp
+++ b/tests/clzones_test.cpp
@@ -1,6 +1,7 @@
 #include <climits>
 #include <functional>
 #include <initializer_list>
+#include <list>
 #include <optional>
 #include <set>
 #include <string>
@@ -2252,4 +2253,34 @@ TEST_CASE( "zone_sort_think_prunes_empty_sources", "[zones][items][activities][s
     CHECK( !dummy.activity );
     // Apple should have been delivered to the food zone
     CHECK( count_items_or_charges( dest_pos, itype_test_apple, std::nullopt ) == 1 );
+}
+
+// Activities with multi_activity=true get auto_resume=true on assignment.
+// cancel_activity() must clear auto_resume before pushing to the backlog,
+// otherwise resume_backlog_activity() (called right after in
+// cancel_activity_query) immediately restores the activity, making it
+// impossible for the player to cancel.  Regression test for #85838/#85840.
+TEST_CASE( "cancel_activity_clears_auto_resume_for_multi_type",
+           "[zones][activities][cancel]" )
+{
+    avatar &dummy = get_avatar();
+    clear_avatar();
+    clear_map_without_vision();
+
+    // unload_loot has multi_activity: true in player_activities.json,
+    // so assign_activity(actor) sets auto_resume = true.
+    dummy.assign_activity( unload_loot_activity_actor() );
+    REQUIRE( dummy.activity );
+    REQUIRE( dummy.activity.is_multi_type() );
+    REQUIRE( dummy.activity.auto_resume );
+
+    // Simulate what cancel_activity_query does when the player presses '.'
+    // and confirms: cancel_activity() followed by resume_backlog_activity().
+    dummy.cancel_activity();
+    dummy.resume_backlog_activity();
+
+    // The activity must stay cancelled -- not silently restored.
+    CHECK( !dummy.activity );
+    CHECK( ( dummy.backlog.empty() ||
+             !dummy.backlog.front().auto_resume ) );
 }


### PR DESCRIPTION
#### Summary
Bugfixes "Fix zone activities ignoring player cancel"

#### Purpose of change

Zone activities with `multi_activity=true` in their JSON definition (unload loot, construct, disassemble, vehicle repair, etc.) cannot be cancelled by the player. Pressing `.` and confirming has no effect -- the activity immediately restarts.

Fixes #85838, fixes #85840

#### Describe the solution

`assign_activity(const activity_actor&)` sets `auto_resume = true` on any activity where `is_multi_type()` returns true. When the player cancels, `cancel_activity()` pushes the activity to the backlog preserving that flag. Then `cancel_activity_query()` calls `resume_backlog_activity()`, which finds `auto_resume = true` on the front item and immediately restores the activity. Round trip, nothing happened.

The fix clears `auto_resume` before pushing to backlog in `cancel_activity()`. The stamina "continue after a break" path uses `assign_activity()` (not `cancel_activity()`) to push to backlog, so that flow is unaffected.

#### Describe alternatives you've considered

Could also remove the `resume_backlog_activity()` call from `cancel_activity_query()`, but that has wider implications for activities that legitimately need backlog resume after cancel (stamina "maybe later" already sets `auto_resume = false` before calling `cancel_activity`, so the current fix handles it cleanly).

#### Testing

Regression test added: assigns an `unload_loot_activity_actor` (multi_activity=true), verifies `auto_resume` is set, simulates the cancel flow, asserts the activity stays null. Fails without fix, passes with it. All 35 zone tests and 36 activity tests pass.

#### Additional context

Follow-up to #85835 which fixed a related backlog loop in `player_activity::do_turn` by gating `resume_backlog_activity` on `!has_destination()`. That fix covered the natural-finish path but not the explicit-cancel path in `cancel_activity_query()`.