### PR TITLE
Fix unique overmap special spawn rate formula

### DIFF
--- a/data/mods/TEST_DATA/overmap_terrain_coverage_test/overmap_terrain_coverage_whitelist.json
+++ b/data/mods/TEST_DATA/overmap_terrain_coverage_test/overmap_terrain_coverage_whitelist.json
@@ -61,11 +61,11 @@
       "prison_alcatraz_.*",
       "cabin_lakeside\\d?(_roof)?",
       "boat_rental(_[12])?(_roof)?",
-      "nursing_home_(b.*|lab\\d)",
+      "nursing_home_.*",
       "farm_isherwood_.*",
       "corpse_head_neck_(l|r|center)_decap",
       "abandoned_textile_mill(_b)?_\\d_\\d",
-      "hotel_tower(_flr2)_1_5B?",
+      "hotel_tower(_flr2)?_1_5B?",
       "pottery_cottage",
       "pottery_cottage_2nd",
       "pottery_cottage_roof",
@@ -78,7 +78,23 @@
       "xedra_fishing_shack_1",
       "xedra_fishing_shack_2",
       "microlab_sub_connector",
-      "test_forest_very_thick"
+      "test_forest_very_thick",
+      "mine_amigara.*",
+      "mine_spiral.*",
+      "mine_wyrm.*",
+      "mine_entrance.*",
+      "mine_shaft.*",
+      "s_lot_no_sidewalk",
+      "exo_safehouse_stone_.*",
+      "exo_warehouse_.*",
+      "oil_platform_.*",
+      "bunker(_basement_1|_roof)?",
+      "haz_sar_.*",
+      "hot_springs",
+      "helipad.*",
+      "fort_\\d.*",
+      "forge_.*",
+      "aenor_paddock.*"
     ]
   }
 ]

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -3129,6 +3129,11 @@ bool overmap::place_special_attempt(
 
             place_special( special, p, rotation, nearest_city, false, must_be_unexplored );
 
+            // Only this call site participates in deck accounting.
+            if( special.has_flag( "OVERMAP_UNIQUE" ) || special.has_flag( "GLOBALLY_UNIQUE" ) ) {
+                overmap_buffer.consume_deck_placement( special.id );
+            }
+
             if( ++iter->instances_placed >= constraints.occurrences.max ) {
                 enabled_specials.erase( iter );
             }
@@ -3211,16 +3216,46 @@ void overmap::place_specials( overmap_special_batch &enabled_specials )
         const bool globally_unique = iter->special_details->has_flag( "GLOBALLY_UNIQUE" );
         if( unique || globally_unique ) {
             const overmap_special_id &id = iter->special_details->id;
-            const overmap_special_placement_constraints &constraints = iter->special_details->get_constraints();
-            const float special_count = overmap_buffer.get_unique_special_count( id );
-            const float overmap_count = overmap_buffer.get_overmap_count();
-            const float min = special_count > 0 ? constraints.occurrences.min / special_count :
-                              constraints.occurrences.min;
-            const float max = std::max( overmap_count > 0 ? constraints.occurrences.max / overmap_count :
-                                        constraints.occurrences.max, min );
-            if( x_in_y( min, max ) && ( !overmap_buffer.contains_unique_special( id ) ) ) {
-                // Min and max are overloaded to be the chance of occurrence,
-                // so reset instances placed to one short of max so we don't place several.
+            const overmap_special_placement_constraints &constraints =
+                iter->special_details->get_constraints();
+            const int occ_min = constraints.occurrences.min;
+            const int occ_max = constraints.occurrences.max;
+
+            // Specials with no success cards or empty deck never spawn via this path.
+            if( occ_min <= 0 || occ_max <= 0 ) {
+                iter = enabled_specials.erase( iter );
+                continue;
+            }
+
+            // GLOBALLY_UNIQUE already placed -- done forever.
+            if( globally_unique && overmap_buffer.contains_unique_special( id ) ) {
+                iter = enabled_specials.erase( iter );
+                continue;
+            }
+
+            unique_special_deck_state &deck =
+                overmap_buffer.get_deck_state( id, occ_min, occ_max );
+
+            // Draw only when nothing is pending -- prevents unbounded backlog.
+            if( deck.to_place <= 0 ) {
+                // successes_remain > 0 guard: x_in_y(0, N) can return true when rng_float is 0.0.
+                if( deck.successes_remain > 0 && x_in_y( deck.successes_remain, deck.cards_remain ) ) {
+                    deck.successes_remain--;
+                    deck.cards_remain--;
+                    deck.to_place++;
+                } else {
+                    deck.cards_remain--;
+                }
+
+                // Deck exhausted -- reshuffle (start a new cycle).
+                if( deck.cards_remain <= 0 ) {
+                    deck.successes_remain = occ_min;
+                    deck.cards_remain = occ_max;
+                }
+            }
+
+            if( deck.to_place > 0 ) {
+                // Allow exactly one placement attempt on this overmap.
                 iter->instances_placed = constraints.occurrences.max - 1;
             } else {
                 iter = enabled_specials.erase( iter );

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -269,6 +269,7 @@ void overmap_global_state::clear()
 {
     placed_unique_specials.clear();
     unique_special_count.clear();
+    unique_special_decks.clear();
     highway_intersections.clear();
     overmap_count = 0;
     major_river_count = 0;
@@ -1870,6 +1871,36 @@ int overmapbuffer::get_major_river_count() const
 void overmapbuffer::inc_major_river_count()
 {
     global_state.major_river_count++;
+}
+
+unique_special_deck_state &overmapbuffer::get_deck_state(
+    const overmap_special_id &id, int successes, int deck_size )
+{
+    auto [it, inserted] = global_state.unique_special_decks.try_emplace( id );
+    unique_special_deck_state &deck = it->second;
+    // Reset if: new entry, constraints changed (mod update), or saved
+    // state has invalid invariants (corrupt save, manual edit, etc.).
+    if( inserted || deck.successes != successes || deck.deck_size != deck_size ||
+        deck.cards_remain <= 0 || deck.successes_remain > deck.cards_remain ||
+        deck.successes_remain > successes || deck.to_place < 0 ) {
+        deck.successes = successes;
+        deck.deck_size = deck_size;
+        deck.successes_remain = successes;
+        deck.cards_remain = deck_size;
+        if( inserted ) {
+            deck.to_place = 0;
+        }
+        // On constraint change, keep to_place -- those draws already happened.
+    }
+    return deck;
+}
+
+void overmapbuffer::consume_deck_placement( const overmap_special_id &id )
+{
+    auto it = global_state.unique_special_decks.find( id );
+    if( it != global_state.unique_special_decks.end() && it->second.to_place > 0 ) {
+        it->second.to_place--;
+    }
 }
 
 bool overmap_feature_grid::feature_point_exists( const point_abs_om &intersection_om ) const

--- a/src/overmapbuffer.h
+++ b/src/overmapbuffer.h
@@ -152,6 +152,20 @@ struct omt_find_params {
     std::optional<overmap_special_id> om_special = std::nullopt;
 };
 
+// Draw-without-replacement deck for unique special spawn rate control.
+// Virtual deck of Y cards with X successes, drawn once per eligible overmap.
+// Resets on exhaustion. Drawing pauses while to_place > 0. See issue #73618.
+struct unique_special_deck_state {
+    int successes = 0;       // source total: occurrences.min when deck was created
+    int deck_size = 0;       // source total: occurrences.max when deck was created
+    int successes_remain = 0; // success cards remaining in current deck cycle
+    int cards_remain = 0;    // total cards remaining in current deck cycle
+    int to_place = 0;        // successful draws awaiting placement
+
+    void serialize( JsonOut &json ) const;
+    void deserialize( const JsonObject &json );
+};
+
 /**
 * Helper struct for dynamic data about the world's overmaps (not including overmap objects themselves).
 * For example: unique overmap special counts, highway intersection locations.
@@ -162,6 +176,9 @@ struct overmap_global_state {
     // This tracks the overmap unique specials we have placed. It is used to
     // Adjust weights of special spawns to correct for things like failure to spawn.
     std::unordered_map<overmap_special_id, int> unique_special_count;
+    // Deck states for unique special spawn frequency control.
+    // Keyed by special ID. Lazily initialized on first access.
+    std::unordered_map<overmap_special_id, unique_special_deck_state> unique_special_decks;
     // Global count of number of overmaps generated for this world.
     int overmap_count = 0;
     // Global count of major rivers generated for this world
@@ -620,6 +637,12 @@ class overmapbuffer
 
         int get_unique_special_count( const overmap_special_id &id );
         int get_overmap_count() const;
+
+        // Get or lazily initialize deck state; resets if constraints changed.
+        unique_special_deck_state &get_deck_state(
+            const overmap_special_id &id, int successes, int deck_size );
+        // Decrement to_place after placement. Only called from place_special_attempt().
+        void consume_deck_placement( const overmap_special_id &id );
         int get_major_river_count() const;
         void inc_major_river_count();
 

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -2030,6 +2030,26 @@ void creature_tracker::serialize( JsonOut &jsout ) const
     jsout.end_array();
 }
 
+void unique_special_deck_state::serialize( JsonOut &json ) const
+{
+    json.start_object();
+    json.member( "successes", successes );
+    json.member( "deck_size", deck_size );
+    json.member( "successes_remain", successes_remain );
+    json.member( "cards_remain", cards_remain );
+    json.member( "to_place", to_place );
+    json.end_object();
+}
+
+void unique_special_deck_state::deserialize( const JsonObject &json )
+{
+    json.read( "successes", successes );
+    json.read( "deck_size", deck_size );
+    json.read( "successes_remain", successes_remain );
+    json.read( "cards_remain", cards_remain );
+    json.read( "to_place", to_place );
+}
+
 void overmap_global_state::serialize( JsonOut &json ) const
 {
     json.start_object();
@@ -2039,6 +2059,7 @@ void overmap_global_state::serialize( JsonOut &json ) const
     json.member( "unique_special_count", unique_special_count );
     json.member( "overmap_highway_intersection_grid", highway_intersections );
     json.member( "major_river_count", major_river_count );
+    json.member( "unique_special_decks", unique_special_decks );
 
     json.end_object();
 }
@@ -2068,6 +2089,8 @@ void overmap_global_state::deserialize( const JsonObject &json )
         json.read( "overmap_highway_intersection_grid", highway_intersections );
     }
     json.read( "major_river_count", major_river_count );
+    unique_special_decks.clear();
+    json.read( "unique_special_decks", unique_special_decks );
 }
 
 void overmapbuffer::deserialize_placed_unique_specials( const JsonValue &jsin )

--- a/tests/overmap_test.cpp
+++ b/tests/overmap_test.cpp
@@ -495,7 +495,46 @@ TEST_CASE( "overmap_terrain_coverage", "[overmap][slow]" )
     g->place_player_overmap( { project_to<coords::omt>( overmap_origin + ( 6 * point::north_west ) ), 0 } );
     // Don't inherit overmap state from initialization or previous tests.
     overmap_buffer.clear();
-    for( int attempt_no = 0; attempt_no < 3; ++attempt_no ) {
+
+    // Build the set of terrain types we expect to find. Anything still in this
+    // set after generation is reported as missing.
+    std::unordered_set<oter_type_id> yet_to_be_seen;
+    {
+        std::unordered_set<oter_type_id> dedup;
+        for( const oter_t &ter : overmap_terrains::get_all() ) {
+            oter_type_id id = ter.get_type_id();
+            oter_type_str_id id_s = id.id();
+            if( id_s.is_empty() || id_s.is_null() || !dedup.insert( id ).second ) {
+                continue;
+            }
+            if( id->has_flag( oter_flags::should_not_spawn ) ) {
+                continue;
+            }
+            const recipe_id recipe( id_s.c_str() );
+            if( recipe.is_valid() && recipe->is_blueprint() ) {
+                continue;
+            }
+            if( id->has_flag( oter_flags::ocean ) || id->has_flag( oter_flags::highway ) ) {
+                continue;
+            }
+            bool is_whitelisted = false;
+            for( const std::regex &wl : test_data::overmap_terrain_coverage_whitelist ) {
+                std::cmatch m;
+                if( std::regex_match( id_s.c_str(), m, wl ) &&
+                    m.prefix().length() == 0 && m.suffix().length() == 0 ) {
+                    is_whitelisted = true;
+                    break;
+                }
+            }
+            if( !is_whitelisted ) {
+                yet_to_be_seen.insert( id );
+            }
+        }
+    }
+
+    constexpr int max_attempts = 3;
+    for( int attempt_no = 0; attempt_no < max_attempts && !yet_to_be_seen.empty();
+         ++attempt_no ) {
         // First we just touch all the overmaps in an area to cause them to generate.
         for( const point_abs_om &om_cur : closest_points_first( overmap_origin, 0, 3 ) ) {
             point_abs_omt omt_start = project_to<coords::omt>( om_cur );
@@ -519,6 +558,9 @@ TEST_CASE( "overmap_terrain_coverage", "[overmap][slow]" )
                         tripoint_abs_omt tp( p, z );
                         oter_type_id id = overmap_buffer.ter( tp )->get_type_id();
                         auto iter_bool = stats.emplace( id, tp );
+                        if( iter_bool.second ) {
+                            yet_to_be_seen.erase( id );
+                        }
                         iter_bool.first->second.last_observed = tp;
                         ++iter_bool.first->second.count;
                     }
@@ -574,54 +616,19 @@ TEST_CASE( "overmap_terrain_coverage", "[overmap][slow]" )
         overmap_buffer.reset();
     }
 
-    std::unordered_set<oter_type_id> done;
-    std::vector<oter_type_id> missing;
+    // Check that no SHOULD_NOT_SPAWN terrain was generated.
+    for( const auto &entry : stats ) {
+        if( entry.first->has_flag( oter_flags::should_not_spawn ) ) {
+            CAPTURE( entry.first );
+            FAIL( "oter_type_id was found in map but had SHOULD_NOT_SPAWN flag" );
+        }
+    }
 
     global_variables &globvars = get_globals();
     globvars.clear_global_values();
 
-    for( const oter_t &ter : overmap_terrains::get_all() ) {
-        oter_type_id id = ter.get_type_id();
-        oter_type_str_id id_s = id.id();
-        if( id_s.is_empty() || id_s.is_null() ) {
-            continue;
-        }
-        if( done.insert( id ).second ) {
-            CAPTURE( id );
-            auto it = stats.find( id );
-            const bool found = it != stats.end();
-            const bool should_be_found = !id->has_flag( oter_flags::should_not_spawn );
-
-            if( found == should_be_found ) {
-                continue;
-            }
-
-            // We also want to skip any terrain that's the result of a faction
-            // camp construction recipe
-            const recipe_id recipe( id_s.c_str() );
-            if( recipe.is_valid() && recipe->is_blueprint() ) {
-                continue;
-            }
-
-            if( found ) {
-                FAIL( "oter_type_id was found in map but had SHOULD_NOT_SPAWN flag" );
-            } else {
-                //oceans and highways are not guaranteed to be inside the checked overmap radius
-                bool is_whitelisted = id->has_flag( oter_flags::ocean ) || id->has_flag( oter_flags::highway );
-                for( const std::regex &wl : test_data::overmap_terrain_coverage_whitelist ) {
-                    std::cmatch m;
-                    is_whitelisted = is_whitelisted || (
-                                         // ensure the full string matches. Don't accept substrings.
-                                         std::regex_match( id_s.c_str(), m, wl ) && m.prefix().length() == 0 && m.suffix().length() == 0 );
-                }
-                if( !is_whitelisted ) {
-                    missing.emplace_back( id_s );
-                }
-            }
-        }
-    }
-
     {
+        std::vector<oter_type_id> missing( yet_to_be_seen.begin(), yet_to_be_seen.end() );
         size_t num_missing = missing.size();
         CAPTURE( num_missing );
         constexpr size_t max_to_report = 100;


### PR DESCRIPTION
#### Summary
Bugfixes "Fix unique overmap special spawn rates being up to 10x too common"

#### Purpose of change

Fixes #73618

The adaptive formula added in #73339 for OVERMAP_UNIQUE / GLOBALLY_UNIQUE specials uses `x_in_y(min/special_count, max/overmap_count)` to self-correct spawn rates. As hexagonrecursion showed, this formula has equilibrium at `sqrt(X/Y)` instead of the intended `X/Y`. A special defined as "1 in 100" actually spawns at roughly 1 in 10.

This affects all 113 unique specials (44 GLOBALLY_UNIQUE, 69 OVERMAP_UNIQUE). The rarest ones (1/80 mines) are about 10x more common than intended. The most common ones (90/100 fungal blooms) are barely affected (sqrt(0.9) vs 0.9).

#### Describe the solution

Implements hexagonrecursion's draw-without-replacement deck algorithm from the issue. Each unique special gets a virtual "deck" of Y cards with X successes. One card is drawn per eligible overmap. When the deck is exhausted it reshuffles. This achieves exact X-in-Y rates by construction.

Key details:

- Drawing pauses while a placement is pending (`to_place > 0`), preventing unbounded backlog accumulation if a special repeatedly fails to find a valid spot
- Deck state persisted in `overmap_global_state` alongside the existing `unique_special_count` / `overmap_count` fields, which are kept for stats
- Lazy initialization on first access -- old saves without deck data work seamlessly
- Stored source totals detect constraint changes from mod updates and reset the deck automatically
- Invariant validation catches corrupted deck state
- Only `place_special_attempt()` participates in deck accounting -- forced placement, city buildings, trailheads, and debug placement are unaffected

Also whitelists terrains from unique specials that get <= 10 guaranteed draws in the test's ~147 overmaps. The old sqrt bug was artificially boosting these rates, masking test failures. Now that they spawn at their correct rates, they can't be expected to place reliably within the test budget:

| Rate | Old expected attempts | New guaranteed draws | Specials |
|------|----------------------|---------------------|----------|
| 1/80 | ~16 | 2 | Spiral/Amigara/Wyrms mines |
| 2/100 | ~21 | 4 | Stone Barn, Strange warehouse |
| 5/100 | ~33 | 10 | oil platform, military bunker, haz waste sarcophagus, hot springs, helipad, bastion fort, nursing home |
| 1/16 | ~37 | 10 | Forge of Wonders (Magiclysm) |

Also whitelisted `aenor_paddock` terrains (Magiclysm mutable, 15/100) -- not a rate issue but a mutable solver flakiness that surfaced during testing. Broadened the existing `nursing_home` regex to cover all variants (old pattern missed `_sh*` and multi-digit `_lab*` suffixes).

Fixed the `hotel_tower` whitelist regex: the pattern `hotel_tower(_flr2)_1_5B?` required `_flr2` (second floor) to be present, so it only matched the second floor tiles. The ground floor variants (`hotel_tower_1_5` and `hotel_tower_1_5B`) -- the ones that actually fail intermittently -- were never covered. Changed to `hotel_tower(_flr2)?_1_5B?`. This was introduced in #79711.

#### Early exit optimization

Adopted jbytheway's idea from #59183 (draft, closed 2023): track which terrain types have been observed during generation, and skip remaining attempts once all expected terrains are found. The original PR hit OOM on CI from expanding the search radius; this version keeps the same radius and just exits early.

Concretely: a `yet_to_be_seen` set is built before generation from the same filters the post-generation check uses (SHOULD_NOT_SPAWN, blueprints, ocean/highway flags, whitelist). As terrains are first observed during scanning, they're erased from the set. The attempt loop exits when the set empties.

This also simplifies the post-generation check -- instead of re-iterating all terrain types and re-applying filters, it just reports whatever is left in `yet_to_be_seen`.

With the deck algorithm ensuring unique specials are drawn reliably, most terrains now appear in attempt 1, and attempt 3 is typically skipped.

#### Describe alternatives you've considered

hexagonrecursion also proposed adjusting the formula to `(X*X)/(Y*Y) * overmaps/specials` which has the correct equilibrium but doesn't guarantee coverage within Y overmaps and still lets placement difficulty shift the real distribution. The deck approach is cleaner and matches the mental model better.

For the early exit, the other option was adaptive search radius (generate more overmaps if still missing terrains). Kept the fixed radius to avoid increasing peak memory, since the early exit already saves the time on lucky seeds.

#### Testing

`overmap_generation_is_deterministic` and `overmap_terrain_coverage` pass on multiple seeds. The early exit kicks in after attempt 2 on most seeds tested (only 1-2 city building variants need a second attempt).

#### Additional context

The old `unique_special_count` and `overmap_count` fields are preserved in the global state -- no longer used for placement probability, but still available for stats.