### PR TITLE
Let cunning ferals stab through fences

### DIFF
--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -1,6 +1,7 @@
 #include "mattack_actors.h"
 
 #include <algorithm>
+#include <cstdlib>
 #include <functional>
 #include <iterator>
 #include <limits>
@@ -530,14 +531,41 @@ Creature *melee_actor::find_target( monster &z ) const
         return nullptr;
     }
 
+    if( range == 1 && !z.is_adjacent( target, /*bool allow_z_levels =*/ false ) ) {
+        return nullptr;
+    }
+
     if( range > 1 ) {
-        if( !z.sees( here, *target ) ||
-            !here.clear_path( z.pos_bub( here ), target->pos_bub( here ), range, 1, 200 ) ) {
+        if( !z.sees( here, *target ) ) {
             return nullptr;
         }
 
-    } else if( !z.is_adjacent( target, false ) ) {
-        return nullptr;
+        const int horiz_dist = rl_dist( z.pos_bub().xy(), target->pos_bub().xy() );
+
+        // Little patch until trig_dist updates. Hopefully you aren't reading this in 2030+ :)
+        const int vert_distance_scale = 4;
+        const int vert_dist = std::abs( z.pos_bub().z() - target->pos_bub().z() ) * vert_distance_scale;
+
+        if( horiz_dist + vert_dist > range ) {
+            return nullptr;
+        }
+
+        std::vector<tripoint_bub_ms> path = line_to( z.pos_bub(), target->pos_bub(), 0, 0 );
+        path.pop_back(); // Last point is our target
+
+        // Scaled-down reimplementation of Character::reach_attack() with character-specific values removed.
+        for( const tripoint_bub_ms &path_point : path ) {
+            Creature *collateral_damage = get_creature_tracker().creature_at( path_point );
+            if( collateral_damage ) {
+                return nullptr; // Something else in the way, can't attack
+            }
+            // All ranged melee specials are considered to be "Spear" type attacks or otherwise capable of passing through thin obstacles
+            if( here.impassable( path_point ) &&
+                !here.has_flag( ter_furn_flag::TFLAG_THIN_OBSTACLE, path_point ) ) {
+                return nullptr; // Wall or something
+            }
+        }
+        return target; // Nothing in the way, is in range, we can hit it!
     }
 
     return target;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Fixes #85862

#### Describe the solution
https://github.com/CleverRaven/Cataclysm-DDA/issues/85862#issuecomment-4063374655

Refactor a bit to make it clear what it's doing, and iterate the tiles manually the same as character reach attacks do.

Do some math if the reach attack would go across z-levels to make sure that the range isn't going beyond our tile scale.

#### Describe alternatives you've considered
Maybe we should promote vert_reach_range() to something more than a static function, we are duplicating it a bit as-is

Similarly the minor bits of duplication between here and character::reach_attack() aren't great. We should probably have some sort of creature::reach_attack().

#### Testing
It is *hilariously* impossible for cunning ferals to actually hurt you with their reach attacks due to some bad existing math.

<img width="621" height="106" alt="image" src="https://github.com/user-attachments/assets/43a4d005-7106-4bf7-9352-4fa38c5dc882" />


But now they can properly stab you when you can stab them. And they can't stab you when you can't stab them. (assuming you also have a spear)

#### Additional context

