### PR TITLE
Add missed unarmed reach range

### DIFF
--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1030,6 +1030,8 @@ bool Character::can_reach_attack( const Creature &target ) const
     int vert_reach = 0;
     if( maybe_weapon ) {
         vert_reach = maybe_weapon->current_reach_range( *this ).second;
+    } else {
+        vert_reach = null_item_reference().current_reach_range( *this ).second;
     }
 
     if( std::abs( pos_bub().z() - target.pos_bub().z() ) > vert_reach ) {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
https://github.com/CleverRaven/Cataclysm-DDA/pull/85863#issuecomment-4063523365

#### Describe the solution
Unarmed gets to calculate range too. Of course you can be unarmed and have extra range. Silly me.

#### Describe alternatives you've considered
Maybe we should change get_wielded_item() into two separate functions - one to see if we're actually wielding anything (the nullptr check), and one to simply get an item reference to whatever we're wielding (fists being a fake item). Or maybe considering fists is a fake item is a bad idea. IDK.

#### Testing
<img width="355" height="95" alt="image" src="https://github.com/user-attachments/assets/94bd0591-d149-4ecb-8496-23b18cfc2b58" />


#### Additional context
