### PR TITLE
Fix monster melee special attacks being insanely inaccurate

### DIFF
--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -38,6 +38,7 @@
 #include "map_iterator.h"
 #include "map_scale_constants.h"
 #include "mapdata.h"
+#include "melee.h"
 #include "messages.h"
 #include "monster.h"
 #include "mtype.h"
@@ -805,7 +806,7 @@ bool melee_actor::call( monster &z ) const
 
     // Dodge check
     const int acc = accuracy >= 0 ? accuracy : z.type->melee_skill;
-    int hitspread = target->deal_melee_attack( &z, dice( acc, 10 ) );
+    int hitspread = target->deal_melee_attack( &z, melee::melee_hit_range( acc ) );
 
     // Pick bodyparts hit
     std::vector<bodypart_id> bodyparts_hit;


### PR DESCRIPTION
#### Summary
Bugfixes "Fix monster melee special attacks being insanely inaccurate"

#### Purpose of change
While working on #85864 to fix #85862 I discovered that a 0-skill character in plain clothes can dodge most melee special attacks 100% of the time until their stamina drops to about half:
<img width="621" height="106" alt="image" src="https://github.com/user-attachments/assets/a05210e4-0583-4b2e-8b48-945142b01a03" />

This is because the special actor uses a very old dice roll, which was replaced years ago but never updated in the melee actor.

https://github.com/CleverRaven/Cataclysm-DDA/blob/c62165965c6b74c291c5201cabc3a6e0f385afec/src/monster.cpp#L2150-L2151

https://github.com/CleverRaven/Cataclysm-DDA/blob/c62165965c6b74c291c5201cabc3a6e0f385afec/src/mattack_actors.cpp#L807-L808


#### Describe the solution
Update the melee actor to use melee::melee_hit_range().

#### Describe alternatives you've considered


#### Testing
Before:
<img width="595" height="1293" alt="image" src="https://github.com/user-attachments/assets/9836c8f4-8a09-4099-bb10-484a3d5f5438" />


After:
<img width="625" height="1340" alt="image" src="https://github.com/user-attachments/assets/902f462c-f495-4bb8-8801-cd078b5e1a35" />


#### Additional context

Nobody **ever** complains when the player character is magically brokenly strong for years. 🙄 
