### PR TITLE
[MoM] No more astral projecting while driving

### DIFF
--- a/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
@@ -24,48 +24,53 @@
     "required_event": "spellcasting_finish",
     "condition": { "test_eoc": "EOC_CONDITION_SPELLCASTING_FINISH_TRAIT_AND_SCHOOL_LIST" },
     "effect": [
-      { "math": [ "u_latest_channeled_power_difficulty = _difficulty" ] },
       {
-        "run_eocs": [
+        "if": { "not": { "u_has_effect": "effect_no_nether_attunement_from_channel" } },
+        "then": [
+          { "math": [ "u_latest_channeled_power_difficulty = _difficulty" ] },
           {
-            "id": "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_SCALING_CHECK",
-            "condition": { "math": [ "u_vitamin('vitamin_psionic_drain') < 15" ] },
-            "effect": [
+            "run_eocs": [
               {
-                "run_eocs": [
+                "id": "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_SCALING_CHECK",
+                "condition": { "math": [ "u_vitamin('vitamin_psionic_drain') < 15" ] },
+                "effect": [
                   {
-                    "id": "EOC_RAISE_ATTUNEMENT_BELOW_THRESHOLD_CHECKER",
-                    "condition": {
-                      "x_in_y_chance": {
-                        "x": {
-                          "math": [
-                            "(u_latest_channeled_power_difficulty * u_latest_channeled_power_difficulty) + (u_nether_conduit_repeated_channeling_value / 3) + (u_vitamin('vitamin_maintained_powers') * 3)"
-                          ]
+                    "run_eocs": [
+                      {
+                        "id": "EOC_RAISE_ATTUNEMENT_BELOW_THRESHOLD_CHECKER",
+                        "condition": {
+                          "x_in_y_chance": {
+                            "x": {
+                              "math": [
+                                "(u_latest_channeled_power_difficulty * u_latest_channeled_power_difficulty) + (u_nether_conduit_repeated_channeling_value / 3) + (u_vitamin('vitamin_maintained_powers') * 3)"
+                              ]
+                            },
+                            "y": 100
+                          }
                         },
-                        "y": 100
+                        "effect": [ { "run_eocs": [ "EOC_RAISE_ATTUNEMENT_BELOW_THRESHOLD", "EOC_XE_RAISE_ATTUNEMENT_NETHER_SORCERY_INTERACTION" ] } ]
                       }
-                    },
-                    "effect": [ { "run_eocs": [ "EOC_RAISE_ATTUNEMENT_BELOW_THRESHOLD", "EOC_XE_RAISE_ATTUNEMENT_NETHER_SORCERY_INTERACTION" ] } ]
+                    ]
                   }
-                ]
-              }
-            ],
-            "false_effect": [
-              {
-                "run_eocs": [
+                ],
+                "false_effect": [
                   {
-                    "id": "EOC_RAISE_ATTUNEMENT_ABOVE_THRESHOLD_CHECKER",
-                    "condition": {
-                      "x_in_y_chance": {
-                        "x": {
-                          "math": [
-                            "(u_latest_channeled_power_difficulty * u_latest_channeled_power_difficulty) + u_nether_conduit_repeated_channeling_value  + (u_vitamin('vitamin_maintained_powers') * 3)"
-                          ]
+                    "run_eocs": [
+                      {
+                        "id": "EOC_RAISE_ATTUNEMENT_ABOVE_THRESHOLD_CHECKER",
+                        "condition": {
+                          "x_in_y_chance": {
+                            "x": {
+                              "math": [
+                                "(u_latest_channeled_power_difficulty * u_latest_channeled_power_difficulty) + u_nether_conduit_repeated_channeling_value  + (u_vitamin('vitamin_maintained_powers') * 3)"
+                              ]
+                            },
+                            "y": 100
+                          }
                         },
-                        "y": 100
+                        "effect": [ { "run_eocs": [ "EOC_RAISE_ATTUNEMENT_BELOW_THRESHOLD", "EOC_XE_RAISE_ATTUNEMENT_NETHER_SORCERY_INTERACTION" ] } ]
                       }
-                    },
-                    "effect": [ { "run_eocs": [ "EOC_RAISE_ATTUNEMENT_BELOW_THRESHOLD", "EOC_XE_RAISE_ATTUNEMENT_NETHER_SORCERY_INTERACTION" ] } ]
+                    ]
                   }
                 ]
               }

--- a/data/mods/MindOverMatter/effects/effects_other.json
+++ b/data/mods/MindOverMatter/effects/effects_other.json
@@ -17,6 +17,14 @@
   },
   {
     "type": "effect_type",
+    "id": "effect_no_nether_attunement_from_channel",
+    "//": "Hidden effect, used as a tracker",
+    "name": [ "" ],
+    "desc": [ "" ],
+    "rating": "good"
+  },
+  {
+    "type": "effect_type",
     "id": "effect_vitakin_wakeful_resting",
     "//": "Hidden effect, used as a tracker",
     "name": [ "" ],

--- a/data/mods/MindOverMatter/powers/clairsentience_eoc.json
+++ b/data/mods/MindOverMatter/powers/clairsentience_eoc.json
@@ -219,6 +219,19 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_CLAIR_ASTRAL_PROJECTION_INITIATE",
+    "condition": { "not": "u_controlling_vehicle" },
+    "effect": [ { "run_eocs": "EOC_CLAIR_ASTRAL_PROJECTION_INITIATE_POST_VEHICLE_CHECK" } ],
+    "false_effect": [
+      { "u_add_effect": "effect_no_nether_attunement_from_channel", "duration": 0 },
+      {
+        "u_message": "Trying to send your spirit out of your body while driving is dangerous at best and suicidal at worst.  You had better not do it.",
+        "type": "mixed"
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CLAIR_ASTRAL_PROJECTION_INITIATE_POST_VEHICLE_CHECK",
     "effect": [
       { "u_location_variable": { "u_val": "clair_astral_projection_original_location" }, "min_radius": 0, "max_radius": 0 },
       { "u_add_effect": "effect_clair_astral_projection", "duration": "PERMANENT" },
@@ -237,7 +250,6 @@
       { "u_remove_item_with": "item_clair_astral_projection_cord" },
       { "u_lose_effect": [ "effect_clair_astral_projection", "incorporeal" ] },
       { "u_lose_trait": "CLAIR_ASTRAL_PROJECTION_APPEARANCE" },
-      { "math": [ "u_spell_level('clair_astral_projection_passwall') = -1" ] },
       { "math": [ "u_spell_level('clair_astral_projection_return') = -1" ] },
       {
         "u_teleport": { "u_val": "clair_astral_projection_original_location" },

--- a/data/mods/MindOverMatter/powers/electrokinesis_concentration_eocs.json
+++ b/data/mods/MindOverMatter/powers/electrokinesis_concentration_eocs.json
@@ -349,7 +349,10 @@
     "id": "EOC_ELECTROKIN_PERSONAL_BATTERY_INITIATE",
     "condition": { "not": { "u_has_effect": "effect_nether_attunement_electrokinetic_power_drain" } },
     "effect": [ { "run_eocs": "EOC_ELECTROKIN_PERSONAL_BATTERY_INITIATE_REAL" } ],
-    "false_effect": [ { "u_message": "The power you channel vanishes into nothingness.", "type": "bad" } ]
+    "false_effect": [
+      { "u_add_effect": "effect_no_nether_attunement_from_channel", "duration": 0 },
+      { "u_message": "The power you channel vanishes into nothingness.", "type": "bad" }
+    ]
   },
   {
     "type": "effect_on_condition",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[MoM] No more astral projecting while driving"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

It was possible and we can't actually represent the dangers of being able to do so (losing control and crashing the car and injuring your unconscious body), so better to disallow it for now. 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Make it so that if you're controlling a car, you can't use astral projection. 

Also add an effect, applied for 0 turns, that means you don't get Nether Attunement or risk backlash when you are told you decide not to use your powers. Also apply this to Electron Overflow when you have the Power Drain backlash active. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Tried to astrally project while controlling  car, could not. 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
