### PR TITLE
stop molotovs from detonating in your arms, fix it crashing the game

### DIFF
--- a/data/json/ammo_effects.json
+++ b/data/json/ammo_effects.json
@@ -223,7 +223,7 @@
       { "field_type": "fd_fire", "intensity_min": 1, "intensity_max": 1, "size": 1, "chance": 50 },
       { "field_type": "fd_smoke", "intensity_min": 1, "intensity_max": 1, "size": 1, "chance": 25 }
     ],
-    "aoe_effects": [ { "effect": "onfire", "duration": "1 m", "intensity_min": 1, "chance": 50 } ]
+    "aoe_effects": [ { "effect": "onfire", "duration": "1 m", "intensity_min": 1, "chance": 50, "hits_amount": [ 1, 3 ] } ]
   },
   {
     "id": "GELLED_MOLOTOV",
@@ -233,7 +233,7 @@
       { "field_type": "fd_fire", "intensity_min": 1, "intensity_max": 1, "size": 1, "chance": 60 },
       { "field_type": "fd_smoke", "intensity_min": 1, "intensity_max": 2, "size": 1, "chance": 70 }
     ],
-    "aoe_effects": [ { "effect": "onfire", "duration": "1 m", "intensity_min": 2, "chance": 80 } ]
+    "aoe_effects": [ { "effect": "onfire", "duration": "1 m", "intensity_min": 2, "chance": 80, "hits_amount": [ 2, 6 ] } ]
   },
   {
     "id": "ACIDBOMB",

--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -2087,6 +2087,11 @@
     "type": "json_flag"
   },
   {
+    "id": "NO_MANUAL_ACTIVATION",
+    "//": "This item cannot be activated by player or NPC, only by some internal game means like by throwing",
+    "type": "json_flag"
+  },
+  {
     "id": "BACKBLAST",
     "type": "json_flag"
   },

--- a/data/json/items/tool/explosives.json
+++ b/data/json/items/tool/explosives.json
@@ -764,7 +764,8 @@
       "WATER_EXTINGUISH",
       "DESTROY_ON_CHARGE_USE",
       "SPAWN_ACTIVE",
-      "ACT_ON_RANGED_HIT"
+      "ACT_ON_RANGED_HIT",
+      "NO_MANUAL_ACTIVATION"
     ]
   },
   {
@@ -808,7 +809,8 @@
       "WATER_EXTINGUISH",
       "DESTROY_ON_CHARGE_USE",
       "SPAWN_ACTIVE",
-      "ACT_ON_RANGED_HIT"
+      "ACT_ON_RANGED_HIT",
+      "NO_MANUAL_ACTIVATION"
     ]
   },
   {

--- a/doc/JSON/ITEM.md
+++ b/doc/JSON/ITEM.md
@@ -300,6 +300,8 @@ ammo_effects define what effect the projectile, that you shoot, would have. List
       "intensity_max": 3,     // max intensity of the field; default intensity_min
       "radius": 5,            // radius of a field to spawn; default 1
       "chance": 100,          // probability to apply the field on each separate creature in area, from 1 to 100; default 100
+      "all_bp": false,        // if true, effect is applied evenly on all limbs, otherwise applies at random limbs hits_amount of times
+      "hits_amount": [ 1, 3 ] // how many instances this effect will be applied onto body, a-la spread across multiple limbs
     } 
   ],
   "do_flashbang": false,     // Creates a hardcoded flashbang explosion; default false

--- a/doc/JSON/JSON_FLAGS.md
+++ b/doc/JSON/JSON_FLAGS.md
@@ -1542,6 +1542,7 @@ Techniques may be used by tools, armors, weapons and anything else that can be w
 - ```WET``` Item is wet and will slowly dry off (e.g. towel).
 - ```WIND_EXTINGUISH``` This item will be extinguished by the wind.
 - ```WRITE_MESSAGE``` This item could be used to write messages on signs.
+- ```NO_MANUAL_ACTIVATION``` Prevents item from being activated by player/NPCs. Currently used for items that should be activated by throwing, like Molotovs
 
 
 ### `use_action`

--- a/src/ammo_effect.cpp
+++ b/src/ammo_effect.cpp
@@ -66,6 +66,8 @@ void aoe_effect::deserialize( const JsonObject &jo )
               intensity_min );
     optional( jo, was_loaded, "chance", chance, numeric_bound_reader<int> {0, 100}, 100 );
     optional( jo, was_loaded, "radius", radius, numeric_bound_reader<int> {0}, 1 );
+    optional( jo, was_loaded, "hits_amount", hits_amount, pair_reader<int> {} );
+    optional( jo, was_loaded, "all_bp", all_bp, false );
 }
 
 void on_hit_effect::deserialize( const JsonObject &jo )

--- a/src/ammo_effect.h
+++ b/src/ammo_effect.h
@@ -36,6 +36,8 @@ struct aoe_effect {
     int intensity_max;
     int chance;
     int radius;
+    std::pair<int, int> hits_amount = {1, 1};
+    bool all_bp;
 
     void deserialize( const JsonObject &jo );
     bool was_loaded = false;

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -247,6 +247,8 @@ static const efftype_id effect_weak_antibiotic_visible( "weak_antibiotic_visible
 static const efftype_id effect_webbed( "webbed" );
 static const efftype_id effect_weed_high( "weed_high" );
 
+static const flag_id json_flag_NO_MANUAL_ACTIVATION( "NO_MANUAL_ACTIVATION" );
+
 static const furn_str_id furn_f_translocator_buoy( "f_translocator_buoy" );
 
 static const itype_id itype_advanced_ecig( "advanced_ecig" );
@@ -9264,6 +9266,9 @@ ret_val<void> use_function::can_call( const Character &p, const item &it,
                                             it.tname() );
     } else if( it.is_broken() ) {
         return ret_val<void>::make_failure( _( "Your %s is broken and won't activate." ),
+                                            it.tname() );
+    } else if( it.has_flag( json_flag_NO_MANUAL_ACTIVATION ) ) {
+        return ret_val<void>::make_failure( _( "You can't do anything interesting with your %s." ),
                                             it.tname() );
     }
     return actor->can_use( p, it, here, pos );

--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -187,8 +187,18 @@ void apply_ammo_effects( Creature *source, const tripoint_bub_ms &p,
             // apply aoe_effects (but not on_hit_effects, this one is in apply_effects_nodamage())
             for( const aoe_effect &eff : ae.aoe_effects ) {
                 for( Creature *cr : here.get_creatures_in_radius_circ( p, eff.radius ) ) {
-                    cr->add_effect( effect_source( source ), eff.effect, eff.duration, false, rng( eff.intensity_min,
-                                    eff.intensity_max ) );
+                    if( eff.all_bp ) {
+                        for( const bodypart_id &bp : cr->get_all_body_parts() ) {
+                            cr->add_effect( effect_source( source ), eff.effect, eff.duration, bp,
+                                            false, rng( eff.intensity_min, eff.intensity_max ) );
+                        }
+                    } else {
+                        const int hits = rng( eff.hits_amount.first, eff.hits_amount.second );
+                        for( int i = 0; i < hits; ++i ) {
+                            cr->add_effect( effect_source( source ), eff.effect, eff.duration, cr->random_body_part( true ),
+                                            false, rng( eff.intensity_min, eff.intensity_max ) );
+                        }
+                    }
                 }
             }
 

--- a/src/projectile.cpp
+++ b/src/projectile.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "ammo_effect.h"
+#include "bodypart.h"
 #include "calendar.h"
 #include "character.h"
 #include "condition.h"


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fix #85851
#### Describe the solution
As all cool things, this bug is a combination of two issues: 
Firstly, it is the fact that molotovs, opposite to the rest of explosives, detonate not from "countdown_action", but from "use_action", since it has to be activated when thrown, not by timer. What it means is once you try to activate already active molotov, it detonates right in your hands
And secondly, when i jsonified molotovs, i forgot to properly accomodate code to pick a targeted limb, which, for characters (including NPCs) made it that their bp_null got ignited, and since bp_null is not a valid bodypart, the game crashed trying to access some undefined stuff
First one is resolved by adding NO_MANUAL_ACTIVATION flag, that prevent use_action of item from being used at all
Second one is solved by adding `hits_amount` and `all_bp` fields for aoe ammo effects, and rearranging the code to use them, instead of passing whatever garbage limb the code decided to pass
Also added hits_amount to molotovs as a case study
#### Testing
Used test save, activated active molotov, cannot activate it anymore
Threw molotov at NPC, no crash either, instead NPCs get multiple of their limbs ignited. How strong this change is can be reviewed separately
#### Additional context
It is telling that no one in a span of 2 month since jsonified molotovs were merged no one tried to molotov NPCs