### PR TITLE
Fix multi-zone activity hang on large zones

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -4740,7 +4740,50 @@ bool multi_zone_activity_actor::simulate_turn( player_activity &act, Character &
     player_activity current_act_copy = act;
     activity_id current_activity = current_act_copy.id();
 
-    std::unordered_set<tripoint_abs_ms> src_set = multi_activity_locations( you );
+    // Prevent zero-move spinning from auto_resume backlog restore.
+    if( !check_only ) {
+        you.mod_moves( -1 );
+    }
+
+    // Cache checked-and-failed sources so the move budget makes
+    // progress across turns. Stored as a static because multi_zone
+    // actors get cloned through the backlog (member state won't
+    // persist). Fetch activities bypass it (dynamic requirement state).
+    struct source_cache {
+        std::unordered_set<tripoint_abs_ms> sources;
+        size_t initial_count = 0;
+        activity_id act_type = activity_id::NULL_ID();
+        tripoint_abs_ms origin;
+        character_id who;
+        unsigned int zone_count = 0;
+    };
+    static source_cache cache;
+
+    const bool use_cache = !check_only && current_activity != ACT_FETCH_REQUIRED;
+    const unsigned int cur_zone_count = zone_manager::get_manager().size();
+
+    bool cache_hit = use_cache &&
+                     cache.act_type == current_activity &&
+                     cache.origin == abspos &&
+                     cache.who == you.getID() &&
+                     cache.zone_count == cur_zone_count &&
+                     ( !cache.sources.empty() || cache.initial_count == 0 );
+
+    std::unordered_set<tripoint_abs_ms> src_set;
+    if( cache_hit ) {
+        src_set = cache.sources;
+    } else {
+        src_set = multi_activity_locations( you );
+        if( use_cache ) {
+            cache.initial_count = src_set.size();
+            cache.sources = src_set;
+            cache.act_type = current_activity;
+            cache.origin = abspos;
+            cache.who = you.getID();
+            cache.zone_count = cur_zone_count;
+        }
+    }
+
     std::vector<tripoint_abs_ms> src_sorted = get_sorted_tiles_by_distance( abspos, src_set );
     // now loop through the work-spot tiles and judge whether its worth traveling to it yet
     // or if we need to fetch something first.
@@ -4789,11 +4832,25 @@ bool multi_zone_activity_actor::simulate_turn( player_activity &act, Character &
         const requirement_check_result req_res = check_requirements( you, act_info, src, src_bub, src_set,
                 check_only );
         if( req_res == requirement_check_result::RETURN_EARLY ) {
-            // activity cancelled
+            // Fetch dispatched -- prune so we don't re-trigger it.
+            if( use_cache ) {
+                cache.sources.erase( src );
+            }
             return false;
         }
         req_fail_reason.convert_requirement_check_result( req_res );
         if( req_fail_reason.check_skip_location() ) {
+            if( use_cache ) {
+                cache.sources.erase( src );
+            }
+            // Charge 1 move for expensive skips (zone/inventory scan).
+            if( !check_only &&
+                multi_activity_actor::activity_reason_continue( act_info.reason ) ) {
+                you.mod_moves( -1 );
+                if( you.get_moves() <= 0 ) {
+                    break;
+                }
+            }
             continue;
         }
 
@@ -4803,6 +4860,9 @@ bool multi_zone_activity_actor::simulate_turn( player_activity &act, Character &
         std::optional<bool> route_result = multi_activity_actor::route(
                                                you, current_act_copy, src_bub, req_fail_reason, check_only );
         if( !route_result ) {
+            if( use_cache ) {
+                cache.sources.erase( src );
+            }
             continue;
         }
         if( *route_result ) {

--- a/tests/clzones_test.cpp
+++ b/tests/clzones_test.cpp
@@ -27,9 +27,11 @@
 #include "ret_val.h"
 #include "type_id.h"
 #include "units.h"
+#include "veh_type.h"
 #include "vehicle.h"
 #include "visitable.h"
 #include "vpart_position.h"
+#include "vpart_range.h"
 
 static const faction_id faction_your_followers( "your_followers" );
 
@@ -60,6 +62,7 @@ static const zone_type_id zone_type_LOOT_PDRINK( "LOOT_PDRINK" );
 static const zone_type_id zone_type_LOOT_PFOOD( "LOOT_PFOOD" );
 static const zone_type_id zone_type_LOOT_UNSORTED( "LOOT_UNSORTED" );
 static const zone_type_id zone_type_UNLOAD_ALL( "UNLOAD_ALL" );
+static const zone_type_id zone_type_VEHICLE_REPAIR( "VEHICLE_REPAIR" );
 
 namespace
 {
@@ -2324,4 +2327,68 @@ TEST_CASE( "cancel_activity_clears_auto_resume_for_multi_type",
     CHECK( !dummy.activity );
     CHECK( ( dummy.backlog.empty() ||
              !dummy.backlog.front().auto_resume ) );
+}
+
+// #85853: selecting Vehicle Repair from zone activities freezes the game
+// when the VEHICLE_REPAIR zone is large and repair items are unavailable.
+// simulate_turn must bound per-frame work and prune checked sources.
+TEST_CASE( "multi_zone_vehicle_repair_large_zone_no_hang",
+           "[zones][activities][vehicle]" )
+{
+    avatar &dummy = get_avatar();
+    map &here = get_map();
+
+    clear_avatar();
+    clear_map_without_vision();
+    dummy.activity = player_activity();
+    dummy.backlog.clear();
+    dummy.clear_destination();
+    zone_manager::get_manager().clear();
+
+    const tripoint_bub_ms start_pos( 60, 60, 0 );
+    dummy.setpos( here, start_pos );
+
+    // Place a shopping cart and damage it so parts are repairable.
+    // Without repair items or skills, every tile triggers check_requirements
+    // and gets pruned from the cache.
+    const tripoint_bub_ms veh_pos = start_pos + tripoint( 2, 0, 0 );
+    here.ter_set( veh_pos, ter_t_floor );
+    vehicle *veh = here.add_vehicle( vehicle_prototype_test_shopping_cart,
+                                     veh_pos, 0_degrees, 0, 0 );
+    REQUIRE( veh != nullptr );
+    for( const vpart_reference &vpr : veh->get_all_parts() ) {
+        veh->set_hp( vpr.part(), vpr.part().info().durability / 2, false );
+    }
+
+    // 20x20 VEHICLE_REPAIR zone -- 400 tiles, mostly empty
+    const tripoint_abs_ms zone_start = here.get_abs( start_pos - point( 10, 10 ) );
+    const tripoint_abs_ms zone_end = here.get_abs( start_pos + point( 9, 9 ) );
+    zone_manager &zm = zone_manager::get_manager();
+    zm.add( "Vehicle Repair", zone_type_VEHICLE_REPAIR, faction_your_followers,
+            false, true, zone_start, zone_end );
+
+    // No repair items given -- every tile should fail check_requirements
+    dummy.assign_activity( multi_vehicle_repair_activity_actor() );
+
+    // Turn-limited loop -- pattern from act_build_test.cpp.
+    // Without the fix, this either hangs (unbounded single-frame work)
+    // or exceeds the turn limit (re-scanning failed sources every turn).
+    int turns = 0;
+    const int max_turns = 50;
+    while( ( !dummy.activity.is_null() || dummy.is_auto_moving() ) && turns < max_turns ) {
+        dummy.set_moves( dummy.get_speed() );
+        if( dummy.is_auto_moving() ) {
+            dummy.setpos( here, here.get_bub( *dummy.destination_point ) );
+            here.build_map_cache( dummy.posz() );
+            dummy.start_destination_activity();
+        }
+        if( dummy.activity ) {
+            dummy.activity.do_turn( dummy );
+        }
+        turns++;
+    }
+
+    CHECK( !dummy.activity );
+    // Should finish quickly -- not use all 50 turns
+    CHECK( turns < max_turns );
 }


### PR DESCRIPTION
#### Summary
Bugfixes "Fix multi-zone activity hang on large zones"

#### Purpose of change

Fixes #85853, related to #85826 and #85750.

`multi_zone_activity_actor::simulate_turn` re-fetches all zone locations from scratch every call and iterates them with no move budget. For large VEHICLE_REPAIR zones (300+ tiles), each tile with a repairable vehicle part triggers expensive requirement checks (`crafting_inventory`, `get_point_set_loot`, `are_requirements_nearby`) -- all in one frame, appearing as a freeze.

#### Describe the solution

Static source cache in `simulate_turn` that persists across the backlog clone cycle (multi_zone actors get cloned every turn, so member state doesn't survive). Keyed on activity type, player position, character, and zone count. Sources are pruned from the cache when they fail requirement checks, route, or trigger a fetch dispatch. Combined with a per-source move budget that only charges for the expensive `activity_reason_continue` path (zone/inventory scanning) -- cheap skips like NO_ZONE or DONT_HAVE_SKILL are free.

Also charges 1 move per `simulate_turn` call to prevent zero-move spinning from the `auto_resume` backlog restore cycle.

#### Describe alternatives you've considered

Adding `pending_sources` as a member on `multi_zone_activity_actor` (like `zone_sort_activity_actor`'s `coord_set`) -- abandoned because the actor gets cloned through the backlog via `clone_ptr` every turn, so member state never persists between `simulate_turn` calls. Move-budget-only without any progress tracking -- stalls forever on zones larger than the per-turn move budget.

#### Testing

Regression test with a 20x20 VEHICLE_REPAIR zone (400 tiles) and a damaged vehicle. All 38 zone tests and 3 construction tests pass (430 + 72 assertions). Verified with the save file from #85853.

#### Additional context

This is the same class of issue as #85829 and #85835 -- `simulate_turn` doing unbounded single-frame work after ShnitzelX2's multi-activity overhaul (#84894, #85292). The overhaul made `multi_zone_activity_actor` explicitly stateless, which prevented the `coord_set` pruning pattern used by `zone_sort_activity_actor`. The static cache works around this limitation.