### PR TITLE
Remove Catch2 v2 internal API usage from test runner

### DIFF
--- a/tests/normalized_test_names_test.cpp
+++ b/tests/normalized_test_names_test.cpp
@@ -5,6 +5,17 @@
 
 #include "cata_catch.h"
 
+// Wraps Catch2 internal test-enumeration API in one place.
+static std::vector<std::string> get_all_test_case_names()
+{
+    std::vector<std::string> names;
+    for( const Catch::TestCase &tc :
+         Catch::getAllTestCasesSorted( *Catch::getCurrentContext().getConfig() ) ) {
+        names.push_back( tc.getTestCaseInfo().name );
+    }
+    return names;
+}
+
 TEST_CASE( "enforce_normalized_test_cases" )
 {
     const static std::string allowed_chars =
@@ -17,9 +28,7 @@ TEST_CASE( "enforce_normalized_test_cases" )
     INFO( "Prefer simple characters for TEST_CASE names to avoid need for escaping" );
     CAPTURE( allowed_chars );
 
-    for( const Catch::TestCase &tc :
-         Catch::getAllTestCasesSorted( *Catch::getCurrentContext().getConfig() ) ) {
-        const std::string &test_case_name = tc.name;
+    for( const std::string &test_case_name : get_all_test_case_names() ) {
         CAPTURE( test_case_name );
         int i = 0;
         for( ; i < static_cast<int>( test_case_name.size() ); i++ ) {

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -9,9 +9,9 @@
 #include <cstdlib>
 #include <exception>
 #include <functional>
+#include <iostream>
 #include <memory>
 #include <optional>
-#include <ostream>
 #include <random>
 #include <string>
 #include <string_view>
@@ -50,7 +50,6 @@
 #include "path_info.h"
 #include "point.h"
 #include "rng.h"
-#include "string_formatter.h"
 #include "type_id.h"
 #include "weather.h"
 #include "weather_type.h"
@@ -73,7 +72,7 @@ static std::chrono::system_clock::time_point end_time;
 static bool error_during_initialization{ false };
 static bool fail_to_init_game_state{ false };
 
-static bool needs_game{ false };
+static bool game_initialized{ false };
 
 static std::vector<mod_id> extract_mod_selection( const std::string_view mod_string )
 {
@@ -207,24 +206,7 @@ struct CataListener : Catch::TestEventListenerBase {
     using TestEventListenerBase::TestEventListenerBase;
 
     void testRunStarting( Catch::TestRunInfo const & ) override {
-        static bool game_initialized = false;
-        if( needs_game && !game_initialized ) {
-            try {
-                init_global_game_state( mods, option_overrides_for_test_suite, user_dir );
-            } catch( ... ) {
-                DebugLog( D_INFO, DC_ALL ) << "Fail to initialize global game state" << std::endl;
-                // NOLINTNEXTLINE(cata-tests-must-restore-global-state)
-                fail_to_init_game_state = true;
-                throw;
-            }
-            game_initialized = true;
-            // NOLINTNEXTLINE(cata-tests-must-restore-global-state)
-            error_during_initialization = debug_has_error_been_observed();
-
-            DebugLog( D_INFO, DC_ALL ) << "Game data loaded, running Catch2 session:" << std::endl;
-        } else if( !needs_game ) {
-            DebugLog( D_INFO, DC_ALL ) << "Running Catch2 session:" << std::endl;
-        }
+        DebugLog( D_INFO, DC_ALL ) << "Running Catch2 session:" << std::endl;
         if( start_time == std::chrono::system_clock::time_point{} ) {
             start_time = std::chrono::system_clock::now();
         }
@@ -233,6 +215,29 @@ struct CataListener : Catch::TestEventListenerBase {
 
     void testRunEnded( Catch::TestRunStats const & ) override {
         end_time = std::chrono::system_clock::now();
+    }
+
+    void testCaseStarting( Catch::TestCaseInfo const &testInfo ) override {
+        if( !game_initialized && !fail_to_init_game_state ) {
+            bool is_nogame = std::find( testInfo.tags.begin(), testInfo.tags.end(),
+                                        "nogame" ) != testInfo.tags.end();
+            if( !is_nogame ) {
+                try {
+                    init_global_game_state( mods, option_overrides_for_test_suite, user_dir );
+                } catch( ... ) {
+                    DebugLog( D_INFO, DC_ALL ) << "Fail to initialize global game state"
+                                               << std::endl;
+                    // NOLINTNEXTLINE(cata-tests-must-restore-global-state)
+                    fail_to_init_game_state = true;
+                    throw;
+                }
+                // NOLINTNEXTLINE(cata-tests-must-restore-global-state)
+                game_initialized = true;
+                // NOLINTNEXTLINE(cata-tests-must-restore-global-state)
+                error_during_initialization = debug_has_error_been_observed();
+                DebugLog( D_INFO, DC_ALL ) << "Game data loaded" << std::endl;
+            }
+        }
     }
 
     void sectionStarting( Catch::SectionInfo const &sectionInfo ) override {
@@ -257,13 +262,13 @@ struct CataListener : Catch::TestEventListenerBase {
                         Messages::recent_messages( 0 );
             if( !messages.empty() ) {
                 if( !sectionStats.assertions.allPassed() ) {
-                    stream << "Log messages during failed test:\n";
+                    std::cerr << "Log messages during failed test:\n";
                 } else {
-                    stream << "Log messages during successful test:\n";
+                    std::cerr << "Log messages during successful test:\n";
                 }
             }
             for( const std::pair<std::string, std::string> &message : messages ) {
-                stream << message.first << ": " << message.second << '\n';
+                std::cerr << message.first << ": " << message.second << '\n';
             }
             Messages::clear_messages();
         }
@@ -271,7 +276,7 @@ struct CataListener : Catch::TestEventListenerBase {
 
     void testCaseEnded( Catch::TestCaseStats const &testCaseStats ) override {
         TestEventListenerBase::testCaseEnded( testCaseStats );
-        if( !needs_game ) {
+        if( !game_initialized ) {
             return;
         }
         // Reset lightweight global state that tests commonly modify without
@@ -291,8 +296,8 @@ struct CataListener : Catch::TestEventListenerBase {
         if( result.getResultType() == Catch::ResultWas::FatalErrorCondition ) {
             // We are in a signal handler for a fatal error condition, so print a
             // backtrace
-            stream << "Stack trace at fatal error:\n";
-            debug_write_backtrace( stream );
+            std::cerr << "Stack trace at fatal error:\n";
+            debug_write_backtrace( std::cerr );
         }
 #endif
 
@@ -302,23 +307,6 @@ struct CataListener : Catch::TestEventListenerBase {
 };
 
 CATCH_REGISTER_LISTENER( CataListener )
-
-struct CataCIReporter: Catch::ConsoleReporter {
-    explicit CataCIReporter( Catch::ReporterConfig const &config ) : Catch::ConsoleReporter(
-            config ) {};
-
-    void testCaseStarting( Catch::TestCaseInfo const &testInfo ) override {
-        Catch::ConsoleReporter::testCaseStarting( testInfo );
-        std::string tag_string;
-        for( const std::string &tag : testInfo.tags ) {
-            tag_string += string_format( "[%s]", tag );
-        }
-        // NOLINTNEXTLINE(cata-text-style)
-        DebugLog( D_INFO, DC_ALL ) << "  Testing " << testInfo.name << " " << tag_string << "...";
-    }
-};
-
-CATCH_REGISTER_REPORTER( "cata-ci-reporter", CataCIReporter )
 
 // NOLINTNEXTLINE(cata-test-filename)
 TEST_CASE( "noop_test", "[.]" )
@@ -459,31 +447,6 @@ int main( int argc, const char *argv[] )
         }
     }
 
-    // Tests not requiring the global game initialized are tagged with [nogame]
-    {
-        using namespace Catch;
-        Config const &config = session.config();
-        std::vector<TestCase> const &tcs = filterTests(
-                                               getAllTestCasesSorted( config ),
-                                               config.testSpec(),
-                                               config
-                                           );
-        for( TestCase const &tc : tcs ) {
-            // NOLINTNEXTLINE(cata-tests-must-restore-global-state)
-            needs_game = true;
-            for( std::string const &tag : tc.getTestCaseInfo().tags ) {
-                if( tag == "nogame" ) {
-                    // NOLINTNEXTLINE(cata-tests-must-restore-global-state)
-                    needs_game = false;
-                    break;
-                }
-            }
-            if( needs_game ) {
-                break;
-            }
-        }
-    }
-
     try {
         if( rng_seed_fuzz_iterations > 1 ) {
             // NOLINTNEXTLINE(cata-determinism)
@@ -516,7 +479,7 @@ int main( int argc, const char *argv[] )
         return EXIT_FAILURE;
     }
 
-    if( world_generator ) {
+    if( game_initialized && world_generator ) {
         std::string world_name = world_generator->active_world->world_name;
         if( result == 0 || dont_save || fail_to_init_game_state ) {
             world_generator->delete_world( world_name, true );


### PR DESCRIPTION
#### Summary
Infrastructure "Remove Catch2 v2 internal API usage from test runner"

#### Purpose of change

The test runner uses three Catch2 v2 internal APIs that don't exist (or work differently) in v3: `filterTests`, `getAllTestCasesSorted`, and `ConsoleReporter` subclassing. These are the only parts of the test infra that would require non-mechanical porting if we ever upgrade Catch2. This PR isolates or removes them.

#### Describe the solution

Lazy game init replaces the `filterTests`/`getAllTestCasesSorted` pre-scan in `main()`. Instead of enumerating all selected tests upfront to check for `[nogame]`, the listener's `testCaseStarting` checks each test's tags and initializes the game on the first non-`[nogame]` test. The `needs_game` file-scope flag is replaced by `game_initialized`.

`CataCIReporter` removed. It subclassed `ConsoleReporter` just to add a debug log line on test case start. No CI script ever selected it (`--reporter cata-ci-reporter` appears nowhere in CI). Not worth carrying a reporter subclass dependency for an unused feature.

`normalized_test_names_test` now calls `getAllTestCasesSorted` through a small helper function instead of inline in the test body. The test logic itself uses only `std::vector<std::string>`.

#### Describe alternatives you've considered

N/A

#### Testing

Doesn't affect test execution lifecycle. Full suite passes. Verified `[nogame]`-only runs skip game init, regular tests trigger lazy init, `enforce_normalized_test_cases` passes with the extracted helper.

#### Additional context

None