### PR TITLE
Allow melee attacks on matching stairs across z-levels

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3307,6 +3307,25 @@ bool map::has_flag_ter_or_furn( const ter_furn_flag flag, const tripoint_bub_ms 
            current_submap->get_furn( l ).obj().has_flag( flag );
 }
 
+bool map::on_matching_stairs( const tripoint_bub_ms &a, const tripoint_bub_ms &b ) const
+{
+    if( a.xy() != b.xy() ) {
+        return false;
+    }
+    const int dz = b.z() - a.z();
+    if( std::abs( dz ) != 1 ) {
+        return false;
+    }
+    const tripoint_bub_ms &lower = dz > 0 ? a : b;
+    const tripoint_bub_ms &upper = dz > 0 ? b : a;
+    if( has_flag( ter_furn_flag::TFLAG_DIFFICULT_Z, lower ) ||
+        has_flag( ter_furn_flag::TFLAG_DIFFICULT_Z, upper ) ) {
+        return false;
+    }
+    return has_flag( ter_furn_flag::TFLAG_GOES_UP, lower ) &&
+           has_flag( ter_furn_flag::TFLAG_GOES_DOWN, upper );
+}
+
 // End of 3D flags
 
 // returns 0 if not damageable

--- a/src/map.h
+++ b/src/map.h
@@ -1056,6 +1056,10 @@ class map
         // Checks terrain or furniture
         bool has_flag_ter_or_furn( ter_furn_flag flag, const tripoint_bub_ms &p ) const;
 
+        // Returns true if a and b are on matching stairs connecting them
+        // across exactly one z-level (one has GOES_UP, the other GOES_DOWN).
+        bool on_matching_stairs( const tripoint_bub_ms &a, const tripoint_bub_ms &b ) const;
+
         // Bashable
         /** Returns true if there is a bashable vehicle part or the furn/terrain is bashable at p */
         bool is_bashable( const tripoint_bub_ms &p, bool allow_floor = false ) const;

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -574,7 +574,8 @@ bool Character::melee_attack( Creature &t, bool allow_special, const matec_id &f
         add_msg_if_player( m_info, _( "You lack the substance to affect anything." ) );
         return false;
     }
-    if( !is_adjacent( &t, false ) ) {
+    if( !is_adjacent( &t, false ) &&
+        !get_map().on_matching_stairs( pos_bub(), t.pos_bub() ) ) {
         return false;
     }
 
@@ -1026,6 +1027,13 @@ int Character::get_total_melee_stamina_cost( const item *weap ) const
 
 bool Character::can_reach_attack( const Creature &target ) const
 {
+    if( pos_bub().z() == target.pos_bub().z() ) {
+        return true;
+    }
+    if( get_map().on_matching_stairs( pos_bub(), target.pos_bub() ) ) {
+        return true;
+    }
+
     item_location maybe_weapon = get_wielded_item();
     int vert_reach = 0;
     if( maybe_weapon ) {

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1233,7 +1233,8 @@ void monster::move()
                     continue;
                 }
                 const Attitude att = attitude_to( *target );
-                if( att == Attitude::HOSTILE && !is_z_move ) {
+                if( att == Attitude::HOSTILE &&
+                    ( !is_z_move || here.on_matching_stairs( pos_bub(), candidate ) ) ) {
                     // When attacking an adjacent enemy, we're direct.
                     moved = true;
                     next_step = candidate_abs;
@@ -1919,7 +1920,8 @@ bool monster::attack_at( const tripoint_bub_ms &p )
     Character &player_character = get_player_character();
     const bool sees_player = sees( here, player_character );
     // Targeting player location
-    if( p == player_character.pos_bub() && p.z() == pos_bub().z() ) {
+    if( p == player_character.pos_bub() &&
+        ( p.z() == pos_bub().z() || here.on_matching_stairs( pos_bub(), p ) ) ) {
         if( sees_player ) {
             return melee_attack( player_character );
         } else {

--- a/tests/monster_attack_test.cpp
+++ b/tests/monster_attack_test.cpp
@@ -136,7 +136,7 @@ static void monster_attack_zlevel( const std::string &title, const tripoint &off
             }
         }
         if( on_stairs ) {
-            test_monster_attack( offset, false, expected_adjacent );
+            test_monster_attack( offset, true, expected_adjacent );
         } else {
             test_monster_attack( offset, expected_vertical, expected_vertical );
         }


### PR DESCRIPTION
#### Summary
Bugfixes "Allow melee attacks on matching stairs across z-levels"

#### Purpose of change

Fixes #85876.

#85753 disabled all cross-z-level melee to prevent rooftop spear cheese, but it also broke melee on stairs. Standing on one end of a stairway with an enemy on the other creates an invulnerability exploit -- neither side can attack, and the enemy can't traverse because the tile is occupied.

#### Describe the solution

Add `map::on_matching_stairs(a, b)` -- returns true when both positions are on the same XY, exactly 1 z-level apart, lower tile has `GOES_UP` and upper tile has `GOES_DOWN`. Excludes tiles with `DIFFICULT_Z` (ladders, ropes, scaffolding) since fighting while climbing those is questionable at best.

Use this as a targeted exception in the four blocking sites from #85753:

- `Character::melee_attack()` -- player can attack on stairs
- `Character::can_reach_attack()` -- stair targets show up for autoattack and target selection
- `monster::attack_at()` -- monsters can attack the player on stairs
- `monster::move()` z-gate -- monsters choose "attack directly" for stair targets

Rooftop and ledge attacks remain disabled.

#### Describe alternatives you've considered

Adding a third `allow_z_levels` mode to `is_adjacent` for "stairs only" -- more invasive for the same result.

#### Testing

Updated the existing `monster_attack_zlevel` tests to expect successful attacks on stairs (both up and down). All 1170 assertions pass. Ledge and floor/ceiling tests are unchanged and still pass.

#### Additional context

The `on_matching_stairs` helper checks terrain flags rather than specific terrain IDs, so any modded terrain with `GOES_UP`/`GOES_DOWN` (but not `DIFFICULT_Z`) gets stair combat automatically.