### PR TITLE
Make mod conflict checks bidirectional

### DIFF
--- a/src/mod_manager.h
+++ b/src/mod_manager.h
@@ -4,6 +4,7 @@
 
 #include <cstddef>
 #include <map>
+#include <optional>
 #include <set>
 #include <string>
 #include <utility>
@@ -203,7 +204,8 @@ class mod_ui
         void try_rem( size_t selection, std::vector<mod_id> &active_list );
         void try_shift( char direction, size_t &selection, std::vector<mod_id> &active_list );
 
-        bool confirm_mod_compatibility( const mod_id &checked_mod, const std::vector<mod_id> &active_list );
+        std::optional<mod_id> find_mod_conflict( const mod_id &checked_mod,
+                const std::vector<mod_id> &active_list );
 
         bool can_shift_up( size_t selection, const std::vector<mod_id> &active_list );
         bool can_shift_down( size_t selection, const std::vector<mod_id> &active_list );

--- a/src/mod_manager_ui.cpp
+++ b/src/mod_manager_ui.cpp
@@ -68,17 +68,26 @@ std::string mod_ui::get_information( const MOD_INFORMATION *mod )
     return info;
 }
 
-bool mod_ui::confirm_mod_compatibility( const mod_id &checked_mod,
-                                        const std::vector<mod_id> &active_list )
+std::optional<mod_id> mod_ui::find_mod_conflict( const mod_id &checked_mod,
+        const std::vector<mod_id> &active_list )
 {
-    for( mod_id some_active_mod : active_list ) {
-        for( mod_id conflict_mod_id : some_active_mod->conflicts ) {
+    for( const mod_id &some_active_mod : active_list ) {
+        for( const mod_id &conflict_mod_id : some_active_mod->conflicts ) {
             if( conflict_mod_id == checked_mod ) {
-                return false;
+                return some_active_mod;
             }
         }
     }
-    return true;
+    if( checked_mod.is_valid() ) {
+        for( const mod_id &conflict_mod_id : checked_mod->conflicts ) {
+            std::vector<mod_id>::const_iterator it = std::find( active_list.begin(),
+                    active_list.end(), conflict_mod_id );
+            if( it != active_list.end() ) {
+                return *it;
+            }
+        }
+    }
+    return std::nullopt;
 }
 
 void mod_ui::try_add( const mod_id &mod_to_add,
@@ -92,9 +101,10 @@ void mod_ui::try_add( const mod_id &mod_to_add,
         debugmsg( "Unable to load mod \"%s\".", mod_to_add.c_str() );
         return;
     }
-    if( !confirm_mod_compatibility( mod_to_add, active_list ) ) {
-        popup( _( "Unable to add %s.  It is incompatible with a currently active mod." ),
-               mod_to_add->name() );
+    std::optional<mod_id> conflict = find_mod_conflict( mod_to_add, active_list );
+    if( conflict ) {
+        popup( _( "Unable to add %s.  It conflicts with %s." ),
+               mod_to_add->name(), ( *conflict )->name() );
         return;
     }
 

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -193,9 +193,12 @@ WORLD *worldfactory::make_new_world( bool show_prompt, const std::string &world_
         }
     }
 
-    for( mod_id checked_mod : retworld->active_mod_order ) {
-        if( !mman_ui->confirm_mod_compatibility( checked_mod, retworld->active_mod_order ) ) {
-            popup( _( "Unable to create new world, some active mods are incompatible." ) );
+    for( const mod_id &checked_mod : retworld->active_mod_order ) {
+        std::optional<mod_id> conflict = mman_ui->find_mod_conflict( checked_mod,
+                                         retworld->active_mod_order );
+        if( conflict ) {
+            popup( _( "Unable to create new world: %s conflicts with %s." ),
+                   checked_mod->name(), ( *conflict )->name() );
             return nullptr;
         }
     }
@@ -851,8 +854,11 @@ std::map<int, inclusive_rectangle<point>> worldfactory::draw_mod_list( const cat
 
                     }
                     mod_entry_name += string_format( _( " [%s]" ), mod_entry_id.str() );
-                    if( !mman_ui->confirm_mod_compatibility( mod_entry_id, potential_conflicts ) ) {
-                        mod_entry_name += _( " --- INCOMPATIBLE!" );
+                    std::optional<mod_id> conflict = mman_ui->find_mod_conflict( mod_entry_id,
+                                                     potential_conflicts );
+                    if( conflict ) {
+                        mod_entry_name += string_format( _( " --- conflicts with %s" ),
+                                                         ( *conflict )->name() );
                         mod_entry_color = c_pink;
                     }
                     trim_and_print( w, point( 4, iNum - start ), wwidth, mod_entry_color, mod_entry_name );


### PR DESCRIPTION
#### Summary
Bugfixes "Make mod conflict checks bidirectional and name the conflicting mod"

#### Purpose of change

Closes #85878

Mod conflict checks were one-directional: if Mod A declared a conflict with Mod B, only adding A after B was blocked. Adding B first and then A slipped through the UI and only failed at world creation with a generic error. The error messages also never said *which* mod was the problem.

#### Describe the solution

Renamed `confirm_mod_compatibility()` to `find_mod_conflict()` and changed its return type from `bool` to `std::optional<mod_id>`. It now checks both directions -- whether any active mod declares a conflict with the candidate, and whether the candidate declares a conflict with any active mod. On conflict, it returns the offending mod instead of just `false`.

All three callers updated to use the conflicting mod's name in their messages:
- `try_add()` popup: "Unable to add X. It conflicts with Y."
- `draw_mod_list()` label: "--- conflicts with Y"
- World creation validation: "Unable to create new world: X conflicts with Y."

#### Describe alternatives you've considered

Could have kept the bool return and done a second pass to find the name, but that's just doing the same work twice for no reason.

#### Testing

Straightforward: the new reverse check mirrors the existing forward check with the roles swapped.

#### Additional context

None