### PR TITLE
Fix SWIM_UNDER melee asymmetry, NPC stuck state, and visibility

### DIFF
--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -379,8 +379,12 @@ bool avatar_action::move( avatar &you, map &m, const tripoint_rel_ms &d )
 
     if( monster *const mon_ptr = creatures.creature_at<monster>( dest_loc, true ) ) {
         monster &critter = *mon_ptr;
-        if( critter.friendly == 0 &&
-            !critter.has_effect( effect_pet ) ) {
+        // Creatures swimming under a solid surface don't block surface movement
+        if( critter.is_underwater() &&
+            m.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, dest_loc ) ) {
+            // They're under the walkway/ice, player walks over them
+        } else if( critter.friendly == 0 &&
+                   !critter.has_effect( effect_pet ) ) {
             if( you.is_auto_moving() ) {
                 add_msg( m_warning, _( "Monster in the way.  Auto move canceled." ) );
                 add_msg( m_info, _( "Move into the monster to attack." ) );

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -3981,6 +3981,17 @@ bool cata_tiles::draw_critter_at( const tripoint_bub_ms &p, lit_level ll, int &h
     Creature::Attitude attitude;
     Character &you = get_player_character();
     const Creature *pcritter = get_creature_tracker().creature_at( p, true );
+    // creature_at returns monsters first. If the monster is underwater beneath a
+    // solid surface (invisible), fall back to the player/NPC sharing the tile.
+    if( pcritter != nullptr && pcritter->is_underwater() &&
+        here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, p ) &&
+        !you.is_underwater() ) {
+        if( you.pos_bub() == p ) {
+            pcritter = &you;
+        } else {
+            pcritter = get_creature_tracker().creature_at<npc>( p );
+        }
+    }
     const bool always_visible = pcritter && pcritter->has_flag( mon_flag_ALWAYS_VISIBLE );
     const auto override = monster_override.find( p );
     if( override != monster_override.end() ) {

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -573,6 +573,13 @@ bool Creature::sees( const map &here, const Creature &critter ) const
         return ch == nullptr || !ch->is_invisible();
     };
 
+    // Creatures underwater beneath a solid surface (walkway, ice) are hidden
+    // from non-underwater observers. Underwater observers can still see each other.
+    if( !is_likely_underwater( here ) && critter.is_underwater() &&
+        here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, critter_pos ) ) {
+        return false;
+    }
+
     // Can always see adjacent monsters on the same level.
     // We also bypass lighting for vertically adjacent monsters, but still check for floors.
     if( target_range <= 1 ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8082,42 +8082,48 @@ point_rel_sm game::place_player( const tripoint_bub_ms &dest_loc, bool quick )
     }
 
     if( monster *const mon_ptr = get_creature_tracker().creature_at<monster>( dest_loc ) ) {
-        // We displaced a monster. It's probably a bug if it wasn't a friendly mon...
-        // Immobile monsters can't be displaced.
         monster &critter = *mon_ptr;
-        // TODO: handling for ridden creatures other than players mount.
-        if( !critter.has_effect( effect_ridden ) ) {
-            if( u.is_mounted() ) {
-                std::vector<tripoint_bub_ms> maybe_valid;
-                for( const tripoint_bub_ms &jk : here.points_in_radius( critter.pos_bub(), 1 ) ) {
-                    if( is_empty( jk ) ) {
-                        maybe_valid.push_back( jk );
+        // Creatures under a solid surface coexist with the player on the tile
+        if( critter.is_underwater() &&
+            here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, dest_loc ) ) {
+            // Fish stays under the walkway/ice, no displacement needed
+        } else {
+            // We displaced a monster. It's probably a bug if it wasn't a friendly mon...
+            // Immobile monsters can't be displaced.
+            // TODO: handling for ridden creatures other than players mount.
+            if( !critter.has_effect( effect_ridden ) ) {
+                if( u.is_mounted() ) {
+                    std::vector<tripoint_bub_ms> maybe_valid;
+                    for( const tripoint_bub_ms &jk : here.points_in_radius( critter.pos_bub(), 1 ) ) {
+                        if( is_empty( jk ) ) {
+                            maybe_valid.push_back( jk );
+                        }
                     }
-                }
-                bool moved = false;
-                while( !maybe_valid.empty() ) {
-                    if( critter.move_to( random_entry_removed( maybe_valid ) ) ) {
-                        add_msg( _( "You push the %s out of the way." ), critter.name() );
-                        moved = true;
+                    bool moved = false;
+                    while( !maybe_valid.empty() ) {
+                        if( critter.move_to( random_entry_removed( maybe_valid ) ) ) {
+                            add_msg( _( "You push the %s out of the way." ), critter.name() );
+                            moved = true;
+                        }
                     }
-                }
-                if( !moved ) {
-                    add_msg( _( "There is no room to push the %s out of the way." ), critter.name() );
-                    return point_rel_sm::zero;
-                }
-            } else {
-                // Force the movement even though the player is there right now.
-                const bool moved = critter.move_to( u.pos_bub(), /*force=*/false, /*step_on_critter=*/true );
-                if( moved ) {
-                    add_msg( _( "You displace the %s." ), critter.name() );
+                    if( !moved ) {
+                        add_msg( _( "There is no room to push the %s out of the way." ), critter.name() );
+                        return point_rel_sm::zero;
+                    }
                 } else {
-                    add_msg( _( "You cannot move the %s out of the way." ), critter.name() );
-                    return point_rel_sm::zero;
+                    // Force the movement even though the player is there right now.
+                    const bool moved = critter.move_to( u.pos_bub(), /*force=*/false, /*step_on_critter=*/true );
+                    if( moved ) {
+                        add_msg( _( "You displace the %s." ), critter.name() );
+                    } else {
+                        add_msg( _( "You cannot move the %s out of the way." ), critter.name() );
+                        return point_rel_sm::zero;
+                    }
                 }
+            } else if( !u.has_effect( effect_riding ) ) {
+                add_msg( _( "You cannot move the %s out of the way." ), critter.name() );
+                return point_rel_sm::zero;
             }
-        } else if( !u.has_effect( effect_riding ) ) {
-            add_msg( _( "You cannot move the %s out of the way." ), critter.name() );
-            return point_rel_sm::zero;
         }
     }
 

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1902,9 +1902,9 @@ bool monster::attack_at( const tripoint_bub_ms &p )
     const map &here = get_map();
 
     // Aquatic monsters that are underwater should not be able to attack
-    // through tile above them, except they may attack other monsters
+    // through the surface above them, except they may attack other monsters
     // that are also underwater (fish fighting under the ice).
-    if( is_underwater() && here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, p ) ) {
+    if( is_underwater() && here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, pos_bub() ) ) {
         creature_tracker &creatures = get_creature_tracker();
         monster *target_mon = creatures.creature_at<monster>( p );
         if( !( target_mon != nullptr && target_mon->is_underwater() ) ) {
@@ -2057,7 +2057,10 @@ bool monster::move_to( const tripoint_bub_ms &p, bool force, bool step_on_critte
             // If the destination terrain has SWIM_UNDER, swimmers should remain submerged there.
             ( swims() && here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, destination ) )
         ) && ( here.is_divable( destination ) ||
-               here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, destination ) );
+               here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, destination ) ||
+               // AQUATIC creatures stay submerged in any swimmable terrain (including shallow water)
+               ( has_flag( mon_flag_AQUATIC ) &&
+                 here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, destination ) ) );
 
     if( get_option<bool>( "LOG_MONSTER_MOVEMENT" ) ) {
         //Birds and other flying creatures flying over the deep water terrain

--- a/src/npc_attack.cpp
+++ b/src/npc_attack.cpp
@@ -23,6 +23,7 @@
 #include "magic.h"
 #include "magic_spell_effect_helpers.h"
 #include "map.h"
+#include "mapdata.h"
 #include "messages.h"
 #include "npc.h"
 #include "pimpl.h"
@@ -414,6 +415,14 @@ npc_attack_rating npc_attack_melee::evaluate_critter( const npc &source,
 {
     if( !critter ) {
         return npc_attack_rating{};
+    }
+
+    // Can't melee creatures that are underwater beneath a solid surface
+    if( critter->is_underwater() ) {
+        const map &here = get_map();
+        if( here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, critter->pos_bub() ) ) {
+            return npc_attack_rating{};
+        }
     }
 
     // TODO: Give bashing weapons a better

--- a/tests/swim_under_test.cpp
+++ b/tests/swim_under_test.cpp
@@ -1,0 +1,256 @@
+#include <memory>
+#include <optional>
+#include <string>
+
+#include "avatar.h"
+#include "avatar_action.h"
+#include "cata_catch.h"
+#include "character.h"
+#include "character_id.h"
+#include "coordinates.h"
+#include "creature.h"
+#include "creature_tracker.h"
+#include "game.h"
+#include "item.h"
+#include "map.h"
+#include "map_helpers.h"
+#include "mapdata.h"
+#include "monster.h"
+#include "npc.h"
+#include "npc_attack.h"
+#include "options_helpers.h"
+#include "overmap_ui.h"
+#include "player_helpers.h"
+#include "point.h"
+#include "type_id.h"
+
+static const faction_id faction_your_followers( "your_followers" );
+static const itype_id itype_knife_large( "knife_large" );
+static const mtype_id mon_fish_brook_trout( "mon_fish_brook_trout" );
+static const mtype_id mon_sewer_fish( "mon_sewer_fish" );
+static const mtype_id mon_zombie( "mon_zombie" );
+static const string_id<npc_template> npc_template_test_talker( "test_talker" );
+static const ter_str_id ter_t_bridge( "t_bridge" );
+static const ter_str_id ter_t_floor( "t_floor" );
+static const weather_type_id weather_sunny( "sunny" );
+
+static constexpr tripoint_bub_ms fish_pos{ 65, 65, 0 };
+static constexpr tripoint_bub_ms adjacent_pos{ 66, 65, 0 };
+
+static void reset_caches( int zlev )
+{
+    Character &you = get_player_character();
+    map &here = get_map();
+    g->reset_light_level();
+    here.invalidate_visibility_cache();
+    here.update_visibility_cache( zlev );
+    here.invalidate_map_cache( zlev );
+    here.build_map_cache( zlev );
+    here.invalidate_visibility_cache();
+    here.update_visibility_cache( zlev );
+    here.invalidate_map_cache( zlev );
+    here.build_map_cache( zlev );
+    you.recalc_sight_limits();
+}
+
+// Phase 1: monster::attack_at SWIM_UNDER position check
+TEST_CASE( "monsters_cannot_attack_through_swim_under", "[swim_under][melee]" )
+{
+    clear_map_and_put_player_underground();
+    clear_vehicles();
+    map &here = get_map();
+
+    // Set up walkway at fish position, regular floor adjacent
+    here.ter_set( fish_pos, ter_t_bridge );
+    here.ter_set( adjacent_pos, ter_t_floor );
+
+    SECTION( "underwater monster on SWIM_UNDER tile cannot attack adjacent surface creature" ) {
+        // Spawn seweranha on the walkway tile, set it underwater
+        monster &fish = spawn_test_monster( mon_sewer_fish.str(), fish_pos );
+        fish.underwater = true;
+        REQUIRE( fish.is_underwater() );
+        REQUIRE( here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, fish_pos ) );
+        REQUIRE( !here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, adjacent_pos ) );
+
+        // Place player on the adjacent floor tile
+        Character &player = get_player_character();
+        player.setpos( here, adjacent_pos );
+        REQUIRE( !player.is_underwater() );
+
+        // Fish should NOT be able to attack through the solid surface
+        CHECK_FALSE( fish.attack_at( adjacent_pos ) );
+    }
+
+    SECTION( "underwater monsters on SWIM_UNDER can fight each other" ) {
+        // Seweranha (mutant_piscivores) hates fish faction, so use a brook trout
+        // as a hostile underwater target to verify the SWIM_UNDER gate passes.
+        monster &predator = spawn_test_monster( mon_sewer_fish.str(), fish_pos );
+        predator.underwater = true;
+
+        // Prey fish on an adjacent walkway tile (fish_small -> fish faction, hostile)
+        here.ter_set( adjacent_pos, ter_t_bridge );
+        monster &prey = spawn_test_monster( mon_fish_brook_trout.str(), adjacent_pos );
+        prey.underwater = true;
+
+        REQUIRE( predator.is_underwater() );
+        REQUIRE( prey.is_underwater() );
+        REQUIRE( predator.attitude_to( prey ) == Creature::Attitude::HOSTILE );
+
+        // attack_at should succeed for underwater-to-underwater through SWIM_UNDER
+        CHECK( predator.attack_at( adjacent_pos ) );
+    }
+
+    SECTION( "player cannot melee underwater creature on SWIM_UNDER tile" ) {
+        monster &fish = spawn_test_monster( mon_sewer_fish.str(), fish_pos );
+        fish.underwater = true;
+
+        Character &player = get_player_character();
+        player.setpos( here, adjacent_pos );
+        clear_character( player );
+
+        REQUIRE( fish.is_underwater() );
+        REQUIRE( here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, fish_pos ) );
+
+        // Player melee should be blocked (this already works, regression guard)
+        CHECK_FALSE( player.melee_attack( fish, false ) );
+    }
+}
+
+// Phase 2: NPC melee evaluation should skip SWIM_UNDER targets
+TEST_CASE( "npc_does_not_target_swim_under_creatures", "[swim_under][npc_attack]" )
+{
+    clear_map_and_put_player_underground();
+    clear_vehicles();
+    scoped_weather_override sunny_weather( weather_sunny );
+    map &here = get_map();
+    creature_tracker &creatures = get_creature_tracker();
+
+    // Place player out of the way
+    get_player_character().setpos( here, { 40, 40, 0 } );
+
+    // Spawn NPC at adjacent_pos
+    static constexpr point_bub_ms npc_start{ adjacent_pos.xy() };
+    static constexpr tripoint_bub_ms npc_start_tri{ npc_start, 0 };
+    REQUIRE( creatures.creature_at<Creature>( npc_start_tri ) == nullptr );
+    const character_id npc_id = here.place_npc( npc_start, npc_template_test_talker );
+    npc &test_npc = *g->find_npc( npc_id );
+    clear_character( test_npc );
+    test_npc.setpos( here, npc_start_tri );
+    test_npc.set_fac( faction_your_followers );
+    g->load_npcs();
+    REQUIRE( creatures.creature_at<npc>( npc_start_tri ) != nullptr );
+
+    // Give NPC a weapon
+    item weapon( itype_knife_large );
+    test_npc.set_wielded_item( weapon );
+
+    SECTION( "NPC melee evaluation skips underwater SWIM_UNDER target" ) {
+        here.ter_set( fish_pos, ter_t_bridge );
+        here.ter_set( adjacent_pos, ter_t_floor );
+
+        monster *fish = g->place_critter_at( mon_sewer_fish, fish_pos );
+        REQUIRE( fish != nullptr );
+        fish->underwater = true;
+        REQUIRE( fish->is_underwater() );
+        REQUIRE( here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, fish_pos ) );
+
+        test_npc.evaluate_best_attack( fish );
+        const npc_attack_rating &rating = test_npc.get_current_attack_evaluation();
+        // The rating should have no value (target unreachable)
+        CHECK_FALSE( rating.value().has_value() );
+    }
+
+    SECTION( "NPC melee evaluation works for normal hostile target" ) {
+        here.ter_set( fish_pos, ter_t_floor );
+        here.ter_set( adjacent_pos, ter_t_floor );
+
+        monster *zombie = g->place_critter_at( mon_zombie, fish_pos );
+        REQUIRE( zombie != nullptr );
+        REQUIRE( !zombie->is_underwater() );
+
+        test_npc.evaluate_best_attack( zombie );
+        const npc_attack_rating &rating = test_npc.get_current_attack_evaluation();
+        // Normal zombie should get a positive rating
+        CHECK( rating.value().has_value() );
+        CHECK( *rating.value() > 0 );
+    }
+}
+
+// Phase 2b: player can walk over SWIM_UNDER creatures
+TEST_CASE( "player_can_walk_over_swim_under_creatures", "[swim_under][movement]" )
+{
+    clear_map_and_put_player_underground();
+    clear_vehicles();
+    scoped_weather_override sunny_weather( weather_sunny );
+    map &here = get_map();
+
+    here.ter_set( fish_pos, ter_t_bridge );
+    here.ter_set( adjacent_pos, ter_t_floor );
+
+    SECTION( "bumping into SWIM_UNDER tile with underwater creature does not attack" ) {
+        monster &fish = spawn_test_monster( mon_sewer_fish.str(), fish_pos );
+        fish.underwater = true;
+
+        Character &player = get_player_character();
+        player.setpos( here, adjacent_pos );
+        clear_character( player );
+        player.set_moves( 200 );
+        REQUIRE( fish.is_underwater() );
+        REQUIRE( here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, fish_pos ) );
+
+        reset_caches( 0 );
+
+        // Moving towards the fish tile should succeed (walk over the walkway)
+        // The fish is under the surface and should not block movement
+        tripoint_rel_ms direction( fish_pos.raw() - adjacent_pos.raw() );
+        avatar &you = get_avatar();
+        you.setpos( here, adjacent_pos );
+        you.set_moves( 200 );
+        bool moved = avatar_action::move( you, here, direction );
+        CHECK( moved );
+        CHECK( you.pos_bub() == fish_pos );
+    }
+}
+
+// Phase 3: visibility of creatures under SWIM_UNDER terrain
+TEST_CASE( "creatures_under_swim_under_are_invisible", "[swim_under][vision]" )
+{
+    clear_map_and_put_player_underground();
+    clear_vehicles();
+    scoped_weather_override sunny_weather( weather_sunny );
+    map &here = get_map();
+
+    here.ter_set( fish_pos, ter_t_bridge );
+    here.ter_set( adjacent_pos, ter_t_floor );
+
+    SECTION( "surface observer cannot see underwater creature on SWIM_UNDER tile" ) {
+        monster &fish = spawn_test_monster( mon_sewer_fish.str(), fish_pos );
+        fish.underwater = true;
+
+        Character &player = get_player_character();
+        player.setpos( here, adjacent_pos );
+        REQUIRE( !player.is_underwater() );
+        REQUIRE( fish.is_underwater() );
+        REQUIRE( here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, fish_pos ) );
+
+        reset_caches( 0 );
+
+        // Player should NOT be able to see fish under the walkway
+        CHECK_FALSE( player.sees( here, fish ) );
+    }
+
+    SECTION( "underwater observer can see underwater creature on SWIM_UNDER tile" ) {
+        here.ter_set( adjacent_pos, ter_t_bridge );
+
+        monster &fish1 = spawn_test_monster( mon_sewer_fish.str(), fish_pos );
+        fish1.underwater = true;
+
+        monster &fish2 = spawn_test_monster( mon_sewer_fish.str(), adjacent_pos );
+        fish2.underwater = true;
+
+        reset_caches( 0 );
+
+        // Underwater fish should see each other
+        CHECK( fish1.sees( here, fish2 ) );
+    }
+}


### PR DESCRIPTION
#### Summary
Bugfixes "Fix creatures under SWIM_UNDER terrain attacking through the surface, NPCs getting stuck, and visibility"

#### Purpose of change
Closes #85748

PR #84902 generalized the THICK_ICE melee block to all SWIM_UNDER terrain but `monster::attack_at()` checked the *target's* tile for the flag instead of the monster's own tile. A fish under a walkway attacking a player on adjacent floor would pass the check because the floor tile lacked SWIM_UNDER. NPC companions would get stuck trying to melee the unreachable fish and eventually faint. The creatures were also visible when they shouldn't be.

#### Describe the solution

Seven changes across the codebase:

- **monster::attack_at** - check `pos_bub()` (monster's tile) instead of `p` (target's tile)
- **npc_attack_melee::evaluate_critter** - return empty rating for underwater SWIM_UNDER targets, preventing the zero-move faint loop
- **Creature::sees** - hide underwater SWIM_UNDER creatures from surface observers, placed before the adjacency bypass
- **avatar_action::move** - skip melee interaction on bump-move, player walks over the surface
- **game::place_player** - skip displacement, fish and player coexist on the tile
- **cata_tiles::draw_critter_at** - when creature_at returns an invisible SWIM_UNDER monster, fall back to drawing the player/NPC sharing the tile
- **monster::move_to** - fix `will_be_water` for AQUATIC creatures on shallow SWIMMABLE terrain (t_sewage), which falsely triggered "leaps" transition messages every move

#### Describe alternatives you've considered

Could have modified `creature_at` to skip SWIM_UNDER creatures globally, but that would change behavior for code that legitimately needs to find them (pathfinding, AI targeting). Targeted checks at each interaction point is less elegant but safer.

#### Testing

New test file `tests/swim_under_test.cpp` with 4 test cases (73 assertions):

- Underwater monster on SWIM_UNDER cannot melee adjacent surface creature; hostile underwater fish can still fight each other; player melee is still blocked (regression)
- NPC melee evaluation returns empty rating for underwater SWIM_UNDER target; still works for normal zombies (regression)
- Player can bump-move onto SWIM_UNDER tile with underwater creature
- Surface observer cannot see underwater creature on SWIM_UNDER; underwater creatures can still see each other

Tested in-game: seweranha invisible under walkway, can't attack player, player walks over freely, no "leaps" spam, player renders correctly on shared tile.

#### Additional context

None.