### PR TITLE
Clear highway intersection grid in overmapbuffer::reset()

### DIFF
--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -254,6 +254,7 @@ void overmapbuffer::save()
 void overmapbuffer::reset()
 {
     overmaps.clear();
+    global_state.highway_intersections.clear();
     last_requested_overmap = nullptr;
 }
 


### PR DESCRIPTION
#### Summary
Bugfixes "Fix stale highway grid causing hw_reserved tiles to survive finalize_highways()"

#### Purpose of change

`overmapbuffer::reset()` was created in #73037 (2024-04) to preserve `placed_unique_specials` across `overmap_terrain_coverage` test iterations. When highways were added 14 months later in #81602 (2025-06), `highway_intersections` was correctly added to `clear()` but not to `reset()` -- it didn't exist when `reset()` was written.

So the highway intersection grid accidentally persists across test attempts. The grid stores intersection positions with offsets computed for the previous attempt's overmaps. New overmaps generate highway paths against this stale grid, producing geometries that can't occur during normal generation and leaving unreplaced hw_reserved placeholder tiles.

#### Describe the solution

One line: add `global_state.highway_intersections.clear()` to `reset()`.

Other `global_state` fields are left alone -- preserving `placed_unique_specials` was the original intent, and `overmap_count`/`unique_special_count` become stats-only after #85849.

#### Describe alternatives you've considered

Could switch the test to `clear()` entirely, but that changes unique special behavior across attempts.

#### Testing

Wrote a minimal overmap_terrain_coverage-like highways-targeted test (5 attempts with reset() in between), fuzzed seeds until one failed, reproduced it separately, added the highway grid clear to reset(), problem is gone.