### PR TITLE
Fix butchery yield for sub-gram harvest items

### DIFF
--- a/src/butchery.cpp
+++ b/src/butchery.cpp
@@ -828,8 +828,9 @@ bool butchery_drops_harvest( butchery_data bt, Character &you )
                 // apply skill before converting to items, but only if mass_ratio is defined
                 roll *= butchery_dissect_yield_mult( skill_level, you.get_dex(), tool_quality );
                 monster_weight_remaining -= roll;
-                roll = std::ceil( static_cast<double>( roll ) /
-                                  to_gram( drop->weight ) );
+                // use milligrams to avoid truncation for sub-gram items
+                roll = std::ceil( static_cast<double>( roll ) * 1000.0 /
+                                  to_milligram( drop->weight ) );
             } else {
                 monster_weight_remaining -= roll * to_gram( drop->weight );
             }

--- a/tests/harvest_test.cpp
+++ b/tests/harvest_test.cpp
@@ -1,4 +1,5 @@
 #include <string>
+#include <vector>
 
 #include "activity_actor_definitions.h"
 #include "butchery.h"
@@ -22,6 +23,7 @@ static const item_group_id
 Item_spawn_data_cattle_sample_single( "cattle_sample_single" );
 
 static const itype_id itype_debug_backpack( "debug_backpack" );
+static const itype_id itype_down_feather( "down_feather" );
 static const itype_id itype_fake_lift_light( "fake_lift_light" );
 static const itype_id itype_hacksaw( "hacksaw" );
 static const itype_id itype_knife_combat( "knife_combat" );
@@ -29,6 +31,7 @@ static const itype_id itype_plastic_sheet( "plastic_sheet" );
 static const itype_id itype_rope_30( "rope_30" );
 static const itype_id itype_scalpel( "scalpel" );
 
+static const mtype_id mon_chicken( "mon_chicken" );
 static const mtype_id mon_deer( "mon_deer" );
 static const mtype_id mon_test_CBM( "mon_test_CBM" );
 static const mtype_id mon_test_bovine( "mon_test_bovine" );
@@ -140,4 +143,57 @@ static void do_butchery_timing( int expected_turns, butcher_type butchery_type,
 TEST_CASE( "butchery_speed", "[harvest]" )
 {
     do_butchery_timing( 8 * 60 * 60, butcher_type::FULL, 5, mon_deer );
+}
+
+// Regression test for #85877 / #85136: butchering birds with sub-gram harvest
+// items (down_feather weighs 10 mg) caused division by zero in the yield
+// calculation because to_gram() truncates sub-gram weights to 0.
+// On x86 this silently produces 0 feathers; on ARM64 it produces 333333 per tile.
+TEST_CASE( "butchery_sub_gram_harvest_items", "[harvest]" )
+{
+    Character &u = get_player_character();
+    map &here = get_map();
+    const tripoint_abs_ms orig_pos = u.pos_abs();
+
+    clear_character( u, true );
+    u.set_skill_level( skill_firstaid, 10 );
+    u.set_skill_level( skill_survival, 10 );
+    u.worn.wear_item( u, item( itype_debug_backpack ), false, false );
+    u.i_add( item( itype_knife_combat ) );
+
+    monster bird( mon_chicken, mon_pos );
+    const tripoint_bub_ms bird_loc = bird.pos_bub();
+    here.i_clear( bird_loc );
+    bird.die( &here, nullptr );
+    u.move_to( bird.pos_abs() );
+
+    item_location loc = item_location( map_cursor( u.pos_abs() ), &*here.i_at( bird_loc ).begin() );
+    butchery_data bd( loc, butcher_type::FULL );
+    butchery_activity_actor act( bd );
+    act.calculate_butchery_data( u, bd );
+    destroy_the_carcass( bd, u );
+
+    // Count down_feather charges on the butchery tile and all overflow tiles
+    int total_down_feathers = 0;
+    for( const tripoint_bub_ms &p : closest_points_first( bird_loc, 0, 3 ) ) {
+        for( const item &it : here.i_at( p ) ) {
+            if( it.typeId() == itype_down_feather ) {
+                total_down_feathers += it.charges;
+            }
+        }
+    }
+
+    // Chicken is 2 kg, down_feather mass_ratio is 0.005, so 10g of feather material.
+    // Each down_feather weighs 10 mg, so the correct yield is around 500-1000
+    // (depending on skill multiplier which maxes at 1.0).
+    // Before the fix: 0 on x86 (negative roll from UB), 333333/tile on ARM64.
+    CAPTURE( total_down_feathers );
+    CHECK( total_down_feathers > 0 );
+    CHECK( total_down_feathers < 5000 );
+
+    // Clean up all tiles that might have overflow items
+    for( const tripoint_bub_ms &p : closest_points_first( bird_loc, 0, 3 ) ) {
+        here.i_clear( p );
+    }
+    u.move_to( orig_pos );
 }


### PR DESCRIPTION
#### Summary
Bugfixes "Fix butchery yield for sub-gram harvest items like down feathers"

#### Purpose of change

Fixes #85877. Fixes #85136.

`to_gram()` returns `int64_t`, so items weighing less than 1 g get truncated to 0 -- causing division by zero in the butchery yield calculation. On x86, the undefined behavior produces a negative roll (silently harvesting 0 feathers). On ARM64 (Android), it saturates to INT_MAX, which then gets capped by tile volume to 333333 feathers per tile.

Currently only affects `down_feather` (10 mg), which appears in every bird harvest entry.

#### Describe the solution

Replace `to_gram(drop->weight)` with `to_milligram(drop->weight)` and multiply the numerator by 1000 to keep units consistent. This avoids the integer truncation entirely.

#### Describe alternatives you've considered

Could have changed `to_gram()` itself to return `double`, but that would affect every caller across the codebase for a problem that only manifests here.

#### Testing

Added a regression test that butchers a chicken and checks that down feathers are actually produced in a sane quantity (> 0, < 5000). Before the fix: `"You fail to harvest: down feather"` with 0 produced. After: passes with a reasonable count.

All existing `[harvest]` tests pass.

#### Additional context

The magic number 333333 from the bug reports is `DEFAULT_TILE_VOLUME / volume_per_down_feather` = 1,000,000 ml / 3 ml -- the maximum charges that fit in a single tile.