### PR TITLE
[WIP] [CR] Unify abstraction of cloth made from cotton and other plant fibers

### DIFF
--- a/data/json/materials.json
+++ b/data/json/materials.json
@@ -609,6 +609,31 @@
   },
   {
     "type": "material",
+    "id": "textile",
+    "name": "Fabric Blend",
+    "density": 0.5,
+    "specific_heat_liquid": 0.02,
+    "specific_heat_solid": 0.02,
+    "latent_heat": 205,
+    "soft": true,
+    "chip_resist": 6,
+    "breathability": "AVERAGE",
+    "wind_resist": 70,
+    "repaired_with": "cotton_patchwork",
+    "salvaged_into": "cotton_patchwork",
+    "dmg_adj": [ "ripped", "torn", "shredded", "tattered" ],
+    "bash_dmg_verb": "ripped",
+    "cut_dmg_verb": "cut",
+    "burn_data": [
+      { "fuel": 0.05, "smoke": 1, "burn": 0.015 },
+      { "fuel": 0.1, "smoke": 1, "burn": 0.04 },
+      { "fuel": 0.2, "smoke": 1, "burn": 0.06 }
+    ],
+    "resist": { "bash": 1, "cut": 1, "acid": 3, "heat": 0, "bullet": 1 },
+    "repair_difficulty": 1
+  },
+  {
+    "type": "material",
     "id": "cotton",
     "name": "Cotton Blend",
     "density": 0.5,


### PR DESCRIPTION
#### Summary
Content "Unify abstraction of cloth made from cotton and other plant fibers"

#### Purpose of change

Work towards a solution of https://github.com/CleverRaven/Cataclysm-DDA/issues/85856

#### Describe the solution

Cotton fiber is a common base material for cloths and crafts. But other natural fibers can be used, too. Instead of tracking individual plant fiber materials, this PR unifies them into one abstraction.

The word "cotton" means different things depending on the context. It can mean the plant as in

>   {
    "type": "ITEM",
    "subtypes": [ "SEED", "MILLING", "COMESTIBLE" ],
    "id": "seed_cotton_boll",
    "copy-from": "seed",
    "price": "1 cent",
    "name": { "str_sp": "cotton seeds" },
    "description": "Some cotton seeds.  Can be processed to produce an edible oil.",
    "weight": "5 g",
    "flags": [ "PLANTABLE_SEED", "NUTRIENT_OVERRIDE", "INEDIBLE" ],
    "volume": "6 ml",
    "plant_name": "cotton",
    "fruit": "cotton_boll",
    "byproducts": [ "withered" ],
    "growth_stages": [
      { "GROWTH_SEED": "33 days" },
      { "GROWTH_SEEDLING": "33 days" },
      { "GROWTH_MATURE": "33 days" },
      { "GROWTH_HARVEST": "32 days" },
      { "GROWTH_OVERGROWN": "1 hour" }
    ],
    "into": "paste_seed",
    "recipe": "paste_seed_mill_8_1"
  },

or the base material for items as in

>   {
    "type": "material",
    "id": "cotton",
    "name": "Cotton Blend",
    "density": 0.5,
    "specific_heat_liquid": 0.02,
    "specific_heat_solid": 0.02,
    "latent_heat": 205,
    "soft": true,
    "chip_resist": 6,
    "breathability": "AVERAGE",
    "wind_resist": 70,
    "repaired_with": "cotton_patchwork",
    "salvaged_into": "cotton_patchwork",
    "dmg_adj": [ "ripped", "torn", "shredded", "tattered" ],
    "bash_dmg_verb": "ripped",
    "cut_dmg_verb": "cut",
    "burn_data": [
      { "fuel": 0.05, "smoke": 1, "burn": 0.015 },
      { "fuel": 0.1, "smoke": 1, "burn": 0.04 },
      { "fuel": 0.2, "smoke": 1, "burn": 0.06 }
    ],
    "resist": { "bash": 1, "cut": 1, "acid": 3, "heat": 0, "bullet": 1 },
    "repair_difficulty": 1
  },

or the cloth made from it as in

>   {
    "id": "sheet_cotton",
    "type": "ITEM",
    "category": "spare_parts",
    "name": { "str": "cotton sheet" },
    "description": "A 12-inch by 24-inch sheet of cotton fabric, suitable for making clothing.  You can use it to stop bleeding, but it is very wasteful.",
    "weight": "23 g",
    "volume": "47 ml",
    "//": "Medium weight cotton fabric with a GSM of 203",
    "flags": [ "SINGLE_USE" ],
    "use_action": { "type": "heal", "bandages_power": 2, "bleed": 10, "move_cost": 6000 },
    "price": "10 USD",
    "price_postapoc": "10 cent",
    "material": [ "cotton" ],
    "symbol": "=",
    "color": "dark_gray"
  },

and more.

This PR unifies plant fibers after their refinement to textile to replace the base material cotton where appropriate.

#### Describe alternatives you've considered

Don't unify plant fibers but instead track each individually.

#### Testing

Nothing yet

#### Additional context

This PR is a work-in-progress preview of the branch I'm working on. It's here to gather early feedback.
