### PR TITLE
Make morale recovery non-destructive, init mutation state on load

### DIFF
--- a/src/character_morale.cpp
+++ b/src/character_morale.cpp
@@ -239,7 +239,7 @@ void Character::check_and_recover_morale()
         add_msg_debug( debugmode::DF_CHARACTER, "Actual %s morale:\n%s\n", disp_name( true ),
                        morale->to_string_writable() );
 
-        *morale = player_morale( test_morale ); // Recover consistency
+        morale->sync_permanent( test_morale ); // Recover only permanent morale
         add_msg_debug( debugmode::DF_CHARACTER, "%s morale was recovered.", disp_name( true ) );
     }
 }

--- a/src/morale.cpp
+++ b/src/morale.cpp
@@ -876,6 +876,36 @@ bool player_morale::consistent_with( const player_morale &morale ) const
     return test_points( *this, morale ) && test_points( morale, *this );
 }
 
+void player_morale::sync_permanent( const player_morale &reference )
+{
+    // Remove all permanent points, keep temporaries
+    const auto new_end = std::remove_if( points.begin(), points.end(),
+    []( const morale_point & mp ) {
+        return mp.is_permanent();
+    } );
+    points.erase( new_end, points.end() );
+
+    // Copy permanent points from reference
+    for( const morale_point &mp : reference.points ) {
+        if( mp.is_permanent() ) {
+            points.push_back( mp );
+        }
+    }
+
+    // Sync non-point state that consistent_with() checks
+    took_prozac = reference.took_prozac;
+    took_prozac_bad = reference.took_prozac_bad;
+    perceived_pain = reference.perceived_pain;
+    radiation = reference.radiation;
+
+    // Sync mutation and body part state for correct future updates
+    body_parts = reference.body_parts;
+    no_body_part = reference.no_body_part;
+    mutations = reference.mutations;
+
+    invalidate();
+}
+
 void player_morale::clear()
 {
     points.clear();

--- a/src/morale.h
+++ b/src/morale.h
@@ -50,6 +50,9 @@ class player_morale
         /** Returns false whether morale is inconsistent with the argument.
          *  Only permanent morale is checked */
         bool consistent_with( const player_morale &morale ) const;
+        /** Replaces permanent morale points and non-point state from reference,
+         *  preserving all temporary morale */
+        void sync_permanent( const player_morale &reference );
 
         /**calculates the percentage contribution for each morale point*/
         void calculate_percentage();

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -1075,6 +1075,13 @@ void Character::load( const JsonObject &data )
 
     morale->load( data );
 
+    // morale->load() only restores morale points, not mutation active flags.
+    // Activate mutations so update_masochist_bonus / update_constrained_penalty
+    // compute correct values when stat changes or item equips fire below.
+    for( const trait_id &mut : get_functioning_mutations() ) {
+        morale->on_mutation_gain( mut );
+    }
+
     _skills->clear();
     JsonObject skill_data = data.get_object( "skills" );
     skill_data.allow_omitted_members();

--- a/tests/morale_test.cpp
+++ b/tests/morale_test.cpp
@@ -1,4 +1,5 @@
 #include <cstddef>
+#include <functional>
 #include <memory>
 #include <string>
 #include <vector>
@@ -8,6 +9,7 @@
 #include "calendar.h"
 #include "cata_catch.h"
 #include "character.h"
+#include "debug.h"
 #include "coordinates.h"
 #include "item.h"
 #include "item_location.h"
@@ -674,5 +676,114 @@ TEST_CASE( "player_morale_stacking", "[player_morale]" )
 
             CHECK( m.get_level() == 10 );
         }
+    }
+}
+
+// Regression test for GitHub #85895: check_and_recover_morale was replacing
+// the entire morale object when it found a permanent-point inconsistency,
+// which destroyed all temporary morale (food, music, etc.).
+TEST_CASE( "check_and_recover_morale_preserves_temporary_morale", "[player_morale]" )
+{
+    clear_avatar();
+    avatar &dummy = get_avatar();
+    player_morale &m = *dummy.morale;
+
+    SECTION( "temporary morale survives when permanent point is inconsistent" ) {
+        // Add temporary morale
+        m.add( morale_food_good, 20, 40, 20_turns, 10_turns );
+        REQUIRE( m.has( morale_food_good ) == 20 );
+
+        // Inject a stale permanent point that the character should not have.
+        // The avatar has no constrained mutations, so test_morale will
+        // compute constrained = 0 and detect an inconsistency.
+        m.set_permanent( morale_perm_constrained, -5 );
+        REQUIRE( m.has( morale_perm_constrained ) == -5 );
+
+        // The inconsistency triggers a debugmsg; capture it so the test
+        // framework does not treat it as a failure.
+        std::string dmsg = capture_debugmsg_during( [&dummy]() {
+            dummy.check_and_recover_morale();
+        } );
+        CHECK_THAT( dmsg, Catch::Contains( "is inconsistent" ) );
+
+        // Recovery should fix the permanent point...
+        CHECK( m.has( morale_perm_constrained ) == 0 );
+        // ...without destroying the temporary morale
+        CHECK( m.has( morale_food_good ) == 20 );
+    }
+
+    SECTION( "multiple temporary bonuses survive recovery" ) {
+        m.add( morale_food_good, 15, 30, 20_turns, 10_turns );
+        m.add( morale_book, 8, 16, 30_turns, 15_turns );
+        REQUIRE( m.has( morale_food_good ) == 15 );
+        REQUIRE( m.has( morale_book ) == 8 );
+
+        // Inject inconsistency
+        m.set_permanent( morale_perm_constrained, -3 );
+
+        std::string dmsg = capture_debugmsg_during( [&dummy]() {
+            dummy.check_and_recover_morale();
+        } );
+        CHECK_THAT( dmsg, Catch::Contains( "is inconsistent" ) );
+
+        CHECK( m.has( morale_food_good ) == 15 );
+        CHECK( m.has( morale_book ) == 8 );
+        CHECK( m.has( morale_perm_constrained ) == 0 );
+    }
+}
+
+// Regression test for the save-load root cause: player_morale's mutation
+// tracking is not initialized during load, so update_constrained_penalty()
+// and update_masochist_bonus() compute wrong values when triggered.
+TEST_CASE( "morale_mutation_state_after_load_like_sequence", "[player_morale]" )
+{
+    clear_avatar();
+    avatar &dummy = get_avatar();
+    player_morale &m = *dummy.morale;
+
+    SECTION( "constrained penalty without mutation activation" ) {
+        dummy.toggle_trait( trait_FLOWERS );
+        REQUIRE( dummy.has_trait( trait_FLOWERS ) );
+
+        // First verify correct behavior when properly set up
+        const item hat( itype_tinfoil_hat, calendar::turn_zero );
+        m.on_mutation_gain( trait_FLOWERS );
+        m.on_item_wear( hat );
+        REQUIRE( m.has( morale_perm_constrained ) == -10 );
+
+        // Now simulate what save-load does: clear morale and rebuild
+        // WITHOUT activating mutations (the bug)
+        dummy.clear_morale();
+        // Only replay item wear (as savegame_json.cpp:918 does)
+        m.on_item_wear( hat );
+        // Without mutation activation, constrained penalty is wrong
+        CHECK( m.has( morale_perm_constrained ) == 0 );
+
+        // After activating mutations (the fix), penalty is correct
+        m.on_mutation_gain( trait_FLOWERS );
+        CHECK( m.has( morale_perm_constrained ) == -10 );
+    }
+
+    SECTION( "temporary morale preserved through recovery after load fix" ) {
+        dummy.toggle_trait( trait_FLOWERS );
+
+        // Wear the hat through the Character so check_and_recover_morale
+        // will see it when rebuilding test_morale from worn items.
+        dummy.wear_item( item( itype_tinfoil_hat ) );
+
+        // Activate mutations in morale (simulates the fix in savegame_json)
+        for( const trait_id &mut : dummy.get_functioning_mutations() ) {
+            m.on_mutation_gain( mut );
+        }
+
+        // Add temporary morale
+        m.add( morale_food_good, 20, 40, 20_turns, 10_turns );
+        REQUIRE( m.has( morale_food_good ) == 20 );
+        REQUIRE( m.has( morale_perm_constrained ) == -10 );
+
+        // check_and_recover should find consistency -- no wipe
+        dummy.check_and_recover_morale();
+        CHECK( m.has( morale_food_good ) == 20 );
+        CHECK( m.has( morale_perm_constrained ) == -10 );
     }
 }


### PR DESCRIPTION
#### Summary
Bugfixes "Fix morale inconsistency wiping all temporary morale bonuses"

#### Purpose of change

Fixes #85895, fixes #85616, fixes #84673, fixes #78559

When `check_and_recover_morale()` detected a permanent morale inconsistency ("Uncomfortable gear", "Masochism", "Filthy Gear", etc.), it replaced the entire morale object with a freshly-built one containing only permanent items. This wiped all temporary morale -- food, music, social, everything.

Root cause: during save loading, `player_morale`'s internal mutation tracking was never initialized. `has_mutation()` returned false for all traits, so `update_constrained_penalty()` and `update_masochist_bonus()` computed wrong values when triggered by item equips or stat changes. The periodic consistency check then detected the drift and nuked all morale to "fix" it.

#### Describe the solution

1. New `sync_permanent()` method replaces only permanent morale points and non-point state from the reference, preserving all temporary morale. `check_and_recover_morale()` uses this instead of full object replacement.

2. After `morale->load()` in save loading, activate each functioning mutation in morale's internal tracking so `has_mutation()` returns correct values when stat changes fire immediately after.


#### Describe alternatives you've considered

Could serialize the full `player_morale` state (mutation flags, body_parts, took_prozac, etc.) instead of just the points vector. Decided against it -- reconstructing on load is simpler than maintaining backwards-compatible serialization for internal bookkeeping.

#### Testing

Two new test cases:
- Injects a stale permanent point, verifies temporary morale survives recovery
- Verifies mutation activation is necessary for constrained penalty, and the fixed load sequence produces correct consistent state

All 173 assertions across 16 `[player_morale]` tests pass, zero regressions.

#### Additional context

Long-standing systemic issue reported since 2020 across Stylish, Masochism, Bad Tempered, Filthy Gear, and Uncomfortable Gear morale types. PR #84048 fixed the masochist accumulation formula but didn't address the mutation-state-not-initialized root cause or the destructive recovery.