### PR TITLE
Add item UID for stable item_location serialization

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -457,6 +457,7 @@ game::game() :
     u_shared_ptr( &u, null_deleter{} ),
     next_npc_id( 1 ),
     next_mission_id( 1 ),
+    next_item_uid( 1 ),
     remoteveh_cache_time( calendar::before_time_starts ),
     last_mouse_edge_scroll( std::chrono::steady_clock::now() )
 {
@@ -673,6 +674,7 @@ void game::setup()
 
     next_npc_id = character_id( 1 );
     next_mission_id = 1;
+    next_item_uid = 1;
     uquit = QUIT_NO;   // We haven't quit the game
     bVMonsterLookFire = true;
 
@@ -3608,6 +3610,11 @@ character_id game::assign_npc_id()
     character_id ret = next_npc_id;
     ++next_npc_id;
     return ret;
+}
+
+int64_t game::assign_item_uid()
+{
+    return next_item_uid++;
 }
 
 Creature *game::is_hostile_nearby()

--- a/src/game.h
+++ b/src/game.h
@@ -4,6 +4,7 @@
 
 #include <array>
 #include <chrono>
+#include <cstdint>
 #include <ctime>
 #include <functional>
 #include <iosfwd>
@@ -676,6 +677,7 @@ class game
         unsigned char light_level( int zlev ) const;
         void reset_light_level();
         character_id assign_npc_id();
+        int64_t assign_item_uid();
         Creature *is_hostile_nearby();
         Creature *is_hostile_very_close( bool dangerous = false );
         field_entry *is_in_dangerous_field();
@@ -1249,6 +1251,7 @@ class game
         bool bVMonsterLookFire = false;
         character_id next_npc_id; // NOLINT(cata-serialize)
         int next_mission_id = 0; // NOLINT(cata-serialize)
+        int64_t next_item_uid = 1; // NOLINT(cata-serialize)
         // Keep track of follower NPC IDs
         std::set<character_id> follower_ids; // NOLINT(cata-serialize)
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -173,7 +173,8 @@ item::item() : bday( calendar::start_of_cataclysm )
     select_itype_variant();
 }
 
-item::item( const itype *type, time_point turn, int qty ) : type( type ), bday( turn )
+item::item( const itype *type, time_point turn, int qty ) : type( type ), bday( turn ),
+    uid_( generate_next_item_uid() )
 {
     contents = item_contents( type->pockets );
     if( type->countdown_interval > 0_seconds ) {

--- a/src/item.h
+++ b/src/item.h
@@ -30,6 +30,7 @@
 #include "item_location.h"
 #include "item_pocket.h"
 #include "item_tname.h"
+#include "item_uid.h"
 #include "material.h"
 #include "math_parser_diag_value.h"
 #include "point.h"
@@ -230,6 +231,12 @@ class item : public visitable
         /** Return a pointer-like type that's automatically invalidated if this
          * item is destroyed or assigned-to */
         safe_reference<item> get_safe_reference();
+
+        /** Persistent unique identifier for this item instance.
+         * Returns const ref to avoid triggering item_uid's copy-generates-new semantics. */
+        const item_uid &uid() const {
+            return uid_;
+        }
 
         /**
          * Filter converting this instance to another type preserving all other aspects
@@ -3411,6 +3418,7 @@ class item : public visitable
         time_point last_temp_check = calendar::turn_zero;
         /// The time the item was created.
         time_point bday;
+        item_uid uid_; // persistent unique identifier, survives save/load
         /**
          * Current phase state, inherits a default at room temperature from
          * itype and can be changed through item processing.  This is a static

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <cstdint>
 #include <iterator>
 #include <list>
 #include <memory>
@@ -22,6 +23,7 @@
 #include "game_constants.h"
 #include "item.h"
 #include "item_pocket.h"
+#include "item_uid.h"
 #include "itype.h"
 #include "json.h"
 #include "line.h"
@@ -48,14 +50,16 @@ template <typename T>
 static int find_index( const T &sel, const item *obj )
 {
     int idx = -1;
-    sel.visit_items( [&idx, &obj]( const item * e, item * ) {
+    bool found = false;
+    sel.visit_items( [&idx, &obj, &found]( const item * e, item * ) {
         idx++;
         if( e == obj ) {
+            found = true;
             return VisitResponse::ABORT;
         }
         return VisitResponse::NEXT;
     } );
-    return idx;
+    return found ? idx : -1;
 }
 
 template <typename T>
@@ -64,6 +68,20 @@ static item *retrieve_index( const T &sel, int idx )
     item *obj = nullptr;
     sel.visit_items( [&idx, &obj]( const item * e, item * ) {
         if( idx-- == 0 ) {
+            obj = const_cast<item *>( e );
+            return VisitResponse::ABORT;
+        }
+        return VisitResponse::NEXT;
+    } );
+    return obj;
+}
+
+template <typename T>
+static item *retrieve_by_uid( const T &sel, int64_t uid )
+{
+    item *obj = nullptr;
+    sel.visit_items( [&uid, &obj]( const item * e, item * ) {
+        if( e->uid().get_value() == uid ) {
             obj = const_cast<item *>( e );
             return VisitResponse::ABORT;
         }
@@ -84,6 +102,7 @@ class item_location::impl
         impl() = default;
         explicit impl( item *i ) : what( i->get_safe_reference() ) {}
         explicit impl( int idx ) : idx( idx ), needs_unpacking( true ) {}
+        impl( int idx, int64_t uid ) : idx( idx ), uid_hint( uid ), needs_unpacking( true ) {}
 
         virtual ~impl() = default;
 
@@ -113,6 +132,9 @@ class item_location::impl
         virtual void on_contents_changed() = 0;
         virtual void serialize( JsonOut &js ) const = 0;
         virtual item *unpack( int ) const = 0;
+        virtual item *unpack_by_uid( int64_t ) const {
+            return nullptr;
+        }
 
         item *target() const {
             ensure_unpacked();
@@ -127,7 +149,15 @@ class item_location::impl
     private:
         void ensure_unpacked() const {
             if( needs_unpacking ) {
-                if( item *i = unpack( idx ) ) {
+                item *i = nullptr;
+                if( uid_hint > 0 ) {
+                    i = unpack_by_uid( uid_hint );
+                }
+                if( !i && uid_hint == 0 ) {
+                    // Legacy save or vehicle base item: use index
+                    i = unpack( idx );
+                }
+                if( i ) {
                     what = i->get_safe_reference();
                 } else {
                     debugmsg( "item_location lost its target item during a save/load cycle" );
@@ -137,6 +167,7 @@ class item_location::impl
         }
         mutable safe_reference<item> what;
         mutable int idx = -1;
+        mutable int64_t uid_hint = 0;
         mutable bool needs_unpacking = false;
 
     public:
@@ -220,17 +251,34 @@ class item_location::impl::item_on_map : public item_location::impl
     public:
         item_on_map( const map_cursor &cur, item *which ) : impl( which ), cur( cur ) {}
         item_on_map( const map_cursor &cur, int idx ) : impl( idx ), cur( cur ) {}
+        item_on_map( const map_cursor &cur, int idx, int64_t uid ) : impl( idx, uid ), cur( cur ) {}
 
         void serialize( JsonOut &js ) const override {
+            if( !target() ) {
+                item_location::nowhere.serialize( js );
+                return;
+            }
+            int idx = find_index( cur, target() );
+            if( idx < 0 ) {
+                item_location::nowhere.serialize( js );
+                return;
+            }
             js.start_object();
             js.member( "type", "map" );
             js.member( "position", pos_abs() );
-            js.member( "idx", find_index( cur, target() ) );
+            js.member( "idx", idx );
+            if( target()->uid().is_valid() ) {
+                js.member( "uid", target()->uid().get_value() );
+            }
             js.end_object();
         }
 
         item *unpack( int idx ) const override {
             return retrieve_index( cur, idx );
+        }
+
+        item *unpack_by_uid( int64_t uid ) const override {
+            return retrieve_by_uid( cur, uid );
         }
 
         type where() const override {
@@ -340,19 +388,30 @@ class item_location::impl::item_on_person : public item_location::impl
         }
 
         item_on_person( character_id who_id, int idx ) : impl( idx ), who_id( who_id ), who( nullptr ) {}
+        item_on_person( character_id who_id, int idx, int64_t uid ) :
+            impl( idx, uid ), who_id( who_id ), who( nullptr ) {}
 
         void serialize( JsonOut &js ) const override {
             if( !ensure_who_unpacked() ) {
-                // Write an invalid item_location to avoid invalid json
-                js.start_object();
-                js.member( "type", "null" );
-                js.end_object();
+                item_location::nowhere.serialize( js );
+                return;
+            }
+            if( !target() ) {
+                item_location::nowhere.serialize( js );
+                return;
+            }
+            int idx = find_index( *who, target() );
+            if( idx < 0 ) {
+                item_location::nowhere.serialize( js );
                 return;
             }
             js.start_object();
             js.member( "type", "character" );
             js.member( "character", who_id );
-            js.member( "idx", find_index( *who, target() ) );
+            js.member( "idx", idx );
+            if( target()->uid().is_valid() ) {
+                js.member( "uid", target()->uid().get_value() );
+            }
             js.end_object();
         }
 
@@ -361,6 +420,13 @@ class item_location::impl::item_on_person : public item_location::impl
                 return nullptr;
             }
             return retrieve_index( *who, idx );
+        }
+
+        item *unpack_by_uid( int64_t uid ) const override {
+            if( !ensure_who_unpacked() ) {
+                return nullptr;
+            }
+            return retrieve_by_uid( *who, uid );
         }
 
         type where() const override {
@@ -490,6 +556,8 @@ class item_location::impl::item_on_vehicle : public item_location::impl
     public:
         item_on_vehicle( const vehicle_cursor &cur, item *which ) : impl( which ), cur( cur ) {}
         item_on_vehicle( const vehicle_cursor &cur, int idx ) : impl( idx ), cur( cur ) {}
+        item_on_vehicle( const vehicle_cursor &cur, int idx, int64_t uid ) :
+            impl( idx, uid ), cur( cur ) {}
 
         void serialize( JsonOut &js ) const override {
             const std::vector<wrapped_vehicle> &vehicles = get_map().get_vehicles();
@@ -498,24 +566,41 @@ class item_location::impl::item_on_vehicle : public item_location::impl
             };
             if( std::find_if( vehicles.begin(), vehicles.end(), same_veh ) == vehicles.end() ) {
                 debugmsg( "Could not find vehicle for item_location on vehicle" );
-                // This is intended as a temporary patch, but if you're reading this you know how it goes sometimes.
-                // Serialize exactly like an item_location::nowhere just in case this sticks around long enough for that to change...
-                item_location dummy = item_location::nowhere;
-                dummy.serialize( js );
+                item_location::nowhere.serialize( js );
                 return;
+            }
+            if( !target() ) {
+                item_location::nowhere.serialize( js );
+                return;
+            }
+            bool is_base_item = target() == &cur.veh.part( cur.part ).base;
+            int idx = -1;
+            if( !is_base_item ) {
+                idx = find_index( cur, target() );
+                if( idx < 0 ) {
+                    item_location::nowhere.serialize( js );
+                    return;
+                }
             }
             js.start_object();
             js.member( "type", "vehicle" );
             js.member( "position", pos_abs() );
             js.member( "part", cur.part );
-            if( target() != &cur.veh.part( cur.part ).base ) {
-                js.member( "idx", find_index( cur, target() ) );
+            if( !is_base_item ) {
+                js.member( "idx", idx );
+                if( target()->uid().is_valid() ) {
+                    js.member( "uid", target()->uid().get_value() );
+                }
             }
             js.end_object();
         }
 
         item *unpack( int idx ) const override {
             return idx >= 0 ? retrieve_index( cur, idx ) : &cur.veh.part( cur.part ).base;
+        }
+
+        item *unpack_by_uid( int64_t uid ) const override {
+            return retrieve_by_uid( cur, uid );
         }
 
         type where() const override {
@@ -636,10 +721,7 @@ class item_location::impl::item_in_container : public item_location::impl
                 }
                 idx++;
             }
-            if( container->empty() ) {
-                return -1;
-            }
-            return idx;
+            return -1;
         }
     public:
         item_location parent_item() const override {
@@ -662,10 +744,22 @@ class item_location::impl::item_in_container : public item_location::impl
             impl( which ), container( container ) {}
 
         void serialize( JsonOut &js ) const override {
+            if( !target() ) {
+                item_location::nowhere.serialize( js );
+                return;
+            }
+            int idx = calc_index();
+            if( idx < 0 ) {
+                item_location::nowhere.serialize( js );
+                return;
+            }
             js.start_object();
-            js.member( "idx", calc_index() );
+            js.member( "idx", idx );
             js.member( "type", "in_container" );
             js.member( "parent", container );
+            if( target()->uid().is_valid() ) {
+                js.member( "uid", target()->uid().get_value() );
+            }
             js.end_object();
         }
 
@@ -868,10 +962,12 @@ void item_location::deserialize( const JsonObject &obj )
     std::string type = obj.get_string( "type" );
 
     int idx = -1;
+    int64_t uid = 0;
     tripoint_bub_ms pos_ = tripoint_bub_ms::invalid;
     tripoint_abs_ms position = tripoint_abs_ms::invalid;
 
     obj.read( "idx", idx );
+    obj.read( "uid", uid );
     if( !obj.read( "position", position ) ) {
         // Save compatibility for change made 2025-02-19
         obj.read( "pos", pos_ );
@@ -887,16 +983,16 @@ void item_location::deserialize( const JsonObject &obj )
             // character item locations were assumed to be on g->u
             who_id = get_player_character().getID();
         }
-        ptr = std::make_shared<impl::item_on_person>( who_id, idx );
+        ptr = std::make_shared<impl::item_on_person>( who_id, idx, uid );
 
     } else if( type == "map" ) {
-        ptr = std::make_shared<impl::item_on_map>( map_cursor( position ), idx );
+        ptr = std::make_shared<impl::item_on_map>( map_cursor( position ), idx, uid );
 
     } else if( type == "vehicle" ) {
         vehicle *const veh = veh_pointer_or_null( here.veh_at( position ) );
         int part = obj.get_int( "part" );
         if( veh && part >= 0 && part < veh->part_count() ) {
-            ptr = std::make_shared<impl::item_on_vehicle>( vehicle_cursor( *veh, part ), idx );
+            ptr = std::make_shared<impl::item_on_vehicle>( vehicle_cursor( *veh, part ), idx, uid );
         }
     } else if( type == "in_container" ) {
         item_location parent;
@@ -904,7 +1000,7 @@ void item_location::deserialize( const JsonObject &obj )
         if( !parent.ptr->valid() ) {
             if( parent == nowhere ) {
                 debugmsg( "parent location doesn't exist.  Item_location has lost its target over a save/load cycle." );
-                ptr = std::make_shared<impl::nowhere>( );
+                ptr = std::make_shared<impl::nowhere>();
                 return;
             }
             debugmsg( "parent location does not point to valid item" );
@@ -912,13 +1008,32 @@ void item_location::deserialize( const JsonObject &obj )
             return;
         }
         const std::list<item *> parent_contents = parent->all_items_container_top();
-        if( idx > -1 && idx < static_cast<int>( parent_contents.size() ) ) {
+
+        item *found = nullptr;
+        if( uid > 0 ) {
+            for( item *it : parent_contents ) {
+                if( it->uid().get_value() == uid ) {
+                    found = it;
+                    break;
+                }
+            }
+            if( !found ) {
+                debugmsg( "item_location UID not found in container contents" );
+                ptr = std::make_shared<impl::nowhere>();
+                return;
+            }
+        } else if( idx > -1 && idx < static_cast<int>( parent_contents.size() ) ) {
+            // Legacy save: no UID, use index
             auto iter = parent_contents.begin();
             std::advance( iter, idx );
-            ptr = std::make_shared<impl::item_in_container>( parent, *iter );
+            found = *iter;
+        }
+
+        if( found ) {
+            ptr = std::make_shared<impl::item_in_container>( parent, found );
         } else {
-            // probably pointing to the wrong item
             debugmsg( "contents index greater than contents size" );
+            ptr = std::make_shared<impl::nowhere>();
         }
     }
 }

--- a/src/item_uid.cpp
+++ b/src/item_uid.cpp
@@ -1,0 +1,30 @@
+#include "item_uid.h"
+
+#include <memory>
+#include <ostream>
+
+#include "game.h"
+#include "json.h"
+
+int64_t generate_next_item_uid()
+{
+    if( !g ) {
+        return 0;
+    }
+    return g->assign_item_uid();
+}
+
+void item_uid::serialize( JsonOut &jsout ) const
+{
+    jsout.write( value );
+}
+
+void item_uid::deserialize( int64_t i )
+{
+    value = i;
+}
+
+std::ostream &operator<<( std::ostream &o, const item_uid &id )
+{
+    return o << id.get_value();
+}

--- a/src/item_uid.h
+++ b/src/item_uid.h
@@ -1,0 +1,69 @@
+#pragma once
+#ifndef CATA_SRC_ITEM_UID_H
+#define CATA_SRC_ITEM_UID_H
+
+#include <cstdint>
+#include <iosfwd>
+
+class JsonOut;
+
+// Generate a fresh UID from the global counter.
+// Returns 0 if the game state is not yet initialized.
+int64_t generate_next_item_uid();
+
+class item_uid
+{
+    public:
+        item_uid() : value( 0 ) {}
+
+        explicit item_uid( int64_t i ) : value( i ) {}
+
+        // Copy: generate fresh UID (like safe_reference_anchor)
+        item_uid( const item_uid & ) : value( generate_next_item_uid() ) {}
+
+        // Move: transfer value, zero source
+        item_uid( item_uid &&other ) noexcept : value( other.value ) {
+            other.value = 0;
+        }
+
+        // Copy assignment: generate fresh UID
+        item_uid &operator=( const item_uid & ) {
+            value = generate_next_item_uid();
+            return *this;
+        }
+
+        // Move assignment: transfer value, zero source
+        item_uid &operator=( item_uid &&other ) noexcept {
+            value = other.value;
+            other.value = 0;
+            return *this;
+        }
+
+        bool is_valid() const {
+            return value > 0;
+        }
+
+        int64_t get_value() const {
+            return value;
+        }
+
+        void serialize( JsonOut & ) const;
+        void deserialize( int64_t );
+
+    private:
+        int64_t value;
+};
+
+inline bool operator==( const item_uid &l, const item_uid &r )
+{
+    return l.get_value() == r.get_value();
+}
+
+inline bool operator!=( const item_uid &l, const item_uid &r )
+{
+    return l.get_value() != r.get_value();
+}
+
+std::ostream &operator<<( std::ostream &o, const item_uid &id );
+
+#endif // CATA_SRC_ITEM_UID_H

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -1675,6 +1675,8 @@ void game::unserialize_master( const JsonValue &jv )
             next_mission_id = jsin.get_int();
         } else if( name == "next_npc_id" ) {
             next_npc_id.deserialize( jsin );
+        } else if( name == "next_item_uid" ) {
+            jsin.read( next_item_uid );
         } else if( name == "active_missions" ) {
             mission::unserialize_all( jsin );
         } else if( name == "factions" ) {
@@ -1876,6 +1878,7 @@ void game::serialize_master( std::ostream &fout )
 
         json.member( "next_mission_id", next_mission_id );
         json.member( "next_npc_id", next_npc_id );
+        json.member( "next_item_uid", next_item_uid );
 
         json.member( "active_missions" );
         mission::serialize_all( json );

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2912,6 +2912,14 @@ void item::io( Archive &archive )
         return i.get_id().str();
     }, io::required_tag() );
 
+    // Persistent unique identifier for item instances
+    archive.io( "uid", uid_, item_uid() );
+    if constexpr( Archive::is_input::value ) {
+        if( !uid_.is_valid() ) {
+            uid_ = item_uid( generate_next_item_uid() );
+        }
+    }
+
     // normalize legacy saves to always have charges >= 0
     archive.io( "charges", charges, 0 );
     charges = std::max( charges, 0 );

--- a/tests/item_location_test.cpp
+++ b/tests/item_location_test.cpp
@@ -1,17 +1,36 @@
+#include <cstdint>
 #include <functional>
 #include <list>
+#include <memory>
 #include <optional>
+#include <sstream>
+#include <string>
+#include <vector>
 
 #include "cata_catch.h"
 #include "character.h"
 #include "coordinates.h"
+#include "debug.h"
+#include "flexbuffer_json.h"
+#include "inventory.h"
 #include "item.h"
 #include "item_location.h"
+#include "item_pocket.h"
+#include "item_uid.h"
+#include "json.h"
+#include "json_loader.h"
 #include "map.h"
 #include "map_helpers.h"
 #include "map_selector.h"
+#include "pimpl.h"
 #include "player_helpers.h"
 #include "pocket_type.h"
+#include "units.h"
+#include "vehicle.h"
+#include "vehicle_selector.h"
+#include "veh_type.h"
+#include "vpart_position.h"
+#include "vpart_range.h"
 #include "point.h"
 #include "ret_val.h"
 #include "rng.h"
@@ -21,6 +40,8 @@
 static const itype_id itype_backpack( "backpack" );
 static const itype_id itype_jeans( "jeans" );
 static const itype_id itype_tshirt( "tshirt" );
+static const vproto_id vehicle_prototype_bicycle( "bicycle" );
+static const vproto_id vehicle_prototype_car( "car" );
 
 TEST_CASE( "item_location_can_maintain_reference_despite_item_removal", "[item][item_location]" )
 {
@@ -97,4 +118,529 @@ TEST_CASE( "item_in_container", "[item][item_location]" )
     CHECK( obtain_cost_calculation == jeans_loc.obtain_cost( dummy ) );
 
     CHECK( jeans_loc.parent_item() == backpack_loc );
+}
+
+// Helper: serialize an item_location to a JSON string
+static std::string serialize_item_location( const item_location &loc )
+{
+    std::ostringstream os;
+    JsonOut jsout( os );
+    loc.serialize( jsout );
+    return os.str();
+}
+
+// Helper: deserialize an item_location from a JSON string
+static item_location deserialize_item_location( const std::string &json_str )
+{
+    item_location loc;
+    JsonValue jv = json_loader::from_string( json_str );
+    JsonObject jo = jv;
+    loc.deserialize( jo );
+    return loc;
+}
+
+TEST_CASE( "items_get_unique_uids", "[item][item_uid]" )
+{
+    item a( itype_jeans );
+    item b( itype_jeans );
+    item c( itype_tshirt );
+
+    CHECK( a.uid().is_valid() );
+    CHECK( b.uid().is_valid() );
+    CHECK( c.uid().is_valid() );
+
+    CHECK( a.uid().get_value() != b.uid().get_value() );
+    CHECK( a.uid().get_value() != c.uid().get_value() );
+    CHECK( b.uid().get_value() != c.uid().get_value() );
+
+    // Default-constructed item has invalid UID
+    item null_item;
+    CHECK_FALSE( null_item.uid().is_valid() );
+}
+
+TEST_CASE( "item_copies_get_new_uids", "[item][item_uid]" )
+{
+    item a( itype_jeans );
+    int64_t a_uid = a.uid().get_value();
+    REQUIRE( a.uid().is_valid() );
+
+    // Copy construction - NOLINT: b is intentionally a copy, not const, to test uid semantics
+    item b( a ); // NOLINT(performance-unnecessary-copy-initialization)
+    CHECK( b.uid().is_valid() );
+    CHECK( b.uid().get_value() != a_uid );
+    // Original unchanged
+    CHECK( a.uid().get_value() == a_uid );
+
+    // Copy assignment
+    item c( itype_tshirt );
+    int64_t c_old_uid = c.uid().get_value();
+    c = a;
+    CHECK( c.uid().is_valid() );
+    CHECK( c.uid().get_value() != a_uid );
+    CHECK( c.uid().get_value() != c_old_uid );
+}
+
+TEST_CASE( "item_uid_survives_serialization", "[item][item_uid]" )
+{
+    item original( itype_jeans );
+    REQUIRE( original.uid().is_valid() );
+    int64_t original_uid = original.uid().get_value();
+
+    // Serialize
+    std::ostringstream os;
+    JsonOut jsout( os );
+    original.serialize( jsout );
+    std::string json_str = os.str();
+
+    // Deserialize
+    item loaded;
+    JsonValue jv = json_loader::from_string( json_str );
+    JsonObject jo = jv;
+    loaded.deserialize( jo );
+
+    CHECK( loaded.uid().is_valid() );
+    CHECK( loaded.uid().get_value() == original_uid );
+}
+
+TEST_CASE( "item_location_in_container_survives_restack", "[item][item_location][item_uid]" )
+{
+    clear_map_without_vision();
+    map &m = get_map();
+    tripoint_bub_ms pos( 60, 60, 0 );
+    m.i_clear( pos );
+
+    // Place a backpack on the ground with items inside
+    item backpack_item( itype_backpack );
+    item jeans1( itype_jeans );
+    item tshirt( itype_tshirt );
+    item jeans2( itype_jeans );
+    backpack_item.put_in( jeans1, pocket_type::CONTAINER );
+    backpack_item.put_in( tshirt, pocket_type::CONTAINER );
+    backpack_item.put_in( jeans2, pocket_type::CONTAINER );
+
+    m.add_item( pos, backpack_item );
+    item &placed_backpack = m.i_at( pos ).only_item();
+
+    // Find the tshirt inside the backpack
+    item *tshirt_ptr = nullptr;
+    for( item *it : placed_backpack.all_items_container_top() ) {
+        if( it->typeId() == itype_tshirt ) {
+            tshirt_ptr = it;
+            break;
+        }
+    }
+    REQUIRE( tshirt_ptr != nullptr );
+
+    // Create item_location pointing to tshirt inside backpack
+    item_location backpack_loc( map_cursor( pos ), &placed_backpack );
+    item_location tshirt_loc( backpack_loc, tshirt_ptr );
+    REQUIRE( tshirt_loc->typeId() == itype_tshirt );
+
+    // Serialize
+    std::string json_str = serialize_item_location( tshirt_loc );
+
+    // Trigger restack (merges the two jeans, changing indices)
+    for( item_pocket *pkt : placed_backpack.get_standard_pockets() ) {
+        pkt->restack();
+    }
+
+    // Deserialize - should find tshirt by UID despite index shift
+    item_location loaded = deserialize_item_location( json_str );
+    REQUIRE( loaded );
+    CHECK( loaded->typeId() == itype_tshirt );
+}
+
+TEST_CASE( "item_location_in_container_survives_removal", "[item][item_location][item_uid]" )
+{
+    clear_map_without_vision();
+    map &m = get_map();
+    tripoint_bub_ms pos( 60, 60, 0 );
+    m.i_clear( pos );
+
+    // Place a backpack on the ground with items inside
+    item backpack_item( itype_backpack );
+    item jeans_a( itype_jeans );
+    item tshirt( itype_tshirt );
+    backpack_item.put_in( jeans_a, pocket_type::CONTAINER );
+    backpack_item.put_in( tshirt, pocket_type::CONTAINER );
+
+    m.add_item( pos, backpack_item );
+    item &placed_backpack = m.i_at( pos ).only_item();
+
+    // Find items
+    item *tshirt_ptr = nullptr;
+    item *jeans_ptr = nullptr;
+    for( item *it : placed_backpack.all_items_container_top() ) {
+        if( it->typeId() == itype_tshirt ) {
+            tshirt_ptr = it;
+        } else if( it->typeId() == itype_jeans ) {
+            jeans_ptr = it;
+        }
+    }
+    REQUIRE( tshirt_ptr != nullptr );
+    REQUIRE( jeans_ptr != nullptr );
+
+    // Create item_location pointing to tshirt
+    item_location backpack_loc( map_cursor( pos ), &placed_backpack );
+    item_location tshirt_loc( backpack_loc, tshirt_ptr );
+
+    // Serialize
+    std::string json_str = serialize_item_location( tshirt_loc );
+
+    // Remove jeans (shifts indices)
+    placed_backpack.remove_item( *jeans_ptr );
+
+    // Deserialize - should find tshirt by UID despite index shift
+    item_location loaded = deserialize_item_location( json_str );
+    REQUIRE( loaded );
+    CHECK( loaded->typeId() == itype_tshirt );
+}
+
+TEST_CASE( "item_location_in_container_uid_miss_becomes_nowhere",
+           "[item][item_location][item_uid]" )
+{
+    clear_map_without_vision();
+    map &m = get_map();
+    tripoint_bub_ms pos( 60, 60, 0 );
+    m.i_clear( pos );
+
+    // Place a backpack with a tshirt inside
+    item backpack_item( itype_backpack );
+    item tshirt( itype_tshirt );
+    backpack_item.put_in( tshirt, pocket_type::CONTAINER );
+
+    m.add_item( pos, backpack_item );
+    item &placed_backpack = m.i_at( pos ).only_item();
+
+    item *tshirt_ptr = nullptr;
+    for( item *it : placed_backpack.all_items_container_top() ) {
+        if( it->typeId() == itype_tshirt ) {
+            tshirt_ptr = it;
+            break;
+        }
+    }
+    REQUIRE( tshirt_ptr != nullptr );
+
+    item_location backpack_loc( map_cursor( pos ), &placed_backpack );
+    item_location tshirt_loc( backpack_loc, tshirt_ptr );
+
+    // Serialize
+    std::string json_str = serialize_item_location( tshirt_loc );
+
+    // Remove the target item entirely
+    placed_backpack.remove_item( *tshirt_ptr );
+
+    // Put a different item so index 0 exists but is wrong
+    item jeans_replacement( itype_jeans );
+    placed_backpack.put_in( jeans_replacement, pocket_type::CONTAINER );
+
+    // Deserialize - UID present but item gone, should become nowhere
+    // (NOT fall back to index and bind to the jeans)
+    item_location loaded;
+    std::string dmsg = capture_debugmsg_during( [&]() {
+        loaded = deserialize_item_location( json_str );
+    } );
+    CHECK_FALSE( loaded );
+    CHECK_FALSE( dmsg.empty() );
+}
+
+TEST_CASE( "item_location_on_map_survives_removal", "[item][item_location][item_uid]" )
+{
+    clear_map_without_vision();
+    map &m = get_map();
+    tripoint_bub_ms pos( 60, 60, 0 );
+    m.i_clear( pos );
+
+    // Place multiple items on the map
+    m.add_item( pos, item( itype_jeans ) );
+    m.add_item( pos, item( itype_tshirt ) );
+    m.add_item( pos, item( itype_jeans ) );
+
+    // Find the tshirt
+    item *tshirt_ptr = nullptr;
+    item *first_jeans = nullptr;
+    for( item &it : m.i_at( pos ) ) {
+        if( it.typeId() == itype_tshirt ) {
+            tshirt_ptr = &it;
+        } else if( it.typeId() == itype_jeans && !first_jeans ) {
+            first_jeans = &it;
+        }
+    }
+    REQUIRE( tshirt_ptr != nullptr );
+    REQUIRE( first_jeans != nullptr );
+
+    item_location tshirt_loc( map_cursor( pos ), tshirt_ptr );
+    REQUIRE( tshirt_loc->typeId() == itype_tshirt );
+
+    // Serialize
+    std::string json_str = serialize_item_location( tshirt_loc );
+
+    // Remove the first jeans (shifts indices)
+    m.i_rem( pos, first_jeans );
+
+    // Deserialize and access (triggers ensure_unpacked for map locations)
+    item_location loaded = deserialize_item_location( json_str );
+    REQUIRE( loaded );
+    CHECK( loaded->typeId() == itype_tshirt );
+}
+
+TEST_CASE( "item_location_deserialize_without_uid_falls_back_to_index",
+           "[item][item_location][item_uid]" )
+{
+    clear_map_without_vision();
+    map &m = get_map();
+    tripoint_bub_ms pos( 60, 60, 0 );
+    m.i_clear( pos );
+
+    // Place items on map
+    m.add_item( pos, item( itype_jeans ) );
+    m.add_item( pos, item( itype_tshirt ) );
+
+    // Hand-craft old-format JSON (no "uid" field) pointing to index 1
+    tripoint_abs_ms abs_pos = m.get_abs( pos );
+    std::ostringstream os;
+    JsonOut jsout( os );
+    jsout.start_object();
+    jsout.member( "type", "map" );
+    jsout.member( "position", abs_pos );
+    jsout.member( "idx", 1 );
+    jsout.end_object();
+    std::string json_str = os.str();
+
+    // Deserialize - should use index fallback since no UID
+    item_location loaded = deserialize_item_location( json_str );
+    REQUIRE( loaded );
+    CHECK( loaded->typeId() == itype_tshirt );
+}
+
+TEST_CASE( "item_location_on_person_survives_restack", "[item][item_location][item_uid]" )
+{
+    clear_map_without_vision();
+    Character &dummy = get_player_character();
+    clear_avatar();
+
+    // Add items directly to inventory
+    item_location jeans1_loc = dummy.i_add( item( itype_jeans ) );
+    item_location tshirt_loc = dummy.i_add( item( itype_tshirt ) );
+    item_location jeans2_loc = dummy.i_add( item( itype_jeans ) );
+
+    REQUIRE( tshirt_loc );
+    REQUIRE( tshirt_loc->typeId() == itype_tshirt );
+
+    // Serialize the tshirt location
+    std::string json_str = serialize_item_location( tshirt_loc );
+
+    // Restack inventory (may merge the two jeans, shifting indices)
+    dummy.inv->restack( dummy );
+
+    // Deserialize - should find tshirt by UID
+    item_location loaded = deserialize_item_location( json_str );
+    REQUIRE( loaded );
+    CHECK( loaded->typeId() == itype_tshirt );
+}
+
+TEST_CASE( "item_location_on_vehicle_base_item", "[item][item_location][item_uid]" )
+{
+    clear_map_without_vision();
+    map &m = get_map();
+    clear_vehicles();
+
+    // Place a simple vehicle
+    tripoint_bub_ms veh_pos( 60, 60, 0 );
+    vehicle *veh = m.add_vehicle( vehicle_prototype_bicycle, veh_pos, 0_degrees, -1, 100 );
+    REQUIRE( veh != nullptr );
+
+    // Get a vehicle part and create item_location for its base item
+    int part_idx = 0;
+    const item &base = veh->part( part_idx ).get_base();
+
+    vehicle_cursor cur( *veh, part_idx );
+    item_location base_loc( cur, const_cast<item *>( &base ) );
+    REQUIRE( base_loc );
+
+    // Serialize - base items omit idx and uid
+    std::string json_str = serialize_item_location( base_loc );
+
+    // Verify the serialized JSON omits idx and uid (the base item invariant)
+    JsonValue jv_check = json_loader::from_string( json_str );
+    JsonObject jo_check = jv_check;
+    jo_check.allow_omitted_members();
+    CHECK( jo_check.get_string( "type" ) == "vehicle" );
+    CHECK_FALSE( jo_check.has_member( "idx" ) );
+    CHECK_FALSE( jo_check.has_member( "uid" ) );
+
+    // Deserialize - should resolve via idx < 0 path (no uid needed)
+    item_location loaded = deserialize_item_location( json_str );
+    REQUIRE( loaded );
+    CHECK( loaded->typeId() == base.typeId() );
+}
+
+TEST_CASE( "item_location_on_vehicle_cargo_survives_removal",
+           "[item][item_location][item_uid]" )
+{
+    clear_map_without_vision();
+    map &m = get_map();
+    clear_vehicles();
+
+    // Place a vehicle with cargo -- use a car which has trunk/cargo
+    tripoint_bub_ms veh_pos( 60, 60, 0 );
+    vehicle *veh = m.add_vehicle( vehicle_prototype_car, veh_pos, 0_degrees, -1, 100 );
+    REQUIRE( veh != nullptr );
+
+    // Find the largest cargo part (trunk)
+    int cargo_part_idx = -1;
+    units::volume best_vol = 0_ml;
+    for( const vpart_reference &vpr : veh->get_all_parts() ) {
+        if( vpr.has_feature( "CARGO" ) ) {
+            units::volume vol = vpr.info().size;
+            if( vol > best_vol ) {
+                best_vol = vol;
+                cargo_part_idx = vpr.part_index();
+            }
+        }
+    }
+    REQUIRE( cargo_part_idx >= 0 );
+
+    // Add items to cargo
+    std::optional<vehicle_stack::iterator> added_jeans =
+        veh->add_item( m, veh->part( cargo_part_idx ), item( itype_jeans ) );
+    REQUIRE( added_jeans.has_value() );
+    std::optional<vehicle_stack::iterator> added_tshirt =
+        veh->add_item( m, veh->part( cargo_part_idx ), item( itype_tshirt ) );
+    REQUIRE( added_tshirt.has_value() );
+
+    vehicle_cursor cur( *veh, cargo_part_idx );
+    item_location tshirt_loc( cur, & **added_tshirt );
+    REQUIRE( tshirt_loc->typeId() == itype_tshirt );
+
+    // Serialize
+    std::string json_str = serialize_item_location( tshirt_loc );
+
+    // Remove jeans (shifts indices)
+    veh->remove_item( veh->part( cargo_part_idx ), *added_jeans );
+
+    // Deserialize - should find tshirt by UID
+    item_location loaded = deserialize_item_location( json_str );
+    REQUIRE( loaded );
+    CHECK( loaded->typeId() == itype_tshirt );
+}
+
+TEST_CASE( "expired_item_location_serializes_as_nowhere", "[item][item_location][item_uid]" )
+{
+    clear_map_without_vision();
+    map &m = get_map();
+    tripoint_bub_ms pos( 60, 60, 0 );
+    m.i_clear( pos );
+
+    m.add_item( pos, item( itype_tshirt ) );
+    item_location loc( map_cursor( pos ), &m.i_at( pos ).only_item() );
+    REQUIRE( loc );
+    REQUIRE( loc->typeId() == itype_tshirt );
+
+    // Remove the target item, invalidating the safe_reference
+    m.i_rem( pos, &*loc );
+
+    // The item_location's safe_reference is now expired.
+    // Serializing should produce "type": "null" (nowhere), not a bogus map+idx.
+    std::string json_str = serialize_item_location( loc );
+
+    // Check that the serialized JSON is a nowhere location
+    JsonValue jv = json_loader::from_string( json_str );
+    JsonObject jo = jv;
+    std::string type = jo.get_string( "type" );
+    CHECK( type == "null" );
+}
+
+TEST_CASE( "expired_vehicle_cargo_item_location_serializes_as_nowhere",
+           "[item][item_location][item_uid]" )
+{
+    clear_map_without_vision();
+    map &m = get_map();
+    clear_vehicles();
+
+    tripoint_bub_ms veh_pos( 60, 60, 0 );
+    vehicle *veh = m.add_vehicle( vehicle_prototype_car, veh_pos, 0_degrees, -1, 100 );
+    REQUIRE( veh != nullptr );
+
+    // Find the largest cargo part
+    int cargo_part_idx = -1;
+    units::volume best_vol = 0_ml;
+    for( const vpart_reference &vpr : veh->get_all_parts() ) {
+        if( vpr.has_feature( "CARGO" ) ) {
+            units::volume vol = vpr.info().size;
+            if( vol > best_vol ) {
+                best_vol = vol;
+                cargo_part_idx = vpr.part_index();
+            }
+        }
+    }
+    REQUIRE( cargo_part_idx >= 0 );
+
+    // Add an item to cargo
+    std::optional<vehicle_stack::iterator> added =
+        veh->add_item( m, veh->part( cargo_part_idx ), item( itype_tshirt ) );
+    REQUIRE( added.has_value() );
+
+    vehicle_cursor cur( *veh, cargo_part_idx );
+    item_location loc( cur, & **added );
+    REQUIRE( loc );
+
+    // Remove the item, invalidating the safe_reference
+    veh->remove_item( veh->part( cargo_part_idx ), *added );
+
+    // Serializing should produce "type": "null", not a partial vehicle object
+    // that would be misread as a base item (idx defaults to -1 on load)
+    std::string json_str = serialize_item_location( loc );
+
+    JsonValue jv = json_loader::from_string( json_str );
+    JsonObject jo = jv;
+    std::string type = jo.get_string( "type" );
+    CHECK( type == "null" );
+}
+
+TEST_CASE( "item_location_in_container_deserialize_without_uid_falls_back_to_index",
+           "[item][item_location][item_uid]" )
+{
+    clear_map_without_vision();
+    map &m = get_map();
+    tripoint_bub_ms pos( 60, 60, 0 );
+    m.i_clear( pos );
+
+    // Place a backpack with items inside
+    item backpack_item( itype_backpack );
+    backpack_item.put_in( item( itype_jeans ), pocket_type::CONTAINER );
+    backpack_item.put_in( item( itype_tshirt ), pocket_type::CONTAINER );
+
+    m.add_item( pos, backpack_item );
+    item &placed_backpack = m.i_at( pos ).only_item();
+
+    // First, serialize the parent (backpack on map) normally -- it has a UID
+    item_location backpack_loc( map_cursor( pos ), &placed_backpack );
+
+    // Find the actual index of the tshirt in the container
+    int tshirt_idx = -1;
+    int idx = 0;
+    for( const item *it : placed_backpack.all_items_container_top() ) {
+        if( it->typeId() == itype_tshirt ) {
+            tshirt_idx = idx;
+            break;
+        }
+        idx++;
+    }
+    REQUIRE( tshirt_idx >= 0 );
+
+    // Hand-craft old-format in_container JSON: has idx but no uid
+    std::ostringstream os;
+    JsonOut jsout( os );
+    jsout.start_object();
+    jsout.member( "idx", tshirt_idx );
+    jsout.member( "type", "in_container" );
+    jsout.member( "parent", backpack_loc );
+    jsout.end_object();
+    std::string json_str = os.str();
+
+    // Deserialize - should use index fallback since no UID
+    item_location loaded = deserialize_item_location( json_str );
+    REQUIRE( loaded );
+    CHECK( loaded->typeId() == itype_tshirt );
 }


### PR DESCRIPTION
#### Summary
Bugfixes "Fix item_location losing target across save/load when container contents change"

#### Purpose of change

`item_location` serializes items-in-containers using a positional index into the container's item list. When container contents change between serialize and deserialize -- items consumed during eating, merged by `restack()`, removed by crafting -- the index goes stale. On load it either points out of bounds ("contents index greater than contents size") or silently binds to the wrong item.

This has been reported in 17+ issues spanning 2023-2026, including #69796, #70034, #74074, #75607, #80112, #84492, #85108, #85762, #85839. Root cause confirmed in #85108: 13 stacked `ACT_EAT_MENU` activities with stale container indices in the player backlog. The only prior fix was #84466 which hardened the vehicle serialization path specifically.

#### Describe the solution

Add a persistent unique identifier (`item_uid`, int64_t wrapper) to `item`. On construction, each item gets a fresh UID from a global counter. Copies get new UIDs automatically (the copy constructor generates a fresh one, following the `safe_reference_anchor` pattern). UIDs survive serialization via the standard `item::io()` archive.

`item_location` now serializes the target item's UID alongside the positional index. On deserialization:
- If UID is present, look up by UID. If found, use it. If not found, the item was genuinely removed -- resolve to `nowhere` with a debugmsg. Do NOT fall back to index (that would silently bind to the wrong item).
- If UID is absent (legacy save), fall back to index-based lookup (existing behavior).

All four `item_location` types (map, character, vehicle, container) get UID support. The container path resolves eagerly during deserialize; the other three use the existing lazy `ensure_unpacked()` mechanism with a new `unpack_by_uid()` virtual and raw `int64_t uid_hint` storage (raw int64_t, not `item_uid`, to avoid triggering copy-generates-new semantics).

Additional hardening:
- All `serialize()` methods now check for null `target()` and serialize as `nowhere` instead of calling `find_index()`/`calc_index()` on a dead pointer
- `find_index()` and `calc_index()` fixed to return -1 on miss (were returning last-visited index / list size)
- Failed index also triggers serialize-as-nowhere
- The vehicle non-base-item path now checks index before opening the JSON object (was emitting a partial vehicle object that would be misread as base item on load)
- The error recovery path in `deserialize()` now sets `ptr` to `nowhere` instead of leaving it null

#### Describe alternatives you've considered

Could scope this to only the `in_container` type since that's where the bug reports cluster, but all four types have the same fragile index pattern and the fix is uniform. Could also use a hash of item properties instead of a UID, but that breaks for identical stacked items and doesn't survive `restack()` merges cleanly.

#### Testing

14 new test cases covering:
- UID basics: construction, uniqueness, copy-gets-new, serialization round-trip
- Container item_location: survives restack, survives removal, UID miss becomes nowhere
- Map item_location: survives removal across save/load
- Character item_location: survives inventory restack
- Vehicle item_location: base item round-trip (verifies idx/uid omitted in JSON), cargo survives removal
- Serialize guards: expired map item_location serializes as nowhere, expired vehicle cargo serializes as nowhere
- Legacy compatibility: old-format map JSON (no uid) uses index fallback, old-format in_container JSON uses index fallback

All existing `[item_location]` tests pass (997+ assertions).

#### Additional context

The global UID counter is persisted in `master.gsav` alongside `next_npc_id` and `next_mission_id`. Old saves without UIDs get fresh ones on first load via migration in `item::io()`. The `item_uid` type uses copy-generates-new semantics (like `safe_reference_anchor`), so `item::uid()` returns `const item_uid&` and all internal storage in `item_location` uses raw `int64_t` to avoid accidental copies.

Known gap: the `find_index() < 0` serialize guard (target exists but not in selector) is not directly tested because it requires the item to move between containers without invalidating the safe_reference, which is hard to trigger deterministically.