### PR TITLE
Apply NPC_starting_traits to randomly generated NPCs

### DIFF
--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -71,6 +71,7 @@
 #include "start_location.h"
 #include "string_formatter.h"
 #include "text_snippets.h"
+#include "trait_group.h"
 #include "translation.h"
 #include "translations.h"
 #include "type_id.h"
@@ -95,6 +96,9 @@ static const matype_id style_none( "style_none" );
 
 static const profession_group_id
 profession_group_adult_basic_background( "adult_basic_background" );
+
+static const trait_group::Trait_group_tag
+Trait_group_NPC_starting_traits( "NPC_starting_traits" );
 
 static const trait_id trait_SMELLY( "SMELLY" );
 static const trait_id trait_WEAKSCENT( "WEAKSCENT" );
@@ -590,6 +594,11 @@ void Character::randomize( const bool random_scenario, bool play_now )
     reset_cardio_acc();
 
     if( is_npc() ) {
+        for( const trait_and_var &cur : trait_group::traits_from( Trait_group_NPC_starting_traits ) ) {
+            if( !has_conflicting_trait( cur.trait ) ) {
+                set_mutation( cur.trait, cur.trait->variant( cur.variant ) );
+            }
+        }
         as_npc()->randomize_personality();
         as_npc()->generate_personality_traits();
         initialize();


### PR DESCRIPTION
#### Summary
Bugfixes "Apply NPC_starting_traits to randomly generated NPCs"

#### Purpose of change

Fixes #85891

#76935 moved random NPC generation to `Character::randomize`, but that path never applies the `NPC_starting_traits` trait group. Mods that override it (like Magiclysm's 50% fantasy species) have been silently broken since.

#### Describe the solution

Apply `trait_group::traits_from("NPC_starting_traits")` in the `is_npc()` block of `Character::randomize`, with a conflicting-trait guard so earlier profession/hobby traits aren't clobbered.

#### Describe alternatives you've considered

Could also stop special-casing NC_NONE and let it go through the npc_class trait path, but that would reintroduce the old stat/skill rolling and equipment logic that #76935 intentionally replaced.

#### Testing

#### Additional context

None