### PR TITLE
Use Catch::Matchers:: namespace for all test matchers

### DIFF
--- a/tests/ammo_set_test.cpp
+++ b/tests/ammo_set_test.cpp
@@ -95,7 +95,7 @@ TEST_CASE( "ammo_set_items_with_MAGAZINE_pockets", "[ammo_set][magazine][ammo]" 
                 cz75mag_20rd.ammo_set( ammo308_id, 15 );
             } );
             THEN( "get debugmsg with \"Tried to set invalid ammo of 308 for cz75mag_20rd\"" ) {
-                CHECK_THAT( dmsg, Catch::EndsWith( "Tried to set invalid ammo of 308 for cz75mag_20rd" ) );
+                CHECK_THAT( dmsg, Catch::Matchers::EndsWith( "Tried to set invalid ammo of 308 for cz75mag_20rd" ) );
                 AND_THEN( "magazine has 0 round of null" ) {
                     CHECK( cz75mag_20rd.ammo_remaining( ) == 0 );
                     CHECK( cz75mag_20rd.ammo_current().is_null() );
@@ -177,7 +177,7 @@ TEST_CASE( "ammo_set_items_with_MAGAZINE_pockets", "[ammo_set][magazine][ammo]" 
                 m24.ammo_set( ammo9mm_id, 2 );
             } );
             THEN( "get debugmsg with \"Tried to set invalid ammo of 9mm for M24\"" ) {
-                CHECK_THAT( dmsg, Catch::EndsWith( "Tried to set invalid ammo of 9mm for M24" ) );
+                CHECK_THAT( dmsg, Catch::Matchers::EndsWith( "Tried to set invalid ammo of 9mm for M24" ) );
                 AND_THEN( "gun has 0 round of null" ) {
                     CHECK( m24.ammo_remaining( ) == 0 );
                     CHECK( m24.ammo_current().is_null() );
@@ -287,7 +287,7 @@ TEST_CASE( "ammo_set_items_with_MAGAZINE_WELL_pockets_with_magazine",
                 cz75.ammo_set( ammo308_id, 15 );
             } );
             THEN( "get debugmsg with \"Tried to set invalid ammo of 308 for cz75\"" ) {
-                CHECK_THAT( dmsg, Catch::EndsWith( "Tried to set invalid ammo of 308 for cz75" ) );
+                CHECK_THAT( dmsg, Catch::Matchers::EndsWith( "Tried to set invalid ammo of 308 for cz75" ) );
                 AND_THEN( "gun has 0 round of null" ) {
                     CHECK( cz75.ammo_remaining( ) == 0 );
                     CHECK( cz75.ammo_current().is_null() );
@@ -367,7 +367,7 @@ TEST_CASE( "ammo_set_items_with_MAGAZINE_WELL_pockets_without_magazine",
             } );
             THEN( "get debugmsg with \"Tried to set invalid ammo of 308 for cz75\"" ) {
                 REQUIRE( !dmsg.empty() );
-                CHECK_THAT( dmsg, Catch::EndsWith( "Tried to set invalid ammo of 308 for cz75" ) );
+                CHECK_THAT( dmsg, Catch::Matchers::EndsWith( "Tried to set invalid ammo of 308 for cz75" ) );
                 AND_THEN( "gun w/o magazine has 0 round of null" ) {
                     CHECK( cz75.ammo_remaining( ) == 0 );
                     CHECK( cz75.ammo_current().is_null() );
@@ -393,7 +393,7 @@ TEST_CASE( "ammo_set_items_with_CONTAINER_pockets", "[ammo_set][magazine][ammo]"
                 box.ammo_set( ammo9mm_id, 10 );
             } );
             THEN( "get debugmsg with \"Tried to set invalid ammo of 9mm for box_small\"" ) {
-                CHECK_THAT( dmsg, Catch::EndsWith( "Tried to set invalid ammo of 9mm for box_small" ) );
+                CHECK_THAT( dmsg, Catch::Matchers::EndsWith( "Tried to set invalid ammo of 9mm for box_small" ) );
                 AND_THEN( "small box still empty" ) {
                     REQUIRE_FALSE( box.is_gun() );
                     REQUIRE_FALSE( box.is_magazine() );

--- a/tests/ammo_set_test.cpp
+++ b/tests/ammo_set_test.cpp
@@ -95,7 +95,8 @@ TEST_CASE( "ammo_set_items_with_MAGAZINE_pockets", "[ammo_set][magazine][ammo]" 
                 cz75mag_20rd.ammo_set( ammo308_id, 15 );
             } );
             THEN( "get debugmsg with \"Tried to set invalid ammo of 308 for cz75mag_20rd\"" ) {
-                CHECK_THAT( dmsg, Catch::Matchers::EndsWith( "Tried to set invalid ammo of 308 for cz75mag_20rd" ) );
+                CHECK_THAT( dmsg,
+                            Catch::Matchers::EndsWith( "Tried to set invalid ammo of 308 for cz75mag_20rd" ) );
                 AND_THEN( "magazine has 0 round of null" ) {
                     CHECK( cz75mag_20rd.ammo_remaining( ) == 0 );
                     CHECK( cz75mag_20rd.ammo_current().is_null() );

--- a/tests/battery_mod_test.cpp
+++ b/tests/battery_mod_test.cpp
@@ -363,7 +363,7 @@ TEST_CASE( "installing_battery_in_tool", "[battery][tool][install]" )
             ret_val<void> result = flashlight.put_in( med_bat_cell, pocket_type::MAGAZINE_WELL );
             CHECK_FALSE( result.success() );
         } );
-        CHECK_THAT( dmsg, Catch::EndsWith( "holster does not accept this item type or form factor" ) );
+        CHECK_THAT( dmsg, Catch::Matchers::EndsWith( "holster does not accept this item type or form factor" ) );
         CHECK_FALSE( flashlight.magazine_current() );
     }
 }

--- a/tests/battery_mod_test.cpp
+++ b/tests/battery_mod_test.cpp
@@ -363,7 +363,8 @@ TEST_CASE( "installing_battery_in_tool", "[battery][tool][install]" )
             ret_val<void> result = flashlight.put_in( med_bat_cell, pocket_type::MAGAZINE_WELL );
             CHECK_FALSE( result.success() );
         } );
-        CHECK_THAT( dmsg, Catch::Matchers::EndsWith( "holster does not accept this item type or form factor" ) );
+        CHECK_THAT( dmsg,
+                    Catch::Matchers::EndsWith( "holster does not accept this item type or form factor" ) );
         CHECK_FALSE( flashlight.magazine_current() );
     }
 }

--- a/tests/item_pocket_test.cpp
+++ b/tests/item_pocket_test.cpp
@@ -290,7 +290,7 @@ TEST_CASE( "max_item_length", "[pocket][max_item_length]" )
                 ret_val<void> result = box.put_in( rod_15, pocket_type::CONTAINER );
                 CHECK_FALSE( result.success() );
             } );
-            CHECK_THAT( dmsg, Catch::EndsWith( "item is too long" ) );
+            CHECK_THAT( dmsg, Catch::Matchers::EndsWith( "item is too long" ) );
             // Box should still be empty
             CHECK( box.is_container_empty() );
         }

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -1273,7 +1273,7 @@ TEST_CASE( "armor_fit_and_sizing", "[iteminfo][armor][fit]" )
 
     item power_armor( itype_test_power_armor );
     CHECK_THAT( item_info_str( power_armor, powerarmor ),
-                Catch::EndsWith( "* This gear is a part of power armor.\n" ) );
+                Catch::Matchers::EndsWith( "* This gear is a part of power armor.\n" ) );
 }
 
 static void expected_armor_values( const item &armor, float bash, float cut, float stab,

--- a/tests/json_test.cpp
+++ b/tests/json_test.cpp
@@ -226,7 +226,7 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
     // NOLINTBEGIN(cata-text-style)
     // string, ascii
     test_translation_text_style_check(
-        Catch::Equals(
+        Catch::Matchers::Equals(
             R"((json-error))" "\n"
             R"(Json error: file <unknown source file>, at line 1, character 5:)" "\n"
             R"(insufficient spaces at this location.  2 required, but only 1 found.)"
@@ -239,7 +239,7 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
         R"("foo. bar.")" );
     // string, unicode
     test_translation_text_style_check(
-        Catch::Equals(
+        Catch::Matchers::Equals(
             R"((json-error))" "\n"
             R"(Json error: file <unknown source file>, at line 1, character 8:)" "\n"
             R"(insufficient spaces at this location.  2 required, but only 1 found.)"
@@ -252,7 +252,7 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
         R"("…foo. bar.")" );
     // string, escape sequence
     test_translation_text_style_check(
-        Catch::Equals(
+        Catch::Matchers::Equals(
             R"((json-error))" "\n"
             R"(Json error: file <unknown source file>, at line 1, character 11:)" "\n"
             R"(insufficient spaces at this location.  2 required, but only 1 found.)"
@@ -265,7 +265,7 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
         R"("\u2026foo. bar.")" );
     // object, ascii
     test_translation_text_style_check(
-        Catch::Equals(
+        Catch::Matchers::Equals(
             R"((json-error))" "\n"
             R"(Json error: file <unknown source file>, at line 1, character 13:)" "\n"
             R"(insufficient spaces at this location.  2 required, but only 1 found.)"
@@ -278,7 +278,7 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
         R"({"str": "foo. bar."})" );
     // object, unicode
     test_translation_text_style_check(
-        Catch::Equals(
+        Catch::Matchers::Equals(
             R"((json-error))" "\n"
             R"(Json error: file <unknown source file>, at line 1, character 16:)" "\n"
             R"(insufficient spaces at this location.  2 required, but only 1 found.)"
@@ -291,7 +291,7 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
         R"({"str": "…foo. bar."})" );
     // object, escape sequence
     test_translation_text_style_check(
-        Catch::Equals(
+        Catch::Matchers::Equals(
             R"((json-error))" "\n"
             R"(Json error: file <unknown source file>, at line 1, character 19:)" "\n"
             R"(insufficient spaces at this location.  2 required, but only 1 found.)"
@@ -305,7 +305,7 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
 
     // test unexpected plural forms
     test_translation_text_style_check(
-        Catch::Equals(
+        Catch::Matchers::Equals(
             R"((json-error))" "\n"
             R"(Json error: file <unknown source file>, at line 1, character 11:)" "\n"
             R"(str_sp not supported here)" "\n"
@@ -314,7 +314,7 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
             R"(         ▲▲▲)" "\n" ),
         R"({"str_sp": "foo"})" );
     test_translation_text_style_check(
-        Catch::Equals(
+        Catch::Matchers::Equals(
             R"((json-error))" "\n"
             R"(Json error: file <unknown source file>, at line 1, character 25:)" "\n"
             R"(str_pl not supported here)" "\n"
@@ -325,17 +325,17 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
 
     // test plural forms
     test_translation_text_style_check(
-        Catch::Equals( "" ),
+        Catch::Matchers::Equals( "" ),
         R"("box")" );
     test_translation_text_style_check(
-        Catch::Equals( "" ),
+        Catch::Matchers::Equals( "" ),
         R"({"str": "box"})" );
 
     test_pl_translation_text_style_check(
-        Catch::Equals( "" ),
+        Catch::Matchers::Equals( "" ),
         R"("bar")" );
     test_pl_translation_text_style_check(
-        Catch::Equals(
+        Catch::Matchers::Equals(
             R"((json-error))" "\n"
             R"(Json error: <unknown source file>:EOF:)" "\n"
             R"(Cannot autogenerate plural form.  )"
@@ -344,10 +344,10 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
         R"("box")" );
 
     test_pl_translation_text_style_check(
-        Catch::Equals( "" ),
+        Catch::Matchers::Equals( "" ),
         R"({"str": "bar"})" );
     test_pl_translation_text_style_check(
-        Catch::Equals(
+        Catch::Matchers::Equals(
             R"((json-error))" "\n"
             R"(Json error: file <unknown source file>, at line 1, character 8:)" "\n"
             R"(Cannot autogenerate plural form.  )"
@@ -359,14 +359,14 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
             R"(      ▲▲▲)" "\n" ),
         R"({"str": "box"})" );
     test_pl_translation_text_style_check(
-        Catch::Equals( "" ),
+        Catch::Matchers::Equals( "" ),
         R"({"str_sp": "bar"})" );
     test_pl_translation_text_style_check(
-        Catch::Equals( "" ),
+        Catch::Matchers::Equals( "" ),
         R"({"str_sp": "box"})" );
 
     test_pl_translation_text_style_check(
-        Catch::Equals(
+        Catch::Matchers::Equals(
             R"((json-error))" "\n"
             R"(Json error: file <unknown source file>, at line 1, character 25:)" "\n"
             R"("str_pl" is not necessary here since the plural form can be automatically generated.)"
@@ -376,7 +376,7 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
             R"(                       ▲▲▲)" "\n" ),
         R"({"str": "bar", "str_pl": "bars"})" );
     test_pl_translation_text_style_check(
-        Catch::Equals(
+        Catch::Matchers::Equals(
             R"((json-error))" "\n"
             R"(Json error: file <unknown source file>, at line 1, character 25:)" "\n"
             R"(Please use "str_sp" instead of "str" and "str_pl" for text with identical singular and plural forms)"
@@ -386,37 +386,37 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
             R"(                       ▲▲▲)" "\n" ),
         R"({"str": "bar", "str_pl": "bar"})" );
     test_pl_translation_text_style_check(
-        Catch::Equals( "" ),
+        Catch::Matchers::Equals( "" ),
         R"({"str": "box", "str_pl": "boxs"})" );
     test_pl_translation_text_style_check(
-        Catch::Equals( "" ),
+        Catch::Matchers::Equals( "" ),
         R"({"str": "box", "str_pl": "boxes"})" );
 
     // ensure nolint member suppresses text style check
     test_translation_text_style_check(
-        Catch::Equals( "" ),
+        Catch::Matchers::Equals( "" ),
         R"~({"str": "foo. bar", "//NOLINT(cata-text-style)": "blah"})~" );
     test_pl_translation_text_style_check(
-        Catch::Equals( "" ),
+        Catch::Matchers::Equals( "" ),
         R"~({"str": "box", "//NOLINT(cata-text-style)": "blah"})~" );
     test_pl_translation_text_style_check(
-        Catch::Equals( "" ),
+        Catch::Matchers::Equals( "" ),
         R"~({"str": "bar", "str_pl": "bars", "//NOLINT(cata-text-style)": "blah"})~" );
     test_pl_translation_text_style_check(
-        Catch::Equals( "" ),
+        Catch::Matchers::Equals( "" ),
         R"~({"str": "bar", "str_pl": "bar", "//NOLINT(cata-text-style)": "blah"})~" );
 
     {
         restore_on_out_of_scope restore_check_plural_2( check_plural );
         check_plural = check_plural_t::none;
         test_pl_translation_text_style_check(
-            Catch::Equals( "" ),
+            Catch::Matchers::Equals( "" ),
             R"("box")" );
         test_pl_translation_text_style_check(
-            Catch::Equals( "" ),
+            Catch::Matchers::Equals( "" ),
             R"({"str": "box"})" );
         test_pl_translation_text_style_check(
-            Catch::Equals(
+            Catch::Matchers::Equals(
                 R"((json-error))" "\n"
                 R"(Json error: file <unknown source file>, at line 1, character 25:)" "\n"
                 R"("str_pl" is not necessary here since the plural form can be automatically generated.)" "\n"
@@ -425,7 +425,7 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
                 R"(                       ▲▲▲)" "\n" ),
             R"({"str": "bar", "str_pl": "bars"})" );
         test_pl_translation_text_style_check(
-            Catch::Equals(
+            Catch::Matchers::Equals(
                 R"((json-error))" "\n"
                 R"(Json error: file <unknown source file>, at line 1, character 25:)" "\n"
                 R"(Please use "str_sp" instead of "str" and "str_pl" for text with identical singular and plural forms)"
@@ -435,7 +435,7 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
                 R"(                       ▲▲▲)" "\n" ),
             R"({"str": "bar", "str_pl": "bar"})" );
         test_translation_text_style_check(
-            Catch::Equals(
+            Catch::Matchers::Equals(
                 R"((json-error))" "\n"
                 R"(Json error: file <unknown source file>, at line 1, character 11:)" "\n"
                 R"(str_sp not supported here)" "\n"
@@ -444,7 +444,7 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
                 R"(         ▲▲▲)" "\n" ),
             R"({"str_sp": "foo"})" );
         test_translation_text_style_check(
-            Catch::Equals(
+            Catch::Matchers::Equals(
                 R"((json-error))" "\n"
                 R"(Json error: file <unknown source file>, at line 1, character 25:)" "\n"
                 R"(str_pl not supported here)" "\n"
@@ -453,7 +453,7 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
                 R"(                       ▲▲▲)" "\n" ),
             R"({"str": "foo", "str_pl": "foo"})" );
         test_translation_text_style_check(
-            Catch::Equals(
+            Catch::Matchers::Equals(
                 R"((json-error))" "\n"
                 R"(Json error: file <unknown source file>, at line 1, character 5:)" "\n"
                 R"(insufficient spaces at this location.  2 required, but only 1 found.)"
@@ -468,16 +468,16 @@ TEST_CASE( "translation_text_style_check", "[json][translation]" )
 
     // ensure sentence text style check is disabled when plural form is enabled
     test_pl_translation_text_style_check(
-        Catch::Equals( "" ),
+        Catch::Matchers::Equals( "" ),
         R"("foo. bar")" );
     test_pl_translation_text_style_check(
-        Catch::Equals( "" ),
+        Catch::Matchers::Equals( "" ),
         R"({"str": "foo. bar"})" );
     test_pl_translation_text_style_check(
-        Catch::Equals( "" ),
+        Catch::Matchers::Equals( "" ),
         R"({"str": "foo. bar", "str_pl": "foo. baz"})" );
     test_pl_translation_text_style_check(
-        Catch::Equals( "" ),
+        Catch::Matchers::Equals( "" ),
         R"({"str_sp": "foo. bar"})" );
     // NOLINTEND(cata-text-style)
 }
@@ -504,7 +504,7 @@ TEST_CASE( "translation_text_style_check_error_recovery", "[json][translation]" 
         // check that the correct debug message is shown
         CHECK_THAT(
             dmsg,
-            Catch::Equals(
+            Catch::Matchers::Equals(
                 R"((json-error))" "\n"
                 R"(Json error: file <unknown source file>, at line 2, character 7:)" "\n"
                 R"(insufficient spaces at this location.  2 required, but only 1 found.)"
@@ -534,7 +534,7 @@ TEST_CASE( "translation_text_style_check_error_recovery", "[json][translation]" 
         // check that the correct debug message is shown
         CHECK_THAT(
             dmsg,
-            Catch::Equals(
+            Catch::Matchers::Equals(
                 R"((json-error))" "\n"
                 R"(Json error: file <unknown source file>, at line 2, character 16:)" "\n"
                 R"(insufficient spaces at this location.  2 required, but only 1 found.)"
@@ -567,7 +567,7 @@ TEST_CASE( "report_unvisited_members", "[json]" )
         } );
         CHECK_THAT(
             dmsg,
-            Catch::Equals(
+            Catch::Matchers::Equals(
                 R"((json-error))" "\n"
                 R"(Json error: file <unknown source file>, at line 1, character 22:)" "\n"
                 R"(Unread data.  Invalid or misplaced field name "bar" in JSON data)"
@@ -582,7 +582,7 @@ TEST_CASE( "report_unvisited_members", "[json]" )
             JsonObject jo = json_loader::from_string( json );
             jo.get_string( "foo" );
         } );
-        CHECK_THAT( dmsg, Catch::Equals( "" ) );
+        CHECK_THAT( dmsg, Catch::Matchers::Equals( "" ) );
     }
 
     SECTION( "misplaced translator comments" ) {
@@ -593,7 +593,7 @@ TEST_CASE( "report_unvisited_members", "[json]" )
         } );
         CHECK_THAT(
             dmsg,
-            Catch::Equals(
+            Catch::Matchers::Equals(
                 R"((json-error))" "\n"
                 R"(Json error: file <unknown source file>, at line 1, character 22:)" "\n"
                 R"("//~" should be within a text object and contain comments for translators.)"
@@ -609,7 +609,7 @@ TEST_CASE( "report_unvisited_members", "[json]" )
             translation msg;
             jv.read( msg );
         } );
-        CHECK_THAT( dmsg, Catch::Equals( "" ) );
+        CHECK_THAT( dmsg, Catch::Matchers::Equals( "" ) );
     }
     // NOLINTEND(cata-text-style)
 }
@@ -640,7 +640,7 @@ TEST_CASE( "correct_cursor_position_for_unicode_json_error", "[json]" )
             "\n"
             R"(                                                     ▲▲▲)"
             "\n";
-        CHECK_THAT( e_what, Catch::Equals( e_expected ) );
+        CHECK_THAT( e_what, Catch::Matchers::Equals( e_expected ) );
         SUCCEED();
         return;
     }
@@ -706,30 +706,30 @@ TEST_CASE( "jsonin_get_string", "[json]" )
 
     // empty json
     test_get_string_throws_matches(
-        Catch::Message(
+        Catch::Matchers::Message(
             "Json error: <unknown source file>:EOF:" "\n" "input file is empty" ),
         std::string() );
     // no starting quote
     test_get_string_throws_matches(
-        Catch::Message(
+        Catch::Matchers::Message(
             "Json error: <unknown source file>:EOF:" "\n" "cannot parse value starting with: abc" ),
         R"(abc)" );
     // no ending quote
     test_get_string_throws_matches(
-        Catch::Message(
+        Catch::Matchers::Message(
             "Json error: <unknown source file>:EOF:" "\n" "illegal character in string constant" ),
         R"(")" );
     test_get_string_throws_matches(
-        Catch::Message(
+        Catch::Matchers::Message(
             "Json error: <unknown source file>:EOF:" "\n" "illegal character in string constant" ),
         R"("foo)" );
     // incomplete escape sequence and no ending quote
     test_get_string_throws_matches(
-        Catch::Message(
+        Catch::Matchers::Message(
             "Json error: <unknown source file>:EOF:" "\n" "unknown escape code in string constant" ),
         R"("\)" );
     test_get_string_throws_matches(
-        Catch::Message(
+        Catch::Matchers::Message(
             R"(Json error: file <unknown source file>, at line 1, character 3:)" "\n"
             "escape code must be followed by 4 hex digits" "\n"
             R"()" "\n"
@@ -738,7 +738,7 @@ TEST_CASE( "jsonin_get_string", "[json]" )
         R"("\u12)" );
     // incorrect escape sequence
     test_get_string_throws_matches(
-        Catch::Message(
+        Catch::Matchers::Message(
             R"(Json error: file <unknown source file>, at line 1, character 2:)" "\n"
             "unknown escape code in string constant" "\n"
             R"()" "\n"
@@ -746,7 +746,7 @@ TEST_CASE( "jsonin_get_string", "[json]" )
             R"(▲▲▲)" "\n" ),
         R"("\.")" );
     test_get_string_throws_matches(
-        Catch::Message(
+        Catch::Matchers::Message(
             R"(Json error: file <unknown source file>, at line 1, character 3:)" "\n"
             "escape code must be followed by 4 hex digits" "\n"
             R"()" "\n"
@@ -755,24 +755,24 @@ TEST_CASE( "jsonin_get_string", "[json]" )
         R"("\uDEFG")" );
     // not a valid utf8 sequence
     test_get_string_throws_matches(
-        Catch::Message(
+        Catch::Matchers::Message(
             "Json error: <unknown source file>:EOF:" "\n" "illegal UTF-8 sequence" ),
         "\"\x80\"" );
     test_get_string_throws_matches(
-        Catch::Message(
+        Catch::Matchers::Message(
             "Json error: <unknown source file>:EOF:" "\n" "illegal UTF-8 sequence" ),
         "\"\xFC\x80\"" );
     test_get_string_throws_matches(
-        Catch::Message(
+        Catch::Matchers::Message(
             R"(Json error: <unknown source file>:EOF:)" "\n" "illegal UTF-8 sequence" ),
         "\"\xFD\x80\x80\x80\x80\x80\"" );
     test_get_string_throws_matches(
-        Catch::Message(
+        Catch::Matchers::Message(
             R"(Json error: <unknown source file>:EOF:)" "\n" "illegal UTF-8 sequence" ),
         "\"\xFC\x80\x80\x80\x80\xC0\"" );
     // end of line
     test_get_string_throws_matches(
-        Catch::Message(
+        Catch::Matchers::Message(
             R"(Json error: file <unknown source file>, at line 1, character 2:)" "\n"
             "illegal character in string constant" "\n"
             R"()" "\n"
@@ -780,7 +780,7 @@ TEST_CASE( "jsonin_get_string", "[json]" )
             R"(▲▲▲)" "\n\"\n" ),
         "\"a\n\"" );
     test_get_string_throws_matches(
-        Catch::Message(
+        Catch::Matchers::Message(
             R"(Json error: file <unknown source file>, at line 1, character 2:)" "\n"
             "illegal character in string constant" "\n"
             R"()" "\n"
@@ -791,7 +791,7 @@ TEST_CASE( "jsonin_get_string", "[json]" )
     // test throwing error after the given number of unicode characters
     // ascii
     test_string_error_throws_matches(
-        Catch::Message(
+        Catch::Matchers::Message(
             R"(Json error: file <unknown source file>, at line 1, character 1:)" "\n"
             "<message>" "\n"
             R"()" "\n"
@@ -799,7 +799,7 @@ TEST_CASE( "jsonin_get_string", "[json]" )
             R"(▲▲▲)" "\n" ),
         R"("foobar")", 0 );
     test_string_error_throws_matches(
-        Catch::Message(
+        Catch::Matchers::Message(
             R"(Json error: file <unknown source file>, at line 1, character 4:)" "\n"
             "<message>" "\n"
             R"()" "\n"
@@ -808,7 +808,7 @@ TEST_CASE( "jsonin_get_string", "[json]" )
         R"("foobar")", 3 );
     // unicode
     test_string_error_throws_matches(
-        Catch::Message(
+        Catch::Matchers::Message(
             R"(Json error: file <unknown source file>, at line 1, character 4:)" "\n"
             "<message>" "\n"
             R"()" "\n"
@@ -816,7 +816,7 @@ TEST_CASE( "jsonin_get_string", "[json]" )
             R"(  ▲▲▲)" "\n" ),
         R"("foo…bar1")", 3 );
     test_string_error_throws_matches(
-        Catch::Message(
+        Catch::Matchers::Message(
             R"(Json error: file <unknown source file>, at line 1, character 7:)" "\n"
             "<message>" "\n"
             R"()" "\n"
@@ -824,7 +824,7 @@ TEST_CASE( "jsonin_get_string", "[json]" )
             R"(   ▲▲▲)" "\n" ),
         R"("foo…bar2")", 4 );
     test_string_error_throws_matches(
-        Catch::Message(
+        Catch::Matchers::Message(
             R"(Json error: file <unknown source file>, at line 1, character 8:)" "\n"
             "<message>" "\n"
             R"()" "\n"
@@ -833,7 +833,7 @@ TEST_CASE( "jsonin_get_string", "[json]" )
         R"("foo…bar3")", 5 );
     // escape sequence
     test_string_error_throws_matches(
-        Catch::Message(
+        Catch::Matchers::Message(
             R"(Json error: file <unknown source file>, at line 1, character 11:)" "\n"
             "<message>" "\n"
             R"()" "\n"
@@ -841,7 +841,7 @@ TEST_CASE( "jsonin_get_string", "[json]" )
             R"(         ▲▲▲)" "\n" ),
         R"("foo\u2026bar")", 5 );
     test_string_error_throws_matches(
-        Catch::Message(
+        Catch::Matchers::Message(
             R"(Json error: file <unknown source file>, at line 1, character 7:)" "\n"
             "<message>" "\n"
             R"()" "\n"

--- a/tests/map_test_case_test.cpp
+++ b/tests/map_test_case_test.cpp
@@ -100,7 +100,7 @@ TEST_CASE( "map_test_case_transform_consistency", "[map_test_case]" )
     );
     neigh_vec.push_back( tripoint::zero );
     CHECK_THAT( std::vector<tripoint>( tiles.begin(), tiles.end() ),
-                Catch::UnorderedEquals( neigh_vec ) );
+                Catch::Matchers::UnorderedEquals( neigh_vec ) );
 
     tst.for_each_tile( [&]( mtc::tile t ) {
         CHECK( t.expect_c == t.setup_c );


### PR DESCRIPTION
#### Summary
Infrastructure "Use Catch::Matchers:: namespace for all test matchers"

#### Purpose of change

Catch2 v2 exposes matchers in both `Catch::` and `Catch::Matchers::` namespaces. v3 only supports the latter. Moving all call sites now means the eventual v3 migration has 74 fewer changes to deal with.

Follows #85874 which removed the other major v2-internal API dependencies from the test runner.

#### Describe the solution

Mechanical search-replace across 6 test files:

- `Catch::Equals` -> `Catch::Matchers::Equals` (42 sites in json_test.cpp)
- `Catch::EndsWith` -> `Catch::Matchers::EndsWith` (8 sites across 4 files)
- `Catch::UnorderedEquals` -> `Catch::Matchers::UnorderedEquals` (1 site)
- `Catch::Message` -> `Catch::Matchers::Message` (21 sites in json_test.cpp)

Both namespaces resolve to the same symbols in v2, so this is a no-op at the binary level.

#### Describe alternatives you've considered

Could just do it all in the v3 migration PR, but that PR is already going to touch build system + runner + PCH. Keeping the mechanical namespace churn separate makes review easier on both sides.

#### Testing

Clean build passed. No behavioral change -- the matchers are identical under both namespaces in v2.

#### Additional context