### PR TITLE
[MoM] LIXA interactions

### DIFF
--- a/data/mods/MindOverMatter/effects/effects_edited.json
+++ b/data/mods/MindOverMatter/effects/effects_edited.json
@@ -41,5 +41,20 @@
     "id": "teleglow",
     "type": "effect_type",
     "immune_flags": [ "TELESTOP" ]
+  },
+  {
+    "type": "effect_type",
+    "id": "LIXA_illuminated",
+    "name": [ "illuminated" ],
+    "desc": [ "You're covered in congealed light!" ],
+    "apply_message": "The sticky globs of light cover you, and begin to burn!",
+    "rating": "bad",
+    "max_duration": "6 seconds",
+    "max_intensity": 3,
+    "int_dur_factor": "2 seconds",
+    "base_mods": { "hurt_min": [ 1 ], "hurt_chance": [ 3 ] },
+    "scaling_mods": { "hurt_min": [ 1 ] },
+    "show_in_info": true,
+    "immune_flags": [ "PHOTOKIN_CHAR_IMMUNE" ]
   }
 ]

--- a/data/mods/MindOverMatter/items/fake_guns.json
+++ b/data/mods/MindOverMatter/items/fake_guns.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": "LIXA_spit_light",
+    "type": "ITEM",
+    "subtypes": [ "GUN" ],
+    "copy-from": "LIXA_spit_light",
+    "ranged_damage": { "damage_type": "psi_photokinetic_damage", "amount": 4 }
+  }
+]

--- a/data/mods/MindOverMatter/items/fake_guns.json
+++ b/data/mods/MindOverMatter/items/fake_guns.json
@@ -5,5 +5,12 @@
     "subtypes": [ "GUN" ],
     "copy-from": "LIXA_spit_light",
     "ranged_damage": { "damage_type": "psi_photokinetic_damage", "amount": 4 }
+  },
+  {
+    "id": "LIXA_vector_volley",
+    "type": "ITEM",
+    "subtypes": [ "GUN" ],
+    "copy-from": "LIXA_vector_volley",
+    "ranged_damage": [ { "damage_type": "pure", "amount": 8 }, { "damage_type": "psi_teleporter_teleporting_damage", "amount": 1 } ]
   }
 ]

--- a/data/mods/MindOverMatter/monsters/monster_overrides.json
+++ b/data/mods/MindOverMatter/monsters/monster_overrides.json
@@ -642,36 +642,42 @@
     "id": "mon_eigenspectre_1",
     "copy-from": "mon_eigenspectre_1",
     "type": "MONSTER",
-    "species": [ "NETHER_EMANATION", "TELEKIN_PUSHPULL_NULL", "TELEKIN_IMMUNE" ]
+    "species": [ "NETHER_EMANATION", "TELEKIN_PUSHPULL_NULL" ],
+    "extend": { "flags": [ "TELEKIN_IMMUNE" ] }
   },
   {
     "id": "mon_eigenspectre_2",
     "copy-from": "mon_eigenspectre_2",
     "type": "MONSTER",
-    "species": [ "NETHER_EMANATION", "PHOTOKIN_MONSTER_IMMUNE", "TELEKIN_PUSHPULL_NULL", "TELEKIN_IMMUNE" ]
-  },
-  {
-    "id": "mon_eigenspectre_2",
-    "copy-from": "mon_eigenspectre_3",
-    "type": "MONSTER",
-    "species": [ "NETHER_EMANATION", "TELEKIN_PUSHPULL_NULL", "TELEKIN_IMMUNE" ]
+    "species": [ "NETHER_EMANATION", "TELEKIN_PUSHPULL_NULL" ],
+    "extend": { "flags": [ "PHOTOKIN_MONSTER_IMMUNE", "TELEKIN_IMMUNE" ] }
   },
   {
     "id": "mon_eigenspectre_3",
+    "copy-from": "mon_eigenspectre_3",
+    "type": "MONSTER",
+    "species": [ "NETHER_EMANATION", "TELEKIN_PUSHPULL_NULL" ],
+    "extend": { "flags": [ "TELEKIN_IMMUNE" ] }
+  },
+  {
+    "id": "mon_eigenspectre_3_echo",
     "copy-from": "mon_eigenspectre_3_echo",
     "type": "MONSTER",
-    "species": [ "NETHER_EMANATION", "TELEKIN_PUSHPULL_NULL", "TELEKIN_IMMUNE" ]
+    "species": [ "NETHER_EMANATION", "TELEKIN_PUSHPULL_NULL" ],
+    "extend": { "flags": [ "TELEKIN_IMMUNE" ] }
   },
   {
     "id": "mon_eigenspectre_4",
     "copy-from": "mon_eigenspectre_4",
     "type": "MONSTER",
-    "species": [ "NETHER_EMANATION", "TELEKIN_PUSHPULL_NULL", "TELEKIN_IMMUNE" ]
+    "species": [ "NETHER_EMANATION", "TELEKIN_PUSHPULL_NULL" ],
+    "extend": { "flags": [ "TELEKIN_IMMUNE" ] }
   },
   {
     "id": "mon_living_vector",
     "copy-from": "mon_living_vector",
     "type": "MONSTER",
-    "species": [ "NETHER_EMANATION", "TELEKIN_PUSHPULL_NULL", "TELEKIN_IMMUNE" ]
+    "species": [ "NETHER_EMANATION", "TELEKIN_PUSHPULL_NULL" ],
+    "extend": { "flags": [ "TELEKIN_IMMUNE" ] }
   }
 ]

--- a/data/mods/MindOverMatter/monsters/monster_overrides.json
+++ b/data/mods/MindOverMatter/monsters/monster_overrides.json
@@ -637,5 +637,41 @@
     "copy-from": "mon_cow",
     "type": "MONSTER",
     "reproduction": { "baby_type": { "baby_monster_group": "GROUP_REPRODUCTION_COW_MUTANT_BABIES" }, "baby_count": 1, "baby_timer": 343 }
+  },
+  {
+    "id": "mon_eigenspectre_1",
+    "copy-from": "mon_eigenspectre_1",
+    "type": "MONSTER",
+    "species": [ "NETHER_EMANATION", "TELEKIN_PUSHPULL_NULL", "TELEKIN_IMMUNE" ]
+  },
+  {
+    "id": "mon_eigenspectre_2",
+    "copy-from": "mon_eigenspectre_2",
+    "type": "MONSTER",
+    "species": [ "NETHER_EMANATION", "PHOTOKIN_MONSTER_IMMUNE", "TELEKIN_PUSHPULL_NULL", "TELEKIN_IMMUNE" ]
+  },
+  {
+    "id": "mon_eigenspectre_2",
+    "copy-from": "mon_eigenspectre_3",
+    "type": "MONSTER",
+    "species": [ "NETHER_EMANATION", "TELEKIN_PUSHPULL_NULL", "TELEKIN_IMMUNE" ]
+  },
+  {
+    "id": "mon_eigenspectre_3",
+    "copy-from": "mon_eigenspectre_3_echo",
+    "type": "MONSTER",
+    "species": [ "NETHER_EMANATION", "TELEKIN_PUSHPULL_NULL", "TELEKIN_IMMUNE" ]
+  },
+  {
+    "id": "mon_eigenspectre_4",
+    "copy-from": "mon_eigenspectre_4",
+    "type": "MONSTER",
+    "species": [ "NETHER_EMANATION", "TELEKIN_PUSHPULL_NULL", "TELEKIN_IMMUNE" ]
+  },
+  {
+    "id": "mon_living_vector",
+    "copy-from": "mon_living_vector",
+    "type": "MONSTER",
+    "species": [ "NETHER_EMANATION", "TELEKIN_PUSHPULL_NULL", "TELEKIN_IMMUNE" ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[MoM] LIXA interactions"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Now that I've actually done LIXA, time to modify it when using MoM. 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

- [X] Photonic Eigenspectres now do photokinetic damage with their attacks.
- [X] You are immune to the effects of Congealed Light if you have Lucent Barrier active.
- [X] Photonic Eigenspectres are immune to photokinetic damage
- [X] All eigenspectres are immune to telekinesis 
- [X] The unfolded impossibilty also does 1 point of teleporting damage (which blinks you) with its `coordinate rotation volley`

More to come. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Spawned some spectres, fought them in various ways. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
