### PR TITLE
Skip corpse placement when monster group is empty

### DIFF
--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -2924,6 +2924,9 @@ class jmapgen_corpse : public jmapgen_piece
                     const std::string &/*context*/ ) const override {
             const std::vector<mtype_id> monster_group =
                 MonsterGroupManager::GetMonstersFromGroup( group, true );
+            if( monster_group.empty() ) {
+                return;
+            }
             const mtype_id &corpse_type = random_entry_ref( monster_group );
             item corpse = item::make_corpse( corpse_type,
                                              std::max( calendar::turn - age, calendar::start_of_cataclysm ) );


### PR DESCRIPTION
#### Summary
Bugfixes "Fix flaky all-mods CI failure from corpse mapgen with empty monster groups"

#### Purpose of change

Observed in CI: https://github.com/CleverRaven/Cataclysm-DDA/pull/85907

#### Describe the solution

Found the problem with a custom test that exercises `GetMonstersFromGroup` for all monster groups used by `place_corpses` mapgen with classic_zombies loaded. `GROUP_TOXIC_WASTE_CORPSES` and `FERAL_HUMANS` come back empty because of the mod's exclusive monster whitelist (CLASSIC + WILDLIFE only). `random_entry_ref` on an empty vector returns a default-constructed `mtype_id("")` -- not `NULL_ID` which is `"mon_null"` -- and `make_corpse` errors on it. Flaky because whether the affected terrain gets generated depends on the RNG seed.

Early return in `jmapgen_corpse::apply` when the monster group is empty.

#### Describe alternatives you've considered

Could guard in `make_corpse` itself, but that would silently swallow genuinely invalid mtype_ids from other callers.

#### Testing

Verified locally.

#### Additional context