### PR TITLE
Respect magazine_well when calculating encumbrance

### DIFF
--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -2251,7 +2251,7 @@ void item_contents::add_pocket( const item &pocket_item )
         // need to update it once it's stored in the contents list
         ( ++contents.rbegin() )->name_as_description = true;
         total_nonrigid_volume += i_pocket->volume_capacity();
-        effective_nonrigid_volume += i_pocket->volume_capacity() *
+        effective_nonrigid_volume += ( i_pocket->volume_capacity() - i_pocket->magazine_well() ) *
                                      i_pocket->get_pocket_data()->volume_encumber_modifier;
     }
     additional_pockets_volume += total_nonrigid_volume;
@@ -2279,7 +2279,7 @@ item item_contents::remove_pocket( int index )
     units::volume effective_nonrigid_volume = 0_ml;
     for( item_pocket *i_pocket : additional_pockets[index].get_container_pockets() ) {
         total_nonrigid_volume += i_pocket->volume_capacity();
-        effective_nonrigid_volume += i_pocket->volume_capacity() *
+        effective_nonrigid_volume += ( i_pocket->volume_capacity() - i_pocket->magazine_well() ) *
                                      i_pocket->get_pocket_data()->volume_encumber_modifier;
 
         // move items from the consolidated pockets to the item that will be returned
@@ -2637,8 +2637,8 @@ float item_contents::relative_encumbrance() const
         }
         // need to modify by pockets volume encumbrance modifier since some pockets may have less effect than others
         float modifier = pocket.get_pocket_data()->volume_encumber_modifier;
-        nonrigid_volume += pocket.contents_volume() * modifier;
-        nonrigid_max_volume += pocket.volume_capacity() * modifier;
+        nonrigid_volume += std::max( 0_ml, ( pocket.contents_volume() - pocket.magazine_well() ) ) * modifier;
+        nonrigid_max_volume += ( pocket.volume_capacity() - pocket.magazine_well() ) * modifier;
     }
     if( nonrigid_volume > nonrigid_max_volume ) {
         // volume exceeds capacity and will spill until 1 or lower if picked up, so assume 1

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -2637,7 +2637,8 @@ float item_contents::relative_encumbrance() const
         }
         // need to modify by pockets volume encumbrance modifier since some pockets may have less effect than others
         float modifier = pocket.get_pocket_data()->volume_encumber_modifier;
-        nonrigid_volume += std::max( 0_ml, ( pocket.contents_volume() - pocket.magazine_well() ) ) * modifier;
+        nonrigid_volume += std::max( 0_ml,
+                                     ( pocket.contents_volume() - pocket.magazine_well() ) ) * modifier;
         nonrigid_max_volume += ( pocket.volume_capacity() - pocket.magazine_well() ) * modifier;
     }
     if( nonrigid_volume > nonrigid_max_volume ) {


### PR DESCRIPTION
#### Summary
Balance "Respect magazine_well when calculating encumbrance"

#### Purpose of change
https://github.com/CleverRaven/Cataclysm-DDA/blob/736fd3ef7d9d1dd934b44802c3086ead22573169/doc/JSON/ITEM.md?plain=1#L739
`magazine_well` was added years ago but never considered when calculating encumbrance, and I'd like to take it into account.

#### Describe the solution
Take the volume of `magazine_well` into account in `relative_encumbrance` and `additional_pockets_effective_volume`.

#### Describe alternatives you've considered

#### Testing
Take [sheath](https://cdda-guide.nornagon.net/item/sheath) as an example.
https://github.com/CleverRaven/Cataclysm-DDA/blob/7c0aa2c09494e3d52ee7dcfe3d8130a3fde9f6f7/data/json/items/armor/sheath.json#L486-L495
It has `"magazine_well": "350 ml"` defined but not taken into account in encumbrance calculation. As encumbrance is calculated using std::ceil, any amount of effective volume will add 1 encumbrance to it.
<img width="685" height="504" alt="2026-03-17 194919" src="https://github.com/user-attachments/assets/cafc42af-18ad-453a-a8fe-86b014ab00bf" />

After the patch it no longer get an extra encumbrance when carrying a hunting knife, both on its own and when attached to a MOLLE equipment.
<img width="526" height="425" alt="2026-03-17 194434" src="https://github.com/user-attachments/assets/0faf16b7-d361-4ec6-b109-032d7cb45e13" />
<img width="623" height="473" alt="2026-03-17 201911" src="https://github.com/user-attachments/assets/5f8fa3cd-5b5b-4ff8-9cc9-7c588a6341e8" />
While carrying shears which is big enough still add encumbrance to it.
<img width="628" height="494" alt="2026-03-17 194542" src="https://github.com/user-attachments/assets/d1cd815f-585f-4142-9e24-0cf87d1db833" />
<img width="598" height="545" alt="2026-03-17 201942" src="https://github.com/user-attachments/assets/a87305df-888d-4ca6-ae68-1be2973e50f2" />

#### Additional context
