### PR TITLE
Add steps to bread recipe

### DIFF
--- a/data/json/recipes/food/bread.json
+++ b/data/json/recipes/food/bread.json
@@ -87,15 +87,12 @@
   },
   {
     "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
     "result": "bread",
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREAD",
     "skill_used": "cooking",
     "difficulty": 2,
     "charges": 10,
-    "time": "20 m",
-    "batch_time_factors": [ 50, 4 ],
     "book_learn": [
       [ "family_cookbook", 1 ],
       [ "baking_book", 1 ],
@@ -103,10 +100,25 @@
       [ "cookbook_italian", 3 ],
       [ "atomic_survival", 6 ]
     ],
-    "qualities": [ { "id": "OVEN", "level": 1 } ],
-    "tools": [ [ [ "surface_heat", 22, "LIST" ] ] ],
-    "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_baking" }, { "proficiency": "prof_baking_bread" } ],
-    "components": [ [ [ "flour", 22 ], [ "bread_flour", 5 ] ], [ [ "yeast", 1 ] ], [ [ "water_clean", 2 ] ], [ [ "sugar", 4 ] ] ]
+    "components": [ [ [ "flour", 22 ], [ "bread_flour", 5 ] ], [ [ "yeast", 1 ] ], [ [ "water_clean", 2 ] ], [ [ "sugar", 4 ] ] ],
+    "steps": [
+      {
+        "name": "Mix dough",
+        "time": "5 m",
+        "activity_level": "MODERATE_EXERCISE",
+        "batch_time_factors": [ 25, 4 ],
+        "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_baking" }, { "proficiency": "prof_baking_bread" } ]
+      },
+      { "name": "Let dough rise", "time": "10 m", "activity_level": "NO_EXERCISE", "batch_time_factors": [ 5, 4 ] },
+      {
+        "name": "Bake",
+        "time": "5 m",
+        "activity_level": "LIGHT_EXERCISE",
+        "batch_time_factors": [ 50, 4 ],
+        "qualities": [ { "id": "OVEN", "level": 1 } ],
+        "tools": [ [ [ "surface_heat", 22, "LIST" ] ] ]
+      }
+    ]
   },
   {
     "type": "recipe",

--- a/data/mods/TEST_DATA/proficiencies.json
+++ b/data/mods/TEST_DATA/proficiencies.json
@@ -9,5 +9,38 @@
     "default_time_multiplier": 1.5,
     "time_to_learn": "24 h",
     "default_skill_penalty": 0.4
+  },
+  {
+    "type": "proficiency",
+    "id": "prof_test_step_a",
+    "category": "prof_test_category",
+    "name": { "str": "Test Step Proficiency A" },
+    "description": "Test proficiency for recipe step tests.",
+    "can_learn": true,
+    "default_time_multiplier": 2.0,
+    "time_to_learn": "10 h",
+    "default_skill_penalty": 0.5
+  },
+  {
+    "type": "proficiency",
+    "id": "prof_test_step_b",
+    "category": "prof_test_category",
+    "name": { "str": "Test Step Proficiency B" },
+    "description": "Test proficiency for recipe step tests.",
+    "can_learn": true,
+    "default_time_multiplier": 1.5,
+    "time_to_learn": "10 h",
+    "default_skill_penalty": 0.3
+  },
+  {
+    "type": "proficiency",
+    "id": "prof_test_step_required",
+    "category": "prof_test_category",
+    "name": { "str": "Test Step Required Proficiency" },
+    "description": "Required proficiency for recipe step tests.",
+    "can_learn": true,
+    "default_time_multiplier": 2.0,
+    "time_to_learn": "10 h",
+    "default_skill_penalty": 0.5
   }
 ]

--- a/data/mods/TEST_DATA/recipes.json
+++ b/data/mods/TEST_DATA/recipes.json
@@ -367,5 +367,84 @@
       [ [ "sheet_kevlar_layered", 1 ] ]
     ],
     "proficiencies": [ { "proficiency": "prof_millinery" }, { "proficiency": "prof_polymerworking" } ]
+  },
+  {
+    "type": "recipe",
+    "result": "cudgel",
+    "id_suffix": "test_steps_basic",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_BASHING",
+    "skill_used": "fabrication",
+    "difficulty": 1,
+    "autolearn": true,
+    "components": [ [ [ "2x4", 1 ] ] ],
+    "steps": [
+      {
+        "name": "Shape",
+        "time": "10 m",
+        "activity_level": "MODERATE_EXERCISE",
+        "batch_time_factors": [ 25, 4 ],
+        "proficiencies": [ { "proficiency": "prof_test_step_a" } ]
+      },
+      { "name": "Sand", "time": "5 m", "activity_level": "LIGHT_EXERCISE", "batch_time_factors": [ 50, 4 ] },
+      {
+        "name": "Finish",
+        "time": "5 m",
+        "activity_level": "NO_EXERCISE",
+        "batch_time_factors": [ 80, 2 ],
+        "proficiencies": [ { "proficiency": "prof_test_step_b" } ],
+        "qualities": [ { "id": "CUT", "level": 1 } ]
+      }
+    ]
+  },
+  {
+    "type": "recipe",
+    "result": "cudgel",
+    "id_suffix": "test_steps_shared_prof",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_BASHING",
+    "skill_used": "fabrication",
+    "difficulty": 1,
+    "autolearn": true,
+    "components": [ [ [ "2x4", 1 ] ] ],
+    "steps": [
+      {
+        "name": "Rough shape",
+        "time": "10 m",
+        "activity_level": "MODERATE_EXERCISE",
+        "proficiencies": [ { "proficiency": "prof_test_step_a" } ]
+      },
+      {
+        "name": "Fine shape",
+        "time": "10 m",
+        "activity_level": "LIGHT_EXERCISE",
+        "proficiencies": [ { "proficiency": "prof_test_step_a" } ]
+      }
+    ]
+  },
+  {
+    "type": "recipe",
+    "result": "cudgel",
+    "id_suffix": "test_steps_required_prof",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_BASHING",
+    "skill_used": "fabrication",
+    "difficulty": 1,
+    "autolearn": true,
+    "components": [ [ [ "2x4", 1 ] ] ],
+    "steps": [
+      {
+        "name": "Check",
+        "time": "5 m",
+        "activity_level": "NO_EXERCISE",
+        "proficiencies": [ { "proficiency": "prof_test_step_required", "required": true } ]
+      },
+      {
+        "name": "Work",
+        "time": "10 m",
+        "activity_level": "MODERATE_EXERCISE",
+        "proficiencies": [ { "proficiency": "prof_test_step_a" } ]
+      }
+    ]
   }
 ]

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1063,7 +1063,11 @@ bool Character::craft_proficiency_gain( const item &craft, const time_duration &
 
     for( Character *p : all_crafters ) {
         std::vector<learn_subject> subjects;
-        for( const recipe_proficiency &prof : making.proficiencies ) {
+        for( const recipe_proficiency &prof : making.get_proficiencies() ) {
+            // Required profs (time_multiplier == 0) gate access, not learning
+            if( prof.time_multiplier == 0.0f ) {
+                continue;
+            }
             if( !p->_proficiencies->has_learned( prof.id ) &&
                 prof.id->can_learn() &&
                 p->_proficiencies->has_prereqs( prof.id ) ) {
@@ -1166,7 +1170,7 @@ float Character::get_recipe_weighted_skill_average( const recipe &making ) const
                    total_skill_modifiers, get_int() / 4.f );
 
     // Missing proficiencies penalize skill level
-    for( const recipe_proficiency &recip : making.proficiencies ) {
+    for( const recipe_proficiency &recip : making.get_proficiencies() ) {
         if( !recip.required && !has_proficiency( recip.id ) ) {
             total_skill_modifiers -= recip.skill_penalty;
         }

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <initializer_list>
 #include <memory>
 #include <numeric>
 #include <optional>
@@ -108,6 +109,17 @@ time_duration recipe::time_to_craft( const Character &guy, recipe_time_flag flag
 
 int64_t recipe::time_to_craft_moves( const Character &guy, recipe_time_flag flags ) const
 {
+    if( has_steps() ) {
+        double total = 0.0;
+        for( const recipe_step &s : steps_ ) {
+            if( flags == recipe_time_flag::ignore_proficiencies ) {
+                total += s.time;
+            } else {
+                total += s.time * proficiency_time_maluses_for_step( guy, s );
+            }
+        }
+        return static_cast<int64_t>( total );
+    }
     if( flags == recipe_time_flag::ignore_proficiencies ) {
         return time;
     }
@@ -148,8 +160,18 @@ int64_t recipe::batch_time( const Character &guy, int batch, float multiplier,
         multiplier = 1.0f;
     }
 
-    const double local_time = static_cast<double>( time_to_craft_moves( guy ) ) / multiplier;
-    double total_time = batch_info.apply( local_time, batch );
+    double total_time;
+
+    if( has_steps() ) {
+        total_time = 0.0;
+        for( const recipe_step &s : steps_ ) {
+            double step_time = s.time * proficiency_time_maluses_for_step( guy, s ) / multiplier;
+            total_time += s.batch_info.apply( step_time, batch );
+        }
+    } else {
+        const double local_time = static_cast<double>( time_to_craft_moves( guy ) ) / multiplier;
+        total_time = batch_info.apply( local_time, batch );
+    }
 
     //Assistants can decrease the time for production but never less than that of one unit
     if( assistants == 1 ) {
@@ -157,8 +179,9 @@ int64_t recipe::batch_time( const Character &guy, int batch, float multiplier,
     } else if( assistants >= 2 ) {
         total_time = total_time * .60;
     }
-    if( total_time < local_time ) {
-        total_time = local_time;
+    const double single_time = static_cast<double>( time_to_craft_moves( guy ) ) / multiplier;
+    if( total_time < single_time ) {
+        total_time = single_time;
     }
 
     return static_cast<int64_t>( total_time );
@@ -246,7 +269,56 @@ void recipe::load( const JsonObject &jo, const std::string_view src )
         return;
     }
 
-    optional( jo, was_loaded, "time", time, time_duration_as_moves_reader{}, 0 );
+    // --- Recipe steps detection and schema validation ---
+    // Capture whether inherited step state exists from copy-from base,
+    // then clear so copied state cannot leak on reload/override.
+    const bool had_inherited_steps = !steps_.empty();
+    steps_.clear();
+    aggregate_proficiencies_.clear();
+
+    const bool is_step_recipe = jo.has_array( "steps" );
+
+    // Clear legacy requirement state so a reload from stepless to step-based
+    // does not silently retain old root tools/components/proficiencies.
+    if( is_step_recipe ) {
+        requirements_ = requirement_data();
+        deduped_requirements_ = deduped_requirement_data();
+        reqs_external.clear();
+        reqs_internal.clear();
+        proficiencies.clear();
+        time = 0;
+        batch_info = batch_savings();
+        exertion = 0.0f;
+    }
+
+    if( had_inherited_steps && !is_step_recipe ) {
+        jo.throw_error( "non-step recipe cannot inherit from a step recipe base" );
+    }
+
+    if( is_step_recipe ) {
+        if( abstract ) {
+            jo.throw_error( "abstract recipes cannot have steps" );
+        }
+        if( jo.has_string( "copy-from" ) ) {
+            jo.throw_error( "step recipes cannot use copy-from" );
+        }
+        for( const char *field : {
+                 "tools", "qualities", "proficiencies",
+                 "batch_time_factors", "time",
+                 "activity_level", "using"
+             } ) {
+            if( jo.has_member( field ) ) {
+                jo.throw_error( string_format(
+                                    "step recipes must not have root-level '%s'", field ) );
+            }
+        }
+    }
+
+    // --- Fields that only apply to stepless recipes ---
+    if( !is_step_recipe ) {
+        optional( jo, was_loaded, "time", time, time_duration_as_moves_reader{}, 0 );
+    }
+
     optional( jo, was_loaded, "difficulty", difficulty, numeric_bound_reader<int> {0, MAX_SKILL} );
     optional( jo, was_loaded, "flags", flags );
 
@@ -259,10 +331,12 @@ void recipe::load( const JsonObject &jo, const std::string_view src )
     optional( jo, false, "container_variant", container_variant );
     optional( jo, was_loaded, "sealed", sealed, true );
 
-    optional( jo, was_loaded, "batch_time_factors", batch_info );
-    if( batch_savings::linear *lin = std::get_if<batch_savings::linear>( &batch_info.data ) ) {
-        if( lin->offset > time ) {
-            jo.throw_error( "batch scaling time greater than recipe time" );
+    if( !is_step_recipe ) {
+        optional( jo, was_loaded, "batch_time_factors", batch_info );
+        if( batch_savings::linear *lin = std::get_if<batch_savings::linear>( &batch_info.data ) ) {
+            if( lin->offset > time ) {
+                jo.throw_error( "batch scaling time greater than recipe time" );
+            }
         }
     }
 
@@ -290,7 +364,9 @@ void recipe::load( const JsonObject &jo, const std::string_view src )
         }
     }
 
-    jo.read( "proficiencies", proficiencies );
+    if( !is_step_recipe ) {
+        jo.read( "proficiencies", proficiencies );
+    }
 
     // simplified autolearn sets requirements equal to required skills at finalization
     if( jo.has_bool( "autolearn" ) ) {
@@ -305,8 +381,10 @@ void recipe::load( const JsonObject &jo, const std::string_view src )
 
     optional( jo, was_loaded, "morale_modifier", morale_modifier, {0, 0_seconds} );
 
-    // Mandatory: This recipe's exertion level
-    mandatory( jo, was_loaded, "activity_level", exertion, activity_level_reader{} );
+    // Mandatory for stepless recipes; step recipes compute exertion during finalize
+    if( !is_step_recipe ) {
+        mandatory( jo, was_loaded, "activity_level", exertion, activity_level_reader{} );
+    }
 
     // Never let the player have a debug or NPC recipe
     optional( jo, was_loaded, "never_learn", never_learn, false );
@@ -342,7 +420,10 @@ void recipe::load( const JsonObject &jo, const std::string_view src )
         flags_to_delete = jo.get_tags<flag_id>( "delete_flags" );
     }
 
-    optional( jo, was_loaded, "using", reqs_external, weighted_string_id_reader<requirement_id, int> { 1 } );
+    if( !is_step_recipe ) {
+        optional( jo, was_loaded, "using", reqs_external,
+                  weighted_string_id_reader<requirement_id, int> { 1 } );
+    }
 
     bool inherited_tools = false;
     bool inherited_qualities = false;
@@ -489,20 +570,61 @@ void recipe::load( const JsonObject &jo, const std::string_view src )
     requirement_data::load_requirement( jo, req_id, false, abstract );
     reqs_internal.emplace_back( req_id, 1 );
 
-    if( inherited_tools && !jo.has_member( "tools" ) ) {
-        debugmsg( "Recipe %s inherits from recipe that has tools, but does not have any of its own.  "
-                  "This is probably an error.", id.str() );
+    // Parse recipe steps
+    if( is_step_recipe ) {
+        int step_index = 0;
+        for( JsonObject step_jo : jo.get_array( "steps" ) ) {
+            recipe_step step;
+            step.load( step_jo, id.str(), step_index++ );
+            steps_.emplace_back( std::move( step ) );
+        }
+        if( steps_.empty() ) {
+            jo.throw_error( "steps array must not be empty" );
+        }
     }
 
-    if( inherited_qualities && !jo.has_member( "qualities" ) ) {
-        debugmsg( "Recipe %s inherits from recipe that has qualities, but does not have any of its own.  "
-                  "This is probably an error.", id.str() );
+    if( !is_step_recipe ) {
+        if( inherited_tools && !jo.has_member( "tools" ) ) {
+            debugmsg( "Recipe %s inherits from recipe that has tools, but does not have any of its own.  "
+                      "This is probably an error.", id.str() );
+        }
+
+        if( inherited_qualities && !jo.has_member( "qualities" ) ) {
+            debugmsg( "Recipe %s inherits from recipe that has qualities, but does not have any of its own.  "
+                      "This is probably an error.", id.str() );
+        }
+
+        if( inherited_components  && !jo.has_member( "components" ) ) {
+            debugmsg( "Recipe %s inherits from recipe that has components, but does not have any of its own.  "
+                      "This is probably an error.", id.str() );
+        }
+    }
+}
+
+void recipe_step::load( const JsonObject &jo, const std::string &recipe_name, int step_index )
+{
+    jo.allow_omitted_members();
+
+    mandatory( jo, false, "name", name );
+    mandatory( jo, false, "time", time, time_duration_as_moves_reader{} );
+    if( time <= 0 ) {
+        jo.throw_error( "step time must be positive" );
+    }
+    mandatory( jo, false, "activity_level", exertion, activity_level_reader{} );
+
+    optional( jo, false, "batch_time_factors", batch_info );
+    jo.read( "proficiencies", proficiencies );
+
+    if( jo.has_member( "components" ) ) {
+        jo.throw_error( "step recipes must not have per-step components; "
+                        "use root-level components" );
     }
 
-    if( inherited_components  && !jo.has_member( "components" ) ) {
-        debugmsg( "Recipe %s inherits from recipe that has components, but does not have any of its own.  "
-                  "This is probably an error.", id.str() );
-    }
+    // Load inline tools/qualities for this step
+    const requirement_id step_req_id( "inline_recipe_" + recipe_name + "_step_"
+                                      + std::to_string( step_index ) );
+    requirement_data::load_requirement( jo, step_req_id, false, false );
+    reqs_internal.emplace_back( step_req_id, 1 );
 }
 
 static cata::value_ptr<parameterized_build_reqs> calculate_all_blueprint_reqs(
@@ -622,6 +744,41 @@ void recipe::finalize()
 
     if( !blueprint.is_empty() ) {
         incorporate_build_reqs();
+    } else if( has_steps() ) {
+        // Step recipes: merge root components + per-step tools/qualities
+        add_requirements( reqs_internal );  // root components
+        reqs_internal.clear();
+
+        for( recipe_step &step : steps_ ) {
+            // Resolve each step's inline requirements
+            step.requirements = std::accumulate(
+                                    step.reqs_internal.begin(), step.reqs_internal.end(),
+                                    step.requirements );
+            // Merge step requirements into recipe-level for whole-recipe gating
+            requirements_ = requirements_ + step.requirements;
+            step.reqs_internal.clear();
+        }
+
+        deduped_requirements_ = deduped_requirement_data( requirements_, ident() );
+
+        // Compute aggregate time
+        time = 0;
+        for( const recipe_step &step : steps_ ) {
+            time += step.time;
+        }
+
+        // Compute time-weighted average exertion
+        double weighted_exertion = 0.0;
+        for( const recipe_step &step : steps_ ) {
+            weighted_exertion += step.exertion * step.time;
+        }
+        exertion = static_cast<float>( weighted_exertion / time );
+
+        // Step recipes use per-step batch logic, not recipe-level
+        batch_info = batch_savings();
+
+        // Build aggregate proficiency view and validate
+        finalize_step_proficiencies();
     } else {
         // concatenate both external and inline requirements
         add_requirements( reqs_external );
@@ -642,6 +799,7 @@ void recipe::finalize()
 
     std::set<proficiency_id> required;
     std::set<proficiency_id> used;
+    // For step recipes, proficiencies is empty; validation done in finalize_step_proficiencies
     for( recipe_proficiency &rpof : proficiencies ) {
         if( !rpof.id.is_valid() ) {
             debugmsg( "proficiency %s does not exist in recipe %s", rpof.id.str(), id.str() );
@@ -699,6 +857,91 @@ void recipe::finalize()
 void recipe::add_requirements( const std::vector<std::pair<requirement_id, int>> &reqs )
 {
     requirements_ = std::accumulate( reqs.begin(), reqs.end(), requirements_ );
+}
+
+void recipe::finalize_step_proficiencies()
+{
+    // Validate per-step proficiencies and build aggregate view.
+    // Ordering: first-seen across steps, merged into existing slot if duplicate.
+    aggregate_proficiencies_.clear();
+
+    // Track required vs non-required state per proficiency ID
+    std::map<proficiency_id, bool> seen_required;
+
+    for( recipe_step &step : steps_ ) {
+        for( recipe_proficiency &rpof : step.proficiencies ) {
+            if( !rpof.id.is_valid() ) {
+                debugmsg( "proficiency %s does not exist in step recipe %s",
+                          rpof.id.str(), id.str() );
+                continue;
+            }
+
+            if( rpof.required && rpof.time_multiplier != 0.0f ) {
+                debugmsg( "proficiency %s in step recipe %s cannot be both "
+                          "required and provide a malus", rpof.id.str(), id.str() );
+            }
+
+            // Apply defaults, then normalize required profs
+            if( rpof.time_multiplier == 0.0f ) {
+                rpof.time_multiplier = rpof.id->default_time_multiplier();
+            }
+            if( !rpof._skill_penalty_assigned ) {
+                rpof.skill_penalty = rpof.id->default_skill_penalty();
+            }
+            if( rpof.required ) {
+                rpof.time_multiplier = 0.0f;
+                rpof.skill_penalty = 0.0f;
+            }
+
+            // Check for required/optional conflict across steps
+            auto it = seen_required.find( rpof.id );
+            if( it != seen_required.end() && it->second != rpof.required ) {
+                debugmsg( "proficiency %s is required in one step but optional "
+                          "in another in recipe %s; treating as required",
+                          rpof.id.str(), id.str() );
+                // Fallback: required wins, zero multipliers
+                rpof.required = true;
+                rpof.time_multiplier = 0.0f;
+                rpof.skill_penalty = 0.0f;
+            }
+            seen_required[rpof.id] = rpof.required;
+
+            // Merge into aggregate: first-seen order
+            bool found = false;
+            for( recipe_proficiency &existing : aggregate_proficiencies_ ) {
+                if( existing.id == rpof.id ) {
+                    // Duplicate: merge using conservative rules
+                    if( rpof.required ) {
+                        existing.required = true;
+                        existing.time_multiplier = 0.0f;
+                        existing.skill_penalty = 0.0f;
+                    } else {
+                        existing.time_multiplier = std::max( existing.time_multiplier,
+                                                             rpof.time_multiplier );
+                        existing.skill_penalty = std::max( existing.skill_penalty,
+                                                           rpof.skill_penalty );
+                        existing.learning_time_mult = std::max( existing.learning_time_mult,
+                                                                rpof.learning_time_mult );
+                        // nullopt wins (no artificial cap)
+                        if( !rpof.max_experience.has_value() ) {
+                            existing.max_experience = std::nullopt;
+                        }
+                    }
+                    found = true;
+                    break;
+                }
+            }
+            if( !found ) {
+                recipe_proficiency entry = rpof;
+                // Required profs in aggregate must have zero multipliers
+                if( entry.required ) {
+                    entry.time_multiplier = 0.0f;
+                    entry.skill_penalty = 0.0f;
+                }
+                aggregate_proficiencies_.push_back( entry );
+            }
+        }
+    }
 }
 
 std::string recipe::get_consistency_error() const
@@ -958,7 +1201,7 @@ std::string recipe::required_proficiencies_string( const Character *c ) const
 {
     std::vector<proficiency_id> required_profs;
 
-    for( const recipe_proficiency &rec : proficiencies ) {
+    for( const recipe_proficiency &rec : get_proficiencies() ) {
         if( rec.required ) {
             required_profs.push_back( rec.id );
         }
@@ -1015,7 +1258,7 @@ std::string recipe::used_proficiencies_string( const Character *c ) const
     }
     std::vector<prof_penalty> used_profs;
 
-    for( const recipe_proficiency &rec : proficiencies ) {
+    for( const recipe_proficiency &rec : get_proficiencies() ) {
         if( !rec.required ) {
             if( c->has_proficiency( rec.id ) || helpers_have_proficiencies( *c, rec.id ) )  {
                 used_profs.push_back( { rec.id, rec.time_multiplier, rec.skill_penalty} );
@@ -1037,7 +1280,7 @@ std::string recipe::recipe_proficiencies_string() const
     std::vector<proficiency_id> profs;
 
     profs.reserve( proficiencies.size() );
-    for( const recipe_proficiency &rec : proficiencies ) {
+    for( const recipe_proficiency &rec : get_proficiencies() ) {
         profs.push_back( rec.id );
     }
     std::string list = enumerate_as_string( profs.begin(),
@@ -1051,7 +1294,7 @@ std::string recipe::recipe_proficiencies_string() const
 std::vector<proficiency_id> recipe::required_proficiencies() const
 {
     std::vector<proficiency_id> ret;
-    for( const recipe_proficiency &rec : proficiencies ) {
+    for( const recipe_proficiency &rec : get_proficiencies() ) {
         if( rec.required ) {
             ret.emplace_back( rec.id );
         }
@@ -1072,7 +1315,7 @@ bool recipe::character_has_required_proficiencies( const Character &c ) const
 std::vector<proficiency_id> recipe::used_proficiencies() const
 {
     std::vector<proficiency_id> ret;
-    for( const recipe_proficiency &rec : proficiencies ) {
+    for( const recipe_proficiency &rec : get_proficiencies() ) {
         if( !rec.required ) {
             ret.emplace_back( rec.id );
         }
@@ -1108,8 +1351,22 @@ static float proficiency_time_malus( const Character &crafter, const recipe_prof
 
 float recipe::proficiency_time_maluses( const Character &crafter ) const
 {
+    if( has_steps() && time > 0 ) {
+        // For step recipes, compute as effective ratio from per-step aggregation
+        return static_cast<float>( time_to_craft_moves( crafter ) ) / static_cast<float>( time );
+    }
     float total_malus = 1.0f;
-    for( const recipe_proficiency &prof : proficiencies ) {
+    for( const recipe_proficiency &prof : get_proficiencies() ) {
+        total_malus *= proficiency_time_malus( crafter, prof );
+    }
+    return total_malus;
+}
+
+float recipe::proficiency_time_maluses_for_step(
+    const Character &crafter, const recipe_step &step )
+{
+    float total_malus = 1.0f;
+    for( const recipe_proficiency &prof : step.proficiencies ) {
         total_malus *= proficiency_time_malus( crafter, prof );
     }
     return total_malus;
@@ -1117,8 +1374,22 @@ float recipe::proficiency_time_maluses( const Character &crafter ) const
 
 float recipe::max_proficiency_time_maluses( const Character & ) const
 {
+    if( has_steps() && time > 0 ) {
+        // For step recipes, compute max malus from per-step data.
+        // Required profs (time_multiplier=0) contribute 1.0 (no penalty),
+        // not 0.0 which would drag the weighted average down.
+        double total = 0.0;
+        for( const recipe_step &s : steps_ ) {
+            float step_malus = 1.0f;
+            for( const recipe_proficiency &prof : s.proficiencies ) {
+                step_malus *= prof.time_multiplier > 0.0f ? prof.time_multiplier : 1.0f;
+            }
+            total += s.time * step_malus;
+        }
+        return static_cast<float>( total / time );
+    }
     float total_malus = 1.0f;
-    for( const recipe_proficiency &prof : proficiencies ) {
+    for( const recipe_proficiency &prof : get_proficiencies() ) {
         total_malus *= prof.time_multiplier;
     }
     return total_malus;
@@ -1144,7 +1415,7 @@ static float proficiency_skill_malus( const Character &crafter, const recipe_pro
 float recipe::proficiency_skill_maluses( const Character &crafter ) const
 {
     float total_malus = 0.f;
-    for( const recipe_proficiency &prof : proficiencies ) {
+    for( const recipe_proficiency &prof : get_proficiencies() ) {
         total_malus += proficiency_skill_malus( crafter, prof );
     }
     return total_malus;
@@ -1153,7 +1424,7 @@ float recipe::proficiency_skill_maluses( const Character &crafter ) const
 float recipe::max_proficiency_skill_maluses( const Character & ) const
 {
     float total_malus = 0.f;
-    for( const recipe_proficiency &prof : proficiencies ) {
+    for( const recipe_proficiency &prof : get_proficiencies() ) {
         total_malus += prof.skill_penalty;
     }
     return total_malus;
@@ -1168,7 +1439,7 @@ std::string recipe::missing_proficiencies_string( const Character *crafter ) con
 
     const book_proficiency_bonuses book_bonuses =
         crafter->crafting_inventory().get_book_proficiency_bonuses();
-    for( const recipe_proficiency &prof : proficiencies ) {
+    for( const recipe_proficiency &prof : get_proficiencies() ) {
         if( !prof.required ) {
             if( !( crafter->has_proficiency( prof.id ) || helpers_have_proficiencies( *crafter, prof.id ) ) ) {
                 prof_penalty pen = { prof.id,
@@ -1278,6 +1549,9 @@ std::string batch_savings::savings_string() const
 
 std::string recipe::batch_savings_string() const
 {
+    if( has_steps() ) {
+        return _( "varies by step" );
+    }
     return batch_info.savings_string();
 }
 

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -110,6 +110,20 @@ struct batch_savings {
     batch_savings() : data( none{} ) {}
 };
 
+struct recipe_step {
+    translation name;
+    int64_t time = 0;  // movement points
+    float exertion = 0.0f;
+    std::vector<recipe_proficiency> proficiencies;
+    batch_savings batch_info;
+    // Stored as requirement_id refs during load, resolved during finalize
+    std::vector<std::pair<requirement_id, int>> reqs_internal;
+    // Populated during finalize from reqs_internal
+    requirement_data requirements;
+
+    void load( const JsonObject &jo, const std::string &recipe_name, int step_index );
+};
+
 class recipe
 {
         friend class recipe_dictionary;
@@ -221,6 +235,7 @@ class recipe
         std::pair<int, time_duration> morale_modifier;
         skill_id skill_used;
         std::map<skill_id, int> required_skills;
+        // For step recipes, use get_proficiencies() instead -- this field is empty.
         std::vector<recipe_proficiency> proficiencies;
 
         std::map<skill_id, int> autolearn_requirements; // Skill levels required to autolearn
@@ -266,6 +281,24 @@ class recipe
 
         // How active of exercise this recipe is
         float exertion_level() const;
+
+        // Recipe steps support
+        bool has_steps() const {
+            return !steps_.empty();
+        }
+        const std::vector<recipe_step> &steps() const {
+            return steps_;
+        }
+        // Returns aggregate proficiencies for step recipes, or the legacy
+        // proficiencies field for stepless recipes.  This is a conservative
+        // whole-recipe approximation used for display, gating, approximate
+        // learning, and approximate failure/success math.
+        const std::vector<recipe_proficiency> &get_proficiencies() const {
+            return has_steps() ? aggregate_proficiencies_ : proficiencies;
+        }
+        // Per-step proficiency time malus (uses step's own proficiency list)
+        static float proficiency_time_maluses_for_step(
+            const Character &crafter, const recipe_step &step );
 
         // This is used by the basecamp bulletin board.
         std::string required_all_skills_string( const std::map<skill_id, int> & ) const;
@@ -340,6 +373,7 @@ class recipe
     private:
         void incorporate_build_reqs();
         void add_requirements( const std::vector<std::pair<requirement_id, int>> &reqs );
+        void finalize_step_proficiencies();
 
         recipe_id id = recipe_id::NULL_ID();
         std::vector<std::pair<recipe_id, mod_id>> src;
@@ -379,6 +413,11 @@ class recipe
 
         /** Deduped version constructed from the above requirements_ */
         deduped_requirement_data deduped_requirements_;
+
+        /** Recipe steps (empty for stepless/legacy recipes) */
+        std::vector<recipe_step> steps_;
+        /** Aggregate proficiency view for step recipes (empty for stepless) */
+        std::vector<recipe_proficiency> aggregate_proficiencies_;
 
         std::set<std::string> flags;
 

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -502,7 +502,7 @@ static void grant_skills_to_character( Character &you, const recipe &r, int offs
 
 static void grant_profs_to_character( Character &you, const recipe &r )
 {
-    for( const recipe_proficiency &rprof : r.proficiencies ) {
+    for( const recipe_proficiency &rprof : r.get_proficiencies() ) {
         you.add_proficiency( rprof.id, true );
     }
 }
@@ -748,7 +748,7 @@ static void test_fail_scenario( const std::string &scen, const recipe_id &rid, i
     REQUIRE_FALSE( player_character.has_trait( trait_DEBUG_CNF ) );
     // Ensure that they either have the profs we gave them, or no profs.
     if( has_profs ) {
-        for( const recipe_proficiency &prof : rec.proficiencies ) {
+        for( const recipe_proficiency &prof : rec.get_proficiencies() ) {
             REQUIRE( player_character.has_proficiency( prof.id ) );
         }
     } else {

--- a/tests/recipe_steps_test.cpp
+++ b/tests/recipe_steps_test.cpp
@@ -1,0 +1,827 @@
+#include <cstdint>
+#include <cstdlib>
+#include <functional>
+#include <string>
+#include <vector>
+
+#include "avatar.h"
+#include "calendar.h"
+#include "cata_catch.h"
+#include "cata_utility.h"
+#include "character.h"
+#include "coordinates.h"
+#include "debug.h"
+#include "flexbuffer_json.h"
+#include "item.h"
+#include "item_location.h"
+#include "json_loader.h"
+#include "map.h"
+#include "map_helpers.h"
+#include "player_activity.h"
+#include "player_helpers.h"
+#include "point.h"
+#include "proficiency.h"
+#include "recipe.h"
+#include "requirements.h"
+#include "translation.h"
+#include "type_id.h"
+
+static const activity_id ACT_CRAFT( "ACT_CRAFT" );
+
+static const itype_id itype_2x4( "2x4" );
+static const itype_id itype_cudgel( "cudgel" );
+static const itype_id itype_knife_hunting( "knife_hunting" );
+
+static const proficiency_id proficiency_prof_test_step_a( "prof_test_step_a" );
+static const proficiency_id proficiency_prof_test_step_b( "prof_test_step_b" );
+static const proficiency_id proficiency_prof_test_step_required( "prof_test_step_required" );
+
+static const recipe_id recipe_cudgel_test_steps_basic( "cudgel_test_steps_basic" );
+static const recipe_id recipe_cudgel_test_steps_required_prof(
+    "cudgel_test_steps_required_prof" );
+static const recipe_id recipe_cudgel_test_steps_shared_prof(
+    "cudgel_test_steps_shared_prof" );
+static const recipe_id recipe_flatbread( "flatbread" );
+
+static const skill_id skill_cooking( "cooking" );
+static const skill_id skill_fabrication( "fabrication" );
+
+static const trait_id trait_DEBUG_CNF( "DEBUG_CNF" );
+
+// ---- Data model tests ----
+
+TEST_CASE( "step_recipe_loads_correctly", "[recipe][steps]" )
+{
+    const recipe &r = recipe_cudgel_test_steps_basic.obj();
+
+    REQUIRE( r.has_steps() );
+    const std::vector<recipe_step> &steps = r.steps();
+    REQUIRE( steps.size() == 3 );
+
+    CHECK( steps[0].name.translated() == "Shape" );
+    CHECK( steps[1].name.translated() == "Sand" );
+    CHECK( steps[2].name.translated() == "Finish" );
+
+    CHECK( steps[0].time == to_moves<int64_t>( 10_minutes ) );
+    CHECK( steps[1].time == to_moves<int64_t>( 5_minutes ) );
+    CHECK( steps[2].time == to_moves<int64_t>( 5_minutes ) );
+}
+
+TEST_CASE( "step_recipe_aggregate_time", "[recipe][steps]" )
+{
+    const recipe &r = recipe_cudgel_test_steps_basic.obj();
+    clear_avatar();
+    Character &guy = get_player_character();
+    guy.set_skill_level( skill_fabrication, 10 );
+
+    const int64_t expected = to_moves<int64_t>( 20_minutes );
+    CHECK( r.time_to_craft_moves( guy, recipe_time_flag::ignore_proficiencies ) == expected );
+}
+
+TEST_CASE( "step_recipe_root_components_preserved", "[recipe][steps]" )
+{
+    const recipe &r = recipe_cudgel_test_steps_basic.obj();
+    const requirement_data &reqs = r.simple_requirements();
+
+    bool has_2x4 = false;
+    for( const std::vector<item_comp> &comp_group : reqs.get_components() ) {
+        for( const item_comp &comp : comp_group ) {
+            if( comp.type.str() == "2x4" ) {
+                has_2x4 = true;
+            }
+        }
+    }
+    CHECK( has_2x4 );
+}
+
+TEST_CASE( "step_recipe_tools_merged", "[recipe][steps]" )
+{
+    const recipe &r = recipe_cudgel_test_steps_basic.obj();
+    const requirement_data &reqs = r.simple_requirements();
+
+    bool has_cut = false;
+    for( const std::vector<quality_requirement> &qual_group : reqs.get_qualities() ) {
+        for( const quality_requirement &qual : qual_group ) {
+            if( qual.type.str() == "CUT" && qual.level >= 1 ) {
+                has_cut = true;
+            }
+        }
+    }
+    CHECK( has_cut );
+}
+
+TEST_CASE( "step_recipe_deduped_requirements_craftable", "[recipe][steps]" )
+{
+    const recipe &r = recipe_cudgel_test_steps_basic.obj();
+    const deduped_requirement_data &dreqs = r.deduped_requirements();
+
+    REQUIRE( !dreqs.alternatives().empty() );
+
+    clear_avatar();
+    clear_map();
+    Character &guy = get_player_character();
+    guy.set_skill_level( skill_fabrication, 10 );
+    guy.add_proficiency( proficiency_prof_test_step_a, true );
+    guy.add_proficiency( proficiency_prof_test_step_b, true );
+
+    guy.i_add( item( itype_2x4 ) );
+    guy.i_add( item( itype_knife_hunting ) );
+    guy.invalidate_crafting_inventory();
+
+    CHECK( guy.can_start_craft( &r, recipe_filter_flags::none, 1 ) );
+}
+
+TEST_CASE( "step_recipe_get_proficiencies", "[recipe][steps]" )
+{
+    const recipe &r = recipe_cudgel_test_steps_basic.obj();
+    const std::vector<recipe_proficiency> &profs = r.get_proficiencies();
+
+    CHECK( profs.size() == 2 );
+
+    bool has_a = false;
+    bool has_b = false;
+    for( const recipe_proficiency &p : profs ) {
+        if( p.id == proficiency_prof_test_step_a ) {
+            has_a = true;
+            CHECK( p.time_multiplier == Approx( 2.0f ) );
+            CHECK( p.skill_penalty == Approx( 0.5f ) );
+        }
+        if( p.id == proficiency_prof_test_step_b ) {
+            has_b = true;
+            CHECK( p.time_multiplier == Approx( 1.5f ) );
+            CHECK( p.skill_penalty == Approx( 0.3f ) );
+        }
+    }
+    CHECK( has_a );
+    CHECK( has_b );
+}
+
+TEST_CASE( "step_recipe_can_start_craft_requires_all_step_tools", "[recipe][steps]" )
+{
+    clear_avatar();
+    clear_map();
+    Character &guy = get_player_character();
+    guy.set_skill_level( skill_fabrication, 10 );
+    guy.add_proficiency( proficiency_prof_test_step_a, true );
+    guy.add_proficiency( proficiency_prof_test_step_b, true );
+
+    const recipe &r = recipe_cudgel_test_steps_basic.obj();
+
+    // Component present but CUT quality from Finish step is missing
+    guy.i_add( item( itype_2x4 ) );
+    guy.invalidate_crafting_inventory();
+
+    CHECK_FALSE( guy.can_start_craft( &r, recipe_filter_flags::none, 1 ) );
+}
+
+// ---- Proficiency time math ----
+
+TEST_CASE( "step_recipe_proficiency_malus_clean_miss", "[recipe][steps]" )
+{
+    clear_avatar();
+    Character &guy = get_player_character();
+    guy.set_skill_level( skill_fabrication, 10 );
+
+    const recipe &r = recipe_cudgel_test_steps_basic.obj();
+    const int64_t raw_time = to_moves<int64_t>( 20_minutes );
+
+    // Shape: 10m * 2.0, Sand: 5m * 1.0, Finish: 5m * 1.5 => 32.5m total
+    const int64_t with_malus = r.time_to_craft_moves( guy );
+    const double expected = 10.0 * to_moves<int64_t>( 1_minutes ) * 2.0 +
+                            5.0 * to_moves<int64_t>( 1_minutes ) * 1.0 +
+                            5.0 * to_moves<int64_t>( 1_minutes ) * 1.5;
+    CHECK( with_malus == static_cast<int64_t>( expected ) );
+    CHECK( with_malus > raw_time );
+    CHECK( with_malus < raw_time * 2 );
+}
+
+TEST_CASE( "step_recipe_proficiency_grant_removes_step_penalty", "[recipe][steps]" )
+{
+    clear_avatar();
+    Character &guy = get_player_character();
+    guy.set_skill_level( skill_fabrication, 10 );
+
+    const recipe &r = recipe_cudgel_test_steps_basic.obj();
+
+    const int64_t full_malus_time = r.time_to_craft_moves( guy );
+
+    guy.add_proficiency( proficiency_prof_test_step_a, true );
+    const int64_t no_a_malus_time = r.time_to_craft_moves( guy );
+
+    CHECK( full_malus_time > no_a_malus_time );
+
+    // Difference is exactly the Shape step penalty: 10m * (2.0 - 1.0)
+    const int64_t diff = full_malus_time - no_a_malus_time;
+    CHECK( diff == to_moves<int64_t>( 10_minutes ) );
+}
+
+TEST_CASE( "step_recipe_partial_proficiency_sigmoid_mitigation", "[recipe][steps]" )
+{
+    clear_avatar();
+    Character &guy = get_player_character();
+    guy.set_skill_level( skill_fabrication, 10 );
+
+    const recipe &r = recipe_cudgel_test_steps_basic.obj();
+
+    const int64_t full_malus = r.time_to_craft_moves( guy );
+
+    guy.add_proficiency( proficiency_prof_test_step_a, true );
+    const int64_t no_malus = r.time_to_craft_moves( guy );
+
+    // Train to ~75%, well past the sigmoid midpoint
+    guy.lose_proficiency( proficiency_prof_test_step_a, true );
+    const time_duration three_quarter = proficiency_prof_test_step_a->time_to_learn() * 3 / 4;
+    guy.practice_proficiency( proficiency_prof_test_step_a, three_quarter );
+    REQUIRE( !guy.has_proficiency( proficiency_prof_test_step_a ) );
+    const int64_t partial_malus = r.time_to_craft_moves( guy );
+
+    CHECK( partial_malus < full_malus );
+    CHECK( partial_malus > no_malus );
+    // At 75% the sigmoid should have mitigated most of the penalty
+    CHECK( partial_malus < ( full_malus + no_malus ) / 2 );
+}
+
+TEST_CASE( "step_recipe_same_prof_in_two_steps", "[recipe][steps]" )
+{
+    const recipe &r = recipe_cudgel_test_steps_shared_prof.obj();
+
+    REQUIRE( r.has_steps() );
+    REQUIRE( r.steps().size() == 2 );
+
+    // Aggregate should deduplicate to one entry with max time_multiplier
+    const std::vector<recipe_proficiency> &profs = r.get_proficiencies();
+    CHECK( profs.size() == 1 );
+    CHECK( profs[0].id == proficiency_prof_test_step_a );
+    CHECK( profs[0].time_multiplier == Approx( 2.0f ) );
+
+    // Both steps penalized independently: 10m * 2.0 + 10m * 2.0 = 40m
+    clear_avatar();
+    Character &guy = get_player_character();
+    guy.set_skill_level( skill_fabrication, 10 );
+
+    const int64_t with_malus = r.time_to_craft_moves( guy );
+    const double expected = 20.0 * to_moves<int64_t>( 1_minutes ) * 2.0;
+    CHECK( with_malus == static_cast<int64_t>( expected ) );
+}
+
+// ---- Proficiency display ----
+
+TEST_CASE( "step_recipe_missing_proficiencies_string", "[recipe][steps]" )
+{
+    clear_avatar();
+    Character &guy = get_player_character();
+    guy.set_skill_level( skill_fabrication, 10 );
+
+    const recipe &r = recipe_cudgel_test_steps_basic.obj();
+    const std::string missing = r.missing_proficiencies_string( &guy );
+
+    CHECK( missing.find( "Test Step Proficiency A" ) != std::string::npos );
+    CHECK( missing.find( "Test Step Proficiency B" ) != std::string::npos );
+    CHECK( missing.find( "time" ) != std::string::npos );
+}
+
+TEST_CASE( "step_recipe_display_malus_is_step_derived", "[recipe][steps]" )
+{
+    clear_avatar();
+    Character &guy = get_player_character();
+    guy.set_skill_level( skill_fabrication, 10 );
+
+    const recipe &r = recipe_cudgel_test_steps_basic.obj();
+
+    const float display_malus = r.proficiency_time_maluses( guy );
+    const int64_t raw_time = to_moves<int64_t>( 20_minutes );
+    const int64_t actual_time = r.time_to_craft_moves( guy );
+
+    // Display ratio should match actual_time / raw_time
+    CHECK( display_malus == Approx( static_cast<float>( actual_time ) /
+                                    static_cast<float>( raw_time ) ).margin( 0.01f ) );
+
+    // Should NOT be the raw product of aggregate profs (2.0 * 1.5 = 3.0)
+    CHECK( display_malus < 3.0f );
+}
+
+// ---- Batch ----
+
+TEST_CASE( "step_recipe_per_step_batch_savings", "[recipe][steps]" )
+{
+    clear_avatar();
+    Character &guy = get_player_character();
+    guy.set_skill_level( skill_fabrication, 10 );
+    guy.add_proficiency( proficiency_prof_test_step_a, true );
+    guy.add_proficiency( proficiency_prof_test_step_b, true );
+
+    const recipe &r = recipe_cudgel_test_steps_basic.obj();
+    const int batch = 4;
+
+    const int64_t batch4_time = r.batch_time( guy, batch, 1.0f, 0 );
+    const int64_t single_time = r.batch_time( guy, 1, 1.0f, 0 );
+
+    CHECK( batch4_time < single_time * 4 );
+    CHECK( batch4_time > single_time );
+
+    // Verify against manual per-step calculation
+    double manual_batch = 0.0;
+    for( const recipe_step &s : r.steps() ) {
+        manual_batch += s.batch_info.apply( static_cast<double>( s.time ), batch );
+    }
+    CHECK( batch4_time == static_cast<int64_t>( manual_batch ) );
+}
+
+// ---- Backwards compatibility ----
+
+TEST_CASE( "stepless_recipe_unchanged", "[recipe][steps]" )
+{
+    const recipe &r = recipe_flatbread.obj();
+
+    CHECK_FALSE( r.has_steps() );
+
+    clear_avatar();
+    Character &guy = get_player_character();
+    guy.set_skill_level( skill_cooking, 10 );
+
+    CHECK( r.time_to_craft_moves( guy, recipe_time_flag::ignore_proficiencies ) ==
+           to_moves<int64_t>( 15_minutes ) );
+    CHECK_FALSE( r.simple_requirements().get_components().empty() );
+    CHECK_FALSE( r.get_proficiencies().empty() );
+}
+
+// ---- Schema rejection (load-time throws) ----
+
+static void check_step_recipe_throws( const std::string &json )
+{
+    JsonObject jo = json_loader::from_string( json );
+    jo.allow_omitted_members();
+    recipe r;
+    CHECK_THROWS_AS( r.load( jo, "dda" ), JsonError );
+}
+
+TEST_CASE( "step_recipe_schema_rejection", "[recipe][steps]" )
+{
+    // Verify a well-formed step recipe loads without throwing
+    const std::string base = R"({
+        "type": "recipe",
+        "result": "cudgel",
+        "id_suffix": "test_schema",
+        "category": "CC_WEAPON",
+        "subcategory": "CSC_WEAPON_BASHING",
+        "skill_used": "fabrication",
+        "difficulty": 1,
+        "components": [[ [ "2x4", 1 ] ]],
+        "steps": [
+            { "name": "Work", "time": "10 m", "activity_level": "MODERATE_EXERCISE" }
+        ]
+    })";
+    {
+        JsonObject jo = json_loader::from_string( base );
+        recipe r;
+        CHECK_NOTHROW( r.load( jo, "dda" ) );
+    }
+
+    SECTION( "empty steps array" ) {
+        check_step_recipe_throws( R"({
+            "type": "recipe", "result": "cudgel", "id_suffix": "test_empty",
+            "category": "CC_WEAPON", "subcategory": "CSC_WEAPON_BASHING",
+            "skill_used": "fabrication", "difficulty": 1,
+            "components": [[ [ "2x4", 1 ] ]],
+            "steps": []
+        })" );
+    }
+
+    SECTION( "zero-time step" ) {
+        check_step_recipe_throws( R"({
+            "type": "recipe", "result": "cudgel", "id_suffix": "test_zero",
+            "category": "CC_WEAPON", "subcategory": "CSC_WEAPON_BASHING",
+            "skill_used": "fabrication", "difficulty": 1,
+            "components": [[ [ "2x4", 1 ] ]],
+            "steps": [
+                { "name": "Bad", "time": "0 m", "activity_level": "NO_EXERCISE" }
+            ]
+        })" );
+    }
+
+    SECTION( "step with components" ) {
+        check_step_recipe_throws( R"({
+            "type": "recipe", "result": "cudgel", "id_suffix": "test_comp",
+            "category": "CC_WEAPON", "subcategory": "CSC_WEAPON_BASHING",
+            "skill_used": "fabrication", "difficulty": 1,
+            "components": [[ [ "2x4", 1 ] ]],
+            "steps": [
+                { "name": "Bad", "time": "5 m", "activity_level": "NO_EXERCISE",
+                  "components": [[ [ "2x4", 1 ] ]] }
+            ]
+        })" );
+    }
+
+    SECTION( "root-level tools" ) {
+        check_step_recipe_throws( R"({
+            "type": "recipe", "result": "cudgel", "id_suffix": "test_tools",
+            "category": "CC_WEAPON", "subcategory": "CSC_WEAPON_BASHING",
+            "skill_used": "fabrication", "difficulty": 1,
+            "components": [[ [ "2x4", 1 ] ]],
+            "tools": [[ [ "hammer", -1 ] ]],
+            "steps": [
+                { "name": "Work", "time": "5 m", "activity_level": "NO_EXERCISE" }
+            ]
+        })" );
+    }
+
+    SECTION( "root-level proficiencies" ) {
+        check_step_recipe_throws( R"({
+            "type": "recipe", "result": "cudgel", "id_suffix": "test_prof",
+            "category": "CC_WEAPON", "subcategory": "CSC_WEAPON_BASHING",
+            "skill_used": "fabrication", "difficulty": 1,
+            "components": [[ [ "2x4", 1 ] ]],
+            "proficiencies": [ { "proficiency": "prof_test" } ],
+            "steps": [
+                { "name": "Work", "time": "5 m", "activity_level": "NO_EXERCISE" }
+            ]
+        })" );
+    }
+
+    SECTION( "root-level time" ) {
+        check_step_recipe_throws( R"({
+            "type": "recipe", "result": "cudgel", "id_suffix": "test_time",
+            "category": "CC_WEAPON", "subcategory": "CSC_WEAPON_BASHING",
+            "skill_used": "fabrication", "difficulty": 1,
+            "time": "10 m",
+            "components": [[ [ "2x4", 1 ] ]],
+            "steps": [
+                { "name": "Work", "time": "5 m", "activity_level": "NO_EXERCISE" }
+            ]
+        })" );
+    }
+
+    SECTION( "root-level batch_time_factors" ) {
+        check_step_recipe_throws( R"({
+            "type": "recipe", "result": "cudgel", "id_suffix": "test_batch",
+            "category": "CC_WEAPON", "subcategory": "CSC_WEAPON_BASHING",
+            "skill_used": "fabrication", "difficulty": 1,
+            "batch_time_factors": [ 50, 4 ],
+            "components": [[ [ "2x4", 1 ] ]],
+            "steps": [
+                { "name": "Work", "time": "5 m", "activity_level": "NO_EXERCISE" }
+            ]
+        })" );
+    }
+
+    SECTION( "root-level activity_level" ) {
+        check_step_recipe_throws( R"({
+            "type": "recipe", "result": "cudgel", "id_suffix": "test_exertion",
+            "category": "CC_WEAPON", "subcategory": "CSC_WEAPON_BASHING",
+            "skill_used": "fabrication", "difficulty": 1,
+            "activity_level": "MODERATE_EXERCISE",
+            "components": [[ [ "2x4", 1 ] ]],
+            "steps": [
+                { "name": "Work", "time": "5 m", "activity_level": "NO_EXERCISE" }
+            ]
+        })" );
+    }
+
+    SECTION( "root-level using" ) {
+        check_step_recipe_throws( R"({
+            "type": "recipe", "result": "cudgel", "id_suffix": "test_using",
+            "category": "CC_WEAPON", "subcategory": "CSC_WEAPON_BASHING",
+            "skill_used": "fabrication", "difficulty": 1,
+            "using": [ [ "sewing_standard", 1 ] ],
+            "components": [[ [ "2x4", 1 ] ]],
+            "steps": [
+                { "name": "Work", "time": "5 m", "activity_level": "NO_EXERCISE" }
+            ]
+        })" );
+    }
+
+    SECTION( "abstract step recipe" ) {
+        check_step_recipe_throws( R"({
+            "abstract": "test_abstract_step",
+            "type": "recipe",
+            "steps": [
+                { "name": "Work", "time": "5 m", "activity_level": "NO_EXERCISE" }
+            ]
+        })" );
+    }
+
+    SECTION( "copy-from on step recipe" ) {
+        check_step_recipe_throws( R"({
+            "type": "recipe",
+            "result": "cudgel",
+            "id_suffix": "test_copyfrom",
+            "copy-from": "cudgel",
+            "category": "CC_WEAPON",
+            "subcategory": "CSC_WEAPON_BASHING",
+            "skill_used": "fabrication",
+            "difficulty": 1,
+            "components": [[ [ "2x4", 1 ] ]],
+            "steps": [
+                { "name": "Work", "time": "5 m", "activity_level": "NO_EXERCISE" }
+            ]
+        })" );
+    }
+}
+
+// ---- End-to-end craft ----
+
+static void setup_step_craft( const recipe_id &rid )
+{
+    clear_avatar();
+    clear_map();
+    map &here = get_map();
+    avatar &guy = get_avatar();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    guy.setpos( here, origin );
+    guy.toggle_trait( trait_DEBUG_CNF );
+
+    const recipe &r = rid.obj();
+    guy.set_skill_level( r.skill_used, r.difficulty + 1 );
+    for( const recipe_proficiency &p : r.get_proficiencies() ) {
+        guy.add_proficiency( p.id, true );
+    }
+
+    for( const std::vector<item_comp> &comp_group : r.simple_requirements().get_components() ) {
+        if( !comp_group.empty() ) {
+            here.add_item( origin, item( comp_group.front().type, calendar::turn,
+                                         comp_group.front().count ) );
+        }
+    }
+    for( const std::vector<quality_requirement> &qual_group :
+         r.simple_requirements().get_qualities() ) {
+        for( const quality_requirement &qual : qual_group ) {
+            if( qual.type.str() == "CUT" ) {
+                here.add_item( origin, item( itype_knife_hunting ) );
+            }
+        }
+    }
+    guy.invalidate_crafting_inventory();
+    guy.learn_recipe( &r );
+
+    set_time( calendar::turn_zero + 12_hours );
+    guy.remove_weapon();
+    guy.make_craft( rid, 1 );
+    REQUIRE( guy.activity );
+    REQUIRE( guy.activity.id() == ACT_CRAFT );
+}
+
+static int run_craft_to_completion( avatar &guy )
+{
+    int turns = 0;
+    while( guy.activity.id() == ACT_CRAFT ) {
+        ++turns;
+        guy.set_moves( 100 );
+        guy.activity.do_turn( guy );
+        if( turns % 60 == 0 ) {
+            guy.update_mental_focus();
+        }
+        if( turns > 100000 ) {
+            FAIL( "craft did not complete within 100000 turns" );
+            break;
+        }
+    }
+    return turns;
+}
+
+TEST_CASE( "step_recipe_end_to_end_craft", "[recipe][steps][crafting]" )
+{
+    setup_step_craft( recipe_cudgel_test_steps_basic );
+    avatar &guy = get_avatar();
+    const recipe &r = recipe_cudgel_test_steps_basic.obj();
+
+    const int expected_moves = r.batch_time( guy, 1, 1.0f, 0 );
+    const int expected_turns = divide_round_up( expected_moves, 100 );
+    REQUIRE( expected_turns > 2 );
+
+    const int actual_turns = run_craft_to_completion( guy );
+
+    CHECK( std::abs( actual_turns - expected_turns ) <= 1 );
+
+    bool has_cudgel = false;
+    for( const item *it : guy.inv_dump() ) {
+        if( it->typeId() == itype_cudgel ) {
+            has_cudgel = true;
+        }
+    }
+    if( !has_cudgel && guy.get_wielded_item() &&
+        guy.get_wielded_item()->typeId() == itype_cudgel ) {
+        has_cudgel = true;
+    }
+    CHECK( has_cudgel );
+}
+
+TEST_CASE( "step_recipe_interrupt_and_resume", "[recipe][steps][crafting]" )
+{
+    setup_step_craft( recipe_cudgel_test_steps_basic );
+    avatar &guy = get_avatar();
+    const recipe &r = recipe_cudgel_test_steps_basic.obj();
+
+    const int expected_moves = r.batch_time( guy, 1, 1.0f, 0 );
+    const int expected_turns = divide_round_up( expected_moves, 100 );
+    REQUIRE( expected_turns > 10 );
+
+    int first_turns = 0;
+    while( guy.activity.id() == ACT_CRAFT && first_turns < 5 ) {
+        ++first_turns;
+        guy.set_moves( 100 );
+        guy.activity.do_turn( guy );
+    }
+    REQUIRE( first_turns == 5 );
+
+    // Kill light to force interrupt
+    set_time( calendar::turn_zero + 0_hours );
+    guy.set_moves( 100 );
+    guy.activity.do_turn( guy );
+    const bool craft_stopped = !guy.activity || guy.activity.id() != ACT_CRAFT;
+    REQUIRE( craft_stopped );
+
+    // Find in-progress craft and resume
+    std::vector<item *> crafts = guy.items_with( []( const item & itm ) {
+        return itm.is_craft();
+    } );
+    REQUIRE( crafts.size() == 1 );
+    item *craft = crafts.front();
+
+    set_time( calendar::turn_zero + 12_hours );
+    REQUIRE( !guy.activity );
+    guy.use( guy.get_item_position( craft ) );
+    REQUIRE( guy.activity );
+    REQUIRE( guy.activity.id() == ACT_CRAFT );
+
+    const int resume_turns = run_craft_to_completion( guy );
+
+    const int total_turns = first_turns + resume_turns;
+    CHECK( std::abs( total_turns - expected_turns ) <= 1 );
+}
+
+// ---- XP distribution (documents phase-1 approximate behavior) ----
+
+TEST_CASE( "step_recipe_xp_distribution", "[recipe][steps][crafting]" )
+{
+    setup_step_craft( recipe_cudgel_test_steps_basic );
+    avatar &guy = get_avatar();
+
+    guy.lose_proficiency( proficiency_prof_test_step_a, true );
+    guy.lose_proficiency( proficiency_prof_test_step_b, true );
+    REQUIRE( !guy.has_proficiency( proficiency_prof_test_step_a ) );
+    REQUIRE( !guy.has_proficiency( proficiency_prof_test_step_b ) );
+
+    // Restart craft without profs, re-supplying consumed components
+    guy.cancel_activity();
+    guy.remove_weapon();
+    const recipe &r = recipe_cudgel_test_steps_basic.obj();
+    map &here = get_map();
+    for( const std::vector<item_comp> &comp_group : r.simple_requirements().get_components() ) {
+        if( !comp_group.empty() ) {
+            here.add_item( guy.pos_bub(), item( comp_group.front().type, calendar::turn,
+                                                comp_group.front().count ) );
+        }
+    }
+    guy.invalidate_crafting_inventory();
+    guy.set_focus( 100 );
+    guy.make_craft( recipe_cudgel_test_steps_basic, 1 );
+    REQUIRE( guy.activity );
+    REQUIRE( guy.activity.id() == ACT_CRAFT );
+
+    run_craft_to_completion( guy );
+
+    // Both step proficiencies should have received non-zero practice.
+    // Phase 1 distributes XP across all aggregate profs uniformly.
+    CHECK( guy.get_proficiency_practice( proficiency_prof_test_step_a ) > 0.0f );
+    CHECK( guy.get_proficiency_practice( proficiency_prof_test_step_b ) > 0.0f );
+}
+
+// ---- Edge case: inherited steps on non-step child ----
+
+TEST_CASE( "step_recipe_inherited_steps_rejected", "[recipe][steps]" )
+{
+    // Load a step recipe to populate steps_, then load non-step JSON onto the
+    // same object. This simulates a non-step child that copy-from'd a step base.
+    recipe r;
+    REQUIRE( r.steps().empty() );
+    {
+        const std::string step_json = R"({
+            "type": "recipe",
+            "result": "cudgel",
+            "id_suffix": "test_inherit_base",
+            "category": "CC_WEAPON",
+            "subcategory": "CSC_WEAPON_BASHING",
+            "skill_used": "fabrication",
+            "difficulty": 1,
+            "components": [[ [ "2x4", 1 ] ]],
+            "steps": [
+                { "name": "Work", "time": "10 m", "activity_level": "MODERATE_EXERCISE" }
+            ]
+        })";
+        JsonObject jo = json_loader::from_string( step_json );
+        jo.allow_omitted_members();
+        r.load( jo, "dda" );
+    }
+    REQUIRE( r.has_steps() );
+
+    const std::string child_json = R"({
+        "type": "recipe",
+        "result": "cudgel",
+        "id_suffix": "test_inherit_child",
+        "category": "CC_WEAPON",
+        "subcategory": "CSC_WEAPON_BASHING",
+        "skill_used": "fabrication",
+        "difficulty": 1,
+        "time": "10 m",
+        "activity_level": "MODERATE_EXERCISE",
+        "components": [[ [ "2x4", 1 ] ]]
+    })";
+    JsonObject jo2 = json_loader::from_string( child_json );
+    jo2.allow_omitted_members();
+    CHECK_THROWS_AS( r.load( jo2, "dda" ), JsonError );
+}
+
+// ---- Edge case: required/optional proficiency conflict across steps ----
+
+TEST_CASE( "step_recipe_required_optional_prof_conflict", "[recipe][steps]" )
+{
+    const std::string json = R"({
+        "type": "recipe",
+        "result": "cudgel",
+        "id_suffix": "test_prof_conflict",
+        "category": "CC_WEAPON",
+        "subcategory": "CSC_WEAPON_BASHING",
+        "skill_used": "fabrication",
+        "difficulty": 1,
+        "components": [[ [ "2x4", 1 ] ]],
+        "steps": [
+            {
+                "name": "Step A",
+                "time": "5 m",
+                "activity_level": "MODERATE_EXERCISE",
+                "proficiencies": [ { "proficiency": "prof_test_step_required", "required": true } ]
+            },
+            {
+                "name": "Step B",
+                "time": "5 m",
+                "activity_level": "LIGHT_EXERCISE",
+                "proficiencies": [ { "proficiency": "prof_test_step_required" } ]
+            }
+        ]
+    })";
+
+    JsonObject jo = json_loader::from_string( json );
+    jo.allow_omitted_members();
+    recipe r;
+    r.load( jo, "dda" );
+
+    const std::string dmsg = capture_debugmsg_during( [&]() {
+        r.finalize();
+    } );
+    CHECK( dmsg.find( "required in one step but optional" ) != std::string::npos );
+
+    // Fallback: required wins, multipliers zeroed
+    const std::vector<recipe_proficiency> &profs = r.get_proficiencies();
+    REQUIRE( profs.size() == 1 );
+    CHECK( profs[0].id == proficiency_prof_test_step_required );
+    CHECK( profs[0].required == true );
+    CHECK( profs[0].time_multiplier == 0.0f );
+    CHECK( profs[0].skill_penalty == 0.0f );
+}
+
+// ---- Edge case: required prof zero-divisor guard in craft_proficiency_gain ----
+
+TEST_CASE( "step_recipe_required_prof_no_crash_in_learning", "[recipe][steps][crafting]" )
+{
+    // This recipe has a required prof (zero time_multiplier in aggregate) and
+    // an optional prof. Without the guard in craft_proficiency_gain, the
+    // required prof would cause division by zero during learning.
+    const recipe &r = recipe_cudgel_test_steps_required_prof.obj();
+
+    bool has_zero_mult = false;
+    for( const recipe_proficiency &p : r.get_proficiencies() ) {
+        if( p.required && p.time_multiplier == 0.0f ) {
+            has_zero_mult = true;
+        }
+    }
+    REQUIRE( has_zero_mult );
+
+    clear_avatar();
+    clear_map();
+    map &here = get_map();
+    avatar &guy = get_avatar();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    guy.setpos( here, origin );
+    guy.toggle_trait( trait_DEBUG_CNF );
+    guy.set_skill_level( skill_fabrication, 10 );
+    // Grant required prof (gating), but NOT the optional one (will be learned)
+    guy.add_proficiency( proficiency_prof_test_step_required, true );
+    REQUIRE( !guy.has_proficiency( proficiency_prof_test_step_a ) );
+
+    here.add_item( origin, item( itype_2x4 ) );
+    guy.invalidate_crafting_inventory();
+    guy.learn_recipe( &r );
+
+    set_time( calendar::turn_zero + 12_hours );
+    guy.remove_weapon();
+    guy.set_focus( 100 );
+    guy.make_craft( recipe_cudgel_test_steps_required_prof, 1 );
+    REQUIRE( guy.activity );
+    REQUIRE( guy.activity.id() == ACT_CRAFT );
+
+    // Without the zero-divisor guard this crashes with SIGFPE
+    const int turns = run_craft_to_completion( guy );
+    CHECK( turns > 0 );
+
+    CHECK( guy.get_proficiency_practice( proficiency_prof_test_step_a ) > 0.0f );
+}

--- a/tests/vehicle_part_test.cpp
+++ b/tests/vehicle_part_test.cpp
@@ -144,7 +144,7 @@ static void test_craft_via_rig( const std::vector<item> &items, int give_battery
     for( const std::pair<const skill_id, int> &req : recipe.required_skills ) {
         character.set_skill_level( req.first, req.second + 1 );
     }
-    for( const recipe_proficiency &prof : recipe.proficiencies ) {
+    for( const recipe_proficiency &prof : recipe.get_proficiencies() ) {
         character.add_proficiency( prof.id );
     }
     character.learn_recipe( &recipe );


### PR DESCRIPTION
#### Summary
Features "Add steps to bread recipe"

#### Purpose of change

Noticed bread recipe lacks steps. It's a 20-minute monolithic blob where you apparently mix, rise, and bake simultaneously. Figured I'd fix that.

Alright, just kidding, this adds recipe steps infrastructure (#49525, #74677, #45157). Recipes can now define per-step time, tools, proficiencies, batch scaling, and activity level. Bread is the proof-of-concept conversion.

#### Describe the solution

What this does and doesn't do:

- Single progress bar, whole-recipe tool/component gating
- Time-weighted-average exertion
- Correct aggregate time math with per-step proficiency maluses and per-step batch savings
- Approximate XP distribution across step proficiencies (not step-targeted)
- Aggregate proficiency vector for display, gating, learning, and failure/success math (max penalty per unique prof ID, duplicates across steps collapse)
- No step-specific failure segmentation
- Tool gating is all-upfront (same items needed regardless), components consumed at start (unchanged), proficiency learning uniform across aggregate (can segment later), exertion is time-weighted average, batch display says "varies by step" (calculation is correct, detailed display later)

`recipe_step` struct holds per-step time, exertion, proficiencies, batch_time_factors, and inline tool/quality requirements. During `finalize()`, step requirements merge into `requirements_` for whole-recipe deduplication (dedup needs cross-step lookahead to resolve shared tools). `time_to_craft_moves()` and `batch_time()` accumulate per-step. All consumers of `recipe::proficiencies` updated to `get_proficiencies()`.

Step recipes ban root-level time, tools, qualities, proficiencies, batch_time_factors, activity_level, using. Components stay at root. copy-from and abstract banned for step recipes for now.

Also fixes required proficiencies generating XP in `craft_proficiency_gain` -- they gate access, shouldn't produce learning.

#### Describe alternatives you've considered

- Blanket tool speed multiplier on quality -- inaccurate, fast cutter shouldn't speed up sewing
- Duplicate recipes per tool combination -- combinatorial explosion
- Recursive recipes (#81236) -- rejected due to evaluation cost of unbounded recursion across the recipe set
- Not adding steps -- but then I can't have a sewing machine, and I want a sewing machine. Everyone wants a sewing machine.

#### Testing

Loaded. Cooked. Ate. Yummy.


https://github.com/user-attachments/assets/86aa9f6f-fa4e-447a-b72b-5ff1c50a7a78



But also: 30 new tests in `tests/recipe_steps_test.cpp`
- Data model (7): step loading, aggregate time, root components, merged tools, deduped requirements, aggregate proficiencies, tool gating.
- Proficiency math (4): clean miss, grant removes penalty, sigmoid mitigation, shared prof across steps.
- Display (2): missing proficiencies string, display malus derived from step computation.
- Batch (1): per-step savings match manual calc.
- Backwards compat (1): stepless recipe unchanged.
- Schema rejection (12): empty steps, zero-time, step components, root tools/prof/time/batch/activity/using, copy-from, abstract, inherited steps.
- Finalize validation (1): required/optional conflict.
- End-to-end (2): correct completion time, interrupt+resume.
- Learning (1): all step profs get non-zero practice.

Existing [recipe] and [crafting] suites pass.

#### Additional context

Things this unblocks down the road: per-step execution with step progress tracking, tool speed modifiers applied to relevant steps only (sewing machines, power tools), passive/idle steps where you can do other things while dough rises, per-step component consumption.

Related: #49525, #74677, #45157