### PR TITLE
Wire up NPC behavior tree as debug diagnostic

### DIFF
--- a/src/character_oracle.cpp
+++ b/src/character_oracle.cpp
@@ -87,8 +87,7 @@ status_t character_oracle_t::can_make_fire( std::string_view ) const
 
 status_t character_oracle_t::can_take_shelter( std::string_view ) const
 {
-    // There be no shelter here.
-    // The frontline is everywhere.
+    // Stub: shelter detection not implemented yet. See #28681.
     return status_t::failure;
 }
 

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -259,6 +259,7 @@ std::string filter_name( debug_filter value )
         case DF_NPC_COMBATAI: return "DF_NPC_COMBATAI";
         case DF_NPC_ITEMAI: return "DF_NPC_ITEMAI";
         case DF_NPC_MOVEAI: return "DF_NPC_MOVEAI";
+        case DF_NPC_NEEDS: return "DF_NPC_NEEDS";
         case DF_OVERMAP: return "DF_OVERMAP";
         case DF_RADIO: return "DF_RADIO";
         case DF_RANGED: return "DF_RANGED";

--- a/src/debug.h
+++ b/src/debug.h
@@ -279,6 +279,7 @@ enum debug_filter : int {
     DF_NPC_COMBATAI, // npc combat and danger assessment logic
     DF_NPC_ITEMAI, // npc weapon/item logic - weapon choices, decision to reload, etc.
     DF_NPC_MOVEAI, // Pathfinding and movement logic.  For the NPC with places to be.
+    DF_NPC_NEEDS, // NPC behavior tree needs evaluation (npc_behavior.json)
     DF_OVERMAP, // overmap generic
     DF_RADIO, // radio stuff
     DF_RANGED, // ranged generic

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1918,6 +1918,9 @@ int npc::assigned_missions_value() const
     return ret;
 }
 
+// Legacy need ranking. Scores each need 0-20, sorts by urgency.
+// The behavior tree (npc_behavior.json + character_oracle.cpp)
+// is the intended replacement for survival needs. See #28681.
 void npc::decide_needs()
 {
     const item_location weapon = get_wielded_item();

--- a/src/npc.h
+++ b/src/npc.h
@@ -193,6 +193,9 @@ std::string npc_class_name_str( const npc_class_id & );
 
 enum npc_action : int;
 
+// Legacy need ranking used by decide_needs() and set_omt_destination().
+// The behavior tree (npc_behavior.json) is the intended replacement
+// for immediate survival needs (warmth, food, water). See #28681.
 enum npc_need {
     need_none,
     need_ammo, need_weapon, need_gun,

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -17,6 +17,7 @@
 #include <string>
 #include <tuple>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -24,6 +25,7 @@
 #include "activity_actor_definitions.h"
 #include "avatar.h"
 #include "basecamp.h"
+#include "behavior.h"
 #include "bionics.h"
 #include "body_part_set.h"
 #include "bodypart.h"
@@ -32,6 +34,7 @@
 #include "character.h"
 #include "character_attire.h"
 #include "character_id.h"
+#include "character_oracle.h"
 #include "clzones.h"
 #include "coordinates.h"
 #include "creature.h"
@@ -188,6 +191,8 @@ static const npc_class_id NC_EVAC_SHOPKEEP( "NC_EVAC_SHOPKEEP" );
 
 static const skill_id skill_firstaid( "firstaid" );
 
+static const string_id<behavior::node_t> behavior_node_t_npc_needs( "npc_needs" );
+
 static const trait_id trait_IGNORE_SOUND( "IGNORE_SOUND" );
 static const trait_id trait_RETURN_TO_START_POS( "RETURN_TO_START_POS" );
 
@@ -196,6 +201,9 @@ static const zone_type_id zone_type_NPC_RETREAT( "NPC_RETREAT" );
 
 static constexpr float MAX_FLOAT = 5000000000.0f;
 
+// Legacy thresholds for NPC food consumption and complaints.
+// The behavior tree in npc_behavior.json uses different thresholds
+// via character_oracle predicates (see character_oracle.cpp).
 // TODO: These would be much better using common code or constants from character.cpp,
 // which handles the player formatting of thirst/hunger levels. Right now we
 // have magic numbers all over the place. ;(
@@ -1407,6 +1415,15 @@ void npc::move()
     }
     add_msg_debug( debugmode::DF_NPC, "NPC %s: target = %s, danger = %.1f, range = %d",
                    get_name(), target_name, ai_cache.danger, *confident_range_cache );
+
+    if( debug_mode && debugmode::enabled_filters.count( debugmode::DF_NPC_NEEDS ) ) {
+        behavior::character_oracle_t oracle( this );
+        behavior::tree needs;
+        needs.add( &behavior_node_t_npc_needs.obj() );
+        const std::string bt_goal = needs.tick( &oracle );
+        add_msg_debug( debugmode::DF_NPC_NEEDS,
+                       "NPC %s: BT needs goal = %s", get_name(), bt_goal );
+    }
 
     Character &player_character = get_player_character();
     //faction opinion determines if it should consider you hostile
@@ -4732,7 +4749,7 @@ bool npc::consume_food()
 
     if( inv_food.empty() ) {
         if( !needs_food() ) {
-            // TODO: Remove this and let player "exploit" hungry NPCs
+            // When NO_NPC_FOOD is active and NPC has no food, silently reset hunger/thirst
             set_hunger( 0 );
             set_thirst( 0 );
         }
@@ -5405,7 +5422,7 @@ bool npc::complain()
     }
 
     // Hunger every 3-6 hours
-    // Since NPCs can't starve to death, respect the rules
+    // Complaint frequency scales with hunger level
     if( get_hunger() > NPC_HUNGER_COMPLAIN &&
         complain_about( hunger_string,
                         std::max( 3_hours, time_duration::from_minutes( 60 * 8 - get_hunger() ) ),
@@ -5414,7 +5431,6 @@ bool npc::complain()
     }
 
     // Thirst every 2 hours
-    // Since NPCs can't dry to death, respect the rules
     if( get_thirst() > NPC_THIRST_COMPLAIN &&
         complain_about( thirst_string, 2_hours, chat_snippets().snip_thirsty.translated() ) ) {
         return true;

--- a/tests/behavior_test.cpp
+++ b/tests/behavior_test.cpp
@@ -34,6 +34,8 @@
 #include "weather.h"
 #include "weighted_list.h"
 
+static const item_group_id Item_spawn_data_test_bottle_water( "test_bottle_water" );
+
 static const itype_id itype_2x4( "2x4" );
 static const itype_id itype_backpack( "backpack" );
 static const itype_id itype_corpse( "corpse" );
@@ -212,12 +214,11 @@ TEST_CASE( "check_npc_behavior_tree", "[npc][behavior]" )
         CHECK( npc_needs.tick( &oracle ) == "idle" );
     }
     SECTION( "Thirsty" ) {
-        item_group_id grp_bottle_water( "test_bottle_water" );
-        const item_group::ItemList items = item_group::items_from( grp_bottle_water );
+        const item_group::ItemList items = item_group::items_from( Item_spawn_data_test_bottle_water );
 
         // make sure only water bottles are in this group
         REQUIRE( items.size() == 1 );
-        REQUIRE( item_group::group_contains_item( grp_bottle_water, itype_water_clean ) );
+        REQUIRE( item_group::group_contains_item( Item_spawn_data_test_bottle_water, itype_water_clean ) );
 
         test_npc.set_thirst( 700 );
         REQUIRE( oracle.needs_water_badly( "" ) == behavior::status_t::running );
@@ -229,6 +230,22 @@ TEST_CASE( "check_npc_behavior_tree", "[npc][behavior]" )
         CHECK( npc_needs.tick( &oracle ) == "drink_water" );
         water.remove_item();
         CHECK( npc_needs.tick( &oracle ) == "idle" );
+    }
+    SECTION( "Thirsty and hungry" ) {
+        // When both thirsty and hungry, thirst takes priority
+        // (npc_thirst comes before npc_hunger in sequential_until_done)
+        test_npc.set_thirst( 700 );
+        test_npc.set_hunger( 500 );
+        test_npc.set_stored_kcal( 1000 );
+        REQUIRE( oracle.needs_water_badly( "" ) == behavior::status_t::running );
+        REQUIRE( oracle.needs_food_badly( "" ) == behavior::status_t::running );
+        const item_group::ItemList water_items = item_group::items_from(
+                    Item_spawn_data_test_bottle_water );
+        test_npc.i_add( water_items.front() );
+        test_npc.i_add( item( itype_sandwich_cheese_grilled ) );
+        REQUIRE( oracle.has_water( "" ) == behavior::status_t::running );
+        REQUIRE( oracle.has_food( "" ) == behavior::status_t::running );
+        CHECK( npc_needs.tick( &oracle ) == "drink_water" );
     }
 }
 

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -5,6 +5,7 @@
 #include <optional>
 #include <set>
 #include <sstream>
+#include <unordered_set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -12,11 +13,13 @@
 #include "bodypart.h"
 #include "calendar.h"
 #include "cata_catch.h"
+#include "cata_scope_helpers.h"
 #include "character.h"
 #include "common_types.h"
 #include "coordinates.h"
 #include "creature_tracker.h"
 #include "damage.h"
+#include "debug.h"
 #include "faction.h"
 #include "field.h"
 #include "field_type.h"
@@ -28,6 +31,7 @@
 #include "map.h"
 #include "map_helpers.h"
 #include "memory_fast.h"
+#include "messages.h"
 #include "monster.h"
 #include "npc.h"
 #include "npctalk.h"
@@ -59,6 +63,7 @@ static const itype_id itype_M24( "M24" );
 static const itype_id itype_bat( "bat" );
 static const itype_id itype_debug_backpack( "debug_backpack" );
 static const itype_id itype_leather_belt( "leather_belt" );
+static const itype_id itype_sandwich_cheese_grilled( "sandwich_cheese_grilled" );
 
 static const trait_id trait_WEB_WEAVER( "WEB_WEAVER" );
 
@@ -744,4 +749,57 @@ TEST_CASE( "npc_extracts_weapon_from_wielded_container", "[npc_ai]" )
 
     // The backpack should no longer be wielded
     CHECK( hostile.get_wielded_item()->typeId() != itype_debug_backpack );
+}
+
+TEST_CASE( "npc_needs_bt_diagnostic_during_move", "[npc][behavior]" )
+{
+    // RAII: save and restore debug globals so later tests are unaffected
+    restore_on_out_of_scope<bool> restore_debug( debug_mode );
+    restore_on_out_of_scope<std::unordered_set<debugmode::debug_filter>>
+            restore_filters( debugmode::enabled_filters );
+
+    clear_map_without_vision();
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy );
+
+    // Make NPC hungry with food available
+    guy.set_hunger( 500 );
+    guy.set_stored_kcal( 1000 );
+    guy.i_add( item( itype_sandwich_cheese_grilled ) );
+
+    SECTION( "filter enabled - BT goal appears in messages" ) {
+        debug_mode = true;
+        debugmode::enabled_filters.clear();
+        debugmode::enabled_filters.emplace( debugmode::DF_NPC_NEEDS );
+
+        Messages::clear_messages();
+        guy.set_moves( 100 );
+        guy.move();
+
+        const auto msgs = Messages::recent_messages( 100 );
+        bool found_bt_msg = false;
+        for( const auto &msg : msgs ) {
+            if( msg.second.find( "BT needs goal" ) != std::string::npos ) {
+                found_bt_msg = true;
+                CHECK( msg.second.find( "eat_food" ) != std::string::npos );
+                break;
+            }
+        }
+        CHECK( found_bt_msg );
+    }
+
+    SECTION( "filter absent - no BT evaluation" ) {
+        debug_mode = true;
+        debugmode::enabled_filters.clear();
+        // DF_NPC_NEEDS deliberately NOT added
+
+        Messages::clear_messages();
+        guy.set_moves( 100 );
+        guy.move();
+
+        const auto msgs = Messages::recent_messages( 100 );
+        for( const auto &msg : msgs ) {
+            CHECK( msg.second.find( "BT needs goal" ) == std::string::npos );
+        }
+    }
 }


### PR DESCRIPTION
#### Summary
Infrastructure "Add debug filter for NPC behavior tree needs evaluation"

#### Purpose of change

The NPC behavior tree for survival needs has been sitting in `npc_behavior.json` since 2019. It works. It has tests. It's connected to absolutely nothing.

Meanwhile `npcmove.cpp` has comments claiming NPCs can't starve to death, which stopped being true at some point and nobody updated the comments. Presumably because nobody looks at this code expecting it to matter.

#### Describe the solution

New `DF_NPC_NEEDS` debug filter. Toggle it on and each NPC turn evaluates the behavior tree, logging the goal to the message log -- `idle`, `eat_food`, `drink_water`, `wear_warmer_clothes`, `start_fire`. Same pattern as monster BT dispatch in `monmove.cpp`, except we only log. Zero behavior change, zero cost when off.

Comment fixes: "NPCs can't starve" (they can), the mysterious TODO about exploiting hungry NPCs, the `can_take_shelter` joke. Legacy markers on `enum npc_need` and `decide_needs()` pointing to the BT replacement path.

#### Describe alternatives you've considered

Could show the BT result in the debug menu NPC info panel, but the message log lets you watch all NPCs at once without clicking through each one.

#### Testing

New BT precedence section: when both thirsty and hungry, thirst wins (tree order). Integration test in `npc_test.cpp` with positive (filter on, hungry NPC, message shows `eat_food`) and negative (filter off, no BT message) cases. `restore_on_out_of_scope` for debug globals so nothing leaks.

Verified in-game as well.

#### Additional context

Related to #28681.