### PR TITLE
Let saprophages and saprovores eat parasitic food without warning

### DIFF
--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -1013,7 +1013,8 @@ ret_val<edible_rating> Character::will_eat( const item &food, bool interactive )
     }
 
     if( food.get_comestible()->parasites > 0 && !food.has_flag( flag_NO_PARASITES ) &&
-        !has_flag( json_flag_PARAIMMUNE ) && ( !food.has_flag( flag_HEMOVORE_FUN ) ||
+        !has_flag( json_flag_PARAIMMUNE ) && !saprophage && !has_trait( trait_SAPROVORE ) &&
+        ( !food.has_flag( flag_HEMOVORE_FUN ) ||
                 ( !has_flag( json_flag_HEMOVORE ) && !has_flag( json_flag_BLOODFEEDER ) ) ) ) {
         add_consequence( string_format( _( "Consuming this %s probably isn't very healthy." ),
                                         food.tname() ),

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -1015,7 +1015,7 @@ ret_val<edible_rating> Character::will_eat( const item &food, bool interactive )
     if( food.get_comestible()->parasites > 0 && !food.has_flag( flag_NO_PARASITES ) &&
         !has_flag( json_flag_PARAIMMUNE ) && !saprophage && !has_trait( trait_SAPROVORE ) &&
         ( !food.has_flag( flag_HEMOVORE_FUN ) ||
-                ( !has_flag( json_flag_HEMOVORE ) && !has_flag( json_flag_BLOODFEEDER ) ) ) ) {
+          ( !has_flag( json_flag_HEMOVORE ) && !has_flag( json_flag_BLOODFEEDER ) ) ) ) {
         add_consequence( string_format( _( "Consuming this %s probably isn't very healthy." ),
                                         food.tname() ),
                          PARASITES );


### PR DESCRIPTION
#### Summary
Bugfixes "Saprophages and saprovores no longer get parasite warnings for food they can safely eat"

#### Purpose of change

will_eat() warns about parasites for everyone except PARAIMMUNE. Saprophages and saprovores eat rotten stuff all day but still get the warning for parasitic food, which doesn't make much sense.

#### Describe the solution

Added saprophage/saprovore to the existing parasite exemption check. Both variables are already in scope.

#### Describe alternatives you've considered

Not really, it's a one-line fix.

#### Testing

Read the surrounding code, the condition sits right next to similar HEMOVORE/BLOODFEEDER checks.

#### Additional context

Came up while working on NPC food rating improvements.