### PR TITLE
Replace blanket use_methods rejection in NPC rate_food with targeted checks

### DIFF
--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -195,6 +195,8 @@ static const string_id<behavior::node_t> behavior_node_t_npc_needs( "npc_needs" 
 
 static const trait_id trait_IGNORE_SOUND( "IGNORE_SOUND" );
 static const trait_id trait_RETURN_TO_START_POS( "RETURN_TO_START_POS" );
+static const trait_id trait_SAPROPHAGE( "SAPROPHAGE" );
+static const trait_id trait_SAPROVORE( "SAPROVORE" );
 
 static const zone_type_id zone_type_NO_NPC_PICKUP( "NO_NPC_PICKUP" );
 static const zone_type_id zone_type_NPC_RETREAT( "NPC_RETREAT" );
@@ -4593,15 +4595,19 @@ void npc::use_painkiller()
 // Be eaten before it rots (favor soon-to-rot perishables)
 //
 // TODO: Cache the results of this, *especially* if there's nothing we want to eat.
-static float rate_food( const item &it, int want_nutr, int want_quench )
+static float rate_food( const Character &who, const item &it, int want_nutr,
+                        int want_quench )
 {
     const auto &food = it.get_comestible();
     if( !food ) {
         return 0.0f;
     }
 
-    // Don't eat it if it's filled with parasites
-    if( food->parasites && !it.has_flag( flag_NO_PARASITES ) ) {
+    const bool can_consume_rot = who.has_trait( trait_SAPROPHAGE ) ||
+                                 who.has_trait( trait_SAPROVORE );
+
+    // Don't eat it if it's filled with parasites (saprophages/saprovores are fine with it)
+    if( food->parasites && !it.has_flag( flag_NO_PARASITES ) && !can_consume_rot ) {
         return 0.0;
     }
 
@@ -4614,21 +4620,21 @@ static float rate_food( const item &it, int want_nutr, int want_quench )
         return 0.0f;
     }
 
-    if( !it.type->use_methods.empty() ) {
-        // TODO: Get a good method of telling apart:
-        // raw meat (parasites - don't eat unless mutant)
-        // zed meat (poison - don't eat unless mutant)
-        // alcohol (debuffs, health drop - supplement diet but don't bulk-consume)
-        // caffeine (fine to consume, but expensive and prevents sleep)
-        // hallucination mushrooms (NPCs don't hallucinate, so don't eat those)
-        // honeycomb (harmless iuse)
-        // royal jelly (way too expensive to eat as food)
-        // mutagenic crap (don't eat, we want player to micromanage muties)
-        // marloss (NPCs don't turn fungal)
-        // weed brownies (small debuff)
-        // seeds (too expensive)
+    // Don't eat medicine as food (NPC self-medication is handled in use_painkiller)
+    if( food->comesttype == "MED" ) {
+        return 0.0f;
+    }
 
-        // For now skip all of those
+    // Reject marloss/mycus items -- player should control the fungal path
+    if( it.has_flag( flag_MYCUS_OK ) ||
+        it.type->use_methods.count( "MARLOSS" ) ||
+        it.type->use_methods.count( "MARLOSS_SEED" ) ||
+        it.type->use_methods.count( "MARLOSS_GEL" ) ) {
+        return 0.0f;
+    }
+
+    // Reject tainted/poisonous items (saprophages/saprovores can handle it)
+    if( it.type->use_methods.count( "POISON" ) && !can_consume_rot ) {
         return 0.0f;
     }
 
@@ -4755,7 +4761,7 @@ bool npc::consume_food()
         }
     } else {
         for( const item_location &food_item : inv_food ) {
-            float cur_weight = rate_food( *food_item, want_hunger, want_quench );
+            float cur_weight = rate_food( *this, *food_item, want_hunger, want_quench );
             // Note: will_eat is expensive, avoid calling it if possible
             if( cur_weight > best_weight && will_eat( *food_item ).success() ) {
                 best_weight = cur_weight;

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -62,9 +62,17 @@ static const item_group_id Item_spawn_data_test_NPC_guns( "test_NPC_guns" );
 static const itype_id itype_M24( "M24" );
 static const itype_id itype_bat( "bat" );
 static const itype_id itype_debug_backpack( "debug_backpack" );
+static const itype_id itype_honeycomb( "honeycomb" );
 static const itype_id itype_leather_belt( "leather_belt" );
+static const itype_id itype_marloss_berry( "marloss_berry" );
+static const itype_id itype_marloss_gel( "marloss_gel" );
+static const itype_id itype_meat( "meat" );
+static const itype_id itype_meat_tainted( "meat_tainted" );
+static const itype_id itype_mutagen( "mutagen" );
 static const itype_id itype_sandwich_cheese_grilled( "sandwich_cheese_grilled" );
+static const itype_id itype_space_cake( "space_cake" );
 
+static const trait_id trait_SAPROVORE( "SAPROVORE" );
 static const trait_id trait_WEB_WEAVER( "WEB_WEAVER" );
 
 static const vpart_id vpart_frame( "frame" );
@@ -801,5 +809,75 @@ TEST_CASE( "npc_needs_bt_diagnostic_during_move", "[npc][behavior]" )
         for( const auto &msg : msgs ) {
             CHECK( msg.second.find( "BT needs goal" ) == std::string::npos );
         }
+    }
+}
+
+TEST_CASE( "npc_eats_food_with_harmless_iuse", "[npc][food]" )
+{
+    clear_map_without_vision();
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy );
+
+    // Make NPC hungry enough that rate_food scores positively
+    guy.set_hunger( 300 );
+    guy.set_stored_kcal( 5000 );
+    guy.set_thirst( 0 );
+
+    // Items with use_methods that NPCs SHOULD eat:
+    SECTION( "eats honeycomb" ) {
+        // harmless iuse -- spawns wax, good nutrition
+        guy.i_add( item( itype_honeycomb ) );
+        CHECK( guy.consume_food() );
+    }
+
+    SECTION( "eats weed brownies" ) {
+        // WEED_CAKE iuse -- small debuff, but edible food
+        guy.i_add( item( itype_space_cake ) );
+        CHECK( guy.consume_food() );
+    }
+
+    // Items without use_methods that are still rejected by other checks:
+    SECTION( "refuses raw meat" ) {
+        // parasites field -- caught by parasites check, not use_methods
+        guy.i_add( item( itype_meat ) );
+        CHECK_FALSE( guy.consume_food() );
+    }
+
+    // Items with use_methods that NPCs should NOT eat:
+    SECTION( "refuses tainted meat" ) {
+        // POISON iuse -- zed meat, tainted organs
+        guy.i_add( item( itype_meat_tainted ) );
+        CHECK_FALSE( guy.consume_food() );
+    }
+
+    SECTION( "refuses marloss berry" ) {
+        // MARLOSS iuse + MYCUS_OK flag -- fungal transformation
+        guy.i_add( item( itype_marloss_berry ) );
+        CHECK_FALSE( guy.consume_food() );
+    }
+
+    SECTION( "refuses marloss gel" ) {
+        // MARLOSS_GEL iuse -- fungal transformation, no MYCUS_OK flag
+        guy.i_add( item( itype_marloss_gel ) );
+        CHECK_FALSE( guy.consume_food() );
+    }
+
+    SECTION( "refuses mutagen" ) {
+        // consume_drug iuse, MED type -- player-controlled mutation
+        guy.i_add( item( itype_mutagen ) );
+        CHECK_FALSE( guy.consume_food() );
+    }
+
+    SECTION( "saprovore eats tainted meat" ) {
+        // Saprovore mutation allows eating parasitic/tainted food
+        guy.set_mutation( trait_SAPROVORE );
+        guy.i_add( item( itype_meat_tainted ) );
+        CHECK( guy.consume_food() );
+    }
+
+    SECTION( "saprovore eats raw meat" ) {
+        guy.set_mutation( trait_SAPROVORE );
+        guy.i_add( item( itype_meat ) );
+        CHECK( guy.consume_food() );
     }
 }


### PR DESCRIPTION
#### Summary
Bugfixes "NPCs no longer refuse to eat honeycomb, brownies, and other food with harmless effects"

#### Purpose of change

rate_food() rejects every item that has any use_methods, including honeycomb (spawns wax), weed brownies (small debuff), and anything else with a harmless iuse. This has been a known issue since the TODO list was written. NPCs starve with food in their inventory because rate_food scores it at 0.

#### Describe the solution

Replace the blanket `!use_methods.empty()` check with targeted rejections:
- MED comesttype (drugs, mutagen, purifier)
- Marloss/mycus items (MYCUS_OK flag + MARLOSS/MARLOSS_SEED/MARLOSS_GEL use_methods)
- POISON use_method (tainted meat), unless NPC is saprophage/saprovore

Saprophage/saprovore NPCs can now eat parasitic and tainted food, matching their mutations. rate_food() takes a `const Character &who` reference for mutation checks.

#### Describe alternatives you've considered

Could allowlist specific harmless use_methods instead, but that requires updating the list every time a new food iuse is added. Targeted rejection of known-dangerous items is more future-proof.

#### Testing

Tests for: honeycomb (eats), weed brownies (eats), raw meat (refuses -- parasites), tainted meat (refuses -- POISON), marloss berry (refuses -- MYCUS_OK), marloss gel (refuses -- MARLOSS_GEL), mutagen (refuses -- MED type), saprovore eating tainted and raw meat (eats).

#### Additional context

Depends on #85927 and #85929.