### PR TITLE
SDL transparency issues hotfix

### DIFF
--- a/src/sdl_geometry.cpp
+++ b/src/sdl_geometry.cpp
@@ -51,7 +51,7 @@ ColorModulatedGeometryRenderer::ColorModulatedGeometryRenderer( const SDL_Render
     tex.reset( SDL_CreateTextureFromSurface( renderer.get(), alt_surf.get() ) );
     alt_surf.reset();
 
-    SetTextureBlendMode( tex, SDL_BLENDMODE_BLEND );
+    // SetTextureBlendMode( tex, SDL_BLENDMODE_BLEND );
 
     // Test to make sure color modulation is supported by renderer
     bool tex_enable = !SetTextureColorMod( tex, 0, 0, 0 );
@@ -67,7 +67,7 @@ void ColorModulatedGeometryRenderer::rect( const SDL_Renderer_Ptr &renderer, con
 {
     if( tex ) {
         SetTextureColorMod( tex, color.r, color.g, color.b );
-        SDL_SetTextureAlphaMod( tex.get(), color.a );
+        // SDL_SetTextureAlphaMod( tex.get(), color.a );
         RenderCopy( renderer, tex, nullptr, &rect );
     } else {
         DefaultGeometryRenderer::rect( renderer, rect, color );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "SDL transparency issues hotfix"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

For a quite while I got rendering issues when playing experimental. Specifically, I play with Neodays, and there are lots of rendering artifacts when you move the map, or combine with map memory. Because there is a lot of black/alpha, moving the screen causes issues as previous frame isn't correctly clear.

After some git bisecting, I found  https://github.com/CleverRaven/Cataclysm-DDA/pull/84269 was the culprit. The reason is, for some UI overlay I presume, it changes rendering to BLEND colors.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

This is the code I have sitting in my computer for a while, and playing with it. Yeah, I just commented out those lines. I don't believe these are the proper fix, but as I have no idea how to locate myself in the rendering code, that's seems to work. I'm sharing here as a means to highlight the issue, and hopefully some more experienced dev can help or do a proper fix.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

I imagine the fix would be to reset the SDL state machine after the overlay or whatever this blend was required. I assume there is a "clear screen" code before every frame, but maybe that's not working as intended? That could be another sort of fix.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
