### PR TITLE
pop talker from dialogue if they are dead

### DIFF
--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -5710,9 +5710,14 @@ talk_effect_fun_t::func f_ranged_attack( bool is_npc )
 
 talk_effect_fun_t::func f_die( bool is_npc )
 {
-    return [is_npc]( dialogue const & d ) {
+    return [is_npc]( dialogue & d ) {
         map &here = get_map();
         d.actor( is_npc )->die( &here );
+        if( is_npc ) {
+            d.has_beta = false;
+        } else {
+            d.has_alpha = false;
+        }
     };
 }
 
@@ -5735,7 +5740,7 @@ talk_effect_fun_t::func f_die_advanced( const JsonObject &jo, std::string_view m
     }
 
     return [remove_corpse, supress_message, remove_from_creature_tracker,
-                   is_npc]( dialogue const & d ) {
+                   is_npc]( dialogue & d ) {
         map &here = get_map();
 
         if( d.actor( is_npc )->get_monster() ) {
@@ -5753,6 +5758,11 @@ talk_effect_fun_t::func f_die_advanced( const JsonObject &jo, std::string_view m
         }
 
         d.actor( is_npc )->die( &here );
+        if( is_npc ) {
+            d.has_beta = false;
+        } else {
+            d.has_alpha = false;
+        }
     };
 }
 


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Received next EoC from modder
```json
  {
    "type": "effect_on_condition",
    "id": "EOC_foobar",
    "//": "n_ is the item",
    "effect": [
      "n_die",
      { "u_spawn_item": "another_item" },
    ]
  },
```
what it does is tries to spawn	another_item, but `u_spawn_item` has a code that checks if opposite talker is presented, and if so, creates a popup "npc_name gives you Foo". Sadly in this case `"n_die"` killed our NPC before, but didn't made the dialogue aware about it, making this json result in crash
#### Describe the solution
Pop talker from dialogue if _die effect is used, so future code can safely use has_talker() and bail out if talker is not presented, or throw an error for calling talker when such do not exist anymore
#### Testing
Run the same code, instead of segfault, the game is properly guarded by has_talker(), do not try to access talker name and, therefore, do not segfault