### PR TITLE
[Innawoods] Fix broken starting locations

### DIFF
--- a/data/mods/Magiclysm/mod_interactions/innawood/mapgen/druid_giant_tree_empty.json
+++ b/data/mods/Magiclysm/mod_interactions/innawood/mapgen/druid_giant_tree_empty.json
@@ -19,8 +19,6 @@
     ],
     "locations": [ "forest_center" ],
     "spawns": { "group": "GROUP_FOREST_SPIRIT", "population": [ 2, 20 ], "radius": [ 1, 6 ] },
-    "city_distance": [ 30, -1 ],
-    "city_sizes": [ 0, 20 ],
     "occurrences": [ 1, 5 ],
     "flags": [ "WILDERNESS" ]
   },

--- a/data/mods/Magiclysm/mod_interactions/innawood/overmap/overmap_overrides.json
+++ b/data/mods/Magiclysm/mod_interactions/innawood/overmap/overmap_overrides.json
@@ -35,8 +35,6 @@
       { "point": [ 4, 2, 1 ], "overmap": "goblin_5C_roof_north" }
     ],
     "locations": [ "forest_center" ],
-    "city_distance": [ 30, -1 ],
-    "city_sizes": [ 0, 20 ],
     "occurrences": [ 50, 100 ],
     "flags": [ "OVERMAP_UNIQUE" ]
   },
@@ -45,8 +43,6 @@
     "id": "orc_village",
     "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "orc_village_north" } ],
     "locations": [ "forest_without_trail" ],
-    "city_distance": [ 20, -1 ],
-    "city_sizes": [ 0, -1 ],
     "occurrences": [ 0, 1 ],
     "spawns": { "group": "GROUP_ALL_GOBLINS", "population": [ 10, 30 ], "radius": [ 1, 10 ] }
   }

--- a/data/mods/innawood/mapgen/ravine_mutable.json
+++ b/data/mods/innawood/mapgen/ravine_mutable.json
@@ -4,8 +4,6 @@
     "id": "Ravine Mutable",
     "subtype": "mutable",
     "locations": [ "field", "forest_with_swamp", "subterranean_empty" ],
-    "city_distance": [ 0, -1 ],
-    "city_sizes": [ 0, -1 ],
     "priority": 3,
     "occurrences": [ 0, 2 ],
     "flags": [ "WILDERNESS" ],

--- a/data/mods/innawood/overmap/specials_kept.json
+++ b/data/mods/innawood/overmap/specials_kept.json
@@ -11,7 +11,6 @@
       { "point": [ 0, 0, -5 ], "overmap": "temple_finale_north" }
     ],
     "locations": [ "forest" ],
-    "city_distance": [ 40, -1 ],
     "occurrences": [ 10, 100 ],
     "flags": [ "WILDERNESS", "OVERMAP_UNIQUE" ]
   },
@@ -20,7 +19,6 @@
     "id": "Standing stones",
     "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "standing_stones" } ],
     "locations": [ "forest" ],
-    "city_distance": [ 40, -1 ],
     "occurrences": [ 10, 100 ],
     "rotate": false,
     "flags": [ "WILDERNESS", "OVERMAP_UNIQUE" ]
@@ -33,7 +31,6 @@
       { "point": [ 0, 0, -1 ], "overmap": "spider_pit_under_north" }
     ],
     "locations": [ "forest" ],
-    "city_sizes": [ 0, 12 ],
     "occurrences": [ 33, 100 ],
     "rotate": false,
     "flags": [ "WILDERNESS", "OVERMAP_UNIQUE" ]
@@ -47,7 +44,6 @@
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "forest_trail", "connection": "forest_trail" } ],
     "locations": [ "forest" ],
-    "city_distance": [ 8, -1 ],
     "occurrences": [ 0, 5 ],
     "flags": [ "CLASSIC", "WILDERNESS" ]
   },
@@ -59,7 +55,6 @@
       { "point": [ 0, 0, -1 ], "overmap": "cave_underground_innawood" }
     ],
     "locations": [ "forest" ],
-    "city_distance": [ 8, -1 ],
     "occurrences": [ 0, 5 ],
     "flags": [ "CLASSIC", "WILDERNESS" ]
   },
@@ -72,7 +67,6 @@
       { "point": [ 0, 0, -2 ], "overmap": "cave_rat_innawood" }
     ],
     "locations": [ "forest" ],
-    "city_distance": [ 8, -1 ],
     "occurrences": [ 10, 100 ],
     "flags": [ "WILDERNESS", "OVERMAP_UNIQUE" ]
   },
@@ -81,7 +75,6 @@
     "id": "Pond",
     "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "pond_field_north" } ],
     "locations": [ "field" ],
-    "city_distance": [ 15, -1 ],
     "occurrences": [ 0, 5 ],
     "flags": [ "CLASSIC", "WILDERNESS" ]
   },
@@ -90,7 +83,6 @@
     "id": "Hot Springs",
     "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "hot_springs_north" } ],
     "locations": [ "field" ],
-    "city_distance": [ 15, -1 ],
     "occurrences": [ 0, 2 ],
     "flags": [ "CLASSIC", "WILDERNESS" ]
   },
@@ -102,7 +94,6 @@
       { "point": [ 0, 0, -1 ], "overmap": "ws_giant_sinkhole_2_north" }
     ],
     "locations": [ "wilderness" ],
-    "city_distance": [ 15, -1 ],
     "occurrences": [ 10, 100 ],
     "flags": [ "CLASSIC", "WILDERNESS", "OVERMAP_UNIQUE" ]
   },
@@ -148,8 +139,6 @@
       { "point": [ 5, 5, 0 ], "overmap": "lake_surface" }
     ],
     "locations": [ "lake_surface" ],
-    "city_distance": [ 3, -1 ],
-    "city_sizes": [ 4, 12 ],
     "occurrences": [ 0, 1 ],
     "flags": [ "CLASSIC", "LAKE", "WILDERNESS" ]
   },
@@ -195,8 +184,6 @@
       { "point": [ 5, 5, 0 ], "overmap": "lake_surface" }
     ],
     "locations": [ "lake_surface" ],
-    "city_distance": [ 3, -1 ],
-    "city_sizes": [ 4, 12 ],
     "occurrences": [ 0, 1 ],
     "flags": [ "CLASSIC", "LAKE", "WILDERNESS" ]
   },
@@ -215,8 +202,6 @@
       { "point": [ 2, 2, 0 ], "overmap": "lake_surface" }
     ],
     "locations": [ "lake_surface" ],
-    "city_distance": [ 3, -1 ],
-    "city_sizes": [ 4, 12 ],
     "occurrences": [ 0, 1 ],
     "flags": [ "CLASSIC", "LAKE", "WILDERNESS" ]
   },
@@ -268,8 +253,6 @@
       { "point": [ 6, 5, 0 ], "overmap": "lake_surface" }
     ],
     "locations": [ "lake_surface" ],
-    "city_distance": [ 3, -1 ],
-    "city_sizes": [ 4, 12 ],
     "occurrences": [ 0, 1 ],
     "flags": [ "CLASSIC", "LAKE", "WILDERNESS" ]
   },
@@ -321,8 +304,6 @@
       { "point": [ 6, 5, 0 ], "overmap": "lake_surface" }
     ],
     "locations": [ "lake_surface" ],
-    "city_distance": [ 3, -1 ],
-    "city_sizes": [ 4, 12 ],
     "occurrences": [ 0, 1 ],
     "flags": [ "CLASSIC", "LAKE", "WILDERNESS" ]
   },
@@ -374,8 +355,6 @@
       { "point": [ 6, 5, 0 ], "overmap": "lake_surface" }
     ],
     "locations": [ "lake_surface" ],
-    "city_distance": [ 3, -1 ],
-    "city_sizes": [ 4, 12 ],
     "occurrences": [ 0, 1 ],
     "flags": [ "CLASSIC", "LAKE", "WILDERNESS" ]
   },
@@ -434,8 +413,6 @@
       { "point": [ 6, 6, 0 ], "overmap": "lake_surface" }
     ],
     "locations": [ "lake_surface" ],
-    "city_distance": [ 3, -1 ],
-    "city_sizes": [ 4, 12 ],
     "occurrences": [ 0, 1 ],
     "flags": [ "CLASSIC", "LAKE", "WILDERNESS" ]
   },
@@ -470,8 +447,6 @@
       { "point": [ 4, 4, 0 ], "overmap": "lake_surface" }
     ],
     "locations": [ "lake_surface" ],
-    "city_distance": [ 3, -1 ],
-    "city_sizes": [ 4, 12 ],
     "occurrences": [ 0, 1 ],
     "flags": [ "CLASSIC", "LAKE", "WILDERNESS" ]
   },
@@ -506,8 +481,6 @@
       { "point": [ 4, 4, 0 ], "overmap": "lake_surface" }
     ],
     "locations": [ "lake_surface" ],
-    "city_distance": [ 3, -1 ],
-    "city_sizes": [ 4, 12 ],
     "occurrences": [ 0, 1 ],
     "flags": [ "CLASSIC", "LAKE", "WILDERNESS" ]
   },
@@ -542,8 +515,6 @@
       { "point": [ 4, 4, 0 ], "overmap": "lake_surface" }
     ],
     "locations": [ "lake_surface" ],
-    "city_distance": [ 3, -1 ],
-    "city_sizes": [ 4, 12 ],
     "occurrences": [ 0, 1 ],
     "flags": [ "CLASSIC", "LAKE", "WILDERNESS" ]
   },
@@ -578,8 +549,6 @@
       { "point": [ 4, 4, 0 ], "overmap": "lake_surface" }
     ],
     "locations": [ "lake_surface" ],
-    "city_distance": [ 3, -1 ],
-    "city_sizes": [ 4, 12 ],
     "occurrences": [ 0, 1 ],
     "flags": [ "CLASSIC", "LAKE", "WILDERNESS" ]
   }

--- a/data/mods/innawood/overmap/specials_new.json
+++ b/data/mods/innawood/overmap/specials_new.json
@@ -10,8 +10,6 @@
       { "point": [ 1, 0, -2 ], "overmap": "innawood_ore_vein_surface_z2_right_side_north" }
     ],
     "locations": [ "wilderness" ],
-    "city_distance": [ 20, -1 ],
-    "city_sizes": [ 0, 13 ],
     "occurrences": [ 0, 5 ]
   },
   {
@@ -26,8 +24,6 @@
       { "point": [ 1, 0, -3 ], "overmap": "innawood_ore_vein_surface_z3_right_side_north" }
     ],
     "locations": [ "wilderness" ],
-    "city_distance": [ 20, -1 ],
-    "city_sizes": [ 0, 13 ],
     "occurrences": [ 3, 10 ]
   },
   {
@@ -47,8 +43,6 @@
       { "point": [ 1, 0, -4 ], "overmap": "innawood_ore_vein_surface_z2_right_side_north" }
     ],
     "locations": [ "wilderness" ],
-    "city_distance": [ 20, -1 ],
-    "city_sizes": [ 0, 13 ],
     "occurrences": [ 50, 100 ],
     "flags": [ "OVERMAP_UNIQUE" ]
   }


### PR DESCRIPTION
#### Summary
Bugfixes "Fix broken starting locations for Innawoods"

#### Purpose of change

Fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/85916

#### Describe the solution

Remove references to city_distance and city_sizes for start locations in Innawoods.

#### Describe alternatives you've considered

Completely removing broken starting locations for Innawoods as implemented in https://github.com/CleverRaven/Cataclysm-DDA/pull/85918

#### Testing

Checkout the branch, open the file `data/mods/innawood/scenarios.json` and change line 367 from

```
    "allowed_locs": [ "sloc_field", "sloc_forest", "sloc_desert_island", "sloc_river" ],
```

to

```
    "allowed_locs": [  "sloc_desert_island" ],
```

to force the starting location for the scenario `wilderness` to be an island. Create a character in that scenario. Good luck surviving.

#### Additional context

I'm unsure about commit cb9015a8f84df16e40a565963a9588fd499264f0

I noticed an issue and implemented this fix with guidance from reviewers. I don't know *really* what is going on, but it works.