### PR TITLE
Guard reload_activity_actor::deserialize against invalid ammo_loc

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -7392,7 +7392,9 @@ std::unique_ptr<activity_actor> reload_activity_actor::deserialize( JsonValue &j
     data.read( "ammo_loc", actor.ammo_loc );
     data.read( "seconds_per_round", actor.seconds_per_round );
     data.read( "already_loaded", actor.already_loaded );
-    actor.ammo_id = actor.ammo_loc->type->id;
+    if( actor.ammo_loc ) {
+        actor.ammo_id = actor.ammo_loc->type->id;
+    }
 
     return actor.clone();
 }


### PR DESCRIPTION
#### Summary
Bugfixes "Fix crash loading saves with stale reload activity"

#### Purpose of change

Followup to #85905. Discovered via #85762 -- a pre-fix save crashes with SIGSEGV on load because `reload_activity_actor::deserialize` unconditionally dereferences `ammo_loc` to extract `ammo_id`, but the referenced ammo item no longer exists and the location deserializes to `nowhere`.

#### Describe the solution

Check `ammo_loc` validity before dereferencing.

#### Describe alternatives you've considered

N/A

#### Testing

Tested with the save from #85762. Load no longer crashes.

#### Additional context

N/A