### PR TITLE
Step iteration for recipe steps

### DIFF
--- a/doc/JSON/ITEM_CRAFT_AND_DISASSEMBLY.md
+++ b/doc/JSON/ITEM_CRAFT_AND_DISASSEMBLY.md
@@ -3,6 +3,7 @@
 *Contents*
 
 - [Recipes](#recipes)
+  - [Recipe steps](#recipe-steps)
   - [Practice recipes](#practice-recipes)
   - [Nested recipes](#nested-recipes)
   - [Recipe requirements](#recipe-requirements)
@@ -137,6 +138,91 @@ It is specified as follows:
 "batch_time_factors": { "mode": "linear": "setup": "12 m" },
 "batch_time_factors": { "mode": "linear": "setup": "12 m", "max": 20 },
 ```
+
+## Recipe steps
+
+Recipes can optionally define a `"steps"` array to split the craft into named phases.  Each step has its own time, activity level, proficiencies, tools, qualities, and batch savings.
+
+When `"steps"` is present, the following fields must appear per-step and must **not** appear at root level: `"time"`, `"activity_level"`, `"tools"`, `"qualities"`, `"proficiencies"`, `"batch_time_factors"`.
+
+`"using"` is also not allowed at root level for step recipes.  Step-level `"using"` is not yet supported.
+
+`"components"` remains at root level.  All other recipe fields (`"result"`, `"skill_used"`, `"difficulty"`, `"book_learn"`, `"autolearn"`, etc.) also remain at root.
+
+Step recipes cannot use `"copy-from"` or `"abstract"`.
+
+### Step fields
+
+Each entry in the `"steps"` array is an object with these fields:
+
+```jsonc
+"name":               // (Mandatory) Translatable string.  Shown in the crafting progress message.
+"time":               // (Mandatory) Duration (e.g. "5 m").  Must be > 0.
+"activity_level":     // (Mandatory) Same values as the recipe-level field.
+"proficiencies":      // (Optional)  Same format as recipe-level.  Only these proficiencies are
+                      //             trained while the craft is in this step.
+"tools":              // (Optional)  Same format as recipe-level.
+"qualities":          // (Optional)  Same format as recipe-level.
+"batch_time_factors": // (Optional)  Same format as recipe-level.
+```
+
+`"components"` at step level is not allowed.
+
+### Example
+
+```jsonc
+{
+  "type": "recipe",
+  "result": "bread",
+  "category": "CC_FOOD",
+  "subcategory": "CSC_FOOD_BREAD",
+  "skill_used": "cooking",
+  "difficulty": 2,
+  "charges": 10,
+  "components": [
+    [ [ "flour", 22 ], [ "bread_flour", 5 ] ],
+    [ [ "yeast", 1 ] ],
+    [ [ "water_clean", 2 ] ],
+    [ [ "sugar", 4 ] ]
+  ],
+  "steps": [
+    {
+      "name": "Mix dough",
+      "time": "5 m",
+      "activity_level": "MODERATE_EXERCISE",
+      "batch_time_factors": [ 25, 4 ],
+      "proficiencies": [
+        { "proficiency": "prof_food_prep" },
+        { "proficiency": "prof_baking" },
+        { "proficiency": "prof_baking_bread" }
+      ]
+    },
+    {
+      "name": "Let dough rise",
+      "time": "10 m",
+      "activity_level": "NO_EXERCISE",
+      "batch_time_factors": [ 5, 4 ]
+    },
+    {
+      "name": "Bake",
+      "time": "5 m",
+      "activity_level": "LIGHT_EXERCISE",
+      "batch_time_factors": [ 50, 4 ],
+      "qualities": [ { "id": "OVEN", "level": 1 } ],
+      "tools": [ [ [ "surface_heat", 22, "LIST" ] ] ]
+    }
+  ]
+}
+```
+
+### Runtime behavior
+
+- All step tools and qualities are merged and checked at craft start.
+- The craft tracks a single overall progress bar.
+- The activity level changes as the craft moves between steps.
+- Proficiency training is limited to the proficiencies listed on the current step.
+- Batch savings are applied per-step and summed.
+- The current step name appears in the crafting progress message.
 
 ## Practice recipes
 
@@ -409,12 +495,14 @@ error during recipe finalization that your recipe is too complex.  In this
 case, the game may not be able to correctly predict whether it can be crafted.
 
 To work around this issue, if you do not wish to simplify the recipe
-requirements, then you can split your recipe into multiple steps.  For
-example, if we wanted to simplify the above survivor telescope recipe we could
-introduce an intermediate item "survivor eyepiece", which requires one of
-either lens, and then the telescope would require a high-quality lens and an
-eyepiece.  Overall, the requirements are the same, but neither recipe has any
-overlap.
+requirements, you can introduce intermediate items to break the overlap.
+For example, if we wanted to simplify the above survivor telescope recipe we
+could introduce an intermediate item "survivor eyepiece", which requires one
+of either lens, and then the telescope would require a high-quality lens and
+an eyepiece.  Overall, the requirements are the same, but neither recipe has
+any overlap.
+
+Note: this is different from [recipe steps](#recipe-steps), which split a single recipe into named phases with per-step tools and proficiencies but do not create intermediate items.
 
 For more details, see [this pull
 request](https://github.com/CleverRaven/Cataclysm-DDA/pull/36657) and the

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -5719,6 +5719,28 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
     const std::optional<tripoint_bub_ms> location = craft_item.where() == item_location::type::character
             ? std::optional<tripoint_bub_ms>() : std::optional<tripoint_bub_ms>( craft_item.pos_bub( here ) );
     const recipe &rec = craft.get_making();
+
+    // Legacy migration: older saves have step recipes with item_counter but no
+    // current_step/step_progress. Derive step state once, before any work or
+    // exertion computation. Guard ensures this runs at most once.
+    if( rec.has_steps() && craft.get_current_step() == 0 &&
+        craft.get_step_progress() == 0.0 && craft.item_counter > 0 ) {
+        // Need base_total_moves for conversion; compute it fresh here.
+        const double migration_base = std::max( 1.0,
+                                                static_cast<double>( rec.batch_time( crafter, craft.get_making_batch_size(), 1.0f, 0 ) ) );
+        double accumulated = craft.item_counter * migration_base / 10000000.0;
+        for( size_t i = 0; i < rec.steps().size(); ++i ) {
+            double budget = rec.step_budget_moves( crafter, i,
+                                                   craft.get_making_batch_size() );
+            if( accumulated < budget || i == rec.steps().size() - 1 ) {
+                craft.set_current_step( static_cast<int>( i ) );
+                craft.set_step_progress( accumulated );
+                break;
+            }
+            accumulated -= budget;
+        }
+    }
+
     if( !use_cached_workbench_multiplier ) {
         cached_workbench_multiplier = crafter.workbench_crafting_speed_multiplier( craft, location );
         use_cached_workbench_multiplier = true;
@@ -5768,6 +5790,21 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
 
     // This is to ensure we don't over count skill steps
     craft.item_counter = std::min( craft.item_counter, 10000000 );
+
+    // Step transitions: accumulate work and advance through step boundaries.
+    if( rec.has_steps() ) {
+        craft.mod_step_progress( delta_progress );
+        const int last_step_idx = static_cast<int>( rec.steps().size() ) - 1;
+        while( craft.get_current_step() < last_step_idx ) {
+            const double budget = rec.step_budget_moves( crafter,
+                                  craft.get_current_step(), craft.get_making_batch_size() );
+            if( craft.get_step_progress() < budget ) {
+                break;
+            }
+            craft.set_step_progress( craft.get_step_progress() - budget );
+            craft.set_current_step( craft.get_current_step() + 1 );
+        }
+    }
 
     // This nominal craft time is also how many practice ticks to perform
     // spread out evenly across the actual duration.
@@ -5879,11 +5916,32 @@ std::string craft_activity_actor::get_progress_message( const player_activity & 
         //We have somehow lost the craft item.  This will be handled in do_turn in the check_if_craft_is_ok call.
         return "";
     }
-    return craft_item.get_item()->tname();
+    const item *it = craft_item.get_item();
+    const recipe &making = it->get_making();
+    if( making.has_steps() ) {
+        int step_idx = it->get_current_step();
+        step_idx = std::clamp( step_idx, 0,
+                               static_cast<int>( making.steps().size() ) - 1 );
+        const recipe_step &step = making.steps()[step_idx];
+        return string_format( "%s - %s", it->tname(), step.name.translated() );
+    }
+    return it->tname();
 }
 
 float craft_activity_actor::exertion_level() const
 {
+    if( craft_item ) {
+        const item *it = craft_item.get_item();
+        if( it ) {
+            const recipe &rec = it->get_making();
+            if( rec.has_steps() ) {
+                int step = it->get_current_step();
+                step = std::clamp( step, 0,
+                                   static_cast<int>( rec.steps().size() ) - 1 );
+                return rec.steps()[step].exertion;
+            }
+        }
+    }
     return activity_override;
 }
 

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1061,9 +1061,17 @@ bool Character::craft_proficiency_gain( const item &craft, const time_duration &
 
     bool this_character_gained = false;
 
+    // For step recipes, use the current step's proficiency list so learning
+    // is targeted to the step being worked on. For stepless recipes, use the
+    // recipe-wide aggregate.
+    const std::vector<recipe_proficiency> &active_profs =
+        making.has_steps()
+        ? making.steps()[craft.get_current_step()].proficiencies
+        : making.get_proficiencies();
+
     for( Character *p : all_crafters ) {
         std::vector<learn_subject> subjects;
-        for( const recipe_proficiency &prof : making.get_proficiencies() ) {
+        for( const recipe_proficiency &prof : active_profs ) {
             // Required profs (time_multiplier == 0) gate access, not learning
             if( prof.time_multiplier == 0.0f ) {
                 continue;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4846,6 +4846,40 @@ const std::vector<comp_selection<tool_comp>> &item::get_cached_tool_selections()
     return craft_data_->cached_tool_selections;
 }
 
+int item::get_current_step() const
+{
+    cata_assert( craft_data_ );
+    if( craft_data_->making && craft_data_->making->has_steps() ) {
+        int max_step = static_cast<int>( craft_data_->making->steps().size() ) - 1;
+        return std::clamp( craft_data_->current_step, 0, max_step );
+    }
+    return 0;
+}
+
+void item::set_current_step( int step )
+{
+    cata_assert( craft_data_ );
+    craft_data_->current_step = step;
+}
+
+double item::get_step_progress() const
+{
+    cata_assert( craft_data_ );
+    return craft_data_->step_progress;
+}
+
+void item::set_step_progress( double progress )
+{
+    cata_assert( craft_data_ );
+    craft_data_->step_progress = progress;
+}
+
+void item::mod_step_progress( double delta )
+{
+    cata_assert( craft_data_ );
+    craft_data_->step_progress += delta;
+}
+
 const cata::value_ptr<islot_comestible> &item::get_comestible() const
 {
     if( is_craft() && !craft_data_->disassembly ) {

--- a/src/item.h
+++ b/src/item.h
@@ -3094,6 +3094,14 @@ class item : public visitable
         void set_cached_tool_selections( const std::vector<comp_selection<tool_comp>> &selections );
         const std::vector<comp_selection<tool_comp>> &get_cached_tool_selections() const;
 
+        // Step iteration state for step recipes.
+        // get_current_step clamps to valid range as a defensive measure.
+        int get_current_step() const;
+        void set_current_step( int step );
+        double get_step_progress() const;
+        void set_step_progress( double progress );
+        void mod_step_progress( double delta );
+
         std::vector<enchant_cache> get_proc_enchantments() const;
         std::vector<enchantment> get_defined_enchantments() const;
         // calculates the enchantment value as if this item were wielded.
@@ -3354,6 +3362,11 @@ class item : public visitable
                 std::vector<comp_selection<tool_comp>> cached_tool_selections;
                 std::optional<units::mass> cached_weight; // NOLINT(cata-serialize)
                 std::optional<units::volume> cached_volume; // NOLINT(cata-serialize)
+
+                // Step iteration state for step recipes.
+                // Authoritative: advanced by tracking consumed work against step budgets.
+                int current_step = 0;
+                double step_progress = 0.0; // base-speed moves consumed within current step
 
                 // if this is an in progress disassembly as opposed to craft
                 bool disassembly = false;

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -1372,6 +1372,14 @@ float recipe::proficiency_time_maluses_for_step(
     return total_malus;
 }
 
+double recipe::step_budget_moves( const Character &guy, size_t step_idx, int batch ) const
+{
+    cata_assert( step_idx < steps_.size() );
+    const recipe_step &s = steps_[step_idx];
+    double t = s.time * proficiency_time_maluses_for_step( guy, s );
+    return s.batch_info.apply( t, batch );
+}
+
 float recipe::max_proficiency_time_maluses( const Character & ) const
 {
     if( has_steps() && time > 0 ) {

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -299,6 +299,9 @@ class recipe
         // Per-step proficiency time malus (uses step's own proficiency list)
         static float proficiency_time_maluses_for_step(
             const Character &crafter, const recipe_step &step );
+        // Per-step time budget in base moves (with proficiency malus and batch savings).
+        // Same per-step formula that batch_time() uses internally.
+        double step_budget_moves( const Character &guy, size_t step_idx, int batch ) const;
 
         // This is used by the basecamp bulletin board.
         std::string required_all_skills_string( const std::map<skill_id, int> & ) const;

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2802,6 +2802,8 @@ void item::craft_data::serialize( JsonOut &jsout ) const
     jsout.member( "tools_to_continue", tools_to_continue );
     jsout.member( "batch_size", batch_size );
     jsout.member( "cached_tool_selections", cached_tool_selections );
+    jsout.member( "current_step", current_step );
+    jsout.member( "step_progress", step_progress );
     jsout.end_object();
 }
 
@@ -2826,6 +2828,16 @@ void item::craft_data::deserialize( const JsonObject &obj )
     tools_to_continue = obj.get_bool( "tools_to_continue", false );
     batch_size = obj.get_int( "batch_size", -1 );
     obj.read( "cached_tool_selections", cached_tool_selections );
+    current_step = obj.get_int( "current_step", 0 );
+    step_progress = obj.get_float( "step_progress", 0.0 );
+    // Validate step index against the recipe's actual step count.
+    if( making && making->has_steps() ) {
+        int max_step = static_cast<int>( making->steps().size() ) - 1;
+        current_step = std::clamp( current_step, 0, max_step );
+    } else {
+        current_step = 0;
+        step_progress = 0.0;
+    }
 }
 
 void item::link_data::serialize( JsonOut &jsout ) const

--- a/tests/recipe_steps_test.cpp
+++ b/tests/recipe_steps_test.cpp
@@ -1,6 +1,8 @@
 #include <cstdint>
 #include <cstdlib>
 #include <functional>
+#include <optional>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -14,6 +16,7 @@
 #include "flexbuffer_json.h"
 #include "item.h"
 #include "item_location.h"
+#include "json.h"
 #include "json_loader.h"
 #include "map.h"
 #include "map_helpers.h"
@@ -36,6 +39,7 @@ static const proficiency_id proficiency_prof_test_step_a( "prof_test_step_a" );
 static const proficiency_id proficiency_prof_test_step_b( "prof_test_step_b" );
 static const proficiency_id proficiency_prof_test_step_required( "prof_test_step_required" );
 
+static const recipe_id recipe_cudgel_simple( "cudgel_simple" );
 static const recipe_id recipe_cudgel_test_steps_basic( "cudgel_test_steps_basic" );
 static const recipe_id recipe_cudgel_test_steps_required_prof(
     "cudgel_test_steps_required_prof" );
@@ -649,22 +653,25 @@ TEST_CASE( "step_recipe_interrupt_and_resume", "[recipe][steps][crafting]" )
     CHECK( std::abs( total_turns - expected_turns ) <= 1 );
 }
 
-// ---- XP distribution (documents phase-1 approximate behavior) ----
+// ---- Step iteration tests ----
 
-TEST_CASE( "step_recipe_xp_distribution", "[recipe][steps][crafting]" )
+// Helper: setup step craft WITHOUT granting proficiencies
+static void setup_step_craft_no_profs( const recipe_id &rid )
 {
-    setup_step_craft( recipe_cudgel_test_steps_basic );
+    setup_step_craft( rid );
     avatar &guy = get_avatar();
+    const recipe &r = rid.obj();
 
-    guy.lose_proficiency( proficiency_prof_test_step_a, true );
-    guy.lose_proficiency( proficiency_prof_test_step_b, true );
-    REQUIRE( !guy.has_proficiency( proficiency_prof_test_step_a ) );
-    REQUIRE( !guy.has_proficiency( proficiency_prof_test_step_b ) );
+    // Strip all step proficiencies (setup_step_craft grants them)
+    for( const recipe_proficiency &p : r.get_proficiencies() ) {
+        if( !p.required ) {
+            guy.lose_proficiency( p.id, true );
+        }
+    }
 
     // Restart craft without profs, re-supplying consumed components
     guy.cancel_activity();
     guy.remove_weapon();
-    const recipe &r = recipe_cudgel_test_steps_basic.obj();
     map &here = get_map();
     for( const std::vector<item_comp> &comp_group : r.simple_requirements().get_components() ) {
         if( !comp_group.empty() ) {
@@ -674,16 +681,538 @@ TEST_CASE( "step_recipe_xp_distribution", "[recipe][steps][crafting]" )
     }
     guy.invalidate_crafting_inventory();
     guy.set_focus( 100 );
-    guy.make_craft( recipe_cudgel_test_steps_basic, 1 );
+    guy.make_craft( rid, 1 );
+    REQUIRE( guy.activity );
+    REQUIRE( guy.activity.id() == ACT_CRAFT );
+}
+
+// Helper: advance N turns, with periodic focus updates
+static void advance_turns( avatar &guy, int n )
+{
+    for( int i = 0; i < n && guy.activity.id() == ACT_CRAFT; ++i ) {
+        guy.set_moves( 100 );
+        guy.activity.do_turn( guy );
+        if( i % 60 == 0 ) {
+            guy.update_mental_focus();
+        }
+    }
+}
+
+// Helper: advance until craft reaches a given step index
+static void advance_until_step( avatar &guy, int target_step )
+{
+    int safety = 0;
+    while( guy.activity.id() == ACT_CRAFT && safety < 100000 ) {
+        // Find the in-progress craft item
+        item *craft = nullptr;
+        for( item *it : guy.items_with( []( const item & itm ) {
+        return itm.is_craft();
+        } ) ) {
+            craft = it;
+            break;
+        }
+        if( !craft ) {
+            // Craft is wielded
+            if( guy.get_wielded_item() && guy.get_wielded_item()->is_craft() ) {
+                craft = &*guy.get_wielded_item();
+            }
+        }
+        if( craft && craft->get_current_step() >= target_step ) {
+            break;
+        }
+        guy.set_moves( 100 );
+        guy.activity.do_turn( guy );
+        ++safety;
+        if( safety % 60 == 0 ) {
+            guy.update_mental_focus();
+        }
+    }
+    REQUIRE( safety < 100000 );
+}
+
+// Helper: find the in-progress craft item on the avatar
+static item *find_craft_item( avatar &guy )
+{
+    for( item *it : guy.items_with( []( const item & itm ) {
+    return itm.is_craft();
+    } ) ) {
+        return it;
+    }
+    if( guy.get_wielded_item() && guy.get_wielded_item()->is_craft() ) {
+        return &*guy.get_wielded_item();
+    }
+    return nullptr;
+}
+
+// step_budget_moves helper returns correct values
+TEST_CASE( "step_budget_moves_direct", "[recipe][steps]" )
+{
+    clear_avatar();
+    avatar &guy = get_avatar();
+    guy.set_skill_level( skill_fabrication, 10 );
+    guy.add_proficiency( proficiency_prof_test_step_a, true );
+    guy.add_proficiency( proficiency_prof_test_step_b, true );
+
+    const recipe &r = recipe_cudgel_test_steps_basic.obj();
+    REQUIRE( r.has_steps() );
+    REQUIRE( r.steps().size() == 3 );
+
+    SECTION( "all profs known, batch 1" ) {
+        CHECK( r.step_budget_moves( guy, 0, 1 ) == Approx( 60000.0 ) );
+        CHECK( r.step_budget_moves( guy, 1, 1 ) == Approx( 30000.0 ) );
+        CHECK( r.step_budget_moves( guy, 2, 1 ) == Approx( 30000.0 ) );
+
+        double sum = r.step_budget_moves( guy, 0, 1 ) +
+                     r.step_budget_moves( guy, 1, 1 ) +
+                     r.step_budget_moves( guy, 2, 1 );
+        CHECK( std::abs( sum - r.batch_time( guy, 1, 1.0f, 0 ) ) <= 1.0 );
+    }
+
+    SECTION( "prof_A missing, batch 1" ) {
+        guy.lose_proficiency( proficiency_prof_test_step_a, true );
+        // Step 0 has prof_A with 2x malus -> doubled
+        CHECK( r.step_budget_moves( guy, 0, 1 ) == Approx( 120000.0 ) );
+        // Other steps unaffected
+        CHECK( r.step_budget_moves( guy, 1, 1 ) == Approx( 30000.0 ) );
+        CHECK( r.step_budget_moves( guy, 2, 1 ) == Approx( 30000.0 ) );
+    }
+
+    SECTION( "all profs known, batch 4" ) {
+        double sum = 0.0;
+        for( size_t i = 0; i < r.steps().size(); ++i ) {
+            sum += r.step_budget_moves( guy, i, 4 );
+        }
+        CHECK( std::abs( sum - r.batch_time( guy, 4, 1.0f, 0 ) ) <= 1.0 );
+    }
+}
+
+// step transitions at exact boundaries
+TEST_CASE( "step_transitions_exact_boundaries", "[recipe][steps][crafting]" )
+{
+    setup_step_craft( recipe_cudgel_test_steps_basic );
+    avatar &guy = get_avatar();
+    const recipe &r = recipe_cudgel_test_steps_basic.obj();
+
+    // With all profs and batch=1, step budgets are 600, 300, 300 turns
+    const int step_0_turns = static_cast<int>( r.step_budget_moves( guy, 0, 1 ) / 100 );
+    const int step_1_turns = static_cast<int>( r.step_budget_moves( guy, 1, 1 ) / 100 );
+    REQUIRE( step_0_turns == 600 );
+    REQUIRE( step_1_turns == 300 );
+
+    item *craft = find_craft_item( guy );
+    REQUIRE( craft );
+
+    // Just before step 0 boundary
+    advance_turns( guy, step_0_turns - 1 );
+    CHECK( craft->get_current_step() == 0 );
+
+    // Cross step 0 boundary
+    advance_turns( guy, 1 );
+    CHECK( craft->get_current_step() == 1 );
+    // Remainder should be small (at most one turn's worth of work)
+    CHECK( craft->get_step_progress() >= 0.0 );
+    CHECK( craft->get_step_progress() < 200.0 );
+
+    // Cross step 1 boundary
+    advance_turns( guy, step_1_turns );
+    CHECK( craft->get_current_step() == 2 );
+
+    // Complete
+    run_craft_to_completion( guy );
+}
+
+// multiple step boundaries crossed in single turn
+TEST_CASE( "step_multi_boundary_single_turn", "[recipe][steps][crafting]" )
+{
+    setup_step_craft( recipe_cudgel_test_steps_basic );
+    avatar &guy = get_avatar();
+
+    item *craft = find_craft_item( guy );
+    REQUIRE( craft );
+
+    // Step budgets: 60000 + 30000 + 30000 = 120000mv.
+    // Give 100000 moves -> crosses step 0 and step 1, lands in step 2.
+    guy.set_moves( 100000 );
+    guy.activity.do_turn( guy );
+
+    CHECK( craft->get_current_step() == 2 );
+    CHECK( craft->get_step_progress() == Approx( 100000.0 - 60000.0 - 30000.0 ).margin( 100.0 ) );
+    // Should NOT have completed (need 120000 total)
+    CHECK( guy.activity.id() == ACT_CRAFT );
+}
+
+// exertion changes per step
+TEST_CASE( "step_exertion_per_step", "[recipe][steps][crafting]" )
+{
+    setup_step_craft( recipe_cudgel_test_steps_basic );
+    avatar &guy = get_avatar();
+
+    const recipe &r = recipe_cudgel_test_steps_basic.obj();
+    // Step 0: MODERATE_EXERCISE
+    CHECK( guy.activity.exertion_level() == Approx( r.steps()[0].exertion ) );
+
+    // Advance to step 1 (LIGHT_EXERCISE)
+    advance_until_step( guy, 1 );
+    // Need one more do_turn for exertion_level to read the updated step
+    guy.set_moves( 100 );
+    guy.activity.do_turn( guy );
+    CHECK( guy.activity.exertion_level() == Approx( r.steps()[1].exertion ) );
+
+    // Advance to step 2 (NO_EXERCISE)
+    advance_until_step( guy, 2 );
+    guy.set_moves( 100 );
+    guy.activity.do_turn( guy );
+    CHECK( guy.activity.exertion_level() == Approx( r.steps()[2].exertion ) );
+}
+
+// exertion correct on resume
+TEST_CASE( "step_exertion_correct_on_resume", "[recipe][steps][crafting]" )
+{
+    setup_step_craft( recipe_cudgel_test_steps_basic );
+    avatar &guy = get_avatar();
+
+    // Advance into step 1
+    advance_until_step( guy, 1 );
+
+    // Interrupt (kill light)
+    set_time( calendar::turn_zero + 0_hours );
+    guy.set_moves( 100 );
+    guy.activity.do_turn( guy );
+    {
+        const bool craft_stopped = !guy.activity || guy.activity.id() != ACT_CRAFT;
+        REQUIRE( craft_stopped );
+    }
+
+    // Resume
+    item *craft = find_craft_item( guy );
+    REQUIRE( craft );
+    REQUIRE( craft->get_current_step() == 1 );
+
+    set_time( calendar::turn_zero + 12_hours );
+    guy.use( guy.get_item_position( craft ) );
     REQUIRE( guy.activity );
     REQUIRE( guy.activity.id() == ACT_CRAFT );
 
-    run_craft_to_completion( guy );
+    // Exertion should be step 1's value (LIGHT_EXERCISE), not step 0 or average
+    const recipe &r = recipe_cudgel_test_steps_basic.obj();
+    CHECK( guy.activity.exertion_level() == Approx( r.steps()[1].exertion ) );
+}
 
-    // Both step proficiencies should have received non-zero practice.
-    // Phase 1 distributes XP across all aggregate profs uniformly.
-    CHECK( guy.get_proficiency_practice( proficiency_prof_test_step_a ) > 0.0f );
+// proficiency learning is targeted to current step
+TEST_CASE( "step_proficiency_learning_targeted", "[recipe][steps][crafting]" )
+{
+    setup_step_craft_no_profs( recipe_cudgel_test_steps_basic );
+    avatar &guy = get_avatar();
+
+    REQUIRE( !guy.has_proficiency( proficiency_prof_test_step_a ) );
+    REQUIRE( !guy.has_proficiency( proficiency_prof_test_step_b ) );
+
+    item *craft = find_craft_item( guy );
+    REQUIRE( craft );
+
+    // Run through step 0 into step 1. Step 0 has prof_A.
+    advance_until_step( guy, 1 );
+
+    // At this point, all step 0 learning is done. Snapshot.
+    float prof_a_at_step1_entry = guy.get_proficiency_practice( proficiency_prof_test_step_a );
+    float prof_b_at_step1_entry = guy.get_proficiency_practice( proficiency_prof_test_step_b );
+    CHECK( prof_a_at_step1_entry > 0.0f );
+    CHECK( prof_b_at_step1_entry == 0.0f );
+
+    // Run in step 1 (Sand, no profs) past a 5% tick boundary.
+    const int counter_at_step1_entry = craft->item_counter;
+    while( craft->get_current_step() == 1 &&
+           craft->item_counter / 500000 == counter_at_step1_entry / 500000 ) {
+        guy.set_moves( 100 );
+        guy.activity.do_turn( guy );
+        if( !guy.activity || guy.activity.id() != ACT_CRAFT ) {
+            break;
+        }
+    }
+    // Verify we crossed a 5% tick while in step 1
+    REQUIRE( craft->item_counter / 500000 > counter_at_step1_entry / 500000 );
+
+    // prof_A should not have changed (Sand has no profs)
+    CHECK( guy.get_proficiency_practice( proficiency_prof_test_step_a ) ==
+           Approx( prof_a_at_step1_entry ) );
+    CHECK( guy.get_proficiency_practice( proficiency_prof_test_step_b ) == 0.0f );
+
+    // Advance into step 2 (Finish, prof_B). Run past a 5% tick.
+    advance_until_step( guy, 2 );
+    const int counter_at_step2_entry = craft->item_counter;
+    while( craft->get_current_step() == 2 &&
+           craft->item_counter / 500000 == counter_at_step2_entry / 500000 ) {
+        guy.set_moves( 100 );
+        guy.activity.do_turn( guy );
+        if( !guy.activity || guy.activity.id() != ACT_CRAFT ) {
+            break;
+        }
+    }
     CHECK( guy.get_proficiency_practice( proficiency_prof_test_step_b ) > 0.0f );
+}
+
+// retroactive repricing when proficiency learned mid-step
+TEST_CASE( "step_retroactive_repricing", "[recipe][steps][crafting]" )
+{
+    setup_step_craft_no_profs( recipe_cudgel_test_steps_basic );
+    avatar &guy = get_avatar();
+
+    item *craft = find_craft_item( guy );
+    REQUIRE( craft );
+
+    // Step 0 budget with missing prof_A (2x) = 120000mv = 1200 turns.
+    // Run 800 turns (2/3 of doubled budget).
+    advance_turns( guy, 800 );
+    REQUIRE( guy.activity.id() == ACT_CRAFT );
+    CHECK( craft->get_current_step() == 0 );
+
+    // Grant prof_A. Budget drops to 60000mv. step_progress (~80000) > new budget.
+    guy.add_proficiency( proficiency_prof_test_step_a, true );
+
+    // Next turn should transition past step 0.
+    guy.set_moves( 100 );
+    guy.activity.do_turn( guy );
+    CHECK( craft->get_current_step() == 1 );
+}
+
+// progress message contains step name
+TEST_CASE( "step_progress_message_contains_step_name", "[recipe][steps][crafting]" )
+{
+    setup_step_craft( recipe_cudgel_test_steps_basic );
+    avatar &guy = get_avatar();
+
+    std::optional<std::string> msg = guy.activity.get_progress_message( guy );
+    REQUIRE( msg.has_value() );
+    CHECK( msg->find( "Shape" ) != std::string::npos );
+
+    advance_until_step( guy, 1 );
+    // Need one turn to update the progress message path
+    guy.set_moves( 100 );
+    guy.activity.do_turn( guy );
+    msg = guy.activity.get_progress_message( guy );
+    REQUIRE( msg.has_value() );
+    CHECK( msg->find( "Sand" ) != std::string::npos );
+
+    advance_until_step( guy, 2 );
+    guy.set_moves( 100 );
+    guy.activity.do_turn( guy );
+    msg = guy.activity.get_progress_message( guy );
+    REQUIRE( msg.has_value() );
+    CHECK( msg->find( "Finish" ) != std::string::npos );
+}
+
+// item round-trip preserves step state
+TEST_CASE( "step_item_state_round_trip", "[recipe][steps][crafting]" )
+{
+    setup_step_craft( recipe_cudgel_test_steps_basic );
+    avatar &guy = get_avatar();
+
+    advance_until_step( guy, 1 );
+
+    item *craft = find_craft_item( guy );
+    REQUIRE( craft );
+    REQUIRE( craft->get_current_step() == 1 );
+    REQUIRE( craft->get_step_progress() >= 0.0 );
+
+    // Advance a few more turns to accumulate some step_progress
+    advance_turns( guy, 10 );
+
+    const int saved_step = craft->get_current_step();
+    const double saved_progress = craft->get_step_progress();
+    const int saved_counter = craft->item_counter;
+
+    // Serialize
+    std::string serialized;
+    {
+        std::ostringstream os;
+        JsonOut jsout( os );
+        craft->serialize( jsout );
+        serialized = os.str();
+    }
+
+    // Deserialize into fresh item
+    item loaded_item;
+    {
+        std::istringstream is( serialized );
+        JsonValue jsin = json_loader::from_string( serialized );
+        loaded_item.deserialize( jsin );
+    }
+
+    CHECK( loaded_item.get_current_step() == saved_step );
+    CHECK( loaded_item.get_step_progress() == Approx( saved_progress ) );
+    CHECK( loaded_item.item_counter == saved_counter );
+}
+
+// interrupt and resume completes at expected time
+TEST_CASE( "step_interrupt_resume_completes", "[recipe][steps][crafting]" )
+{
+    setup_step_craft( recipe_cudgel_test_steps_basic );
+    avatar &guy = get_avatar();
+    const recipe &r = recipe_cudgel_test_steps_basic.obj();
+
+    const int expected_moves = r.batch_time( guy, 1, 1.0f, 0 );
+    const int expected_turns = divide_round_up( expected_moves, 100 );
+
+    // Advance into step 1
+    advance_until_step( guy, 1 );
+
+    // Count turns so far
+    item *craft = find_craft_item( guy );
+    REQUIRE( craft );
+    int first_turns = static_cast<int>( craft->item_counter *
+                                        static_cast<double>( expected_turns ) / 10000000.0 );
+
+    // Interrupt
+    set_time( calendar::turn_zero + 0_hours );
+    guy.set_moves( 100 );
+    guy.activity.do_turn( guy );
+    {
+        const bool craft_stopped = !guy.activity || guy.activity.id() != ACT_CRAFT;
+        REQUIRE( craft_stopped );
+    }
+
+    // Resume
+    craft = find_craft_item( guy );
+    REQUIRE( craft );
+    set_time( calendar::turn_zero + 12_hours );
+    guy.use( guy.get_item_position( craft ) );
+    REQUIRE( guy.activity.id() == ACT_CRAFT );
+
+    const int resume_turns = run_craft_to_completion( guy );
+    const int total_turns = first_turns + resume_turns;
+    CHECK( std::abs( total_turns - expected_turns ) <= 2 );
+}
+
+// legacy migration from saves without step fields
+// Strips a JSON key-value pair from a serialized string.
+static void strip_json_field( std::string &json, const std::string &field_name )
+{
+    std::string quoted = "\"" + field_name + "\"";
+    std::string::size_type pos = json.find( quoted );
+    if( pos == std::string::npos ) {
+        return;
+    }
+    std::string::size_type end = json.find_first_of( ",}", pos );
+    if( end != std::string::npos && json[end] == ',' ) {
+        json.erase( pos, end - pos + 1 );
+    } else if( end != std::string::npos ) {
+        std::string::size_type comma = json.rfind( ',', pos );
+        if( comma != std::string::npos ) {
+            json.erase( comma, end - comma );
+        }
+    }
+}
+
+TEST_CASE( "step_legacy_migration", "[recipe][steps][crafting]" )
+{
+    setup_step_craft( recipe_cudgel_test_steps_basic );
+    avatar &guy = get_avatar();
+    const recipe &r = recipe_cudgel_test_steps_basic.obj();
+
+    // Advance to ~60% progress
+    const int total_turns = divide_round_up(
+                                static_cast<int>( r.batch_time( guy, 1, 1.0f, 0 ) ), 100 );
+    advance_turns( guy, total_turns * 6 / 10 );
+    REQUIRE( guy.activity.id() == ACT_CRAFT );
+
+    item *craft = find_craft_item( guy );
+    REQUIRE( craft );
+    REQUIRE( craft->item_counter > 0 );
+
+    // Interrupt the craft so we can swap the item
+    set_time( calendar::turn_zero + 0_hours );
+    guy.set_moves( 100 );
+    guy.activity.do_turn( guy );
+    {
+        const bool craft_stopped = !guy.activity || guy.activity.id() != ACT_CRAFT;
+        REQUIRE( craft_stopped );
+    }
+
+    // Find the interrupted craft item
+    craft = find_craft_item( guy );
+    REQUIRE( craft );
+    const int saved_counter = craft->item_counter;
+    REQUIRE( saved_counter > 0 );
+
+    // Serialize it, strip the step fields to simulate a pre-step-iteration save
+    std::string serialized;
+    {
+        std::ostringstream os;
+        JsonOut jsout( os );
+        craft->serialize( jsout );
+        serialized = os.str();
+    }
+    strip_json_field( serialized, "current_step" );
+    strip_json_field( serialized, "step_progress" );
+    CHECK( serialized.find( "current_step" ) == std::string::npos );
+    CHECK( serialized.find( "step_progress" ) == std::string::npos );
+
+    // Deserialize into a legacy item (missing fields default to 0)
+    item legacy_item;
+    {
+        JsonValue jsin = json_loader::from_string( serialized );
+        legacy_item.deserialize( jsin );
+    }
+    REQUIRE( legacy_item.is_craft() );
+    CHECK( legacy_item.get_current_step() == 0 );
+    CHECK( legacy_item.get_step_progress() == 0.0 );
+    CHECK( legacy_item.item_counter == saved_counter );
+
+    // Swap: remove the current craft, add the legacy item
+    guy.i_rem( craft );
+    guy.i_add( legacy_item );
+    guy.invalidate_crafting_inventory();
+
+    // Resume the legacy craft
+    set_time( calendar::turn_zero + 12_hours );
+    item *legacy_craft = find_craft_item( guy );
+    REQUIRE( legacy_craft );
+    guy.use( guy.get_item_position( legacy_craft ) );
+    REQUIRE( guy.activity );
+    REQUIRE( guy.activity.id() == ACT_CRAFT );
+
+    // Find the craft item again (may have moved due to wielding)
+    legacy_craft = find_craft_item( guy );
+    REQUIRE( legacy_craft );
+
+    // Run one turn to trigger migration
+    guy.set_moves( 100 );
+    guy.activity.do_turn( guy );
+
+    // At 60% progress: step 0 is 50% of total, so migration should land in step 1
+    CHECK( legacy_craft->get_current_step() == 1 );
+    CHECK( legacy_craft->get_step_progress() > 0.0 );
+}
+
+// stepless recipe is unaffected by step iteration
+TEST_CASE( "stepless_recipe_step_state_unchanged", "[recipe][steps][crafting]" )
+{
+    // Use cudgel_simple from TEST_DATA -- a non-step recipe
+    setup_step_craft( recipe_cudgel_simple );
+    avatar &guy = get_avatar();
+
+    const recipe &r = recipe_cudgel_simple.obj();
+    REQUIRE_FALSE( r.has_steps() );
+
+    item *craft = find_craft_item( guy );
+    REQUIRE( craft );
+
+    // Run partway
+    advance_turns( guy, 50 );
+    REQUIRE( guy.activity.id() == ACT_CRAFT );
+
+    CHECK( craft->get_current_step() == 0 );
+    CHECK( craft->get_step_progress() == 0.0 );
+
+    // Exertion is recipe-level
+    CHECK( guy.activity.exertion_level() == Approx( r.exertion_level() ) );
+
+    // Progress message contains craft name but no step names
+    std::optional<std::string> msg = guy.activity.get_progress_message( guy );
+    REQUIRE( msg.has_value() );
+    CHECK( msg->find( "Shape" ) == std::string::npos );
+    CHECK( msg->find( "Sand" ) == std::string::npos );
+    CHECK( msg->find( "Finish" ) == std::string::npos );
 }
 
 // ---- Edge case: inherited steps on non-step child ----


### PR DESCRIPTION
#### Summary
Features "Step iteration for recipe steps"

#### Purpose of change

#85913 added the recipe steps data model but the crafting activity itself was still monolithic -- one progress bar, flat exertion, all proficiencies learning uniformly. This makes `do_turn()` actually know which step it's in.

#### Describe the solution

What this does:

- `current_step` + `step_progress` (double) on `craft_data`, serialized, validated on deserialize
- `step_budget_moves()` helper -- same per-step formula `batch_time()` uses internally
- Step transitions in `do_turn()`: accumulates `delta_progress` as double (truncating to int every turn would drift), advances through boundaries, can cross multiple steps in one turn
- `exertion_level()` reads the current step's exertion directly from the craft item -- no cached `activity_override` for step recipes, so no stale values on resume or migration
- `craft_proficiency_gain()` uses the current step's proficiency list. Steps with no proficiencies (like "Sand") produce no learning
- Progress message: "Crafting: bread" becomes "Crafting: bread - Mixing dough"
- Legacy migration for saves from between #85913 and this PR
- Recipe steps documentation in `ITEM_CRAFT_AND_DISASSEMBLY.md`

What this doesn't do:

- Per-step tool consumption (tool charges still consumed recipe-wide)
- Passive/idle steps (#62618)
- Tool speed modifiers per-step (the sewing machine unlock -- still needs its own PR)

Accepted approximations:
- 5% tick at a step boundary attributes to whichever step you're in post-transition
- Proficiency learned mid-step retroactively reprices the step budget (same semantic as item_counter -- you got faster, so your accumulated work covers more of the now-smaller budget)
- One turn of stale exertion on legacy migration (deserialize has the recipe but not the Character for budget math)

#### Describe alternatives you've considered

- Deriving step from `item_counter` each turn instead of authoritative state -- proficiency changes shift step boundaries, making derivation unstable. Unattended steps (#62618) will need to pause at step boundaries, which requires explicit state
- `step_progress` as int64_t -- `delta_progress` is double, truncating every turn causes cumulative drift that desynchronizes step boundaries from overall progress

#### Testing

13 new tests:
- Budget (1): direct helper validation with all profs / missing prof / batch=4
- Boundaries (2): exact transition at 600th turn, multi-boundary crossing with 100k moves in one turn
- Exertion (2): per-step values, correct on resume after interrupt
- Proficiency (2): targeted learning to current step's profs, retroactive repricing on mid-step prof grant
- Display (1): progress message contains step name
- Save/load (2): item round-trip preserves step state, interrupt+resume completes at expected time
- Legacy (1): E2E with stripped JSON fields, deserialized item swapped into avatar, migration lands in correct step
- Regression (1): stepless recipe unaffected

Existing [recipe] and [crafting] suites pass.

#### Additional context

Related: #49525, #62618, #62635