### PR TITLE
[ Xedra Evolved ] Abnegation and Pontage Proficiencies

### DIFF
--- a/data/mods/Xedra_Evolved/achievements/achievements.json
+++ b/data/mods/Xedra_Evolved/achievements/achievements.json
@@ -1,5 +1,11 @@
 [
   {
+    "id": "achievement_banish",
+    "type": "achievement",
+    "name": "Begone, unholy creature!",
+    "requirements": [ { "event_statistic": "num_avatar_casts_banish", "is": ">=", "target": 1 } ]
+  },
+  {
     "id": "achievement_kill_changeling",
     "type": "achievement",
     "name": "Smashed a pixie.",

--- a/data/mods/Xedra_Evolved/achievements/achievements.json
+++ b/data/mods/Xedra_Evolved/achievements/achievements.json
@@ -6,6 +6,48 @@
     "requirements": [ { "event_statistic": "num_avatar_casts_banish", "is": ">=", "target": 1 } ]
   },
   {
+    "id": "achievement_banish",
+    "type": "achievement",
+    "name": "āšipu",
+    "requirements": [ { "event_statistic": "num_avatar_casts_banish", "is": ">=", "target": 10 } ]
+  },
+  {
+    "id": "achievement_banish",
+    "type": "achievement",
+    "name": "Solomon",
+    "requirements": [ { "event_statistic": "num_avatar_casts_banish", "is": ">=", "target": 100 } ]
+  },
+  {
+    "id": "achievement_banish",
+    "type": "achievement",
+    "name": "Shiro Fujimoto",
+    "requirements": [ { "event_statistic": "num_avatar_casts_banish", "is": ">=", "target": 1000 } ]
+  },
+  {
+    "id": "achievement_summon",
+    "type": "achievement",
+    "name": "John 'Faust' Cataclysm",
+    "requirements": [ { "event_statistic": "num_avatar_casts_summon", "is": ">=", "target": 1 } ]
+  },
+  {
+    "id": "achievement_summon",
+    "type": "achievement",
+    "name": "Circe",
+    "requirements": [ { "event_statistic": "num_avatar_casts_summon", "is": ">=", "target": 10 } ]
+  },
+  {
+    "id": "achievement_summon",
+    "type": "achievement",
+    "name": "Abe no Seimei",
+    "requirements": [ { "event_statistic": "num_avatar_casts_summon", "is": ">=", "target": 100 } ]
+  },
+  {
+    "id": "achievement_summon",
+    "type": "achievement",
+    "name": "Baba Yaga",
+    "requirements": [ { "event_statistic": "num_avatar_casts_summon", "is": ">=", "target": 1000 } ]
+  },
+  {
     "id": "achievement_kill_changeling",
     "type": "achievement",
     "name": "Smashed a pixie.",

--- a/data/mods/Xedra_Evolved/achievements/statistics.json
+++ b/data/mods/Xedra_Evolved/achievements/statistics.json
@@ -37,5 +37,18 @@
     "type": "event_transformation",
     "event_transformation": "avatar_casts_banish",
     "value_constraints": { "spell_effect": { "equals": [ "effect_id", "banishment" ] } }
+  },
+  {
+    "id": "num_avatar_casts_summon",
+    "type": "event_statistic",
+    "stat_type": "count",
+    "event_transformation": "avatar_casts_summon",
+    "description": { "str_sp": "summons cast" }
+  },
+  {
+    "id": "avatar_casts_summon",
+    "type": "event_transformation",
+    "event_transformation": "avatar_casts_summon",
+    "value_constraints": { "spell_effect": { "equals": [ "effect_id", "summon" ] } }
   }
 ]

--- a/data/mods/Xedra_Evolved/achievements/statistics.json
+++ b/data/mods/Xedra_Evolved/achievements/statistics.json
@@ -24,5 +24,18 @@
     "stat_type": "count",
     "event_transformation": "avatar_vampire_kills",
     "description": { "str": "vampire killed", "str_pl": "vampires killed" }
+  },
+  {
+    "id": "num_avatar_casts_banish",
+    "type": "event_statistic",
+    "stat_type": "count",
+    "event_transformation": "avatar_casts_banish",
+    "description": { "str_sp": "banishes cast" }
+  },
+  {
+    "id": "avatar_casts_banish",
+    "type": "event_transformation",
+    "event_transformation": "avatar_casts_banish",
+    "value_constraints": { "spell_effect": { "equals": [ "effect_id", "banishment" ] } }
   }
 ]

--- a/data/mods/Xedra_Evolved/eocs/eater_eocs.json
+++ b/data/mods/Xedra_Evolved/eocs/eater_eocs.json
@@ -14,5 +14,16 @@
     "false_effect": [
       { "u_message": "You shiver as the night closes in…", "type": "bad", "popup": true, "popup_w_interrupt_query": true }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_WAKEUP_NETHER_HUNTER",
+    "eoc_type": "EVENT",
+    "required_event": "character_wakes_up",
+    "condition": { "and": [ { "event_statistic('num_avatar_nether_kills') >= 100" }, { "u_has_trait": "EATER" } ] },
+    "effect": [
+      { "math": [ "u_proficiency('prof_abnegation', 'format': 'percent', 'direct': true) += 5" ] },
+      { "u_message": "You gain a certainty that the things you've killed never belonged here at all."}
+    ]
   }
 ]

--- a/data/mods/Xedra_Evolved/items/books_deduction.json
+++ b/data/mods/Xedra_Evolved/items/books_deduction.json
@@ -121,6 +121,59 @@
     "read_fun": -7
   },
   {
+    "id": "book_jung_man_and_his_symbols",
+    "type": "ITEM",
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "Man and his Symbols by Jung", "str_pl": "copies of Man and his Symbols by Jung" },
+    "description": "The landmark text about the inner workings of the unconscious mind—from the symbolism that unlocks the meaning of our dreams to their effect on our waking lives and artistic impulses—featuring more than a hundred images that break down Carl Jung’s revolutionary ideas.",
+    "//": "When possible, this should be a book.  There is currently no way to hook EOCs to reading a certain book.",
+    "weight": "830 g",
+    "volume": "1320 ml",
+    "price": "1 USD",
+    "material": [ "paper" ],
+    "looks_like": "cookbook",
+    "symbol": "?",
+    "color": "dark_gray",
+    "use_action": { "type": "effect_on_conditions", "description": "Read the book.", "effect_on_conditions": [ "EOC_READ_BOOK_SYMBOLS" ] },
+    "flags": [ "TRADER_AVOID" ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_READ_BOOK_SYMBOLS",
+    "condition": { "math": [ "u_skill('deduction') >= 3" ] },
+    "effect": [ { "run_eocs": [ "EOC_READ_BOOK_SYMBOLS_REAL" ] } ],
+    "false_effect": [ { "u_message": "You read the landmark book on dreaming and it's nature.  You feel like there is something more hidden in the text pertinent to this post Cataclysm world.", "type": "good" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_READ_BOOK_SYMBOLS_REAL",
+    "condition": { "and": [ { "math": [ "u_proficiency('prof_lucid_dreaming') < 100" ] }, { "math": [ "u_jung < 5" ] } ] },
+    "effect": [
+      { "u_assign_activity": "ACT_READING_BOOK_JUNG", "duration": "2 hours" },
+      { "u_message": "You begin reading about dreams and the subconscious.", "type": "good" },
+      { "math": [ "u_jung += 1" ] }
+    ],
+    "false_effect": [ { "u_message": "You've learned everything you can from this book.", "type": "good" } ]
+  },
+  {
+    "id": "ACT_READING_BOOK_JUNG",
+    "type": "activity_type",
+    "activity_level": "NO_EXERCISE",
+    "verb": "reading",
+    "based_on": "time",
+    "can_resume": true,
+    "rooted": true,
+    "completion_eoc": "EOC_PROFICIENCY_FROM_BOOK_JUNG"
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PROFICIENCY_FROM_BOOK_JUNG",
+    "effect": [
+      { "math": [ "u_jung += 1" ] },
+      { "math": [ "u_proficiency('prof_lucid_dreaming', 'format': 'percent') += 1" ] }
+    ]
+  },
+  {
     "id": "book_deduction_lies",
     "type": "ITEM",
     "subtypes": [ "TOOL" ],

--- a/data/mods/Xedra_Evolved/items/books_deduction.json
+++ b/data/mods/Xedra_Evolved/items/books_deduction.json
@@ -150,8 +150,7 @@
     "condition": { "and": [ { "math": [ "u_proficiency('prof_lucid_dreaming') < 100" ] }, { "math": [ "u_jung < 5" ] } ] },
     "effect": [
       { "u_assign_activity": "ACT_READING_BOOK_JUNG", "duration": "2 hours" },
-      { "u_message": "You begin reading about dreams and the subconscious.", "type": "good" },
-      { "math": [ "u_jung += 1" ] }
+      { "u_message": "You begin reading about dreams and the subconscious.", "type": "good" }
     ],
     "false_effect": [ { "u_message": "You've learned everything you can from this book.", "type": "good" } ]
   },

--- a/data/mods/Xedra_Evolved/items/books_deduction.json
+++ b/data/mods/Xedra_Evolved/items/books_deduction.json
@@ -142,7 +142,12 @@
     "id": "EOC_READ_BOOK_SYMBOLS",
     "condition": { "math": [ "u_skill('deduction') >= 3" ] },
     "effect": [ { "run_eocs": [ "EOC_READ_BOOK_SYMBOLS_REAL" ] } ],
-    "false_effect": [ { "u_message": "You read the landmark book on dreaming and it's nature.  You feel like there is something more hidden in the text pertinent to this post Cataclysm world.", "type": "good" } ]
+    "false_effect": [
+      {
+        "u_message": "You read the landmark book on dreaming and it's nature.  You feel like there is something more hidden in the text pertinent to this post Cataclysm world.",
+        "type": "good"
+      }
+    ]
   },
   {
     "type": "effect_on_condition",
@@ -167,10 +172,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_PROFICIENCY_FROM_BOOK_JUNG",
-    "effect": [
-      { "math": [ "u_jung += 1" ] },
-      { "math": [ "u_proficiency('prof_lucid_dreaming', 'format': 'percent') += 1" ] }
-    ]
+    "effect": [ { "math": [ "u_jung += 1" ] }, { "math": [ "u_proficiency('prof_lucid_dreaming', 'format': 'percent') += 1" ] } ]
   },
   {
     "id": "book_deduction_lies",

--- a/data/mods/Xedra_Evolved/jmath.json
+++ b/data/mods/Xedra_Evolved/jmath.json
@@ -372,6 +372,18 @@
     "return": "1 + ( ( (u_proficiency('prof_lucid_dreaming', 'format': 'percent') / 1000) ) * 3)"
   },
   {
+    "type": "jmath_function",
+    "id": "abnegation_proficiency_modifier",
+    "num_args": 0,
+    "return": "1 + ( (u_proficiency('prof_abnegation', 'format': 'percent') / 1000) )"
+  },
+  {
+    "type": "jmath_function",
+    "id": "pontage_proficiency_modifier",
+    "num_args": 0,
+    "return": "1 + ( (u_proficiency('prof_pontage', 'format': 'percent') / 1000) )"
+  },
+  {
     "id": "xe_nether_sorcery_failure_chance",
     "type": "jmath_function",
     "num_args": 0,

--- a/data/mods/Xedra_Evolved/player/proficiencies.json
+++ b/data/mods/Xedra_Evolved/player/proficiencies.json
@@ -92,5 +92,33 @@
     "time_to_learn": "16 h",
     "default_time_multiplier": 1,
     "default_skill_penalty": 0.1
+  },
+  {
+    "type": "proficiency_category",
+    "id": "prof_magick_skills",
+    "name": "Magickal Skills",
+    "description": "The ability to control your dreams during sleep."
+  },
+  {
+    "type": "proficiency",
+    "id": "prof_abnegation",
+    "category": "prof_magick_skills",
+    "name": { "str": "Abnegation" },
+    "description": "This enhances your ability to banish things from reality to places elsewhere.",
+    "can_learn": true,
+    "time_to_learn": "16 h",
+    "default_time_multiplier": 1,
+    "default_skill_penalty": 0.1
+  },
+  {
+    "type": "proficiency",
+    "id": "prof_pontage",
+    "category": "prof_magick_skills",
+    "name": { "str": "Pontage" },
+    "description": "This enhances your ability to bring things from places elsewhere to here.",
+    "can_learn": true,
+    "time_to_learn": "16 h",
+    "default_time_multiplier": 1,
+    "default_skill_penalty": 0.1
   }
 ]

--- a/data/mods/Xedra_Evolved/spells/dreamer_spells.json
+++ b/data/mods/Xedra_Evolved/spells/dreamer_spells.json
@@ -115,7 +115,7 @@
     "description": "Attempts to banish things clearly inimical to local physics back to their home dimension.",
     "teachable": false,
     "valid_targets": [ "hostile" ],
-    "effect": "attack",
+    "effect": "banishment",
     "shape": "blast",
     "targeted_monster_species": [ "NETHER" ],
     "spell_class": "DREAMER",

--- a/src/cata_variant.cpp
+++ b/src/cata_variant.cpp
@@ -45,6 +45,7 @@ std::string enum_to_string<cata_variant_type>( cata_variant_type type )
         case cata_variant_type::character_id: return "character_id";
         case cata_variant_type::chrono_seconds: return "chrono_seconds";
         case cata_variant_type::debug_menu_index: return "debug_menu_index";
+        case cata_variant_type::effect_id: return "effect_id";
         case cata_variant_type::efftype_id: return "efftype_id";
         case cata_variant_type::faction_id: return "faction_id";
         case cata_variant_type::field_type_id: return "field_type_id";

--- a/src/cata_variant.h
+++ b/src/cata_variant.h
@@ -44,6 +44,7 @@ enum class cata_variant_type : int {
     character_id,
     chrono_seconds,
     debug_menu_index,
+    effect_id,
     efftype_id,
     faction_id,
     field_type_id,

--- a/src/event.h
+++ b/src/event.h
@@ -307,6 +307,7 @@ template<>
 struct event_spec<event_type::character_casts_spell> {
     static constexpr std::array<event_field, 7> fields = { {
             { "character", cata_variant_type::character_id },
+            { "spell_effect", cata_variant_type::effect_id },
             { "spell", cata_variant_type::spell_id },
             { "school", cata_variant_type::trait_id },
             { "difficulty", cata_variant_type::int_},

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2154,8 +2154,8 @@ void spell::cast_spell_effect( Creature &source, const tripoint_bub_ms &target )
         character_id c_id = caster->getID();
         // send casting to the event bus
         get_event_bus().send<event_type::character_casts_spell>( c_id, this->id(), this->spell_class(),
-                this->get_difficulty( source ), this->energy_cost( *caster ), this->casting_time( *caster ),
-                this->damage( source ) );
+                this->effect(), this->get_difficulty( source ), this->energy_cost( *caster ),
+                this->casting_time( *caster ), this->damage( source ) );
     }
 
     type->effect( *this, source, target );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
XE is going to have a lot of weird proficiencies that can't be trained via normal means.  This is an expansion of that idea.  Specifically Abnegation and Pontage which are respectively the proficiencies of banishing non Earth native critters and summoning.  I've noticed that most banishes and summons are with the dreamer class and I may do some shifting of things or I may look at things to see how best these should be supported in future.  
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
New Proficiencies and make use of the ability to check statistics to award EOC effects from.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
