### PR TITLE
Tool speed modifiers for recipe steps

### DIFF
--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -5645,5 +5645,43 @@
     "symbol": ";",
     "color": "light_gray",
     "qualities": [ [ "LOCKPICK", 3 ] ]
+  },
+  {
+    "type": "ITEM",
+    "id": "test_fast_cutter",
+    "name": { "str": "fast cutter" },
+    "description": "A test tool with fast CUT speed.",
+    "weight": "200 g",
+    "volume": "250 ml",
+    "price": "0 cent",
+    "price_postapoc": "0 cent",
+    "material": [ "steel" ],
+    "symbol": "/",
+    "color": "light_cyan",
+    "qualities": [ { "id": "CUT", "level": 1, "speed": 0.5 } ]
+  },
+  {
+    "type": "ITEM",
+    "id": "test_slow_cutter",
+    "name": { "str": "slow cutter" },
+    "description": "A test tool with slow CUT speed.",
+    "weight": "200 g",
+    "volume": "250 ml",
+    "price": "0 cent",
+    "price_postapoc": "0 cent",
+    "material": [ "steel" ],
+    "symbol": "/",
+    "color": "light_red",
+    "qualities": [ { "id": "CUT", "level": 1, "speed": 1.5 } ]
+  },
+  {
+    "type": "ITEM",
+    "subtypes": [ "TOOL" ],
+    "id": "test_charged_fast_cutter",
+    "copy-from": "cordless_drill",
+    "name": { "str": "charged fast cutter" },
+    "description": "A test powered tool with fast CUT speed when charged.",
+    "qualities": [ [ "SCREW", 1 ] ],
+    "charged_qualities": [ { "id": "CUT", "level": 2, "speed": 0.3 } ]
   }
 ]

--- a/doc/JSON/ITEM.md
+++ b/doc/JSON/ITEM.md
@@ -959,7 +959,10 @@ Gun mods can be defined like this:
 "fuel_efficiency": 0.2, // When combined with being a UPS this item will burn fuel for its given energy value to produce energy with the efficiency provided. Needs to be > 0 for this to work
 "use_action": [ "firestarter" ], // Action performed when tool is used, see special definition below
 "qualities": [ [ "SCREW", 1 ] ], // Inherent item qualities like hammering, sawing, screwing (see tool_qualities.json)
+// Qualities also accept object format: { "id": "SEW", "level": 2, "speed": 0.3 }
+// "speed" is optional (default 1.0). Values < 1.0 make recipe steps using this quality faster.
 "charged_qualities": [ [ "DRILL", 3 ] ], // Qualities available if tool has at least charges_per_use charges left
+// charged_qualities also accept the object format with "speed".
 // Only TOOL type items may define the following fields:
 "tool_ammo": [ "NULL" ],        // Ammo types used for reloading
 "charge_factor": 5,        // this tool uses charge_factor charges for every charge required in a recipe; intended for tools that have a "sub" field but use a different ammo that the original tool

--- a/doc/JSON/ITEM_CRAFT_AND_DISASSEMBLY.md
+++ b/doc/JSON/ITEM_CRAFT_AND_DISASSEMBLY.md
@@ -223,6 +223,7 @@ Each entry in the `"steps"` array is an object with these fields:
 - Proficiency training is limited to the proficiencies listed on the current step.
 - Batch savings are applied per-step and summed.
 - The current step name appears in the crafting progress message.
+- Tool speed modifiers (see `"speed"` in item quality definitions) apply per-step: a tool with `"speed": 0.5` on a quality halves the time of steps requiring that quality, without affecting other steps.
 
 ## Practice recipes
 

--- a/doc/JSON/JSON_INFO.md
+++ b/doc/JSON/JSON_INFO.md
@@ -2698,6 +2698,14 @@ definitions in the json files by adding a `"qualities":` line.
 For example: `"qualities": [ [ "ANVIL", 2 ] ],` associates the `ANVIL` quality
 at level `2` to the item.
 
+Qualities also accept an object format with an optional `speed` field:
+`"qualities": [ { "id": "SEW", "level": 2, "speed": 0.3 } ]`.
+The `speed` value (default 1.0) is a multiplier applied to recipe steps that
+require this quality. Values below 1.0 make the step faster (e.g. a sewing
+machine with speed 0.3 completes sewing steps in 30% of the base time).
+Both array and object formats can be mixed freely. `charged_qualities` accepts
+the same format.
+
 ### Traits/Mutations
 
 See [MUTATIONS.md](MUTATIONS.md)

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -1444,14 +1444,14 @@ int hacksaw_activity_actor::get_tool_quality() const
     int qual = 0;
     if( type.has_value() ) {
         item veh_tool = item( type.value(), calendar::turn );
-        for( const std::pair<const quality_id, int> &quality : type.value()->qualities ) {
+        for( const auto &quality : type.value()->qualities ) {
             if( quality.first == qual_SAW_M ) {
-                qual = quality.second;
+                qual = quality.second.level;
             }
         }
-        for( const std::pair<const quality_id, int> &quality : type.value()->charged_qualities ) {
+        for( const auto &quality : type.value()->charged_qualities ) {
             if( quality.first == qual_SAW_M ) {
-                qual = std::max( qual, quality.second );
+                qual = std::max( qual, quality.second.level );
             }
         }
     } else {
@@ -5759,15 +5759,18 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
     if( cached_crafting_speed != crafting_speed || cached_assistants != assistants ) {
         cached_crafting_speed = crafting_speed;
         cached_assistants = assistants;
+        // Recompute per-step tool speed from current crafting inventory
+        cached_tool_speeds = compute_tool_speeds( rec, crafter );
+        const std::vector<float> *ts = cached_tool_speeds.empty() ? nullptr : &cached_tool_speeds;
 
         // Base moves for batch size with no speed modifier or assistants
         // Must ensure >= 1 so we don't divide by 0;
         cached_base_total_moves = std::max( static_cast<int64_t>( 1 ),
-                                            rec.batch_time( crafter, craft.get_making_batch_size(), 1.0f, 0 ) );
+                                            rec.batch_time( crafter, craft.get_making_batch_size(), 1.0f, 0, ts ) );
         // Current expected total moves, includes crafting speed modifiers and assistants
         cached_cur_total_moves = std::max( static_cast<int64_t>( 1 ),
                                            rec.batch_time( crafter, craft.get_making_batch_size(), crafting_speed,
-                                                   assistants ) );
+                                                   assistants, ts ) );
     }
     const double base_total_moves = cached_base_total_moves;
     const double cur_total_moves = cached_cur_total_moves;
@@ -5795,9 +5798,10 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
     if( rec.has_steps() ) {
         craft.mod_step_progress( delta_progress );
         const int last_step_idx = static_cast<int>( rec.steps().size() ) - 1;
+        const std::vector<float> *ts = cached_tool_speeds.empty() ? nullptr : &cached_tool_speeds;
         while( craft.get_current_step() < last_step_idx ) {
             const double budget = rec.step_budget_moves( crafter,
-                                  craft.get_current_step(), craft.get_making_batch_size() );
+                                  craft.get_current_step(), craft.get_making_batch_size(), ts );
             if( craft.get_step_progress() < budget ) {
                 break;
             }

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -1908,6 +1908,7 @@ class craft_activity_actor : public activity_actor
         std::optional<requirement_data> cached_continuation_requirements; // NOLINT(cata-serialize)
         float cached_crafting_speed; // NOLINT(cata-serialize)
         int cached_assistants; // NOLINT(cata-serialize)
+        std::vector<float> cached_tool_speeds; // NOLINT(cata-serialize)
         double cached_base_total_moves; // NOLINT(cata-serialize)
         double cached_cur_total_moves; // NOLINT(cata-serialize)
         float cached_workbench_multiplier; // NOLINT(cata-serialize)

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -485,7 +485,9 @@ int64_t Character::expected_time_to_craft( const recipe &rec, int batch_size ) c
 {
     const size_t assistants = available_assistant_count( rec );
     float modifier = crafting_speed_multiplier( rec );
-    return rec.batch_time( *this, batch_size, modifier, assistants );
+    std::vector<float> tool_speeds = compute_tool_speeds( rec, *this );
+    const std::vector<float> *ts = tool_speeds.empty() ? nullptr : &tool_speeds;
+    return rec.batch_time( *this, batch_size, modifier, assistants, ts );
 }
 
 bool Character::check_eligible_containers_for_crafting( const recipe &rec, int batch_size ) const

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -2200,9 +2200,9 @@ int item::get_quality_nonrecursive( const quality_id &id, const bool strict_boil
     int return_quality = INT_MIN;
 
     // Check for inherent item quality
-    for( const std::pair<const quality_id, int> &quality : type->qualities ) {
+    for( const auto &quality : type->qualities ) {
         if( quality.first == id ) {
-            return_quality = quality.second;
+            return_quality = quality.second.level;
         }
     }
 
@@ -2210,9 +2210,9 @@ int item::get_quality_nonrecursive( const quality_id &id, const bool strict_boil
     // (using ammo_remaining() with player character to include bionic/UPS power)
     if( !type->charged_qualities.empty() && ammo_sufficient( &get_player_character() ) ) {
         // see if any charged qualities are better than the current one
-        for( const std::pair<const quality_id, int> &quality : type->charged_qualities ) {
+        for( const auto &quality : type->charged_qualities ) {
             if( quality.first == id ) {
-                return_quality = std::max( return_quality, quality.second );
+                return_quality = std::max( return_quality, quality.second.level );
             }
         }
     }
@@ -2236,6 +2236,69 @@ int item::get_quality( const quality_id &id, const bool strict_boiling ) const
     return_quality = std::max( return_quality, contents.best_quality( id ) );
 
     return return_quality;
+}
+
+float item::get_quality_speed( const quality_id &id, int level,
+                               const Character *crafter ) const
+{
+    // BOIL special case: empty containers only (mirrors get_quality)
+    if( id == qual_BOIL && !contents.empty_container() ) {
+        return 1.0f;
+    }
+
+    bool found = false;
+    float best_speed = 1.0f;
+
+    // Helper: consider a source that provides the quality at qual_level with speed s
+    const auto consider = [&]( int qual_level, float s ) {
+        if( qual_level >= level ) {
+            if( !found || s < best_speed ) {
+                best_speed = s;
+                found = true;
+            }
+        }
+    };
+
+    // Inherent qualities
+    auto it = type->qualities.find( id );
+    if( it != type->qualities.end() ) {
+        consider( it->second.level, it->second.speed );
+    }
+
+    // Charged qualities (only if crafter provided for ammo_sufficient check)
+    if( crafter && !type->charged_qualities.empty() && ammo_sufficient( crafter ) ) {
+        auto cit = type->charged_qualities.find( id );
+        if( cit != type->charged_qualities.end() ) {
+            consider( cit->second.level, cit->second.speed );
+        }
+    }
+
+    // Contained items: recursive through contents (mirrors get_quality -> contents.best_quality)
+    for( const item *contained : contents.all_items_top() ) {
+        // Recurse: child checks its own inherent, charged, and contained items
+        float child_speed = contained->get_quality_speed( id, level, crafter );
+        // Child already returns 1.0 if it doesn't qualify, but we use found flag
+        // to distinguish "qualifies at 1.0" from "doesn't qualify". Check the
+        // child's quality level directly without leaking get_player_character():
+        // use the same crafter-aware resolution we do above.
+        int child_level = INT_MIN;
+        auto cit = contained->type->qualities.find( id );
+        if( cit != contained->type->qualities.end() ) {
+            child_level = cit->second.level;
+        }
+        if( crafter && !contained->type->charged_qualities.empty() &&
+            contained->ammo_sufficient( crafter ) ) {
+            auto ccit = contained->type->charged_qualities.find( id );
+            if( ccit != contained->type->charged_qualities.end() ) {
+                child_level = std::max( child_level, ccit->second.level );
+            }
+        }
+        if( child_level >= level ) {
+            consider( child_level, child_speed );
+        }
+    }
+
+    return best_speed;
 }
 
 int item::get_comestible_fun() const

--- a/src/item.h
+++ b/src/item.h
@@ -1076,6 +1076,14 @@ class item : public visitable
          * @param strict_boiling True if containers must be empty to have BOIL quality
          */
         int get_quality( const quality_id &id, bool strict_boiling = true ) const;
+        /**
+         * Speed modifier for a quality this item provides at >= level.
+         * Mirrors get_quality() resolution: inherent, charged (if crafter provided),
+         * BOIL special case, contained items.
+         * Returns 1.0f if item doesn't qualify or has no speed modifier.
+         */
+        float get_quality_speed( const quality_id &id, int level,
+                                 const Character *crafter = nullptr ) const;
 
         /**
          * Return true if this item's type is counted by charges

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -71,6 +71,61 @@
 
 template <typename T> struct enum_traits;
 
+// Reader for item qualities that accepts both legacy array ["CUT", 1] and
+// new object {"id": "CUT", "level": 1, "speed": 0.5} formats.
+// Produces std::pair<quality_id, itype::item_quality> for use with optional()
+// so that copy-from / extend / delete / proportional / relative all work.
+class item_quality_reader : public generic_typed_reader<item_quality_reader>
+{
+    public:
+        static constexpr bool read_objects = true;
+
+        std::pair<quality_id, itype::item_quality> get_next( const JsonValue &val ) const {
+            if( val.test_array() ) {
+                // Legacy: ["CUT", 1]
+                JsonArray arr = val.get_array();
+                if( arr.size() != 2 ) {
+                    arr.throw_error( "quality array must have exactly 2 entries [id, level]" );
+                }
+                return { quality_id( arr[0].get_string() ),
+                         itype::item_quality{ arr[1].get_int(), 1.0f } };
+            } else if( val.test_object() ) {
+                // New: {"id": "CUT", "level": 1, "speed": 0.5}
+                JsonObject obj = val.get_object();
+                quality_id qid( obj.get_string( "id" ) );
+                int level = obj.get_int( "level" );
+                float speed = obj.get_float( "speed", 1.0f );
+                if( speed <= 0.0f ) {
+                    obj.throw_error_at( "speed", "quality speed must be > 0" );
+                }
+                return { qid, itype::item_quality{ level, speed } };
+            } else if( val.test_string() ) {
+                // Bare string: "COOK" (used in "delete" context)
+                return { quality_id( val.get_string() ), itype::item_quality{ 0, 1.0f } };
+            } else if( val.is_member() ) {
+                // Map format: { "CUT": 1 }
+                const JsonMember &jm = dynamic_cast<const JsonMember &>( val );
+                return { quality_id( jm.name() ),
+                         itype::item_quality{ static_cast<int>( val.get_float() ), 1.0f } };
+            }
+            val.throw_error( "quality entry must be an array, object, or string" );
+        }
+
+        // Override relative_next to bypass the supports_relative<item_quality> trait
+        // which the PCH may evaluate before item_quality has operator+=.
+        // "relative" on qualities means add to level, leave speed unchanged.
+        template<typename C>
+        void relative_next( JsonValue &jv, C &container ) const {
+            auto parsed = get_next( jv );
+            auto iter = container.find( parsed.first );
+            if( iter == container.end() ) {
+                jv.throw_error( "relative: no existing quality to modify" );
+                return;
+            }
+            iter->second.level += parsed.second.level;
+        }
+};
+
 static const ammo_effect_str_id ammo_effect_COOKOFF( "COOKOFF" );
 static const ammo_effect_str_id ammo_effect_INCENDIARY( "INCENDIARY" );
 static const ammo_effect_str_id ammo_effect_SPECIAL_COOKOFF( "SPECIAL_COOKOFF" );
@@ -348,7 +403,7 @@ void Item_factory::finalize_pre( itype &obj )
     // if a method was already set the specific values remain unchanged
     for( const auto &q : obj.qualities ) {
         for( const auto &u : q.first.obj().usages ) {
-            if( q.second >= u.first ) {
+            if( q.second.level >= u.first ) {
                 emplace_usage( obj.use_methods, u.second );
                 // As far as I know all the actions provided by quality level do not consume ammo
                 // So it is safe to set all to 0
@@ -359,7 +414,7 @@ void Item_factory::finalize_pre( itype &obj )
     }
     for( const auto &q : obj.charged_qualities ) {
         for( const auto &u : q.first.obj().usages ) {
-            if( q.second >= u.first ) {
+            if( q.second.level >= u.first ) {
                 emplace_usage( obj.use_methods, u.second );
                 // I do not know how to get the ammo scale, so hopefully it naturally comes with the item's scale?
             }
@@ -837,9 +892,9 @@ void Item_factory::finalize_post( itype &obj )
     if( obj.gun && !obj.gunmod && !obj.has_flag( flag_PRIMITIVE_RANGED_WEAPON ) ) {
         const quality_id qual_gun_skill( to_upper_case( obj.gun->skill_used.str() ) );
 
-        obj.qualities[qual_GUN] = std::max( obj.qualities[qual_GUN], 1 );
+        obj.qualities[qual_GUN].level = std::max( obj.qualities[qual_GUN].level, 1 );
         if( qual_gun_skill.is_valid() ) {
-            obj.qualities[qual_gun_skill] = std::max( obj.qualities[qual_gun_skill], 1 );
+            obj.qualities[qual_gun_skill].level = std::max( obj.qualities[qual_gun_skill].level, 1 );
         }
     }
 
@@ -4228,9 +4283,8 @@ void itype::load( const JsonObject &jo, std::string_view src )
         }
     }
 
-    optional( jo, was_loaded, "qualities", qualities, weighted_string_id_reader<quality_id, int> {1} );
-    optional( jo, was_loaded, "charged_qualities", charged_qualities,
-              weighted_string_id_reader<quality_id, int> {1} );
+    optional( jo, was_loaded, "qualities", qualities, item_quality_reader {} );
+    optional( jo, was_loaded, "charged_qualities", charged_qualities, item_quality_reader {} );
 
     optional( jo, was_loaded, "properties", properties );
 

--- a/src/item_info.cpp
+++ b/src/item_info.cpp
@@ -3269,9 +3269,18 @@ void item::qualities_info( std::vector<iteminfo> &info, const iteminfo_query *pa
     if( parts->test( iteminfo_parts::QUALITIES ) && has_any_qualities ) {
         insert_separation_line( info );
         // List all inherent (unconditional) qualities
+        // Helper to extract level-only pairs for display from item_quality maps
+        const auto to_level_pairs = []( const std::map<quality_id, itype::item_quality> &qmap ) {
+            std::map<quality_id, int> result;
+            for( const auto &e : qmap ) {
+                result[e.first] = e.second.level;
+            }
+            return result;
+        };
+
         if( !type->qualities.empty() ) {
             info.emplace_back( "QUALITIES", "", _( "<bold>Has qualities</bold>:" ) );
-            for( const std::pair<quality_id, int> &q : sorted_lex( type->qualities ) ) {
+            for( const std::pair<quality_id, int> &q : sorted_lex( to_level_pairs( type->qualities ) ) ) {
                 name_quality( q );
             }
         }
@@ -3286,7 +3295,8 @@ void item::qualities_info( std::vector<iteminfo> &info, const iteminfo_query *pa
                                    string_format( _( "<bad>Needs %d or more charges</bad> for qualities:" ),
                                                   type->charges_to_use() ) );
             }
-            for( const std::pair<quality_id, int> &q : sorted_lex( type->charged_qualities ) ) {
+            for( const std::pair<quality_id, int> &q : sorted_lex(
+                     to_level_pairs( type->charged_qualities ) ) ) {
                 name_quality( q );
             }
         }
@@ -3301,11 +3311,11 @@ void item::qualities_info( std::vector<iteminfo> &info, const iteminfo_query *pa
         info.emplace_back( "QUALITIES", "", _( "Contains items with qualities:" ) );
         std::map<quality_id, int, quality_id::LexCmp> most_quality;
         for( const item *e : contents.all_items_top() ) {
-            for( const std::pair<const quality_id, int> &q : e->type->qualities ) {
-                auto emplace_result = most_quality.emplace( q );
+            for( const auto &q : e->type->qualities ) {
+                auto emplace_result = most_quality.emplace( q.first, q.second.level );
                 if( !emplace_result.second &&
-                    most_quality.at( emplace_result.first->first ) < q.second ) {
-                    most_quality[ q.first ] = q.second;
+                    most_quality.at( emplace_result.first->first ) < q.second.level ) {
+                    most_quality[ q.first ] = q.second.level;
                 }
             }
         }

--- a/src/itype.cpp
+++ b/src/itype.cpp
@@ -14,7 +14,6 @@
 #include "map.h"
 #include "material.h"
 #include "recipe.h"
-#include "requirements.h"
 #include "ret_val.h"
 #include "subbodypart.h"
 #include "translations.h"
@@ -129,10 +128,10 @@ int itype::damage_level( int damage ) const
 bool itype::has_any_quality( std::string_view quality ) const
 {
     return std::any_of( qualities.begin(),
-    qualities.end(), [&quality]( const std::pair<quality_id, int> &e ) {
+    qualities.end(), [&quality]( const auto & e ) {
         return lcmatch( e.first->name, quality );
     } ) || std::any_of( charged_qualities.begin(),
-    charged_qualities.end(), [&quality]( const std::pair<quality_id, int> &e ) {
+    charged_qualities.end(), [&quality]( const auto & e ) {
         return lcmatch( e.first->name, quality );
     } );
 }

--- a/src/itype.h
+++ b/src/itype.h
@@ -1379,10 +1379,22 @@ struct itype {
 
         std::set<weapon_category_id> weapon_category;
 
+        // Per-quality data on an item type: level and optional speed modifier.
+        struct item_quality {
+            int level = 0;
+            float speed = 1.0f; // <1.0 = faster, 1.0 = default, >1.0 = slower
+
+            // Supports "relative" in copy-from: adds to level, leaves speed unchanged.
+            item_quality &operator+=( const item_quality &rhs ) {
+                level += rhs.level;
+                return *this;
+            }
+        };
+
         // Tool qualities and levels for those that work even when tool is not charged
-        std::map<quality_id, int> qualities;
+        std::map<quality_id, item_quality> qualities;
         // Tool qualities that work only when the tool has charges_to_use charges remaining
-        std::map<quality_id, int> charged_qualities;
+        std::map<quality_id, item_quality> charged_qualities;
 
         // True if this has given quality or charged_quality (regardless of current charge).
         bool has_any_quality( std::string_view quality ) const;

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -1,6 +1,7 @@
 #include "recipe.h"
 
 #include <algorithm>
+#include <climits>
 #include <cmath>
 #include <initializer_list>
 #include <memory>
@@ -50,6 +51,7 @@
 #include "uistate.h"
 #include "units.h"
 #include "value_ptr.h"
+#include "visitable.h"
 
 static const itype_id itype_atomic_coffeepot( "atomic_coffeepot" );
 static const itype_id itype_hotplate( "hotplate" );
@@ -151,7 +153,7 @@ double batch_savings::apply( double time, int batch_size ) const
 }
 
 int64_t recipe::batch_time( const Character &guy, int batch, float multiplier,
-                            size_t assistants ) const
+                            size_t assistants, const std::vector<float> *tool_speeds ) const
 {
     // 1.0f is full speed
     // 0.33f is 1/3 speed
@@ -164,8 +166,13 @@ int64_t recipe::batch_time( const Character &guy, int batch, float multiplier,
 
     if( has_steps() ) {
         total_time = 0.0;
-        for( const recipe_step &s : steps_ ) {
-            double step_time = s.time * proficiency_time_maluses_for_step( guy, s ) / multiplier;
+        for( size_t i = 0; i < steps_.size(); ++i ) {
+            const recipe_step &s = steps_[i];
+            double step_time = s.time * proficiency_time_maluses_for_step( guy, s );
+            if( tool_speeds && i < tool_speeds->size() ) {
+                step_time *= ( *tool_speeds )[i];
+            }
+            step_time /= multiplier;
             total_time += s.batch_info.apply( step_time, batch );
         }
     } else {
@@ -179,7 +186,23 @@ int64_t recipe::batch_time( const Character &guy, int batch, float multiplier,
     } else if( assistants >= 2 ) {
         total_time = total_time * .60;
     }
-    const double single_time = static_cast<double>( time_to_craft_moves( guy ) ) / multiplier;
+    // Single-item floor: total can't be less than crafting one unit.
+    // For step recipes with tool speed, the floor must also be speed-aware.
+    double single_time;
+    if( has_steps() && tool_speeds ) {
+        single_time = 0.0;
+        for( size_t i = 0; i < steps_.size(); ++i ) {
+            const recipe_step &s = steps_[i];
+            double st = s.time * proficiency_time_maluses_for_step( guy, s );
+            if( i < tool_speeds->size() ) {
+                st *= ( *tool_speeds )[i];
+            }
+            st /= multiplier;
+            single_time += s.batch_info.apply( st, 1 );
+        }
+    } else {
+        single_time = static_cast<double>( time_to_craft_moves( guy ) ) / multiplier;
+    }
     if( total_time < single_time ) {
         total_time = single_time;
     }
@@ -1372,12 +1395,93 @@ float recipe::proficiency_time_maluses_for_step(
     return total_malus;
 }
 
-double recipe::step_budget_moves( const Character &guy, size_t step_idx, int batch ) const
+double recipe::step_budget_moves( const Character &guy, size_t step_idx, int batch,
+                                  const std::vector<float> *tool_speeds ) const
 {
     cata_assert( step_idx < steps_.size() );
     const recipe_step &s = steps_[step_idx];
     double t = s.time * proficiency_time_maluses_for_step( guy, s );
+    if( tool_speeds && step_idx < tool_speeds->size() ) {
+        t *= ( *tool_speeds )[step_idx];
+    }
     return s.batch_info.apply( t, batch );
+}
+
+// Crafter-aware quality level check for a single item.
+// Mirrors item::get_quality_nonrecursive but uses the given crafter for
+// charged_qualities instead of get_player_character().
+static int get_quality_for_crafter( const item &it, const quality_id &qual,
+                                    const Character &crafter )
+{
+    int result = INT_MIN;
+    auto qit = it.type->qualities.find( qual );
+    if( qit != it.type->qualities.end() ) {
+        result = qit->second.level;
+    }
+    if( !it.type->charged_qualities.empty() && it.ammo_sufficient( &crafter ) ) {
+        auto cit = it.type->charged_qualities.find( qual );
+        if( cit != it.type->charged_qualities.end() ) {
+            result = std::max( result, cit->second.level );
+        }
+    }
+    return result;
+}
+
+float best_quality_speed_modifier( const read_only_visitable &inv,
+                                   const Character &crafter,
+                                   const quality_id &qual, int level )
+{
+    bool found = false;
+    float best = 1.0f;
+    inv.visit_items( [&]( item * e, item * ) {
+        // Use crafter-aware qualification, not get_quality() which
+        // uses get_player_character() for charged qualities.
+        if( get_quality_for_crafter( *e, qual, crafter ) >= level ) {
+            float s = e->get_quality_speed( qual, level, &crafter );
+            if( !found || s < best ) {
+                best = s;
+                found = true;
+            }
+        }
+        return VisitResponse::NEXT;
+    } );
+    // Character-provided qualities (bionics, mutations) have no speed modifier.
+    if( !found && crafter.has_quality( qual, level ) ) {
+        return 1.0f;
+    }
+    return best;
+}
+
+std::vector<float> compute_tool_speeds( const recipe &rec, const Character &crafter )
+{
+    if( !rec.has_steps() ) {
+        return {};
+    }
+    const read_only_visitable &inv = crafter.crafting_inventory();
+    std::vector<float> result;
+    result.reserve( rec.steps().size() );
+    for( const recipe_step &step : rec.steps() ) {
+        float step_speed = 1.0f;
+        for( const auto &group : step.requirements.get_qualities() ) {
+            bool found = false;
+            float best_in_group = 1.0f;
+            for( const quality_requirement &alt : group ) {
+                // Crafter-aware qualification check (no get_player_character leak)
+                if( !inv.has_quality( alt.type, alt.level, alt.count ) &&
+                    !crafter.has_quality( alt.type, alt.level, alt.count ) ) {
+                    continue;
+                }
+                float s = best_quality_speed_modifier( inv, crafter, alt.type, alt.level );
+                if( !found || s < best_in_group ) {
+                    best_in_group = s;
+                    found = true;
+                }
+            }
+            step_speed *= best_in_group;
+        }
+        result.push_back( std::clamp( step_speed, 0.01f, 100.0f ) );
+    }
+    return result;
 }
 
 float recipe::max_proficiency_time_maluses( const Character & ) const

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -27,6 +27,7 @@ class JsonValue;
 class cata_variant;
 class item;
 class item_components;
+class read_only_visitable;
 template <typename E> struct enum_traits;
 
 enum class recipe_filter_flags : int {
@@ -301,7 +302,9 @@ class recipe
             const Character &crafter, const recipe_step &step );
         // Per-step time budget in base moves (with proficiency malus and batch savings).
         // Same per-step formula that batch_time() uses internally.
-        double step_budget_moves( const Character &guy, size_t step_idx, int batch ) const;
+        // Optional tool_speeds vector applies per-step speed modifier.
+        double step_budget_moves( const Character &guy, size_t step_idx, int batch,
+                                  const std::vector<float> *tool_speeds = nullptr ) const;
 
         // This is used by the basecamp bulletin board.
         std::string required_all_skills_string( const std::map<skill_id, int> & ) const;
@@ -324,7 +327,8 @@ class recipe
         bool in_byproducts( const itype_id &it ) const;
         bool has_byproducts() const;
 
-        int64_t batch_time( const Character &guy, int batch, float multiplier, size_t assistants ) const;
+        int64_t batch_time( const Character &guy, int batch, float multiplier, size_t assistants,
+                            const std::vector<float> *tool_speeds = nullptr ) const;
         time_duration batch_duration( const Character &guy, int batch = 1, float multiplier = 1.0,
                                       size_t assistants = 0 ) const;
 
@@ -454,5 +458,18 @@ class recipe
         bool check_blueprint_needs = false;
         cata::value_ptr<parameterized_build_reqs> bp_build_reqs;
 };
+
+// ---------- Tool speed modifiers ----------
+
+// Best (lowest) speed modifier for a quality at a given level from available items.
+// Returns 1.0f if no items have a speed modifier for this quality.
+// crafter is used for charged_qualities (ammo_sufficient check).
+float best_quality_speed_modifier( const read_only_visitable &inv,
+                                   const Character &crafter, const quality_id &qual, int level );
+
+// Compute per-step tool speed modifiers for a recipe from the crafter's inventory.
+// Returns a vector with one float per step (1.0 = no modifier).
+// For stepless recipes, returns empty vector.
+std::vector<float> compute_tool_speeds( const recipe &rec, const Character &crafter );
 
 #endif // CATA_SRC_RECIPE_H

--- a/src/requirements.cpp
+++ b/src/requirements.cpp
@@ -1139,7 +1139,7 @@ bool requirement_data::check_enough_materials( const item_comp &comp,
     const itype *it = item::find_type( comp.type );
     for( const auto &ql : it->qualities ) {
         const quality_requirement *qr = find_by_type( qualities, ql.first );
-        if( qr == nullptr || qr->level > ql.second ) {
+        if( qr == nullptr || qr->level > ql.second.level ) {
             continue;
         }
         // This item can be used for the quality requirement, same as above for specific

--- a/tests/recipe_steps_test.cpp
+++ b/tests/recipe_steps_test.cpp
@@ -1,9 +1,11 @@
 #include <cstdint>
 #include <cstdlib>
 #include <functional>
+#include <map>
 #include <optional>
 #include <sstream>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "avatar.h"
@@ -14,30 +16,45 @@
 #include "coordinates.h"
 #include "debug.h"
 #include "flexbuffer_json.h"
+#include "inventory.h"
 #include "item.h"
 #include "item_location.h"
+#include "itype.h"
 #include "json.h"
 #include "json_loader.h"
 #include "map.h"
 #include "map_helpers.h"
+#include "npc.h"
 #include "player_activity.h"
 #include "player_helpers.h"
+#include "pocket_type.h"
 #include "point.h"
 #include "proficiency.h"
 #include "recipe.h"
 #include "requirements.h"
+#include "ret_val.h"
 #include "translation.h"
 #include "type_id.h"
+
+class read_only_visitable;
 
 static const activity_id ACT_CRAFT( "ACT_CRAFT" );
 
 static const itype_id itype_2x4( "2x4" );
+static const itype_id itype_battery( "battery" );
 static const itype_id itype_cudgel( "cudgel" );
+static const itype_id itype_heavy_battery_cell( "heavy_battery_cell" );
 static const itype_id itype_knife_hunting( "knife_hunting" );
+static const itype_id itype_test_charged_fast_cutter( "test_charged_fast_cutter" );
+static const itype_id itype_test_fast_cutter( "test_fast_cutter" );
+static const itype_id itype_test_slow_cutter( "test_slow_cutter" );
 
 static const proficiency_id proficiency_prof_test_step_a( "prof_test_step_a" );
 static const proficiency_id proficiency_prof_test_step_b( "prof_test_step_b" );
 static const proficiency_id proficiency_prof_test_step_required( "prof_test_step_required" );
+
+static const quality_id qual_BUTCHER( "BUTCHER" );
+static const quality_id qual_CUT( "CUT" );
 
 static const recipe_id recipe_cudgel_simple( "cudgel_simple" );
 static const recipe_id recipe_cudgel_test_steps_basic( "cudgel_test_steps_basic" );
@@ -1353,4 +1370,473 @@ TEST_CASE( "step_recipe_required_prof_no_crash_in_learning", "[recipe][steps][cr
     CHECK( turns > 0 );
 
     CHECK( guy.get_proficiency_practice( proficiency_prof_test_step_a ) > 0.0f );
+}
+
+// ---- Tool speed modifier tests ----
+
+// Helper: place a single item on the ground at avatar origin and refresh crafting inv.
+static void place_tool( const itype_id &tool_id )
+{
+    map &here = get_map();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    here.add_item( origin, item( tool_id ) );
+    get_avatar().invalidate_crafting_inventory();
+}
+
+TEST_CASE( "tool_quality_object_loads", "[recipe][steps][tool_speed]" )
+{
+    // test_fast_cutter uses object quality format with speed
+    const itype *fast = &*itype_test_fast_cutter;
+    REQUIRE( fast != nullptr );
+
+    auto it = fast->qualities.find( qual_CUT );
+    REQUIRE( it != fast->qualities.end() );
+    CHECK( it->second.level == 1 );
+    CHECK( it->second.speed == Approx( 0.5f ) );
+}
+
+TEST_CASE( "tool_quality_array_still_works", "[recipe][steps][tool_speed]" )
+{
+    // knife_hunting uses old array format, speed defaults to 1.0
+    const itype *knife = &*itype_knife_hunting;
+    REQUIRE( knife != nullptr );
+
+    auto it = knife->qualities.find( qual_CUT );
+    REQUIRE( it != knife->qualities.end() );
+    CHECK( it->second.level >= 1 );
+    CHECK( it->second.speed == Approx( 1.0f ) );
+}
+
+TEST_CASE( "tool_quality_speed_only_declared", "[recipe][steps][tool_speed]" )
+{
+    // Speed only applies to the quality it's declared on.
+    // test_fast_cutter has CUT with speed 0.5 but no BUTCHER quality at all.
+    const itype *fast = &*itype_test_fast_cutter;
+    REQUIRE( fast != nullptr );
+
+    auto cut_it = fast->qualities.find( qual_CUT );
+    REQUIRE( cut_it != fast->qualities.end() );
+    CHECK( cut_it->second.speed == Approx( 0.5f ) );
+
+    // BUTCHER must not be present -- verifies the default-speed path:
+    // a missing quality means no speed modifier (effectively 1.0)
+    auto butcher_it = fast->qualities.find( qual_BUTCHER );
+    CHECK( butcher_it == fast->qualities.end() );
+
+    // Also verify a tool that HAS multiple qualities gets speed only on declared ones.
+    // knife_hunting has CUT and BUTCHER, both without speed -> both default to 1.0
+    const itype *knife = &*itype_knife_hunting;
+    REQUIRE( knife != nullptr );
+    auto knife_cut = knife->qualities.find( qual_CUT );
+    REQUIRE( knife_cut != knife->qualities.end() );
+    CHECK( knife_cut->second.speed == Approx( 1.0f ) );
+    auto knife_butcher = knife->qualities.find( qual_BUTCHER );
+    REQUIRE( knife_butcher != knife->qualities.end() );
+    CHECK( knife_butcher->second.speed == Approx( 1.0f ) );
+}
+
+// ---- Tool speed: query infrastructure ----
+
+TEST_CASE( "best_speed_single_item", "[recipe][steps][tool_speed]" )
+{
+    // Single fast tool on ground, query returns its speed
+    clear_avatar();
+    clear_map();
+    avatar &guy = get_avatar();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    guy.setpos( get_map(), origin );
+
+    place_tool( itype_test_fast_cutter );
+    const read_only_visitable &inv = guy.crafting_inventory();
+
+    CHECK( best_quality_speed_modifier( inv, guy, qual_CUT, 1 ) == Approx( 0.5f ) );
+}
+
+TEST_CASE( "best_speed_picks_fastest", "[recipe][steps][tool_speed]" )
+{
+    // Two tools, one fast (0.5) one slow (1.5), should pick fastest
+    clear_avatar();
+    clear_map();
+    avatar &guy = get_avatar();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    guy.setpos( get_map(), origin );
+
+    place_tool( itype_test_fast_cutter );
+    place_tool( itype_test_slow_cutter );
+    const read_only_visitable &inv = guy.crafting_inventory();
+
+    CHECK( best_quality_speed_modifier( inv, guy, qual_CUT, 1 ) == Approx( 0.5f ) );
+}
+
+TEST_CASE( "best_speed_no_modifier_returns_one", "[recipe][steps][tool_speed]" )
+{
+    // knife_hunting has CUT but no speed modifier -> 1.0
+    clear_avatar();
+    clear_map();
+    avatar &guy = get_avatar();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    guy.setpos( get_map(), origin );
+
+    place_tool( itype_knife_hunting );
+    const read_only_visitable &inv = guy.crafting_inventory();
+
+    CHECK( best_quality_speed_modifier( inv, guy, qual_CUT, 1 ) == Approx( 1.0f ) );
+}
+
+TEST_CASE( "best_speed_insufficient_level_ignored", "[recipe][steps][tool_speed]" )
+{
+    // test_fast_cutter is CUT level 1; query for CUT level 2 -> doesn't qualify -> 1.0
+    clear_avatar();
+    clear_map();
+    avatar &guy = get_avatar();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    guy.setpos( get_map(), origin );
+
+    place_tool( itype_test_fast_cutter );
+    const read_only_visitable &inv = guy.crafting_inventory();
+
+    // Level 1 should work
+    CHECK( best_quality_speed_modifier( inv, guy, qual_CUT, 1 ) == Approx( 0.5f ) );
+    // Level 2 should not qualify
+    CHECK( best_quality_speed_modifier( inv, guy, qual_CUT, 2 ) == Approx( 1.0f ) );
+}
+
+TEST_CASE( "best_speed_slow_tool_returns_above_one", "[recipe][steps][tool_speed]" )
+{
+    // Slow tool (1.5x) is the only qualifying item -- must return 1.5, not 1.0
+    clear_avatar();
+    clear_map();
+    avatar &guy = get_avatar();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    guy.setpos( get_map(), origin );
+
+    place_tool( itype_test_slow_cutter );
+    const read_only_visitable &inv = guy.crafting_inventory();
+
+    CHECK( best_quality_speed_modifier( inv, guy, qual_CUT, 1 ) == Approx( 1.5f ) );
+}
+
+TEST_CASE( "best_speed_charged_quality_when_charged", "[recipe][steps][tool_speed]" )
+{
+    // Charged tool (copy-from cordless_drill) with CUT level 2, speed 0.3
+    clear_avatar();
+    clear_map();
+    map &here = get_map();
+    avatar &guy = get_avatar();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    guy.setpos( here, origin );
+
+    // Create the tool and give it a loaded battery magazine
+    item tool( itype_test_charged_fast_cutter );
+    // Insert a charged battery into the magazine well
+    item battery( itype_heavy_battery_cell );
+    battery.ammo_set( itype_battery, 100 );
+    tool.put_in( battery, pocket_type::MAGAZINE_WELL );
+    REQUIRE( tool.ammo_sufficient( &guy ) );
+
+    here.add_item( origin, tool );
+    guy.invalidate_crafting_inventory();
+    const read_only_visitable &inv = guy.crafting_inventory();
+
+    // Level 1 query -- charged quality at level 2 qualifies, speed 0.3
+    CHECK( best_quality_speed_modifier( inv, guy, qual_CUT, 1 ) == Approx( 0.3f ) );
+    // Level 2 query -- still qualifies (charged quality is level 2)
+    CHECK( best_quality_speed_modifier( inv, guy, qual_CUT, 2 ) == Approx( 0.3f ) );
+}
+
+// ---- Tool speed: step time integration ----
+
+// cudgel_test_steps_basic: Shape (10m/60000mv, no quals), Sand (5m/30000mv, no quals),
+//                          Finish (5m/30000mv, CUT quality level 1)
+// With all profs known, no tool speed: budgets are 60000, 30000, 30000.
+
+TEST_CASE( "step_budget_with_tool_speed", "[recipe][steps][tool_speed]" )
+{
+    // Finish step with fast cutter (0.5x) -> 15000. Without -> 30000.
+    clear_avatar();
+    avatar &guy = get_avatar();
+    guy.set_skill_level( skill_fabrication, 10 );
+    guy.add_proficiency( proficiency_prof_test_step_a, true );
+    guy.add_proficiency( proficiency_prof_test_step_b, true );
+
+    const recipe &r = recipe_cudgel_test_steps_basic.obj();
+    REQUIRE( r.has_steps() );
+    REQUIRE( r.steps().size() == 3 );
+
+    // Without tool speed: Finish step (idx 2) budget = 30000
+    CHECK( r.step_budget_moves( guy, 2, 1 ) == Approx( 30000.0 ) );
+
+    // With tool speed vector: [1.0, 1.0, 0.5] -- only Finish affected
+    std::vector<float> speeds = { 1.0f, 1.0f, 0.5f };
+    CHECK( r.step_budget_moves( guy, 0, 1, &speeds ) == Approx( 60000.0 ) );
+    CHECK( r.step_budget_moves( guy, 1, 1, &speeds ) == Approx( 30000.0 ) );
+    CHECK( r.step_budget_moves( guy, 2, 1, &speeds ) == Approx( 15000.0 ) );
+}
+
+TEST_CASE( "tool_speed_composes_with_proficiency", "[recipe][steps][tool_speed]" )
+{
+    // Missing prof_B (1.5x malus on Finish), fast cutter (0.5x) -> 30000*1.5*0.5 = 22500
+    clear_avatar();
+    avatar &guy = get_avatar();
+    guy.set_skill_level( skill_fabrication, 10 );
+    guy.add_proficiency( proficiency_prof_test_step_a, true );
+    // prof_B NOT granted -- Finish step has it with time_multiplier 1.5
+
+    const recipe &r = recipe_cudgel_test_steps_basic.obj();
+    std::vector<float> speeds = { 1.0f, 1.0f, 0.5f };
+    CHECK( r.step_budget_moves( guy, 2, 1, &speeds ) == Approx( 22500.0 ) );
+}
+
+TEST_CASE( "batch_time_with_tool_speed", "[recipe][steps][tool_speed]" )
+{
+    // batch_time with fast tool < without
+    clear_avatar();
+    avatar &guy = get_avatar();
+    guy.set_skill_level( skill_fabrication, 10 );
+    guy.add_proficiency( proficiency_prof_test_step_a, true );
+    guy.add_proficiency( proficiency_prof_test_step_b, true );
+
+    const recipe &r = recipe_cudgel_test_steps_basic.obj();
+    int64_t time_no_speed = r.batch_time( guy, 1, 1.0f, 0 );
+    std::vector<float> speeds = { 1.0f, 1.0f, 0.5f };
+    int64_t time_with_speed = r.batch_time( guy, 1, 1.0f, 0, &speeds );
+
+    // Finish step is 30000 -> 15000 with tool speed, so total drops by 15000
+    CHECK( time_with_speed < time_no_speed );
+    CHECK( time_no_speed - time_with_speed == 15000 );
+}
+
+TEST_CASE( "step_without_qualities_unaffected", "[recipe][steps][tool_speed]" )
+{
+    // Shape and Sand steps have no qualities; tool speed doesn't affect them
+    clear_avatar();
+    avatar &guy = get_avatar();
+    guy.set_skill_level( skill_fabrication, 10 );
+    guy.add_proficiency( proficiency_prof_test_step_a, true );
+    guy.add_proficiency( proficiency_prof_test_step_b, true );
+
+    const recipe &r = recipe_cudgel_test_steps_basic.obj();
+
+    // Even with a speed vector that has non-1.0 values, steps without
+    // qualities in their requirements should use 1.0 regardless.
+    // (The tool_speed_for_step computation would return 1.0 for them.)
+    // But step_budget_moves takes the vector directly, so the values matter.
+    // This test verifies that the CALLER (compute_tool_speeds) produces 1.0
+    // for steps without quality requirements. For now, test the vector path.
+    std::vector<float> speeds = { 1.0f, 1.0f, 0.5f };
+    CHECK( r.step_budget_moves( guy, 0, 1, &speeds ) == Approx( 60000.0 ) );
+    CHECK( r.step_budget_moves( guy, 1, 1, &speeds ) == Approx( 30000.0 ) );
+}
+
+TEST_CASE( "slow_tool_increases_step_time", "[recipe][steps][tool_speed]" )
+{
+    // Slow tool (1.5x) on Finish step -> 45000
+    clear_avatar();
+    avatar &guy = get_avatar();
+    guy.set_skill_level( skill_fabrication, 10 );
+    guy.add_proficiency( proficiency_prof_test_step_a, true );
+    guy.add_proficiency( proficiency_prof_test_step_b, true );
+
+    const recipe &r = recipe_cudgel_test_steps_basic.obj();
+    std::vector<float> speeds = { 1.0f, 1.0f, 1.5f };
+    CHECK( r.step_budget_moves( guy, 2, 1, &speeds ) == Approx( 45000.0 ) );
+}
+
+TEST_CASE( "mixed_speed_multi_step_invariant", "[recipe][steps][tool_speed]" )
+{
+    // sum(step_budget_moves) ~= batch_time() with the same speed vector
+    clear_avatar();
+    avatar &guy = get_avatar();
+    guy.set_skill_level( skill_fabrication, 10 );
+    guy.add_proficiency( proficiency_prof_test_step_a, true );
+    guy.add_proficiency( proficiency_prof_test_step_b, true );
+
+    const recipe &r = recipe_cudgel_test_steps_basic.obj();
+    std::vector<float> speeds = { 1.0f, 1.0f, 0.5f };
+
+    double sum = 0.0;
+    for( size_t i = 0; i < r.steps().size(); ++i ) {
+        sum += r.step_budget_moves( guy, i, 1, &speeds );
+    }
+    int64_t bt = r.batch_time( guy, 1, 1.0f, 0, &speeds );
+    // batch_time truncates to int64_t; sum is double. Within 1 move.
+    CHECK( std::abs( sum - static_cast<double>( bt ) ) <= 1.0 );
+}
+
+TEST_CASE( "single_item_floor_with_tool_speed", "[recipe][steps][tool_speed]" )
+{
+    // batch=1 with fast tool. The single-item floor in batch_time()
+    // must be speed-aware. Result should be less than without tool speed.
+    clear_avatar();
+    avatar &guy = get_avatar();
+    guy.set_skill_level( skill_fabrication, 10 );
+    guy.add_proficiency( proficiency_prof_test_step_a, true );
+    guy.add_proficiency( proficiency_prof_test_step_b, true );
+
+    const recipe &r = recipe_cudgel_test_steps_basic.obj();
+    int64_t no_speed = r.batch_time( guy, 1, 1.0f, 0 );
+    std::vector<float> speeds = { 1.0f, 1.0f, 0.5f };
+    int64_t with_speed = r.batch_time( guy, 1, 1.0f, 0, &speeds );
+
+    // batch=1 hits the single-item floor. If the floor is NOT speed-aware,
+    // with_speed would equal no_speed (clamped back up). It must be less.
+    CHECK( with_speed < no_speed );
+}
+
+// ---- Tool speed: end-to-end ----
+
+// Variant of setup_step_craft that places a specific tool for CUT quality.
+static void setup_step_craft_with_tool( const recipe_id &rid, const itype_id &cut_tool )
+{
+    clear_avatar();
+    clear_map();
+    map &here = get_map();
+    avatar &guy = get_avatar();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    guy.setpos( here, origin );
+    guy.toggle_trait( trait_DEBUG_CNF );
+
+    const recipe &r = rid.obj();
+    guy.set_skill_level( r.skill_used, r.difficulty + 1 );
+    for( const recipe_proficiency &p : r.get_proficiencies() ) {
+        guy.add_proficiency( p.id, true );
+    }
+
+    for( const std::vector<item_comp> &comp_group : r.simple_requirements().get_components() ) {
+        if( !comp_group.empty() ) {
+            here.add_item( origin, item( comp_group.front().type, calendar::turn,
+                                         comp_group.front().count ) );
+        }
+    }
+    // Place the specified tool for CUT quality instead of knife_hunting
+    here.add_item( origin, item( cut_tool ) );
+    guy.invalidate_crafting_inventory();
+    guy.learn_recipe( &r );
+
+    set_time( calendar::turn_zero + 12_hours );
+    guy.remove_weapon();
+    guy.set_focus( 100 );
+    guy.make_craft( rid, 1 );
+    REQUIRE( guy.activity );
+    REQUIRE( guy.activity.id() == ACT_CRAFT );
+}
+
+TEST_CASE( "craft_completes_faster_with_fast_tool", "[recipe][steps][tool_speed]" )
+{
+    // End-to-end craft with fast cutter takes fewer turns.
+    // Run with normal knife
+    setup_step_craft_with_tool( recipe_cudgel_test_steps_basic, itype_knife_hunting );
+    avatar &guy1 = get_avatar();
+    const int normal_turns = run_craft_to_completion( guy1 );
+
+    // Run with fast cutter (0.5x on CUT quality, Finish step)
+    setup_step_craft_with_tool( recipe_cudgel_test_steps_basic, itype_test_fast_cutter );
+    avatar &guy2 = get_avatar();
+    const int fast_turns = run_craft_to_completion( guy2 );
+
+    // Fast tool should complete in fewer turns
+    CHECK( fast_turns < normal_turns );
+
+    // The difference should be approximately half of the Finish step time
+    // Finish step = 30000mv = 300 turns at 100 moves/turn.
+    // With 0.5x speed: 150 turns. Saved: ~150 turns.
+    int saved = normal_turns - fast_turns;
+    CHECK( saved > 100 );  // at least 100 turns saved (conservative)
+    CHECK( saved < 200 );  // not more than 200 (only Finish step affected)
+}
+
+TEST_CASE( "stepless_recipe_unaffected_by_tool_speed", "[recipe][steps][tool_speed]" )
+{
+    // Non-step recipe time unchanged by tool speed items nearby
+    clear_avatar();
+    clear_map();
+    map &here = get_map();
+    avatar &guy = get_avatar();
+    const tripoint_bub_ms origin( 60, 60, 0 );
+    guy.setpos( here, origin );
+
+    const recipe &r = recipe_flatbread.obj();
+    REQUIRE( !r.has_steps() );
+
+    guy.set_skill_level( skill_cooking, r.difficulty + 1 );
+    for( const recipe_proficiency &p : r.get_proficiencies() ) {
+        guy.add_proficiency( p.id, true );
+    }
+
+    // batch_time with and without tool speeds should be identical for stepless
+    int64_t no_speed = r.batch_time( guy, 1, 1.0f, 0 );
+    std::vector<float> speeds;  // empty for stepless
+    int64_t with_speed = r.batch_time( guy, 1, 1.0f, 0, &speeds );
+    CHECK( no_speed == with_speed );
+}
+
+// ---- Tool speed: validation ----
+
+// ---- Tool speed: crafter-aware qualification in compute_tool_speeds ----
+
+TEST_CASE( "compute_tool_speeds_charged_quality_npc_crafter", "[recipe][steps][tool_speed]" )
+{
+    // Regression: compute_tool_speeds() gates alternatives with inv.has_quality()
+    // which resolves charged qualities via get_player_character(), not the actual
+    // crafter.  This test uses an NPC as crafter to expose the leak.
+    clear_avatar();
+    clear_map();
+    map &here = get_map();
+    const tripoint_bub_ms npc_pos( 60, 60, 0 );
+
+    // Create an NPC at the test position
+    standard_npc crafter_npc( "TestCrafter", npc_pos, {}, 0, 8, 8, 8, 8 );
+    crafter_npc.setpos( here, npc_pos );
+
+    // Place charged fast cutter (charged_qualities CUT level 2 speed 0.3) on ground
+    item tool( itype_test_charged_fast_cutter );
+    item battery( itype_heavy_battery_cell );
+    battery.ammo_set( itype_battery, 100 );
+    tool.put_in( battery, pocket_type::MAGAZINE_WELL );
+    REQUIRE( tool.ammo_sufficient( &crafter_npc ) );
+    here.add_item( npc_pos, tool );
+
+    const recipe &r = recipe_cudgel_test_steps_basic.obj();
+    REQUIRE( r.has_steps() );
+
+    // compute_tool_speeds with the NPC as crafter (not the player character)
+    std::vector<float> speeds = compute_tool_speeds( r, crafter_npc );
+    REQUIRE( speeds.size() == 3 );
+
+    // Steps 0 and 1 have no CUT quality -> 1.0
+    CHECK( speeds[0] == Approx( 1.0f ) );
+    CHECK( speeds[1] == Approx( 1.0f ) );
+    // Step 2 (Finish) has CUT quality -> charged tool should provide 0.3
+    CHECK( speeds[2] == Approx( 0.3f ) );
+}
+
+// Helper to load an item type from inline JSON.  Throws on invalid data.
+static void check_item_quality_throws( const std::string &json )
+{
+    JsonObject jo = json_loader::from_string( json );
+    jo.allow_omitted_members();
+    itype dummy;
+    CHECK_THROWS_AS( dummy.load( jo, "dda" ), JsonError );
+}
+
+TEST_CASE( "tool_speed_zero_rejected", "[recipe][steps][tool_speed]" )
+{
+    check_item_quality_throws( R"({
+        "type": "ITEM", "id": "test_bad_speed_zero",
+        "name": "bad", "description": "bad",
+        "weight": "1 g", "volume": "1 ml",
+        "symbol": "x", "color": "white",
+        "qualities": [ { "id": "CUT", "level": 1, "speed": 0 } ]
+    })" );
+}
+
+TEST_CASE( "tool_speed_negative_rejected", "[recipe][steps][tool_speed]" )
+{
+    check_item_quality_throws( R"({
+        "type": "ITEM", "id": "test_bad_speed_neg",
+        "name": "bad", "description": "bad",
+        "weight": "1 g", "volume": "1 ml",
+        "symbol": "x", "color": "white",
+        "qualities": [ { "id": "CUT", "level": 1, "speed": -1 } ]
+    })" );
 }


### PR DESCRIPTION
#### Summary
Features "Tool speed modifiers for recipe steps"

#### Purpose of change

#85913 added recipe steps, #85943 made the activity step-aware. This adds the missing piece: ~~sewing machines~~ tools can now make specific steps faster. The 5-year-old ask (#49525, #74677, #45157).

#### Describe the solution

What this does:

- Item qualities accept a new object format: `{"id": "SEW", "level": 2, "speed": 0.3}`. Legacy array format `["SEW", 2]` still works (speed defaults to 1.0). Both `qualities` and `charged_qualities` support it
- `item_quality` struct on `itype` replaces `map<quality_id, int>`. `item_quality_reader` preserves copy-from / extend / relative / delete semantics through the generic_factory path
- `item::get_quality_speed()` mirrors `get_quality()` resolution: inherent qualities, charged qualities (crafter-aware via `ammo_sufficient`), contained items
- `best_quality_speed_modifier()` scans crafting inventory for the fastest qualifying tool
- `compute_tool_speeds()` produces a per-step float vector from the crafter's inventory
- `step_budget_moves()` and `batch_time()` accept optional tool speed vector. Speed multiplies with proficiency malus before character speed division
- Speed-aware single-item floor in `batch_time()` (without this, batch=1 clamps back to no-tool time)
- `do_turn()` recomputes tool speeds on cache invalidation (same trigger as crafting speed / proficiency changes). Retroactive repricing accepted, same semantics as proficiency mid-craft changes
- `expected_time_to_craft()` passes tool speeds through so the crafting menu shows correct times
- Loader rejects `speed <= 0`

What this doesn't do:

- Per-step tool charge consumption (charges still consumed recipe-wide)
- Passive/idle steps (#62618)
- Tool speed for stepless recipes (steps are the prerequisite)
- Per-step activity level changes from tools (separate axis from speed)
- Migration of existing items to object quality format (parser accepts both indefinitely)
- Vehicle part quality speed

Accepted approximations:
- Tool speed is recomputed on cache invalidation, not locked at craft start. If a tool runs out mid-craft and a slower fallback is selected, remaining time reprices (same as proficiency changes)
- `compute_tool_speeds()` qualification gate uses `inv.has_quality()` which resolves charged qualities via `get_player_character()` internally. For non-player crafters with UPS-dependent tools this can mis-gate. Documented limitation; the systemic `get_player_character()` usage in `item::get_quality()` predates this PR
- Multitool stacking: if a single tool satisfies multiple quality groups in one step, their speed modifiers stack multiplicatively (e.g. a multitool that's fast at both CUT 0.5x and HAMMER 0.7x on a step requiring both gives 0.5 * 0.7 = 0.35x). This is intentional -- the groups represent independent sub-tasks, and a tool that's fast at both genuinely reduces both portions of the work

#### Describe alternatives you've considered

- Speed on the recipe step (per-quality modifier in the step JSON) -- doesn't scale, adding a new fast tool would require editing every recipe
- Speed on the quality definition itself -- conflates capability gating with speed
- Enchantment-based (`CRAFTING_SPEED_MULTIPLIER`) -- global, not per-quality or per-step
- Parallel `quality_speed` map on itype -- works but creates a parallel structure to keep in sync

#### Testing

Sewn some socks.


https://github.com/user-attachments/assets/13b8056a-95fc-4e95-8574-23e3695e3b7d


New tests covering data model, speed query, charged qualities, step time integration, end-to-end crafting, NPC crafter path, and loader validation. Existing [recipe], [steps], and [crafting] suites pass.

#### Additional context

Related: #49525, #74677, #45157, #62618