### PR TITLE
[Xedra Evolved] Elemental magic rework: Salamander

### DIFF
--- a/data/mods/Xedra_Evolved/items/mutagen.json
+++ b/data/mods/Xedra_Evolved/items/mutagen.json
@@ -61,11 +61,23 @@
     "name": "Salamander destiny draught",
     "description": "This magical potion will further your transformation from newly sentient creature to elemental powerhouse.",
     "price": "5 kUSD",
-    "use_action": {
-      "type": "consume_drug",
-      "activation_message": "You drink the %s.",
-      "vitamins": [ [ "mutagen_flamekin", 550 ], [ "mutagen", 550 ] ]
-    }
+    "consumption_effect_on_conditions": [ "EOC_XE_DRINK_DESTINY_DRAUGHT_SALAMANDER" ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_XE_DRINK_DESTINY_DRAUGHT_SALAMANDER",
+    "effect": [
+      { "math": [ "u_vitamin('mutagen_flamekin') += 550" ] },
+      { "math": [ "u_vitamin('mutagen') += 550" ] },
+      { "u_message": "You drink the Salamander destiny draught.", "type": "info" },
+      {
+        "run_eocs": [
+          "EOC_SALAMANDER_SPELL_EXPERIENCE_INCREASER_SELECTOR",
+          "EOC_SALAMANDER_SPELL_EXPERIENCE_INCREASER_SELECTOR",
+          "EOC_SALAMANDER_SPELL_EXPERIENCE_INCREASER_SELECTOR"
+        ]
+      }
+    ]
   },
   {
     "id": "mutagen_dollkin",

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutation_spells.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutation_spells.json
@@ -322,8 +322,8 @@
     "flags": [ "SOMATIC", "VERBAL", "NO_LEGS", "NO_HANDS" ],
     "max_level": 15,
     "difficulty": 8,
-    "base_casting_time": { "math": [ "max( (180000 + (u_spell_count('school': 'ARVORE') * -986) + (u_skill('gramarye') * -3185) ), 6000)" ] },
     "magic_type": "xedra_arvore_magick",
+    "base_casting_time": { "math": [ "max( (180000 + (u_spell_count('school': 'ARVORE') * -986) + (u_skill('gramarye') * -3185) ), 6000)" ] },
     "base_energy_cost": { "math": [ "max( (450 + (u_spell_count('school': 'ARVORE') * -4.2) + (u_skill('gramarye') * -6) ), 350)" ] }
   },
   {

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/salamander_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/salamander_eocs.json
@@ -107,11 +107,13 @@
     "effect": [
       {
         "u_add_effect": "effect_salamander_levitation",
-        "duration": { "math": [ "( 12 + (u_spell_level('salamander_fire_fly') * rng(2,4) )) " ] }
+        "duration": {
+          "math": [ "( 12 + ( ( (u_spell_count('school': 'SALAMANDER') * 1.6) + (u_skill('gramarye') * 2.4) ) * rng(2,4) )) " ]
+        }
       },
       {
         "u_add_effect": "effect_salamander_featherfall",
-        "duration": { "math": [ "( 15 + (u_spell_level('salamander_fire_fly') * 4 )) " ] }
+        "duration": { "math": [ "( 15 + ( ( (u_spell_count('school': 'SALAMANDER') * 1.6) + (u_skill('gramarye') * 2.4) ) * 4 )) " ] }
       },
       { "u_cast_spell": { "id": "salamander_fire_fly_real" }, "targeted": true }
     ],

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/salamander_mutation_spells.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/salamander_mutation_spells.json
@@ -81,7 +81,7 @@
     "name": "Light",
     "description": "Creates a magical light.",
     "valid_targets": [ "self" ],
-    "flags": [ "NO_LEGS" ],
+    "flags": [ "NO_LEGS", "RANDOM_DURATION" ],
     "min_range": 0,
     "max_range": 0,
     "min_damage": 1,
@@ -93,12 +93,19 @@
     "spell_class": "SALAMANDER",
     "magic_type": "xedra_salamader_magick",
     "difficulty": 2,
-    "max_level": 20,
+    "max_level": 15,
     "base_casting_time": 200,
     "base_energy_cost": 150,
-    "min_duration": 100000,
-    "max_duration": 1000000,
-    "duration_increment": 45000
+    "min_duration": {
+      "math": [
+        "( 75318 + (u_spell_count('school': 'SALAMANDER') * 19135) + (u_skill('gramarye') * 28436) ) * scaling_factor(u_val('perception') )"
+      ]
+    },
+    "max_duration": {
+      "math": [
+        "( 129425 + (u_spell_count('school': 'SALAMANDER') * 37512) + (u_skill('gramarye') * 51835) ) * scaling_factor(u_val('perception') )"
+      ]
+    }
   },
   {
     "id": "salamander_make_fire",
@@ -110,20 +117,16 @@
     "teachable": false,
     "spell_class": "SALAMANDER",
     "flags": [ "IGNITE_FLAMMABLE", "VERBAL", "NO_HANDS", "NO_LEGS" ],
-    "max_level": { "math": [ "str_to_level(1)" ] },
+    "max_level": 15,
     "effect": "attack",
     "shape": "blast",
     "damage_type": "heat",
     "difficulty": 1,
-    "min_range": { "math": [ "(1 + (u_spell_level('salamander_make_fire') * 0.15) * (scaling_factor(u_val('strength') ) ) )" ] },
-    "max_range": 5,
+    "min_range": { "math": [ "min( (1 + (u_spell_count('school': 'SALAMANDER') * 0.08) + (u_skill('gramarye') * 0.25) ), 5)" ] },
+    "max_range": { "math": [ "min( (1 + (u_spell_count('school': 'SALAMANDER') * 0.08) + (u_skill('gramarye') * 0.25) ), 5)" ] },
     "magic_type": "xedra_salamader_magick",
-    "base_energy_cost": 200,
-    "final_energy_cost": 75,
-    "energy_increment": -8,
-    "base_casting_time": 125,
-    "final_casting_time": 75,
-    "casting_time_increment": -4,
+    "base_energy_cost": { "math": [ "max( (200 + (u_spell_count('school': 'SALAMANDER') * -4.8) + (u_skill('gramarye') * -6.1) ), 75)" ] },
+    "base_casting_time": { "math": [ "max( (125 + (u_spell_count('school': 'SALAMANDER') * -2.6) + (u_skill('gramarye') * -3.2) ), 75)" ] },
     "field_id": "fd_fire",
     "min_field_intensity": 1,
     "max_field_intensity": 2,
@@ -147,18 +150,22 @@
     "shape": "blast",
     "damage_type": "heat",
     "difficulty": 3,
-    "max_level": { "math": [ "str_to_level(1)" ] },
-    "min_damage": { "math": [ "(6 + (u_spell_level('salamander_flame_punch_spell') * 2) * (scaling_factor(u_val('strength') ) ) )" ] },
-    "max_damage": { "math": [ "(15 + (u_spell_level('salamander_flame_punch_spell') * 4.5) * (scaling_factor(u_val('strength') ) ) )" ] },
+    "max_level": 15,
+    "min_damage": {
+      "math": [
+        "( 6 + (u_spell_count('school': 'SALAMANDER') * 0.9) + (u_skill('gramarye') * 1.4) ) * scaling_factor(u_val('strength') )"
+      ]
+    },
+    "max_damage": {
+      "math": [
+        "( 15 + (u_spell_count('school': 'SALAMANDER') * 2.1) + (u_skill('gramarye') * 3.3) ) * scaling_factor(u_val('strength') )"
+      ]
+    },
     "min_range": 1,
     "max_range": 1,
     "magic_type": "xedra_salamader_magick",
-    "base_energy_cost": 150,
-    "final_energy_cost": 50,
-    "energy_increment": -6,
-    "base_casting_time": 75,
-    "final_casting_time": 25,
-    "casting_time_increment": -3,
+    "base_energy_cost": { "math": [ "max( (150 + (u_spell_count('school': 'SALAMANDER') * -3.5) + (u_skill('gramarye') * -4.9) ), 50)" ] },
+    "base_casting_time": { "math": [ "max( (75 + (u_spell_count('school': 'SALAMANDER') * -2.6) + (u_skill('gramarye') * -3.2) ), 25)" ] },
     "sound_type": "combat",
     "sound_description": "a crackle!"
   },
@@ -170,13 +177,12 @@
     "message": "",
     "skill": "deduction",
     "valid_targets": [ "ally", "hostile", "item", "ground" ],
-    "flags": [ "SILENT", "NO_EXPLOSION_SFX" ],
+    "flags": [ "SILENT", "NO_EXPLOSION_SFX", "RANDOM_DAMAGE" ],
     "effect": "directed_push",
     "shape": "blast",
-    "max_level": { "math": [ "str_to_level(1)" ] },
-    "min_damage": 2,
-    "max_damage": 6,
-    "damage_increment": 0.15,
+    "max_level": 15,
+    "min_damage": 1,
+    "max_damage": 3,
     "min_range": 1,
     "max_range": 1
   },
@@ -194,22 +200,22 @@
     "effect_str": "salamander_flaming_summon_whip",
     "shape": "blast",
     "difficulty": 5,
-    "max_level": { "math": [ "dex_to_level(1)" ] },
+    "max_level": 15,
     "min_damage": 1,
     "max_damage": 1,
     "min_duration": {
-      "math": [ "(24000 + (u_spell_level('salamander_flaming_whip_spell') * 20000) * (scaling_factor(u_val('dexterity') ) ) )" ]
+      "math": [
+        "( 23485 + (u_spell_count('school': 'SALAMANDER') * 9815) + (u_skill('gramarye') * 18553) ) * scaling_factor(u_val('dexterity') )"
+      ]
     },
     "max_duration": {
-      "math": [ "(48000 + (u_spell_level('salamander_flaming_whip_spell') * 35000) * (scaling_factor(u_val('dexterity') ) ) )" ]
+      "math": [
+        "( 51398 + (u_spell_count('school': 'SALAMANDER') * 24851) + (u_skill('gramarye') * 39915) ) * scaling_factor(u_val('dexterity') )"
+      ]
     },
     "magic_type": "xedra_salamader_magick",
-    "base_energy_cost": 250,
-    "final_energy_cost": 100,
-    "energy_increment": -6,
-    "base_casting_time": 1000,
-    "final_casting_time": 750,
-    "casting_time_increment": -10,
+    "base_energy_cost": { "math": [ "max( (250 + (u_spell_count('school': 'SALAMANDER') * -5.9) + (u_skill('gramarye') * -8.2) ), 100)" ] },
+    "base_casting_time": { "math": [ "max( (1000 + (u_spell_count('school': 'SALAMANDER') * -8.2) + (u_skill('gramarye') * -12.6) ), 750)" ] },
     "learn_spells": { "salamander_fire_dot_spell": 6 }
   },
   {
@@ -229,7 +235,7 @@
     ],
     "shape": "blast",
     "difficulty": 3,
-    "max_level": { "math": [ "per_to_level(1)" ] },
+    "max_level": 15,
     "min_aoe": 1,
     "max_aoe": 5,
     "min_range": 10,
@@ -281,7 +287,7 @@
     "affected_body_parts": [ "head", "torso", "arm_l", "arm_r", "leg_l", "leg_r" ],
     "shape": "blast",
     "flags": [ "SOMATIC", "VERBAL", "NO_LEGS", "NO_HANDS" ],
-    "max_level": { "math": [ "str_to_level(1)" ] },
+    "max_level": 15,
     "difficulty": 6,
     "min_range": 1,
     "min_duration": 1000,
@@ -304,7 +310,7 @@
     "teachable": false,
     "spell_class": "SALAMANDER",
     "difficulty": 5,
-    "max_level": { "math": [ "dex_to_level(1)" ] },
+    "max_level": 15,
     "effect": "attack",
     "effect_str": "effect_salamander_fire_dot",
     "damage_type": "heat",
@@ -336,7 +342,7 @@
     "effect_str": "effect_salamander_increase_speed",
     "shape": "blast",
     "flags": [ "SOMATIC", "VERBAL", "RANDOM_DURATION", "NO_LEGS", "NO_HANDS" ],
-    "max_level": { "math": [ "str_to_level(1)" ] },
+    "max_level": 15,
     "difficulty": 6,
     "min_range": 1,
     "min_duration": {
@@ -366,7 +372,7 @@
     "effect_str": "effect_salamander_emit_heat",
     "shape": "blast",
     "flags": [ "SOMATIC", "VERBAL", "NO_LEGS", "NO_HANDS" ],
-    "max_level": { "math": [ "str_to_level(1)" ] },
+    "max_level": 15,
     "difficulty": 6,
     "min_duration": { "math": [ "(15000 + (u_spell_level('salamander_emit_heat') * 3000) * (scaling_factor(u_val('strength') ) ) )" ] },
     "max_duration": { "math": [ "(45000 + (u_spell_level('salamander_emit_heat') * 9000) * (scaling_factor(u_val('strength') ) ) )" ] },
@@ -418,7 +424,7 @@
     "skill": "deduction",
     "teachable": false,
     "spell_class": "SALAMANDER",
-    "max_level": { "math": [ "per_to_level(1)" ] },
+    "max_level": 15,
     "difficulty": 4,
     "effect": "summon",
     "effect_str": "mon_salamander_firebird",
@@ -450,7 +456,7 @@
     "effect": "attack",
     "shape": "cone",
     "difficulty": 2,
-    "max_level": { "math": [ "str_to_level(1)" ] },
+    "max_level": 15,
     "min_damage": 0,
     "max_damage": 0,
     "min_range": {
@@ -487,7 +493,7 @@
     "shape": "cone",
     "damage_type": "heat",
     "difficulty": 5,
-    "max_level": { "math": [ "str_to_level(1)" ] },
+    "max_level": 15,
     "min_damage": { "math": [ "( (u_spell_level('salamander_fire_breath') * 2) + 15) * (scaling_factor(u_val('strength') ) )" ] },
     "max_damage": { "math": [ "( (u_spell_level('salamander_fire_breath') * 3) + 30) * (scaling_factor(u_val('strength') ) )" ] },
     "min_range": {
@@ -523,7 +529,7 @@
     "spell_class": "SALAMANDER",
     "flags": [ "VERBAL", "NO_HANDS", "LOUD" ],
     "difficulty": 4,
-    "max_level": { "math": [ "str_to_level(1)" ] },
+    "max_level": 15,
     "effect": "dash",
     "extra_effects": [ { "id": "salamander_aoe_explosion", "hit_self": true, "max_level": 4 } ],
     "shape": "cone",
@@ -549,7 +555,7 @@
     "skill": "deduction",
     "teachable": false,
     "spell_class": "SALAMANDER",
-    "max_level": { "math": [ "per_to_level(1)" ] },
+    "max_level": 15,
     "difficulty": 5,
     "effect": "add_trap",
     "effect_str": "tr_salamander_bomb",
@@ -605,7 +611,7 @@
     "effect": "effect_on_condition",
     "effect_str": "EOC_SALAMANDER_GOBLIN_FRUIT",
     "shape": "blast",
-    "max_level": { "math": [ "str_to_level(1)" ] },
+    "max_level": 15,
     "difficulty": 8,
     "magic_type": "xedra_salamader_magick",
     "base_energy_cost": 450,
@@ -626,7 +632,7 @@
     "effect": "effect_on_condition",
     "effect_str": "EOC_SALAMANDER_FIRE_FLY",
     "shape": "blast",
-    "max_level": { "math": [ "str_to_level(1)" ] },
+    "max_level": 15,
     "difficulty": 6,
     "magic_type": "xedra_salamader_magick",
     "base_energy_cost": 250,
@@ -645,7 +651,7 @@
     "effect": "short_range_teleport",
     "extra_effects": [ { "id": "salamander_aoe_explosion", "hit_self": true, "max_level": 5 } ],
     "shape": "blast",
-    "max_level": { "math": [ "str_to_level(1)" ] },
+    "max_level": 15,
     "min_range": { "math": [ "(2 + (u_spell_level('salamander_fire_fly') * 0.35) * (scaling_factor(u_val('strength') ) ) )" ] },
     "max_range": { "math": [ "(2 + (u_spell_level('salamander_fire_fly') * 0.35) * (scaling_factor(u_val('strength') ) ) )" ] }
   },
@@ -662,7 +668,7 @@
     "effect_str": "effect_flame_immunity",
     "shape": "blast",
     "flags": [ "SOMATIC", "VERBAL", "NO_LEGS", "NO_HANDS" ],
-    "max_level": { "math": [ "per_to_level(1)" ] },
+    "max_level": 15,
     "difficulty": 7,
     "min_range": 1,
     "max_range": 5,
@@ -687,7 +693,7 @@
     "skill": "deduction",
     "flags": [ "LOUD", "VERBAL", "IGNITE_FLAMMABLE", "RANDOM_DAMAGE", "NO_HANDS", "NO_LEGS" ],
     "difficulty": 9,
-    "max_level": { "math": [ "per_to_level(1)" ] },
+    "max_level": 15,
     "effect": "attack",
     "extra_effects": [ { "id": "salamander_explosion_and_heal_spell_self_heal", "hit_self": true } ],
     "shape": "blast",

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/salamander_mutation_spells.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/salamander_mutation_spells.json
@@ -591,10 +591,8 @@
     "max_level": 15,
     "difficulty": 8,
     "magic_type": "xedra_salamader_magick",
-    "base_energy_cost": 450,
-    "base_casting_time": 180000,
-    "final_casting_time": 100,
-    "casting_time_increment": -6000
+    "base_casting_time": { "math": [ "max( (180000 + (u_spell_count('school': 'SALAMANDER') * -986) + (u_skill('gramarye') * -3185) ), 6000)" ] },
+    "base_energy_cost": { "math": [ "max( (450 + (u_spell_count('school': 'SALAMANDER') * -4.2) + (u_skill('gramarye') * -6) ), 350)" ] }
   },
   {
     "id": "salamander_fire_fly",
@@ -612,10 +610,8 @@
     "max_level": 15,
     "difficulty": 6,
     "magic_type": "xedra_salamader_magick",
-    "base_energy_cost": 250,
-    "base_casting_time": 150,
-    "final_casting_time": 50,
-    "casting_time_increment": -5
+    "base_casting_time": { "math": [ "max( (150 + (u_spell_count('school': 'SALAMANDER') * -3.9) + (u_skill('gramarye') * -5.1) ), 50)" ] },
+    "base_energy_cost": 250
   },
   {
     "id": "salamander_fire_fly_real",
@@ -629,8 +625,8 @@
     "extra_effects": [ { "id": "salamander_aoe_explosion", "hit_self": true, "max_level": 5 } ],
     "shape": "blast",
     "max_level": 15,
-    "min_range": { "math": [ "(2 + (u_spell_level('salamander_fire_fly') * 0.35) * (scaling_factor(u_val('strength') ) ) )" ] },
-    "max_range": { "math": [ "(2 + (u_spell_level('salamander_fire_fly') * 0.35) * (scaling_factor(u_val('strength') ) ) )" ] }
+    "min_range": { "math": [ "min( (2 + (u_spell_count('school': 'SALAMANDER') * 0.15) + (u_skill('gramarye') * 0.37) ), 9)" ] },
+    "max_range": { "math": [ "min( (2 + (u_spell_count('school': 'SALAMANDER') * 0.15) + (u_skill('gramarye') * 0.37) ), 9)" ] }
   },
   {
     "id": "salamander_ally_flame_immune_spell",
@@ -647,17 +643,21 @@
     "flags": [ "SOMATIC", "VERBAL", "NO_LEGS", "NO_HANDS" ],
     "max_level": 15,
     "difficulty": 7,
-    "min_range": 1,
-    "max_range": 5,
-    "range_increment": 0.4,
-    "base_casting_time": 6000,
+    "min_range": { "math": [ "min( (1 + (u_spell_count('school': 'SALAMANDER') * 0.15) + (u_skill('gramarye') * 0.37) ), 5)" ] },
+    "max_range": { "math": [ "min( (1 + (u_spell_count('school': 'SALAMANDER') * 0.15) + (u_skill('gramarye') * 0.37) ), 5)" ] },
+    "min_duration": {
+      "math": [
+        "( 8952 + (u_spell_count('school': 'SALAMANDER') * 4284) + (u_skill('gramarye') * 9815) ) * scaling_factor(u_val('strength') )"
+      ]
+    },
+    "max_duration": {
+      "math": [
+        "( 32485 + (u_spell_count('school': 'SALAMANDER') * 9985) + (u_skill('gramarye') * 22815) ) * scaling_factor(u_val('strength') )"
+      ]
+    },
     "magic_type": "xedra_salamader_magick",
-    "base_energy_cost": 750,
-    "final_energy_cost": 500,
-    "energy_increment": -10,
-    "min_duration": 30000,
-    "max_duration": 1080000,
-    "duration_increment": 16500
+    "base_casting_time": 6000,
+    "base_energy_cost": { "math": [ "max( (750 + (u_spell_count('school': 'SALAMANDER') * -8.5) + (u_skill('gramarye') * -11.9) ), 500)" ] }
   },
   {
     "id": "salamander_explosion_and_heal_spell",
@@ -675,18 +675,10 @@
     "extra_effects": [ { "id": "salamander_explosion_and_heal_spell_self_heal", "hit_self": true } ],
     "shape": "blast",
     "damage_type": "heat",
-    "min_damage": {
-      "math": [ "( (u_spell_level('salamander_explosion_and_heal_spell') * 5) + 65) * (scaling_factor(u_val('perception') ) ) " ]
-    },
-    "max_damage": {
-      "math": [ "( (u_spell_level('salamander_explosion_and_heal_spell') * 8.5) + 169) * (scaling_factor(u_val('perception') ) )" ]
-    },
-    "min_aoe": {
-      "math": [
-        "min( (( (u_spell_level('salamander_explosion_and_heal_spell') * 0.9) + 4) * (scaling_factor(u_val('perception') ) )), 35)"
-      ]
-    },
-    "max_aoe": 35,
+    "min_damage": { "math": [ "65 + (u_spell_count('school': 'SALAMANDER') * 8.5) + (u_skill('gramarye') * 12.9)" ] },
+    "max_damage": { "math": [ "169 + (u_spell_count('school': 'SALAMANDER') * 15.9) + (u_skill('gramarye') * 23.1)" ] },
+    "min_aoe": { "math": [ "min( (4 + (u_spell_count('school': 'SALAMANDER') * 0.6) + (u_skill('gramarye') * 1.5) ), 35)" ] },
+    "max_aoe": { "math": [ "min( (4 + (u_spell_count('school': 'SALAMANDER') * 0.6) + (u_skill('gramarye') * 1.5) ), 35)" ] },
     "field_id": "fd_fire",
     "min_field_intensity": 2,
     "max_field_intensity": 2,
@@ -694,12 +686,8 @@
     "field_intensity_variance": 1,
     "field_chance": 2,
     "magic_type": "xedra_salamader_magick",
-    "base_energy_cost": 2250,
-    "final_energy_cost": 1750,
-    "energy_increment": -15,
-    "base_casting_time": 175,
-    "final_casting_time": 55,
-    "casting_time_increment": -8,
+    "base_casting_time": { "math": [ "max( (2250 + (u_spell_count('school': 'SALAMANDER') * -23.5) + (u_skill('gramarye') * -37.6) ), 1750)" ] },
+    "base_energy_cost": { "math": [ "max( (175 + (u_spell_count('school': 'SALAMANDER') * -6.9) + (u_skill('gramarye') * -8.1) ), 55)" ] },
     "sound_type": "combat",
     "sound_id": "fire_spell",
     "sound_description": "the roar of flames!"

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/salamander_mutation_spells.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/salamander_mutation_spells.json
@@ -374,15 +374,19 @@
     "flags": [ "SOMATIC", "VERBAL", "NO_LEGS", "NO_HANDS" ],
     "max_level": 15,
     "difficulty": 6,
-    "min_duration": { "math": [ "(15000 + (u_spell_level('salamander_emit_heat') * 3000) * (scaling_factor(u_val('strength') ) ) )" ] },
-    "max_duration": { "math": [ "(45000 + (u_spell_level('salamander_emit_heat') * 9000) * (scaling_factor(u_val('strength') ) ) )" ] },
+    "min_duration": {
+      "math": [
+        "( 11385 + (u_spell_count('school': 'SALAMANDER') * 1823) + (u_skill('gramarye') * 4552) ) * scaling_factor(u_val('strength') )"
+      ]
+    },
+    "max_duration": {
+      "math": [
+        "( 48135 + (u_spell_count('school': 'SALAMANDER') * 5842) + (u_skill('gramarye') * 11253) ) * scaling_factor(u_val('strength') )"
+      ]
+    },
     "magic_type": "xedra_salamader_magick",
-    "base_energy_cost": 700,
-    "final_energy_cost": 450,
-    "energy_increment": -25,
-    "base_casting_time": 500,
-    "final_casting_time": 150,
-    "casting_time_increment": -15
+    "base_energy_cost": { "math": [ "max( (700 + (u_spell_count('school': 'SALAMANDER') * -14.4) + (u_skill('gramarye') * -16.5) ), 450)" ] },
+    "base_casting_time": { "math": [ "max( (500 + (u_spell_count('school': 'SALAMANDER') * -14.2) + (u_skill('gramarye') * -16.9) ), 150)" ] }
   },
   {
     "id": "salamander_summon_fire_spirit",
@@ -394,25 +398,30 @@
     "skill": "deduction",
     "teachable": false,
     "spell_class": "SALAMANDER",
-    "max_level": 35,
+    "max_level": 15,
     "difficulty": 3,
     "effect": "summon",
     "effect_str": "GROUP_GENIUS_SALAMANDER",
     "shape": "blast",
-    "min_damage": 1,
-    "max_damage": 8,
-    "damage_increment": 0.5,
-    "min_range": 1,
-    "max_range": 15,
-    "range_increment": 1,
+    "min_damage": { "math": [ "min( (1 + (u_spell_count('school': 'SALAMANDER') * 0.16) + (u_skill('gramarye') * 0.25) ), 8)" ] },
+    "max_damage": { "math": [ "min( (1 + (u_spell_count('school': 'SALAMANDER') * 0.16) + (u_skill('gramarye') * 0.25) ), 8)" ] },
+    "min_range": { "math": [ "min( (1 + (u_spell_count('school': 'SALAMANDER') * 0.22) + (u_skill('gramarye') * 0.4) ), 15)" ] },
+    "max_range": { "math": [ "min( (1 + (u_spell_count('school': 'SALAMANDER') * 0.22) + (u_skill('gramarye') * 0.4) ), 15)" ] },
     "min_aoe": 2,
     "max_aoe": 2,
+    "min_duration": {
+      "math": [
+        "( 22845 + (u_spell_count('school': 'SALAMANDER') * 2548) + (u_skill('gramarye') * 8165) ) * scaling_factor(u_val('intelligence') )"
+      ]
+    },
+    "max_duration": {
+      "math": [
+        "( 49285 + (u_spell_count('school': 'SALAMANDER') * 5942) + (u_skill('gramarye') * 14953) ) * scaling_factor(u_val('intelligence') )"
+      ]
+    },
     "magic_type": "xedra_salamader_magick",
     "base_energy_cost": 200,
-    "base_casting_time": 3000,
-    "min_duration": 36000,
-    "max_duration": 1080000,
-    "duration_increment": 36000
+    "base_casting_time": 3000
   },
   {
     "id": "salamander_summon_firebird_spell",
@@ -431,17 +440,13 @@
     "shape": "blast",
     "min_damage": 1,
     "max_damage": 1,
-    "min_range": { "math": [ "( (u_spell_level('salamander_summon_firebird_spell') * 1) + 2) * scaling_factor(u_val('perception') )" ] },
-    "max_range": { "math": [ "( (u_spell_level('salamander_summon_firebird_spell') * 1) + 2) * scaling_factor(u_val('perception') )" ] },
+    "min_range": { "math": [ "min( (2 + (u_spell_count('school': 'SALAMANDER') * 0.42) + (u_skill('gramarye') * 0.65) ), 18)" ] },
+    "max_range": { "math": [ "min( (2 + (u_spell_count('school': 'SALAMANDER') * 0.42) + (u_skill('gramarye') * 0.65) ), 18)" ] },
     "min_duration": 3000,
     "max_duration": 3000,
     "magic_type": "xedra_salamader_magick",
-    "base_energy_cost": 400,
-    "final_energy_cost": 250,
-    "energy_increment": -5,
-    "base_casting_time": 300,
-    "final_casting_time": 75,
-    "casting_time_increment": -10
+    "base_energy_cost": { "math": [ "max( (400 + (u_spell_count('school': 'SALAMANDER') * -14.4) + (u_skill('gramarye') * -16.5) ), 250)" ] },
+    "base_casting_time": { "math": [ "max( (300 + (u_spell_count('school': 'SALAMANDER') * -14.2) + (u_skill('gramarye') * -16.9) ), 75)" ] }
   },
   {
     "id": "salamander_ash_breath_spell",
@@ -459,12 +464,8 @@
     "max_level": 15,
     "min_damage": 0,
     "max_damage": 0,
-    "min_range": {
-      "math": [ "min((( (u_spell_level('salamander_ash_breath_spell') * 1.1) + 2) * (scaling_factor(u_val('strength') ) )),20)" ]
-    },
-    "max_range": {
-      "math": [ "min((( (u_spell_level('salamander_ash_breath_spell') * 1.1) + 2) * (scaling_factor(u_val('strength') ) )),20)" ]
-    },
+    "min_range": { "math": [ "min( (2 + (u_spell_count('school': 'SALAMANDER') * 0.75) + (u_skill('gramarye') * 1.25) ), 20)" ] },
+    "max_range": { "math": [ "min( (2 + (u_spell_count('school': 'SALAMANDER') * 0.75) + (u_skill('gramarye') * 1.25) ), 20)" ] },
     "min_aoe": 60,
     "max_aoe": 60,
     "field_id": "fd_smoke",
@@ -472,12 +473,8 @@
     "max_field_intensity": 3,
     "field_chance": 1,
     "magic_type": "xedra_salamader_magick",
-    "base_energy_cost": 150,
-    "final_energy_cost": 75,
-    "energy_increment": -5,
-    "base_casting_time": 50,
-    "final_casting_time": 25,
-    "casting_time_increment": -2
+    "base_energy_cost": { "math": [ "max( (150 + (u_spell_count('school': 'SALAMANDER') * -3.5) + (u_skill('gramarye') * -4.9) ), 50)" ] },
+    "base_casting_time": { "math": [ "max( (100 + (u_spell_count('school': 'SALAMANDER') * -6.9) + (u_skill('gramarye') * -8.5) ), 50)" ] }
   },
   {
     "id": "salamander_fire_breath",
@@ -494,27 +491,19 @@
     "damage_type": "heat",
     "difficulty": 5,
     "max_level": 15,
-    "min_damage": { "math": [ "( (u_spell_level('salamander_fire_breath') * 2) + 15) * (scaling_factor(u_val('strength') ) )" ] },
-    "max_damage": { "math": [ "( (u_spell_level('salamander_fire_breath') * 3) + 30) * (scaling_factor(u_val('strength') ) )" ] },
-    "min_range": {
-      "math": [ "min((( (u_spell_level('salamander_fire_breath') * 0.25) + 2) * (scaling_factor(u_val('strength') ) )),8)" ]
-    },
-    "max_range": {
-      "math": [ "min((( (u_spell_level('salamander_fire_breath') * 0.25) + 2) * (scaling_factor(u_val('strength') ) )),8)" ]
-    },
-    "min_aoe": { "math": [ "( (u_spell_level('salamander_fire_breath') * 3) + 27) * (scaling_factor(u_val('strength') ) )" ] },
-    "max_aoe": 180,
+    "min_damage": { "math": [ "14 + (u_spell_count('school': 'SALAMANDER') * 1.5) + (u_skill('gramarye') * 5.6)" ] },
+    "max_damage": { "math": [ "27 + (u_spell_count('school': 'SALAMANDER') * 2.6) + (u_skill('gramarye') * 8.9)" ] },
+    "min_range": { "math": [ "min( (2 + (u_spell_count('school': 'SALAMANDER') * 0.15) + (u_skill('gramarye') * 0.4) ), 8)" ] },
+    "max_range": { "math": [ "min( (2 + (u_spell_count('school': 'SALAMANDER') * 0.15) + (u_skill('gramarye') * 0.4) ), 8)" ] },
+    "min_aoe": { "math": [ "min( (30 + (u_spell_count('school': 'SALAMANDER') * 3.6) + (u_skill('gramarye') * 5.5) ), 120)" ] },
+    "max_aoe": { "math": [ "min( (30 + (u_spell_count('school': 'SALAMANDER') * 3.6) + (u_skill('gramarye') * 5.5) ), 120)" ] },
     "field_id": "fd_fire",
     "min_field_intensity": 1,
     "max_field_intensity": 2,
     "field_chance": 3,
     "magic_type": "xedra_salamader_magick",
-    "base_energy_cost": 350,
-    "final_energy_cost": 250,
-    "energy_increment": -5,
-    "base_casting_time": 100,
-    "final_casting_time": 75,
-    "casting_time_increment": -2,
+    "base_energy_cost": { "math": [ "max( (350 + (u_spell_count('school': 'SALAMANDER') * -3.5) + (u_skill('gramarye') * -4.9) ), 250)" ] },
+    "base_casting_time": { "math": [ "max( (100 + (u_spell_count('school': 'SALAMANDER') * -6.9) + (u_skill('gramarye') * -8.5) ), 75)" ] },
     "sound_type": "combat",
     "sound_description": "a crackle!"
   },
@@ -522,7 +511,7 @@
     "id": "salamander_dash_boom_spell",
     "type": "SPELL",
     "name": { "str": "Fiery Charge" },
-    "description": "Hurl yourself forward in a burst of speed, causing an explosion at your arrive point.",
+    "description": "Hurl yourself forward in a burst of speed, causing an explosion at your arrival point.",
     "valid_targets": [ "hostile", "ground" ],
     "skill": "deduction",
     "teachable": false,
@@ -535,15 +524,11 @@
     "shape": "cone",
     "min_damage": 0,
     "max_damage": 0,
-    "min_range": { "math": [ "(3 + (u_spell_level('salamander_dash_boom_spell') * 0.75) * (scaling_factor(u_val('strength') ) ) )" ] },
-    "max_range": { "math": [ "(3 + (u_spell_level('salamander_dash_boom_spell') * 0.75) * (scaling_factor(u_val('strength') ) ) )" ] },
+    "min_range": { "math": [ "min( (3 + (u_spell_count('school': 'SALAMANDER') * 0.29) + (u_skill('gramarye') * 0.46) ), 12)" ] },
+    "max_range": { "math": [ "min( (3 + (u_spell_count('school': 'SALAMANDER') * 0.29) + (u_skill('gramarye') * 0.46) ), 12)" ] },
     "magic_type": "xedra_salamader_magick",
-    "base_energy_cost": 350,
-    "final_energy_cost": 200,
-    "energy_increment": -6,
-    "base_casting_time": 200,
-    "final_casting_time": 50,
-    "casting_time_increment": -6
+    "base_energy_cost": { "math": [ "max( (350 + (u_spell_count('school': 'SALAMANDER') * -4.2) + (u_skill('gramarye') * -6.4) ), 200)" ] },
+    "base_casting_time": { "math": [ "max( (200 + (u_spell_count('school': 'SALAMANDER') * -5.8) + (u_skill('gramarye') * -7.2) ), 50)" ] }
   },
   {
     "id": "salamander_explosion_trap_spell",
@@ -560,19 +545,11 @@
     "effect": "add_trap",
     "effect_str": "tr_salamander_bomb",
     "shape": "blast",
-    "min_range": {
-      "math": [ "(3 + (u_spell_level('salamander_explosion_trap_spell') * 1) * (scaling_factor(u_val('perception') ) ) )" ]
-    },
-    "max_range": {
-      "math": [ "(3 + (u_spell_level('salamander_explosion_trap_spell') * 1) * (scaling_factor(u_val('perception') ) ) )" ]
-    },
+    "min_range": { "math": [ "min( (3 + (u_spell_count('school': 'SALAMANDER') * 0.52) + (u_skill('gramarye') * 0.85) ), 20)" ] },
+    "max_range": { "math": [ "min( (3 + (u_spell_count('school': 'SALAMANDER') * 0.52) + (u_skill('gramarye') * 0.85) ), 20)" ] },
     "magic_type": "xedra_salamader_magick",
-    "base_energy_cost": 200,
-    "final_energy_cost": 75,
-    "energy_increment": -6,
-    "base_casting_time": 125,
-    "final_casting_time": 75,
-    "casting_time_increment": -3
+    "base_energy_cost": { "math": [ "max( (200 + (u_spell_count('school': 'SALAMANDER') * -5.8) + (u_skill('gramarye') * -7.2) ), 50)" ] },
+    "base_casting_time": { "math": [ "max( (125 + (u_spell_count('school': 'SALAMANDER') * -2.6) + (u_skill('gramarye') * -3.2) ), 75)" ] }
   },
   {
     "id": "salamander_explosion_trap_spell_activated",

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/salamander_mutation_spells.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/salamander_mutation_spells.json
@@ -241,9 +241,7 @@
     "min_range": 10,
     "max_range": 10,
     "magic_type": "xedra_salamader_magick",
-    "base_energy_cost": 250,
-    "final_energy_cost": 150,
-    "energy_increment": -5,
+    "base_energy_cost": { "math": [ "max( (250 + (u_spell_count('school': 'SALAMANDER') * -4.3) + (u_skill('gramarye') * -6.0) ), 150)" ] },
     "base_casting_time": 50
   },
   {
@@ -293,9 +291,7 @@
     "min_duration": 1000,
     "max_duration": 3000,
     "magic_type": "xedra_salamader_magick",
-    "base_energy_cost": 800,
-    "final_energy_cost": 550,
-    "energy_increment": -6,
+    "base_energy_cost": { "math": [ "max( (800 + (u_spell_count('school': 'SALAMANDER') * -10.9) + (u_skill('gramarye') * -13.1) ), 550)" ] },
     "base_casting_time": 3000,
     "learn_spells": { "salamander_fire_dot_spell": 7 }
   },
@@ -317,17 +313,21 @@
     "shape": "blast",
     "min_dot": 1,
     "max_dot": 1,
-    "min_duration": { "math": [ "(1500 + (u_spell_level('salamander_fire_dot_spell') * 50) * (scaling_factor(u_val('dexterity') ) ) )" ] },
-    "max_duration": { "math": [ "(3500 + (u_spell_level('salamander_fire_dot_spell') * 350) * (scaling_factor(u_val('dexterity') ) ) )" ] },
-    "min_range": { "math": [ "(3 + (u_spell_level('salamander_fire_dot_spell') * 1.1) * (scaling_factor(u_val('dexterity') ) ) )" ] },
-    "max_range": { "math": [ "(3 + (u_spell_level('salamander_fire_dot_spell') * 1.1) * (scaling_factor(u_val('dexterity') ) ) )" ] },
+    "min_duration": {
+      "math": [
+        "( 1259 + (u_spell_count('school': 'SALAMANDER') * 26) + (u_skill('gramarye') * 112) ) * scaling_factor(u_val('dexterity') )"
+      ]
+    },
+    "max_duration": {
+      "math": [
+        "( 3482 + (u_spell_count('school': 'SALAMANDER') * 85) + (u_skill('gramarye') * 295) ) * scaling_factor(u_val('dexterity') )"
+      ]
+    },
+    "min_range": { "math": [ "min( (3 + (u_spell_count('school': 'SALAMANDER') * 0.6) + (u_skill('gramarye') * 1) ), 25)" ] },
+    "max_range": { "math": [ "min( (3 + (u_spell_count('school': 'SALAMANDER') * 0.6) + (u_skill('gramarye') * 1) ), 25)" ] },
     "magic_type": "xedra_salamader_magick",
-    "base_energy_cost": 250,
-    "final_energy_cost": 100,
-    "energy_increment": -10,
-    "base_casting_time": 100,
-    "final_casting_time": 40,
-    "casting_time_increment": -6
+    "base_energy_cost": { "math": [ "max( (250 + (u_spell_count('school': 'SALAMANDER') * -6.9) + (u_skill('gramarye') * -8.6) ), 100)" ] },
+    "base_casting_time": { "math": [ "max( (1000 + (u_spell_count('school': 'SALAMANDER') * -8.2) + (u_skill('gramarye') * -12.6) ), 750)" ] }
   },
   {
     "id": "salamander_increase_speed_spell",
@@ -346,18 +346,18 @@
     "difficulty": 6,
     "min_range": 1,
     "min_duration": {
-      "math": [ "(10000 + (u_spell_level('salamander_increase_speed_spell') * 5000) * (scaling_factor(u_val('strength') ) ) )" ]
+      "math": [
+        "( 8952 + (u_spell_count('school': 'SALAMANDER') * 4284) + (u_skill('gramarye') * 9815) ) * scaling_factor(u_val('strength') )"
+      ]
     },
     "max_duration": {
-      "math": [ "(30000 + (u_spell_level('salamander_increase_speed_spell') * 8000) * (scaling_factor(u_val('strength') ) ) )" ]
+      "math": [
+        "( 32485 + (u_spell_count('school': 'SALAMANDER') * 9985) + (u_skill('gramarye') * 22815) ) * scaling_factor(u_val('strength') )"
+      ]
     },
     "magic_type": "xedra_salamader_magick",
-    "base_energy_cost": 550,
-    "final_energy_cost": 250,
-    "energy_increment": -20,
-    "base_casting_time": 250,
-    "final_casting_time": 100,
-    "casting_time_increment": -4
+    "base_energy_cost": { "math": [ "max( (550 + (u_spell_count('school': 'SALAMANDER') * -8.4) + (u_skill('gramarye') * -11.9) ), 250)" ] },
+    "base_casting_time": { "math": [ "max( (250 + (u_spell_count('school': 'SALAMANDER') * -5.9) + (u_skill('gramarye') * -7.9) ), 100)" ] }
   },
   {
     "id": "salamander_emit_heat",

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/salamander_spell_learning_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/salamander_spell_learning_eocs.json
@@ -54,25 +54,25 @@
     "//": "This is a separate EoC to allow looping through until it finds a spell the Salamander knows. Probability is [11-Difficulty]",
     "condition": {
       "or": [
-        { "math": [ "u_spell_level('salamander_make_fire') < str_to_level(1)" ] },
-        { "math": [ "u_spell_level('salamander_dash_boom_spell') < str_to_level(1)" ] },
-        { "math": [ "u_spell_level('salamander_explosion_trap_spell') < per_to_level(1)" ] },
-        { "math": [ "u_spell_level('salamander_smoke_teleport_spell') < per_to_level(1)" ] },
-        { "math": [ "u_spell_level('salamander_flame_punch_spell') < str_to_level(1)" ] },
-        { "math": [ "u_spell_level('salamander_summon_fire_spirit') < 35" ] },
-        { "math": [ "u_spell_level('salamander_ash_breath_spell') < str_to_level(1)" ] },
-        { "math": [ "u_spell_level('salamander_fire_breath') < str_to_level(1)" ] },
-        { "math": [ "u_spell_level('salamander_summon_firebird_spell') < per_to_level(1)" ] },
-        { "math": [ "u_spell_level('salamander_increase_speed_spell') < str_to_level(1)" ] },
-        { "math": [ "u_spell_level('salamander_flaming_whip_spell') < dex_to_level(1)" ] },
-        { "math": [ "u_spell_level('salamander_emit_heat') < str_to_level(1)" ] },
-        { "math": [ "u_spell_level('salamander_cure_conditions') < str_to_level(1)" ] },
-        { "math": [ "u_spell_level('salamander_fire_dot_spell') < dex_to_level(1)" ] },
-        { "math": [ "u_spell_level('create_light_salamander') < 20" ] },
-        { "math": [ "u_spell_level('salamander_fire_fly') < str_to_level(1)" ] },
-        { "math": [ "u_spell_level('salamander_ally_flame_immune_spell') < per_to_level(1)" ] },
-        { "math": [ "u_spell_level('salamander_explosion_and_heal_spell') < per_to_level(1)" ] },
-        { "math": [ "u_spell_level('salamander_cultivate_goblin_fruit') < str_to_level(1)" ] },
+        { "math": [ "u_spell_level('salamander_make_fire') < 15" ] },
+        { "math": [ "u_spell_level('salamander_dash_boom_spell') < 15" ] },
+        { "math": [ "u_spell_level('salamander_explosion_trap_spell') < 15" ] },
+        { "math": [ "u_spell_level('salamander_smoke_teleport_spell') < 15" ] },
+        { "math": [ "u_spell_level('salamander_flame_punch_spell') < 15" ] },
+        { "math": [ "u_spell_level('salamander_summon_fire_spirit') < 15" ] },
+        { "math": [ "u_spell_level('salamander_ash_breath_spell') < 15" ] },
+        { "math": [ "u_spell_level('salamander_fire_breath') < 15" ] },
+        { "math": [ "u_spell_level('salamander_summon_firebird_spell') < 15" ] },
+        { "math": [ "u_spell_level('salamander_increase_speed_spell') < 15" ] },
+        { "math": [ "u_spell_level('salamander_flaming_whip_spell') < 15" ] },
+        { "math": [ "u_spell_level('salamander_emit_heat') < 15" ] },
+        { "math": [ "u_spell_level('salamander_cure_conditions') < 15" ] },
+        { "math": [ "u_spell_level('salamander_fire_dot_spell') < 15" ] },
+        { "math": [ "u_spell_level('create_light_salamander') < 15" ] },
+        { "math": [ "u_spell_level('salamander_fire_fly') < 15" ] },
+        { "math": [ "u_spell_level('salamander_ally_flame_immune_spell') < 15" ] },
+        { "math": [ "u_spell_level('salamander_explosion_and_heal_spell') < 15" ] },
+        { "math": [ "u_spell_level('salamander_cultivate_goblin_fruit') < 15" ] },
         { "math": [ "u_spell_level('paraclesian_spell_make_gossamer') < 8" ] }
       ]
     },
@@ -107,7 +107,7 @@
     "condition": {
       "and": [
         { "math": [ "u_spell_level('salamander_make_fire') >= 0" ] },
-        { "math": [ "u_spell_level('salamander_make_fire') < str_to_level(1)" ] }
+        { "math": [ "u_spell_level('salamander_make_fire') < 15" ] }
       ]
     },
     "effect": [
@@ -125,7 +125,7 @@
     "condition": {
       "and": [
         { "math": [ "u_spell_level('salamander_dash_boom_spell') >= 0" ] },
-        { "math": [ "u_spell_level('salamander_dash_boom_spell') < str_to_level(1)" ] }
+        { "math": [ "u_spell_level('salamander_dash_boom_spell') < 15" ] }
       ]
     },
     "effect": [
@@ -143,7 +143,7 @@
     "condition": {
       "and": [
         { "math": [ "u_spell_level('salamander_explosion_trap_spell') >= 0" ] },
-        { "math": [ "u_spell_level('salamander_explosion_trap_spell') < per_to_level(1)" ] }
+        { "math": [ "u_spell_level('salamander_explosion_trap_spell') < 15" ] }
       ]
     },
     "effect": [
@@ -161,7 +161,7 @@
     "condition": {
       "and": [
         { "math": [ "u_spell_level('salamander_smoke_teleport_spell') >= 0" ] },
-        { "math": [ "u_spell_level('salamander_smoke_teleport_spell') < per_to_level(1)" ] }
+        { "math": [ "u_spell_level('salamander_smoke_teleport_spell') < 15" ] }
       ]
     },
     "effect": [
@@ -179,7 +179,7 @@
     "condition": {
       "and": [
         { "math": [ "u_spell_level('salamander_flame_punch_spell') >= 0" ] },
-        { "math": [ "u_spell_level('salamander_flame_punch_spell') < str_to_level(1)" ] }
+        { "math": [ "u_spell_level('salamander_flame_punch_spell') < 15" ] }
       ]
     },
     "effect": [
@@ -215,7 +215,7 @@
     "condition": {
       "and": [
         { "math": [ "u_spell_level('salamander_ash_breath_spell') >= 0" ] },
-        { "math": [ "u_spell_level('salamander_ash_breath_spell') < str_to_level(1)" ] }
+        { "math": [ "u_spell_level('salamander_ash_breath_spell') < 15" ] }
       ]
     },
     "effect": [
@@ -233,7 +233,7 @@
     "condition": {
       "and": [
         { "math": [ "u_spell_level('salamander_fire_breath') >= 0" ] },
-        { "math": [ "u_spell_level('salamander_fire_breath') < str_to_level(1)" ] }
+        { "math": [ "u_spell_level('salamander_fire_breath') < 15" ] }
       ]
     },
     "effect": [
@@ -251,7 +251,7 @@
     "condition": {
       "and": [
         { "math": [ "u_spell_level('salamander_summon_firebird_spell') >= 0" ] },
-        { "math": [ "u_spell_level('salamander_summon_firebird_spell') < per_to_level(1)" ] }
+        { "math": [ "u_spell_level('salamander_summon_firebird_spell') < 15" ] }
       ]
     },
     "effect": [
@@ -269,7 +269,7 @@
     "condition": {
       "and": [
         { "math": [ "u_spell_level('salamander_increase_speed_spell') >= 0" ] },
-        { "math": [ "u_spell_level('salamander_increase_speed_spell') < str_to_level(1)" ] }
+        { "math": [ "u_spell_level('salamander_increase_speed_spell') < 15" ] }
       ]
     },
     "effect": [
@@ -287,7 +287,7 @@
     "condition": {
       "and": [
         { "math": [ "u_spell_level('salamander_flaming_whip_spell') >= 0" ] },
-        { "math": [ "u_spell_level('salamander_flaming_whip_spell') < dex_to_level(1)" ] }
+        { "math": [ "u_spell_level('salamander_flaming_whip_spell') < 15" ] }
       ]
     },
     "effect": [
@@ -305,7 +305,7 @@
     "condition": {
       "and": [
         { "math": [ "u_spell_level('salamander_emit_heat') >= 0" ] },
-        { "math": [ "u_spell_level('salamander_emit_heat') < str_to_level(1)" ] }
+        { "math": [ "u_spell_level('salamander_emit_heat') < 15" ] }
       ]
     },
     "effect": [
@@ -323,7 +323,7 @@
     "condition": {
       "and": [
         { "math": [ "u_spell_level('salamander_cure_conditions') >= 0" ] },
-        { "math": [ "u_spell_level('salamander_cure_conditions') < str_to_level(1)" ] }
+        { "math": [ "u_spell_level('salamander_cure_conditions') < 15" ] }
       ]
     },
     "effect": [
@@ -341,7 +341,7 @@
     "condition": {
       "and": [
         { "math": [ "u_spell_level('salamander_fire_dot_spell') >= 0" ] },
-        { "math": [ "u_spell_level('salamander_fire_dot_spell') < dex_to_level(1)" ] }
+        { "math": [ "u_spell_level('salamander_fire_dot_spell') < 15" ] }
       ]
     },
     "effect": [
@@ -377,7 +377,7 @@
     "condition": {
       "and": [
         { "math": [ "u_spell_level('salamander_fire_fly') >= 0" ] },
-        { "math": [ "u_spell_level('salamander_fire_fly') < str_to_level(1)" ] }
+        { "math": [ "u_spell_level('salamander_fire_fly') < 15" ] }
       ]
     },
     "effect": [
@@ -395,7 +395,7 @@
     "condition": {
       "and": [
         { "math": [ "u_spell_level('salamander_ally_flame_immune_spell') >= 0" ] },
-        { "math": [ "u_spell_level('salamander_ally_flame_immune_spell') < per_to_level(1)" ] }
+        { "math": [ "u_spell_level('salamander_ally_flame_immune_spell') < 15" ] }
       ]
     },
     "effect": [
@@ -413,7 +413,7 @@
     "condition": {
       "and": [
         { "math": [ "u_spell_level('salamander_explosion_and_heal_spell') >= 0" ] },
-        { "math": [ "u_spell_level('salamander_explosion_and_heal_spell') < per_to_level(1)" ] }
+        { "math": [ "u_spell_level('salamander_explosion_and_heal_spell') < 15" ] }
       ]
     },
     "effect": [
@@ -431,7 +431,7 @@
     "condition": {
       "and": [
         { "math": [ "u_spell_level('salamander_cultivate_goblin_fruit') >= 0" ] },
-        { "math": [ "u_spell_level('salamander_cultivate_goblin_fruit') < str_to_level(1)" ] }
+        { "math": [ "u_spell_level('salamander_cultivate_goblin_fruit') < 15" ] }
       ]
     },
     "effect": [


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Xedra Evolved] Elemental magic rework: Salamander"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Continuation of elemental fae magic rework, rescaling all spells to scale based on `gramarye` skill on total number of spells rather than spell level and use spell level to gain new spells. 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Set max level of all spells to 15 and apply scaling based on `u_spell_count` and `u_skill` for `gramarye`

Your spells level by spending time near flames or in hot temperatures or by drinking Salamander Destiny Draughts. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Got some spells, checked their abilities as I raised and lowered gramarye. 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
