### PR TITLE
Split battery percentage into a separate widget

### DIFF
--- a/data/json/ui/vehicle.json
+++ b/data/json/ui/vehicle.json
@@ -81,6 +81,11 @@
     "label": "Vehicle",
     "style": "layout",
     "arrange": "rows",
-    "widgets": [ "vehicle_azimuth_desc_no_label", "vehicle_cruise_desc_no_label", "vehicle_battery_desc_no_label", "vehicle_fuel_desc_no_label" ]
+    "widgets": [
+      "vehicle_azimuth_desc_no_label",
+      "vehicle_cruise_desc_no_label",
+      "vehicle_battery_desc_no_label",
+      "vehicle_fuel_desc_no_label"
+    ]
   }
 ]

--- a/data/json/ui/vehicle.json
+++ b/data/json/ui/vehicle.json
@@ -27,6 +27,15 @@
     "//": "Current/max fuel for active vehicle engine from display::vehicle_fuel_text_color"
   },
   {
+    "id": "vehicle_battery_desc_label",
+    "type": "widget",
+    "label": "Battery",
+    "style": "text",
+    "flags": [ "W_DISABLED_WHEN_EMPTY" ],
+    "var": "veh_battery_text",
+    "//": "Current/max vehicle battery from display::vehicle_battery_text_color"
+  },
+  {
     "id": "vehicle_azimuth_desc_no_label",
     "type": "widget",
     "copy-from": "vehicle_azimuth_desc_label",
@@ -45,12 +54,18 @@
     "flags": [ "W_LABEL_NONE" ]
   },
   {
+    "id": "vehicle_battery_desc_no_label",
+    "type": "widget",
+    "copy-from": "vehicle_battery_desc_label",
+    "flags": [ "W_LABEL_NONE" ]
+  },
+  {
     "id": "vehicle_acf_label_layout",
     "type": "widget",
     "label": "Vehicle",
     "style": "layout",
     "arrange": "rows",
-    "widgets": [ "vehicle_azimuth_desc_label", "vehicle_cruise_desc_label", "vehicle_fuel_desc_label" ]
+    "widgets": [ "vehicle_azimuth_desc_label", "vehicle_cruise_desc_label", "vehicle_battery_desc_label", "vehicle_fuel_desc_label" ]
   },
   {
     "id": "vehicle_acf_label_layout_columns",
@@ -58,7 +73,7 @@
     "label": "Vehicle",
     "style": "layout",
     "arrange": "columns",
-    "widgets": [ "vehicle_azimuth_desc_label", "vehicle_cruise_desc_label", "vehicle_fuel_desc_label" ]
+    "widgets": [ "vehicle_azimuth_desc_label", "vehicle_cruise_desc_label", "vehicle_battery_desc_label", "vehicle_fuel_desc_label" ]
   },
   {
     "id": "vehicle_acf_no_label_layout",
@@ -66,6 +81,6 @@
     "label": "Vehicle",
     "style": "layout",
     "arrange": "rows",
-    "widgets": [ "vehicle_azimuth_desc_no_label", "vehicle_cruise_desc_no_label", "vehicle_fuel_desc_no_label" ]
+    "widgets": [ "vehicle_azimuth_desc_no_label", "vehicle_cruise_desc_no_label", "vehicle_battery_desc_no_label", "vehicle_fuel_desc_no_label" ]
   }
 ]

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -21,7 +21,6 @@
 #include "faction.h"
 #include "game.h"
 #include "game_constants.h"
-#include "itype.h"
 #include "map.h"
 #include "mood_face.h"
 #include "move_mode.h"

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -21,6 +21,7 @@
 #include "faction.h"
 #include "game.h"
 #include "game_constants.h"
+#include "itype.h"
 #include "map.h"
 #include "mood_face.h"
 #include "move_mode.h"
@@ -62,6 +63,7 @@ static const efftype_id effect_infected( "infected" );
 
 static const flag_id json_flag_THERMOMETER( "THERMOMETER" );
 
+static const itype_id fuel_type_battery( "battery" );
 static const itype_id fuel_type_muscle( "muscle" );
 
 // Cache for the overmap widget string
@@ -1064,6 +1066,7 @@ std::pair<std::string, nc_color> display::vehicle_fuel_percent_text_color( const
             const vehicle_part &vp = veh->part( p );
             if( veh->is_engine_on( vp )
                 && !veh->is_perpetual_type( vp )
+                && !veh->is_engine_type( vp, fuel_type_battery )
                 && !veh->is_engine_type( vp, fuel_type_muscle ) ) {
                 // Get the fuel type of the first engine that is turned on
                 fuel_type = vp.fuel_current();
@@ -1080,6 +1083,29 @@ std::pair<std::string, nc_color> display::vehicle_fuel_percent_text_color( const
     }
 
     return std::make_pair( fuel_text, fuel_color );
+}
+
+std::pair<std::string, nc_color> display::vehicle_battery_percent_text_color( const Character &u )
+{
+    map &here = get_map();
+
+    // Defaults in case no vehicle is found
+    std::string battery_text;
+    nc_color battery_color = c_light_gray;
+
+    const vehicle *veh = vehicle_driven( u );
+    if( veh ) {
+        const int max_battery = veh->fuel_capacity( here, fuel_type_battery );
+        const int cur_battery = veh->fuel_left( here, fuel_type_battery );
+        if( max_battery != 0 ) {
+            int percent = cur_battery * 100 / max_battery;
+            // Simple percent indicator, yellow under 25%, red under 10%
+            battery_text = string_format( "%d %%", percent );
+            battery_color = percent < 10 ? c_red : ( percent < 25 ? c_yellow : c_green );
+        }
+    }
+
+    return std::make_pair( battery_text, battery_color );
 }
 
 // Single-letter move mode (W, R, C, P)

--- a/src/display.h
+++ b/src/display.h
@@ -132,6 +132,8 @@ std::string vehicle_azimuth_text( const Character &u );
 std::pair<std::string, nc_color> vehicle_cruise_text_color( const Character &u );
 // Vehicle percent of fuel remaining for currently running engine
 std::pair<std::string, nc_color> vehicle_fuel_percent_text_color( const Character &u );
+// Vehicle remaining battery percent
+std::pair<std::string, nc_color> vehicle_battery_percent_text_color( const Character &u );
 
 // Functions returning (text, color) pairs
 std::pair<translation, nc_color> weariness_text_color( size_t weariness );

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -214,6 +214,8 @@ std::string enum_to_string<widget_var>( widget_var data )
             return "time_text";
         case widget_var::veh_azimuth_text:
             return "veh_azimuth_text";
+        case widget_var::veh_battery_text:
+            return "veh_battery_text";
         case widget_var::veh_cruise_text:
             return "veh_cruise_text";
         case widget_var::veh_fuel_text:
@@ -1173,6 +1175,7 @@ bool widget::uses_text_function() const
         case widget_var::sundial_time_text:
         case widget_var::time_text:
         case widget_var::veh_azimuth_text:
+        case widget_var::veh_battery_text:
         case widget_var::veh_cruise_text:
         case widget_var::veh_fuel_text:
         case widget_var::weariness_text:
@@ -1318,6 +1321,9 @@ std::string widget::color_text_function_string( const avatar &ava, unsigned int 
             break;
         case widget_var::veh_azimuth_text:
             desc.first = display::vehicle_azimuth_text( ava );
+            break;
+        case widget_var::veh_battery_text:
+            desc = display::vehicle_battery_percent_text_color( ava );
             break;
         case widget_var::veh_cruise_text:
             desc = display::vehicle_cruise_text_color( ava );

--- a/src/widget.h
+++ b/src/widget.h
@@ -91,6 +91,7 @@ enum class widget_var : int {
     sundial_time_text,   // Current time - exact if character has a watch, sundial otherwise
     time_text,      // Current time - exact if character has a watch, approximate otherwise
     veh_azimuth_text, // Azimuth or heading in degrees, string
+    veh_battery_text,  // Current/total battery in vehicle engine, color string
     veh_cruise_text, // Current/target cruising speed in vehicle, color string
     veh_fuel_text,  // Current/total fuel for active vehicle engine, color string
     weariness_text, // Weariness description text, color string


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Interface "Split battery percentage into a separate widget from fuel"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Battery is a relevant percentage apart from fuel, for example when you're on your RV doing crafting from mounted kitchen, or with a tool connected to your car electronic control unit. Have them as separate widgets is helpful in this case.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

Make a separate widget just for battery, and conditionally skip battery from current fuel widget - that's already happen when fuel is muscle for example. On default layout, keep battery before fuel so UI is visually stable (the conditionally hidden pieces are at botton/last).

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Doing the battery widget, but keep fuel as-is. That would create visual duplication in hybrid vehicles.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

Run the game, get into my (pristine!) hybrid car, play a bit with engine controls to see how widgets behave.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

<img width="165" height="53" alt="Screenshot 2026-03-19 at 13 32 34" src="https://github.com/user-attachments/assets/dbef997a-ccfb-4b69-b6d0-3eeeead20b60" />

That's on "labels" sidebar.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
