### PR TITLE
Extract crafting menu helpers for testability

### DIFF
--- a/data/mods/TEST_DATA/recipes.json
+++ b/data/mods/TEST_DATA/recipes.json
@@ -446,5 +446,17 @@
         "proficiencies": [ { "proficiency": "prof_test_step_a" } ]
       }
     ]
+  },
+  {
+    "id": "test_nested_weapons",
+    "type": "nested_category",
+    "activity_level": "NO_EXERCISE",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_BASHING",
+    "name": "test nested weapons",
+    "description": "Test nested category for crafting GUI tests.",
+    "skill_used": "fabrication",
+    "nested_category_data": [ "cudgel_test_no_tools" ],
+    "difficulty": 0
   }
 ]

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -24,6 +24,7 @@
 #include "character_id.h"
 #include "color.h"
 #include "crafting.h"
+#include "crafting_gui_helpers.h"
 #include "cuboid_rectangle.h"
 #include "cursesdef.h"
 #include "debug.h"
@@ -199,166 +200,6 @@ void reset_recipe_categories()
     craft_cat_list.reset();
 }
 
-static bool cannot_gain_skill_or_prof( const Character &crafter, const recipe &recp )
-{
-    if( recp.skill_used &&
-        static_cast<int>( crafter.get_skill_level( recp.skill_used ) ) <= recp.get_skill_cap() ) {
-        return false;
-    }
-    for( const proficiency_id &prof : recp.used_proficiencies() ) {
-        if( !crafter.has_proficiency( prof ) ) {
-            return false;
-        }
-    }
-    return true;
-}
-
-namespace
-{
-struct availability {
-        explicit availability( Character &_crafter, const recipe *r, int batch_size = 1,
-                               bool camp_crafting = false, inventory *inventory_override = nullptr ) :
-            crafter( _crafter ) {
-            rec = r;
-            inv_override = inventory_override;
-            const inventory &inv = camp_crafting ? *inv_override : crafter.crafting_inventory();
-            auto all_items_filter = r->get_component_filter( recipe_filter_flags::none );
-            auto no_rotten_filter = r->get_component_filter( recipe_filter_flags::no_rotten );
-            auto no_favorite_filter = r->get_component_filter( recipe_filter_flags::no_favorite );
-            const deduped_requirement_data &req = r->deduped_requirements();
-            has_all_skills = r->skill_used.is_null() ||
-                             crafter.get_skill_level( r->skill_used ) >= r->get_difficulty( crafter );
-            crafter_has_primary_skill = r->skill_used.is_null()
-                                        || crafter.get_knowledge_level( rec->skill_used )
-                                        >= static_cast<int>( rec->get_difficulty( crafter ) * 0.8f );
-            has_proficiencies = r->character_has_required_proficiencies( crafter );
-            std::string reason;
-            craft_flags flag = camp_crafting ? craft_flags::none : craft_flags::start_only;
-
-            if( crafter.is_npc() && !r->npc_can_craft( reason ) && !camp_crafting ) {
-                can_craft = false;
-            } else if( r->is_nested() ) {
-                can_craft = check_can_craft_nested( _crafter, *r );
-            } else {
-                can_craft = ( !r->is_practice() || has_all_skills ) && has_proficiencies &&
-                            req.can_make_with_inventory( inv, all_items_filter, batch_size, flag );
-            }
-            would_use_rotten = !req.can_make_with_inventory( inv, no_rotten_filter, batch_size,
-                               flag );
-            would_use_favorite = !req.can_make_with_inventory( inv, no_favorite_filter, batch_size,
-                                 flag );
-            useless_practice = r->is_practice() && cannot_gain_skill_or_prof( crafter, *r );
-            is_nested_category = r->is_nested();
-            const requirement_data &simple_req = r->simple_requirements();
-            apparently_craftable = ( !r->is_practice() || has_all_skills ) && has_proficiencies &&
-                                   simple_req.can_make_with_inventory( inv, all_items_filter, batch_size, flag );
-            for( const auto& [skill, skill_lvl] : r->required_skills ) {
-                if( crafter.get_skill_level( skill ) < skill_lvl ) {
-                    has_all_skills = false;
-                    break;
-                }
-            }
-        }
-        Character &crafter;
-        bool can_craft;
-        // group can introduce recipe this crafter cannot craft because of low primary skill
-        bool crafter_has_primary_skill;
-        bool would_use_rotten;
-        bool would_use_favorite;
-        bool useless_practice;
-        bool apparently_craftable;
-        bool has_proficiencies;
-        bool has_all_skills;
-        bool is_nested_category;
-        // Used as an indicator to see if crafting is called via camp. if not nullptr, we must be camp crafting
-        inventory *inv_override;
-    private:
-        const recipe *rec;
-        mutable float proficiency_time_maluses = -1.0f;
-        mutable float max_proficiency_time_maluses = -1.0f;
-        mutable float proficiency_skill_maluses = -1.0f;
-        mutable float max_proficiency_skill_maluses = -1.0f;
-    public:
-        float get_proficiency_time_maluses() const {
-            if( proficiency_time_maluses < 0 ) {
-                proficiency_time_maluses = rec->proficiency_time_maluses( crafter );
-            }
-
-            return proficiency_time_maluses;
-        }
-        float get_max_proficiency_time_maluses() const {
-            if( max_proficiency_time_maluses < 0 ) {
-                max_proficiency_time_maluses = rec->max_proficiency_time_maluses( crafter );
-            }
-
-            return max_proficiency_time_maluses;
-        }
-        float get_proficiency_skill_maluses() const {
-            if( proficiency_skill_maluses < 0 ) {
-                proficiency_skill_maluses = rec->proficiency_skill_maluses( crafter );
-            }
-
-            return proficiency_skill_maluses;
-        }
-        float get_max_proficiency_skill_maluses() const {
-            if( max_proficiency_skill_maluses < 0 ) {
-                max_proficiency_skill_maluses = rec->max_proficiency_skill_maluses( crafter );
-            }
-
-            return max_proficiency_skill_maluses;
-        }
-
-        nc_color selected_color() const {
-            if( !can_craft && is_nested_category ) {
-                return h_blue;
-            } else if( !can_craft ) {
-                return h_dark_gray;
-            } else if( !crafter_has_primary_skill && is_nested_category ) {
-                return h_magenta;
-            } else if( !crafter_has_primary_skill ) {
-                return h_light_red;
-            } else if( is_nested_category ) {
-                return h_light_blue;
-            }  else if( would_use_rotten || useless_practice ) {
-                return has_all_skills ? h_brown : h_red;
-            } else if( would_use_favorite ) {
-                return has_all_skills ? h_pink : h_red;
-            } else {
-                return has_all_skills ? h_white : h_yellow;
-            }
-        }
-
-        nc_color color( bool ignore_missing_skills = false ) const {
-            if( !can_craft && is_nested_category ) {
-                return c_blue;
-            } else if( !can_craft ) {
-                return c_dark_gray;
-            } else if( !crafter_has_primary_skill && is_nested_category ) {
-                return c_magenta;
-            } else if( !crafter_has_primary_skill ) {
-                return c_light_red;
-            } else if( is_nested_category ) {
-                return c_light_blue;
-            } else if( would_use_rotten || useless_practice ) {
-                return has_all_skills || ignore_missing_skills ? c_brown : c_red;
-            } else if( would_use_favorite ) {
-                return has_all_skills ? c_pink : c_red;
-            } else {
-                return has_all_skills || ignore_missing_skills ? c_white : c_yellow;
-            }
-        }
-
-        static bool check_can_craft_nested( Character &_crafter, const recipe &r ) {
-            // recursively check if you can craft anything in the nest
-            for( const recipe_id &nested_r : r.nested_category_data ) {
-                if( availability( _crafter, &nested_r.obj() ).can_craft ) {
-                    return true;
-                }
-            }
-            return false;
-        }
-};
-} // namespace
 
 static std::string craft_success_chance_string( const recipe &recp, const Character &guy )
 {
@@ -1741,32 +1582,15 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
                 }
 
                 if( subtab.cur() != "CSC_*_RECENT" ) {
+                    const bool want_unread = highlight_unread_recipes && unread_recipes_first;
                     std::stable_sort( current.begin(), current.end(), [
-                       crafter, &availability_cache, unread_recipes_first,
-                       highlight_unread_recipes
+                       crafter, &availability_cache, want_unread
                     ]( const recipe * const a, const recipe * const b ) {
-                        if( highlight_unread_recipes && unread_recipes_first ) {
-                            const bool a_read = uistate.read_recipes.count( a->ident() );
-                            const bool b_read = uistate.read_recipes.count( b->ident() );
-                            if( a_read != b_read ) {
-                                return !a_read;
-                            }
-                        }
-                        const bool can_craft_a = availability_cache->at( a ).can_craft;
-                        const bool can_craft_b = availability_cache->at( b ).can_craft;
-                        if( can_craft_a != can_craft_b ) {
-                            return can_craft_a;
-                        }
-                        if( b->difficulty != a->difficulty ) {
-                            return b->difficulty < a->difficulty;
-                        }
-                        const std::string a_name = a->result_name();
-                        const std::string b_name = b->result_name();
-                        if( a_name != b_name ) {
-                            return localized_compare( a_name, b_name );
-                        }
-                        return b->time_to_craft( *crafter ) <
-                               a->time_to_craft( *crafter );
+                        const bool a_read = !want_unread || uistate.read_recipes.count( a->ident() );
+                        const bool b_read = !want_unread || uistate.read_recipes.count( b->ident() );
+                        return recipe_sort_compare( a, b,
+                                                    availability_cache->at( a ), availability_cache->at( b ),
+                                                    *crafter, a_read, b_read, want_unread );
                     } );
                 }
 
@@ -1945,19 +1769,28 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
                 popup( _( "Nothing selected!" ) );
             } else if( current[line]->is_nested() ) {
                 nested_toggle( current[line]->ident(), recalc, keepline );
-            } else if( !available[line].can_craft ||
-                       !available[line].crafter_has_primary_skill ) {
-                popup( _( "Crafter can't craft that!" ) );
-            } else if( available[line].inv_override == nullptr &&
-                       !crafter->check_eligible_containers_for_crafting( *current[line], batch ? line + 1 : 1 ) ) {
-                // popup is already inside check
-            } else if( crafter->lighting_craft_speed_multiplier( *current[line] ) <= 0.0f ) {
-                popup( _( "Crafter can't see!" ) );
             } else {
-                chosen = current[line];
-                batch_size_out = batch ? line + 1 : 1;
-                done = true;
-                uistate.read_recipes.insert( chosen->ident() );
+                const int bs = batch ? line + 1 : 1;
+                craft_confirm_result confirm = can_start_craft(
+                                                   *current[line], available[line], *crafter );
+                switch( confirm ) {
+                    case craft_confirm_result::cannot_craft:
+                        popup( _( "Crafter can't craft that!" ) );
+                        break;
+                    case craft_confirm_result::too_dark:
+                        popup( _( "Crafter can't see!" ) );
+                        break;
+                    case craft_confirm_result::ok:
+                        if( available[line].inv_override == nullptr &&
+                            !crafter->check_eligible_containers_for_crafting( *current[line], bs ) ) {
+                            break; // popup already inside check
+                        }
+                        chosen = current[line];
+                        batch_size_out = bs;
+                        done = true;
+                        uistate.read_recipes.insert( chosen->ident() );
+                        break;
+                }
             }
         } else if( action == "HELP_RECIPE" && selection_ok( current, line, false ) ) {
             uistate.read_recipes.insert( current[line]->ident() );

--- a/src/crafting_gui_helpers.cpp
+++ b/src/crafting_gui_helpers.cpp
@@ -1,0 +1,202 @@
+#include "crafting_gui_helpers.h"
+
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "calendar.h"
+#include "character.h"
+#include "crafting.h"
+#include "inventory.h"
+#include "localized_comparator.h"
+#include "recipe.h"
+#include "requirements.h"
+#include "type_id.h"
+
+bool cannot_gain_skill_or_prof( const Character &crafter, const recipe &recp )
+{
+    if( recp.skill_used &&
+        static_cast<int>( crafter.get_skill_level( recp.skill_used ) ) <= recp.get_skill_cap() ) {
+        return false;
+    }
+    for( const proficiency_id &prof : recp.used_proficiencies() ) {
+        if( !crafter.has_proficiency( prof ) ) {
+            return false;
+        }
+    }
+    return true;
+}
+
+float availability::get_proficiency_time_maluses() const
+{
+    if( proficiency_time_maluses < 0 ) {
+        proficiency_time_maluses = rec->proficiency_time_maluses( crafter );
+    }
+
+    return proficiency_time_maluses;
+}
+
+float availability::get_max_proficiency_time_maluses() const
+{
+    if( max_proficiency_time_maluses < 0 ) {
+        max_proficiency_time_maluses = rec->max_proficiency_time_maluses( crafter );
+    }
+
+    return max_proficiency_time_maluses;
+}
+
+float availability::get_proficiency_skill_maluses() const
+{
+    if( proficiency_skill_maluses < 0 ) {
+        proficiency_skill_maluses = rec->proficiency_skill_maluses( crafter );
+    }
+
+    return proficiency_skill_maluses;
+}
+
+float availability::get_max_proficiency_skill_maluses() const
+{
+    if( max_proficiency_skill_maluses < 0 ) {
+        max_proficiency_skill_maluses = rec->max_proficiency_skill_maluses( crafter );
+    }
+
+    return max_proficiency_skill_maluses;
+}
+
+availability::availability( Character &_crafter, const recipe *r, int batch_size,
+                            bool camp_crafting, inventory *inventory_override ) :
+    crafter( _crafter )
+{
+    rec = r;
+    inv_override = inventory_override;
+    const inventory &inv = camp_crafting ? *inv_override : crafter.crafting_inventory();
+    auto all_items_filter = r->get_component_filter( recipe_filter_flags::none );
+    auto no_rotten_filter = r->get_component_filter( recipe_filter_flags::no_rotten );
+    auto no_favorite_filter = r->get_component_filter( recipe_filter_flags::no_favorite );
+    const deduped_requirement_data &req = r->deduped_requirements();
+    has_all_skills = r->skill_used.is_null() ||
+                     crafter.get_skill_level( r->skill_used ) >= r->get_difficulty( crafter );
+    crafter_has_primary_skill = r->skill_used.is_null()
+                                || crafter.get_knowledge_level( rec->skill_used )
+                                >= static_cast<int>( rec->get_difficulty( crafter ) * 0.8f );
+    has_proficiencies = r->character_has_required_proficiencies( crafter );
+    std::string reason;
+    craft_flags flag = camp_crafting ? craft_flags::none : craft_flags::start_only;
+
+    if( crafter.is_npc() && !r->npc_can_craft( reason ) && !camp_crafting ) {
+        can_craft = false;
+    } else if( r->is_nested() ) {
+        can_craft = check_can_craft_nested( _crafter, *r );
+    } else {
+        can_craft = ( !r->is_practice() || has_all_skills ) && has_proficiencies &&
+                    req.can_make_with_inventory( inv, all_items_filter, batch_size, flag );
+    }
+    would_use_rotten = !req.can_make_with_inventory( inv, no_rotten_filter, batch_size,
+                       flag );
+    would_use_favorite = !req.can_make_with_inventory( inv, no_favorite_filter, batch_size,
+                         flag );
+    useless_practice = r->is_practice() && cannot_gain_skill_or_prof( crafter, *r );
+    is_nested_category = r->is_nested();
+    const requirement_data &simple_req = r->simple_requirements();
+    apparently_craftable = ( !r->is_practice() || has_all_skills ) && has_proficiencies &&
+                           simple_req.can_make_with_inventory( inv, all_items_filter, batch_size, flag );
+    for( const auto &[skill, skill_lvl] : r->required_skills ) {
+        if( crafter.get_skill_level( skill ) < skill_lvl ) {
+            has_all_skills = false;
+            break;
+        }
+    }
+}
+
+nc_color availability::selected_color() const
+{
+    if( !can_craft && is_nested_category ) {
+        return h_blue;
+    } else if( !can_craft ) {
+        return h_dark_gray;
+    } else if( !crafter_has_primary_skill && is_nested_category ) {
+        return h_magenta;
+    } else if( !crafter_has_primary_skill ) {
+        return h_light_red;
+    } else if( is_nested_category ) {
+        return h_light_blue;
+    } else if( would_use_rotten || useless_practice ) {
+        return has_all_skills ? h_brown : h_red;
+    } else if( would_use_favorite ) {
+        return has_all_skills ? h_pink : h_red;
+    } else {
+        return has_all_skills ? h_white : h_yellow;
+    }
+}
+
+nc_color availability::color( bool ignore_missing_skills ) const
+{
+    if( !can_craft && is_nested_category ) {
+        return c_blue;
+    } else if( !can_craft ) {
+        return c_dark_gray;
+    } else if( !crafter_has_primary_skill && is_nested_category ) {
+        return c_magenta;
+    } else if( !crafter_has_primary_skill ) {
+        return c_light_red;
+    } else if( is_nested_category ) {
+        return c_light_blue;
+    } else if( would_use_rotten || useless_practice ) {
+        return has_all_skills || ignore_missing_skills ? c_brown : c_red;
+    } else if( would_use_favorite ) {
+        return has_all_skills ? c_pink : c_red;
+    } else {
+        return has_all_skills || ignore_missing_skills ? c_white : c_yellow;
+    }
+}
+
+bool availability::check_can_craft_nested( Character &_crafter, const recipe &r )
+{
+    for( const recipe_id &nested_r : r.nested_category_data ) {
+        if( availability( _crafter, &nested_r.obj() ).can_craft ) {
+            return true;
+        }
+    }
+    return false;
+}
+
+craft_confirm_result can_start_craft(
+    const recipe &rec,
+    const availability &avail,
+    const Character &crafter )
+{
+    if( !avail.can_craft || !avail.crafter_has_primary_skill ) {
+        return craft_confirm_result::cannot_craft;
+    }
+    if( crafter.lighting_craft_speed_multiplier( rec ) <= 0.0f ) {
+        return craft_confirm_result::too_dark;
+    }
+    return craft_confirm_result::ok;
+}
+
+bool recipe_sort_compare(
+    const recipe *a, const recipe *b,
+    const availability &avail_a, const availability &avail_b,
+    const Character &crafter,
+    bool a_read, bool b_read,
+    bool unread_first )
+{
+    if( unread_first ) {
+        if( a_read != b_read ) {
+            return !a_read;
+        }
+    }
+    if( avail_a.can_craft != avail_b.can_craft ) {
+        return avail_a.can_craft;
+    }
+    if( b->difficulty != a->difficulty ) {
+        return b->difficulty < a->difficulty;
+    }
+    const std::string a_name = a->result_name();
+    const std::string b_name = b->result_name();
+    if( a_name != b_name ) {
+        return localized_compare( a_name, b_name );
+    }
+    return b->time_to_craft( crafter ) < a->time_to_craft( crafter );
+}

--- a/src/crafting_gui_helpers.h
+++ b/src/crafting_gui_helpers.h
@@ -1,0 +1,80 @@
+#pragma once
+#ifndef CATA_SRC_CRAFTING_GUI_HELPERS_H
+#define CATA_SRC_CRAFTING_GUI_HELPERS_H
+
+#include "color.h"
+
+class Character;
+class inventory;
+class recipe;
+
+// Returns true if the character cannot gain any skill or proficiency from this recipe.
+// Used to mark practice recipes as "useless" when the crafter already exceeds
+// the recipe's skill cap and has all used proficiencies.
+bool cannot_gain_skill_or_prof( const Character &crafter, const recipe &recp );
+
+// Computes whether a Character can craft a given recipe.
+// Stores craftability flags, color-coding, and lazy-cached proficiency maluses.
+struct availability {
+        explicit availability( Character &_crafter, const recipe *r, int batch_size = 1,
+                               bool camp_crafting = false, inventory *inventory_override = nullptr );
+        Character &crafter;
+        bool can_craft;
+        // group can introduce recipe this crafter cannot craft because of low primary skill
+        bool crafter_has_primary_skill;
+        bool would_use_rotten;
+        bool would_use_favorite;
+        bool useless_practice;
+        bool apparently_craftable;
+        bool has_proficiencies;
+        bool has_all_skills;
+        bool is_nested_category;
+        // Used as an indicator to see if crafting is called via camp.
+        // If not nullptr, we must be camp crafting.
+        inventory *inv_override;
+    private:
+        const recipe *rec;
+        mutable float proficiency_time_maluses = -1.0f;
+        mutable float max_proficiency_time_maluses = -1.0f;
+        mutable float proficiency_skill_maluses = -1.0f;
+        mutable float max_proficiency_skill_maluses = -1.0f;
+    public:
+        float get_proficiency_time_maluses() const;
+        float get_max_proficiency_time_maluses() const;
+        float get_proficiency_skill_maluses() const;
+        float get_max_proficiency_skill_maluses() const;
+
+        nc_color selected_color() const;
+        nc_color color( bool ignore_missing_skills = false ) const;
+
+        static bool check_can_craft_nested( Character &_crafter, const recipe &r );
+};
+
+enum class craft_confirm_result {
+    ok,
+    cannot_craft,
+    too_dark
+};
+
+// Checks craftability and lighting for the CONFIRM action.
+// Does not check container eligibility.
+craft_confirm_result can_start_craft(
+    const recipe &rec,
+    const availability &avail,
+    const Character &crafter );
+
+// Recipe sort comparator for the crafting menu recipe list.
+// Comparison order:
+//   1. Unread before read (when unread_first is true)
+//   2. Craftable before uncraftable
+//   3. Higher difficulty first
+//   4. Alphabetical by result_name()
+//   5. Longer craft time first (tiebreaker)
+bool recipe_sort_compare(
+    const recipe *a, const recipe *b,
+    const availability &avail_a, const availability &avail_b,
+    const Character &crafter,
+    bool a_read, bool b_read,
+    bool unread_first );
+
+#endif // CATA_SRC_CRAFTING_GUI_HELPERS_H

--- a/tests/crafting_gui_test.cpp
+++ b/tests/crafting_gui_test.cpp
@@ -1,0 +1,448 @@
+#include <functional>
+#include <memory>
+
+#include "avatar.h"
+#include "calendar.h"
+#include "cata_catch.h"
+#include "character.h"
+#include "character_attire.h"
+#include "color.h"
+#include "crafting_gui_helpers.h"
+#include "game.h"
+#include "item.h"
+#include "map.h"
+#include "map_helpers.h"
+#include "options_helpers.h"
+#include "player_helpers.h"
+#include "type_id.h"
+#include "weather_type.h"
+
+class recipe;
+
+static const itype_id itype_2x4( "2x4" );
+static const itype_id itype_billet_wood( "billet_wood" );
+static const itype_id itype_debug_backpack( "debug_backpack" );
+static const itype_id itype_fat( "fat" );
+static const itype_id itype_hammer( "hammer" );
+static const itype_id itype_knife_hunting( "knife_hunting" );
+static const itype_id itype_rock( "rock" );
+
+static const proficiency_id proficiency_prof_carving( "prof_carving" );
+static const proficiency_id proficiency_prof_food_prep( "prof_food_prep" );
+static const proficiency_id proficiency_prof_knapping( "prof_knapping" );
+
+static const recipe_id recipe_cudgel_simple( "cudgel_simple" );
+static const recipe_id recipe_cudgel_slow( "cudgel_slow" );
+static const recipe_id recipe_cudgel_test_no_tools( "cudgel_test_no_tools" );
+static const recipe_id recipe_meat_cooked_test_no_tools( "meat_cooked_test_no_tools" );
+static const recipe_id recipe_prac_knapping( "prac_knapping" );
+static const recipe_id recipe_test_nested_weapons( "test_nested_weapons" );
+static const recipe_id recipe_test_tallow( "test_tallow" );
+
+static const skill_id skill_cooking( "cooking" );
+static const skill_id skill_fabrication( "fabrication" );
+static const skill_id skill_melee( "melee" );
+static const skill_id skill_survival( "survival" );
+
+// Helper: clear everything and return the avatar with a debug backpack
+// so that i_add() has pockets to place items into (clear_avatar strips
+// all worn items, leaving no storage capacity).
+static Character &setup_character()
+{
+    clear_avatar();
+    clear_map_without_vision();
+    Character &guy = get_avatar();
+    guy.worn.wear_item( guy, item( itype_debug_backpack ), false, false );
+    guy.invalidate_crafting_inventory();
+    return guy;
+}
+
+
+TEST_CASE( "recipe_availability_has_components_and_skills", "[crafting][gui]" )
+{
+    Character &guy = setup_character();
+    guy.set_skill_level( skill_cooking, 3 );
+    guy.i_add( item( itype_fat ) );
+    guy.i_add( item( itype_fat ) );
+    guy.i_add( item( itype_knife_hunting ) ); // CUT 2 quality
+    guy.invalidate_crafting_inventory();
+
+    const recipe &rec = recipe_test_tallow.obj();
+    availability avail( guy, &rec );
+
+    CHECK( avail.can_craft );
+    CHECK( avail.has_all_skills );
+    CHECK( avail.color() == c_white );
+}
+
+TEST_CASE( "recipe_availability_missing_component", "[crafting][gui]" )
+{
+    Character &guy = setup_character();
+    guy.set_skill_level( skill_cooking, 3 );
+    guy.i_add( item( itype_knife_hunting ) ); // has tool but no fat
+    guy.invalidate_crafting_inventory();
+
+    const recipe &rec = recipe_test_tallow.obj();
+    availability avail( guy, &rec );
+
+    CHECK_FALSE( avail.can_craft );
+    CHECK( avail.color() == c_dark_gray );
+}
+
+TEST_CASE( "recipe_availability_insufficient_skill", "[crafting][gui]" )
+{
+    Character &guy = setup_character();
+    guy.set_skill_level( skill_cooking, 0 );
+    guy.i_add( item( itype_fat ) );
+    guy.i_add( item( itype_fat ) );
+    guy.i_add( item( itype_knife_hunting ) );
+    guy.invalidate_crafting_inventory();
+
+    const recipe &rec = recipe_test_tallow.obj();
+    availability avail( guy, &rec );
+
+    // can_craft gates on components, not skill level (test_tallow is not practice)
+    CHECK( avail.can_craft );
+    CHECK_FALSE( avail.has_all_skills );
+    // cooking 0 vs difficulty 3: knowledge_level < difficulty*0.8, so no primary skill
+    CHECK_FALSE( avail.crafter_has_primary_skill );
+    CHECK( avail.color() == c_light_red );
+}
+
+TEST_CASE( "recipe_availability_would_use_rotten", "[crafting][gui]" )
+{
+    Character &guy = setup_character();
+    guy.set_skill_level( skill_cooking, 3 );
+    item rotten_fat1( itype_fat );
+    rotten_fat1.set_rot( 1000_hours ); // force rotten
+    guy.i_add( rotten_fat1 );
+    item rotten_fat2( itype_fat );
+    rotten_fat2.set_rot( 1000_hours );
+    guy.i_add( rotten_fat2 );
+    guy.i_add( item( itype_knife_hunting ) );
+    guy.invalidate_crafting_inventory();
+
+    const recipe &rec = recipe_test_tallow.obj();
+    availability avail( guy, &rec );
+
+    CHECK( avail.would_use_rotten );
+    // has_all_skills is true, so rotten color is c_brown
+    CHECK( avail.color() == c_brown );
+}
+
+TEST_CASE( "recipe_availability_would_use_favorite", "[crafting][gui]" )
+{
+    Character &guy = setup_character();
+    guy.set_skill_level( skill_fabrication, 2 );
+    guy.set_skill_level( skill_melee, 1 );
+    item fav_2x4( itype_2x4 );
+    fav_2x4.set_favorite( true );
+    guy.i_add( fav_2x4 );
+    guy.invalidate_crafting_inventory();
+
+    const recipe &rec = recipe_cudgel_test_no_tools.obj();
+    availability avail( guy, &rec );
+
+    CHECK( avail.can_craft );
+    CHECK( avail.would_use_favorite );
+    CHECK( avail.color() == c_pink );
+}
+
+TEST_CASE( "recipe_availability_useless_practice", "[crafting][gui]" )
+{
+    Character &guy = setup_character();
+    // prac_knapping: survival practice, skill_limit 2, requires fabrication 1
+    // also uses prof_knapping
+    guy.set_skill_level( skill_survival, 3 ); // above skill_limit
+    guy.set_skill_level( skill_fabrication, 1 );
+    guy.add_proficiency( proficiency_prof_knapping );
+    // Tools: HAMMER 1 + HAMMER_SOFT 1
+    guy.i_add( item( itype_hammer ) );     // HAMMER quality
+    guy.i_add( item( itype_billet_wood ) ); // HAMMER_SOFT quality
+    // Components: rock
+    guy.i_add( item( itype_rock ) );
+    guy.i_add( item( itype_rock ) );
+    guy.invalidate_crafting_inventory();
+
+    const recipe &rec = recipe_prac_knapping.obj();
+    availability avail( guy, &rec );
+
+    CHECK( avail.useless_practice );
+}
+
+TEST_CASE( "recipe_availability_nested_craftable", "[crafting][gui]" )
+{
+    Character &guy = setup_character();
+    guy.set_skill_level( skill_fabrication, 2 );
+    guy.set_skill_level( skill_melee, 1 );
+    guy.i_add( item( itype_2x4 ) ); // child recipe cudgel_test_no_tools needs 2x4
+    guy.invalidate_crafting_inventory();
+
+    const recipe &rec = recipe_test_nested_weapons.obj();
+    availability avail( guy, &rec );
+
+    CHECK( avail.is_nested_category );
+    CHECK( avail.can_craft ); // at least one child is craftable
+    CHECK( avail.color() == c_light_blue );
+}
+
+TEST_CASE( "recipe_availability_nested_none_craftable", "[crafting][gui]" )
+{
+    Character &guy = setup_character();
+    guy.set_skill_level( skill_fabrication, 2 );
+    guy.set_skill_level( skill_melee, 1 );
+    // No 2x4 -> child recipe is not craftable
+    guy.invalidate_crafting_inventory();
+
+    const recipe &rec = recipe_test_nested_weapons.obj();
+    availability avail( guy, &rec );
+
+    CHECK( avail.is_nested_category );
+    CHECK_FALSE( avail.can_craft );
+    CHECK( avail.color() == c_blue );
+}
+
+TEST_CASE( "recipe_availability_proficiency_cache", "[crafting][gui]" )
+{
+    Character &guy = setup_character();
+    guy.set_skill_level( skill_fabrication, 0 );
+    guy.i_add( item( itype_2x4 ) );
+    // Do NOT grant prof_carving -- malus should be > 1.0
+    guy.invalidate_crafting_inventory();
+
+    const recipe &rec = recipe_cudgel_simple.obj();
+    availability avail( guy, &rec );
+
+    float malus1 = avail.get_proficiency_time_maluses();
+    float malus2 = avail.get_proficiency_time_maluses();
+    CHECK( malus1 >= 1.0f );
+    CHECK( malus1 == malus2 ); // lazy cache returns same value
+}
+
+
+TEST_CASE( "can_start_craft_ok", "[crafting][gui]" )
+{
+    Character &guy = setup_character();
+    guy.set_skill_level( skill_fabrication, 2 );
+    guy.set_skill_level( skill_melee, 1 );
+    guy.i_add( item( itype_2x4 ) );
+    guy.invalidate_crafting_inventory();
+    // Midday for good lighting
+    scoped_weather_override weather_clear( WEATHER_CLEAR );
+    calendar::turn = calendar::turn_zero + 9_hours + 30_minutes;
+    g->reset_light_level();
+    get_map().build_map_cache( 0, false );
+
+    const recipe &rec = recipe_cudgel_test_no_tools.obj();
+    availability avail( guy, &rec );
+
+    CHECK( can_start_craft( rec, avail, guy ) == craft_confirm_result::ok );
+}
+
+TEST_CASE( "can_start_craft_cannot_craft_no_components", "[crafting][gui]" )
+{
+    Character &guy = setup_character();
+    guy.set_skill_level( skill_fabrication, 2 );
+    guy.set_skill_level( skill_melee, 1 );
+    // No 2x4 in inventory
+    guy.invalidate_crafting_inventory();
+    scoped_weather_override weather_clear( WEATHER_CLEAR );
+    calendar::turn = calendar::turn_zero + 9_hours + 30_minutes;
+    g->reset_light_level();
+    get_map().build_map_cache( 0, false );
+
+    const recipe &rec = recipe_cudgel_test_no_tools.obj();
+    availability avail( guy, &rec );
+
+    CHECK_FALSE( avail.can_craft );
+    CHECK( can_start_craft( rec, avail, guy ) == craft_confirm_result::cannot_craft );
+}
+
+TEST_CASE( "can_start_craft_cannot_craft_no_primary_skill", "[crafting][gui]" )
+{
+    Character &guy = setup_character();
+    guy.set_skill_level( skill_fabrication, 0 );
+    guy.set_skill_level( skill_melee, 0 );
+    guy.i_add( item( itype_2x4 ) );
+    guy.invalidate_crafting_inventory();
+    scoped_weather_override weather_clear( WEATHER_CLEAR );
+    calendar::turn = calendar::turn_zero + 9_hours + 30_minutes;
+    g->reset_light_level();
+    get_map().build_map_cache( 0, false );
+
+    const recipe &rec = recipe_cudgel_test_no_tools.obj();
+    availability avail( guy, &rec );
+
+    // Has components so can_craft is true, but primary skill is too low
+    // knowledge_level(0) < difficulty(2) * 0.8 = 1.6
+    CHECK( avail.can_craft );
+    CHECK_FALSE( avail.crafter_has_primary_skill );
+    CHECK( can_start_craft( rec, avail, guy ) == craft_confirm_result::cannot_craft );
+}
+
+TEST_CASE( "can_start_craft_too_dark", "[crafting][gui]" )
+{
+    Character &guy = setup_character();
+    guy.set_skill_level( skill_fabrication, 2 );
+    guy.set_skill_level( skill_melee, 1 );
+    guy.i_add( item( itype_2x4 ) );
+    guy.invalidate_crafting_inventory();
+    // Midnight, no light
+    scoped_weather_override weather_clear( WEATHER_CLEAR );
+    calendar::turn = calendar::turn_zero;
+    g->reset_light_level();
+    get_map().build_map_cache( 0, false );
+
+    const recipe &rec = recipe_cudgel_test_no_tools.obj();
+    availability avail( guy, &rec );
+
+    CHECK( avail.can_craft );
+    CHECK( avail.crafter_has_primary_skill );
+    CHECK( can_start_craft( rec, avail, guy ) == craft_confirm_result::too_dark );
+}
+
+TEST_CASE( "can_start_craft_ok_at_midday", "[crafting][gui]" )
+{
+    Character &guy = setup_character();
+    guy.set_skill_level( skill_fabrication, 2 );
+    guy.set_skill_level( skill_melee, 1 );
+    guy.i_add( item( itype_2x4 ) );
+    guy.invalidate_crafting_inventory();
+    // Midday, good light
+    scoped_weather_override weather_clear( WEATHER_CLEAR );
+    calendar::turn = calendar::turn_zero + 9_hours + 30_minutes;
+    g->reset_light_level();
+    get_map().build_map_cache( 0, false );
+
+    const recipe &rec = recipe_cudgel_test_no_tools.obj();
+    availability avail( guy, &rec );
+
+    CHECK( can_start_craft( rec, avail, guy ) == craft_confirm_result::ok );
+}
+
+
+TEST_CASE( "recipe_sort_craftable_before_uncraftable", "[crafting][gui]" )
+{
+    Character &guy = setup_character();
+    guy.set_skill_level( skill_fabrication, 2 );
+    guy.set_skill_level( skill_melee, 1 );
+    guy.i_add( item( itype_2x4 ) );
+    guy.invalidate_crafting_inventory();
+
+    const recipe &rec = recipe_cudgel_test_no_tools.obj();
+    availability avail_yes( guy, &rec );
+    CHECK( avail_yes.can_craft );
+
+    // Remove the component so a second availability is not craftable
+    guy.remove_items_with( []( const item & it ) {
+        return it.typeId() == itype_2x4;
+    } );
+    guy.invalidate_crafting_inventory();
+    availability avail_no( guy, &rec );
+    CHECK_FALSE( avail_no.can_craft );
+
+    CHECK( recipe_sort_compare( &rec, &rec, avail_yes, avail_no, guy,
+                                true, true, false ) );
+    CHECK_FALSE( recipe_sort_compare( &rec, &rec, avail_no, avail_yes, guy,
+                                      true, true, false ) );
+}
+
+TEST_CASE( "recipe_sort_by_difficulty", "[crafting][gui]" )
+{
+    Character &guy = setup_character();
+    guy.set_skill_level( skill_fabrication, 2 );
+    guy.set_skill_level( skill_melee, 1 );
+    guy.add_proficiency( proficiency_prof_carving );
+    guy.i_add( item( itype_2x4 ) );
+    guy.invalidate_crafting_inventory();
+
+    const recipe &rec_hard = recipe_cudgel_test_no_tools.obj();
+    const recipe &rec_easy = recipe_cudgel_simple.obj();
+    availability avail_hard( guy, &rec_hard );
+    availability avail_easy( guy, &rec_easy );
+
+    // Higher difficulty sorts first (existing behavior: b->difficulty < a->difficulty)
+    CHECK( recipe_sort_compare( &rec_hard, &rec_easy, avail_hard, avail_easy, guy,
+                                true, true, false ) );
+}
+
+TEST_CASE( "recipe_sort_by_name", "[crafting][gui]" )
+{
+    Character &guy = setup_character();
+    guy.set_skill_level( skill_fabrication, 0 );
+    guy.set_skill_level( skill_cooking, 0 );
+    guy.add_proficiency( proficiency_prof_carving );
+    guy.add_proficiency( proficiency_prof_food_prep );
+    guy.i_add( item( itype_2x4 ) );
+    guy.invalidate_crafting_inventory();
+
+    const recipe &rec_cudgel = recipe_cudgel_simple.obj();
+    const recipe &rec_meat = recipe_meat_cooked_test_no_tools.obj();
+    availability avail_cudgel( guy, &rec_cudgel );
+    availability avail_meat( guy, &rec_meat );
+
+    // "cooked meat" < "cudgel" alphabetically
+    CHECK( recipe_sort_compare( &rec_meat, &rec_cudgel, avail_meat, avail_cudgel, guy,
+                                true, true, false ) );
+    CHECK_FALSE( recipe_sort_compare( &rec_cudgel, &rec_meat, avail_cudgel, avail_meat, guy,
+                                      true, true, false ) );
+}
+
+TEST_CASE( "recipe_sort_by_craft_time_tiebreaker", "[crafting][gui]" )
+{
+    Character &guy = setup_character();
+    guy.set_skill_level( skill_fabrication, 0 );
+    guy.add_proficiency( proficiency_prof_carving );
+    guy.i_add( item( itype_2x4 ) );
+    guy.invalidate_crafting_inventory();
+
+    const recipe &rec_fast = recipe_cudgel_simple.obj();
+    const recipe &rec_slow = recipe_cudgel_slow.obj();
+    availability avail_fast( guy, &rec_fast );
+    availability avail_slow( guy, &rec_slow );
+
+    // Same name, same difficulty -> longer craft time sorts first
+    CHECK( recipe_sort_compare( &rec_slow, &rec_fast, avail_slow, avail_fast, guy,
+                                true, true, false ) );
+}
+
+TEST_CASE( "recipe_sort_unread_first", "[crafting][gui]" )
+{
+    Character &guy = setup_character();
+    guy.set_skill_level( skill_fabrication, 2 );
+    guy.set_skill_level( skill_melee, 1 );
+    guy.i_add( item( itype_2x4 ) );
+    guy.invalidate_crafting_inventory();
+
+    const recipe &rec = recipe_cudgel_test_no_tools.obj();
+    availability avail( guy, &rec );
+
+    // a_read=false (unread), b_read=true (read), unread_first=true -> a sorts before b
+    CHECK( recipe_sort_compare( &rec, &rec, avail, avail, guy,
+                                false, true, true ) );
+    // a_read=true (read), b_read=false (unread) -> b should sort first, so a < b is false
+    CHECK_FALSE( recipe_sort_compare( &rec, &rec, avail, avail, guy,
+                                      true, false, true ) );
+}
+
+TEST_CASE( "recipe_sort_unread_disabled", "[crafting][gui]" )
+{
+    Character &guy = setup_character();
+    guy.set_skill_level( skill_fabrication, 2 );
+    guy.set_skill_level( skill_melee, 1 );
+    guy.i_add( item( itype_2x4 ) );
+    guy.invalidate_crafting_inventory();
+
+    const recipe &rec = recipe_cudgel_test_no_tools.obj();
+    availability avail_yes( guy, &rec );
+
+    guy.remove_items_with( []( const item & it ) {
+        return it.typeId() == itype_2x4;
+    } );
+    guy.invalidate_crafting_inventory();
+    availability avail_no( guy, &rec );
+
+    // unread_first=false: read state ignored, craftability dominates
+    CHECK( recipe_sort_compare( &rec, &rec, avail_yes, avail_no, guy,
+                                true, false, false ) );
+}


### PR DESCRIPTION
#### Summary
Infrastructure "Extract crafting menu helpers for testability"

#### Purpose of change

The crafting menu (`crafting_gui.cpp`) is a 2700-line monolith where all types and logic live in anonymous namespaces, making them untestable and inaccessible to other translation units. This is prep work for an eventual ImGui conversion of the crafting menu -- the extracted helpers will be shared between the curses and ImGui implementations.

Related: #62634, #62635, #70909

#### Describe the solution

Create `crafting_gui_helpers.h` and move the `availability` struct (plus `cannot_gain_skill_or_prof()`) out of the anonymous namespace in `crafting_gui.cpp`.

Add two small helpers extracted from the monolithic function:

- `can_start_craft()` -- pure validation for the CONFIRM action path. Checks craftability and lighting without touching the interactive container eligibility prompt (`check_eligible_containers_for_crafting` stays in the caller since it calls `query_yn` internally).
- `recipe_sort_compare()` -- the recipe list sort comparator. Takes read-state as explicit `a_read`/`b_read` bools instead of reading global `uistate.read_recipes`, so it can be tested in isolation.

Also adds a `test_nested_weapons` nested category fixture to TEST_DATA.

#### Describe alternatives you've considered

Tried extracting bigger blocks (the full recalc block, the full action handler) but those have UI coupling (progress popups during search, `query_yn` in actions, `ui.invalidate_ui()` calls) that makes clean extraction part of the ImGui conversion itself rather than prep work.

#### Testing

20 new test cases in `tests/crafting_gui_test.cpp`, 44 assertions total:

- 9 availability tests: craftable, missing components, insufficient skill, rotten/favorite ingredients, useless practice, nested craftable/uncraftable, proficiency cache
- 5 can_start_craft tests: ok, missing components, missing primary skill, too dark, ok at midday
- 6 recipe_sort_compare tests: craftable-first, by difficulty, by name, craft-time tiebreaker, unread-first, unread-disabled

All existing `[crafting]` tests pass unchanged.

#### Additional context

The `availability` struct is moved as-is -- it still stores `Character&`, has mutable cached fields, and returns `nc_color`. This is a mechanical extraction, not an architectural purification. The helpers header is internal to the crafting menu subsystem, not a public API.