### PR TITLE
Extract recipe_info() to crafting_gui_helpers

### DIFF
--- a/data/mods/TEST_DATA/recipes.json
+++ b/data/mods/TEST_DATA/recipes.json
@@ -210,6 +210,7 @@
     "time": "10 m",
     "charges": 3,
     "autolearn": false,
+    "book_learn": [ [ "family_cookbook", 1 ] ],
     "qualities": [ { "id": "CUT", "level": 2 } ],
     "components": [ [ [ "fat", 2 ] ] ]
   },

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -28,11 +28,9 @@
 #include "cuboid_rectangle.h"
 #include "cursesdef.h"
 #include "debug.h"
-#include "display.h"
 #include "flag.h"
 #include "flat_set.h"
 #include "flexbuffer_json.h"
-#include "game_constants.h"
 #include "game_inventory.h"
 #include "generic_factory.h"
 #include "input.h"
@@ -53,7 +51,6 @@
 #include "recipe.h"
 #include "recipe_dictionary.h"
 #include "requirements.h"
-#include "skill.h"
 #include "string_formatter.h"
 #include "translation.h"
 #include "translation_cache.h"
@@ -63,9 +60,6 @@
 #include "ui_iteminfo.h"
 #include "ui_manager.h"
 #include "uistate.h"
-
-static const std::string flag_BLIND_EASY( "BLIND_EASY" );
-static const std::string flag_BLIND_HARD( "BLIND_HARD" );
 
 enum TAB_MODE {
     NORMAL,
@@ -200,263 +194,6 @@ void reset_recipe_categories()
     craft_cat_list.reset();
 }
 
-
-static std::string craft_success_chance_string( const recipe &recp, const Character &guy )
-{
-    float chance = 100.f * ( 1.f - guy.recipe_success_chance( recp ) );
-    std::string color;
-    if( chance > 75 ) {
-        color = "yellow";
-    } else if( chance > 50 ) {
-        color = "light_gray";
-    } else if( chance > 25 ) {
-        color = "green";
-    } else {
-        color = "cyan";
-    }
-
-    return string_format( _( "Minor Failure Chance: <color_%s>%2.2f%%</color>" ), color, chance );
-}
-
-static std::string cata_fail_chance_string( const recipe &recp, const Character &guy )
-{
-    float chance = 100.f * guy.item_destruction_chance( recp );
-    std::string color;
-    if( chance > 50 ) {
-        color = "i_red";
-    } else if( chance > 20 ) {
-        color = "red";
-    } else if( chance > 5 ) {
-        color = "yellow";
-    } else {
-        color = "light_gray";
-    }
-
-    return string_format( _( "Catastrophic Failure Chance: <color_%s>%2.2f%%</color>" ), color,
-                          chance );
-}
-
-static std::vector<std::string> recipe_info(
-    const recipe &recp,
-    const availability &avail,
-    Character &guy,
-    std::string_view qry_comps,
-    const int batch_size,
-    const int fold_width,
-    const nc_color &color,
-    const std::vector<Character *> &crafting_group )
-{
-    std::ostringstream oss;
-    oss << string_format( _( "Crafter: %s\n" ), guy.name_and_maybe_activity() );
-
-    oss << string_format( _( "Primary skill: %s\n" ), recp.primary_skill_string( guy ) );
-    if( !avail.crafter_has_primary_skill ) {
-        if( recp.is_practice() ) {
-            oss << _( "<color_red>Crafter cannot practice this because they "
-                      "lack the theoretical knowledge for it.</color>\n" );
-        } else {
-            oss << _( "<color_red>Crafter cannot craft this because they "
-                      "lack the theoretical knowledge to understand the recipe.</color>\n" );
-        }
-    }
-
-    if( !recp.required_skills.empty() ) {
-        oss << string_format( _( "Other skills: %s\n" ), recp.required_skills_string( guy ) );
-    }
-
-    const std::string req_profs = recp.required_proficiencies_string( &guy );
-    if( !req_profs.empty() ) {
-        oss << string_format( _( "Proficiencies Required: %s\n" ), req_profs );
-    }
-    const std::string used_profs = recp.used_proficiencies_string( &guy );
-    if( !used_profs.empty() ) {
-        oss << string_format( _( "Proficiencies Used: %s\n" ), used_profs );
-    }
-    const std::string missing_profs = recp.missing_proficiencies_string( &guy );
-    if( !missing_profs.empty() ) {
-        oss << string_format( _( "Proficiencies Missing: %s\n" ), missing_profs );
-    }
-
-    oss << craft_success_chance_string( recp, guy ) << "\n";
-    oss << cata_fail_chance_string( recp, guy ) << "\n";
-
-    if( !recp.is_nested() ) {
-        const int expected_turns = guy.expected_time_to_craft( recp, batch_size )
-                                   / to_moves<int>( 1_turns );
-        oss << string_format( _( "Time to complete: <color_cyan>%s</color>\n" ),
-                              to_string( time_duration::from_turns( expected_turns ) ) );
-
-    }
-
-    const std::string batch_savings = recp.batch_savings_string();
-    if( !batch_savings.empty() ) {
-        oss << string_format( _( "Batch time savings: <color_cyan>%s</color>\n" ), batch_savings );
-    }
-
-    oss << string_format( _( "Activity level: <color_cyan>%s</color>\n" ),
-                          display::activity_level_str( recp.exertion_level() ) );
-
-    const int makes = recp.makes_amount();
-    if( makes > 1 ) {
-        oss << string_format( _( "Recipe makes: <color_cyan>%d</color>\n" ), makes );
-    }
-
-    oss << string_format( _( "Craftable in the dark?  <color_cyan>%s</color>\n" ),
-                          recp.has_flag( flag_BLIND_EASY ) ? _( "Easy" ) :
-                          recp.has_flag( flag_BLIND_HARD ) ? _( "Hard" ) :
-                          _( "Impossible" ) );
-
-    const inventory &crafting_inv = avail.inv_override ? *avail.inv_override : guy.crafting_inventory();
-    if( recp.result() ) {
-        const int nearby_amount = crafting_inv.count_item( recp.result() );
-        std::string nearby_string;
-        if( nearby_amount == 0 ) {
-            nearby_string = "<color_light_gray>0</color>";
-        } else if( nearby_amount > 9000 ) {
-            // at some point you get too many to count at a glance and just know you have a lot
-            nearby_string = _( "<color_red>It's Over 9000!!!</color>" );
-        } else {
-            nearby_string = string_format( "<color_yellow>%d</color>", nearby_amount );
-        }
-        oss << string_format( _( "Nearby: %s\n" ), nearby_string );
-    }
-
-    const bool can_craft_this = avail.can_craft;
-    if( can_craft_this && avail.would_use_rotten ) {
-        oss << _( "<color_red>Will use rotten ingredients</color>\n" );
-    }
-    if( can_craft_this && avail.would_use_favorite ) {
-        oss << _( "<color_red>Will use favorited ingredients</color>\n" );
-    }
-    const bool too_complex = recp.deduped_requirements().is_too_complex();
-    if( can_craft_this && too_complex ) {
-        oss << _( "Due to the complex overlapping requirements, this "
-                  "recipe <color_yellow>may appear to be craftable "
-                  "when it is not</color>.\n" );
-    }
-    std::string reason;
-    bool npc_cant = avail.crafter.is_npc() && !recp.npc_can_craft( reason ) && !avail.inv_override ;
-    if( !can_craft_this && avail.apparently_craftable && !recp.is_nested() && !npc_cant ) {
-        oss << _( "<color_red>Cannot be crafted because the same item is needed "
-                  "for multiple components.</color>\n" );
-    }
-
-    if( !can_craft_this && npc_cant ) {
-        oss << colorize( reason, c_red ) << "\n";
-    }
-
-    const bool disp_prof_msg = avail.has_proficiencies && !recp.is_nested();
-    const float time_maluses = avail.get_proficiency_time_maluses();
-    const float max_time_malus = avail.get_max_proficiency_time_maluses();
-    const float skill_maluses = avail.get_proficiency_skill_maluses();
-    const float max_skill_malus = avail.get_max_proficiency_skill_maluses();
-    if( disp_prof_msg && time_maluses < max_time_malus && skill_maluses < max_skill_malus ) {
-        oss << string_format( _( "<color_green>This recipe will be %.2fx faster than normal, "
-                                 "and your effective skill will be %.2f levels higher than normal, because of "
-                                 "the proficiencies the crafter has.</color>\n" ),
-                              max_time_malus / time_maluses, max_skill_malus - skill_maluses );
-    } else if( disp_prof_msg && time_maluses < max_time_malus ) {
-        oss << string_format( _( "<color_green>This recipe will be %.2fx faster than normal, "
-                                 "because of the proficiencies the crafter has.</color>\n" ), max_time_malus / time_maluses );
-    } else if( disp_prof_msg && skill_maluses < max_skill_malus ) {
-        oss << string_format(
-                _( "<color_green>Your effective skill will be %.2f levels higher than normal, "
-                   "because of the proficiencies the crafter has.</color>\n" ), max_skill_malus - skill_maluses );
-    }
-    if( !can_craft_this && !avail.has_proficiencies ) {
-        oss << _( "<color_red>Cannot be crafted because the crafter lacks"
-                  " the required proficiencies.</color>\n" );
-    }
-
-    if( recp.has_byproducts() ) {
-        oss << _( "Byproducts:\n" );
-        for( const std::pair<const itype_id, int> &bp : recp.get_byproducts() ) {
-            const itype *t = item::find_type( bp.first );
-            int amount = bp.second * batch_size;
-            if( t->count_by_charges() ) {
-                oss << string_format( "> %s (%d)\n", t->nname( 1 ), amount );
-            } else {
-                oss << string_format( "> %d %s\n", amount,
-                                      t->nname( static_cast<unsigned int>( amount ) ) );
-            }
-        }
-    }
-
-    std::vector<std::string> result = foldstring( oss.str(), fold_width );
-
-    if( !recp.is_nested() ) {
-        const requirement_data &req = recp.simple_requirements();
-        const std::vector<std::string> tools = req.get_folded_tools_list(
-                fold_width, color, crafting_inv, batch_size );
-        const std::vector<std::string> comps = req.get_folded_components_list(
-                fold_width, color, crafting_inv, recp.get_component_filter(), batch_size, qry_comps );
-        result.insert( result.end(), tools.begin(), tools.end() );
-        result.insert( result.end(), comps.begin(), comps.end() );
-    }
-
-    oss = std::ostringstream();
-    if( !guy.knows_recipe( &recp ) ) {
-        oss << _( "Recipe not memorized yet\n" );
-        const std::set<itype_id> books_with_recipe = guy.get_books_for_recipe( crafting_inv, &recp );
-        if( !books_with_recipe.empty() ) {
-            const std::string enumerated_books = enumerate_as_string( books_with_recipe,
-            []( const itype_id & type_id ) {
-                return colorize( item::nname( type_id ), c_cyan );
-            } );
-            oss << string_format( _( "Written in: %s\n" ), enumerated_books );
-        }
-        std::vector<const Character *> knowing_helpers;
-        for( const Character *helper : crafting_group ) {
-            // guy.getID() != helper->getID(): guy doesn't know the recipe anyway, but this should be faster
-            if( guy.getID() != helper->getID() && helper->knows_recipe( &recp ) ) {
-                knowing_helpers.push_back( helper );
-            }
-        }
-        if( !knowing_helpers.empty() ) {
-            const std::string enumerated_helpers = enumerate_as_string( knowing_helpers,
-            []( const Character * helper ) {
-                return colorize( helper->is_avatar() ? _( "You" ) : helper->get_name(), c_cyan );
-            } );
-            oss << string_format( _( "Known by: %s\n" ), enumerated_helpers );
-        }
-    }
-    std::vector<std::string> tmp = foldstring( oss.str(), fold_width );
-    result.insert( result.end(), tmp.begin(), tmp.end() );
-
-    return result;
-}
-
-static std::string practice_recipe_description( const recipe &recp,
-        const Character &crafter )
-{
-    std::ostringstream oss;
-    oss << recp.get_description( crafter ) << "\n\n";
-    if( recp.practice_data->min_difficulty != recp.practice_data->max_difficulty ) {
-        std::string txt = string_format( _( "Difficulty range: %d to %d" ),
-                                         recp.practice_data->min_difficulty, recp.practice_data->max_difficulty );
-        oss << txt << "\n";
-    }
-    if( recp.skill_used ) {
-        const int player_skill_level = crafter.get_all_skills().get_skill_level( recp.skill_used );
-        if( player_skill_level < recp.practice_data->min_difficulty ) {
-            std::string txt = string_format(
-                                  _( "The crafter does not possess the minimum <color_cyan>%s</color> skill level required to practice this." ),
-                                  recp.skill_used->name() );
-            txt = string_format( "<color_red>%s</color>", txt );
-            oss << txt << "\n";
-        }
-        if( recp.practice_data->skill_limit != MAX_SKILL ) {
-            std::string txt = string_format(
-                                  _( "This practice action will not increase your <color_cyan>%s</color> skill above %d." ),
-                                  recp.skill_used->name(), recp.practice_data->skill_limit );
-            if( player_skill_level >= recp.practice_data->skill_limit ) {
-                txt = string_format( "<color_brown>%s</color>", txt );
-            }
-            oss << txt << "\n";
-        }
-    }
-    return oss.str();
-}
 
 static input_context make_crafting_context( bool highlight_unread_recipes )
 {

--- a/src/crafting_gui_helpers.cpp
+++ b/src/crafting_gui_helpers.cpp
@@ -1,17 +1,29 @@
 #include "crafting_gui_helpers.h"
 
 #include <map>
+#include <optional>
 #include <set>
+#include <sstream>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "calendar.h"
+#include "character_id.h"
 #include "character.h"
 #include "crafting.h"
+#include "display.h"
+#include "game_constants.h"
 #include "inventory.h"
+#include "item.h"
+#include "itype.h"
 #include "localized_comparator.h"
+#include "output.h"
 #include "recipe.h"
 #include "requirements.h"
+#include "skill.h"
+#include "string_formatter.h"
+#include "translations.h"
 #include "type_id.h"
 
 bool cannot_gain_skill_or_prof( const Character &crafter, const recipe &recp )
@@ -199,4 +211,264 @@ bool recipe_sort_compare(
         return localized_compare( a_name, b_name );
     }
     return b->time_to_craft( crafter ) < a->time_to_craft( crafter );
+}
+
+static std::string craft_success_chance_string( const recipe &recp, const Character &guy )
+{
+    float chance = 100.f * ( 1.f - guy.recipe_success_chance( recp ) );
+    std::string color;
+    if( chance > 75 ) {
+        color = "yellow";
+    } else if( chance > 50 ) {
+        color = "light_gray";
+    } else if( chance > 25 ) {
+        color = "green";
+    } else {
+        color = "cyan";
+    }
+
+    return string_format( _( "Minor Failure Chance: <color_%s>%2.2f%%</color>" ), color, chance );
+}
+
+static std::string cata_fail_chance_string( const recipe &recp, const Character &guy )
+{
+    float chance = 100.f * guy.item_destruction_chance( recp );
+    std::string color;
+    if( chance > 50 ) {
+        color = "i_red";
+    } else if( chance > 20 ) {
+        color = "red";
+    } else if( chance > 5 ) {
+        color = "yellow";
+    } else {
+        color = "light_gray";
+    }
+
+    return string_format( _( "Catastrophic Failure Chance: <color_%s>%2.2f%%</color>" ), color,
+                          chance );
+}
+
+std::vector<std::string> recipe_info(
+    const recipe &recp,
+    const availability &avail,
+    Character &guy,
+    std::string_view qry_comps,
+    const int batch_size,
+    const int fold_width,
+    const nc_color &color,
+    const std::vector<Character *> &crafting_group )
+{
+    std::ostringstream oss;
+    oss << string_format( _( "Crafter: %s\n" ), guy.name_and_maybe_activity() );
+
+    oss << string_format( _( "Primary skill: %s\n" ), recp.primary_skill_string( guy ) );
+    if( !avail.crafter_has_primary_skill ) {
+        if( recp.is_practice() ) {
+            oss << _( "<color_red>Crafter cannot practice this because they "
+                      "lack the theoretical knowledge for it.</color>\n" );
+        } else {
+            oss << _( "<color_red>Crafter cannot craft this because they "
+                      "lack the theoretical knowledge to understand the recipe.</color>\n" );
+        }
+    }
+
+    if( !recp.required_skills.empty() ) {
+        oss << string_format( _( "Other skills: %s\n" ), recp.required_skills_string( guy ) );
+    }
+
+    const std::string req_profs = recp.required_proficiencies_string( &guy );
+    if( !req_profs.empty() ) {
+        oss << string_format( _( "Proficiencies Required: %s\n" ), req_profs );
+    }
+    const std::string used_profs = recp.used_proficiencies_string( &guy );
+    if( !used_profs.empty() ) {
+        oss << string_format( _( "Proficiencies Used: %s\n" ), used_profs );
+    }
+    const std::string missing_profs = recp.missing_proficiencies_string( &guy );
+    if( !missing_profs.empty() ) {
+        oss << string_format( _( "Proficiencies Missing: %s\n" ), missing_profs );
+    }
+
+    oss << craft_success_chance_string( recp, guy ) << "\n";
+    oss << cata_fail_chance_string( recp, guy ) << "\n";
+
+    if( !recp.is_nested() ) {
+        const int expected_turns = guy.expected_time_to_craft( recp, batch_size )
+                                   / to_moves<int>( 1_turns );
+        oss << string_format( _( "Time to complete: <color_cyan>%s</color>\n" ),
+                              to_string( time_duration::from_turns( expected_turns ) ) );
+
+    }
+
+    const std::string batch_savings = recp.batch_savings_string();
+    if( !batch_savings.empty() ) {
+        oss << string_format( _( "Batch time savings: <color_cyan>%s</color>\n" ), batch_savings );
+    }
+
+    oss << string_format( _( "Activity level: <color_cyan>%s</color>\n" ),
+                          display::activity_level_str( recp.exertion_level() ) );
+
+    const int makes = recp.makes_amount();
+    if( makes > 1 ) {
+        oss << string_format( _( "Recipe makes: <color_cyan>%d</color>\n" ), makes );
+    }
+
+    oss << string_format( _( "Craftable in the dark?  <color_cyan>%s</color>\n" ),
+                          recp.has_flag( "BLIND_EASY" ) ? _( "Easy" ) :
+                          recp.has_flag( "BLIND_HARD" ) ? _( "Hard" ) :
+                          _( "Impossible" ) );
+
+    const inventory &crafting_inv = avail.inv_override ? *avail.inv_override : guy.crafting_inventory();
+    if( recp.result() ) {
+        const int nearby_amount = crafting_inv.count_item( recp.result() );
+        std::string nearby_string;
+        if( nearby_amount == 0 ) {
+            nearby_string = "<color_light_gray>0</color>";
+        } else if( nearby_amount > 9000 ) {
+            // at some point you get too many to count at a glance and just know you have a lot
+            nearby_string = _( "<color_red>It's Over 9000!!!</color>" );
+        } else {
+            nearby_string = string_format( "<color_yellow>%d</color>", nearby_amount );
+        }
+        oss << string_format( _( "Nearby: %s\n" ), nearby_string );
+    }
+
+    const bool can_craft_this = avail.can_craft;
+    if( can_craft_this && avail.would_use_rotten ) {
+        oss << _( "<color_red>Will use rotten ingredients</color>\n" );
+    }
+    if( can_craft_this && avail.would_use_favorite ) {
+        oss << _( "<color_red>Will use favorited ingredients</color>\n" );
+    }
+    const bool too_complex = recp.deduped_requirements().is_too_complex();
+    if( can_craft_this && too_complex ) {
+        oss << _( "Due to the complex overlapping requirements, this "
+                  "recipe <color_yellow>may appear to be craftable "
+                  "when it is not</color>.\n" );
+    }
+    std::string reason;
+    bool npc_cant = avail.crafter.is_npc() && !recp.npc_can_craft( reason ) && !avail.inv_override ;
+    if( !can_craft_this && avail.apparently_craftable && !recp.is_nested() && !npc_cant ) {
+        oss << _( "<color_red>Cannot be crafted because the same item is needed "
+                  "for multiple components.</color>\n" );
+    }
+
+    if( !can_craft_this && npc_cant ) {
+        oss << colorize( reason, c_red ) << "\n";
+    }
+
+    const bool disp_prof_msg = avail.has_proficiencies && !recp.is_nested();
+    const float time_maluses = avail.get_proficiency_time_maluses();
+    const float max_time_malus = avail.get_max_proficiency_time_maluses();
+    const float skill_maluses = avail.get_proficiency_skill_maluses();
+    const float max_skill_malus = avail.get_max_proficiency_skill_maluses();
+    if( disp_prof_msg && time_maluses < max_time_malus && skill_maluses < max_skill_malus ) {
+        oss << string_format( _( "<color_green>This recipe will be %.2fx faster than normal, "
+                                 "and your effective skill will be %.2f levels higher than normal, because of "
+                                 "the proficiencies the crafter has.</color>\n" ),
+                              max_time_malus / time_maluses, max_skill_malus - skill_maluses );
+    } else if( disp_prof_msg && time_maluses < max_time_malus ) {
+        oss << string_format( _( "<color_green>This recipe will be %.2fx faster than normal, "
+                                 "because of the proficiencies the crafter has.</color>\n" ), max_time_malus / time_maluses );
+    } else if( disp_prof_msg && skill_maluses < max_skill_malus ) {
+        oss << string_format(
+                _( "<color_green>Your effective skill will be %.2f levels higher than normal, "
+                   "because of the proficiencies the crafter has.</color>\n" ), max_skill_malus - skill_maluses );
+    }
+    if( !can_craft_this && !avail.has_proficiencies ) {
+        oss << _( "<color_red>Cannot be crafted because the crafter lacks"
+                  " the required proficiencies.</color>\n" );
+    }
+
+    if( recp.has_byproducts() ) {
+        oss << _( "Byproducts:\n" );
+        for( const std::pair<const itype_id, int> &bp : recp.get_byproducts() ) {
+            const itype *t = item::find_type( bp.first );
+            int amount = bp.second * batch_size;
+            if( t->count_by_charges() ) {
+                oss << string_format( "> %s (%d)\n", t->nname( 1 ), amount );
+            } else {
+                oss << string_format( "> %d %s\n", amount,
+                                      t->nname( static_cast<unsigned int>( amount ) ) );
+            }
+        }
+    }
+
+    std::vector<std::string> result = foldstring( oss.str(), fold_width );
+
+    if( !recp.is_nested() ) {
+        const requirement_data &req = recp.simple_requirements();
+        const std::vector<std::string> tools = req.get_folded_tools_list(
+                fold_width, color, crafting_inv, batch_size );
+        const std::vector<std::string> comps = req.get_folded_components_list(
+                fold_width, color, crafting_inv, recp.get_component_filter(), batch_size, qry_comps );
+        result.insert( result.end(), tools.begin(), tools.end() );
+        result.insert( result.end(), comps.begin(), comps.end() );
+    }
+
+    oss = std::ostringstream();
+    if( !guy.knows_recipe( &recp ) ) {
+        oss << _( "Recipe not memorized yet\n" );
+        const std::set<itype_id> books_with_recipe = guy.get_books_for_recipe( crafting_inv, &recp );
+        if( !books_with_recipe.empty() ) {
+            const std::string enumerated_books = enumerate_as_string( books_with_recipe,
+            []( const itype_id & type_id ) {
+                return colorize( item::nname( type_id ), c_cyan );
+            } );
+            oss << string_format( _( "Written in: %s\n" ), enumerated_books );
+        }
+        std::vector<const Character *> knowing_helpers;
+        for( const Character *helper : crafting_group ) {
+            // guy.getID() != helper->getID(): guy doesn't know the recipe anyway, but this should be faster
+            if( guy.getID() != helper->getID() && helper->knows_recipe( &recp ) ) {
+                knowing_helpers.push_back( helper );
+            }
+        }
+        if( !knowing_helpers.empty() ) {
+            const std::string enumerated_helpers = enumerate_as_string( knowing_helpers,
+            []( const Character * helper ) {
+                return colorize( helper->is_avatar() ? _( "You" ) : helper->get_name(), c_cyan );
+            } );
+            oss << string_format( _( "Known by: %s\n" ), enumerated_helpers );
+        }
+    }
+    std::vector<std::string> tmp = foldstring( oss.str(), fold_width );
+    result.insert( result.end(), tmp.begin(), tmp.end() );
+
+    return result;
+}
+
+std::string practice_recipe_description( const recipe &recp,
+        const Character &crafter )
+{
+    std::ostringstream oss;
+    oss << recp.get_description( crafter ) << "\n\n";
+    if( !recp.practice_data ) {
+        return oss.str();
+    }
+    if( recp.practice_data->min_difficulty != recp.practice_data->max_difficulty ) {
+        std::string txt = string_format( _( "Difficulty range: %d to %d" ),
+                                         recp.practice_data->min_difficulty, recp.practice_data->max_difficulty );
+        oss << txt << "\n";
+    }
+    if( recp.skill_used ) {
+        const int player_skill_level = crafter.get_all_skills().get_skill_level( recp.skill_used );
+        if( player_skill_level < recp.practice_data->min_difficulty ) {
+            std::string txt = string_format(
+                                  _( "The crafter does not possess the minimum <color_cyan>%s</color> skill level required to practice this." ),
+                                  recp.skill_used->name() );
+            txt = string_format( "<color_red>%s</color>", txt );
+            oss << txt << "\n";
+        }
+        if( recp.practice_data->skill_limit != MAX_SKILL ) {
+            std::string txt = string_format(
+                                  _( "This practice action will not increase your <color_cyan>%s</color> skill above %d." ),
+                                  recp.skill_used->name(), recp.practice_data->skill_limit );
+            if( player_skill_level >= recp.practice_data->skill_limit ) {
+                txt = string_format( "<color_brown>%s</color>", txt );
+            }
+            oss << txt << "\n";
+        }
+    }
+    return oss.str();
 }

--- a/src/crafting_gui_helpers.h
+++ b/src/crafting_gui_helpers.h
@@ -2,6 +2,10 @@
 #ifndef CATA_SRC_CRAFTING_GUI_HELPERS_H
 #define CATA_SRC_CRAFTING_GUI_HELPERS_H
 
+#include <string>
+#include <string_view>
+#include <vector>
+
 #include "color.h"
 
 class Character;
@@ -76,5 +80,18 @@ bool recipe_sort_compare(
     const Character &crafter,
     bool a_read, bool b_read,
     bool unread_first );
+
+// Builds the recipe info text for the crafting menu info panel.
+// Returns pre-folded lines at the given fold_width.
+std::vector<std::string> recipe_info(
+    const recipe &recp, const availability &avail,
+    Character &guy, std::string_view qry_comps,
+    int batch_size, int fold_width, const nc_color &color,
+    const std::vector<Character *> &crafting_group );
+
+// Builds the description text for practice recipes.
+// Safe to call on non-practice recipes (returns just the base description).
+std::string practice_recipe_description( const recipe &recp,
+        const Character &crafter );
 
 #endif // CATA_SRC_CRAFTING_GUI_HELPERS_H

--- a/tests/crafting_gui_test.cpp
+++ b/tests/crafting_gui_test.cpp
@@ -1,5 +1,7 @@
 #include <functional>
 #include <memory>
+#include <string>
+#include <vector>
 
 #include "avatar.h"
 #include "calendar.h"
@@ -8,20 +10,21 @@
 #include "character_attire.h"
 #include "color.h"
 #include "crafting_gui_helpers.h"
+#include "npc.h"
 #include "game.h"
 #include "item.h"
 #include "map.h"
 #include "map_helpers.h"
 #include "options_helpers.h"
 #include "player_helpers.h"
+#include "recipe.h"
 #include "type_id.h"
 #include "weather_type.h"
-
-class recipe;
 
 static const itype_id itype_2x4( "2x4" );
 static const itype_id itype_billet_wood( "billet_wood" );
 static const itype_id itype_debug_backpack( "debug_backpack" );
+static const itype_id itype_family_cookbook( "family_cookbook" );
 static const itype_id itype_fat( "fat" );
 static const itype_id itype_hammer( "hammer" );
 static const itype_id itype_knife_hunting( "knife_hunting" );
@@ -445,4 +448,303 @@ TEST_CASE( "recipe_sort_unread_disabled", "[crafting][gui]" )
     // unread_first=false: read state ignored, craftability dominates
     CHECK( recipe_sort_compare( &rec, &rec, avail_yes, avail_no, guy,
                                 true, false, false ) );
+}
+
+// Helper: join vector of strings for substring searching
+static std::string join_lines( const std::vector<std::string> &lines )
+{
+    std::string result;
+    for( const std::string &l : lines ) {
+        result += l + "\n";
+    }
+    return result;
+}
+
+// Wide fold width to avoid wrapping artifacts in tests
+static const int test_fold_width = 500;
+
+TEST_CASE( "recipe_info_basic_content", "[crafting][gui]" )
+{
+    Character &guy = setup_character();
+    guy.set_skill_level( skill_cooking, 3 );
+    guy.i_add( item( itype_fat ) );
+    guy.i_add( item( itype_fat ) );
+    guy.i_add( item( itype_knife_hunting ) );
+    guy.invalidate_crafting_inventory();
+
+    const recipe &rec = recipe_test_tallow.obj();
+    availability avail( guy, &rec );
+    REQUIRE( avail.can_craft );
+    REQUIRE( avail.has_all_skills );
+
+    std::vector<Character *> group = { &guy };
+    std::string output = join_lines(
+                             recipe_info( rec, avail, guy, "", 1, test_fold_width, c_white, group ) );
+
+    CHECK( output.find( "Primary skill:" ) != std::string::npos );
+    CHECK( output.find( "Time to complete:" ) != std::string::npos );
+    CHECK( output.find( "Activity level:" ) != std::string::npos );
+    CHECK( output.find( "Craftable in the dark?" ) != std::string::npos );
+    CHECK( output.find( "Minor Failure Chance:" ) != std::string::npos );
+    CHECK( output.find( "Catastrophic Failure Chance:" ) != std::string::npos );
+}
+
+TEST_CASE( "recipe_info_byproducts", "[crafting][gui]" )
+{
+    Character &guy = setup_character();
+    guy.set_skill_level( skill_cooking, 3 );
+    guy.i_add( item( itype_fat ) );
+    guy.i_add( item( itype_fat ) );
+    guy.i_add( item( itype_knife_hunting ) );
+    guy.invalidate_crafting_inventory();
+
+    const recipe &rec = recipe_test_tallow.obj();
+    REQUIRE( rec.has_byproducts() );
+    availability avail( guy, &rec );
+
+    std::vector<Character *> group = { &guy };
+    std::string output = join_lines(
+                             recipe_info( rec, avail, guy, "", 1, test_fold_width, c_white, group ) );
+
+    CHECK( output.find( "Byproducts:" ) != std::string::npos );
+    CHECK( output.find( "cracklins" ) != std::string::npos );
+    CHECK( output.find( "test chewing gum" ) != std::string::npos );
+}
+
+TEST_CASE( "recipe_info_recipe_makes", "[crafting][gui]" )
+{
+    Character &guy = setup_character();
+    guy.set_skill_level( skill_cooking, 3 );
+    guy.i_add( item( itype_fat ) );
+    guy.i_add( item( itype_fat ) );
+    guy.i_add( item( itype_knife_hunting ) );
+    guy.invalidate_crafting_inventory();
+
+    const recipe &rec = recipe_test_tallow.obj();
+    REQUIRE( rec.makes_amount() > 1 );
+    availability avail( guy, &rec );
+
+    std::vector<Character *> group = { &guy };
+    std::string output = join_lines(
+                             recipe_info( rec, avail, guy, "", 1, test_fold_width, c_white, group ) );
+
+    CHECK( output.find( "Recipe makes:" ) != std::string::npos );
+}
+
+TEST_CASE( "recipe_info_missing_primary_skill", "[crafting][gui]" )
+{
+    Character &guy = setup_character();
+    guy.set_skill_level( skill_fabrication, 0 );
+    guy.set_skill_level( skill_melee, 0 );
+    guy.i_add( item( itype_2x4 ) );
+    guy.invalidate_crafting_inventory();
+
+    const recipe &rec = recipe_cudgel_test_no_tools.obj();
+    availability avail( guy, &rec );
+    REQUIRE_FALSE( avail.crafter_has_primary_skill );
+
+    std::vector<Character *> group = { &guy };
+    std::string output = join_lines(
+                             recipe_info( rec, avail, guy, "", 1, test_fold_width, c_white, group ) );
+
+    CHECK( output.find( "lack the theoretical knowledge" ) != std::string::npos );
+}
+
+TEST_CASE( "recipe_info_would_use_rotten", "[crafting][gui]" )
+{
+    Character &guy = setup_character();
+    guy.set_skill_level( skill_cooking, 3 );
+    item rotten_fat1( itype_fat );
+    rotten_fat1.set_rot( 1000_hours );
+    guy.i_add( rotten_fat1 );
+    item rotten_fat2( itype_fat );
+    rotten_fat2.set_rot( 1000_hours );
+    guy.i_add( rotten_fat2 );
+    guy.i_add( item( itype_knife_hunting ) );
+    guy.invalidate_crafting_inventory();
+
+    const recipe &rec = recipe_test_tallow.obj();
+    availability avail( guy, &rec );
+    REQUIRE( avail.can_craft );
+    REQUIRE( avail.would_use_rotten );
+
+    std::vector<Character *> group = { &guy };
+    std::string output = join_lines(
+                             recipe_info( rec, avail, guy, "", 1, test_fold_width, c_white, group ) );
+
+    CHECK( output.find( "Will use rotten ingredients" ) != std::string::npos );
+}
+
+TEST_CASE( "recipe_info_would_use_favorite", "[crafting][gui]" )
+{
+    Character &guy = setup_character();
+    guy.set_skill_level( skill_fabrication, 2 );
+    guy.set_skill_level( skill_melee, 1 );
+    item fav_2x4( itype_2x4 );
+    fav_2x4.set_favorite( true );
+    guy.i_add( fav_2x4 );
+    guy.invalidate_crafting_inventory();
+
+    const recipe &rec = recipe_cudgel_test_no_tools.obj();
+    availability avail( guy, &rec );
+    REQUIRE( avail.can_craft );
+    REQUIRE( avail.would_use_favorite );
+
+    std::vector<Character *> group = { &guy };
+    std::string output = join_lines(
+                             recipe_info( rec, avail, guy, "", 1, test_fold_width, c_white, group ) );
+
+    CHECK( output.find( "Will use favorited ingredients" ) != std::string::npos );
+}
+
+TEST_CASE( "recipe_info_proficiency_bonus", "[crafting][gui]" )
+{
+    Character &guy = setup_character();
+    guy.set_skill_level( skill_fabrication, 2 );
+    guy.add_proficiency( proficiency_prof_carving );
+    guy.i_add( item( itype_2x4 ) );
+    guy.invalidate_crafting_inventory();
+
+    const recipe &rec = recipe_cudgel_simple.obj();
+    availability avail( guy, &rec );
+    REQUIRE( avail.get_proficiency_time_maluses() < avail.get_max_proficiency_time_maluses() );
+
+    std::vector<Character *> group = { &guy };
+    std::string output = join_lines(
+                             recipe_info( rec, avail, guy, "", 1, test_fold_width, c_white, group ) );
+
+    CHECK( output.find( "faster than normal" ) != std::string::npos );
+}
+
+TEST_CASE( "recipe_info_not_memorized", "[crafting][gui]" )
+{
+    Character &guy = setup_character();
+    guy.set_skill_level( skill_cooking, 3 );
+    guy.i_add( item( itype_fat ) );
+    guy.i_add( item( itype_fat ) );
+    guy.i_add( item( itype_knife_hunting ) );
+    guy.invalidate_crafting_inventory();
+
+    const recipe &rec = recipe_test_tallow.obj();
+    REQUIRE_FALSE( guy.knows_recipe( &rec ) );
+    availability avail( guy, &rec );
+
+    std::vector<Character *> group = { &guy };
+    std::string output = join_lines(
+                             recipe_info( rec, avail, guy, "", 1, test_fold_width, c_white, group ) );
+
+    CHECK( output.find( "Recipe not memorized yet" ) != std::string::npos );
+}
+
+TEST_CASE( "recipe_info_nested_skips_time", "[crafting][gui]" )
+{
+    Character &guy = setup_character();
+    guy.set_skill_level( skill_fabrication, 2 );
+    guy.set_skill_level( skill_melee, 1 );
+    guy.i_add( item( itype_2x4 ) );
+    guy.invalidate_crafting_inventory();
+
+    const recipe &rec = recipe_test_nested_weapons.obj();
+    REQUIRE( rec.is_nested() );
+    availability avail( guy, &rec );
+
+    std::vector<Character *> group = { &guy };
+    std::string output = join_lines(
+                             recipe_info( rec, avail, guy, "", 1, test_fold_width, c_white, group ) );
+
+    CHECK( output.find( "Time to complete:" ) == std::string::npos );
+}
+
+TEST_CASE( "practice_recipe_description_above_limit", "[crafting][gui]" )
+{
+    Character &guy = setup_character();
+    guy.set_skill_level( skill_survival, 3 ); // above skill_limit 2
+
+    const recipe &rec = recipe_prac_knapping.obj();
+    REQUIRE( rec.practice_data );
+
+    std::string output = practice_recipe_description( rec, guy );
+
+    CHECK( output.find( "will not increase" ) != std::string::npos );
+    CHECK( output.find( "<color_brown>" ) != std::string::npos );
+}
+
+TEST_CASE( "practice_recipe_description_below_limit", "[crafting][gui]" )
+{
+    Character &guy = setup_character();
+    guy.set_skill_level( skill_survival, 1 ); // below skill_limit 2
+
+    const recipe &rec = recipe_prac_knapping.obj();
+    REQUIRE( rec.practice_data );
+
+    std::string output = practice_recipe_description( rec, guy );
+
+    CHECK( output.find( "Practice basic knapping" ) != std::string::npos );
+    CHECK( output.find( "Difficulty range:" ) != std::string::npos );
+    CHECK( output.find( "will not increase" ) != std::string::npos );
+    CHECK( output.find( "<color_brown>" ) == std::string::npos );
+}
+
+TEST_CASE( "recipe_info_known_by_helper", "[crafting][gui]" )
+{
+    Character &guy = setup_character();
+    guy.set_skill_level( skill_cooking, 3 );
+    guy.i_add( item( itype_fat ) );
+    guy.i_add( item( itype_fat ) );
+    guy.i_add( item( itype_knife_hunting ) );
+    guy.invalidate_crafting_inventory();
+
+    const recipe &rec = recipe_test_tallow.obj();
+    REQUIRE_FALSE( guy.knows_recipe( &rec ) );
+
+    // Create an NPC helper who knows the recipe
+    standard_npc helper( "TestHelper" );
+    helper.learn_recipe( &rec );
+    REQUIRE( helper.knows_recipe( &rec ) );
+
+    availability avail( guy, &rec );
+    std::vector<Character *> group = { &guy, &helper };
+    std::string output = join_lines(
+                             recipe_info( rec, avail, guy, "", 1, test_fold_width, c_white, group ) );
+
+    CHECK( output.find( "Recipe not memorized yet" ) != std::string::npos );
+    CHECK( output.find( "Known by:" ) != std::string::npos );
+    CHECK( output.find( "TestHelper" ) != std::string::npos );
+}
+
+TEST_CASE( "recipe_info_written_in_book", "[crafting][gui]" )
+{
+    Character &guy = setup_character();
+    guy.set_skill_level( skill_cooking, 3 );
+    guy.i_add( item( itype_fat ) );
+    guy.i_add( item( itype_fat ) );
+    guy.i_add( item( itype_knife_hunting ) );
+    item cookbook( itype_family_cookbook );
+    guy.identify( cookbook );
+    guy.i_add( cookbook );
+    guy.invalidate_crafting_inventory();
+
+    const recipe &rec = recipe_test_tallow.obj();
+    REQUIRE_FALSE( guy.knows_recipe( &rec ) );
+
+    availability avail( guy, &rec );
+    std::vector<Character *> group = { &guy };
+    std::string output = join_lines(
+                             recipe_info( rec, avail, guy, "", 1, test_fold_width, c_white, group ) );
+
+    CHECK( output.find( "Recipe not memorized yet" ) != std::string::npos );
+    CHECK( output.find( "Written in:" ) != std::string::npos );
+}
+
+TEST_CASE( "practice_recipe_description_non_practice_recipe", "[crafting][gui]" )
+{
+    Character &guy = setup_character();
+    guy.set_skill_level( skill_cooking, 3 );
+
+    const recipe &rec = recipe_test_tallow.obj();
+    REQUIRE_FALSE( rec.practice_data );
+
+    // Should not crash -- returns just the base description
+    std::string output = practice_recipe_description( rec, guy );
+    CHECK_FALSE( output.empty() );
 }


### PR DESCRIPTION
#### Summary
Infrastructure "Extract recipe info text builders to shared helpers"

#### Purpose of change
Follow-up to #85959. Continues pulling testable logic out of the monolithic `crafting_gui.cpp` so both the curses UI and a future ImGui crafting menu can share the same text generation code.

#### Describe the solution
Move `recipe_info()` and `practice_recipe_description()` from `crafting_gui.cpp` into `crafting_gui_helpers.cpp/.h`. The two internal helpers (`craft_success_chance_string`, `cata_fail_chance_string`) go along as file-local statics since they have no other callers. `flag_BLIND_EASY` / `flag_BLIND_HARD` are inlined as string literals since they were only used by the moved code.

The caching wrapper (`cached_recipe_info`) stays in `crafting_gui.cpp` -- it's tied to the UI rendering loop and language version tracking.

`practice_recipe_description()` now guards against null `practice_data`, which was safe when the function was file-local but not as exported API.

#### Describe alternatives you've considered
Could have left these as static functions until the ImGui conversion actually starts, but having them testable now catches regressions from upstream recipe changes and establishes the extraction pattern for the remaining pieces.

#### Testing
34 test cases, 90 assertions pass under `[crafting][gui]`. Full `[crafting]` suite shows no regressions.

New tests cover: basic recipe info content, byproducts display, recipe-makes count, missing primary skill warning, rotten/favorite ingredient warnings, proficiency speed bonus text, "Recipe not memorized" path, "Written in:" book source path, "Known by:" NPC helper path, nested recipe skipping time display, practice recipe description above/below skill limit, and the null practice_data guard.

#### Additional context
Depends on #85959 (must merge first).