### PR TITLE
Empty out cabins in the Cabins Reverberation

### DIFF
--- a/data/json/mapgen/reverberations/cabins.json
+++ b/data/json/mapgen/reverberations/cabins.json
@@ -30,7 +30,7 @@
         "              ~         ",
         "              ~         "
       ],
-      "palettes": [ "cabin_palette" ],
+      "palettes": [ "cabin_palette_reverberation" ],
       "place_nested": [
         {
           "chunks": [

--- a/data/json/mapgen_palettes/cabin.json
+++ b/data/json/mapgen_palettes/cabin.json
@@ -186,5 +186,56 @@
       "t": { "param": "floor_types", "fallback": "t_dirtfloor" }
     },
     "furniture": { "R": "f_rack_wood", "t": "f_table", "c": "f_chair" }
+  },
+  {
+    "type": "palette",
+    "id": "cabin_palette_reverberation",
+    "palettes": [ "cabin_palette_common" ],
+    "terrain": {
+      ".": [ [ "t_region_groundcover", 4 ], "t_region_groundcover_forest" ],
+      "~": [ [ "t_region_groundcover_barren", 3 ], "t_region_groundcover" ],
+      "*": [ [ "t_region_groundcover", 15 ], "t_region_shrub" ],
+      "-": "t_fence",
+      "w": "t_window_domestic",
+      "W": [ [ "t_window_boarded", 2 ], "t_window" ],
+      "+": [ [ "t_door_c", 3 ], "t_door_locked" ],
+      "=": "t_door_c"
+    },
+    "furniture": {
+      "B": "f_bed",
+      "b": "f_bench",
+      "c": "f_chair",
+      "D": "f_dresser",
+      "d": "f_desk",
+      "l": "f_stool",
+      "t": "f_table",
+      "O": "f_sofa",
+      "Y": "f_rack_coat",
+      "y": [ "f_indoor_plant_y", "f_indoor_plant" ],
+      "&": "f_trashcan"
+    },
+    "items": {
+      "B": { "item": "bed", "chance": 60 },
+      "d": [ { "item": "SUS_office_desk", "chance": 40 } ],
+      "D": [ { "item": "SUS_dresser_mens", "chance": 50 }, { "item": "SUS_dresser_womens", "chance": 50 } ],
+      "h": { "item": "shower", "chance": 20 },
+      "L": [ { "item": "tools_earthworking", "chance": 30 }, { "item": "tools_home", "chance": 30 } ],
+      "S": { "item": "stash_wood", "chance": 60 },
+      "s": [
+        { "item": "SUS_bathroom_sink", "chance": 60 },
+        { "item": "SUS_hair_drawer", "chance": 30 },
+        { "item": "SUS_bathroom_cabinet", "chance": 60, "repeat": [ 1, 4 ] }
+      ],
+      "t": { "item": "dining", "chance": 30, "repeat": [ 1, 2 ] },
+      "V": { "item": "SUS_oven", "chance": 70 },
+      "Y": { "item": "coat_rack", "chance": 35, "repeat": [ 1, 4 ] },
+      "1": [ { "item": "SUS_dishes", "chance": 50 }, { "item": "SUS_silverware", "chance": 50 } ],
+      "2": { "item": "SUS_cookware", "chance": 100 },
+      "3": [ { "item": "SUS_utensils", "chance": 50 }, { "item": "SUS_knife_drawer", "chance": 50 } ],
+      "4": [ { "item": "SUS_junk_drawer", "chance": 50 } ],
+      "5": { "item": "SUS_kitchen_sink", "chance": 100 },
+      "T": { "item": "SUS_toilet", "chance": 50 }
+    },
+    "toilets": { "T": {  } }
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Balance "remove food and water from the Cabin Reverberation's cabins. Make the item spawn rate slimmer in general"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
having fridges be filled with food, the water tanks filled and the bookshelves have books in them. All that doesn't fit in my vision of the dimension.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Make a new palette that does all the above mentioned things, make the cabin reverberation map use it.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
works
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
