### PR TITLE
Add viewport lock option for zone sorting

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -12907,6 +12907,30 @@ void zone_sort_activity_actor::do_turn( player_activity &act, Character &you )
 {
     update_other_activity_items();
     zone_activity_actor::do_turn( act, you );
+
+    // True completion: activity nulled AND no auto-move destination pending.
+    // route_to_destination sets destination before nulling; true end does not.
+    if( act.is_null() && !you.has_destination() && viewport_was_active ) {
+        restore_viewport( you );
+    }
+}
+
+void zone_sort_activity_actor::canceled( player_activity &, Character &you )
+{
+    restore_viewport( you );
+}
+
+void zone_sort_activity_actor::restore_viewport( Character &you )
+{
+    if( !viewport_was_active || !you.is_avatar() ) {
+        return;
+    }
+    if( !test_mode ) {
+        g->set_zoom( viewport_saved_zoom );
+        g->mark_main_ui_adaptor_resize();
+    }
+    you.as_avatar()->zone_sort_viewport = {};
+    viewport_was_active = false;
 }
 
 void zone_sort_activity_actor::stage_init( player_activity &, Character &you )
@@ -12920,6 +12944,29 @@ void zone_sort_activity_actor::stage_init( player_activity &, Character &you )
                        you.get_faction_id() ) ) {
         coord_set.insert( p );
     }
+
+    if( you.is_avatar() && !coord_set.empty() ) {
+        viewport_was_active = true;
+        viewport_saved_zoom = g->get_zoom();
+
+        zone_sorting::viewport_bbox bbox = zone_sorting::calc_zone_bbox( coord_set );
+        int target = zone_sorting::calc_target_zoom(
+                         bbox.width(), bbox.height(),
+                         TERRAIN_WINDOW_WIDTH, TERRAIN_WINDOW_HEIGHT,
+                         viewport_saved_zoom, viewport_saved_zoom );
+
+        avatar::zone_sort_viewport_t &vp = you.as_avatar()->zone_sort_viewport;
+        vp.active = true;
+        vp.center = bbox.centroid;
+        vp.target_zoom = target;
+        vp.bbox_min = bbox.min_corner;
+        vp.bbox_max = bbox.max_corner;
+        if( !test_mode ) {
+            g->set_zoom( target );
+            g->mark_main_ui_adaptor_resize();
+        }
+    }
+
     stage = THINK;
 }
 
@@ -13495,6 +13542,28 @@ void zone_sort_activity_actor::stage_do( player_activity &act, Character &you )
             if( !drag_worst_tile ) {
                 drag_worst_tile = zone_sorting::worst_drag_tile_on_route( you, dropoff_coords );
             }
+            // Expand viewport bbox to include newly discovered destinations.
+            if( you.is_avatar() && you.as_avatar()->zone_sort_viewport.active ) {
+                avatar::zone_sort_viewport_t &vp = you.as_avatar()->zone_sort_viewport;
+                bool grew = false;
+                for( const tripoint_abs_ms &d : dropoff_coords ) {
+                    grew |= zone_sorting::expand_bbox_raw( vp.bbox_min, vp.bbox_max, d );
+                }
+                if( grew ) {
+                    const int bbox_w = vp.bbox_max.x() - vp.bbox_min.x();
+                    const int bbox_h = vp.bbox_max.y() - vp.bbox_min.y();
+                    vp.center.x() = ( vp.bbox_min.x() + vp.bbox_max.x() ) / 2;
+                    vp.center.y() = ( vp.bbox_min.y() + vp.bbox_max.y() ) / 2;
+                    vp.target_zoom = zone_sorting::calc_target_zoom(
+                                         bbox_w, bbox_h,
+                                         TERRAIN_WINDOW_WIDTH, TERRAIN_WINDOW_HEIGHT,
+                                         g->get_zoom(), viewport_saved_zoom );
+                    if( !test_mode ) {
+                        g->set_zoom( vp.target_zoom );
+                        g->mark_main_ui_adaptor_resize();
+                    }
+                }
+            }
         }
 
         item_location thisitem_loc;
@@ -13991,6 +14060,8 @@ void zone_sort_activity_actor::serialize( JsonOut &jsout ) const
     jsout.member( "dropoff_coords", dropoff_coords );
     jsout.member( "pickup_failure_reported", pickup_failure_reported );
     jsout.member( "virtual_pickup_active", virtual_pickup_active );
+    jsout.member( "viewport_was_active", viewport_was_active );
+    jsout.member( "viewport_saved_zoom", viewport_saved_zoom );
 
     jsout.end_object();
 }
@@ -14015,6 +14086,12 @@ std::unique_ptr<activity_actor> zone_sort_activity_actor::deserialize( JsonValue
     }
     if( data.has_member( "virtual_pickup_active" ) ) {
         data.read( "virtual_pickup_active", actor.virtual_pickup_active );
+    }
+    if( data.has_member( "viewport_was_active" ) ) {
+        data.read( "viewport_was_active", actor.viewport_was_active );
+    }
+    if( data.has_member( "viewport_saved_zoom" ) ) {
+        data.read( "viewport_saved_zoom", actor.viewport_saved_zoom );
     }
     return actor.clone();
 }

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -29,6 +29,7 @@
 #include "recipe.h"
 #include "string_id.h"
 #include "type_id.h"
+#include "uistate.h"
 #include "units.h"
 #include "units_fwd.h"
 #include "vehicle.h"
@@ -4083,6 +4084,7 @@ class zone_sort_activity_actor : public zone_activity_actor
         }
 
         void do_turn( player_activity &act, Character &you ) override;
+        void canceled( player_activity &act, Character &you ) override;
 
         void stage_init( player_activity &, Character &you ) override;
         bool stage_think( player_activity &act, Character &you ) override;
@@ -4092,6 +4094,20 @@ class zone_sort_activity_actor : public zone_activity_actor
         static std::unique_ptr<activity_actor> deserialize( JsonValue &jsin );
 
         void update_other_activity_items();
+
+        // Viewport lock: restore zoom and clear Character viewport state.
+        void restore_viewport( Character &you );
+
+        const std::unordered_set<tripoint_abs_ms> &get_coord_set() const {
+            return coord_set;
+        }
+        const std::vector<tripoint_abs_ms> &get_dropoff_coords() const {
+            return dropoff_coords;
+        }
+
+        // Viewport lock state -- serialized for save/load zoom restoration
+        bool viewport_was_active = false;
+        int viewport_saved_zoom = DEFAULT_TILESET_ZOOM;
 
     private:
         std::vector<item_location> other_activity_items;

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -2,6 +2,7 @@
 #include "activity_item_handling.h" // IWYU pragma: associated
 
 #include <algorithm>
+#include <array>
 #include <climits>
 #include <cmath>
 #include <deque>
@@ -1407,6 +1408,116 @@ std::optional<tripoint_bub_ms> worst_drag_tile_on_route(
         }
     }
     return worst_tile;
+}
+
+int viewport_bbox::width() const
+{
+    return max_corner.x() - min_corner.x();
+}
+
+int viewport_bbox::height() const
+{
+    return max_corner.y() - min_corner.y();
+}
+
+viewport_bbox calc_zone_bbox( const std::unordered_set<tripoint_abs_ms> &tiles )
+{
+    viewport_bbox bbox;
+    if( tiles.empty() ) {
+        return bbox;
+    }
+    auto it = tiles.begin();
+    bbox.min_corner = *it;
+    bbox.max_corner = *it;
+    ++it;
+    for( ; it != tiles.end(); ++it ) {
+        const tripoint_abs_ms &p = *it;
+        bbox.min_corner.x() = std::min( bbox.min_corner.x(), p.x() );
+        bbox.min_corner.y() = std::min( bbox.min_corner.y(), p.y() );
+        bbox.min_corner.z() = std::min( bbox.min_corner.z(), p.z() );
+        bbox.max_corner.x() = std::max( bbox.max_corner.x(), p.x() );
+        bbox.max_corner.y() = std::max( bbox.max_corner.y(), p.y() );
+        bbox.max_corner.z() = std::max( bbox.max_corner.z(), p.z() );
+    }
+    bbox.centroid.x() = ( bbox.min_corner.x() + bbox.max_corner.x() ) / 2;
+    bbox.centroid.y() = ( bbox.min_corner.y() + bbox.max_corner.y() ) / 2;
+    bbox.centroid.z() = ( bbox.min_corner.z() + bbox.max_corner.z() ) / 2;
+    return bbox;
+}
+
+bool expand_bbox( viewport_bbox &bbox, const tripoint_abs_ms &tile )
+{
+    bool grew = false;
+    if( tile.x() < bbox.min_corner.x() ) {
+        bbox.min_corner.x() = tile.x();
+        grew = true;
+    }
+    if( tile.y() < bbox.min_corner.y() ) {
+        bbox.min_corner.y() = tile.y();
+        grew = true;
+    }
+    if( tile.x() > bbox.max_corner.x() ) {
+        bbox.max_corner.x() = tile.x();
+        grew = true;
+    }
+    if( tile.y() > bbox.max_corner.y() ) {
+        bbox.max_corner.y() = tile.y();
+        grew = true;
+    }
+    if( grew ) {
+        bbox.centroid.x() = ( bbox.min_corner.x() + bbox.max_corner.x() ) / 2;
+        bbox.centroid.y() = ( bbox.min_corner.y() + bbox.max_corner.y() ) / 2;
+    }
+    return grew;
+}
+
+bool expand_bbox_raw( tripoint_abs_ms &bbox_min, tripoint_abs_ms &bbox_max,
+                      const tripoint_abs_ms &tile )
+{
+    bool grew = false;
+    if( tile.x() < bbox_min.x() ) {
+        bbox_min.x() = tile.x();
+        grew = true;
+    }
+    if( tile.y() < bbox_min.y() ) {
+        bbox_min.y() = tile.y();
+        grew = true;
+    }
+    if( tile.x() > bbox_max.x() ) {
+        bbox_max.x() = tile.x();
+        grew = true;
+    }
+    if( tile.y() > bbox_max.y() ) {
+        bbox_max.y() = tile.y();
+        grew = true;
+    }
+    return grew;
+}
+
+int calc_target_zoom( int bbox_w, int bbox_h,
+                      int visible_w, int visible_h, int current_zoom,
+                      int saved_zoom, int padding )
+{
+    const int padded_w = bbox_w + padding;
+    const int padded_h = bbox_h + padding;
+    const int screen_px_w = visible_w * current_zoom;
+    const int screen_px_h = visible_h * current_zoom;
+
+    // 64 = most detail / fewest tiles, 4 = least detail / most tiles
+    static const std::array<int, 5> zoom_levels = { 64, 32, 16, 8, 4 };
+    int best = 4;  // fallback: most zoomed out
+    for( const int z : zoom_levels ) {
+        if( z > saved_zoom ) {
+            continue;  // never zoom in beyond original
+        }
+        const int tiles_w = screen_px_w / z;
+        const int tiles_h = screen_px_h / z;
+        if( tiles_w >= padded_w && tiles_h >= padded_h ) {
+            best = z;
+            break;  // first (largest) that fits
+        }
+    }
+    return best;
 }
 } //namespace zone_sorting
 

--- a/src/activity_item_handling.h
+++ b/src/activity_item_handling.h
@@ -7,6 +7,7 @@
 #include "activity_handlers.h"
 #include "character.h"
 #include "coordinates.h"
+#include "point.h"
 #include "game.h"
 #include "item.h"
 #include "map.h"
@@ -128,6 +129,36 @@ int route_length( const Character &you, const tripoint_bub_ms &dest );
 // multi-tile vehicle, or trivial/unreachable route.
 std::optional<tripoint_bub_ms> worst_drag_tile_on_route(
     const Character &who, const std::vector<tripoint_abs_ms> &dropoff_coords );
+
+// Bounding box for viewport lock during zone sorting.
+struct viewport_bbox {
+    tripoint_abs_ms min_corner;
+    tripoint_abs_ms max_corner;
+    tripoint_abs_ms centroid;
+
+    int width() const;
+    int height() const;
+};
+
+// Compute bounding box around a set of tile coordinates.
+// Returns a default bbox at origin if tiles is empty.
+viewport_bbox calc_zone_bbox( const std::unordered_set<tripoint_abs_ms> &tiles );
+
+// Expand bbox to include a new tile. Returns true if bbox actually grew.
+// Updates centroid.
+bool expand_bbox( viewport_bbox &bbox, const tripoint_abs_ms &tile );
+
+// Expand raw min/max corners to include a new tile. Returns true if grew.
+// For use with inline bbox on Character (avoids circular include).
+bool expand_bbox_raw( tripoint_abs_ms &bbox_min, tripoint_abs_ms &bbox_max,
+                      const tripoint_abs_ms &tile );
+
+// Largest zoom from {4,8,16,32,64} where bbox (plus padding) fits on screen.
+// Capped at saved_zoom so we never zoom in beyond the player's original level.
+// visible_w/h are TERRAIN_WINDOW dimensions measured at current_zoom.
+int calc_target_zoom( int bbox_w, int bbox_h,
+                      int visible_w, int visible_h, int current_zoom,
+                      int saved_zoom, int padding = 4 );
 } //namespace zone_sorting
 
 

--- a/src/avatar.h
+++ b/src/avatar.h
@@ -92,6 +92,17 @@ class avatar : public Character
         // NOLINTNEXTLINE(performance-noexcept-move-constructor)
         avatar &operator=( avatar && );
 
+        // Zone sort viewport lock state -- ephemeral, not serialized.
+        // Visual lock only; zoom restoration is on the activity actor.
+        struct zone_sort_viewport_t {
+            bool active = false;
+            tripoint_abs_ms center;
+            int target_zoom = 0;
+            tripoint_abs_ms bbox_min;
+            tripoint_abs_ms bbox_max;
+        };
+        zone_sort_viewport_t zone_sort_viewport; // NOLINT(cata-serialize)
+
         void store( JsonOut &json ) const;
         void load( const JsonObject &data );
         void export_as_npc( const cata_path &path );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -17,6 +17,7 @@
 #include "activity_actor.h"
 #include "activity_actor_definitions.h"
 #include "addiction.h"
+#include "clone_ptr.h"
 #include "anatomy.h"
 #include "avatar.h"
 #include "avatar_action.h"
@@ -116,6 +117,7 @@ static const activity_id ACT_HAND_CRANK( "ACT_HAND_CRANK" );
 static const activity_id ACT_HEATING( "ACT_HEATING" );
 static const activity_id ACT_MEDITATE( "ACT_MEDITATE" );
 static const activity_id ACT_MOVE_ITEMS( "ACT_MOVE_ITEMS" );
+static const activity_id ACT_MOVE_LOOT( "ACT_MOVE_LOOT" );
 static const activity_id ACT_OPERATION( "ACT_OPERATION" );
 static const activity_id ACT_READ( "ACT_READ" );
 static const activity_id ACT_SOCIALIZE( "ACT_SOCIALIZE" );
@@ -1515,6 +1517,11 @@ void Character::clear_destination_activity()
 }
 
 player_activity Character::get_destination_activity() const
+{
+    return destination_activity;
+}
+
+const player_activity &Character::peek_destination_activity() const
 {
     return destination_activity;
 }
@@ -7110,6 +7117,25 @@ void Character::clear_destination()
 
 void Character::abort_automove()
 {
+    // Restore zone sort viewport lock state before clearing destination.
+    // The actor in destination_activity has the authoritative saved_zoom.
+    const bool had_visual_lock = is_avatar() && as_avatar()->zone_sort_viewport.active;
+    const player_activity &dest = peek_destination_activity();
+    if( !dest.is_null() && dest.id() == ACT_MOVE_LOOT ) {
+        if( const auto *a = dynamic_cast<const zone_sort_activity_actor *>(
+                                dest.actor.get() ) ) {
+            if( a->viewport_was_active || had_visual_lock ) {
+                if( !test_mode ) {
+                    g->set_zoom( a->viewport_saved_zoom );
+                    g->mark_main_ui_adaptor_resize();
+                }
+            }
+        }
+    }
+    if( had_visual_lock ) {
+        as_avatar()->zone_sort_viewport = {};
+    }
+
     clear_destination();
     if( g->overmap_data.fast_traveling && is_avatar() ) {
         ui::omap::force_quit();

--- a/src/character.h
+++ b/src/character.h
@@ -3405,6 +3405,7 @@ class Character : public Creature, public visitable
         std::string visible_mutations( int visibility_cap ) const;
 
         player_activity get_destination_activity() const;
+        const player_activity &peek_destination_activity() const;
         void set_destination_activity( const player_activity &new_destination_activity );
         void clear_destination_activity();
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -41,6 +41,7 @@
 #include "action.h"
 #include "activity_actor_definitions.h"
 #include "activity_handlers.h"
+#include "activity_item_handling.h"
 #include "activity_type.h"
 #include "ascii_art.h"
 #include "auto_note.h"
@@ -232,6 +233,7 @@
 #define UNUSED
 #endif
 
+static const activity_id ACT_MOVE_LOOT( "ACT_MOVE_LOOT" );
 static const activity_id ACT_TRAVELLING( "ACT_TRAVELLING" );
 
 static const bionic_id bio_jointservo( "bio_jointservo" );
@@ -3307,6 +3309,15 @@ void game::draw( ui_adaptor &ui )
         return;
     }
 
+    try_activate_zone_sort_viewport();
+
+    // Transient view_offset override for zone sort viewport lock.
+    // Restored after rendering so save never sees the locked value.
+    const tripoint_rel_ms real_offset = u.view_offset;
+    if( u.zone_sort_viewport.active ) {
+        u.view_offset = here.get_bub( u.zone_sort_viewport.center ) - u.pos_bub( here );
+    }
+
     ter_view_p.z() = ( u.pos_bub() + u.view_offset ).z();
     here.build_map_cache( ter_view_p.z() );
     here.update_visibility_cache( ter_view_p.z() );
@@ -3337,6 +3348,8 @@ void game::draw( ui_adaptor &ui )
     // much easier to play with them
     // (e.g. for blind players)
     ui.set_cursor( w_terrain, -u.view_offset.xy().raw() + point( POSX, POSY ) );
+
+    u.view_offset = real_offset;
 }
 
 void game::draw_panels( bool force_draw )
@@ -6405,6 +6418,56 @@ int game::get_zoom() const
 #else
     return DEFAULT_TILESET_ZOOM;
 #endif
+}
+
+void game::try_activate_zone_sort_viewport()
+{
+    if( u.zone_sort_viewport.active ) {
+        return;  // already active
+    }
+    if( !u.is_avatar() ) {
+        return;
+    }
+
+    const zone_sort_activity_actor *actor = nullptr;
+
+    if( u.activity && u.activity.id() == ACT_MOVE_LOOT ) {
+        actor = dynamic_cast<const zone_sort_activity_actor *>( u.activity.actor.get() );
+    }
+    if( !actor ) {
+        const player_activity &dest = u.peek_destination_activity();
+        if( !dest.is_null() && dest.id() == ACT_MOVE_LOOT ) {
+            actor = dynamic_cast<const zone_sort_activity_actor *>( dest.actor.get() );
+        }
+    }
+
+    if( !actor || !actor->viewport_was_active ) {
+        return;
+    }
+
+    std::unordered_set<tripoint_abs_ms> all_tiles = actor->get_coord_set();
+    for( const tripoint_abs_ms &d : actor->get_dropoff_coords() ) {
+        all_tiles.insert( d );
+    }
+    if( all_tiles.empty() ) {
+        return;
+    }
+
+    zone_sorting::viewport_bbox bbox = zone_sorting::calc_zone_bbox( all_tiles );
+    int target = zone_sorting::calc_target_zoom(
+                     bbox.width(), bbox.height(),
+                     TERRAIN_WINDOW_WIDTH, TERRAIN_WINDOW_HEIGHT,
+                     get_zoom(), actor->viewport_saved_zoom );
+
+    u.zone_sort_viewport.active = true;
+    u.zone_sort_viewport.center = bbox.centroid;
+    u.zone_sort_viewport.target_zoom = target;
+    u.zone_sort_viewport.bbox_min = bbox.min_corner;
+    u.zone_sort_viewport.bbox_max = bbox.max_corner;
+    if( !test_mode ) {
+        set_zoom( target );
+        mark_main_ui_adaptor_resize();
+    }
 }
 
 int game::get_moves_since_last_save() const

--- a/src/game.h
+++ b/src/game.h
@@ -263,6 +263,8 @@ class game
         void draw( ui_adaptor &ui );
         void draw_ter( bool draw_sounds = true );
         void draw_ter( const tripoint_bub_ms &center, bool looking = false, bool draw_sounds = true );
+        // Lazy (re)activation of zone sort viewport lock after load or initial setup.
+        void try_activate_zone_sort_viewport();
 
         class draw_callback_t
         {

--- a/tests/clzones_test.cpp
+++ b/tests/clzones_test.cpp
@@ -5,10 +5,13 @@
 #include <optional>
 #include <set>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
+#include "activity_actor.h"
 #include "activity_actor_definitions.h"
 #include "activity_item_handling.h"
+#include "clone_ptr.h"
 #include "avatar.h"
 #include "calendar.h"
 #include "cata_catch.h"
@@ -2391,4 +2394,261 @@ TEST_CASE( "multi_zone_vehicle_repair_large_zone_no_hang",
     CHECK( !dummy.activity );
     // Should finish quickly -- not use all 50 turns
     CHECK( turns < max_turns );
+}
+
+// --- Viewport lock math helpers ---
+
+TEST_CASE( "zone_sort_viewport_bbox", "[zones][viewport]" )
+{
+    using zone_sorting::viewport_bbox;
+    using zone_sorting::calc_zone_bbox;
+    using zone_sorting::expand_bbox;
+
+    SECTION( "single tile" ) {
+        std::unordered_set<tripoint_abs_ms> tiles;
+        tiles.emplace( 10, 20, 0 );
+        viewport_bbox bbox = calc_zone_bbox( tiles );
+        CHECK( bbox.min_corner == tripoint_abs_ms( 10, 20, 0 ) );
+        CHECK( bbox.max_corner == tripoint_abs_ms( 10, 20, 0 ) );
+        CHECK( bbox.centroid == tripoint_abs_ms( 10, 20, 0 ) );
+        CHECK( bbox.width() == 0 );
+        CHECK( bbox.height() == 0 );
+    }
+
+    SECTION( "spread tiles" ) {
+        std::unordered_set<tripoint_abs_ms> tiles;
+        tiles.emplace( 5, 10, 0 );
+        tiles.emplace( 25, 10, 0 );
+        tiles.emplace( 15, 30, 0 );
+        viewport_bbox bbox = calc_zone_bbox( tiles );
+        CHECK( bbox.min_corner == tripoint_abs_ms( 5, 10, 0 ) );
+        CHECK( bbox.max_corner == tripoint_abs_ms( 25, 30, 0 ) );
+        CHECK( bbox.centroid == tripoint_abs_ms( 15, 20, 0 ) );
+        CHECK( bbox.width() == 20 );
+        CHECK( bbox.height() == 20 );
+    }
+
+    SECTION( "empty set" ) {
+        std::unordered_set<tripoint_abs_ms> tiles;
+        viewport_bbox bbox = calc_zone_bbox( tiles );
+        CHECK( bbox.width() == 0 );
+        CHECK( bbox.height() == 0 );
+    }
+
+    SECTION( "expand_bbox grows when tile outside" ) {
+        std::unordered_set<tripoint_abs_ms> tiles;
+        tiles.emplace( 10, 10, 0 );
+        tiles.emplace( 20, 20, 0 );
+        viewport_bbox bbox = calc_zone_bbox( tiles );
+        CHECK( bbox.width() == 10 );
+        CHECK( bbox.height() == 10 );
+
+        bool grew = expand_bbox( bbox, tripoint_abs_ms( 30, 20, 0 ) );
+        CHECK( grew );
+        CHECK( bbox.max_corner.x() == 30 );
+        CHECK( bbox.width() == 20 );
+        CHECK( bbox.centroid.x() == 20 );
+    }
+
+    SECTION( "expand_bbox no-op when tile inside" ) {
+        std::unordered_set<tripoint_abs_ms> tiles;
+        tiles.emplace( 10, 10, 0 );
+        tiles.emplace( 20, 20, 0 );
+        viewport_bbox bbox = calc_zone_bbox( tiles );
+
+        bool grew = expand_bbox( bbox, tripoint_abs_ms( 15, 15, 0 ) );
+        CHECK_FALSE( grew );
+        CHECK( bbox.width() == 10 );
+        CHECK( bbox.height() == 10 );
+    }
+}
+
+TEST_CASE( "zone_sort_viewport_zoom", "[zones][viewport]" )
+{
+    using zone_sorting::calc_target_zoom;
+
+    // Simulate: at zoom 16 (default), 60 tiles wide, 40 tiles tall.
+    // screen_pixels_w = 60 * 16 = 960, screen_pixels_h = 40 * 16 = 640.
+    const int vis_w = 60;
+    const int vis_h = 40;
+    const int cur_zoom = 16;
+    const int saved = 16;
+
+    SECTION( "bbox fits at current zoom" ) {
+        // 20x20 bbox + 4 padding = 24x24, fits in 60x40 at zoom 16
+        int z = calc_target_zoom( 20, 20, vis_w, vis_h, cur_zoom, saved );
+        CHECK( z == 16 );
+    }
+
+    SECTION( "bbox needs one step zoom out" ) {
+        // 100x80 bbox + 4 padding = 104x84.
+        // At zoom 16: 60x40 -- doesn't fit.
+        // At zoom 8: 120x80 -- width fits (120>=104), height doesn't (80<84).
+        // At zoom 4: 240x160 -- fits.
+        int z = calc_target_zoom( 100, 80, vis_w, vis_h, cur_zoom, saved );
+        CHECK( z == 4 );
+    }
+
+    SECTION( "bbox needs moderate zoom out" ) {
+        // 80x30 bbox + 4 = 84x34.
+        // At zoom 16: 60x40 -- width doesn't fit.
+        // At zoom 8: 120x80 -- fits.
+        int z = calc_target_zoom( 80, 30, vis_w, vis_h, cur_zoom, saved );
+        CHECK( z == 8 );
+    }
+
+    SECTION( "clamp at minimum zoom 4" ) {
+        // Huge bbox that doesn't even fit at zoom 4
+        int z = calc_target_zoom( 1000, 1000, vis_w, vis_h, cur_zoom, saved );
+        CHECK( z == 4 );
+    }
+
+    SECTION( "never zoom in beyond saved_zoom" ) {
+        // Small bbox that fits at zoom 32, but saved_zoom is 16
+        // 5x5 bbox + 4 = 9x9. At zoom 32: 30x20 -- fits. But saved=16 caps it.
+        int z = calc_target_zoom( 5, 5, vis_w, vis_h, cur_zoom, saved );
+        CHECK( z == 16 );
+    }
+
+    SECTION( "respects higher saved_zoom" ) {
+        // If player was at zoom 32 (zoomed in), saved_zoom=32
+        // 5x5 bbox + 4 = 9x9. At zoom 32: 30x20 -- fits.
+        int z = calc_target_zoom( 5, 5, vis_w, vis_h, cur_zoom, 32 );
+        CHECK( z == 32 );
+    }
+}
+
+TEST_CASE( "zone_sort_viewport_lifecycle", "[zones][viewport][activities]" )
+{
+    avatar &dummy = get_avatar();
+    map &here = get_map();
+
+    clear_avatar();
+    clear_map();
+    zone_manager::get_manager().clear();
+
+    // Layout:
+    //   source (UNSORTED) at (60,60)
+    //   dest (PFOOD) at (60,55) -- 5 tiles north
+    //   player starts at (60,61)
+    const tripoint_bub_ms start_pos( 60, 61, 0 );
+    dummy.setpos( here, start_pos );
+    dummy.clear_destination();
+    dummy.zone_sort_viewport = avatar::zone_sort_viewport_t{};
+
+    const tripoint_bub_ms src_pos( 60, 60, 0 );
+    here.ter_set( src_pos, ter_t_floor );
+    create_tile_zone( "Unsorted", zone_type_LOOT_UNSORTED, here.get_abs( src_pos ) );
+
+    const tripoint_bub_ms dest_pos( 60, 55, 0 );
+    here.ter_set( dest_pos, ter_t_floor );
+    create_tile_zone( "PFood", zone_type_LOOT_PFOOD, here.get_abs( dest_pos ) );
+
+    here.add_item_or_charges( src_pos, item( itype_test_apple ) );
+
+    here.invalidate_map_cache( 0 );
+    here.build_map_cache( 0, true );
+
+    SECTION( "activates on sort start and deactivates on completion" ) {
+        CHECK_FALSE( dummy.zone_sort_viewport.active );
+
+        dummy.assign_activity( zone_sort_activity_actor() );
+
+        // Run one turn to trigger stage_init
+        dummy.mod_moves( dummy.get_speed() );
+        while( dummy.get_moves() > 0 && dummy.activity ) {
+            dummy.activity.do_turn( dummy );
+        }
+
+        // Viewport should be active after init
+        CHECK( dummy.zone_sort_viewport.active );
+
+        // Run to completion using teleport pattern
+        int teleports = 0;
+        const int max_teleports = 30;
+        do {
+            int turns = 0;
+            while( dummy.activity && turns < 200 ) {
+                dummy.mod_moves( dummy.get_speed() );
+                while( dummy.get_moves() > 0 && dummy.activity ) {
+                    dummy.activity.do_turn( dummy );
+                }
+                turns++;
+            }
+            if( dummy.destination_point ) {
+                dummy.setpos( here, here.get_bub( *dummy.destination_point ) );
+                if( dummy.has_destination_activity() ) {
+                    dummy.start_destination_activity();
+                } else {
+                    dummy.clear_destination();
+                }
+                teleports++;
+            }
+        } while( ( dummy.activity || dummy.destination_point ) && teleports < max_teleports );
+
+        REQUIRE( teleports < max_teleports );
+
+        // Viewport should be deactivated after completion
+        CHECK_FALSE( dummy.zone_sort_viewport.active );
+    }
+
+    SECTION( "stays active during auto-move leg" ) {
+        dummy.assign_activity( zone_sort_activity_actor() );
+
+        // Run until activity goes null (route_to_destination triggers auto-move)
+        int turns = 0;
+        while( dummy.activity && turns < 200 ) {
+            dummy.mod_moves( dummy.get_speed() );
+            while( dummy.get_moves() > 0 && dummy.activity ) {
+                dummy.activity.do_turn( dummy );
+            }
+            turns++;
+        }
+
+        // If we have a destination, we're in an auto-move leg
+        if( dummy.destination_point ) {
+            // Viewport should still be active during the leg
+            CHECK( dummy.zone_sort_viewport.active );
+        }
+    }
+
+    SECTION( "abort_automove restores viewport" ) {
+        dummy.assign_activity( zone_sort_activity_actor() );
+
+        // Run until auto-move starts
+        int turns = 0;
+        while( dummy.activity && turns < 200 ) {
+            dummy.mod_moves( dummy.get_speed() );
+            while( dummy.get_moves() > 0 && dummy.activity ) {
+                dummy.activity.do_turn( dummy );
+            }
+            turns++;
+        }
+
+        if( dummy.destination_point ) {
+            CHECK( dummy.zone_sort_viewport.active );
+            dummy.abort_automove();
+            CHECK_FALSE( dummy.zone_sort_viewport.active );
+        }
+    }
+
+    SECTION( "viewport_saved_zoom survives serialize roundtrip" ) {
+        dummy.assign_activity( zone_sort_activity_actor() );
+
+        // Run one turn to trigger stage_init
+        dummy.mod_moves( dummy.get_speed() );
+        while( dummy.get_moves() > 0 && dummy.activity ) {
+            dummy.activity.do_turn( dummy );
+        }
+
+        REQUIRE( dummy.zone_sort_viewport.active );
+
+        // Serialize and deserialize the activity
+        const zone_sort_activity_actor *actor =
+            dynamic_cast<const zone_sort_activity_actor *>( dummy.activity.actor.get() );
+        if( actor ) {
+            CHECK( actor->viewport_was_active );
+            CHECK( actor->viewport_saved_zoom == 16 );  // DEFAULT_TILESET_ZOOM
+        }
+    }
 }


### PR DESCRIPTION
#### Summary
Interface "Add viewport lock option for zone sorting"

#### Purpose of change

Implements #85956.

Zone sorting involves the player walking back and forth between source and destination zones. The camera follows every step, which can get pretty disorienting on larger bases. This adds an option to lock the camera on the sorting area instead.

#### Describe the solution

On sort start the camera centers on the bounding box of all source zones and zooms out (tiles mode) to fit them on screen. As destination zones are discovered during sorting, the bounding box expands and zoom adjusts. The camera stays locked through auto-move legs and restores the original zoom when sorting finishes, is canceled, or auto-move is interrupted.

The viewport center is stored on Character as ephemeral state (not serialized). view_offset is only overridden transiently inside `game::draw()` and restored after rendering, so the persisted value is never polluted. Zoom restoration lives on the activity actor (serialized), so it survives save/load and works even if the option is toggled off between sessions.

Curses mode gets the locked center but no zoom (since zoom is tiles-only).

#### Describe alternatives you've considered

Modifying view_offset persistently from the activity actor -- rejected because view_offset is serialized and the activity is null during auto-move legs, creating both save-pollution and timing gaps.

Overriding only draw_ter center -- rejected because other renderers (cursor placement, overlays) read view_offset directly and would disagree with the locked center.

#### Testing


https://github.com/user-attachments/assets/a2f34efd-e76b-42ea-b1f6-cd8b2bccbc82



New tests cover the math helpers (bbox calculation, zoom selection, bbox expansion) and the activity lifecycle (activation on sort start, persistence through auto-move legs, deactivation on completion, deactivation on abort_automove, serialization roundtrip of saved zoom). 37 assertions across 3 test cases, all passing.

Manual testing done in tiles mode with zones spread apart -- camera locks, zoom adjusts, restores correctly on completion and on interrupt.

#### Additional context

Another idea for curses was smooth-drift mode, but the snap behavior works fine for now.