### PR TITLE
Adjusts description of Gasoline Fuel Cell CBM.

### DIFF
--- a/data/json/items/bionics.json
+++ b/data/json/items/bionics.json
@@ -927,7 +927,7 @@
     "subtypes": [ "BIONIC_ITEM" ],
     "name": { "str": "Gasoline Fuel Cell CBM" },
     "looks_like": "bio_int_enhancer",
-    "description": "A small gasoline fuel cell able to convert gasoline to bionic power.  It's connected to a diffuse network of bio-plastic bladders able to hold up to 500 mL of gasoline.",
+    "description": "A small gasoline fuel cell able to convert gasoline to bionic power, together with a heat exhaust and a diffuse network of bio-plastic bladders able to hold up to 500 mL of gasoline. When implanted, the system incurs a moderate amount of torso encumbrance.”,
     "price": "4 kUSD 500 USD",
     "price_postapoc": "20 USD",
     "weight": "600 g",

--- a/data/json/items/bionics.json
+++ b/data/json/items/bionics.json
@@ -927,7 +927,7 @@
     "subtypes": [ "BIONIC_ITEM" ],
     "name": { "str": "Gasoline Fuel Cell CBM" },
     "looks_like": "bio_int_enhancer",
-    "description": "A small gasoline fuel cell able to convert gasoline to bionic power.  It's connected to a heat exhaust and a diffuse network of bio-plastic bladders able to hold up to 500 mL of gasoline. When implanted, the system incurs a moderate amount of torso encumbrance.",
+    "description": "A small gasoline fuel cell able to convert gasoline to bionic power.  It's connected to a heat exhaust and a diffuse network of bio-plastic bladders able to hold up to 500 mL of gasoline.  When implanted, the system incurs a moderate amount of torso encumbrance.",
     "price": "4 kUSD 500 USD",
     "price_postapoc": "20 USD",
     "weight": "600 g",

--- a/data/json/items/bionics.json
+++ b/data/json/items/bionics.json
@@ -927,7 +927,7 @@
     "subtypes": [ "BIONIC_ITEM" ],
     "name": { "str": "Gasoline Fuel Cell CBM" },
     "looks_like": "bio_int_enhancer",
-    "description": "A small gasoline fuel cell able to convert gasoline to bionic power, together with a heat exhaust and a diffuse network of bio-plastic bladders able to hold up to 500 mL of gasoline. When implanted, the system incurs a moderate amount of torso encumbrance.”,
+    "description": "A small gasoline fuel cell able to convert gasoline to bionic power, together with a heat exhaust and a diffuse network of bio-plastic bladders able to hold up to 500 mL of gasoline. When implanted, the system incurs a moderate amount of torso encumbrance.",
     "price": "4 kUSD 500 USD",
     "price_postapoc": "20 USD",
     "weight": "600 g",

--- a/data/json/items/bionics.json
+++ b/data/json/items/bionics.json
@@ -927,7 +927,7 @@
     "subtypes": [ "BIONIC_ITEM" ],
     "name": { "str": "Gasoline Fuel Cell CBM" },
     "looks_like": "bio_int_enhancer",
-    "description": "A small gasoline fuel cell able to convert gasoline to bionic power, together with a heat exhaust and a diffuse network of bio-plastic bladders able to hold up to 500 mL of gasoline. When implanted, the system incurs a moderate amount of torso encumbrance.",
+    "description": "A small gasoline fuel cell able to convert gasoline to bionic power.  It's connected to a heat exhaust and a diffuse network of bio-plastic bladders able to hold up to 500 mL of gasoline. When implanted, the system incurs a moderate amount of torso encumbrance.",
     "price": "4 kUSD 500 USD",
     "price_postapoc": "20 USD",
     "weight": "600 g",


### PR DESCRIPTION


#### Summary
Content "Adjusts description of Gasoline Fuel Cell CBM item to warn about encumbrance of installed CBM."

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Baby's first PR.  The Gasoline Fuel cell CBM has a somewhat anomalous 5 torso encumbrance that the other fuel-burning cbms don’t share, and only a few (functional) cbms have any encumbrance either. The description for the item gives no warning about this, which could trip players up, as I was ages ago on a 0.G playthrough.

#### Describe the solution

Slightly reworks and expands the description of the item to give players some awareness before they commit to having it installed.

#### Describe alternatives you've considered

Removing the encumbrance or expanding it to the other fuel-consuming CBMs for consistency. 

#### Testing

Downloaded the latest experimental, copy-pasted the entirety of the changed file over from the branch, confirmed the game loaded, spawned, examined, installed, and activated the CBM, everything worked.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
