### PR TITLE
NPC needs: complaint gate, sapro rotten food, BT utility strategy

### DIFF
--- a/src/behavior.cpp
+++ b/src/behavior.cpp
@@ -31,6 +31,10 @@ void node_t::add_child( const node_t *new_child )
 {
     children.push_back( new_child );
 }
+void node_t::set_score_function( const score_type &func, const std::string &argument )
+{
+    score_function_.emplace( func, argument );
+}
 
 status_t node_t::process_predicates( const oracle_t *subject ) const
 {
@@ -63,15 +67,23 @@ behavior_return node_t::tick( const oracle_t *subject ) const
 {
     if( children.empty() ) {
         status_t result = process_predicates( subject );
-
-        return { result, this };
+        float score = 0.0f;
+        if( result == status_t::running && score_function_ ) {
+            score = score_function_->first( subject, score_function_->second );
+        }
+        return { result, this, score };
     } else {
         cata_assert( strategy != nullptr );
         status_t result = process_predicates( subject );
         if( result == status_t::running ) {
-            return strategy->evaluate( subject, children );
+            behavior_return child_result = strategy->evaluate( subject, children );
+            if( child_result.result == status_t::running && score_function_ ) {
+                child_result.score = score_function_->first( subject,
+                                     score_function_->second );
+            }
+            return child_result;
         } else {
-            return { result, nullptr };
+            return { result, nullptr, 0.0f };
         }
     }
 }
@@ -165,6 +177,18 @@ void node_t::load( const JsonObject &jo, std::string_view )
                                  invert_result );
     }
     optional( jo, was_loaded, "goal", _goal );
+    if( jo.has_string( "score" ) ) {
+        const std::string score_id = jo.get_string( "score" );
+        const std::string score_arg = jo.get_string( "score_argument", "" );
+        auto new_score = score_predicate_map.find( score_id );
+        if( new_score != score_predicate_map.end() ) {
+            score_function_.emplace( new_score->second, score_arg );
+        } else {
+            debugmsg( "While loading %s, failed to find score predicate %s.",
+                      id.str(), score_id );
+            jo.throw_error( "Invalid score predicate in behavior." );
+        }
+    }
 }
 
 void node_t::check() const

--- a/src/behavior.h
+++ b/src/behavior.h
@@ -3,6 +3,7 @@
 #define CATA_SRC_BEHAVIOR_H
 
 #include <functional>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <tuple>
@@ -24,6 +25,7 @@ enum class status_t : char { running, success, failure };
 struct behavior_return {
     status_t result;
     const node_t *selection;
+    float score = 0.0f;
 };
 
 // The behavior tree is (at least initially) intended to decide on a goal for a given subject.
@@ -69,6 +71,8 @@ class node_t
                             new_predicate, const std::string &argument = "", const bool &invert_result = false );
         void set_goal( const std::string &new_goal );
         void add_child( const node_t *new_child );
+        using score_type = std::function<float( const oracle_t *, std::string_view )>;
+        void set_score_function( const score_type &func, const std::string &argument = "" );
 
         // Loading interface.
         void load( const JsonObject &jo, std::string_view src );
@@ -84,6 +88,7 @@ class node_t
         status_t process_predicates( const oracle_t *subject ) const;
         // TODO: make into an ID?
         std::string _goal;
+        std::optional<std::pair<score_type, std::string>> score_function_;
 };
 
 // Deserialization support.

--- a/src/behavior_oracle.cpp
+++ b/src/behavior_oracle.cpp
@@ -48,4 +48,7 @@ predicate_map = {{
     }
 };
 
+std::unordered_map<std::string, std::function<float( const oracle_t *, std::string_view )>>
+        score_predicate_map = {};
+
 } // namespace behavior

--- a/src/behavior_oracle.h
+++ b/src/behavior_oracle.h
@@ -27,5 +27,8 @@ status_t return_running( const oracle_t *, std::string_view );
 extern std::unordered_map<std::string, std::function<status_t( const oracle_t *, std::string_view )>>
         predicate_map;
 
+extern std::unordered_map<std::string, std::function<float( const oracle_t *, std::string_view )>>
+        score_predicate_map;
+
 } // namespace behavior
 #endif // CATA_SRC_BEHAVIOR_ORACLE_H

--- a/src/behavior_strategy.cpp
+++ b/src/behavior_strategy.cpp
@@ -10,11 +10,13 @@ namespace behavior
 static sequential_t default_sequential;
 static fallback_t default_fallback;
 static sequential_until_done_t default_until_done;
+static utility_t default_utility;
 
 std::unordered_map<std::string, const strategy_t *> strategy_map = {{
         { "sequential", &default_sequential },
         { "fallback", &default_fallback },
-        { "sequential_until_done", &default_until_done }
+        { "sequential_until_done", &default_until_done },
+        { "utility", &default_utility }
     }
 };
 } // namespace behavior
@@ -58,4 +60,26 @@ behavior_return sequential_until_done_t::evaluate( const oracle_t *subject,
         }
     }
     return { status_t::success, nullptr };
+}
+
+// Evaluate all children and select the running one with the highest score.
+behavior_return utility_t::evaluate( const oracle_t *subject,
+                                     const std::vector<const node_t *> children ) const
+{
+    behavior_return best = { status_t::failure, nullptr, 0.0f };
+    bool any_success = false;
+    for( const node_t *child : children ) {
+        behavior_return outcome = child->tick( subject );
+        if( outcome.result == status_t::running ) {
+            if( best.result != status_t::running || outcome.score > best.score ) {
+                best = outcome;
+            }
+        } else if( outcome.result == status_t::success ) {
+            any_success = true;
+        }
+    }
+    if( best.result == status_t::running ) {
+        return best;
+    }
+    return { any_success ? status_t::success : status_t::failure, nullptr, 0.0f };
 }

--- a/src/behavior_strategy.h
+++ b/src/behavior_strategy.h
@@ -39,6 +39,14 @@ class sequential_until_done_t : public strategy_t
                                   std::vector<const node_t *> children ) const override;
 };
 
+// Select the running child with the highest score.
+// Children that return success or failure are skipped.
+class utility_t : public strategy_t
+{
+        behavior_return evaluate( const oracle_t *subject,
+                                  std::vector<const node_t *> children ) const override;
+};
+
 extern std::unordered_map<std::string, const strategy_t *> strategy_map;
 
 } // namespace behavior

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -5427,19 +5427,22 @@ bool npc::complain()
         deactivate_bionic_by_id( bio_radscrubber );
     }
 
-    // Hunger every 3-6 hours
-    // Complaint frequency scales with hunger level
-    if( get_hunger() > NPC_HUNGER_COMPLAIN &&
-        complain_about( hunger_string,
-                        std::max( 3_hours, time_duration::from_minutes( 60 * 8 - get_hunger() ) ),
-                        chat_snippets().snip_hungry.translated() ) ) {
-        return true;
-    }
+    // Hunger and thirst complaints only fire when NPC has food needs
+    if( needs_food() ) {
+        // Hunger every 3-6 hours
+        // Complaint frequency scales with hunger level
+        if( get_hunger() > NPC_HUNGER_COMPLAIN &&
+            complain_about( hunger_string,
+                            std::max( 3_hours, time_duration::from_minutes( 60 * 8 - get_hunger() ) ),
+                            chat_snippets().snip_hungry.translated() ) ) {
+            return true;
+        }
 
-    // Thirst every 2 hours
-    if( get_thirst() > NPC_THIRST_COMPLAIN &&
-        complain_about( thirst_string, 2_hours, chat_snippets().snip_thirsty.translated() ) ) {
-        return true;
+        // Thirst every 2 hours
+        if( get_thirst() > NPC_THIRST_COMPLAIN &&
+            complain_about( thirst_string, 2_hours, chat_snippets().snip_thirsty.translated() ) ) {
+            return true;
+        }
     }
 
     //Bleeding every 5 minutes

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -4639,16 +4639,19 @@ static float rate_food( const Character &who, const item &it, int want_nutr,
     }
 
     double relative_rot = it.get_relative_rot();
+    float weight = 0.0f;
 
-    // Don't eat rotten food.
     if( relative_rot >= 1.0f ) {
-        // TODO: Allow sapro mutants to eat it anyway and make them prefer it
-        return 0.0f;
+        if( !can_consume_rot ) {
+            return 0.0f;
+        }
+        // Saprophages/saprovores prefer rotten food
+        weight = 15.0f;
+    } else {
+        // For non-rotten food, weight in range 1-10.
+        // The closer it is to expiring, the more we should aim to eat it.
+        weight = std::max( 1.0f, static_cast<float>( 10.0 * relative_rot ) );
     }
-
-    // For non-rotten food, we have a starting weight in the range 1-10
-    // The closer it is to expiring, the more we should aim to eat it.
-    float weight = std::max( 1.0, 10.0 * relative_rot );
 
     // TODO: I feel like we should exclude *really* un-fun foods (flour, hot sauce, etc)
     //       rather than discount them. Eating cooked liver is fine, eating raw flour... :/

--- a/tests/behavior_test.cpp
+++ b/tests/behavior_test.cpp
@@ -4,16 +4,20 @@
 #include <string>
 #include <string_view>
 #include <tuple>
+#include <unordered_map>
 #include <vector>
 
 #include "behavior.h"
+#include "behavior_oracle.h"
 #include "behavior_strategy.h"
 #include "calendar.h"
 #include "cata_catch.h"
 #include "character_attire.h"
 #include "character_oracle.h"
 #include "coordinates.h"
+#include "flexbuffer_json.h"
 #include "item.h"
+#include "json_loader.h"
 #include "item_group.h"
 #include "item_location.h"
 #include "map.h"
@@ -52,11 +56,11 @@ static const string_id<behavior::node_t> behavior_node_t_npc_needs( "npc_needs" 
 
 namespace behavior
 {
-class oracle_t;
 
 static sequential_t default_sequential;
 static fallback_t default_fallback;
 static sequential_until_done_t default_until_done;
+static utility_t default_utility;
 } // namespace behavior
 
 static behavior::node_t make_test_node( const std::string &goal, const behavior::status_t *status )
@@ -438,5 +442,153 @@ TEST_CASE( "check_monster_behavior_tree_theoretical_absorb", "[monster][behavior
         CHECK( here.i_at( test_monster.pos_bub() ).empty() );
 
         CHECK( monster_goals.tick( &oracle ) == "idle" );
+    }
+}
+
+TEST_CASE( "behavior_tree_utility_strategy", "[behavior]" )
+{
+    SECTION( "leaf nodes with scores" ) {
+        behavior::status_t status_a = behavior::status_t::running;
+        behavior::status_t status_b = behavior::status_t::running;
+        behavior::status_t status_c = behavior::status_t::running;
+        float score_a = 5.0f;
+        float score_b = 10.0f;
+        float score_c = 3.0f;
+
+        behavior::node_t node_a = make_test_node( "goal_a", &status_a );
+        node_a.set_score_function( [&score_a]( const behavior::oracle_t *, std::string_view ) {
+            return score_a;
+        } );
+
+        behavior::node_t node_b = make_test_node( "goal_b", &status_b );
+        node_b.set_score_function( [&score_b]( const behavior::oracle_t *, std::string_view ) {
+            return score_b;
+        } );
+
+        behavior::node_t node_c = make_test_node( "goal_c", &status_c );
+        node_c.set_score_function( [&score_c]( const behavior::oracle_t *, std::string_view ) {
+            return score_c;
+        } );
+
+        behavior::node_t root;
+        root.set_strategy( &behavior::default_utility );
+        root.add_child( &node_a );
+        root.add_child( &node_b );
+        root.add_child( &node_c );
+
+        behavior::tree needs;
+        needs.add( &root );
+
+        // Highest score wins
+        CHECK( needs.tick( nullptr ) == "goal_b" );
+
+        // Change scores -- now A is most urgent
+        score_a = 20.0f;
+        CHECK( needs.tick( nullptr ) == "goal_a" );
+
+        // B succeeds (need met) -- skipped, A still wins
+        status_b = behavior::status_t::success;
+        CHECK( needs.tick( nullptr ) == "goal_a" );
+
+        // A also succeeds -- C is the only running child
+        status_a = behavior::status_t::success;
+        CHECK( needs.tick( nullptr ) == "goal_c" );
+
+        // All succeed -- idle
+        status_c = behavior::status_t::success;
+        CHECK( needs.tick( nullptr ) == "idle" );
+
+        // All fail -- also idle
+        status_a = behavior::status_t::failure;
+        status_b = behavior::status_t::failure;
+        status_c = behavior::status_t::failure;
+        CHECK( needs.tick( nullptr ) == "idle" );
+    }
+
+    SECTION( "branch nodes with scores" ) {
+        // Mimics the real NPC tree structure:
+        // root (utility) -> branch_a (sequential) -> leaf_a1
+        //                 -> branch_b (sequential) -> leaf_b1
+
+        behavior::status_t leaf_a1_status = behavior::status_t::running;
+        behavior::status_t leaf_b1_status = behavior::status_t::running;
+        behavior::status_t branch_a_pred = behavior::status_t::running;
+        behavior::status_t branch_b_pred = behavior::status_t::running;
+        float score_a = 5.0f;
+        float score_b = 10.0f;
+
+        behavior::node_t leaf_a1 = make_test_node( "goal_a1", &leaf_a1_status );
+        behavior::node_t leaf_b1 = make_test_node( "goal_b1", &leaf_b1_status );
+
+        behavior::node_t branch_a;
+        branch_a.set_strategy( &behavior::default_sequential );
+        branch_a.add_predicate( [&branch_a_pred]( const behavior::oracle_t *, std::string_view ) {
+            return branch_a_pred;
+        } );
+        branch_a.add_child( &leaf_a1 );
+        branch_a.set_score_function( [&score_a]( const behavior::oracle_t *, std::string_view ) {
+            return score_a;
+        } );
+
+        behavior::node_t branch_b;
+        branch_b.set_strategy( &behavior::default_sequential );
+        branch_b.add_predicate( [&branch_b_pred]( const behavior::oracle_t *, std::string_view ) {
+            return branch_b_pred;
+        } );
+        branch_b.add_child( &leaf_b1 );
+        branch_b.set_score_function( [&score_b]( const behavior::oracle_t *, std::string_view ) {
+            return score_b;
+        } );
+
+        behavior::node_t root;
+        root.set_strategy( &behavior::default_utility );
+        root.add_child( &branch_a );
+        root.add_child( &branch_b );
+
+        behavior::tree needs;
+        needs.add( &root );
+
+        // Branch B has higher score, so goal_b1 is selected
+        CHECK( needs.tick( nullptr ) == "goal_b1" );
+
+        // Swap scores -- now branch A wins
+        score_a = 15.0f;
+        score_b = 2.0f;
+        CHECK( needs.tick( nullptr ) == "goal_a1" );
+
+        // Branch A's predicate fails -- falls through to B
+        branch_a_pred = behavior::status_t::failure;
+        CHECK( needs.tick( nullptr ) == "goal_b1" );
+    }
+
+    SECTION( "JSON-loaded score predicate" ) {
+        // Exercises the actual node_t::load() path for "score" field parsing
+        float test_score = 42.0f;
+        behavior::score_predicate_map["test_urgency"] =
+        [&test_score]( const behavior::oracle_t *, std::string_view ) {
+            return test_score;
+        };
+
+        // Load a node from JSON with a score predicate, same as the generic factory does
+        const std::string json = R"({
+            "goal": "scored_goal",
+            "score": "test_urgency"
+        })";
+        behavior::node_t node;
+        JsonObject jo = json_loader::from_string( json );
+        node.load( jo, "" );
+
+        // The node should have picked up the score function from the map
+        behavior::node_t root;
+        root.set_strategy( &behavior::default_utility );
+        root.add_child( &node );
+
+        behavior::tree needs;
+        needs.add( &root );
+
+        CHECK( needs.tick( nullptr ) == "scored_goal" );
+
+        // Clean up
+        behavior::score_predicate_map.erase( "test_urgency" );
     }
 }

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -70,10 +70,12 @@ static const itype_id itype_marloss_berry( "marloss_berry" );
 static const itype_id itype_marloss_gel( "marloss_gel" );
 static const itype_id itype_meat( "meat" );
 static const itype_id itype_meat_tainted( "meat_tainted" );
+static const itype_id itype_meat_cooked( "meat_cooked" );
 static const itype_id itype_mutagen( "mutagen" );
 static const itype_id itype_sandwich_cheese_grilled( "sandwich_cheese_grilled" );
 static const itype_id itype_space_cake( "space_cake" );
 
+static const trait_id trait_SAPROPHAGE( "SAPROPHAGE" );
 static const trait_id trait_SAPROVORE( "SAPROVORE" );
 static const trait_id trait_WEB_WEAVER( "WEB_WEAVER" );
 
@@ -914,5 +916,36 @@ TEST_CASE( "npc_no_food_mod_suppresses_complaints", "[npc][needs]" )
         override_option food_on( "NO_NPC_FOOD", "false" );
         REQUIRE( guy.needs_food() );
         CHECK( guy.complain() );
+    }
+}
+
+TEST_CASE( "npc_saprovore_eats_rotten_food", "[npc][food]" )
+{
+    clear_map_without_vision();
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy );
+    guy.set_hunger( 300 );
+    guy.set_stored_kcal( 5000 );
+    guy.set_thirst( 0 );
+
+    item rotten_meat( itype_meat_cooked );
+    rotten_meat.set_relative_rot( 1.01 );
+    REQUIRE( rotten_meat.get_relative_rot() >= 1.0 );
+
+    SECTION( "normal NPC refuses rotten food" ) {
+        guy.i_add( rotten_meat );
+        CHECK_FALSE( guy.consume_food() );
+    }
+
+    SECTION( "saprovore eats rotten food" ) {
+        guy.set_mutation( trait_SAPROVORE );
+        guy.i_add( rotten_meat );
+        CHECK( guy.consume_food() );
+    }
+
+    SECTION( "saprophage eats rotten food" ) {
+        guy.set_mutation( trait_SAPROPHAGE );
+        guy.i_add( rotten_meat );
+        CHECK( guy.consume_food() );
     }
 }

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -51,12 +51,15 @@
 #include "units.h"
 #include "veh_type.h"
 #include "vehicle.h"
+#include "viewer.h"
 #include "vpart_position.h"
 
 class Creature;
 
 static const efftype_id effect_bouldering( "bouldering" );
 static const efftype_id effect_sleep( "sleep" );
+
+static const faction_id faction_your_followers( "your_followers" );
 
 static const item_group_id Item_spawn_data_SUS_trash_forest_manmade( "SUS_trash_forest_manmade" );
 static const item_group_id Item_spawn_data_test_NPC_guns( "test_NPC_guns" );
@@ -69,8 +72,8 @@ static const itype_id itype_leather_belt( "leather_belt" );
 static const itype_id itype_marloss_berry( "marloss_berry" );
 static const itype_id itype_marloss_gel( "marloss_gel" );
 static const itype_id itype_meat( "meat" );
-static const itype_id itype_meat_tainted( "meat_tainted" );
 static const itype_id itype_meat_cooked( "meat_cooked" );
+static const itype_id itype_meat_tainted( "meat_tainted" );
 static const itype_id itype_mutagen( "mutagen" );
 static const itype_id itype_sandwich_cheese_grilled( "sandwich_cheese_grilled" );
 static const itype_id itype_space_cake( "space_cake" );
@@ -886,14 +889,12 @@ TEST_CASE( "npc_eats_food_with_harmless_iuse", "[npc][food]" )
     }
 }
 
-static const faction_id faction_your_followers( "your_followers" );
-
 TEST_CASE( "npc_no_food_mod_suppresses_complaints", "[npc][needs]" )
 {
     clear_map_without_vision();
     avatar &player_character = get_avatar();
     clear_avatar();
-    npc &guy = spawn_npc( player_character.pos_bub().xy() + point( 1, 0 ), "test_talker" );
+    npc &guy = spawn_npc( player_character.pos_bub().xy() + point::east, "test_talker" );
     set_time( calendar::turn_zero + 12_hours );
     clear_character( guy );
     guy.set_attitude( NPCATT_FOLLOW );
@@ -902,9 +903,9 @@ TEST_CASE( "npc_no_food_mod_suppresses_complaints", "[npc][needs]" )
     guy.set_hunger( 300 );   // well above NPC_HUNGER_COMPLAIN (160)
     guy.set_thirst( 200 );   // well above NPC_THIRST_COMPLAIN (80)
 
-    // Assert preconditions so fixture failures are diagnosable
+    // Assert the exact preconditions that npc::complain() checks
     REQUIRE( guy.is_player_ally() );
-    REQUIRE( player_character.sees( get_map(), guy ) );
+    REQUIRE( get_player_view().sees( get_map(), guy ) );
 
     SECTION( "with NO_NPC_FOOD, no hunger/thirst complaints" ) {
         override_option no_food( "NO_NPC_FOOD", "true" );

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -10,6 +10,7 @@
 #include <utility>
 #include <vector>
 
+#include "avatar.h"
 #include "bodypart.h"
 #include "calendar.h"
 #include "cata_catch.h"
@@ -35,6 +36,7 @@
 #include "monster.h"
 #include "npc.h"
 #include "npctalk.h"
+#include "options_helpers.h"
 #include "output.h"
 #include "overmapbuffer.h"
 #include "pathfinding.h"
@@ -879,5 +881,38 @@ TEST_CASE( "npc_eats_food_with_harmless_iuse", "[npc][food]" )
         guy.set_mutation( trait_SAPROVORE );
         guy.i_add( item( itype_meat ) );
         CHECK( guy.consume_food() );
+    }
+}
+
+static const faction_id faction_your_followers( "your_followers" );
+
+TEST_CASE( "npc_no_food_mod_suppresses_complaints", "[npc][needs]" )
+{
+    clear_map_without_vision();
+    avatar &player_character = get_avatar();
+    clear_avatar();
+    npc &guy = spawn_npc( player_character.pos_bub().xy() + point( 1, 0 ), "test_talker" );
+    set_time( calendar::turn_zero + 12_hours );
+    clear_character( guy );
+    guy.set_attitude( NPCATT_FOLLOW );
+    guy.set_fac( faction_your_followers );
+
+    guy.set_hunger( 300 );   // well above NPC_HUNGER_COMPLAIN (160)
+    guy.set_thirst( 200 );   // well above NPC_THIRST_COMPLAIN (80)
+
+    // Assert preconditions so fixture failures are diagnosable
+    REQUIRE( guy.is_player_ally() );
+    REQUIRE( player_character.sees( get_map(), guy ) );
+
+    SECTION( "with NO_NPC_FOOD, no hunger/thirst complaints" ) {
+        override_option no_food( "NO_NPC_FOOD", "true" );
+        REQUIRE_FALSE( guy.needs_food() );
+        CHECK_FALSE( guy.complain() );
+    }
+
+    SECTION( "without NO_NPC_FOOD, hunger complaint fires" ) {
+        override_option food_on( "NO_NPC_FOOD", "false" );
+        REQUIRE( guy.needs_food() );
+        CHECK( guy.complain() );
     }
 }


### PR DESCRIPTION
#### Summary
Features "Gate NPC food complaints behind needs_food(), let saprovores eat rotten food, add BT utility strategy"

#### Purpose of change

The NPC needs system has been stuck since #28681 was opened in 2019. These are three independent low-risk changes that each remove one blocker, following the same pattern as #85927 and #85924.

Depends on #85930 (branched from it).

#### Describe the solution

Three commits:

1. Gate hunger/thirst complaints behind `needs_food()` -- NPCs with the Disable NPC Needs mod still complained about hunger and thirst. Wraps just the hunger and thirst blocks in `complain()`, leaving other complaints (infection, bleeding, sleepiness, radiation) alone.

2. Let saprophage/saprovore NPCs eat rotten food -- resolves a long-standing TODO in `rate_food()`. Sapro NPCs now score rotten food at weight 15 (higher than fresh food's 1-10 range), so they actively prefer it. Restructured the `weight` variable scope so the rotten-food branch can set it.

3. Add utility strategy to behavior tree framework -- the foundational piece for the NPC needs architecture. A new strategy that evaluates all children and picks the running one with the highest score. Score functions attach to both leaf and branch nodes, so a utility parent can pick between scored subtrees (matching the real NPC tree structure). Includes JSON loading for `"score"` fields via `score_predicate_map`, with fatal errors on unknown IDs (matching existing strategy/predicate error handling). The map starts empty -- populated by future PRs adding `time_to_die` oracle methods.

#### Describe alternatives you've considered

Could ship these as three separate PRs, but they're small enough and thematically connected that bundling felt cleaner. The utility strategy could use a different scoring mechanism (e.g. oracle-side score maps), but extending `behavior_return` with a score field was the least invasive approach and keeps scores flowing naturally through the tree.

#### Testing

Each commit was TDD. Tests cover:

- Complaint gate: NPC with NO_NPC_FOOD option doesn't complain about hunger/thirst. Without the option, complaints fire normally. Full visibility and ally preconditions asserted via REQUIRE.
- Sapro rotten food: normal NPC refuses rotten meat, saprovore and saprophage both eat it. Uses `set_relative_rot(1.01)`.
- Utility strategy: leaf node scoring (highest score wins, status changes, all succeed/fail), branch node scoring (subtree selection, score swapping, predicate failure fallthrough), and JSON load path (register score predicate in map, load node via `json_loader::from_string`, verify score propagates).

All behavior/npc tests pass.

#### Additional context

Related to #28681.