### PR TITLE
Extract recipe list pipeline to crafting_gui_helpers

### DIFF
--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -5,7 +5,6 @@
 #include <cstddef>
 #include <cstring>
 #include <functional>
-#include <iterator>
 #include <map>
 #include <optional>
 #include <set>
@@ -321,78 +320,6 @@ static bool mouse_in_window( std::optional<point> coord, const catacurses::windo
         }
     }
     return false;
-}
-
-static void recursively_expand_recipes( std::vector<const recipe *> &current,
-                                        std::vector<int> &indent, std::map<const recipe *, availability> &availability_cache, int i,
-                                        Character &crafter, bool unread_recipes_first, bool highlight_unread_recipes,
-                                        const recipe_subset &available_recipes, const std::set<recipe_id> &hidden_recipes )
-{
-    std::vector<const recipe *> tmp;
-    for( const recipe_id &nested : current[i]->nested_category_data ) {
-
-        if( available_recipes.contains( &nested.obj() )
-            && hidden_recipes.find( nested ) == hidden_recipes.end()
-          ) {
-            // only do this if we can actually craft the recipe
-            tmp.push_back( &nested.obj() );
-            indent.insert( indent.begin() + i + 1, indent[i] + 2 );
-            if( !availability_cache.count( &nested.obj() ) ) {
-                availability_cache.emplace( &nested.obj(), availability( crafter, &nested.obj() ) );
-            }
-        }
-    }
-
-    const bool want_unread = highlight_unread_recipes && unread_recipes_first;
-    std::stable_sort( tmp.begin(), tmp.end(), [
-                       &crafter, &availability_cache, want_unread
-    ]( const recipe * const a, const recipe * const b ) {
-        const bool a_read = !want_unread || uistate.read_recipes.count( a->ident() );
-        const bool b_read = !want_unread || uistate.read_recipes.count( b->ident() );
-        return recipe_sort_compare( a, b,
-                                    availability_cache.at( a ), availability_cache.at( b ),
-                                    crafter, a_read, b_read, want_unread );
-    } );
-
-    current.insert( current.begin() + i + 1, tmp.begin(), tmp.end() );
-}
-
-// take the current and itterate through expanding each recipe
-static void expand_recipes( std::vector<const recipe *> &current,
-                            std::vector<int> &indent, std::map<const recipe *, availability> &availability_cache,
-                            Character &crafter, bool unread_recipes_first, bool highlight_unread_recipes,
-                            const recipe_subset &available_recipes, const std::set<recipe_id> &hidden_recipes )
-{
-    //TODO Make this more effecient
-    for( size_t i = 0; i < current.size(); ++i ) {
-        if( current[i]->is_nested()
-            && uistate.expanded_recipes.find( current[i]->ident() ) != uistate.expanded_recipes.end()
-          ) {
-            // add all the recipes from the nests
-            recursively_expand_recipes( current, indent, availability_cache, i, crafter,
-                                        unread_recipes_first, highlight_unread_recipes, available_recipes, hidden_recipes );
-        }
-    }
-}
-
-static std::string list_nested( Character &crafter, const recipe *rec,
-                                const recipe_subset &available_recipes,
-                                int indent = 0 )
-{
-    std::string description;
-    availability avail( crafter, rec );
-    if( rec->is_nested() ) {
-        description += colorize( std::string( indent,
-                                              ' ' ) + rec->result_name() + ":\n", avail.color() );
-        for( const recipe_id &r : rec->nested_category_data ) {
-            description += list_nested( crafter, &r.obj(), available_recipes, indent + 2 );
-        }
-    } else if( available_recipes.contains( rec ) ) {
-        description += colorize( std::string( indent,
-                                              ' ' ) + rec->result_name() + "\n", avail.color() );
-    }
-
-    return description;
 }
 
 static void nested_toggle( recipe_id rec, bool &recalc, bool &keepline )
@@ -851,9 +778,6 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
                 static_popup popup;
                 std::chrono::steady_clock::time_point last_update = std::chrono::steady_clock::now();
                 static constexpr std::chrono::milliseconds update_interval( 500 );
-                // Get a key description for the cancel button.
-                // Rather than propagating the context, create a new one here as a one-off.
-                // See register_action( "QUIT" ) in recipe_dictionary.cpp (line 289 when this was commited).
                 input_context dummy;
                 dummy.register_action( "QUIT" );
                 std::string cancel_btn = dummy.get_button_text( "QUIT", _( "Cancel" ) );
@@ -872,6 +796,7 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
                 };
 
                 std::vector<const recipe *> picking;
+                bool skip_hidden = false;
                 if( !filterstring.empty() ) {
                     std::string qry = trim( filterstring );
                     recipe_subset filtered_recipes =
@@ -880,56 +805,22 @@ std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &
                 } else {
                     const std::pair<std::vector<const recipe *>, bool> result = recipes_from_cat( available_recipes,
                             crafting_category_id( tab.cur() ), subtab.cur() );
+                    picking = result.first;
+                    skip_hidden = result.second;
                     show_hidden = result.second;
-                    if( show_hidden ) {
-                        current = result.first;
-                    } else {
-                        picking = result.first;
-                    }
                 }
 
-                if( !show_hidden ) {
-                    current.clear();
-                    for( const recipe *i : picking ) {
-                        if( uistate.hidden_recipes.find( i->ident() ) == uistate.hidden_recipes.end() ) {
-                            current.push_back( i );
-                        }
-                    }
-                    num_hidden = picking.size() - current.size();
-                    num_recipe = picking.size();
-                }
-
-                available.reserve( current.size() );
-                // cache recipe availability on first display
-                for( const recipe *e : current ) {
-                    if( !availability_cache->count( e ) ) {
-                        availability_cache->emplace( e, availability( *crafter, e, 1, camp_crafting, inventory_override ) );
-                    }
-                }
-
-                if( subtab.cur() != "CSC_*_RECENT" ) {
-                    const bool want_unread = highlight_unread_recipes && unread_recipes_first;
-                    std::stable_sort( current.begin(), current.end(), [
-                       crafter, &availability_cache, want_unread
-                    ]( const recipe * const a, const recipe * const b ) {
-                        const bool a_read = !want_unread || uistate.read_recipes.count( a->ident() );
-                        const bool b_read = !want_unread || uistate.read_recipes.count( b->ident() );
-                        return recipe_sort_compare( a, b,
-                                                    availability_cache->at( a ), availability_cache->at( b ),
-                                                    *crafter, a_read, b_read, want_unread );
-                    } );
-                }
-
-                // set up indents and append the expanded entries
-                // have to do this after we sort the list
-                indent.assign( current.size(), 0 );
-                expand_recipes( current, indent, *availability_cache, *crafter, unread_recipes_first,
-                                highlight_unread_recipes, available_recipes, uistate.hidden_recipes );
-
-                std::transform( current.begin(), current.end(),
-                std::back_inserter( available ), [&]( const recipe * e ) {
-                    return availability_cache->at( e );
-                } );
+                const bool skip_sort = ( subtab.cur() == "CSC_*_RECENT" );
+                num_recipe = picking.size();
+                recipe_list_data list_result = build_recipe_list(
+                                                   std::move( picking ), skip_hidden, skip_sort,
+                                                   *crafter, camp_crafting, inventory_override,
+                                                   highlight_unread_recipes, unread_recipes_first,
+                                                   *availability_cache, available_recipes );
+                current = std::move( list_result.entries );
+                indent = std::move( list_result.indent );
+                available = std::move( list_result.available );
+                num_hidden = list_result.num_hidden;
             }
 
             line = 0;

--- a/src/crafting_gui_helpers.cpp
+++ b/src/crafting_gui_helpers.cpp
@@ -1,5 +1,6 @@
 #include "crafting_gui_helpers.h"
 
+#include <algorithm>
 #include <iterator>
 #include <map>
 #include <memory>
@@ -30,8 +31,10 @@
 #include "requirements.h"
 #include "skill.h"
 #include "string_formatter.h"
+#include "flat_set.h"
 #include "translations.h"
 #include "type_id.h"
+#include "uistate.h"
 
 bool cannot_gain_skill_or_prof( const Character &crafter, const recipe &recp )
 {
@@ -828,4 +831,144 @@ std::vector<iteminfo> recipe_result_info( const recipe &rec, Character &crafter,
     }
     info.insert( std::end( info ), std::begin( details_info ), std::end( details_info ) );
     return info;
+}
+
+// --- Recipe list pipeline ---
+
+static void recursively_expand_recipes( std::vector<const recipe *> &current,
+                                        std::vector<int> &indent,
+                                        std::map<const recipe *, availability> &availability_cache, int i,
+                                        Character &crafter, bool unread_recipes_first, bool highlight_unread_recipes,
+                                        const recipe_subset &available_recipes, const std::set<recipe_id> &hidden_recipes,
+                                        bool camp_crafting, inventory *inventory_override )
+{
+    std::vector<const recipe *> tmp;
+    for( const recipe_id &nested : current[i]->nested_category_data ) {
+
+        if( available_recipes.contains( &nested.obj() )
+            && hidden_recipes.find( nested ) == hidden_recipes.end()
+          ) {
+            tmp.push_back( &nested.obj() );
+            indent.insert( indent.begin() + i + 1, indent[i] + 2 );
+            if( !availability_cache.count( &nested.obj() ) ) {
+                availability_cache.emplace( &nested.obj(),
+                                            availability( crafter, &nested.obj(), 1,
+                                                    camp_crafting, inventory_override ) );
+            }
+        }
+    }
+
+    const bool want_unread = highlight_unread_recipes && unread_recipes_first;
+    std::stable_sort( tmp.begin(), tmp.end(), [
+                       &crafter, &availability_cache, want_unread
+    ]( const recipe * const a, const recipe * const b ) {
+        const bool a_read = !want_unread || uistate.read_recipes.count( a->ident() );
+        const bool b_read = !want_unread || uistate.read_recipes.count( b->ident() );
+        return recipe_sort_compare( a, b,
+                                    availability_cache.at( a ), availability_cache.at( b ),
+                                    crafter, a_read, b_read, want_unread );
+    } );
+
+    current.insert( current.begin() + i + 1, tmp.begin(), tmp.end() );
+}
+
+// TODO: Make this more efficient
+static void expand_recipes( std::vector<const recipe *> &current,
+                            std::vector<int> &indent,
+                            std::map<const recipe *, availability> &availability_cache,
+                            Character &crafter, bool unread_recipes_first, bool highlight_unread_recipes,
+                            const recipe_subset &available_recipes, const std::set<recipe_id> &hidden_recipes,
+                            bool camp_crafting, inventory *inventory_override )
+{
+    for( size_t i = 0; i < current.size(); ++i ) {
+        if( current[i]->is_nested()
+            && uistate.expanded_recipes.find( current[i]->ident() ) != uistate.expanded_recipes.end()
+          ) {
+            recursively_expand_recipes( current, indent, availability_cache, i, crafter,
+                                        unread_recipes_first, highlight_unread_recipes, available_recipes,
+                                        hidden_recipes, camp_crafting, inventory_override );
+        }
+    }
+}
+
+std::string list_nested( Character &crafter, const recipe *rec,
+                         const recipe_subset &available_recipes,
+                         int indent_level )
+{
+    std::string description;
+    availability avail( crafter, rec );
+    if( rec->is_nested() ) {
+        description += colorize( std::string( indent_level,
+                                              ' ' ) + rec->result_name() + ":\n", avail.color() );
+        for( const recipe_id &r : rec->nested_category_data ) {
+            description += list_nested( crafter, &r.obj(), available_recipes, indent_level + 2 );
+        }
+    } else if( available_recipes.contains( rec ) ) {
+        description += colorize( std::string( indent_level,
+                                              ' ' ) + rec->result_name() + "\n", avail.color() );
+    }
+
+    return description;
+}
+
+recipe_list_data build_recipe_list(
+    std::vector<const recipe *> picking,
+    bool skip_hidden_filter,
+    bool skip_sort,
+    Character &crafter,
+    bool camp_crafting,
+    inventory *inventory_override,
+    bool highlight_unread,
+    bool unread_first,
+    std::map<const recipe *, availability> &availability_cache,
+    const recipe_subset &available_recipes )
+{
+    recipe_list_data result;
+
+    if( skip_hidden_filter ) {
+        result.entries = std::move( picking );
+    } else {
+        for( const recipe *r : picking ) {
+            if( uistate.hidden_recipes.find( r->ident() ) == uistate.hidden_recipes.end() ) {
+                result.entries.push_back( r );
+            }
+        }
+        result.num_hidden = picking.size() - result.entries.size();
+    }
+
+    // Cache availability on first display
+    for( const recipe *e : result.entries ) {
+        if( !availability_cache.count( e ) ) {
+            availability_cache.emplace( e,
+                                        availability( crafter, e, 1, camp_crafting, inventory_override ) );
+        }
+    }
+
+    if( !skip_sort ) {
+        const bool want_unread = highlight_unread && unread_first;
+        std::stable_sort( result.entries.begin(), result.entries.end(), [
+                       &crafter, &availability_cache, want_unread
+        ]( const recipe * const a, const recipe * const b ) {
+            const bool a_read = !want_unread || uistate.read_recipes.count( a->ident() );
+            const bool b_read = !want_unread || uistate.read_recipes.count( b->ident() );
+            return recipe_sort_compare( a, b,
+                                        availability_cache.at( a ), availability_cache.at( b ),
+                                        crafter, a_read, b_read, want_unread );
+        } );
+    }
+
+    // Set up indents and expand nested categories (must happen after sort)
+    result.indent.assign( result.entries.size(), 0 );
+    expand_recipes( result.entries, result.indent, availability_cache, crafter,
+                    unread_first, highlight_unread, available_recipes, uistate.hidden_recipes,
+                    camp_crafting, inventory_override );
+
+    // Build the parallel availability vector
+    result.available.reserve( result.entries.size() );
+    std::transform( result.entries.begin(), result.entries.end(),
+    std::back_inserter( result.available ), [&]( const recipe * e ) {
+        return availability_cache.at( e );
+    } );
+
+    return result;
 }

--- a/src/crafting_gui_helpers.h
+++ b/src/crafting_gui_helpers.h
@@ -4,6 +4,7 @@
 
 #include <cstddef>
 #include <functional>
+#include <map>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -127,5 +128,37 @@ item get_recipe_result_item( const recipe &rec, Character &crafter );
 // with section headers and quantity scaling for batch_size.
 std::vector<iteminfo> recipe_result_info( const recipe &rec, Character &crafter,
         int batch_size, int panel_width );
+
+// Return type for build_recipe_list().
+struct recipe_list_data {
+    std::vector<const recipe *> entries;
+    std::vector<int> indent;
+    std::vector<availability> available;
+    size_t num_hidden = 0;
+};
+
+// Processes a raw recipe list from category lookup or filter:
+// 1. Filters out hidden recipes (unless skip_hidden_filter is true)
+// 2. Caches availability for each recipe in the provided cache
+// 3. Sorts by craftability, difficulty, name (skipped when skip_sort is true)
+// 4. Expands nested recipe categories
+// 5. Builds the parallel availability vector
+recipe_list_data build_recipe_list(
+    std::vector<const recipe *> picking,
+    bool skip_hidden_filter,
+    bool skip_sort,
+    Character &crafter,
+    bool camp_crafting,
+    inventory *inventory_override,
+    bool highlight_unread,
+    bool unread_first,
+    std::map<const recipe *, availability> &availability_cache,
+    const recipe_subset &available_recipes );
+
+// Generates a colored hierarchical text description of nested recipe contents.
+// Used by the item info panel when a nested category is selected.
+std::string list_nested( Character &crafter, const recipe *rec,
+                         const recipe_subset &available_recipes,
+                         int indent_level = 0 );
 
 #endif // CATA_SRC_CRAFTING_GUI_HELPERS_H

--- a/tests/crafting_gui_test.cpp
+++ b/tests/crafting_gui_test.cpp
@@ -1,7 +1,9 @@
 #include <algorithm>
 #include <cstddef>
 #include <functional>
+#include <map>
 #include <memory>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -12,6 +14,7 @@
 #include "character_attire.h"
 #include "color.h"
 #include "crafting_gui_helpers.h"
+#include "flat_set.h"
 #include "npc.h"
 #include "recipe_dictionary.h"
 #include "game.h"
@@ -22,6 +25,7 @@
 #include "player_helpers.h"
 #include "recipe.h"
 #include "type_id.h"
+#include "uistate.h"
 #include "weather_type.h"
 
 static const itype_id itype_2x4( "2x4" );
@@ -43,8 +47,8 @@ static const recipe_id recipe_cudgel_slow( "cudgel_slow" );
 static const recipe_id recipe_cudgel_test_no_tools( "cudgel_test_no_tools" );
 static const recipe_id recipe_meat_cooked_test_no_tools( "meat_cooked_test_no_tools" );
 static const recipe_id recipe_prac_knapping( "prac_knapping" );
-static const recipe_id recipe_test_nested_weapons( "test_nested_weapons" );
 static const recipe_id recipe_test_longshirt_test_poor_fit( "test_longshirt_test_poor_fit" );
+static const recipe_id recipe_test_nested_weapons( "test_nested_weapons" );
 static const recipe_id recipe_test_tallow( "test_tallow" );
 static const recipe_id recipe_water_clean_test_in_jar( "water_clean_test_in_jar" );
 
@@ -1053,4 +1057,130 @@ TEST_CASE( "result_info_varsize_poor_fit_warning", "[crafting][gui][result_info]
     std::vector<iteminfo> info = recipe_result_info( rec, guy, 1, 80 );
 
     CHECK( info_has_text( info, "poorly" ) );
+}
+
+// --- Recipe list pipeline tests ---
+
+static void clear_recipe_ui_state()
+{
+    uistate.hidden_recipes.clear();
+    uistate.expanded_recipes.clear();
+    uistate.read_recipes.clear();
+}
+
+TEST_CASE( "build_recipe_list_hides_hidden", "[crafting][gui][recipe_list]" )
+{
+    clear_recipe_ui_state();
+    Character &guy = setup_character();
+
+    const recipe *cudgel = &recipe_cudgel_test_no_tools.obj();
+    const recipe *tallow = &recipe_test_tallow.obj();
+    std::vector<const recipe *> picking = { cudgel, tallow };
+    recipe_subset available = make_subset( picking );
+
+    uistate.hidden_recipes.insert( recipe_cudgel_test_no_tools );
+
+    std::map<const recipe *, availability> cache;
+    recipe_list_data result = build_recipe_list( picking, false, false,
+                              guy, false, nullptr, false, false, cache, available );
+
+    for( const recipe *entry : result.entries ) {
+        CHECK_FALSE( entry->ident() == recipe_cudgel_test_no_tools );
+    }
+    CHECK( result.num_hidden == 1 );
+}
+
+TEST_CASE( "build_recipe_list_skip_hidden_filter", "[crafting][gui][recipe_list]" )
+{
+    clear_recipe_ui_state();
+    Character &guy = setup_character();
+
+    const recipe *cudgel = &recipe_cudgel_test_no_tools.obj();
+    std::vector<const recipe *> picking = { cudgel };
+    recipe_subset available = make_subset( picking );
+
+    uistate.hidden_recipes.insert( recipe_cudgel_test_no_tools );
+
+    std::map<const recipe *, availability> cache;
+    recipe_list_data result = build_recipe_list( picking, true, false,
+                              guy, false, nullptr, false, false, cache, available );
+
+    CHECK_FALSE( result.entries.empty() );
+    CHECK( result.entries[0]->ident() == recipe_cudgel_test_no_tools );
+    CHECK( result.num_hidden == 0 );
+}
+
+TEST_CASE( "build_recipe_list_sort_craftable_first", "[crafting][gui][recipe_list]" )
+{
+    clear_recipe_ui_state();
+    Character &guy = setup_character();
+    guy.set_skill_level( skill_fabrication, 2 );
+    guy.set_skill_level( skill_melee, 1 );
+    guy.i_add( item( itype_2x4 ) );
+    guy.invalidate_crafting_inventory();
+
+    // cudgel_test_no_tools: needs 2x4, no tools -- craftable with inventory above
+    // test_tallow: needs fat + CUT 2 quality -- not craftable (no fat or knife)
+    const recipe *cudgel = &recipe_cudgel_test_no_tools.obj();
+    const recipe *tallow = &recipe_test_tallow.obj();
+    std::vector<const recipe *> picking = { tallow, cudgel };
+    recipe_subset available = make_subset( picking );
+
+    std::map<const recipe *, availability> cache;
+    recipe_list_data result = build_recipe_list( picking, false, false,
+                              guy, false, nullptr, false, false, cache, available );
+
+    REQUIRE( result.available.size() == 2 );
+    // Craftable recipes come first in sorted order
+    bool seen_uncraftable = false;
+    for( const availability &entry : result.available ) {
+        if( !entry.can_craft ) {
+            seen_uncraftable = true;
+        } else {
+            CHECK_FALSE( seen_uncraftable );
+        }
+    }
+}
+
+TEST_CASE( "build_recipe_list_expands_nested", "[crafting][gui][recipe_list]" )
+{
+    clear_recipe_ui_state();
+    Character &guy = setup_character();
+    guy.set_skill_level( skill_fabrication, 2 );
+    guy.set_skill_level( skill_melee, 1 );
+
+    const recipe *nested = &recipe_test_nested_weapons.obj();
+    const recipe *cudgel = &recipe_cudgel_test_no_tools.obj();
+    std::vector<const recipe *> picking = { nested };
+    // available_recipes must contain the child recipe for expansion to include it
+    recipe_subset available = make_subset( { nested, cudgel } );
+
+    uistate.expanded_recipes.insert( recipe_test_nested_weapons );
+
+    std::map<const recipe *, availability> cache;
+    recipe_list_data result = build_recipe_list( picking, false, false,
+                              guy, false, nullptr, false, false, cache, available );
+
+    // Expansion should have inserted the child after the nested category
+    REQUIRE( result.entries.size() == 2 );
+    CHECK( result.entries[0]->ident() == recipe_test_nested_weapons );
+    CHECK( result.entries[1]->ident() == recipe_cudgel_test_no_tools );
+    CHECK( result.indent[0] < result.indent[1] );
+}
+
+TEST_CASE( "list_nested_generates_tree", "[crafting][gui][recipe_list]" )
+{
+    clear_recipe_ui_state();
+    Character &guy = setup_character();
+    guy.set_skill_level( skill_fabrication, 2 );
+    guy.set_skill_level( skill_melee, 1 );
+
+    const recipe *nested = &recipe_test_nested_weapons.obj();
+    const recipe *cudgel = &recipe_cudgel_test_no_tools.obj();
+    recipe_subset available = make_subset( { nested, cudgel } );
+
+    std::string desc = list_nested( guy, nested, available );
+
+    CHECK( desc.find( "test nested weapons" ) != std::string::npos );
+    CHECK( desc.find( "cudgel" ) != std::string::npos );
 }


### PR DESCRIPTION
#### Summary
Infrastructure "Extract recipe list pipeline for testability"

#### Purpose of change
Follow-up to #85978. The recalc block inside `select_crafter_and_crafting_recipe()` was the largest remaining chunk of pure logic in `crafting_gui.cpp` -- hidden filtering, availability caching, sorting, and nested expansion all tangled together in ~80 lines with zero test coverage.

#### Describe the solution
Pull the pipeline into `build_recipe_list()` in helpers. It takes a raw recipe vector and returns a `recipe_list_data` struct (entries, indent, available, num_hidden). The caller shrinks to category-lookup/filter + a single function call.

`list_nested()` (colored tree text for the nested recipe info panel) moves as a public helper. `expand_recipes()` and `recursively_expand_recipes()` move as file-local statics.

Also fixes a pre-existing bug: nested child availability was always computed with `camp_crafting=false, inventory_override=nullptr` instead of forwarding the actual values. Both expansion functions now take those parameters.

`skip_sort` is derived from subtab state independently of whether a filter is active, preserving the existing behavior where the Recent tab keeps recency order even with a filter string.

#### Describe alternatives you've considered
Considered passing `uistate` sets (hidden_recipes, expanded_recipes, read_recipes) as explicit parameters for full decoupling from global state. Kept direct uistate access instead -- it matches the existing pattern in `recipe_subset::favorite()` etc., and the tests manipulate uistate directly without issues.

#### Testing
Five new test cases covering the pipeline: hidden filtering, skip_hidden_filter bypass, craftable-first sort invariant, nested expansion with correct indent, and list_nested tree generation. Tests use manually constructed recipe subsets to avoid flaky character recipe learning state between test cases.

Full `[crafting][gui]` suite passes with no regressions.

#### Additional context
Depends on #85978.