### PR TITLE
NPC needs: urgency scoring and utility strategy

### DIFF
--- a/data/json/npcs/npc_behavior.json
+++ b/data/json/npcs/npc_behavior.json
@@ -2,7 +2,7 @@
   {
     "type": "behavior",
     "id": "npc_needs",
-    "strategy": "sequential_until_done",
+    "strategy": "utility",
     "children": [ "npc_homeostasis", "npc_thirst", "npc_hunger" ]
   },
   {
@@ -10,7 +10,8 @@
     "id": "npc_homeostasis",
     "strategy": "fallback",
     "conditions": [ { "predicate": "npc_needs_warmth_badly" } ],
-    "children": [ "npc_wear_warmer_clothes", "npc_get_warm" ]
+    "children": [ "npc_wear_warmer_clothes", "npc_get_warm" ],
+    "score": "npc_warmth_urgency"
   },
   {
     "type": "behavior",
@@ -41,7 +42,8 @@
     "id": "npc_thirst",
     "strategy": "sequential",
     "conditions": [ { "predicate": "npc_needs_water_badly" } ],
-    "children": [ "npc_drink_water" ]
+    "children": [ "npc_drink_water" ],
+    "score": "npc_thirst_urgency"
   },
   {
     "type": "behavior",
@@ -54,7 +56,8 @@
     "id": "npc_hunger",
     "strategy": "sequential",
     "conditions": [ { "predicate": "npc_needs_food_badly" } ],
-    "children": [ "npc_eat_food" ]
+    "children": [ "npc_eat_food" ],
+    "score": "npc_hunger_urgency"
   },
   {
     "type": "behavior",

--- a/src/behavior_oracle.cpp
+++ b/src/behavior_oracle.cpp
@@ -30,6 +30,12 @@ make_function( status_t ( monster_oracle_t::* fun )( std::string_view ) const )
     return static_cast<status_t ( oracle_t::* )( std::string_view ) const>( fun );
 }
 
+static std::function<float( const oracle_t *, std::string_view )>
+make_score_function( float ( character_oracle_t::* fun )( std::string_view ) const )
+{
+    return static_cast<float ( oracle_t::* )( std::string_view ) const>( fun );
+}
+
 std::unordered_map<std::string, std::function<status_t( const oracle_t *, std::string_view ) >>
 predicate_map = {{
         { "npc_needs_warmth_badly", make_function( &character_oracle_t::needs_warmth_badly ) },
@@ -49,6 +55,11 @@ predicate_map = {{
 };
 
 std::unordered_map<std::string, std::function<float( const oracle_t *, std::string_view )>>
-        score_predicate_map = {};
+score_predicate_map = {{
+        { "npc_thirst_urgency", make_score_function( &character_oracle_t::thirst_urgency ) },
+        { "npc_hunger_urgency", make_score_function( &character_oracle_t::hunger_urgency ) },
+        { "npc_warmth_urgency", make_score_function( &character_oracle_t::warmth_urgency ) }
+    }
+};
 
 } // namespace behavior

--- a/src/character_oracle.cpp
+++ b/src/character_oracle.cpp
@@ -1,5 +1,6 @@
 #include "character_oracle.h"
 
+#include <algorithm>
 #include <functional>
 #include <memory>
 #include <vector>
@@ -107,6 +108,42 @@ status_t character_oracle_t::has_food( std::string_view ) const
         return cand.is_food() && cand.get_comestible()->has_calories();
     } );
     return found_food ? status_t::running : status_t::failure;
+}
+
+float character_oracle_t::thirst_urgency( std::string_view ) const
+{
+    // 0 = hydrated, 1 = dehydration death (threshold 1200, character_health.cpp).
+    static constexpr float death_threshold = 1200.0f;
+    return std::clamp( subject->get_thirst() / death_threshold, 0.0f, 1.0f );
+}
+
+float character_oracle_t::hunger_urgency( std::string_view ) const
+{
+    // 0 = healthy weight, 1 = starvation death (stored_kcal <= 0, character_health.cpp).
+    const int healthy = subject->get_healthy_kcal();
+    if( healthy <= 0 ) {
+        return 0.0f;
+    }
+    const float kcal_frac = static_cast<float>( subject->get_stored_kcal() ) / healthy;
+    return std::clamp( 1.0f - kcal_frac, 0.0f, 1.0f );
+}
+
+float character_oracle_t::warmth_urgency( std::string_view ) const
+{
+    // 0 = all bodyparts at BODYTEMP_NORM (37C),
+    // 1 = coldest bodypart at BODYTEMP_FREEZING (28C).
+    const float norm = units::to_kelvin( BODYTEMP_NORM );
+    const float freeze = units::to_kelvin( BODYTEMP_FREEZING );
+    const float range = norm - freeze;
+    if( range <= 0.0f ) {
+        return 0.0f;
+    }
+    float coldest = norm;
+    for( const bodypart_id &bp : subject->get_all_body_parts() ) {
+        const float temp = units::to_kelvin( subject->get_part_temp_conv( bp ) );
+        coldest = std::min( coldest, temp );
+    }
+    return std::clamp( ( norm - coldest ) / range, 0.0f, 1.0f );
 }
 
 } // namespace behavior

--- a/src/character_oracle.h
+++ b/src/character_oracle.h
@@ -29,6 +29,12 @@ class character_oracle_t : public oracle_t
         status_t can_take_shelter( std::string_view ) const;
         status_t has_water( std::string_view ) const;
         status_t has_food( std::string_view ) const;
+        /**
+         * Score predicates for utility strategy (return 0-1 urgency).
+         */
+        float thirst_urgency( std::string_view ) const;
+        float hunger_urgency( std::string_view ) const;
+        float warmth_urgency( std::string_view ) const;
     private:
         const Character *subject;
 };

--- a/tests/behavior_test.cpp
+++ b/tests/behavior_test.cpp
@@ -10,6 +10,7 @@
 #include "behavior.h"
 #include "behavior_oracle.h"
 #include "behavior_strategy.h"
+#include "bodypart.h"
 #include "calendar.h"
 #include "cata_catch.h"
 #include "character_attire.h"
@@ -590,5 +591,58 @@ TEST_CASE( "behavior_tree_utility_strategy", "[behavior]" )
 
         // Clean up
         behavior::score_predicate_map.erase( "test_urgency" );
+    }
+}
+
+TEST_CASE( "npc_urgency_score_predicates", "[npc][behavior]" )
+{
+    clear_map_without_vision();
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy );
+    behavior::character_oracle_t oracle( &guy );
+
+    SECTION( "thirst_urgency scales from 0 to 1" ) {
+        guy.set_thirst( 0 );
+        CHECK( oracle.thirst_urgency( "" ) == Approx( 0.0f ).margin( 0.01f ) );
+
+        guy.set_thirst( 600 );
+        CHECK( oracle.thirst_urgency( "" ) == Approx( 0.5f ).margin( 0.01f ) );
+
+        guy.set_thirst( 1200 );
+        CHECK( oracle.thirst_urgency( "" ) == Approx( 1.0f ).margin( 0.01f ) );
+    }
+
+    SECTION( "hunger_urgency scales with kcal deficit" ) {
+        const int healthy = guy.get_healthy_kcal();
+        guy.set_stored_kcal( healthy );
+        CHECK( oracle.hunger_urgency( "" ) == Approx( 0.0f ).margin( 0.01f ) );
+
+        guy.set_stored_kcal( healthy / 2 );
+        CHECK( oracle.hunger_urgency( "" ) == Approx( 0.5f ).margin( 0.05f ) );
+
+        guy.set_stored_kcal( 0 );
+        CHECK( oracle.hunger_urgency( "" ) == Approx( 1.0f ).margin( 0.01f ) );
+    }
+
+    SECTION( "warmth_urgency responds to cold bodyparts" ) {
+        // Explicitly set baseline -- clear_character does not guarantee temps
+        guy.set_all_parts_temp_conv( BODYTEMP_NORM );
+        CHECK( oracle.warmth_urgency( "" ) < 0.01f );
+
+        // Single cold bodypart drives the score
+        guy.set_part_temp_conv( body_part_torso, BODYTEMP_VERY_COLD );
+        float cold_score = oracle.warmth_urgency( "" );
+        CHECK( cold_score > 0.5f );
+        CHECK( cold_score < 1.0f );
+
+        // At BODYTEMP_FREEZING the score saturates near 1.0
+        guy.set_part_temp_conv( body_part_torso, BODYTEMP_FREEZING );
+        CHECK( oracle.warmth_urgency( "" ) == Approx( 1.0f ).margin( 0.05f ) );
+    }
+
+    SECTION( "score predicates registered in score_predicate_map" ) {
+        CHECK( behavior::score_predicate_map.count( "npc_thirst_urgency" ) == 1 );
+        CHECK( behavior::score_predicate_map.count( "npc_hunger_urgency" ) == 1 );
+        CHECK( behavior::score_predicate_map.count( "npc_warmth_urgency" ) == 1 );
     }
 }

--- a/tests/behavior_test.cpp
+++ b/tests/behavior_test.cpp
@@ -237,8 +237,9 @@ TEST_CASE( "check_npc_behavior_tree", "[npc][behavior]" )
         CHECK( npc_needs.tick( &oracle ) == "idle" );
     }
     SECTION( "Thirsty and hungry" ) {
-        // When both thirsty and hungry, thirst takes priority
-        // (npc_thirst comes before npc_hunger in sequential_until_done)
+        // With utility strategy, the more urgent need wins.
+        // Near-starvation (stored_kcal=1000, urgency ~0.98) beats
+        // moderate dehydration (thirst=700, urgency ~0.58).
         test_npc.set_thirst( 700 );
         test_npc.set_hunger( 500 );
         test_npc.set_stored_kcal( 1000 );
@@ -250,7 +251,93 @@ TEST_CASE( "check_npc_behavior_tree", "[npc][behavior]" )
         test_npc.i_add( item( itype_sandwich_cheese_grilled ) );
         REQUIRE( oracle.has_water( "" ) == behavior::status_t::running );
         REQUIRE( oracle.has_food( "" ) == behavior::status_t::running );
+        CHECK( npc_needs.tick( &oracle ) == "eat_food" );
+    }
+    SECTION( "Hunger wins over thirst when starvation is more urgent" ) {
+        // Hunger comes AFTER thirst in tree order, so under sequential_until_done
+        // thirst would always win. With utility, hunger wins when its score is
+        // higher. stored_kcal=1000 gives hunger_urgency ~0.98 vs
+        // thirst_urgency at 600 = 0.5.
+        test_npc.set_stored_kcal( 1000 );
+        test_npc.set_hunger( 500 );
+        test_npc.set_thirst( 600 );
+        REQUIRE( oracle.needs_water_badly( "" ) == behavior::status_t::running );
+        REQUIRE( oracle.needs_food_badly( "" ) == behavior::status_t::running );
+        const item_group::ItemList water_items = item_group::items_from(
+                    Item_spawn_data_test_bottle_water );
+        test_npc.i_add( water_items.front() );
+        test_npc.i_add( item( itype_sandwich_cheese_grilled ) );
+        REQUIRE( oracle.has_water( "" ) == behavior::status_t::running );
+        REQUIRE( oracle.has_food( "" ) == behavior::status_t::running );
+        CHECK( npc_needs.tick( &oracle ) == "eat_food" );
+    }
+    SECTION( "Thirst wins over hunger when dehydration is more urgent" ) {
+        // Guards the "score": "npc_thirst_urgency" wiring on npc_thirst.
+        // Without it, thirst defaults to score 0 and loses to any scored hunger.
+        // At 45% healthy kcal, starvation ~2794 > base_metabolic_rate (2500)
+        // so needs_food_badly fires. But hunger_urgency (0.55) < thirst_urgency
+        // at 800 (0.667), so thirst wins.
+        const int healthy = test_npc.get_healthy_kcal();
+        test_npc.set_stored_kcal( healthy * 45 / 100 );
+        test_npc.set_hunger( 500 );
+        test_npc.set_thirst( 800 );
+        REQUIRE( oracle.needs_water_badly( "" ) == behavior::status_t::running );
+        REQUIRE( oracle.needs_food_badly( "" ) == behavior::status_t::running );
+        const item_group::ItemList water_items = item_group::items_from(
+                    Item_spawn_data_test_bottle_water );
+        test_npc.i_add( water_items.front() );
+        test_npc.i_add( item( itype_sandwich_cheese_grilled ) );
+        REQUIRE( oracle.has_water( "" ) == behavior::status_t::running );
+        REQUIRE( oracle.has_food( "" ) == behavior::status_t::running );
         CHECK( npc_needs.tick( &oracle ) == "drink_water" );
+    }
+    SECTION( "Freezing wins over moderate thirst" ) {
+        weather_manager &weather = get_weather();
+        weather.temperature = units::from_fahrenheit( 0 );
+        weather.clear_temp_cache();
+        test_npc.update_bodytemp();
+        REQUIRE( oracle.needs_warmth_badly( "" ) == behavior::status_t::running );
+
+        test_npc.set_thirst( 700 );
+        REQUIRE( oracle.needs_water_badly( "" ) == behavior::status_t::running );
+
+        // Warm clothes + water available
+        test_npc.worn.wear_item( test_npc, item( itype_backpack ), false, false );
+        test_npc.i_add( item( itype_sweater ) );
+        const item_group::ItemList water_items = item_group::items_from(
+                    Item_spawn_data_test_bottle_water );
+        test_npc.i_add( water_items.front() );
+        REQUIRE( oracle.can_wear_warmer_clothes( "" ) == behavior::status_t::running );
+        REQUIRE( oracle.has_water( "" ) == behavior::status_t::running );
+
+        // warmth_urgency (near 1.0) >> thirst_urgency (0.58)
+        CHECK( npc_needs.tick( &oracle ) == "wear_warmer_clothes" );
+    }
+    SECTION( "Freezing with fire supplies also wins over thirst" ) {
+        // Proves the score lives on npc_homeostasis (the fallback branch),
+        // not on npc_wear_warmer_clothes. If the score were misplaced on
+        // the leaf, this path through npc_make_fire would be unscored.
+        weather_manager &weather = get_weather();
+        weather.temperature = units::from_fahrenheit( 0 );
+        weather.clear_temp_cache();
+        test_npc.update_bodytemp();
+        REQUIRE( oracle.needs_warmth_badly( "" ) == behavior::status_t::running );
+
+        test_npc.set_thirst( 700 );
+        REQUIRE( oracle.needs_water_badly( "" ) == behavior::status_t::running );
+
+        // Fire supplies + water, no warm clothes
+        test_npc.worn.wear_item( test_npc, item( itype_backpack ), false, false );
+        test_npc.i_add( item( itype_lighter ) );
+        test_npc.i_add( item( itype_2x4 ) );
+        const item_group::ItemList water_items = item_group::items_from(
+                    Item_spawn_data_test_bottle_water );
+        test_npc.i_add( water_items.front() );
+        REQUIRE( oracle.can_wear_warmer_clothes( "" ) != behavior::status_t::running );
+        REQUIRE( oracle.can_make_fire( "" ) == behavior::status_t::running );
+        REQUIRE( oracle.has_water( "" ) == behavior::status_t::running );
+
+        CHECK( npc_needs.tick( &oracle ) == "start_fire" );
     }
 }
 


### PR DESCRIPTION
#### Summary
Infrastructure "Add urgency score predicates and switch NPC behavior tree to utility strategy"

#### Purpose of change

The utility strategy landed in #85924 but had no payload -- `score_predicate_map` was empty and `npc_behavior.json` still used `sequential_until_done` at the root. This fills it in so the behavior tree actually prioritizes competing needs by urgency instead of fixed tree order.

Continues the NPC needs architecture from #28681.

#### Describe the solution

Commit 1 adds three float-returning methods on `character_oracle_t`, registered in `score_predicate_map`:

- `thirst_urgency` -- `thirst / 1200` (dehydration death threshold), 0 when hydrated, 1 at death
- `hunger_urgency` -- `1 - stored_kcal / healthy_kcal`, 0 at healthy weight, 1 at starvation
- `warmth_urgency` -- coldest bodypart distance from `BODYTEMP_NORM` toward `BODYTEMP_FREEZING`

Commit 2 switches the `npc_needs` root strategy from `sequential_until_done` to `utility` and adds score fields to the three branch nodes. Scores live on the branch level so all fallback alternatives (wear clothes vs make fire) inherit the parent's urgency.

No gameplay change -- the behavior tree only drives the `DF_NPC_NEEDS` debug diagnostic for now. But the diagnostic shows dynamic priority shifts instead of a hardcoded order.

#### Describe alternatives you've considered

Could have used `1/time_to_die` (reciprocal of estimated turns until death) but that requires modeling consumption rates, stomach water, activity level, enchantments... Normalized 0-1 urgency against the death threshold is simpler, comparable across need types, and good enough to get the architecture working. Fancier formulas can slot in later without changing the tree structure.

#### Testing

Each JSON score field has a dedicated test that breaks if the wiring is missing or misspelled -- hunger score tested by two sections where hunger beats thirst (impossible under old fixed ordering), thirst score by a section where thirst beats hunger (if score missing it defaults to 0 and loses), warmth score by two sections (clothes path and fire path) where warmth beats thirst (catches score misplaced on leaf vs branch).

All 198 behavior tree assertions pass. Verified the hunger-beats-thirst tests fail when reverting the JSON to `sequential_until_done`.

#### Additional context

The debug diagnostic (`DF_NPC_NEEDS` from #85927) now shows whichever need is most urgent each NPC turn, useful for tuning the urgency curves and for contributors working on the action dispatch layer.