### PR TITLE
NPC needs: convergence diagnostic, sleepiness, shelter, can_make_fire fix

### DIFF
--- a/data/json/npcs/npc_behavior.json
+++ b/data/json/npcs/npc_behavior.json
@@ -3,7 +3,7 @@
     "type": "behavior",
     "id": "npc_needs",
     "strategy": "utility",
-    "children": [ "npc_homeostasis", "npc_thirst", "npc_hunger" ]
+    "children": [ "npc_homeostasis", "npc_thirst", "npc_hunger", "npc_sleepiness" ]
   },
   {
     "type": "behavior",
@@ -64,5 +64,19 @@
     "id": "npc_eat_food",
     "conditions": [ { "predicate": "npc_has_food" } ],
     "goal": "eat_food"
+  },
+  {
+    "type": "behavior",
+    "id": "npc_sleepiness",
+    "strategy": "sequential",
+    "conditions": [ { "predicate": "npc_needs_sleep_badly" } ],
+    "children": [ "npc_go_to_sleep" ],
+    "score": "npc_sleepiness_urgency"
+  },
+  {
+    "type": "behavior",
+    "id": "npc_go_to_sleep",
+    "conditions": [ { "predicate": "npc_can_sleep" } ],
+    "goal": "go_to_sleep"
   }
 ]

--- a/src/behavior_oracle.cpp
+++ b/src/behavior_oracle.cpp
@@ -46,6 +46,8 @@ predicate_map = {{
         { "npc_can_take_shelter", make_function( &character_oracle_t::can_take_shelter ) },
         { "npc_has_water", make_function( &character_oracle_t::has_water ) },
         { "npc_has_food", make_function( &character_oracle_t::has_food ) },
+        { "npc_needs_sleep_badly", make_function( &character_oracle_t::needs_sleep_badly ) },
+        { "npc_can_sleep", make_function( &character_oracle_t::can_sleep ) },
         { "monster_not_hallucination", make_function( &monster_oracle_t::not_hallucination ) },
         { "monster_items_available", make_function( &monster_oracle_t::items_available ) },
         { "monster_split_possible", make_function( &monster_oracle_t::split_possible ) },
@@ -58,7 +60,8 @@ std::unordered_map<std::string, std::function<float( const oracle_t *, std::stri
 score_predicate_map = {{
         { "npc_thirst_urgency", make_score_function( &character_oracle_t::thirst_urgency ) },
         { "npc_hunger_urgency", make_score_function( &character_oracle_t::hunger_urgency ) },
-        { "npc_warmth_urgency", make_score_function( &character_oracle_t::warmth_urgency ) }
+        { "npc_warmth_urgency", make_score_function( &character_oracle_t::warmth_urgency ) },
+        { "npc_sleepiness_urgency", make_score_function( &character_oracle_t::sleepiness_urgency ) }
     }
 };
 

--- a/src/character_oracle.cpp
+++ b/src/character_oracle.cpp
@@ -8,14 +8,19 @@
 #include "behavior.h"
 #include "bodypart.h"
 #include "character.h"
+#include "coordinates.h"
 #include "item.h"
 #include "itype.h"
+#include "map.h"
+#include "map_iterator.h"
+#include "mapdata.h"
 #include "ret_val.h"
 #include "type_id.h"
 #include "units.h"
 #include "value_ptr.h"
 #include "weather.h"
 
+static const efftype_id effect_meth( "meth" );
 static const flag_id json_flag_FIRESTARTER( "FIRESTARTER" );
 
 namespace behavior
@@ -83,12 +88,24 @@ status_t character_oracle_t::can_make_fire( std::string_view ) const
         }
         return false;
     } );
-    return found_fire_stuff ? status_t::running : status_t::success;
+    return found_fire_stuff ? status_t::running : status_t::failure;
 }
 
 status_t character_oracle_t::can_take_shelter( std::string_view ) const
 {
-    // Stub: shelter detection not implemented yet. See #28681.
+    // "Take shelter" is an action: move to an indoor tile.
+    // Already indoors -> action not applicable.
+    // Outdoors with adjacent indoor tile -> shelter within reach.
+    const map &here = get_map();
+    const tripoint_bub_ms &pos = subject->pos_bub();
+    if( here.has_flag( ter_furn_flag::TFLAG_INDOORS, pos ) ) {
+        return status_t::failure;
+    }
+    for( const tripoint_bub_ms &adj : here.points_in_radius( pos, 1 ) ) {
+        if( here.has_flag( ter_furn_flag::TFLAG_INDOORS, adj ) && here.passable( adj ) ) {
+            return status_t::running;
+        }
+    }
     return status_t::failure;
 }
 
@@ -108,6 +125,16 @@ status_t character_oracle_t::has_food( std::string_view ) const
         return cand.is_food() && cand.get_comestible()->has_calories();
     } );
     return found_food ? status_t::running : status_t::failure;
+}
+
+status_t character_oracle_t::needs_sleep_badly( std::string_view ) const
+{
+    // DEAD_TIRED (383) = microsleeps start, 38% of MASSIVE_SLEEPINESS.
+    // Parallels needs_water_badly at 43% of death threshold.
+    if( subject->get_sleepiness() >= static_cast<int>( sleepiness_levels::DEAD_TIRED ) ) {
+        return status_t::running;
+    }
+    return status_t::success;
 }
 
 float character_oracle_t::thirst_urgency( std::string_view ) const
@@ -144,6 +171,28 @@ float character_oracle_t::warmth_urgency( std::string_view ) const
         coldest = std::min( coldest, temp );
     }
     return std::clamp( ( norm - coldest ) / range, 0.0f, 1.0f );
+}
+
+status_t character_oracle_t::can_sleep( std::string_view ) const
+{
+    // Meth is the only hard blocker in Character::can_sleep().
+    // Stim, comfort, insomnia, and rng are soft score modifiers whose
+    // net effect depends on location and luck -- the oracle can't
+    // evaluate those without knowing where the NPC will sleep.
+    if( subject->has_effect( effect_meth ) ) {
+        return status_t::failure;
+    }
+    if( subject->get_sleepiness() >= static_cast<int>( sleepiness_levels::EXHAUSTED ) ) {
+        return status_t::running;
+    }
+    return status_t::failure;
+}
+
+float character_oracle_t::sleepiness_urgency( std::string_view ) const
+{
+    // 0 = rested, 1 = forced unconsciousness (MASSIVE_SLEEPINESS = 1000).
+    static constexpr float cap = 1000.0f;
+    return std::clamp( subject->get_sleepiness() / cap, 0.0f, 1.0f );
 }
 
 } // namespace behavior

--- a/src/character_oracle.h
+++ b/src/character_oracle.h
@@ -29,12 +29,15 @@ class character_oracle_t : public oracle_t
         status_t can_take_shelter( std::string_view ) const;
         status_t has_water( std::string_view ) const;
         status_t has_food( std::string_view ) const;
+        status_t needs_sleep_badly( std::string_view ) const;
+        status_t can_sleep( std::string_view ) const;
         /**
          * Score predicates for utility strategy (return 0-1 urgency).
          */
         float thirst_urgency( std::string_view ) const;
         float hunger_urgency( std::string_view ) const;
         float warmth_urgency( std::string_view ) const;
+        float sleepiness_urgency( std::string_view ) const;
     private:
         const Character *subject;
 };

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -1420,11 +1420,17 @@ void npc::move()
 
     if( debug_mode && debugmode::enabled_filters.count( debugmode::DF_NPC_NEEDS ) ) {
         behavior::character_oracle_t oracle( this );
-        behavior::tree needs;
-        needs.add( &behavior_node_t_npc_needs.obj() );
-        const std::string bt_goal = needs.tick( &oracle );
+        behavior::tree bt;
+        bt.add( &behavior_node_t_npc_needs.obj() );
+        const std::string bt_goal = bt.tick( &oracle );
+        const auto saved_needs = needs;
+        decide_needs();
+        const std::string legacy_top = needs.empty()
+                                       ? "need_none" : get_need_str_id( needs[0] );
+        needs = saved_needs;
         add_msg_debug( debugmode::DF_NPC_NEEDS,
-                       "NPC %s: BT needs goal = %s", get_name(), bt_goal );
+                       "NPC %s: BT needs goal = %s, legacy = %s",
+                       get_name(), bt_goal, legacy_top );
     }
 
     Character &player_character = get_player_character();

--- a/tests/behavior_test.cpp
+++ b/tests/behavior_test.cpp
@@ -24,6 +24,7 @@
 #include "map.h"
 #include "map_helpers.h"
 #include "map_iterator.h"
+#include "mapdata.h"
 #include "mapgen.h"
 #include "mapgendata.h"
 #include "monattack.h"
@@ -38,6 +39,8 @@
 #include "units.h"
 #include "weather.h"
 #include "weighted_list.h"
+
+static const efftype_id effect_meth( "meth" );
 
 static const item_group_id Item_spawn_data_test_bottle_water( "test_bottle_water" );
 
@@ -54,6 +57,9 @@ static const itype_id itype_water_clean( "water_clean" );
 static const nested_mapgen_id nested_mapgen_test_seedling( "test_seedling" );
 
 static const string_id<behavior::node_t> behavior_node_t_npc_needs( "npc_needs" );
+
+static const ter_str_id ter_t_floor( "t_floor" );
+static const ter_str_id ter_t_ponywall( "t_ponywall" );
 
 namespace behavior
 {
@@ -338,6 +344,118 @@ TEST_CASE( "check_npc_behavior_tree", "[npc][behavior]" )
         REQUIRE( oracle.has_water( "" ) == behavior::status_t::running );
 
         CHECK( npc_needs.tick( &oracle ) == "start_fire" );
+    }
+    SECTION( "Dead tired but not exhausted -- sleep not feasible" ) {
+        // needs_sleep_badly fires at DEAD_TIRED (383) but can_sleep
+        // requires EXHAUSTED (575). Between the two, the need exists
+        // but the NPC pushes through.
+        test_npc.set_sleepiness( 500 );
+        REQUIRE( oracle.needs_sleep_badly( "" ) == behavior::status_t::running );
+        REQUIRE( oracle.can_sleep( "" ) == behavior::status_t::failure );
+        CHECK( npc_needs.tick( &oracle ) == "idle" );
+    }
+    SECTION( "Exhausted -- sleep is feasible" ) {
+        test_npc.set_sleepiness( 600 );
+        REQUIRE( oracle.needs_sleep_badly( "" ) == behavior::status_t::running );
+        REQUIRE( oracle.can_sleep( "" ) == behavior::status_t::running );
+        CHECK( npc_needs.tick( &oracle ) == "go_to_sleep" );
+    }
+    SECTION( "Exhausted on meth -- sleep blocked" ) {
+        test_npc.set_sleepiness( 600 );
+        test_npc.add_effect( effect_meth, 1_hours );
+        REQUIRE( oracle.needs_sleep_badly( "" ) == behavior::status_t::running );
+        CHECK( oracle.can_sleep( "" ) == behavior::status_t::failure );
+        CHECK( npc_needs.tick( &oracle ) == "idle" );
+    }
+    SECTION( "Exhausted with stim -- sleep still feasible" ) {
+        // Stim is a soft modifier in Character::can_sleep() whose effect
+        // depends on comfort at the sleep location. The oracle can't
+        // evaluate that, so only meth is a hard blocker.
+        test_npc.set_sleepiness( 600 );
+        test_npc.set_stim( 20 );
+        REQUIRE( oracle.needs_sleep_badly( "" ) == behavior::status_t::running );
+        CHECK( oracle.can_sleep( "" ) == behavior::status_t::running );
+    }
+    SECTION( "Exhausted and hungry -- hunger wins" ) {
+        // sleepiness=600 (urgency 0.6), stored_kcal=1000 (urgency ~0.98)
+        // Near-starvation beats moderate exhaustion.
+        test_npc.set_sleepiness( 600 );
+        test_npc.set_stored_kcal( 1000 );
+        test_npc.set_hunger( 500 );
+        REQUIRE( oracle.needs_sleep_badly( "" ) == behavior::status_t::running );
+        REQUIRE( oracle.can_sleep( "" ) == behavior::status_t::running );
+        REQUIRE( oracle.needs_food_badly( "" ) == behavior::status_t::running );
+        test_npc.i_add( item( itype_sandwich_cheese_grilled ) );
+        REQUIRE( oracle.has_food( "" ) == behavior::status_t::running );
+        CHECK( npc_needs.tick( &oracle ) == "eat_food" );
+    }
+    SECTION( "Exhausted beats moderate thirst" ) {
+        // sleepiness=800 (urgency 0.8), thirst=600 (urgency 0.5)
+        test_npc.set_sleepiness( 800 );
+        test_npc.set_thirst( 600 );
+        REQUIRE( oracle.needs_sleep_badly( "" ) == behavior::status_t::running );
+        REQUIRE( oracle.can_sleep( "" ) == behavior::status_t::running );
+        REQUIRE( oracle.needs_water_badly( "" ) == behavior::status_t::running );
+        const item_group::ItemList water_items = item_group::items_from(
+                    Item_spawn_data_test_bottle_water );
+        test_npc.i_add( water_items.front() );
+        REQUIRE( oracle.has_water( "" ) == behavior::status_t::running );
+        CHECK( npc_needs.tick( &oracle ) == "go_to_sleep" );
+    }
+    SECTION( "can_make_fire returns failure without supplies" ) {
+        // Regression: can_make_fire used to return success instead of failure
+        // when no FIRESTARTER or flammable items were present, causing the
+        // warmth fallback to short-circuit to success before reaching shelter.
+        CHECK( oracle.can_make_fire( "" ) == behavior::status_t::failure );
+    }
+    SECTION( "can_take_shelter outdoors with adjacent indoor tile" ) {
+        map &here = get_map();
+        tripoint_bub_ms adj = test_npc.pos_bub() + point::east;
+        here.ter_set( adj, ter_t_floor );
+        CHECK( oracle.can_take_shelter( "" ) == behavior::status_t::running );
+    }
+    SECTION( "can_take_shelter outdoors with no indoor tiles" ) {
+        CHECK( oracle.can_take_shelter( "" ) == behavior::status_t::failure );
+    }
+    SECTION( "can_take_shelter ignores impassable indoor tiles" ) {
+        // A pony wall is INDOORS but impassable -- not a shelter target
+        map &here = get_map();
+        tripoint_bub_ms adj = test_npc.pos_bub() + point::east;
+        here.ter_set( adj, ter_t_ponywall );
+        REQUIRE( here.has_flag( ter_furn_flag::TFLAG_INDOORS, adj ) );
+        REQUIRE( here.impassable( adj ) );
+        CHECK( oracle.can_take_shelter( "" ) == behavior::status_t::failure );
+    }
+    SECTION( "can_take_shelter already indoors" ) {
+        map &here = get_map();
+        here.ter_set( test_npc.pos_bub(), ter_t_floor );
+        CHECK( oracle.can_take_shelter( "" ) == behavior::status_t::failure );
+    }
+    SECTION( "Freezing outdoors next to building" ) {
+        weather_manager &weather = get_weather();
+        weather.temperature = units::from_fahrenheit( 0 );
+        weather.clear_temp_cache();
+        test_npc.update_bodytemp();
+        REQUIRE( oracle.needs_warmth_badly( "" ) == behavior::status_t::running );
+
+        // No warm clothes, no fire, but indoor tile adjacent
+        map &here = get_map();
+        tripoint_bub_ms adj = test_npc.pos_bub() + point::east;
+        here.ter_set( adj, ter_t_floor );
+        REQUIRE( oracle.can_take_shelter( "" ) == behavior::status_t::running );
+
+        CHECK( npc_needs.tick( &oracle ) == "take_shelter" );
+    }
+    SECTION( "Freezing outdoors with no shelter" ) {
+        weather_manager &weather = get_weather();
+        weather.temperature = units::from_fahrenheit( 0 );
+        weather.clear_temp_cache();
+        test_npc.update_bodytemp();
+        REQUIRE( oracle.needs_warmth_badly( "" ) == behavior::status_t::running );
+        REQUIRE( oracle.can_take_shelter( "" ) == behavior::status_t::failure );
+
+        // All warmth options fail -> idle
+        CHECK( npc_needs.tick( &oracle ) == "idle" );
     }
 }
 
@@ -727,9 +845,25 @@ TEST_CASE( "npc_urgency_score_predicates", "[npc][behavior]" )
         CHECK( oracle.warmth_urgency( "" ) == Approx( 1.0f ).margin( 0.05f ) );
     }
 
+    SECTION( "sleepiness_urgency scales from 0 to 1" ) {
+        guy.set_sleepiness( 0 );
+        CHECK( oracle.sleepiness_urgency( "" ) == Approx( 0.0f ).margin( 0.01f ) );
+
+        guy.set_sleepiness( 500 );
+        CHECK( oracle.sleepiness_urgency( "" ) == Approx( 0.5f ).margin( 0.01f ) );
+
+        guy.set_sleepiness( 1000 );
+        CHECK( oracle.sleepiness_urgency( "" ) == Approx( 1.0f ).margin( 0.01f ) );
+    }
+
     SECTION( "score predicates registered in score_predicate_map" ) {
         CHECK( behavior::score_predicate_map.count( "npc_thirst_urgency" ) == 1 );
         CHECK( behavior::score_predicate_map.count( "npc_hunger_urgency" ) == 1 );
         CHECK( behavior::score_predicate_map.count( "npc_warmth_urgency" ) == 1 );
+        CHECK( behavior::score_predicate_map.count( "npc_sleepiness_urgency" ) == 1 );
+    }
+
+    SECTION( "predicates registered in predicate_map" ) {
+        CHECK( behavior::predicate_map.count( "npc_needs_sleep_badly" ) == 1 );
     }
 }

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -797,6 +797,8 @@ TEST_CASE( "npc_needs_bt_diagnostic_during_move", "[npc][behavior]" )
             if( msg.second.find( "BT needs goal" ) != std::string::npos ) {
                 found_bt_msg = true;
                 CHECK( msg.second.find( "eat_food" ) != std::string::npos );
+                // Convergence: legacy need should appear in the same message
+                CHECK( msg.second.find( "need_food" ) != std::string::npos );
                 break;
             }
         }


### PR DESCRIPTION
#### Summary
Infrastructure "Expand NPC behavior tree diagnostic with convergence logging, sleepiness need, shelter detection, and can_make_fire bugfix"

#### Purpose of change

This PR expands the BT diagnostic's coverage and fixes two predicates that were giving wrong answers.

Depends on #85984.

#### Describe the solution

Two commits:

1. Convergence diagnostic -- DF_NPC_NEEDS now logs both the BT goal and the legacy `decide_needs()` top result side-by-side: `BT needs goal = eat_food, legacy = need_food`. Save/restore on the needs vector keeps it non-mutating.

2. Sleepiness + shelter + can_make_fire fix:

- Sleepiness as fourth BT need. `needs_sleep_badly` fires at DEAD_TIRED (383, microsleeps start). `sleepiness_urgency` scores 0-1 against MASSIVE_SLEEPINESS (1000). The `can_sleep` feasibility gate fires at EXHAUSTED (575) -- between DEAD_TIRED and EXHAUSTED the need exists but the NPC pushes through. Meth blocks sleep entirely, matching the hard blocker in `Character::can_sleep()`. Stim and comfort are soft modifiers that depend on sleep location, so the oracle doesn't try to replicate those.

- `can_take_shelter` is now an action predicate. Returns `running` when the NPC is outdoors with an adjacent passable INDOORS tile. Returns `failure` when already indoors, when the adjacent indoor tile is impassable, or when there's nothing nearby.

- `can_make_fire` was returning `success` instead of `failure` when no fire supplies existed. `process_predicates` breaks on non-running results, so the success propagated through the warmth fallback as "handled," hiding the shelter check entirely.

#### Describe alternatives you've considered

Could ship each piece as a separate PR but they're small and thematically connected. The stim check in `can_sleep` went through a few iterations -- tried hard-blocking at a computed threshold, but the real `can_sleep()` formula mixes stim with location comfort and rng, so any fixed cutoff is wrong for some locations. Meth-only is the honest boundary.

#### Testing

Each predicate has direct oracle tests plus tree-level tests verifying utility arbitration.

Sleep: dead-tired-not-exhausted returns idle, exhausted returns go_to_sleep, meth blocks sleep, stim doesn't block, hunger beats sleep when starvation is more urgent, sleep beats moderate thirst.

Shelter: adjacent passable indoor tile returns running, no indoor tiles returns failure, impassable indoor tile (pony wall) returns failure, already indoors returns failure. Tree-level: freezing next to building selects take_shelter, freezing with no shelter returns idle.

can_make_fire: regression test verifying failure without supplies.

Convergence diagnostic: existing integration test extended to check for legacy need string in the message.

#### Additional context

Related to #28681.