### PR TITLE
Improve overmap_terrain_coverage test coverage for rare specials

### DIFF
--- a/src/omdata.h
+++ b/src/omdata.h
@@ -795,6 +795,7 @@ class overmap_special
         //NOTE: only useful for fixed overmap special
         std::vector<overmap_special_terrain> get_terrains() const;
         std::vector<overmap_special_terrain> preview_terrains() const;
+        std::vector<oter_type_id> get_terrain_type_ids() const;
         std::vector<overmap_special_locations> required_locations() const;
         int score_rotation_at( const overmap &om, const tripoint_om_omt &p,
                                om_direction::type r ) const;
@@ -923,6 +924,7 @@ struct overmap_special_data {
     virtual void check( const std::string &context ) const = 0;
     virtual std::vector<overmap_special_terrain> get_terrains() const = 0;
     virtual std::vector<overmap_special_terrain> preview_terrains() const = 0;
+    virtual std::vector<oter_type_id> get_terrain_type_ids() const = 0;
     virtual std::vector<overmap_special_locations> required_locations() const = 0;
     virtual int score_rotation_at( const overmap &om, const tripoint_om_omt &p,
                                    om_direction::type r ) const = 0;
@@ -946,6 +948,7 @@ struct fixed_overmap_special_data : overmap_special_data {
     const overmap_special_terrain &get_terrain_at( const tripoint_rel_omt &p ) const;
     std::vector<overmap_special_terrain> get_terrains() const override;
     std::vector<overmap_special_terrain> preview_terrains() const override;
+    std::vector<oter_type_id> get_terrain_type_ids() const override;
     std::vector<overmap_special_locations> required_locations() const override;
     int score_rotation_at( const overmap &om, const tripoint_om_omt &p,
                            om_direction::type r ) const override;
@@ -1332,6 +1335,7 @@ struct mutable_overmap_special_data : overmap_special_data {
     overmap_special_terrain root_as_overmap_special_terrain() const;
     std::vector<overmap_special_terrain> get_terrains() const override;
     std::vector<overmap_special_terrain> preview_terrains() const override;
+    std::vector<oter_type_id> get_terrain_type_ids() const override;
     std::vector<overmap_special_locations> required_locations() const override;
     int score_rotation_at( const overmap &, const tripoint_om_omt &,
                            om_direction::type ) const override;

--- a/src/overmap_special.cpp
+++ b/src/overmap_special.cpp
@@ -250,6 +250,11 @@ std::vector<overmap_special_terrain> overmap_special::preview_terrains() const
     return data_->preview_terrains();
 }
 
+std::vector<oter_type_id> overmap_special::get_terrain_type_ids() const
+{
+    return data_->get_terrain_type_ids();
+}
+
 std::vector<overmap_special_locations> overmap_special::required_locations() const
 {
     return data_->required_locations();

--- a/src/overmap_special_fixed.cpp
+++ b/src/overmap_special_fixed.cpp
@@ -206,6 +206,18 @@ std::vector<overmap_special_terrain> fixed_overmap_special_data::get_terrains() 
     return terrains;
 }
 
+std::vector<oter_type_id> fixed_overmap_special_data::get_terrain_type_ids() const
+{
+    std::vector<oter_type_id> result;
+    result.reserve( terrains.size() );
+    for( const overmap_special_terrain &ter : terrains ) {
+        if( ter.terrain.is_valid() ) {
+            result.emplace_back( ter.terrain->get_type_id() );
+        }
+    }
+    return result;
+}
+
 std::vector<overmap_special_terrain> fixed_overmap_special_data::preview_terrains() const
 {
     std::vector<overmap_special_terrain> result;

--- a/src/overmap_special_mutable.cpp
+++ b/src/overmap_special_mutable.cpp
@@ -741,6 +741,18 @@ std::vector<overmap_special_terrain> mutable_overmap_special_data::get_terrains(
     return std::vector<overmap_special_terrain> { root_as_overmap_special_terrain() };
 }
 
+std::vector<oter_type_id> mutable_overmap_special_data::get_terrain_type_ids() const
+{
+    std::vector<oter_type_id> result;
+    result.reserve( overmaps.size() );
+    for( const auto &pair : overmaps ) {
+        if( pair.second.terrain.is_valid() ) {
+            result.emplace_back( pair.second.terrain->get_type_id() );
+        }
+    }
+    return result;
+}
+
 std::vector<overmap_special_terrain> mutable_overmap_special_data::preview_terrains() const
 {
     return std::vector<overmap_special_terrain> { root_as_overmap_special_terrain() };

--- a/tests/overmap_test.cpp
+++ b/tests/overmap_test.cpp
@@ -547,9 +547,41 @@ TEST_CASE( "overmap_terrain_coverage", "[overmap][slow]" )
         }
     }
 
+    // Build reverse map: oter_type_id -> info about specials that produce it.
+    // Used for the filtered generation phase and diagnostic logging.
+    struct special_spawn_info {
+        overmap_special_id id;
+        bool is_unique;
+        bool is_optional;
+        bool needs_water;
+        int occ_min;
+        int occ_max;
+    };
+    std::unordered_map<oter_type_id, std::vector<special_spawn_info>> terrain_to_specials;
+    for( const overmap_special &sp : overmap_specials::get_all() ) {
+        if( !sp.can_spawn() ) {
+            continue;
+        }
+        const overmap_special_placement_constraints &constraints = sp.get_constraints();
+        special_spawn_info info;
+        info.id = sp.id;
+        info.is_unique = sp.has_flag( "OVERMAP_UNIQUE" ) || sp.has_flag( "GLOBALLY_UNIQUE" );
+        info.is_optional = constraints.occurrences.min == 0;
+        info.needs_water = sp.has_flag( "LAKE" ) || sp.has_flag( "OCEAN" );
+        info.occ_min = constraints.occurrences.min;
+        info.occ_max = constraints.occurrences.max;
+
+        for( const oter_type_id &tid : sp.get_terrain_type_ids() ) {
+            terrain_to_specials[tid].push_back( info );
+        }
+    }
+
     constexpr int max_attempts = 3;
     for( int attempt_no = 0; attempt_no < max_attempts && !yet_to_be_seen.empty();
          ++attempt_no ) {
+        if( attempt_no > 0 ) {
+            overmap_buffer.reset();
+        }
         // First we just touch all the overmaps in an area to cause them to generate.
         for( const point_abs_om &om_cur : closest_points_first( overmap_origin, 0, 3 ) ) {
             point_abs_omt omt_start = project_to<coords::omt>( om_cur );
@@ -628,8 +660,8 @@ TEST_CASE( "overmap_terrain_coverage", "[overmap][slow]" )
             CAPTURE( msg );
             CAPTURE( msg.empty() );
         }
-        overmap_buffer.reset();
     }
+    // Last attempt's overmaps are still in memory for the forced placement phase.
 
     // Check that no SHOULD_NOT_SPAWN terrain was generated.
     for( const auto &entry : stats ) {
@@ -642,6 +674,84 @@ TEST_CASE( "overmap_terrain_coverage", "[overmap][slow]" )
     global_variables &globvars = get_globals();
     globvars.clear_global_values();
 
+    // Filtered generation: for terrains still missing after normal generation,
+    // run one more attempt with a custom batch containing only the specials that
+    // produce those terrains. With all other specials removed from competition,
+    // the remaining ones get all 144 sectors to themselves.
+    if( !yet_to_be_seen.empty() ) {
+        std::vector<const overmap_special *> filtered;
+        std::unordered_set<overmap_special_id> seen_ids;
+        for( const oter_type_id &tid : yet_to_be_seen ) {
+            auto it = terrain_to_specials.find( tid );
+            if( it == terrain_to_specials.end() ) {
+                continue;
+            }
+            for( const special_spawn_info &info : it->second ) {
+                if( seen_ids.insert( info.id ).second ) {
+                    filtered.push_back( &info.id.obj() );
+                }
+            }
+        }
+
+        if( !filtered.empty() ) {
+            overmap_buffer.reset();
+            overmap_special_batch custom_batch( overmap_origin, filtered );
+            for( const point_abs_om &om_cur :
+                 closest_points_first( overmap_origin, 0, 3 ) ) {
+                overmap_buffer.create_custom_overmap( om_cur, custom_batch );
+            }
+            // Scan the custom overmaps for newly-placed terrains.
+            for( const point_abs_om &om_cur :
+                 closest_points_first( overmap_origin, 0, 5 ) ) {
+                point_abs_omt omt_start = project_to<coords::omt>( om_cur );
+                if( overmap_buffer.ter_existing( { omt_start, 0 } ) == oter_id() ) {
+                    continue;
+                }
+                point_abs_omt omt_end = omt_start + ( point::south_east * OMAPX );
+                for( point_abs_omt p = omt_start; p.y() < omt_end.y(); p.y()++ ) {
+                    for( p.x() = omt_start.x(); p.x() < omt_end.x(); p.x()++ ) {
+                        for( int z = -OVERMAP_DEPTH; z <= OVERMAP_HEIGHT; ++z ) {
+                            tripoint_abs_omt tp( p, z );
+                            oter_type_id id = overmap_buffer.ter( tp )->get_type_id();
+                            auto iter_bool = stats.emplace( id, tp );
+                            if( iter_bool.second ) {
+                                yet_to_be_seen.erase( id );
+                            }
+                            iter_bool.first->second.last_observed = tp;
+                            ++iter_bool.first->second.count;
+                        }
+                    }
+                }
+            }
+            // Mapgen sampling for newly observed terrains.
+            for( std::pair<const oter_type_id, omt_stats> &p : stats ) {
+                int goal_samples = 1;
+                int sample_size = goal_samples - p.second.samples;
+                if( sample_size <= 0 ) {
+                    continue;
+                }
+                const std::string oter_type_id = p.first->id.str();
+                const tripoint_abs_omt pos = p.second.last_observed;
+                CAPTURE( oter_type_id );
+                const std::string msg = capture_debugmsg_during( [pos]() {
+                    MAPBUFFER.clear_outside_reality_bubble();
+                    smallmap tm;
+                    tm.generate( pos, calendar::turn, false );
+                    CHECK( !map_meddler::has_altered_submaps( *tm.cast_to_map() ) );
+                    tm.delete_unmerged_submaps();
+                } );
+                p.second.samples = goal_samples;
+                CAPTURE( msg );
+                CAPTURE( msg.empty() );
+            }
+            WARN( "Ran filtered generation with " << filtered.size()
+                  << " specials for unobserved terrains" );
+        }
+    }
+    overmap_buffer.reset();
+
+    // Final check: anything still in yet_to_be_seen after both normal generation
+    // and forced placement must be in the manual whitelist or it's a failure.
     {
         std::vector<oter_type_id> missing( yet_to_be_seen.begin(), yet_to_be_seen.end() );
         size_t num_missing = missing.size();
@@ -657,6 +767,20 @@ TEST_CASE( "overmap_terrain_coverage", "[overmap][slow]" )
             return id->id.str();
         } );
         CAPTURE( missing_oter_type_ids );
+        for( const oter_type_id &tid : missing ) {
+            auto it = terrain_to_specials.find( tid );
+            if( it != terrain_to_specials.end() ) {
+                for( const special_spawn_info &info : it->second ) {
+                    UNSCOPED_INFO( tid->id.str() << " expected from special "
+                                   << info.id.str() << " (occ=" << info.occ_min
+                                   << "/" << info.occ_max
+                                   << ( info.is_unique ? " unique" : "" )
+                                   << ( info.is_optional ? " optional" : "" )
+                                   << ( info.needs_water ? " water" : "" )
+                                   << ")" );
+                }
+            }
+        }
         INFO( "To resolve errors about missing terrains you can either give the terrain the "
               "SHOULD_NOT_SPAWN flag, intended for terrains that should never spawn, for example "
               "test terrains or work in progress, or tweak the constraints so that the terrain "


### PR DESCRIPTION
#### Summary
Infrastructure "Improve overmap terrain coverage test for rare and optional specials"

#### Purpose of change

Follow-up to #85849. The overmap_terrain_coverage test whitelists ~90 terrain types that don't spawn reliably within the test's ~147 overmaps. Those terrains get no mapgen validation at all -- if someone breaks their mapgen, the whitelist silently hides it.

This adds a filtered generation attempt that covers more of those terrains without touching the whitelist itself.

#### Describe the solution

After the normal 3 generation attempts, if terrains are still unobserved, build a custom `overmap_special_batch` containing only the specials that produce those terrains and run one more generation pass with `create_custom_overmap()`. With all other specials removed from competition, the remaining ones get all 144 sectors to themselves instead of fighting over leftovers.

Uses the real placement pipeline end-to-end -- sectors, city checks, location matching, mutable solver -- so any terrain placed this way would also be valid in a real game.

Also adds `get_terrain_type_ids()` on `overmap_special` (virtual, with fixed and mutable implementations) to support building the terrain-to-special reverse map the filtered phase needs.

The whitelist is unchanged. The filtered phase provides extra coverage on top of it -- terrains that happen to place during the filtered attempt get their mapgen validated even though the whitelist would have excused them.

#### Describe alternatives you've considered

Brute-force position scanning: scan every tile on existing overmaps and call `place_special()` directly, bypassing the sector system entirely. Works but doesn't test the real placement path, and the city-check gating had to be replicated manually. The `create_custom_overmap` approach is simpler and tests the actual pipeline.

Auto-computed whitelist: replace the manual whitelist with a heuristic that skips terrains from optional/rare/water-dependent specials. Simpler but loses coverage entirely for those terrains. The filtered generation approach is strictly better -- it tries to place them first, and only falls back to the whitelist if that also fails.

#### Testing

Passes on multiple seeds, vanilla and Magiclysm. The filtered phase typically fires for 1-3 specials and validates their mapgen. On lucky seeds where normal generation covers everything, the filtered phase is skipped entirely (no overhead).

#### Additional context

Conceptually similar to what GuardianDll suggested in #79711 -- "making another test mod with all terrain having equally high weight and testing against this map instead." This doesn't change weights but achieves the same effect by removing the competition.