### PR TITLE
[Xedra Evolved] Paraclesian eyes are a bodypart

### DIFF
--- a/data/mods/Xedra_Evolved/items/armor/integrated.json
+++ b/data/mods/Xedra_Evolved/items/armor/integrated.json
@@ -138,35 +138,6 @@
     ]
   },
   {
-    "id": "integrated_ierde_eyes",
-    "type": "ITEM",
-    "subtypes": [ "ARMOR" ],
-    "category": "armor",
-    "name": { "str_sp": "ierde eyes" },
-    "description": "Your eyes now reflect your mood in the colors of stone.  You are also immune to the glare of the sun.",
-    "weight": "180 g",
-    "volume": "250 ml",
-    "price": "0 cent",
-    "price_postapoc": "0 cent",
-    "material": [ "fae_flesh" ],
-    "symbol": "[",
-    "color": "dark_gray",
-    "warmth": 0,
-    "material_thickness": 1.5,
-    "environmental_protection": 10,
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "PERSONAL", "SOFT", "WATER_FRIENDLY", "SUN_GLASSES", "NO_REPAIR", "NO_SALVAGE" ],
-    "armor": [
-      {
-        "material": [ { "type": "fae_flesh", "covered_by_mat": 100, "thickness": 0.5 } ],
-        "covers": [ "eyes" ],
-        "coverage": 100,
-        "encumbrance": 0,
-        "rigid_layer_only": true,
-        "cover_vitals": 100
-      }
-    ]
-  },
-  {
     "id": "integrated_ierde_fists",
     "type": "ITEM",
     "subtypes": [ "ARMOR", "ARTIFACT" ],
@@ -289,35 +260,6 @@
     ]
   },
   {
-    "id": "integrated_arvore_eyes",
-    "type": "ITEM",
-    "subtypes": [ "ARMOR" ],
-    "category": "armor",
-    "name": { "str_sp": "arvore eyes" },
-    "description": "Your eyes now reflect the seasons: green, yellow, red, orange, or brown.  You are also immune to the glare of the sun.",
-    "weight": "180 g",
-    "volume": "250 ml",
-    "price": "0 cent",
-    "price_postapoc": "0 cent",
-    "material": [ "fae_flesh" ],
-    "symbol": "[",
-    "color": "green",
-    "warmth": 0,
-    "material_thickness": 1.5,
-    "environmental_protection": 10,
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "PERSONAL", "SOFT", "WATER_FRIENDLY", "SUN_GLASSES", "NO_REPAIR", "NO_SALVAGE" ],
-    "armor": [
-      {
-        "material": [ { "type": "fae_flesh", "covered_by_mat": 100, "thickness": 0.5 } ],
-        "covers": [ "eyes" ],
-        "coverage": 100,
-        "encumbrance": 0,
-        "rigid_layer_only": true,
-        "cover_vitals": 100
-      }
-    ]
-  },
-  {
     "id": "integrated_arvore_thorns",
     "type": "ITEM",
     "subtypes": [ "ARMOR" ],
@@ -427,36 +369,6 @@
     "passive_effects": [ { "id": "flame_skin_enchantment" } ]
   },
   {
-    "id": "integrated_salamander_eyes",
-    "type": "ITEM",
-    "subtypes": [ "ARMOR" ],
-    "category": "armor",
-    "name": { "str_sp": "salamander eyes" },
-    "description": "Your eyes now reflect your mood, the warm red of a campfire or the searing heat of an incendiary weapon.  Glare no longer affects you.",
-    "weight": "180 g",
-    "volume": "250 ml",
-    "price": "0 cent",
-    "price_postapoc": "0 cent",
-    "material": [ "fae_flesh" ],
-    "symbol": "[",
-    "color": "red",
-    "warmth": 0,
-    "material_thickness": 1.5,
-    "environmental_protection": 10,
-    "qualities": [ [ "GLARE", 1 ] ],
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "PERSONAL", "SOFT", "WATER_FRIENDLY", "SUN_GLASSES", "NO_REPAIR", "NO_SALVAGE" ],
-    "armor": [
-      {
-        "material": [ { "type": "fae_flesh", "covered_by_mat": 100, "thickness": 0.5 } ],
-        "covers": [ "eyes" ],
-        "coverage": 100,
-        "encumbrance": 0,
-        "rigid_layer_only": true,
-        "cover_vitals": 100
-      }
-    ]
-  },
-  {
     "id": "item_salamander_cooking_heat",
     "type": "ITEM",
     "subtypes": [ "TOOL", "ARMOR", "ARTIFACT" ],
@@ -520,45 +432,6 @@
         "coverage": 100,
         "encumbrance": 0,
         "breathability": "SECOND_SKIN"
-      }
-    ]
-  },
-  {
-    "id": "integrated_undine_eyes",
-    "type": "ITEM",
-    "subtypes": [ "ARMOR" ],
-    "category": "armor",
-    "name": { "str_sp": "undine eyes" },
-    "description": "Your eyes now reflect your mood in the colors of the deep waters.  From an aquamarine blue when you are pleased to the pitch black of the depths when you are angry or sad.  You are also immune to the glare of the sun and can see under water.",
-    "weight": "180 g",
-    "volume": "250 ml",
-    "price": "0 cent",
-    "price_postapoc": "0 cent",
-    "material": [ "fae_flesh" ],
-    "symbol": "[",
-    "color": "dark_gray",
-    "warmth": 0,
-    "material_thickness": 1.5,
-    "environmental_protection": 10,
-    "flags": [
-      "INTEGRATED",
-      "UNBREAKABLE",
-      "PERSONAL",
-      "SOFT",
-      "WATER_FRIENDLY",
-      "SUN_GLASSES",
-      "NO_REPAIR",
-      "SWIM_GOGGLES",
-      "NO_SALVAGE"
-    ],
-    "armor": [
-      {
-        "material": [ { "type": "fae_flesh", "covered_by_mat": 100, "thickness": 0.5 } ],
-        "covers": [ "eyes" ],
-        "coverage": 100,
-        "encumbrance": 0,
-        "rigid_layer_only": true,
-        "cover_vitals": 100
       }
     ]
   },
@@ -653,45 +526,6 @@
     "passive_effects": [ { "id": "storm_skin_enchantment" } ]
   },
   {
-    "id": "integrated_sylph_eyes",
-    "type": "ITEM",
-    "subtypes": [ "ARMOR" ],
-    "category": "armor",
-    "name": { "str_sp": "sylph eyes" },
-    "description": "Your eyes now reflect your mood in different weather patterns.  Clear blue skies when you are pleased and storms when you are mad.  You are also immune to the glare of the sun.",
-    "weight": "180 g",
-    "volume": "250 ml",
-    "price": "0 cent",
-    "price_postapoc": "0 cent",
-    "material": [ "fae_flesh" ],
-    "symbol": "[",
-    "color": "dark_gray",
-    "warmth": 0,
-    "material_thickness": 1.5,
-    "environmental_protection": 10,
-    "flags": [
-      "INTEGRATED",
-      "UNBREAKABLE",
-      "PERSONAL",
-      "SOFT",
-      "WATER_FRIENDLY",
-      "SUN_GLASSES",
-      "NO_REPAIR",
-      "SWIM_GOGGLES",
-      "NO_SALVAGE"
-    ],
-    "armor": [
-      {
-        "material": [ { "type": "fae_flesh", "covered_by_mat": 100, "thickness": 0.5 } ],
-        "covers": [ "eyes" ],
-        "coverage": 100,
-        "encumbrance": 0,
-        "rigid_layer_only": true,
-        "cover_vitals": 100
-      }
-    ]
-  },
-  {
     "id": "integrated_porcelain_skin",
     "type": "ITEM",
     "subtypes": [ "ARMOR" ],
@@ -738,35 +572,6 @@
         "coverage": 100,
         "encumbrance": 0,
         "breathability": "SECOND_SKIN"
-      }
-    ]
-  },
-  {
-    "id": "integrated_homullus_eyes",
-    "type": "ITEM",
-    "subtypes": [ "ARMOR" ],
-    "category": "armor",
-    "name": { "str_sp": "homullus eyes" },
-    "description": "Your eyes now stare out at the world, impassive and blank like the eyes of a doll.  You are also immune to the glare of the sun.",
-    "weight": "180 g",
-    "volume": "250 ml",
-    "price": "0 cent",
-    "price_postapoc": "0 cent",
-    "material": [ "fae_flesh" ],
-    "symbol": "[",
-    "color": "dark_gray",
-    "warmth": 0,
-    "material_thickness": 1.5,
-    "environmental_protection": 10,
-    "flags": [ "INTEGRATED", "UNBREAKABLE", "PERSONAL", "SOFT", "WATER_FRIENDLY", "SUN_GLASSES", "NO_REPAIR", "NO_SALVAGE" ],
-    "armor": [
-      {
-        "material": [ { "type": "fae_flesh", "covered_by_mat": 100, "thickness": 0.5 } ],
-        "covers": [ "eyes" ],
-        "coverage": 100,
-        "encumbrance": 0,
-        "rigid_layer_only": true,
-        "cover_vitals": 100
       }
     ]
   },

--- a/data/mods/Xedra_Evolved/mutations/mutation_bodyparts.json
+++ b/data/mods/Xedra_Evolved/mutations/mutation_bodyparts.json
@@ -13,9 +13,9 @@
     "copy-from": "eyes",
     "type": "body_part",
     "limb_scores": [ [ "vision", 1.0 ], [ "night_vis", 1.0 ], [ "reaction", 0.7 ] ],
-    "bionic_slots": 0,
     "conditional_flags": [ "GLARE_RESIST" ],
-    "sub_parts": [ "eyes_left", "eyes_right" ]
+    "sub_parts": [ "eyes_left", "eyes_right" ],
+    "similar_bodypart": "eyes"
   },
   {
     "id": "fae_eyes_ierde",
@@ -24,7 +24,8 @@
     "limb_scores": [ [ "vision", 1.0 ], [ "night_vis", 1.5 ], [ "reaction", 0.8 ] ],
     "bionic_slots": 0,
     "conditional_flags": [ "GLARE_RESIST", "SEESLEEP" ],
-    "sub_parts": [ "eyes_left", "eyes_right" ]
+    "sub_parts": [ "eyes_left", "eyes_right" ],
+    "similar_bodypart": "eyes"
   },
   {
     "id": "fae_eyes_salamander",
@@ -33,7 +34,8 @@
     "limb_scores": [ [ "vision", 1.25 ], [ "night_vis", 0.6 ], [ "reaction", 0.95 ] ],
     "bionic_slots": 0,
     "conditional_flags": [ "GLARE_RESIST", "THERMOMETER" ],
-    "sub_parts": [ "eyes_left", "eyes_right" ]
+    "sub_parts": [ "eyes_left", "eyes_right" ],
+    "similar_bodypart": "eyes"
   },
   {
     "id": "fae_eyes_sylph",
@@ -42,7 +44,8 @@
     "limb_scores": [ [ "vision", 1.5 ], [ "night_vis", 1.0 ], [ "reaction", 1.1 ] ],
     "bionic_slots": 0,
     "conditional_flags": [ "GLARE_RESIST" ],
-    "sub_parts": [ "eyes_left", "eyes_right" ]
+    "sub_parts": [ "eyes_left", "eyes_right" ],
+    "similar_bodypart": "eyes"
   },
   {
     "id": "fae_eyes_undine",
@@ -51,6 +54,7 @@
     "limb_scores": [ [ "vision", 1.0 ], [ "night_vis", 1.3 ], [ "reaction", 0.8 ] ],
     "bionic_slots": 0,
     "conditional_flags": [ "GLARE_RESIST", "EYE_MEMBRANE", "SWIM_GOGGLES", "SEESLEEP" ],
-    "sub_parts": [ "eyes_left", "eyes_right" ]
+    "sub_parts": [ "eyes_left", "eyes_right" ],
+    "similar_bodypart": "eyes"
   }
 ]

--- a/data/mods/Xedra_Evolved/mutations/mutation_bodyparts.json
+++ b/data/mods/Xedra_Evolved/mutations/mutation_bodyparts.json
@@ -1,0 +1,56 @@
+[
+  {
+    "id": "fae_eyes_arvore",
+    "copy-from": "eyes",
+    "type": "body_part",
+    "limb_scores": [ [ "vision", 1.25 ], [ "night_vis", 1.0 ], [ "reaction", 0.8 ] ],
+    "bionic_slots": 0,
+    "conditional_flags": [ "GLARE_RESIST" ],
+    "sub_parts": [ "eyes_left", "eyes_right" ]
+  },
+  {
+    "id": "fae_eyes_homullus",
+    "copy-from": "eyes",
+    "type": "body_part",
+    "limb_scores": [ [ "vision", 1.0 ], [ "night_vis", 1.0 ], [ "reaction", 0.7 ] ],
+    "bionic_slots": 0,
+    "conditional_flags": [ "GLARE_RESIST" ],
+    "sub_parts": [ "eyes_left", "eyes_right" ]
+  },
+  {
+    "id": "fae_eyes_ierde",
+    "copy-from": "eyes",
+    "type": "body_part",
+    "limb_scores": [ [ "vision", 1.0 ], [ "night_vis", 1.5 ], [ "reaction", 0.8 ] ],
+    "bionic_slots": 0,
+    "conditional_flags": [ "GLARE_RESIST", "SEESLEEP" ],
+    "sub_parts": [ "eyes_left", "eyes_right" ]
+  },
+  {
+    "id": "fae_eyes_salamander",
+    "copy-from": "eyes",
+    "type": "body_part",
+    "limb_scores": [ [ "vision", 1.25 ], [ "night_vis", 0.6 ], [ "reaction", 0.95 ] ],
+    "bionic_slots": 0,
+    "conditional_flags": [ "GLARE_RESIST", "THERMOMETER" ],
+    "sub_parts": [ "eyes_left", "eyes_right" ]
+  },
+  {
+    "id": "fae_eyes_sylph",
+    "copy-from": "eyes",
+    "type": "body_part",
+    "limb_scores": [ [ "vision", 1.5 ], [ "night_vis", 1.0 ], [ "reaction", 1.1 ] ],
+    "bionic_slots": 0,
+    "conditional_flags": [ "GLARE_RESIST" ],
+    "sub_parts": [ "eyes_left", "eyes_right" ]
+  },
+  {
+    "id": "fae_eyes_undine",
+    "copy-from": "eyes",
+    "type": "body_part",
+    "limb_scores": [ [ "vision", 1.0 ], [ "night_vis", 1.3 ], [ "reaction", 0.8 ] ],
+    "bionic_slots": 0,
+    "conditional_flags": [ "GLARE_RESIST", "EYE_MEMBRANE", "SWIM_GOGGLES", "SEESLEEP" ],
+    "sub_parts": [ "eyes_left", "eyes_right" ]
+  }
+]

--- a/data/mods/Xedra_Evolved/mutations/mutation_bodyparts.json
+++ b/data/mods/Xedra_Evolved/mutations/mutation_bodyparts.json
@@ -12,7 +12,6 @@
     "id": "fae_eyes_homullus",
     "copy-from": "eyes",
     "type": "body_part",
-    "limb_scores": [ [ "vision", 1.0 ], [ "night_vis", 1.0 ], [ "reaction", 0.7 ] ],
     "conditional_flags": [ "GLARE_RESIST" ],
     "sub_parts": [ "eyes_left", "eyes_right" ],
     "similar_bodypart": "eyes"

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutations.json
@@ -824,11 +824,11 @@
     "points": 1,
     "visibility": 2,
     "ugliness": 0,
-    "description": "Upon gaining this ability the Arvore's eyes begin reflecting the seasons: a bright yellow-green in spring; verdant green in summer; red, yellow, or orange in autumn, and dark brown in winter.  Glare no longer impacts them.",
+    "description": "Upon gaining this ability the Arvore's eyes begin reflecting the seasons: a bright yellow-green in spring; verdant green in summer; red, yellow, or orange in autumn, and dark brown in winter.  Glare no longer impacts them, and they have slightly better daytime vision and reaction times.",
     "category": [ "ARVORE", "ARVORE_ALCHEMY" ],
     "purifiable": false,
     "types": [ "EYES" ],
-    "integrated_armor": [ "integrated_arvore_eyes" ]
+    "enchantments": [ { "modified_bodyparts": [ { "lose": "eyes" }, { "gain": "fae_eyes_arvore" } ] } ]
   },
   {
     "type": "mutation",

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/homullus_mutations.json
@@ -80,7 +80,7 @@
     "types": [ "EYES" ],
     "category": [ "HOMULLUS" ],
     "purifiable": false,
-    "integrated_armor": [ "integrated_homullus_eyes" ]
+    "enchantments": [ { "modified_bodyparts": [ { "lose": "eyes" }, { "gain": "fae_eyes_homullus" } ] } ]
   },
   {
     "type": "mutation",

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/ierde_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/ierde_mutations.json
@@ -78,11 +78,10 @@
     "points": 1,
     "visibility": 2,
     "ugliness": 0,
-    "description": "Upon gaining this ability the Ierde's eyes begin reflecting their mood: a pale white streaked with rose when happy; pale green or grey when calm, and pure obsidian black when angry.  Glare no longer impacts them and they are not bothered by light levels when sleeping.",
+    "description": "Upon gaining this ability the Ierde's eyes begin reflecting their mood: a pale white streaked with rose when happy; pale green or grey when calm, and pure obsidian black when angry.  Glare no longer impacts them and they are not bothered by light levels when sleeping.  In addition, they have much better night vision.",
     "category": [ "IERDE" ],
     "purifiable": false,
-    "integrated_armor": [ "integrated_ierde_eyes" ],
-    "flags": [ "SEESLEEP" ]
+    "enchantments": [ { "modified_bodyparts": [ { "lose": "eyes" }, { "gain": "fae_eyes_ierde" } ] } ]
   },
   {
     "type": "mutation",

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/salamander_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/salamander_mutations.json
@@ -264,12 +264,11 @@
     "points": 1,
     "visibility": 2,
     "ugliness": 0,
-    "description": "Upon gaining this ability the Salamander's eyes begin reflecting their mood, with warm yellows and deep reds when happy and blazing oranges, blues, and whites when angry.  Glare no longer impacts them and they can always see exactly what temperature it is.",
+    "description": "Upon gaining this ability the Salamander's eyes begin reflecting their mood, with warm yellows and deep reds when happy and blazing oranges, blues, and whites when angry.  Glare no longer impacts them and they can always see exactly what temperature it is.  In addition, and they have slightly better daytime vision and much reaction times, though their nighttime vision is reduced.",
     "leads_to": [ "SALAMANDER_HEAT_EYES" ],
     "category": [ "SALAMANDER" ],
     "purifiable": false,
-    "integrated_armor": [ "integrated_salamander_eyes" ],
-    "flags": [ "THERMOMETER" ]
+    "enchantments": [ { "modified_bodyparts": [ { "lose": "eyes" }, { "gain": "fae_eyes_salamander" } ] } ]
   },
   {
     "type": "mutation",

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/sylph_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/sylph_mutations.json
@@ -88,10 +88,10 @@
     "points": 1,
     "visibility": 2,
     "ugliness": 0,
-    "description": "Upon gaining this ability the Sylph's eyes begin reflecting their mood with lightning and storms when angry and clear skies when happy.  Glare no longer impacts them.",
+    "description": "Upon gaining this ability the Sylph's eyes begin reflecting their mood with lightning and storms when angry and clear skies when happy.  Glare no longer impacts them, and they have much better daytime vision and much faster reaction times.",
     "category": [ "SYLPH" ],
     "purifiable": false,
-    "integrated_armor": [ "integrated_sylph_eyes" ]
+    "enchantments": [ { "modified_bodyparts": [ { "lose": "eyes" }, { "gain": "fae_eyes_sylph" } ] } ]
   },
   {
     "type": "mutation",

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/undine_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/undine_mutations.json
@@ -301,11 +301,10 @@
     "points": 1,
     "visibility": 2,
     "ugliness": 0,
-    "description": "Upon gaining this ability the Undine's eyes begin reflecting their mood with colors of the deep waters, pitch black when angry or sad and green-blue when pleased.  Glare no longer impacts them, and neither do light levels when trying to sleep.  They can also see without problem underwater.",
+    "description": "Upon gaining this ability the Undine's eyes begin reflecting their mood with colors of the deep waters, pitch black when angry or sad and green-blue when pleased.  Glare no longer impacts them, and neither do light levels when trying to sleep.  They can also see without problem underwater and have better night vision in general.",
     "category": [ "UNDINE" ],
     "purifiable": false,
-    "integrated_armor": [ "integrated_undine_eyes" ],
-    "flags": [ "SEESLEEP", "SWIM_GOGGLES" ]
+    "enchantments": [ { "modified_bodyparts": [ { "lose": "eyes" }, { "gain": "fae_eyes_undine" } ] } ]
   },
   {
     "type": "mutation",

--- a/data/mods/Xedra_Evolved/obsoletion_and_migration/items.json
+++ b/data/mods/Xedra_Evolved/obsoletion_and_migration/items.json
@@ -1,10 +1,20 @@
 [
   {
-    "id": [ "integrated_nobreathe", "integrated_sylph_breath" ],
+    "id": [
+      "integrated_nobreathe",
+      "integrated_sylph_breath",
+      "integrated_arvore_eyes",
+      "integrated_ierde_eyes",
+      "integrated_homullus_eyes",
+      "integrated_salamander_eyes",
+      "integrated_sylph_eyes",
+      "integrated_undine_eyes"
+    ],
     "type": "MIGRATION",
     "replace": "manual_swimming"
   },
   {
+    "//": "Remove after 0.J",
     "id": "aura_ward_off_rain",
     "type": "ITEM",
     "subtypes": [ "ARMOR", "ARTIFACT" ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Xedra Evolved] Paraclesian eyes are a bodypart"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Let's limbify even more things!

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Remove the integrated armor and turn Paraclesian eyes into their own bodypart. These mostly copy-from eyes, with some conditional flags (everyone has `GLARE_RESIST`, Ierde and Undines have `SEESLEEP`, Salamanders have `THERMOMETER`, etc)., and some different limb scores. Reaction is generally higher, Arvore, Sylphs, and Salamanders have better day vision, Ierde and Undines have better night vision, Salamanders have _worse_ night vision (kindle those flames if you want to see), etc. Homullus are the same as human eyes except for the `GLARE_RESIST`

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Mutated various eyes

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
