### PR TITLE
More elaborate support for guns and melee sound effects

### DIFF
--- a/doc/SOUNDPACKS.md
+++ b/doc/SOUNDPACKS.md
@@ -66,15 +66,7 @@ Sound effects can be included with a format like this:
     "type": "sound_effect",
     "id": "menu_move",
     "volume": 100,
-    "files": [ "nenadsimic_menu_selection_click.wav" ]
-  },
-  {
-    "type": "sound_effect",
-    "id": "fire_gun",
-    "volume": 90,
-    "variant": "bio_laser_gun",
-    "season": "summer",
-    "files": [ "guns/energy_generic/weapon_fire_laser.ogg" ]
+    "files": [ "menu_move.ogg" ]
   },
   {
     "type": "sound_effect",
@@ -85,11 +77,23 @@ Sound effects can be included with a format like this:
     "is_indoors": true,
     "is_night": false,
     "files": [ "indoors/open_door_daytime.ogg" ]
+  },
+  {
+    "type": "sound_effect",
+    "id": "fire_gun",
+    "volume": 90,
+    "variant": [
+        "modular_ar15",
+        "modular_m4_carbine",
+        "scar_l"
+    ],
+    "season": "summer",
+    "files": [ "fire_gun/rifles/rifles_1.ogg" ]
   }
 ]
 ```
 
-Each sound effect is identified by an id, a variant, and a season. If a sound effect is played with a variant that does not exist in the json files, but a variant "default" exists, then the "default" variant is played instead. The file name of the sound effect is relative to the soundpack directory, so if the file name is set to "sfx.wav" and your soundpack is in `data/sound/mypack`, the file must be placed at `data/sound/mypack/sfx.wav`.
+Each sound effect is identified by an id, a variant or an array of varinats, and a season. If a sound effect is played with a variant that does not exist in the json files, but a variant "default" exists, then the "default" variant is played instead. Some sound effects may not use "default" variant. The file name of the sound effect is relative to the soundpack directory, so if the file name is set to "sfx.wav" and your soundpack is in `data/sound/mypack`, the file must be placed at `data/sound/mypack/sfx.wav`.
 
 ##### Adding variety
 
@@ -97,7 +101,7 @@ Several optional fields can be defined to target specific situations:
 
 | Field        | Purpose
 |---           |---
-| `variant`    | Defines a specific subset of the id's sound group. (ex: `"id": "environment", "variant": "WEATHER_DRIZZLE"`)
+| `variant`    | Defines a specific subset (or an array of subsets) of the id's sound group. (ex: `"id": "environment", "variant": "WEATHER_DRIZZLE"`, `"id": "fire_ammo", "variant": [ "223", "308" ]`)
 | `season`     | If defined, the sound will only play on the specified season. (possible values are `spring`, `summer`, `autumn`, and `winter`).
 | `is_indoors` | If defined, the sound will only play if the player is indoors/outdoors when true/false.
 | `is_night`   | If defined, the sound will only play if the current time is night/day when true/false.
@@ -179,7 +183,7 @@ A full list of sound effect IDs and variants is given in the following. Each lin
 
 `id variant1|variant2`
 
-Where `id` describes the ID of the sound effect, and a list of variants separated by | follows. When the variants are omitted, the variant "default" is assumed. Where the variants do not represent literal strings, but variables, they will be enclosed in `<` `>`. For instance, `<furniture>` is a placeholder for any valid furniture ID (as in the furniture definition JSON).
+Where `id` describes the ID of the sound effect, and a list of variants separated by | follows. When the variants are omitted, the variant "default" is assumed unless otherwise specified. Where the variants do not represent literal strings, but variables, they will be enclosed in `<` `>`. For instance, `<furniture>` is a placeholder for any valid furniture ID (as in the furniture definition JSON).
 
 ### Open/close doors
 
@@ -197,15 +201,28 @@ Includes special ones that are furniture/terrain specific.
 
 ### Melee
 
-* `melee_swing default|small_bash|small_cutting|small_stabbing|big_bash|big_cutting|big_stabbing`
-* `melee_hit_flesh default|small_bash|small_cutting|small_stabbing|big_bash|big_cutting|big_stabbing|<weapon>`
-* `melee_hit_metal default|small_bash|small_cutting|small_stabbing|big_bash|big_cutting|big_stabbing!<weapon>`
-* `melee_hit <weapon>` # note: use weapon id "null" for unarmed attacks
+Melee sound effects depends on which attack is used. For instance, attacking with a knife will make a stabbing sound, and punching or kicking with Force unarmed or martial arts will make unarmed or default melee sound.
+
+Note: `<weapon>` variant has priority over skill/damage type variant. If everything else fails to play, it will fallback to `"default"` variant.
+
+TODO: critical hit sounds
+
+* `melee_swing default|<weapon>|unarmed|small_bash|small_cutting|small_stabbing|big_bash|big_cutting|big_stabbing`
+* `melee_hit_flesh default|<weapon>|unarmed|small_bash|small_cutting|small_stabbing|big_bash|big_cutting|big_stabbing`
+* `melee_hit_metal default|<weapon>|unarmed|small_bash|small_cutting|small_stabbing|big_bash|big_cutting|big_stabbing`
 
 ### Firearm/ranged weapon
 
-* `fire_gun <weapon>|brass_eject|empty`
-* `fire_gun_distant <weapon>`
+Note: `fire_gun` has priority over `fire_ammo`. `fire_ammo` does not have default variant fallback. If everything else fails to play, it will fallback to `fire_gun default`.
+
+TODO: terrain-specific `brass_eject`, reload sounds id for guns with `RELOAD_ONE` flag
+
+* `fire_gun default|<weapon>|brass_eject|empty`
+* `fire_gun_distant default|<weapon>`
+* `fire_gun_suppressed default|<weapon>` # used if the gun has a gunmod that reduces loudness
+* `fire_ammo <ammo>` # `ammunition_type` used by gun (ex: `"223"`, `"44"`, `"shot"`)
+* `fire_ammo_distant <ammo>`
+* `fire_ammo_suppressed <ammo>`
 * `reload <weapon>`
 * `bullet_hit hit_flesh|hit_wall|hit_metal|hit_glass|hit_water`
 
@@ -236,8 +253,9 @@ Triggered by seeing large numbers of zombies.
 
 ### Chainsaw pack
 
+Note: Unused
+
 * `chainsaw_cord     chainsaw_on`
-* `chainsaw_start    chainsaw_on`
 * `chainsaw_start    chainsaw_on`
 * `chainsaw_stop     chainsaw_on`
 * `chainsaw_idle     chainsaw_on`
@@ -249,6 +267,8 @@ Triggered by seeing large numbers of zombies.
 * `weapon_theme      chainsaw`
 
 ### Monster death and bite attacks
+
+TODO: monster-specific sounds id
 
 * `mon_death zombie_death|zombie_gibbed`
 * `mon_bite bite_miss|bite_hit`
@@ -278,7 +298,7 @@ Example: if `plmove|t_grass_long` is defined it will be played before default `p
 ### Various bionics
 
 * `bionic elec_discharge|elec_crackle_low|elec_crackle_med|elec_crackle_high|elec_blast|elec_blast_muffled|acid_discharge|pixelated`
-* `bionic bio_resonator|bio_hydraulics|`
+* `bionic bio_resonator|bio_hydraulics`
 
 ### Various tools/traps being used
 

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -708,7 +708,7 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
     Character &player_character = get_player_character();
     if( !hits ) {
         int stumble_pen = stumble( *this, cur_weapon );
-        sfx::generate_melee_sound( pos_bub(), t.pos_bub(), false, false );
+        sfx::generate_melee_sound( cur_weap, pos_bub(), t.pos_bub(), false, false );
 
         const ma_technique miss_recovery = martial_arts_data->get_miss_recovery( *this );
 
@@ -918,7 +918,7 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
                     material = "steel";
                 }
             }
-            sfx::generate_melee_sound( pos_bub(), t.pos_bub(), true, t.is_monster(), material );
+            sfx::generate_melee_sound( cur_weap, pos_bub(), t.pos_bub(), true, t.is_monster(), material );
             int dam = dealt_dam.total_damage();
             melee::melee_stats.damage_amount += dam;
 

--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -263,6 +263,14 @@ struct sfx_map {
                                      tod_from_int( bool_or( is_night, -1 ) ), sfx_time_of_day::ANY );
         }
 
+        const std::vector<sound_effect> *find_no_fallback( const std::string &id, const std::string &variant,
+                                                           const std::string &season, const std::optional<bool> &is_indoors,
+                                                           const std::optional<bool> &is_night ) const {
+            return find_closest_sfx( effects, id, "", variant, "", season_from_string( season ),
+                                     sfx_season::NONE, in_or_out_from_int( bool_or( is_indoors, -1 ) ), sfx_in_or_out::EITHER,
+                                     tod_from_int( bool_or( is_night, -1 ) ), sfx_time_of_day::ANY );
+        }
+
     private:
         std::map<std::string, std::map<std::string, std::map<sfx_season, std::map<sfx_in_or_out, std::map<sfx_time_of_day, std::vector<sound_effect>>>>>>
         effects;
@@ -681,14 +689,10 @@ bool sfx::has_exact_variant_sound( const std::string &id, const std::string &var
                                    const std::string &season, const std::optional<bool> &is_indoors,
                                    const std::optional<bool> &is_night )
 {
-    sfx_args key;
-    key.id = id;
-    key.variant = variant;
-    key.season = season;
-    key.indoors = is_indoors;
-    key.night = is_night;
 
-    const std::vector<sound_effect> *iter = sfx_resources.sound_effects.find( key );
+    const std::vector<sound_effect> *iter = sfx_resources.sound_effects.find_no_fallback( id, variant, season,
+                                            is_indoors,
+                                            is_night );
 
     return iter != nullptr;
 }

--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -263,9 +263,10 @@ struct sfx_map {
                                      tod_from_int( bool_or( is_night, -1 ) ), sfx_time_of_day::ANY );
         }
 
-        const std::vector<sound_effect> *find_no_fallback( const std::string &id, const std::string &variant,
-                                                           const std::string &season, const std::optional<bool> &is_indoors,
-                                                           const std::optional<bool> &is_night ) const {
+        const std::vector<sound_effect> *find_no_fallback( const std::string &id,
+                const std::string &variant,
+                const std::string &season, const std::optional<bool> &is_indoors,
+                const std::optional<bool> &is_night ) const {
             return find_closest_sfx( effects, id, "", variant, "", season_from_string( season ),
                                      sfx_season::NONE, in_or_out_from_int( bool_or( is_indoors, -1 ) ), sfx_in_or_out::EITHER,
                                      tod_from_int( bool_or( is_night, -1 ) ), sfx_time_of_day::ANY );

--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -675,6 +675,22 @@ bool sfx::has_variant_sound( const std::string &id, const std::string &variant,
     return find_random_effect( id, variant, season, is_indoors, is_night ) != nullptr;
 }
 
+// Returns a sound effect matching given id and variant.
+// Unlike has_variant_sound(), this doesn't fallback to "default" variants.
+bool sfx::has_exact_variant_sound( const std::string &id, const std::string &variant,
+                                   const std::string &season, const std::optional<bool> &is_indoors,
+                                   const std::optional<bool> &is_night )
+{
+    sfx_args key;
+    key.id = id;
+    key.variant = variant;
+    key.season = season;
+    key.indoors = is_indoors;
+    key.night = is_night;
+    
+    return sfx_resources.sound_effects.find( key ) != nullptr;
+}
+
 static bool is_time_slowed()
 {
     if( g == nullptr || g->uquit != QUIT_NO ) {

--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -690,11 +690,7 @@ bool sfx::has_exact_variant_sound( const std::string &id, const std::string &var
 
     const std::vector<sound_effect> *iter = sfx_resources.sound_effects.find( key );
 
-    if( !iter ) {
-        return false;
-    }
-
-    return &random_entry_ref( *iter );
+    return iter != nullptr;
 }
 
 static bool is_time_slowed()

--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -691,7 +691,8 @@ bool sfx::has_exact_variant_sound( const std::string &id, const std::string &var
                                    const std::optional<bool> &is_night )
 {
 
-    const std::vector<sound_effect> *iter = sfx_resources.sound_effects.find_no_fallback( id, variant, season,
+    const std::vector<sound_effect> *iter = sfx_resources.sound_effects.find_no_fallback( id, variant,
+                                            season,
                                             is_indoors,
                                             is_night );
 

--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -687,8 +687,14 @@ bool sfx::has_exact_variant_sound( const std::string &id, const std::string &var
     key.season = season;
     key.indoors = is_indoors;
     key.night = is_night;
-    
-    return sfx_resources.sound_effects.find( key ) != nullptr;
+
+    const std::vector<sound_effect> *iter = sfx_resources.sound_effects.find( key );
+
+    if( !iter ) {
+        return false;
+    }
+
+    return &random_entry_ref( *iter );
 }
 
 static bool is_time_slowed()

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -1325,6 +1325,7 @@ void sfx::generate_gun_sound( const Character &source_arg, const item &firing )
         heard_volume = 30;
     }
 
+    ammotype ammo_type = firing.ammo_type();
     itype_id weapon_id = firing.typeId();
     units::angle angle = 0_degrees;
     int distance = 0;
@@ -1343,9 +1344,8 @@ void sfx::generate_gun_sound( const Character &source_arg, const item &firing )
         []( const item * e ) {
         return e->type->gunmod->loudness < 0;
     } ) && firing.gun_skill().str() != "archery" ) {
-            weapon_id = itype_weapon_fire_suppressed;
+            selected_sound = "fire_gun_suppressed";
         }
-
     } else {
         angle = get_heard_angle( source );
         distance = sound_distance( player_character.pos_bub(), source );
@@ -1356,8 +1356,19 @@ void sfx::generate_gun_sound( const Character &source_arg, const item &firing )
         }
     }
 
-    play_variant_sound( selected_sound, weapon_id.str(), seas_str, indoors, night,
-                        heard_volume, angle, 0.8, 1.2 );
+    if( has_exact_variant_sound( selected_sound, weapon_id.str(), seas_str, indoors, night ) ) {
+        play_variant_sound( selected_sound, weapon_id.str(), seas_str, indoors, night,
+                            heard_volume, angle, 0.8, 1.2 );
+
+    } else if( !ammo_type.is_null() && has_exact_variant_sound( selected_sound + "_ammo", ammo_type.str(),
+                                       seas_str, indoors, night ) ) {
+        play_variant_sound( selected_sound + "_ammo", ammo_type.str(), seas_str, indoors, night,
+                            heard_volume, angle, 0.8, 1.2 );
+
+    } else {
+        play_variant_sound( selected_sound, "default", seas_str, indoors, night,
+                            heard_volume, angle, 0.8, 1.2 );
+    }
     start_sfx_timestamp = std::chrono::high_resolution_clock::now();
 }
 
@@ -1485,6 +1496,7 @@ void sfx::sound_thread::operator()() const
             std::this_thread::sleep_for( std::chrono::milliseconds( sleep_time ) );
             play_variant_sound( melee_hit_material, weapon_variant, seas_str, indoors,
                                 night, vol_targ, ang_targ, 0.8, 1.2 );
+
         } else {
             std::this_thread::sleep_for( std::chrono::milliseconds( sleep_time ) );
             play_variant_sound( melee_hit_material, skill_variant, seas_str, indoors,

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -88,7 +88,6 @@ static const efftype_id effect_slept_through_alarm( "slept_through_alarm" );
 static const itype_id fuel_type_battery( "battery" );
 static const itype_id fuel_type_muscle( "muscle" );
 static const itype_id fuel_type_wind( "wind" );
-static const itype_id itype_weapon_fire_suppressed( "weapon_fire_suppressed" );
 
 static const json_character_flag json_flag_ALARMCLOCK( "ALARMCLOCK" );
 static const json_character_flag json_flag_HEARING_PROTECTION( "HEARING_PROTECTION" );

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -1468,7 +1468,7 @@ void sfx::sound_thread::operator()() const
         skill_variant = "default";
     }
 
-    if( has_variant_sound( "melee_swing", weapon_variant, seas_str, indoors, night ) ) {
+    if( has_exact_variant_sound( "melee_swing", weapon_variant, seas_str, indoors, night ) ) {
         play_variant_sound( "melee_swing", weapon_variant, seas_str, indoors, night,
                             vol_src, ang_src, 0.8, 1.2 );
     } else {
@@ -1481,7 +1481,7 @@ void sfx::sound_thread::operator()() const
         std::string melee_hit_material = ( targ_mon &&
                                            material == "steel" ) ? "melee_hit_metal" : "melee_hit_flesh";
 
-        if( has_variant_sound( melee_hit_material, weapon_variant, seas_str, indoors, night ) ) {
+        if( has_exact_variant_sound( melee_hit_material, weapon_variant, seas_str, indoors, night ) ) {
             std::this_thread::sleep_for( std::chrono::milliseconds( sleep_time ) );
             play_variant_sound( melee_hit_material, weapon_variant, seas_str, indoors,
                                 night, vol_targ, ang_targ, 0.8, 1.2 );
@@ -1984,6 +1984,15 @@ bool sfx::has_variant_sound( const std::string &id, const std::string &variant )
     return has_variant_sound( id, variant, seas_str, indoors, night );
 }
 
+bool sfx::has_exact_variant_sound( const std::string &id, const std::string &variant )
+{
+    const season_type seas = season_of_year( calendar::turn );
+    const std::string seas_str = season_str( seas );
+    const bool indoors = !is_creature_outside( get_player_character() );
+    const bool night = is_night( calendar::turn );
+    return has_exact_variant_sound( id, variant, seas_str, indoors, night );
+}
+
 #else // if defined(SDL_SOUND)
 
 /** Dummy implementations for builds without sound */
@@ -2021,6 +2030,10 @@ int sfx::set_channel_volume( channel, int )
     return 0;
 }
 bool sfx::has_variant_sound( const std::string &, const std::string & )
+{
+    return false;
+}
+bool sfx::has_exact_variant_sound( const std::string &, const std::string & )
 {
     return false;
 }

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -1360,7 +1360,7 @@ void sfx::generate_gun_sound( const Character &source_arg, const item &firing )
         play_variant_sound( "fire_gun" + selected_sound, weapon_id.str(), seas_str, indoors, night,
                             heard_volume, angle, 0.8, 1.2 );
 
-    } else if( has_exact_variant_sound( "fire_ammo" + selected_sound, ammo_type.str(), seas_str, indoors, night ) ) {
+    } else if( !ammo_type.is_null() && has_exact_variant_sound( "fire_ammo" + selected_sound, ammo_type.str(), seas_str, indoors, night ) ) {
         play_variant_sound( "fire_ammo" + selected_sound, ammo_type.str(), seas_str, indoors, night,
                             heard_volume, angle, 0.8, 1.2 );
 

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -1366,7 +1366,8 @@ void sfx::generate_gun_sound( const Character &source_arg, const item &firing )
         play_variant_sound( "fire_ammo" + selected_sound, ammo_type.str(), seas_str, indoors, night,
                             heard_volume, angle, 0.8, 1.2 );
 
-    } else if( has_exact_variant_sound( "fire_gun" + selected_sound, "default", seas_str, indoors, night ) ) {
+    } else if( has_exact_variant_sound( "fire_gun" + selected_sound, "default", seas_str, indoors,
+                                        night ) ) {
         play_variant_sound( "fire_gun" + selected_sound, "default", seas_str, indoors, night,
                             heard_volume, angle, 0.8, 1.2 );
     } else {

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -1360,7 +1360,9 @@ void sfx::generate_gun_sound( const Character &source_arg, const item &firing )
         play_variant_sound( "fire_gun" + selected_sound, weapon_id.str(), seas_str, indoors, night,
                             heard_volume, angle, 0.8, 1.2 );
 
-    } else if( !ammo_type.is_null() && has_exact_variant_sound( "fire_ammo" + selected_sound, ammo_type.str(), seas_str, indoors, night ) ) {
+    } else if( !ammo_type.is_null() &&
+               has_exact_variant_sound( "fire_ammo" + selected_sound, ammo_type.str(), seas_str, indoors,
+                                        night ) ) {
         play_variant_sound( "fire_ammo" + selected_sound, ammo_type.str(), seas_str, indoors, night,
                             heard_volume, angle, 0.8, 1.2 );
 

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -1435,8 +1435,8 @@ sfx::sound_thread::sound_thread( const item &weapon, const tripoint_bub_ms &sour
     }
     ang_targ = get_heard_angle( target );
     weapon_id = weapon.typeId();
-    weapon_skill = weapon ? weapon.melee_skill() : skill_id::NULL_ID();
-    weapon_volume = weapon ? weapon.volume() / 250_ml : 0;
+    weapon_skill = weapon.is_null() ? skill_unarmed : weapon.melee_skill();
+    weapon_volume = !weapon.is_null() ? weapon.volume() / 250_ml : 0;
 }
 
 // Operator overload required for thread API.

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -1435,8 +1435,8 @@ sfx::sound_thread::sound_thread( const item &weapon, const tripoint_bub_ms &sour
     }
     ang_targ = get_heard_angle( target );
     weapon_id = weapon.typeId();
-    weapon_skill = weapon ? weapon->melee_skill() : skill_id::NULL_ID();
-    weapon_volume = weapon ? weapon->volume() / 250_ml : 0;
+    weapon_skill = weapon ? weapon.melee_skill() : skill_id::NULL_ID();
+    weapon_volume = weapon ? weapon.volume() / 250_ml : 0;
 }
 
 // Operator overload required for thread API.

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -1337,36 +1337,36 @@ void sfx::generate_gun_sound( const Character &source_arg, const item &firing )
     const bool night = is_night( calendar::turn );
     // this does not mean p == avatar (it could be a vehicle turret)
     if( player_character.pos_bub() == source ) {
-        selected_sound = "fire_gun";
+        selected_sound = "";
 
         const auto mods = firing.gunmods();
         if( std::any_of( mods.begin(), mods.end(),
         []( const item * e ) {
         return e->type->gunmod->loudness < 0;
     } ) && firing.gun_skill().str() != "archery" ) {
-            selected_sound = "fire_gun_suppressed";
+            selected_sound = "_suppressed";
         }
     } else {
         angle = get_heard_angle( source );
         distance = sound_distance( player_character.pos_bub(), source );
         if( distance <= 17 ) {
-            selected_sound = "fire_gun";
+            selected_sound = "";
         } else {
-            selected_sound = "fire_gun_distant";
+            selected_sound = "_distant";
         }
     }
 
-    if( has_exact_variant_sound( selected_sound, weapon_id.str(), seas_str, indoors, night ) ) {
-        play_variant_sound( selected_sound, weapon_id.str(), seas_str, indoors, night,
+    if( has_exact_variant_sound( "fire_gun" + selected_sound, weapon_id.str(), seas_str, indoors, night ) ) {
+        play_variant_sound( "fire_gun" + selected_sound, weapon_id.str(), seas_str, indoors, night,
                             heard_volume, angle, 0.8, 1.2 );
 
-    } else if( !ammo_type.is_null() && has_exact_variant_sound( selected_sound + "_ammo", ammo_type.str(),
+    } else if( !ammo_type.is_null() && has_exact_variant_sound( "fire_ammo" + selected_sound, ammo_type.str(),
                                        seas_str, indoors, night ) ) {
-        play_variant_sound( selected_sound + "_ammo", ammo_type.str(), seas_str, indoors, night,
+        play_variant_sound( "fire_ammo" + selected_sound, ammo_type.str(), seas_str, indoors, night,
                             heard_volume, angle, 0.8, 1.2 );
 
     } else {
-        play_variant_sound( selected_sound, "default", seas_str, indoors, night,
+        play_variant_sound( "fire_gun" + selected_sound, "default", seas_str, indoors, night,
                             heard_volume, angle, 0.8, 1.2 );
     }
     start_sfx_timestamp = std::chrono::high_resolution_clock::now();

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -1466,7 +1466,7 @@ void sfx::sound_thread::operator()() const
         skill_variant = "default";
     }
     
-    if( weapon_id != itype_id::NULL_ID() && has_variant_sound( "melee_swing", weapon_variant, seas_str, indoors, night ) ) {
+    if( has_variant_sound( "melee_swing", weapon_variant, seas_str, indoors, night ) ) {
         play_variant_sound( "melee_swing", weapon_variant, seas_str, indoors, night,
                             vol_src, ang_src, 0.8, 1.2 );
     } else {
@@ -1478,7 +1478,7 @@ void sfx::sound_thread::operator()() const
         const int sleep_time = weapon_volume * ( targ_mon ? rng( 12, 16 ) : rng( 9, 12 ) );
         std::string melee_hit_material = ( targ_mon && material == "steel" ) ? "melee_hit_metal" : "melee_hit_flesh";
     
-        if( weapon_id != itype_id::NULL_ID() && has_variant_sound( melee_hit_material, weapon_variant, seas_str, indoors, night ) ) {
+        if( has_variant_sound( melee_hit_material, weapon_variant, seas_str, indoors, night ) ) {
             std::this_thread::sleep_for( std::chrono::milliseconds( sleep_time ) );
             play_variant_sound( melee_hit_material, weapon_variant, seas_str, indoors,
                                 night, vol_targ, ang_targ, 0.8, 1.2 );

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -1355,6 +1355,8 @@ void sfx::generate_gun_sound( const Character &source_arg, const item &firing )
         }
     }
 
+    add_msg_debug( debugmode::DF_SOUND, "ammo_type: %s, sound_id: %s, is_null: %s", ammo_type.str(), "fire_ammo" + selected_sound, ammo_type.is_null() );
+
     if( has_exact_variant_sound( "fire_gun" + selected_sound, weapon_id.str(), seas_str, indoors, night ) ) {
         play_variant_sound( "fire_gun" + selected_sound, weapon_id.str(), seas_str, indoors, night,
                             heard_volume, angle, 0.8, 1.2 );

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -19,6 +19,7 @@
 #include "enums.h"
 #include "game.h"
 #include "game_constants.h"
+#include "item.h"
 #include "itype.h" // IWYU pragma: keep
 #include "line.h"
 #include "map.h"

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -102,6 +102,7 @@ static const material_id material_steel( "steel" );
 static const material_id material_stone( "stone" );
 static const material_id material_veggy( "veggy" );
 
+static const skill_id skill_unarmed( "unarmed" );
 static const skill_id skill_bashing( "bashing" );
 static const skill_id skill_cutting( "cutting" );
 static const skill_id skill_stabbing( "stabbing" );
@@ -1363,13 +1364,14 @@ void sfx::generate_gun_sound( const Character &source_arg, const item &firing )
 namespace sfx
 {
 struct sound_thread {
-    sound_thread( const tripoint_bub_ms &source, const tripoint_bub_ms &target, bool hit, bool targ_mon,
+    sound_thread( const item &weapon, const tripoint_bub_ms &source, const tripoint_bub_ms &target, bool hit, bool targ_mon,
                   const std::string &material );
 
     bool hit;
     bool targ_mon;
     std::string material;
 
+    itype_id weapon_id;
     skill_id weapon_skill;
     int weapon_volume;
     // volume and angle for calls to play_variant_sound
@@ -1383,7 +1385,7 @@ struct sound_thread {
 };
 } // namespace sfx
 
-void sfx::generate_melee_sound( const tripoint_bub_ms &source, const tripoint_bub_ms &target,
+void sfx::generate_melee_sound( const item &weapon, const tripoint_bub_ms &source, const tripoint_bub_ms &target,
                                 bool hit,
                                 bool targ_mon,
                                 const std::string &material )
@@ -1395,7 +1397,7 @@ void sfx::generate_melee_sound( const tripoint_bub_ms &source, const tripoint_bu
     // pool or maybe a single thread that works continuously, but that requires a queue or similar
     // to coordinate its work.
     try {
-        std::thread the_thread( sound_thread( source, target, hit, targ_mon, material ) );
+        std::thread the_thread( sound_thread( weapon, source, target, hit, targ_mon, material ) );
         try {
             if( the_thread.joinable() ) {
                 the_thread.detach();
@@ -1409,7 +1411,7 @@ void sfx::generate_melee_sound( const tripoint_bub_ms &source, const tripoint_bu
     }
 }
 
-sfx::sound_thread::sound_thread( const tripoint_bub_ms &source, const tripoint_bub_ms &target,
+sfx::sound_thread::sound_thread( const item &weapon, const tripoint_bub_ms &source, const tripoint_bub_ms &target,
                                  const bool hit,
                                  const bool targ_mon, const std::string &material )
     : hit( hit )
@@ -1431,8 +1433,8 @@ sfx::sound_thread::sound_thread( const tripoint_bub_ms &source, const tripoint_b
         vol_src = std::max( heard_volume - 30, 0 );
         vol_targ = std::max( heard_volume - 20, 0 );
     }
-    const item_location weapon = you.get_wielded_item();
     ang_targ = get_heard_angle( target );
+    weapon_id = weapon.typeId();
     weapon_skill = weapon ? weapon->melee_skill() : skill_id::NULL_ID();
     weapon_volume = weapon ? weapon->volume() / 250_ml : 0;
 }
@@ -1444,52 +1446,45 @@ void sfx::sound_thread::operator()() const
     // that might change (e.g. g->u.weapon, the character could switch weapons while this thread
     // runs).
     std::this_thread::sleep_for( std::chrono::milliseconds( rng( 1, 2 ) ) );
-    std::string variant_used;
     const season_type seas = season_of_year( calendar::turn );
     const std::string seas_str = season_str( seas );
     const bool indoors = !is_creature_outside( get_player_character() );
     const bool night = is_night( calendar::turn );
 
-    if( weapon_skill == skill_bashing && weapon_volume <= 8 ) {
-        variant_used = "small_bash";
-        play_variant_sound( "melee_swing", "small_bash", seas_str, indoors, night,
-                            vol_src, ang_src, 0.8, 1.2 );
-    } else if( weapon_skill == skill_bashing && weapon_volume >= 9 ) {
-        variant_used = "big_bash";
-        play_variant_sound( "melee_swing", "big_bash", seas_str, indoors, night,
-                            vol_src, ang_src, 0.8, 1.2 );
-    } else if( ( weapon_skill == skill_cutting || weapon_skill == skill_stabbing ) &&
-               weapon_volume <= 6 ) {
-        variant_used = "small_cutting";
-        play_variant_sound( "melee_swing", "small_cutting", seas_str, indoors, night,
-                            vol_src, ang_src, 0.8, 1.2 );
-    } else if( ( weapon_skill == skill_cutting || weapon_skill == skill_stabbing ) &&
-               weapon_volume >= 7 ) {
-        variant_used = "big_cutting";
-        play_variant_sound( "melee_swing", "big_cutting", seas_str, indoors, night,
+    std::string skill_variant;
+    std::string weapon_variant = weapon_id.str();
+
+    if( weapon_skill == skill_bashing ) {
+        skill_variant = ( weapon_volume > 8 ) ? "big_bash" : "small_bash";
+    } else if( weapon_skill == skill_cutting ) {
+        skill_variant = ( weapon_volume > 6 ) ? "big_cutting" : "small_cutting";
+    } else if( weapon_skill == skill_stabbing ) {
+        skill_variant = ( weapon_volume > 4 ) ? "big_stabbing" : "small_stabbing";
+    } else if( weapon_skill == skill_unarmed ) {
+        skill_variant = "unarmed";
+    } else {
+        skill_variant = "default";
+    }
+    
+    if( weapon_id != itype_id::NULL_ID() && has_variant_sound( "melee_swing", weapon_variant, seas_str, indoors, night ) ) {
+        play_variant_sound( "melee_swing", weapon_variant, seas_str, indoors, night,
                             vol_src, ang_src, 0.8, 1.2 );
     } else {
-        variant_used = "default";
-        play_variant_sound( "melee_swing", "default", seas_str, indoors, night,
+        play_variant_sound( "melee_swing", skill_variant, seas_str, indoors, night,
                             vol_src, ang_src, 0.8, 1.2 );
     }
+    
     if( hit ) {
-        if( targ_mon ) {
-            if( material == "steel" ) {
-                std::this_thread::sleep_for( std::chrono::milliseconds( rng( weapon_volume * 12,
-                                             weapon_volume * 16 ) ) );
-                play_variant_sound( "melee_hit_metal", variant_used, seas_str, indoors,
-                                    night, vol_targ, ang_targ, 0.8, 1.2 );
-            } else {
-                std::this_thread::sleep_for( std::chrono::milliseconds( rng( weapon_volume * 12,
-                                             weapon_volume * 16 ) ) );
-                play_variant_sound( "melee_hit_flesh", variant_used, seas_str, indoors,
-                                    night, vol_targ, ang_targ, 0.8, 1.2 );
-            }
+        const int sleep_time = weapon_volume * ( targ_mon ? rng( 12, 16 ) : rng( 9, 12 ) );
+        std::string melee_hit_material = ( targ_mon && material == "steel" ) ? "melee_hit_metal" : "melee_hit_flesh";
+    
+        if( weapon_id != itype_id::NULL_ID() && has_variant_sound( melee_hit_material, weapon_variant, seas_str, indoors, night ) ) {
+            std::this_thread::sleep_for( std::chrono::milliseconds( sleep_time ) );
+            play_variant_sound( melee_hit_material, weapon_variant, seas_str, indoors,
+                                night, vol_targ, ang_targ, 0.8, 1.2 );
         } else {
-            std::this_thread::sleep_for( std::chrono::milliseconds( rng( weapon_volume * 9,
-                                         weapon_volume * 12 ) ) );
-            play_variant_sound( "melee_hit_flesh", variant_used, seas_str, indoors,
+            std::this_thread::sleep_for( std::chrono::milliseconds( sleep_time ) );
+            play_variant_sound( melee_hit_material, skill_variant, seas_str, indoors,
                                 night, vol_targ, ang_targ, 0.8, 1.2 );
         }
     }
@@ -2001,7 +1996,7 @@ void sfx::play_ambient_variant_sound( const std::string &, const std::string &, 
 void sfx::play_activity_sound( const std::string &, const std::string &, int ) { }
 void sfx::end_activity_sounds() { }
 void sfx::generate_gun_sound( const Character &, const item & ) { }
-void sfx::generate_melee_sound( const tripoint_bub_ms &, const tripoint_bub_ms &, bool, bool,
+void sfx::generate_melee_sound( const item &, const tripoint_bub_ms &, const tripoint_bub_ms &, bool, bool,
                                 const std::string & ) { }
 void sfx::do_hearing_loss( int ) { }
 void sfx::remove_hearing_loss() { }

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -1475,7 +1475,7 @@ void sfx::sound_thread::operator()() const
         play_variant_sound( "melee_swing", skill_variant, seas_str, indoors, night,
                             vol_src, ang_src, 0.8, 1.2 );
     }
-    
+
     if( hit ) {
         const int sleep_time = weapon_volume * ( targ_mon ? rng( 12, 16 ) : rng( 9, 12 ) );
         std::string melee_hit_material = ( targ_mon &&

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -1364,7 +1364,8 @@ void sfx::generate_gun_sound( const Character &source_arg, const item &firing )
 namespace sfx
 {
 struct sound_thread {
-    sound_thread( const item &weapon, const tripoint_bub_ms &source, const tripoint_bub_ms &target, bool hit, bool targ_mon,
+    sound_thread( const item &weapon, const tripoint_bub_ms &source, const tripoint_bub_ms &target,
+                  bool hit, bool targ_mon,
                   const std::string &material );
 
     bool hit;
@@ -1385,9 +1386,9 @@ struct sound_thread {
 };
 } // namespace sfx
 
-void sfx::generate_melee_sound( const item &weapon, const tripoint_bub_ms &source, const tripoint_bub_ms &target,
-                                bool hit,
-                                bool targ_mon,
+void sfx::generate_melee_sound( const item &weapon, const tripoint_bub_ms &source,
+                                const tripoint_bub_ms &target,
+                                bool hit, bool targ_mon,
                                 const std::string &material )
 {
     if( test_mode ) {
@@ -1411,7 +1412,8 @@ void sfx::generate_melee_sound( const item &weapon, const tripoint_bub_ms &sourc
     }
 }
 
-sfx::sound_thread::sound_thread( const item &weapon, const tripoint_bub_ms &source, const tripoint_bub_ms &target,
+sfx::sound_thread::sound_thread( const item &weapon, const tripoint_bub_ms &source,
+                                 const tripoint_bub_ms &target,
                                  const bool hit,
                                  const bool targ_mon, const std::string &material )
     : hit( hit )
@@ -1476,7 +1478,8 @@ void sfx::sound_thread::operator()() const
     
     if( hit ) {
         const int sleep_time = weapon_volume * ( targ_mon ? rng( 12, 16 ) : rng( 9, 12 ) );
-        std::string melee_hit_material = ( targ_mon && material == "steel" ) ? "melee_hit_metal" : "melee_hit_flesh";
+        std::string melee_hit_material = ( targ_mon &&
+                                           material == "steel" ) ? "melee_hit_metal" : "melee_hit_flesh";
     
         if( has_variant_sound( melee_hit_material, weapon_variant, seas_str, indoors, night ) ) {
             std::this_thread::sleep_for( std::chrono::milliseconds( sleep_time ) );
@@ -1996,7 +1999,8 @@ void sfx::play_ambient_variant_sound( const std::string &, const std::string &, 
 void sfx::play_activity_sound( const std::string &, const std::string &, int ) { }
 void sfx::end_activity_sounds() { }
 void sfx::generate_gun_sound( const Character &, const item & ) { }
-void sfx::generate_melee_sound( const item &, const tripoint_bub_ms &, const tripoint_bub_ms &, bool, bool,
+void sfx::generate_melee_sound( const item &, const tripoint_bub_ms &, const tripoint_bub_ms &,
+                                bool, bool,
                                 const std::string & ) { }
 void sfx::do_hearing_loss( int ) { }
 void sfx::remove_hearing_loss() { }

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -101,10 +101,10 @@ static const material_id material_steel( "steel" );
 static const material_id material_stone( "stone" );
 static const material_id material_veggy( "veggy" );
 
-static const skill_id skill_unarmed( "unarmed" );
 static const skill_id skill_bashing( "bashing" );
 static const skill_id skill_cutting( "cutting" );
 static const skill_id skill_stabbing( "stabbing" );
+static const skill_id skill_unarmed( "unarmed" );
 
 static const ter_str_id ter_t_bridge( "t_bridge" );
 static const ter_str_id ter_t_chainfence( "t_chainfence" );

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -19,7 +19,6 @@
 #include "enums.h"
 #include "game.h"
 #include "game_constants.h"
-#include "item.h"
 #include "itype.h" // IWYU pragma: keep
 #include "line.h"
 #include "map.h"

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -1324,7 +1324,7 @@ void sfx::generate_gun_sound( const Character &source_arg, const item &firing )
         heard_volume = 30;
     }
 
-    ammotype ammo_type = firing.ammo_type();
+    ammotype ammo_type = firing.loaded_ammo().ammo_type();
     itype_id weapon_id = firing.typeId();
     units::angle angle = 0_degrees;
     int distance = 0;

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -1355,7 +1355,8 @@ void sfx::generate_gun_sound( const Character &source_arg, const item &firing )
         }
     }
 
-    if( has_exact_variant_sound( "fire_gun" + selected_sound, weapon_id.str(), seas_str, indoors, night ) ) {
+    if( has_exact_variant_sound( "fire_gun" + selected_sound, weapon_id.str(), seas_str, indoors,
+                                 night ) ) {
         play_variant_sound( "fire_gun" + selected_sound, weapon_id.str(), seas_str, indoors, night,
                             heard_volume, angle, 0.8, 1.2 );
 

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -1355,8 +1355,6 @@ void sfx::generate_gun_sound( const Character &source_arg, const item &firing )
         }
     }
 
-    add_msg_debug( debugmode::DF_SOUND, "ammo_type: %s, sound_id: %s, is_null: %s", ammo_type.str(), "fire_ammo" + selected_sound, ammo_type.is_null() );
-
     if( has_exact_variant_sound( "fire_gun" + selected_sound, weapon_id.str(), seas_str, indoors, night ) ) {
         play_variant_sound( "fire_gun" + selected_sound, weapon_id.str(), seas_str, indoors, night,
                             heard_volume, angle, 0.8, 1.2 );

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -1467,7 +1467,7 @@ void sfx::sound_thread::operator()() const
     } else {
         skill_variant = "default";
     }
-    
+
     if( has_variant_sound( "melee_swing", weapon_variant, seas_str, indoors, night ) ) {
         play_variant_sound( "melee_swing", weapon_variant, seas_str, indoors, night,
                             vol_src, ang_src, 0.8, 1.2 );
@@ -1480,7 +1480,7 @@ void sfx::sound_thread::operator()() const
         const int sleep_time = weapon_volume * ( targ_mon ? rng( 12, 16 ) : rng( 9, 12 ) );
         std::string melee_hit_material = ( targ_mon &&
                                            material == "steel" ) ? "melee_hit_metal" : "melee_hit_flesh";
-    
+
         if( has_variant_sound( melee_hit_material, weapon_variant, seas_str, indoors, night ) ) {
             std::this_thread::sleep_for( std::chrono::milliseconds( sleep_time ) );
             play_variant_sound( melee_hit_material, weapon_variant, seas_str, indoors,

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -1342,7 +1342,7 @@ void sfx::generate_gun_sound( const Character &source_arg, const item &firing )
         const auto mods = firing.gunmods();
         if( std::any_of( mods.begin(), mods.end(),
         []( const item * e ) {
-        return e->type->gunmod->loudness < 0;
+        return e->type->gunmod->loudness_multiplier < 1.0f;
     } ) && firing.gun_skill().str() != "archery" ) {
             selected_sound = "_suppressed";
         }
@@ -1360,13 +1360,15 @@ void sfx::generate_gun_sound( const Character &source_arg, const item &firing )
         play_variant_sound( "fire_gun" + selected_sound, weapon_id.str(), seas_str, indoors, night,
                             heard_volume, angle, 0.8, 1.2 );
 
-    } else if( !ammo_type.is_null() && has_exact_variant_sound( "fire_ammo" + selected_sound, ammo_type.str(),
-                                       seas_str, indoors, night ) ) {
+    } else if( has_exact_variant_sound( "fire_ammo" + selected_sound, ammo_type.str(), seas_str, indoors, night ) ) {
         play_variant_sound( "fire_ammo" + selected_sound, ammo_type.str(), seas_str, indoors, night,
                             heard_volume, angle, 0.8, 1.2 );
 
-    } else {
+    } else if( has_exact_variant_sound( "fire_gun" + selected_sound, "default", seas_str, indoors, night ) ) {
         play_variant_sound( "fire_gun" + selected_sound, "default", seas_str, indoors, night,
+                            heard_volume, angle, 0.8, 1.2 );
+    } else {
+        play_variant_sound( "fire_gun", "default", seas_str, indoors, night,
                             heard_volume, angle, 0.8, 1.2 );
     }
     start_sfx_timestamp = std::chrono::high_resolution_clock::now();

--- a/src/sounds.h
+++ b/src/sounds.h
@@ -186,6 +186,9 @@ bool has_variant_sound( const std::string &id, const std::string &variant );
 bool has_variant_sound( const std::string &id, const std::string &variant,
                         const std::string &season, const std::optional<bool> &is_indoors,
                         const std::optional<bool> &is_night );
+bool has_exact_variant_sound( const std::string &id, const std::string &variant,
+                              const std::string &season, const std::optional<bool> &is_indoors,
+                              const std::optional<bool> &is_night );
 void stop_sound_effect_fade( channel channel, int duration );
 void stop_sound_effect_timed( channel channel, int time );
 int set_channel_volume( channel channel, int volume );

--- a/src/sounds.h
+++ b/src/sounds.h
@@ -166,7 +166,8 @@ void play_activity_sound( const std::string &id, const std::string &variant,
                           const std::string &season, int volume );
 void end_activity_sounds();
 void generate_gun_sound( const Character &source_arg, const item &firing );
-void generate_melee_sound( const item &weapon, const tripoint_bub_ms &source, const tripoint_bub_ms &target, bool hit,
+void generate_melee_sound( const item &weapon, const tripoint_bub_ms &source,
+                           const tripoint_bub_ms &target, bool hit,
                            bool targ_mon = false, const std::string &material = "flesh" );
 void do_hearing_loss( int turns = -1 );
 void remove_hearing_loss();

--- a/src/sounds.h
+++ b/src/sounds.h
@@ -166,7 +166,7 @@ void play_activity_sound( const std::string &id, const std::string &variant,
                           const std::string &season, int volume );
 void end_activity_sounds();
 void generate_gun_sound( const Character &source_arg, const item &firing );
-void generate_melee_sound( const tripoint_bub_ms &source, const tripoint_bub_ms &target, bool hit,
+void generate_melee_sound( const item &weapon, const tripoint_bub_ms &source, const tripoint_bub_ms &target, bool hit,
                            bool targ_mon = false, const std::string &material = "flesh" );
 void do_hearing_loss( int turns = -1 );
 void remove_hearing_loss();

--- a/src/sounds.h
+++ b/src/sounds.h
@@ -186,6 +186,7 @@ bool has_variant_sound( const std::string &id, const std::string &variant );
 bool has_variant_sound( const std::string &id, const std::string &variant,
                         const std::string &season, const std::optional<bool> &is_indoors,
                         const std::optional<bool> &is_night );
+bool has_exact_variant_sound( const std::string &id, const std::string &variant );
 bool has_exact_variant_sound( const std::string &id, const std::string &variant,
                               const std::string &season, const std::optional<bool> &is_indoors,
                               const std::optional<bool> &is_night );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Infrastructure "Add sound support for ammo_type and specific melee ids"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
- SOUNDPACKS.md mentions that melee sounds accept weapon id as variant, but the code for checking weapon id was removed years ago for performance reasons. This PR reintroduces it to allow soundpack builders to add unique sound effects for melee weapons, and it also makes melee sound effects to respect attacks done with martial arts.

- Closes #85814. Currently, gun fire sound effects are added by defining gun ids. This has two issues:
1. There are so many gun ids to add, [which can bloat sound JSONs](https://github.com/Fris0uman/CDDA-Soundpacks/blob/88586bb600eae4b053a8928bddbd5371d0b1ecc6/sound/CC-Sounds/fire_gun/rifles/rifles.json) and make maintenance hard.
2. It does not account for caliber conversion. Guns with different caliber options, especially HWP, can only have one gun sound effect.

- Fixes and reimplements sound effect support for suppressed guns. Current codebase uses `weapon_fire_suppressed` variant for `fire_gun` sound id, which is unintuitive. It also does not work properly since it checks for gunmods that has `loudness_modifier`, even though suppressors use `loudness_multiplier` now (except for `robofac_gun_smg` and `mp5sd_suppressor`.)

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adds `unarmed` as variant for unarmed specific attacks. `default` still may be used in some cases.

Adds item id as variant for `melee_swing`, `melee_hit_flesh` and `melee_hit_metal` sound effects.

JSON example:
```js
[
  {
    "type": "sound_effect",
    "id": "melee_hit_flesh",
    "variant": [
      "machete",
      "survivor_machete_qt"
    ],
    "volume": 100,
    "files": [
      "melee_hit_flesh/machete/machete_flesh_1.ogg",
      "melee_hit_flesh/machete/machete_flesh_2.ogg"
    ]
  }
]
```


Adds new sound effect ids: `fire_ammo`, `fire_gun_suppressed`, `fire_ammo_suppressed`.
- `fire_ammo` takes `ammunition_type`s as variants, such as `"9mm"`, `"223"`, `"shot"`.
- IDs with `_suppressed` suffix plays when the gun or ammo firing has a gunmod with `loudness_multiplier` less than 1.
JSON example:
```js
[
  {
    "type": "sound_effect",
    "id": "fire_ammo",
    "volume": 100,
    "variant": [
      "223",
      "308"
    ],
    "files": [
      "fire_gun/rifles/rifle_1.ogg"
    ]
  }
]
```


Changes `generate_melee_sound()` to pass item used to attack, instead of using currently wielded item.

Adds a new function for C++: `has_exact_variant_sound()`. Essentially the same as `has_variant_sound()`, except it does not have `"default"` fallback. Useful for when different fallback methods for sound effects are needed.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Updating the outdated SOUNDPACKS.md to delete `<weapon>` as possible variant
Making gun sound effects to use skill type - has too many exceptions
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
The tests in the videos were done with custom built soundpack that uses sound effects from Project Zomboid and Otopack. These are not included in CC-Sounds, and I will not publish or share any sounds used for the soundpack.

- Melee sounds

https://github.com/user-attachments/assets/87cafce3-f6f9-4b90-8235-333cfbf7996a


- Gun/Ammo sounds

https://github.com/user-attachments/assets/d1ad649e-6553-4239-89b8-526dc18eec2a


- Suppressed gun sounds

https://github.com/user-attachments/assets/53c2fc6d-dc73-4339-93d2-b72fccf8d5b1



<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
