### PR TITLE
NPC warmth response: wear clothes, take shelter

### DIFF
--- a/src/npc.h
+++ b/src/npc.h
@@ -1128,6 +1128,8 @@ class npc : public Character
 
         npc_action address_needs();
         npc_action address_needs( float danger );
+        bool wear_warmest_item();
+        bool take_shelter_nearby();
         npc_action address_player();
         npc_action long_term_goal_action();
         int evaluate_sleep_spot( tripoint_bub_ms p );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -191,6 +191,7 @@ static const npc_class_id NC_EVAC_SHOPKEEP( "NC_EVAC_SHOPKEEP" );
 
 static const skill_id skill_firstaid( "firstaid" );
 
+static const string_id<behavior::node_t> behavior_node_t_npc_homeostasis( "npc_homeostasis" );
 static const string_id<behavior::node_t> behavior_node_t_npc_needs( "npc_needs" );
 
 static const trait_id trait_IGNORE_SOUND( "IGNORE_SOUND" );
@@ -2556,6 +2557,24 @@ healing_options npc::patient_assessment( const Character &c )
 
 npc_action npc::address_needs( float danger )
 {
+    // Tick warmth subtree as gate. If not "idle", NPC needs warmth.
+    // Try all supported warmth actions in order. start_fire goal is not
+    // dispatched yet (no fire-starting action code); when it is, switch
+    // to respecting the specific goal string.
+    bool needs_warmth = false;
+    {
+        behavior::character_oracle_t oracle( this );
+        behavior::tree warmth_tree;
+        warmth_tree.add( &behavior_node_t_npc_homeostasis.obj() );
+        std::string warmth_goal = warmth_tree.tick( &oracle );
+        needs_warmth = warmth_goal != "idle";
+        if( needs_warmth ) {
+            add_msg_debug( debugmode::DF_NPC_NEEDS,
+                           "NPC %s: warmth subtree = %s (gate open, trying wear then shelter)",
+                           get_name(), warmth_goal );
+        }
+    }
+
     map &here = get_map();
 
     Character &player_character = get_player_character();
@@ -2625,6 +2644,12 @@ npc_action npc::address_needs( float danger )
         }
     }
 
+    // Warmth: wearing clothes costs a turn but hypothermia is life-threatening.
+    // Before danger gate, like extreme food.
+    if( needs_warmth && wear_warmest_item() ) {
+        return npc_noop;
+    }
+
     // Extreme thirst or hunger, bypass safety check.
     if( get_thirst() > 80 ||
         get_stored_kcal() + stomach.get_calories() < get_healthy_kcal() * 0.75 ) {
@@ -2642,6 +2667,11 @@ npc_action npc::address_needs( float danger )
 
     if( danger > NPC_DANGER_VERY_LOW ) {
         return npc_undecided;
+    }
+
+    // Warmth: shelter requires movement, only safe at low danger.
+    if( needs_warmth && take_shelter_nearby() ) {
+        return npc_noop;
     }
 
     if( one_in( 3 ) && ( get_thirst() > NPC_THIRST_CONSUME ||
@@ -5528,6 +5558,49 @@ void npc::do_reload( const item_location &it )
 
     // Otherwise the NPC may not equip the weapon until they see danger
     has_new_items = true;
+}
+
+bool npc::wear_warmest_item()
+{
+    // Find unworn item with highest warmth that we can wear.
+    item *best = nullptr;
+    int best_warmth = 0;
+    has_item_with( [this, &best, &best_warmth]( const item & candidate ) {
+        if( !is_worn( candidate ) && candidate.get_warmth() > best_warmth &&
+            can_wear( candidate ).success() ) {
+            best = const_cast<item *>( &candidate );
+            best_warmth = candidate.get_warmth();
+        }
+        return false;
+    } );
+    if( !best ) {
+        return false;
+    }
+    item_location loc( *this, best );
+    return wear( loc, false ).has_value();
+}
+
+bool npc::take_shelter_nearby()
+{
+    const map &here = get_map();
+    const tripoint_bub_ms &cur = pos_bub();
+    if( here.has_flag( ter_furn_flag::TFLAG_INDOORS, cur ) ) {
+        return false;
+    }
+    const creature_tracker &creatures = get_creature_tracker();
+    for( const tripoint_bub_ms &adj : here.points_in_radius( cur, 1 ) ) {
+        if( adj == cur ) {
+            continue;
+        }
+        if( here.has_flag( ter_furn_flag::TFLAG_INDOORS, adj ) &&
+            here.passable( adj ) && !creatures.creature_at( adj ) ) {
+            move_to( adj );
+            if( pos_bub() == adj ) {
+                return true;
+            }
+        }
+    }
+    return false;
 }
 
 bool npc::adjust_worn()

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -11,11 +11,14 @@
 #include <vector>
 
 #include "avatar.h"
+#include "behavior.h"
 #include "bodypart.h"
 #include "calendar.h"
 #include "cata_catch.h"
 #include "cata_scope_helpers.h"
 #include "character.h"
+#include "character_attire.h"
+#include "character_oracle.h"
 #include "common_types.h"
 #include "coordinates.h"
 #include "creature_tracker.h"
@@ -53,6 +56,7 @@
 #include "vehicle.h"
 #include "viewer.h"
 #include "vpart_position.h"
+#include "weather.h"
 
 class Creature;
 
@@ -64,11 +68,14 @@ static const faction_id faction_your_followers( "your_followers" );
 static const item_group_id Item_spawn_data_SUS_trash_forest_manmade( "SUS_trash_forest_manmade" );
 static const item_group_id Item_spawn_data_test_NPC_guns( "test_NPC_guns" );
 
+static const itype_id itype_2x4( "2x4" );
 static const itype_id itype_M24( "M24" );
+static const itype_id itype_backpack( "backpack" );
 static const itype_id itype_bat( "bat" );
 static const itype_id itype_debug_backpack( "debug_backpack" );
 static const itype_id itype_honeycomb( "honeycomb" );
 static const itype_id itype_leather_belt( "leather_belt" );
+static const itype_id itype_lighter( "lighter" );
 static const itype_id itype_marloss_berry( "marloss_berry" );
 static const itype_id itype_marloss_gel( "marloss_gel" );
 static const itype_id itype_meat( "meat" );
@@ -77,6 +84,9 @@ static const itype_id itype_meat_tainted( "meat_tainted" );
 static const itype_id itype_mutagen( "mutagen" );
 static const itype_id itype_sandwich_cheese_grilled( "sandwich_cheese_grilled" );
 static const itype_id itype_space_cake( "space_cake" );
+static const itype_id itype_sweater( "sweater" );
+
+static const ter_str_id ter_t_floor( "t_floor" );
 
 static const trait_id trait_SAPROPHAGE( "SAPROPHAGE" );
 static const trait_id trait_SAPROVORE( "SAPROVORE" );
@@ -950,5 +960,128 @@ TEST_CASE( "npc_saprovore_eats_rotten_food", "[npc][food]" )
         guy.set_mutation( trait_SAPROPHAGE );
         guy.i_add( rotten_meat );
         CHECK( guy.consume_food() );
+    }
+}
+
+// npc_action enum values (npc_noop, npc_undecided, etc.) are defined in
+// npcmove.cpp, not exposed in a header. Tests assert NPC state changes
+// (worn items, position) rather than return codes.
+TEST_CASE( "npc_warmth_response_in_address_needs", "[npc]" )
+{
+    clear_map_without_vision();
+    calendar::turn = calendar::start_of_cataclysm;
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy );
+    guy.worn.wear_item( guy, item( itype_backpack ), false, false );
+
+    SECTION( "freezing NPC with sweater wears it" ) {
+        guy.set_all_parts_temp_conv( BODYTEMP_VERY_COLD );
+        behavior::character_oracle_t oracle( &guy );
+        REQUIRE( oracle.needs_warmth_badly( "" ) == behavior::status_t::running );
+
+        guy.i_add( item( itype_sweater ) );
+        REQUIRE( !guy.is_wearing( itype_sweater ) );
+
+        guy.address_needs( 0 );
+
+        CHECK( guy.is_wearing( itype_sweater ) );
+    }
+
+    SECTION( "freezing NPC outdoors moves to adjacent indoor tile" ) {
+        guy.set_all_parts_temp_conv( BODYTEMP_VERY_COLD );
+        behavior::character_oracle_t oracle( &guy );
+        REQUIRE( oracle.needs_warmth_badly( "" ) == behavior::status_t::running );
+
+        map &here = get_map();
+        tripoint_bub_ms adj = guy.pos_bub() + point::east;
+        here.ter_set( adj, ter_t_floor );
+
+        guy.address_needs( 0 );
+
+        CHECK( guy.pos_bub() == adj );
+    }
+
+    SECTION( "prefers wearing clothes over taking shelter" ) {
+        guy.set_all_parts_temp_conv( BODYTEMP_VERY_COLD );
+
+        map &here = get_map();
+        tripoint_bub_ms adj = guy.pos_bub() + point::east;
+        here.ter_set( adj, ter_t_floor );
+
+        guy.i_add( item( itype_sweater ) );
+        const tripoint_bub_ms original_pos = guy.pos_bub();
+
+        guy.address_needs( 0 );
+
+        CHECK( guy.is_wearing( itype_sweater ) );
+        CHECK( guy.pos_bub() == original_pos );
+    }
+
+    SECTION( "warm NPC ignores warmth response" ) {
+        guy.set_all_parts_temp_conv( BODYTEMP_NORM );
+        behavior::character_oracle_t oracle( &guy );
+        REQUIRE( oracle.needs_warmth_badly( "" ) != behavior::status_t::running );
+
+        guy.i_add( item( itype_sweater ) );
+
+        guy.address_needs( 0 );
+
+        CHECK( !guy.is_wearing( itype_sweater ) );
+    }
+
+    SECTION( "shelter blocked by danger gate" ) {
+        guy.set_all_parts_temp_conv( BODYTEMP_VERY_COLD );
+
+        map &here = get_map();
+        tripoint_bub_ms adj = guy.pos_bub() + point::east;
+        here.ter_set( adj, ter_t_floor );
+
+        const tripoint_bub_ms original_pos = guy.pos_bub();
+
+        guy.address_needs( NPC_DANGER_VERY_LOW + 1 );
+
+        CHECK( guy.pos_bub() == original_pos );
+    }
+
+    SECTION( "no warmth items and no shelter falls through" ) {
+        guy.set_all_parts_temp_conv( BODYTEMP_VERY_COLD );
+
+        const tripoint_bub_ms original_pos = guy.pos_bub();
+
+        guy.address_needs( 0 );
+
+        CHECK( guy.pos_bub() == original_pos );
+        CHECK( !guy.is_wearing( itype_sweater ) );
+    }
+
+    SECTION( "fire supplies do not block shelter" ) {
+        guy.set_all_parts_temp_conv( BODYTEMP_VERY_COLD );
+
+        map &here = get_map();
+        tripoint_bub_ms adj = guy.pos_bub() + point::east;
+        here.ter_set( adj, ter_t_floor );
+
+        guy.i_add( item( itype_lighter ) );
+        guy.i_add( item( itype_2x4 ) );
+        behavior::character_oracle_t oracle( &guy );
+        REQUIRE( oracle.can_make_fire( "" ) == behavior::status_t::running );
+
+        guy.address_needs( 0 );
+
+        CHECK( guy.pos_bub() == adj );
+    }
+
+    SECTION( "freezing NPC wears clothes during combat retreat" ) {
+        // Wearing fires even when address_needs() is called from
+        // move_away_from() with elevated danger. The NPC spends one
+        // turn wearing the item instead of fleeing. Accepted trade-off:
+        // hypothermia kills reliably, losing one retreat turn usually
+        // does not.
+        guy.set_all_parts_temp_conv( BODYTEMP_VERY_COLD );
+        guy.i_add( item( itype_sweater ) );
+
+        guy.address_needs( NPC_DANGER_VERY_LOW + 1 );
+
+        CHECK( guy.is_wearing( itype_sweater ) );
     }
 }


### PR DESCRIPTION
#### Summary
Features "NPCs wear warm clothes and move to shelter when freezing"

#### Purpose of change

NPCs have no temperature system -- `update_bodytemp()` only runs for the avatar. They never get cold, never take frostbite damage, and the BT warmth predicates (`needs_warmth_badly`, `can_wear_warmer_clothes`, `can_take_shelter`) never fire in actual gameplay.

This PR adds the action side: when the warmth subtree fires, NPCs now wear warm clothes and move to shelter. It doesn't change current gameplay on its own -- NPC temperature updates still need to be wired in separately.

Depends on #85991

#### Describe the solution

Ticks the `npc_homeostasis` BT subtree as a warmth gate in `address_needs()`. If the subtree returns anything other than "idle", the NPC needs warmth and tries all supported actions in order:

- Wear warmest available item -- greedy pick by total warmth, same checks as the oracle's `can_wear_warmer_clothes`. Fires before the danger gate (hypothermia is life-threatening, like extreme hunger).
- Move to adjacent indoor tile -- checks INDOORS + passable + no creature occupancy, verifies the NPC actually reached the target tile. Fires after the danger gate so NPCs don't wander off mid-fight.

The specific BT goal string is not dispatched individually because `start_fire` has no action code yet and would block `take_shelter` under the JSON fallback ordering. The gate approach means fire supplies don't prevent shelter-seeking.

Scope limits: shelter is adjacent-tile only (no doors, no pathfinding). `wear_warmest_item()` is greedy (ignores layers/encumbrance). `move_to()` is best-effort with `creature_at` precheck.

#### Describe alternatives you've considered

Could have ticked the full `npc_needs` root tree, but that mixes BT utility scoring with legacy thirst/hunger/sleep thresholds that don't match (BT thirst starts at >520, legacy extreme thirst at >80). Warmth-subtree-only avoids that mess.

Could have dispatched on the specific goal string, but `start_fire` comes before `take_shelter` in the JSON fallback, so an NPC with a lighter and fuel would do nothing instead of stepping indoors.

#### Testing

8 test sections covering: wearing sweater, moving to shelter, preferring clothes over shelter, warm NPC ignoring warmth, shelter blocked by danger gate, fallthrough when nothing available, fire supplies not blocking shelter, and wearing clothes during combat retreat (intentional, documented).

Tests drive the predicates by setting `temp_conv` directly. All existing `[npc]` and `[behavior]` tests pass.

#### Additional context

First BT-adjacent action in the NPC action loop. Once NPC temperature updates are wired in, this code activates automatically.