### PR TITLE
[Xedra Evolved] Arvore caster conditions

### DIFF
--- a/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_eocs.json
@@ -492,19 +492,6 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_ARVORE_SUMMON_PRESERVATION_CONTAINER_CHECK",
-    "condition": {
-      "and": [
-        "u_is_outside",
-        { "test_eoc": "EOC_CONDITION_CHECK_ARVORE_ON_NATURAL_TERRAIN" },
-        { "test_eoc": "EOC_CONDITION_CHECK_ARVORE_IN_THE_WILD" }
-      ]
-    },
-    "effect": [ { "u_cast_spell": { "id": "arvore_summon_preservation_container_real" } } ],
-    "false_effect": [ { "u_message": "You must be surrounded by nature to cast To Oppose Decay.", "type": "bad" } ]
-  },
-  {
-    "type": "effect_on_condition",
     "id": "EOC_PERENNIAL_REBIRTH_INITIAL_CHECK",
     "condition": { "not": { "u_has_effect": "arvore_perennial_rebirth_cooldown" } },
     "effect": {
@@ -1008,31 +995,5 @@
         "target_var": { "global_val": "arvore_tree_transform_target" }
       }
     ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_ARVORE_ROOT_TO_ROOT_TRANSLOCATE_CHECK",
-    "condition": {
-      "and": [
-        "u_is_outside",
-        { "test_eoc": "EOC_CONDITION_CHECK_ARVORE_IN_THE_FOREST" },
-        { "not": { "u_at_om_location": "field" } }
-      ]
-    },
-    "effect": [ { "u_cast_spell": { "id": "paraclesian_translocate" } } ],
-    "false_effect": [ { "u_message": "You must be outdoors and within the depths of the forest to cast this spell.", "type": "mixed" } ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_ARVORE_ROOT_TO_ROOT_ATTUNEMENT_CHECK",
-    "condition": {
-      "and": [
-        "u_is_outside",
-        { "test_eoc": "EOC_CONDITION_CHECK_ARVORE_IN_THE_FOREST" },
-        { "not": { "u_at_om_location": "field" } }
-      ]
-    },
-    "effect": [ { "u_cast_spell": { "id": "arvore_forest_translocate_attune_real" }, "targeted": true } ],
-    "false_effect": [ { "u_message": "You must be outdoors and within the depths of the forest to cast this spell.", "type": "mixed" } ]
   }
 ]

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_eocs.json
@@ -173,13 +173,6 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_COMMUNE_WITH_NATURE",
-    "condition": {
-      "and": [
-        "u_is_outside",
-        { "test_eoc": "EOC_CONDITION_CHECK_ARVORE_ON_NATURAL_TERRAIN" },
-        { "test_eoc": "EOC_CONDITION_CHECK_ARVORE_IN_THE_WILD" }
-      ]
-    },
     "effect": [
       {
         "math": [
@@ -205,8 +198,7 @@
         "duration": { "math": [ "_duration" ] },
         "decay_start": { "math": [ "_duration / 2" ] }
       }
-    ],
-    "false_effect": [ { "u_message": "You must be surrounded by nature to commune with nature.", "type": "bad" } ]
+    ]
   },
   {
     "type": "effect_on_condition",
@@ -407,19 +399,6 @@
     "condition": { "is_season": "winter" },
     "effect": { "run_eocs": "EOC_ARVORE_SEED_BEARER_SWITCH_EFFECTS_WINTER", "time_in_future": "24 hours" },
     "false_effect": { "u_add_effect": "effect_arvore_seedbearer_available", "duration": "PERMANENT" }
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_ARVORE_GOBLIN_FRUIT",
-    "condition": {
-      "and": [
-        "u_is_outside",
-        { "test_eoc": "EOC_CONDITION_CHECK_ARVORE_ON_NATURAL_TERRAIN" },
-        { "test_eoc": "EOC_CONDITION_CHECK_ARVORE_IN_THE_WILD" }
-      ]
-    },
-    "effect": { "u_spawn_item": "spell_spawned_goblin_fruit_arvore", "use_item_group": true, "suppress_message": true },
-    "false_effect": [ { "u_message": "You must be surrounded by the wild to call forth a goblin fruit.", "type": "bad" } ]
   },
   {
     "type": "effect_on_condition",
@@ -916,13 +895,6 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_ARVORE_VERDANT_IMPRISONMENT",
-    "condition": "u_is_outside",
-    "effect": [ { "run_eocs": "EOC_ARVORE_VERDANT_IMPRISONMENT_2" } ],
-    "false_effect": [ { "npc_message": "Your target must be outdoors to transform them into a tree." } ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_ARVORE_VERDANT_IMPRISONMENT_2",
     "condition": { "not": "u_is_npc" },
     "effect": [
       { "math": [ "u_arvore_turn_into_tree_intelligence = ( ( n_val('intelligence') + 10) / 20 )" ] },

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutation_spells.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutation_spells.json
@@ -283,6 +283,14 @@
     "name": "Commune with Nature",
     "description": "You concentrate on nature around you and commune with it, improving your health and calming the nearby wildlife.  This spell may only be cast outdoors in natural surroundings.",
     "valid_targets": [ "self" ],
+    "caster_condition": {
+      "and": [
+        "u_is_outside",
+        { "test_eoc": "EOC_CONDITION_CHECK_ARVORE_ON_NATURAL_TERRAIN" },
+        { "test_eoc": "EOC_CONDITION_CHECK_ARVORE_IN_THE_WILD" }
+      ]
+    },
+    "caster_condition_fail_message": "You must be surrounded by nature to commune with nature.",
     "skill": "gramarye",
     "spell_class": "ARVORE",
     "teachable": false,
@@ -314,13 +322,23 @@
     "description": "You may spin a bit of fae magic into a plant, bringing forth a goblin fruit.  Goblin fruit have a variety of effects, never predictable but always at least somewhat beneficial.  This spell may only be cast outdoors in natural surroundings.",
     "valid_targets": [ "self" ],
     "skill": "gramarye",
-    "effect": "effect_on_condition",
-    "effect_str": "EOC_ARVORE_GOBLIN_FRUIT",
+    "flags": [ "SOMATIC", "VERBAL", "NO_LEGS", "PERMANENT", "PERMANENT_ALL_LEVELS", "SPAWN_GROUP" ],
+    "caster_condition": {
+      "and": [
+        "u_is_outside",
+        { "test_eoc": "EOC_CONDITION_CHECK_ARVORE_ON_NATURAL_TERRAIN" },
+        { "test_eoc": "EOC_CONDITION_CHECK_ARVORE_IN_THE_WILD" }
+      ]
+    },
+    "caster_condition_fail_message": "You must be outdoors in natural surroundings to call forth a goblin fruit.",
+    "effect": "spawn_item",
+    "effect_str": "spell_spawned_goblin_fruit_arvore",
     "shape": "blast",
     "spell_class": "ARVORE",
     "teachable": false,
-    "flags": [ "SOMATIC", "VERBAL", "NO_LEGS", "NO_HANDS" ],
     "max_level": 15,
+    "min_damage": 1,
+    "max_damage": 1,
     "difficulty": 8,
     "magic_type": "xedra_arvore_magick",
     "base_casting_time": { "math": [ "max( (180000 + (u_spell_count('school': 'ARVORE') * -986) + (u_skill('gramarye') * -3185) ), 6000)" ] },
@@ -1194,6 +1212,10 @@
     "valid_targets": [ "hostile" ],
     "skill": "gramarye",
     "flags": [ "VERBAL", "SOMATIC", "SILENT", "RANDOM_DAMAGE" ],
+    "caster_condition": "u_is_outside",
+    "caster_condition_fail_message": "You must be outdoors to cast Verdant Imprisonment.",
+    "target_condition": "npc_is_outside",
+    "target_condition_fail_message": "Your target must be outdoors to transform them into a tree.",
     "effect": "effect_on_condition",
     "effect_str": "EOC_ARVORE_VERDANT_IMPRISONMENT",
     "shape": "blast",

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutation_spells.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutation_spells.json
@@ -460,25 +460,15 @@
     "difficulty": 4,
     "spell_class": "ARVORE",
     "valid_targets": [ "self" ],
+    "caster_condition": {
+      "and": [
+        "u_is_outside",
+        { "test_eoc": "EOC_CONDITION_CHECK_ARVORE_ON_NATURAL_TERRAIN" },
+        { "test_eoc": "EOC_CONDITION_CHECK_ARVORE_IN_THE_WILD" }
+      ]
+    },
+    "caster_condition_fail_message": "You must be surrounded by nature to cast To Withstand Decay.",
     "skill": "gramarye",
-    "effect": "effect_on_condition",
-    "effect_str": "EOC_ARVORE_SUMMON_PRESERVATION_CONTAINER_CHECK",
-    "shape": "blast",
-    "magic_type": "xedra_arvore_magick",
-    "base_energy_cost": { "math": [ "max( (800 + (u_spell_count('school': 'ARVORE') * -7.8) + (u_skill('gramarye') * -12.5) ), 300)" ] },
-    "base_casting_time": { "math": [ "max( (6000 + (u_spell_count('school': 'ARVORE') * -85.8) + (u_skill('gramarye') * -127.6) ), 1500)" ] },
-    "learn_spells": { "arvore_create_living_tent_spell": 6, "arvore_summon_floral_boat": 12 }
-  },
-  {
-    "id": "arvore_summon_preservation_container_real",
-    "type": "SPELL",
-    "name": { "str": "To Withstand Decay Real", "//~": "NO_I18N" },
-    "description": { "str": "The actual spell that summons the container.  It's a bug if you have it directly.", "//~": "NO_I18N" },
-    "flags": [ "SILENT", "RANDOM_DURATION" ],
-    "max_level": 15,
-    "difficulty": 3,
-    "spell_class": "ARVORE",
-    "valid_targets": [ "self" ],
     "effect": "spawn_item",
     "effect_str": "arvore_preservation_container",
     "shape": "blast",
@@ -494,7 +484,10 @@
         "( 51840000 + (u_spell_count('school': 'ARVORE') * 30240000) + (u_skill('gramarye') * 7560000) ) * scaling_factor(u_val('perception') )"
       ]
     },
-    "magic_type": "xedra_arvore_magick"
+    "magic_type": "xedra_arvore_magick",
+    "base_energy_cost": { "math": [ "max( (800 + (u_spell_count('school': 'ARVORE') * -7.8) + (u_skill('gramarye') * -12.5) ), 300)" ] },
+    "base_casting_time": { "math": [ "max( (6000 + (u_spell_count('school': 'ARVORE') * -85.8) + (u_skill('gramarye') * -127.6) ), 1500)" ] },
+    "learn_spells": { "arvore_create_living_tent_spell": 6, "arvore_summon_floral_boat": 12 }
   },
   {
     "id": "arvore_summon_floral_boat",
@@ -1147,10 +1140,17 @@
     "spell_class": "ARVORE",
     "skill": "gramarye",
     "flags": [ "VERBAL", "SOMATIC" ],
+    "caster_condition": {
+      "and": [
+        "u_is_outside",
+        { "test_eoc": "EOC_CONDITION_CHECK_ARVORE_IN_THE_FOREST" },
+        { "not": { "u_at_om_location": "field" } }
+      ]
+    },
+    "caster_condition_fail_message": "You must be outdoors and within the depths of the forest to cast this spell.",
     "difficulty": 9,
     "max_level": 15,
-    "effect": "effect_on_condition",
-    "effect_str": "EOC_ARVORE_ROOT_TO_ROOT_TRANSLOCATE_CHECK",
+    "effect": "translocate",
     "shape": "blast",
     "magic_type": "xedra_arvore_magick",
     "base_energy_cost": 1500,
@@ -1162,14 +1162,22 @@
     "name": "Root to Root Attunement",
     "description": "Attune to a location for later traveling.  You must attune within the depths of a forest.",
     "teachable": false,
-    "valid_targets": [ "self" ],
+    "valid_targets": [ "ground" ],
     "spell_class": "ARVORE",
     "skill": "gramarye",
     "flags": [ "VERBAL", "SOMATIC", "NO_FAIL" ],
+    "caster_condition": {
+      "and": [
+        "u_is_outside",
+        { "test_eoc": "EOC_CONDITION_CHECK_ARVORE_IN_THE_FOREST" },
+        { "not": { "u_at_om_location": "field" } }
+      ]
+    },
+    "caster_condition_fail_message": "You must be outdoors and within the depths of the forest to cast this spell.",
     "difficulty": 1,
     "max_level": 1,
-    "effect": "effect_on_condition",
-    "effect_str": "EOC_ARVORE_ROOT_TO_ROOT_ATTUNEMENT_CHECK",
+    "effect": "ter_transform",
+    "effect_str": "ter_arvore_translocate_location_attune",
     "shape": "blast",
     "magic_type": "xedra_arvore_magick",
     "min_range": 1,
@@ -1177,23 +1185,6 @@
     "base_casting_time": {
       "math": [ "max( (2880000 + (u_spell_count('school': 'ARVORE') * 59341) + (u_skill('gramarye') * -98963) ), 180000)" ]
     }
-  },
-  {
-    "id": "arvore_forest_translocate_attune_real",
-    "type": "SPELL",
-    "name": { "str": "Root to Root Attunement Real", "//~": "NO_I18N" },
-    "description": { "str": "The actual Root to Root attunement spell.  It's a bug if you have it.", "//~": "NO_I18N" },
-    "teachable": false,
-    "valid_targets": [ "ground" ],
-    "spell_class": "ARVORE",
-    "skill": "gramarye",
-    "flags": [ "VERBAL", "SOMATIC", "NO_FAIL" ],
-    "difficulty": 1,
-    "max_level": 1,
-    "effect": "ter_transform",
-    "effect_str": "ter_arvore_translocate_location_attune",
-    "shape": "blast",
-    "min_range": 1
   },
   {
     "id": "arvore_turn_into_tree",

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutation_spells.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutation_spells.json
@@ -467,7 +467,7 @@
         { "test_eoc": "EOC_CONDITION_CHECK_ARVORE_IN_THE_WILD" }
       ]
     },
-    "caster_condition_fail_message": "You must be surrounded by nature to cast To Withstand Decay.",
+    "caster_condition_fail_message": "You must be surrounded by nature and away from civiliation to cast To Withstand Decay.",
     "skill": "gramarye",
     "effect": "spawn_item",
     "effect_str": "arvore_preservation_container",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Xedra Evolved] Arvore caster conditions"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Move Arvore spells that rely on EoCs to check caster/target conditions to using the `caster_condition` and `target_condition` fields. 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Swapped over several spells. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Spells have conditions and display failure states in the UI.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Found a pretty serious crash bug I'll have to report when this is merged: After casting a spell with the following caster condition:

```
{
      "and": [
        "u_is_outside",
        { "test_eoc": "EOC_CONDITION_CHECK_ARVORE_ON_NATURAL_TERRAIN" },
        { "test_eoc": "EOC_CONDITION_CHECK_ARVORE_IN_THE_WILD" }
      ]
    },
```

...attempting to reopen the spell menu again silently crashes the game (no crash log is generated)

Edit: could not reproduce this on live, hopefully it's sunspots or something. 

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
