### PR TITLE
NPC needs: bodytemp updates, camp water through stomach, non-ally sleep

### DIFF
--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -87,6 +87,7 @@
 #include "viewer.h"
 #include "visitable.h"
 #include "vpart_position.h"
+#include "weather.h"
 
 static const efftype_id effect_bouldering( "bouldering" );
 static const efftype_id effect_controlled( "controlled" );
@@ -3283,12 +3284,19 @@ void npc::on_unload()
 {
 }
 
+void npc::update_bodytemp_and_wetness()
+{
+    update_bodytemp();
+    update_body_wetness( *get_weather().weather_precise );
+}
+
 // A throtled version of player::update_body since npc's don't need to-the-turn updates.
 void npc::npc_update_body()
 {
     if( calendar::once_every( 10_seconds ) ) {
         update_body( last_updated, calendar::turn );
         last_updated = calendar::turn;
+        update_bodytemp_and_wetness();
     }
 }
 
@@ -3342,6 +3350,11 @@ void npc::on_load( map *here )
             update_mental_focus();
         }
     }
+
+    // Reconcile body temperature and wetness with current weather.
+    // The catch-up loops above ran update_body() but not update_bodytemp();
+    // one recompute at current conditions is enough since temp converges fast.
+    update_bodytemp_and_wetness();
 
     if( dt > 0_turns ) {
         // This ensures food is properly rotten at load

--- a/src/npc.h
+++ b/src/npc.h
@@ -1423,6 +1423,11 @@ class npc : public Character
          * Update body, but throttled.
          */
         void npc_update_body();
+        /**
+         * Recompute body temperature and wetness from current weather.
+         * Shared between npc_update_body() and on_load() catch-up.
+         */
+        void update_bodytemp_and_wetness();
 
         bool get_known_to_u() const;
 

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -1788,11 +1788,21 @@ void npc::execute_action( npc_action action )
             // TODO: Handle empty path better
             if( best_spot == pos_bub() || path.empty() ) {
                 move_pause();
-                if( !has_effect( effect_lying_down ) ) {
+                if( !in_sleep_state() ) {
                     activate_bionic_by_id( bio_soporific );
-                    add_effect( effect_lying_down, 30_minutes, false, 1 );
                     if( !player_character.in_sleep_state() ) {
                         add_msg_if_player_sees( *this, _( "%s lies down to sleep." ), get_name() );
+                    }
+                    // NPCs check can_sleep() for hard blockers (meth, stim)
+                    // but fall asleep directly on success. The lying_down ->
+                    // can_sleep() rng retry cycle is for the player who gets
+                    // "you try to sleep but can't" feedback. Without direct
+                    // fall_asleep(), NPC sleepiness keeps incrementing while
+                    // they lie awake (recovery only runs while asleep).
+                    if( !is_avatar() && can_sleep() ) {
+                        fall_asleep();
+                    } else {
+                        add_effect( effect_lying_down, 30_minutes, false, 1 );
                     }
                 }
             } else {
@@ -2717,9 +2727,7 @@ npc_action npc::address_needs( float danger )
     // TODO: More risky attempts at sleep when exhausted
     if( could_sleep() ) {
         if( !is_player_ally() ) {
-            // TODO: Make tired NPCs handle sleep offscreen
-            set_sleepiness( 0 );
-            return npc_undecided;
+            return npc_sleep;
         }
 
         if( rules.has_flag( ally_rule::allow_sleep ) ||
@@ -4748,13 +4756,18 @@ bool npc::consume_food_from_camp()
     }
     basecamp *bcp = *potential_bc;
 
-    // Handle water
+    // Handle water -- route through stomach so thirst decreases naturally.
     if( get_thirst() > 40 && bcp->has_water() && bcp->allowed_access_by( *this, true ) ) {
-        complain_about( "camp_water_thanks", 1_hours,
-                        chat_snippets().snip_camp_water_thanks.translated(), false );
-        // TODO: Stop skipping the stomach for this, actually put the water in there.
-        set_thirst( 0 );
-        return true;
+        const units::volume want = std::max( 0_ml,
+                                             units::from_milliliter( get_thirst() * 5 ) );
+        const units::volume room = stomach.stomach_remaining( *this );
+        const units::volume intake = std::min( want, room );
+        if( intake > 0_ml ) {
+            stomach.ingest( { intake, 0_ml, {} } );
+            complain_about( "camp_water_thanks", 1_hours,
+                            chat_snippets().snip_camp_water_thanks.translated(), false );
+            return true;
+        }
     }
 
     // Handle food

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "avatar.h"
+#include "basecamp.h"
 #include "behavior.h"
 #include "bodypart.h"
 #include "calendar.h"
@@ -19,6 +20,7 @@
 #include "character.h"
 #include "character_attire.h"
 #include "character_oracle.h"
+#include "clzones.h"
 #include "common_types.h"
 #include "coordinates.h"
 #include "creature_tracker.h"
@@ -34,6 +36,7 @@
 #include "item_location.h"
 #include "map.h"
 #include "map_helpers.h"
+#include "map_scale_constants.h"
 #include "memory_fast.h"
 #include "messages.h"
 #include "monster.h"
@@ -47,6 +50,7 @@
 #include "pimpl.h"
 #include "player_helpers.h"
 #include "point.h"
+#include "stomach.h"
 #include "test_data.h"
 #include "text_snippets.h"
 #include "translation.h"
@@ -59,9 +63,13 @@
 #include "weather.h"
 
 class Creature;
+enum npc_action : int;
 
 static const efftype_id effect_bouldering( "bouldering" );
+static const efftype_id effect_lying_down( "lying_down" );
+static const efftype_id effect_meth( "meth" );
 static const efftype_id effect_sleep( "sleep" );
+static const efftype_id effect_wet( "wet" );
 
 static const faction_id faction_your_followers( "your_followers" );
 
@@ -96,6 +104,9 @@ static const vpart_id vpart_frame( "frame" );
 static const vpart_id vpart_seat( "seat" );
 
 static const vproto_id vehicle_prototype_none( "none" );
+
+static const zone_type_id zone_type_CAMP_FOOD( "CAMP_FOOD" );
+static const zone_type_id zone_type_CAMP_STORAGE( "CAMP_STORAGE" );
 
 static void on_load_test( npc &who, const time_duration &from, const time_duration &to )
 {
@@ -1083,5 +1094,214 @@ TEST_CASE( "npc_warmth_response_in_address_needs", "[npc]" )
         guy.address_needs( NPC_DANGER_VERY_LOW + 1 );
 
         CHECK( guy.is_wearing( itype_sweater ) );
+    }
+}
+
+TEST_CASE( "npc_bodytemp_updates_during_turn", "[npc][needs]" )
+{
+    clear_map_without_vision();
+    weather_manager &weather = get_weather();
+    weather.temperature = units::from_fahrenheit( 0 );
+    weather.clear_temp_cache();
+
+    SECTION( "throttle blocks bodytemp before 10-second boundary" ) {
+        // once_every(10s) fires when (turn - turn_zero) % 10s == 0.
+        // 3 seconds is non-aligned, so the throttle should block.
+        calendar::turn = calendar::turn_zero + 3_seconds;
+        npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+        clear_character( guy, true );
+        guy.set_all_parts_temp_conv( BODYTEMP_NORM );
+        guy.set_all_parts_temp_cur( BODYTEMP_NORM );
+
+        guy.npc_update_body();
+
+        for( const bodypart_id &bp : guy.get_all_body_parts() ) {
+            CHECK( guy.get_part_temp_conv( bp ) == BODYTEMP_NORM );
+        }
+    }
+
+    SECTION( "bodytemp decreases after 10-second boundary in freezing weather" ) {
+        calendar::turn = calendar::turn_zero + 10_seconds;
+        npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+        clear_character( guy, true );
+        guy.set_all_parts_temp_conv( BODYTEMP_NORM );
+        guy.set_all_parts_temp_cur( BODYTEMP_NORM );
+
+        guy.npc_update_body();
+
+        bool any_cooled = false;
+        for( const bodypart_id &bp : guy.get_all_body_parts() ) {
+            if( guy.get_part_temp_conv( bp ) < BODYTEMP_NORM ) {
+                any_cooled = true;
+                break;
+            }
+        }
+        CHECK( any_cooled );
+    }
+
+    SECTION( "wetness updated via effect_wet" ) {
+        calendar::turn = calendar::turn_zero + 10_seconds;
+        npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+        clear_character( guy, true );
+        const bodypart_id bp_torso( "torso" );
+        guy.set_part_wetness( bp_torso, guy.get_part_drench_capacity( bp_torso ) );
+
+        guy.npc_update_body();
+
+        // update_body_wetness adds effect_wet deterministically when wetness > 0
+        CHECK( guy.has_effect( effect_wet, bp_torso ) );
+    }
+
+    SECTION( "on_load catch-up recomputes bodytemp" ) {
+        weather.temperature = units::from_fahrenheit( 0 );
+        weather.clear_temp_cache();
+        npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+        clear_character( guy, true );
+        guy.set_all_parts_temp_conv( BODYTEMP_NORM );
+        guy.set_all_parts_temp_cur( BODYTEMP_NORM );
+
+        on_load_test( guy, 0_seconds, 30_minutes );
+
+        bool any_cooled = false;
+        for( const bodypart_id &bp : guy.get_all_body_parts() ) {
+            if( guy.get_part_temp_conv( bp ) < BODYTEMP_NORM ) {
+                any_cooled = true;
+                break;
+            }
+        }
+        CHECK( any_cooled );
+    }
+}
+
+TEST_CASE( "npc_camp_water_through_stomach", "[npc][needs][camp]" )
+{
+    clear_avatar();
+    clear_map_without_vision();
+    get_player_character().camps.clear();
+    map &m = get_map();
+    // Use mid-map position so NPC and camp share the same OMT regardless
+    // of where the map's absolute origin falls.
+    const tripoint_bub_ms mid{ MAPSIZE_X / 2, MAPSIZE_Y / 2, 0 };
+    const tripoint_abs_ms zone_loc = m.get_abs( mid );
+    REQUIRE( m.inbounds( zone_loc ) );
+    mapgen_place_zone( zone_loc, zone_loc, zone_type_CAMP_FOOD, your_fac, {}, "food" );
+    mapgen_place_zone( zone_loc, zone_loc, zone_type_CAMP_STORAGE, your_fac, {}, "storage" );
+    faction *camp_faction = get_player_character().get_faction();
+    const tripoint_abs_omt this_omt = project_to<coords::omt>( zone_loc );
+    m.add_camp( this_omt, "faction_camp" );
+    std::optional<basecamp *> bcp = overmap_buffer.find_camp( this_omt.xy() );
+    REQUIRE( !!bcp );
+    basecamp *test_camp = *bcp;
+    test_camp->define_camp( this_omt, "faction_base_bare_bones_NPC_camp_0", false );
+    test_camp->set_owner( your_fac );
+    REQUIRE( test_camp->has_water() );
+
+    // Spawn NPC at mid-map so it's in the same OMT as the camp
+    npc &guy = spawn_npc( mid.xy(), "test_talker" );
+    clear_character( guy, true );
+    guy.set_fac( faction_your_followers );
+    guy.stomach.empty();
+    guy.guts.empty();
+    guy.set_hunger( 0 );
+    camp_faction->empty_food_supply();
+
+    SECTION( "camp water enters stomach, NPC-facing thirst drops" ) {
+        guy.set_thirst( 200 );
+        REQUIRE( guy.get_thirst() > 40 );
+
+        CHECK( guy.consume_food_from_camp() );
+        CHECK( guy.stomach.get_water() > 0_ml );
+        CHECK( guy.get_thirst() < 200 );
+    }
+
+    SECTION( "intake capped at stomach capacity" ) {
+        // Pre-fill stomach near capacity, leaving only 50ml room
+        const units::volume room = guy.stomach.stomach_remaining( guy );
+        if( room > 50_ml ) {
+            guy.stomach.ingest( { room - 50_ml, 0_ml, {} } );
+        }
+        guy.set_thirst( 800 );
+
+        guy.consume_food_from_camp();
+
+        CHECK( guy.stomach.contains() <= guy.stomach.capacity( guy ) );
+    }
+
+    SECTION( "full stomach does not waste turn" ) {
+        // Fill stomach to capacity
+        const units::volume room = guy.stomach.stomach_remaining( guy );
+        guy.stomach.ingest( { room, 0_ml, {} } );
+        // Raw thirst must exceed 40 + capacity/5 so NPC-facing thirst
+        // still passes the > 40 gate despite stomach water subtraction.
+        guy.set_thirst( 600 );
+        REQUIRE( guy.get_thirst() > 40 );
+
+        CHECK_FALSE( guy.consume_food_from_camp() );
+    }
+}
+
+TEST_CASE( "npc_nonally_sleeps_when_tired", "[npc][needs]" )
+{
+    clear_map_without_vision();
+    // 30+ minutes past turn_zero so can_sleep()'s 30-minute cooldown
+    // (anchored to last_sleep_check default of turn_zero) does not
+    // block the first evaluation.
+    calendar::turn = calendar::turn_zero + 1_hours;
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy, true );
+    guy.set_hunger( 0 );
+    guy.set_thirst( 0 );
+    guy.set_stored_kcal( guy.get_healthy_kcal() );
+    guy.set_all_parts_temp_conv( BODYTEMP_NORM );
+    guy.set_all_parts_temp_cur( BODYTEMP_NORM );
+    REQUIRE_FALSE( guy.is_player_ally() );
+
+    SECTION( "exhausted non-ally falls asleep when safe" ) {
+        // Sleepiness 800 makes can_sleep() reliably pass despite bare-
+        // ground comfort and rng(-8,8): sleepiness_factor ~26 dominates.
+        guy.set_sleepiness( 800 );
+        guy.set_mission( NPC_MISSION_SHELTER );
+        guy.set_moves( 100 );
+
+        guy.move();
+
+        // NPCs call fall_asleep() directly on can_sleep() success.
+        // Recovery only runs on the asleep branch in update_needs.
+        CHECK( guy.has_effect( effect_sleep ) );
+    }
+
+    SECTION( "meth blocks non-ally sleep" ) {
+        guy.set_sleepiness( 800 );
+        guy.add_effect( effect_meth, 1_hours );
+        guy.set_mission( NPC_MISSION_SHELTER );
+        guy.set_moves( 100 );
+
+        guy.move();
+
+        // can_sleep() returns false on meth, NPC gets lying_down fallback
+        CHECK_FALSE( guy.has_effect( effect_sleep ) );
+        CHECK( guy.has_effect( effect_lying_down ) );
+    }
+
+    SECTION( "non-ally does not sleep in danger" ) {
+        guy.set_sleepiness( 800 );
+        // address_needs decides, execute_action performs. Together they
+        // cover the decision gate and the sleep branch without needing
+        // the full move() pipeline (which requires overmap/vision setup).
+        // execute_action(npc_undecided) is safe -- just pauses.
+        npc_action action = guy.address_needs( NPC_DANGER_VERY_LOW + 1 );
+        guy.execute_action( action );
+
+        CHECK_FALSE( guy.has_effect( effect_sleep ) );
+        CHECK_FALSE( guy.has_effect( effect_lying_down ) );
+    }
+
+    SECTION( "below TIRED threshold does not trigger sleep" ) {
+        guy.set_sleepiness( sleepiness_levels::TIRED / 2 );
+        npc_action action = guy.address_needs( 0 );
+        guy.execute_action( action );
+
+        CHECK_FALSE( guy.has_effect( effect_sleep ) );
+        CHECK_FALSE( guy.has_effect( effect_lying_down ) );
     }
 }


### PR DESCRIPTION
#### Summary
Infrastructure "Wire NPC bodytemp and wetness updates, route camp water through stomach, replace non-ally sleep hack with real sleep"

#### Purpose of change

NPCs never called `update_bodytemp()` or `update_body_wetness()` -- only the avatar had body temperature simulation. The warmth response from #86004 couldn't activate in gameplay because NPCs never got cold.

`consume_food_from_camp()` did `set_thirst(0)` directly, bypassing the stomach. With needs ticking, thirst would spike right back up on the next update since there's no water in the stomach to process.

Non-ally NPCs instantly reset sleepiness to 0 instead of sleeping. No lying down, no recovery, just a hard reset every turn they were tired.

Related to #28681.

#### Describe the solution

Body temperature: shared `update_bodytemp_and_wetness()` helper called from `npc_update_body()` at the existing 10-second throttle and from `on_load()` after the catch-up loops. The avatar calls these every turn for UI feedback; 10-second resolution is enough for NPCs.

Camp water: `stomach.ingest()` with a `food_summary` of water, capped at `stomach.stomach_remaining()`. `npc::get_thirst()` already subtracts stomach water, so NPC-facing thirst drops immediately. Full stomach returns false instead of burning the turn.

Non-ally sleep: routes through `npc_sleep` like allies. In the `npc_sleep` action, NPCs check `can_sleep()` and call `fall_asleep()` directly on success -- preserves the meth blocker and stim modifiers but skips the `lying_down` rng retry cycle that exists for avatar feedback. Without `fall_asleep()`, sleepiness keeps going up because recovery only runs on the asleep branch in `update_needs`.

#### Describe alternatives you've considered

Could recompute bodytemp per-iteration during the on_load catch-up, but historical weather data isn't available for past ticks. One recompute at current conditions works because temperature converges fast.

Could keep the `lying_down` path for non-allies and just remove the sleepiness reset. But `lying_down` depends on `can_sleep()` rng to transition to real sleep, and the 30-minute recheck cooldown means a tired NPC on bare ground can lie there doing nothing for half an hour before even getting another shot at falling asleep.

#### Testing

Bodytemp: throttle blocks update before 10-second boundary, freezing weather cools NPC after boundary fires, wetness tracked via `effect_wet`, `on_load` catch-up recomputes temperature.

Camp water: water enters stomach and NPC-facing thirst drops, intake capped at stomach capacity, full stomach does not waste turn. Integration test with a real camp setup using the NPC bare-bones camp type for `has_water()`.

Sleep: exhausted non-ally gets `effect_sleep` (not just `effect_lying_down`), meth blocks real sleep (falls back to `lying_down`), danger prevents sleep, below-threshold sleepiness does nothing.

#### Additional context

Only fixes the active-NPC paths. Offscreen camp-mission recovery still hard-resets thirst and sleepiness. Sleep stays on the legacy `could_sleep()` gate, not the BT `can_sleep` predicate -- the BT thresholds are for urgency scoring and the dispatch isn't there yet.