### PR TITLE
fixed diamond dental grill price bug.json

### DIFF
--- a/data/json/items/armor/jewelry.json
+++ b/data/json/items/armor/jewelry.json
@@ -141,6 +141,7 @@
     "weight": "10 g",
     "volume": "1 ml",
     "price": "500 USD",
+    "price_postapoc": "50 cent",
     "material": [ "gold" ],
     "symbol": "[",
     "looks_like": "gold_dental_grill",


### PR DESCRIPTION
#### Summary
Balance "Fix diamond dental grill post-apocalypse price bug"

#### Purpose of change
The diamond dental grill had a post-apocalypse price of 500 (same as its pre-apocalypse value). Nobody is going to trade meaningful resources for a diamond-encrusted dental prosthetic after the end of civilization - it's pure vanity with zero survival utility.

#### Describe the solution
Reduced the post-apocalypse price of the diamond dental grill to 50 cents, in line with many similar vanity/cosmetic items that share this price point.

#### Describe alternatives you've considered
No.

#### Testing
Checked item price in-game. No regressions expected — purely a balance value change.

#### Additional context
<img width="986" height="679" alt="image" src="https://github.com/user-attachments/assets/9fe466b5-1ad6-496b-a0db-e82a63f73435" />