### PR TITLE
Fixed roasted coffee beans category.json

### DIFF
--- a/data/json/items/comestibles/seed.json
+++ b/data/json/items/comestibles/seed.json
@@ -1748,7 +1748,7 @@
     "subtypes": [ "COMESTIBLE" ],
     "id": "roasted_coffee_bean",
     "copy-from": "coffee_bean",
-    "category": "other",
+    "category": "FOOD",
     "name": { "str_sp": "roasted coffee beans" },
     "description": "Some roasted coffee beans, can be ground into powder.",
     "extend": { "flags": [ "RAW" ] }


### PR DESCRIPTION
#### Summary
Bugfixes "Recategorize roasted coffee beans from Other to FOOD"

#### Purpose of change
Roasted coffee beans are listed under `Category: Other` despite being a crafting ingredient used in food recipes. While not directly edible on their own, they belong in the `FOOD` category alongside other cooking ingredients.

#### Describe the solution
Changed the category of `roasted_coffee_beans` to `FOOD`.

#### Describe alternatives you've considered
-

#### Testing
-

#### Additional context
-