### PR TITLE
Fix NPC footstep sfx

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2166,7 +2166,7 @@ void Character::make_footstep_noise() const
         sounds::sound( pos_bub(), volume, sounds::sound_t::movement, _( "footsteps" ), true,
                        "none", "none" );    // Sound of footsteps may awaken nearby monsters
     }
-    sfx::do_footstep();
+    sfx::do_footstep( *this );
 }
 
 void Character::make_clatter_sound() const

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -1743,7 +1743,7 @@ void sfx::remove_hearing_loss()
     do_ambient();
 }
 
-void sfx::do_footstep()
+void sfx::do_footstep( const Character &ch )
 {
     map &here = get_map();
 
@@ -1754,9 +1754,8 @@ void sfx::do_footstep()
     end_sfx_timestamp = std::chrono::high_resolution_clock::now();
     sfx_time = end_sfx_timestamp - start_sfx_timestamp;
     if( std::chrono::duration_cast<std::chrono::milliseconds> ( sfx_time ).count() > 400 ) {
-        const Character &player_character = get_player_character();
-        int heard_volume = sfx::get_heard_volume( player_character.pos_bub() );
-        const auto terrain = here.ter( player_character.pos_bub() ).id();
+        int heard_volume = sfx::get_heard_volume( ch.pos_bub() );
+        const auto terrain = here.ter( ch.pos_bub() ).id();
         static const std::set<ter_str_id> grass = {
             ter_t_grass,
             ter_t_shrub,
@@ -1846,18 +1845,18 @@ void sfx::do_footstep()
             start_sfx_timestamp = std::chrono::high_resolution_clock::now();
         };
 
-        auto veh_displayed_part = here.veh_at( player_character.pos_bub() ).part_displayed();
+        auto veh_displayed_part = here.veh_at( ch.pos_bub() ).part_displayed();
 
         const season_type seas = season_of_year( calendar::turn );
         const std::string seas_str = season_str( seas );
-        const bool indoors = !is_creature_outside( player_character );
+        const bool indoors = !is_creature_outside( ch );
         const bool night = is_night( calendar::turn );
         if( !veh_displayed_part && ( terrain->has_flag( ter_furn_flag::TFLAG_DEEP_WATER ) ||
                                      terrain->has_flag( ter_furn_flag::TFLAG_SHALLOW_WATER ) ) ) {
             play_plmove_sound_variant( "walk_water", seas_str, indoors, night );
             return;
         }
-        if( player_character.is_barefoot() ) {
+        if( ch.is_barefoot() ) {
             play_plmove_sound_variant( "walk_barefoot", seas_str, indoors, night );
             return;
         }
@@ -2031,7 +2030,7 @@ void sfx::generate_melee_sound( const item &, const tripoint_bub_ms &, const tri
 void sfx::do_hearing_loss( int ) { }
 void sfx::remove_hearing_loss() { }
 void sfx::do_projectile_hit( const Creature & ) { }
-void sfx::do_footstep() { }
+void sfx::do_footstep( const Character & ) { }
 void sfx::do_danger_music() { }
 void sfx::do_vehicle_engine_sfx() { }
 void sfx::do_vehicle_exterior_engine_sfx() { }

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -1755,6 +1755,12 @@ void sfx::do_footstep( const Character &ch )
     sfx_time = end_sfx_timestamp - start_sfx_timestamp;
     if( std::chrono::duration_cast<std::chrono::milliseconds> ( sfx_time ).count() > 400 ) {
         int heard_volume = sfx::get_heard_volume( ch.pos_bub() );
+
+        if( heard_volume <= 0 ) {
+            return;
+        }
+
+        units::angle heard_angle = ch.is_npc() ? sfx::get_heard_angle( ch.pos_bub() ) : 0_degrees;
         const auto terrain = here.ter( ch.pos_bub() ).id();
         static const std::set<ter_str_id> grass = {
             ter_t_grass,
@@ -1841,7 +1847,7 @@ void sfx::do_footstep( const Character &ch )
                                                const std::optional<bool> &indoors,
         const std::optional<bool> &night ) {
             play_variant_sound( "plmove", variant, season, indoors, night,
-                                heard_volume, 0_degrees, 0.8, 1.2 );
+                                heard_volume, heard_angle, 0.8, 1.2 );
             start_sfx_timestamp = std::chrono::high_resolution_clock::now();
         };
 

--- a/src/sounds.h
+++ b/src/sounds.h
@@ -174,7 +174,7 @@ void remove_hearing_loss();
 void do_projectile_hit( const Creature &target );
 int get_heard_volume( const tripoint_bub_ms &source );
 units::angle get_heard_angle( const tripoint_bub_ms &source );
-void do_footstep();
+void do_footstep( const Character &ch );
 void do_danger_music();
 void do_ambient();
 void do_vehicle_engine_sfx();


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Player and NPCs make footsteps. But the function that makes footstep sfx only checks for the player, which results in:
1. NPCs making wrong footstep sound, such as making metal sounds on water tile while the player is standing on metal floor
2. players hearing NPCs moving from miles away since the sfx is generated on player's position

This PR fixes that.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Make `do_footstep()` function to pass Character instead of getting player.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded the game, applied a soundpack, spawned an NPC
NPCs make footstep noises based on where they are standing on. On grass, dirt, metal, concrete, etc
The sfx also no longer plays on player's position, and the footstep noises gradually get smaller as the NPC runs away from me


https://github.com/user-attachments/assets/24769542-feb7-42bd-8b51-f4c1ed2c8ccd


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
