### PR TITLE
[Sky Island] Fix lab raid start selection 

### DIFF
--- a/data/mods/Sky_Island/effectoncondition/obelisk_selector.json
+++ b/data/mods/Sky_Island/effectoncondition/obelisk_selector.json
@@ -182,7 +182,6 @@
     "//": "Picks a random underground lab and activates the actual teleport EOC.",
     "condition": { "and": [ { "math": [ "labsunlocked == 1" ] }, { "u_has_items": { "item": "warp_labs_catalyst", "count": 1 } } ] },
     "effect": [
-      { "run_eocs": "EOC_SKY_ISLAND_MISSION_DIMENSION_SHIFT" },
       {
         "run_eoc_selector": [
           "EOC_Lab_Science_Loc_Warp",
@@ -191,12 +190,18 @@
           "EOC_Lab_TCL_Loc_Warp",
           "EOC_raidcancel"
         ],
-        "names": [ "Target: Science Lab", "Target: Subway Lab", "Target: Research Facility", "Target: Tran-Coastal Logistics", "Cancel" ],
+        "names": [
+          "Target: Science Lab",
+          "Target: Large Science Lab",
+          "Target: Research Facility",
+          "Target: Tran-Coastal Logistics",
+          "Cancel"
+        ],
         "keys": [ "1", "2", "3", "4", "5" ],
         "title": "Select a starting location",
         "descriptions": [
           "Arrive in subterranean science lab.\nBE WARNED!  You will begin inside a sealed lab, so make sure you have the means to get out!  A second card, to unlock the surface exit, is one option.  You may also consider a homeward mote or a warp skyward beacon.",
-          "Arrive in a sprawling lab connected to a secret network of subways.\nBE WARNED!  You will begin inside a sealed lab, so make sure you have the means to get out!  A second card, to unlock the surface exit, is one option.  You may also consider a homeward mote or a warp skyward beacon.",
+          "Arrive in a sprawling lab built around a hallway.\nBE WARNED!  You will begin inside a sealed lab, so make sure you have the means to get out!  A second card, to unlock the surface exit, is one option.  You may also consider a homeward mote or a warp skyward beacon.",
           "Arrive in an above-ground research facility.\nBE WARNED!  The facility was extremely damaged by the Cataclysm and the environment is filled with hostiles.  Be prepared when you undertake this mission.",
           "Arrive in a lab within a shipping facility.\nBE WARNED!  You will begin inside a sealed facility, so make sure you have the means to get out!  You may also consider a homeward mote or a warp skyward beacon.",
           "Stay on the island for now."


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Sky Island] Fix lab raid start selection "

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Title
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Remove the dimension shift EOC from the lab selection EOC, it should only fire once a lab target is selected, and those EOCs are already setup to do that.
Tweak the text for the lab selection to reflect changes to the labs when old labs were removed.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
EOC works and doesn't double shift while deleting the players home island anymore.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
