### PR TITLE
[Sky Island] Challenge Mode

### DIFF
--- a/data/mods/Sky_Island/dialog_statue.json
+++ b/data/mods/Sky_Island/dialog_statue.json
@@ -258,6 +258,21 @@
         "effect": [ { "assign_mission": "SKYISLAND_UPGRADE_security5" } ],
         "topic": "SKYISLAND_UPGRADES_RAIDS"
       },
+      {
+        "text": "Challenge Mode",
+        "//": "Requires hardest missions unlocked, all bonus missions unlocked and at least stability 6 upgrade",
+        "condition": {
+          "and": [
+            { "not": { "u_has_mission": "SKYISLAND_UPGRADE_challenge_mode" } },
+            { "math": [ "bonusmissions >= 5" ] },
+            { "math": [ "hardestmissions > 0" ] },
+            { "math": [ "bonuspulses >= 6" ] },
+            { "math": [ "islandrank >= 4" ] }
+          ]
+        },
+        "effect": [ { "assign_mission": "SKYISLAND_UPGRADE_challenge_mode" } ],
+        "topic": "SKYISLAND_UPGRADES_RAIDS"
+      },
       { "text": "Nevermind.", "topic": "SKYISLAND_UPGRADE" }
     ]
   },

--- a/data/mods/Sky_Island/effectoncondition/challenge_mode.json
+++ b/data/mods/Sky_Island/effectoncondition/challenge_mode.json
@@ -1,0 +1,106 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_raid_challenge_mode_pre_raid",
+    "//": "This EOC is triggered at the top of the dimension shift before the player even moves since it may alter the dimension being traveled to",
+    "effect": [
+      { "set_string_var": "dimension_sky_island_region", "target_var": { "global_val": "sky_island_target_region_settings" } },
+      { "math": [ "challenge_mode_reward_multiplier = 1.5" ] },
+      {
+        "if": { "math": [ "challenge_mode_active == 1" ] },
+        "then": [
+          {
+            "weighted_list_eocs": [
+              [ "EOC_raid_challenge_mode_hot_dimension", 100 ],
+              [ "EOC_raid_challenge_mode_cold_dimension", 100 ],
+              [ "EOC_raid_challenge_mode_reduced_pulselength", 100 ],
+              [ "EOC_raid_challenge_mode_slow_effect", 100 ]
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_raid_challenge_mode_post_raid",
+    "effect": [ { "u_lose_effect": [ "challenge_mode_speed_reduction" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_raid_challenge_mode_hot_dimension",
+    "effect": [
+      {
+        "run_eocs": {
+          "id": "EOC_raid_challenge_mode_hot_dimension_warning",
+          "effect": [
+            {
+              "u_message": "Something is different about this dimension.  Everything feels hotter than it should be.",
+              "popup": true
+            }
+          ]
+        },
+        "time_in_future": 1
+      },
+      {
+        "set_string_var": "sky_island_raid_region_hot",
+        "target_var": { "global_val": "sky_island_target_region_settings" }
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_raid_challenge_mode_cold_dimension",
+    "effect": [
+      {
+        "run_eocs": {
+          "id": "EOC_raid_challenge_mode_cold_dimension_warning",
+          "effect": [
+            {
+              "u_message": "Something is different about this dimension.  Everything feels colder than it should be.",
+              "popup": true
+            }
+          ]
+        },
+        "time_in_future": 1
+      },
+      {
+        "set_string_var": "sky_island_raid_region_cold",
+        "target_var": { "global_val": "sky_island_target_region_settings" }
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_raid_challenge_mode_reduced_pulselength",
+    "effect": [
+      {
+        "run_eocs": {
+          "id": "EOC_raid_challenge_mode_reduced_pulselength_warning",
+          "effect": [
+            {
+              "u_message": "Something is different about this dimension.  You feel that you have less time than normal.",
+              "popup": true
+            }
+          ]
+        },
+        "time_in_future": 1
+      },
+      { "math": [ "currentpulselength = currentpulselength / 3" ] }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_raid_challenge_mode_slow_effect",
+    "effect": [
+      {
+        "run_eocs": {
+          "id": "EOC_raid_challenge_mode_slow_effect_warning",
+          "effect": [ { "u_message": "Something is different about this dimension.  You're moving slower than normal.", "popup": true } ]
+        },
+        "time_in_future": 1
+      },
+      { "u_add_effect": "challenge_mode_speed_reduction", "duration": "PERMANENT" }
+    ]
+  }
+]

--- a/data/mods/Sky_Island/effectoncondition/obelisk_selector.json
+++ b/data/mods/Sky_Island/effectoncondition/obelisk_selector.json
@@ -4,14 +4,26 @@
     "id": "EOC_warp_statue",
     "effect": [
       {
-        "run_eoc_selector": [ "EOC_raidbegin_short", "EOC_raidbegin_medium", "EOC_raidbegin_long", "EOC_raidcancel" ],
-        "names": [ "Quick Expedition", "Large Expedition", "Extended Expedition", "Cancel" ],
-        "keys": [ "1", "2", "3", "4" ],
-        "title": "Select Expedition Length",
+        "if": { "math": [ "challenge_mode_active == 1" ] },
+        "then": [ { "set_string_var": "<color_red>Enabled</color>", "target_var": { "global_val": "challenge_mode_warning" } } ],
+        "else": [ { "set_string_var": "Disabled", "target_var": { "global_val": "challenge_mode_warning" } } ]
+      },
+      {
+        "run_eoc_selector": [
+          "EOC_raidbegin_short",
+          "EOC_raidbegin_medium",
+          "EOC_raidbegin_long",
+          "EOC_raid_toggle_challenge_mode",
+          "EOC_raidcancel"
+        ],
+        "names": [ "Quick Expedition", "Large Expedition", "Extended Expedition", "Toggle Challenge Mode", "Cancel" ],
+        "keys": [ "1", "2", "3", "4", "5" ],
+        "title": "Select Expedition Length.  Challenge Mode: <global_val:challenge_mode_warning>",
         "descriptions": [
           "A simple, brief expedition at the normal time limit.  Missions and exits will be close together.  A good chance to quickly gather supplies and experience.",
           "A longer expedition that offers twice the time.  Missions and exits will be scattered over a wider area.  You will have more opportunity to dig deeper into surrounding points of interest, but also need more time to travel.  Missions offer extra warp shards as rewards.",
           "A very long expedition that triples the time limit.  Missions and exits will be very far away.  You will have time for extended activities, but a good deal of your time will be spent trying to reach objectives over potentially dangerous terrain.  Missions offer even more warp shards as rewards.",
+          "Toggles Challenge Mode, granting more rewards at the cost of harder expeditions.  A random difficulty modifier will be applied.",
           "Stay on the island for now."
         ]
       }
@@ -59,6 +71,19 @@
       { "math": [ "exfildistancemax = 160" ] },
       { "math": [ "exfildistancemin = 50" ] },
       { "run_eocs": [ "EOC_warp_choose_locale" ] }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_raid_toggle_challenge_mode",
+    "condition": { "math": [ "challenge_mode_available > 0" ] },
+    "effect": [
+      {
+        "if": { "math": [ "challenge_mode_active == 1" ] },
+        "then": [ { "math": [ "challenge_mode_active = 0" ] }, { "u_message": "Challenge Mode has been deactivated.", "popup": true } ],
+        "else": [ { "math": [ "challenge_mode_active = 1" ] }, { "u_message": "Challenge Mode has been activated.", "popup": true } ]
+      },
+      { "run_eocs": [ "EOC_warp_statue" ] }
     ]
   },
   {
@@ -307,6 +332,7 @@
     "type": "effect_on_condition",
     "id": "EOC_SKY_ISLAND_MISSION_DIMENSION_SHIFT",
     "effect": [
+      { "run_eocs": [ "EOC_raid_challenge_mode_pre_raid" ] },
       { "u_location_variable": { "global_val": "OM_HQ_origin" } },
       {
         "u_location_variable": { "global_val": "OM_HQ_origin_npc" },
@@ -356,7 +382,7 @@
       {
         "u_travel_to_dimension": "dimension_sky_island_mission",
         "npc_travel_radius": 10,
-        "region_type": "dimension_sky_island_region"
+        "region_type": { "global_val": "sky_island_target_region_settings" }
       }
     ]
   }

--- a/data/mods/Sky_Island/effectoncondition/teleport.json
+++ b/data/mods/Sky_Island/effectoncondition/teleport.json
@@ -171,7 +171,7 @@
     "id": "EOC_return_OM_teleport",
     "//": "This is the EOC which actually returns you home.  It brings you home and removes all warp-related effects including warp sickness.  It heals you enough to fix broken limbs.  It also resets the awayfromhome counter to 0 so warp sickness can be tracked properly next time you're out.",
     "effect": [
-      { "run_eocs": "EOC_CANCEL_PORTAL_STORM" },
+      { "run_eocs": [ "EOC_CANCEL_PORTAL_STORM", "EOC_raid_challenge_mode_post_raid" ] },
       {
         "u_run_npc_eocs": [
           {
@@ -268,6 +268,10 @@
     "effect": [
       { "math": [ "gettokens = 0" ] },
       { "math": [ "owed_material_tokens = lengthofthisraid * 75 + 50" ] },
+      {
+        "if": { "math": [ "challenge_mode_active == 1" ] },
+        "then": [ { "math": [ "owed_material_tokens = owed_material_tokens * challenge_mode_reward_multiplier" ] } ]
+      },
       {
         "u_message": "You've returned home safely using a designated exit point.  You have earned <global_val:owed_material_tokens> material tokens for your success.",
         "popup": true

--- a/data/mods/Sky_Island/effects.json
+++ b/data/mods/Sky_Island/effects.json
@@ -151,5 +151,15 @@
     "name": [ "" ],
     "desc": [ "" ],
     "flags": [ "LEVITATION" ]
+  },
+  {
+    "id": "challenge_mode_speed_reduction",
+    "type": "effect_type",
+    "name": [ "Slow Dimension" ],
+    "desc": [ { "str": "You are moving slower than usual in this dimension" } ],
+    "rating": "bad",
+    "show_intensity": false,
+    "show_in_info": true,
+    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "SPEED", "multiply": -0.2 } ] } ]
   }
 ]

--- a/data/mods/Sky_Island/furniture_and_terrain.json
+++ b/data/mods/Sky_Island/furniture_and_terrain.json
@@ -47,6 +47,19 @@
     "examine_action": { "type": "effect_on_condition", "effect_on_conditions": [ "EOC_statue_return" ] }
   },
   {
+    "type": "furniture",
+    "id": "f_warpshardrewardstatue",
+    "name": "Warp Shard Obelisk",
+    "description": "A strange statue that is holding some warp shards.",
+    "symbol": "S",
+    "color": "dark_gray",
+    "looks_like": "f_statue",
+    "move_cost_mod": -1,
+    "coverage": 0,
+    "required_str": -1,
+    "flags": [ "NOCOLLIDE", "NO_PICKUP_ON_EXAMINE", "TRANSPARENT" ]
+  },
+  {
     "type": "terrain",
     "id": "t_fake_air",
     "name": "open air",

--- a/data/mods/Sky_Island/missions/raid_missions.json
+++ b/data/mods/Sky_Island/missions/raid_missions.json
@@ -28,8 +28,18 @@
     },
     "end": {
       "effect": [
-        { "run_eocs": "EOC_bonuspulse" },
         { "math": [ "u_missionswon++" ] },
+        { "math": [ "totalbonus = rand(5) + 1" ] },
+        {
+          "if": { "math": [ "challenge_mode_active == 1" ] },
+          "then": [ { "math": [ "totalbonus = totalbonus * challenge_mode_reward_multiplier" ] } ]
+        },
+        {
+          "u_message": "It's done.  You found the statue.  Warp shards filter in from seams in reality.  Your reward rains down on you.",
+          "type": "mixed"
+        },
+        { "run_eocs": "EOC_bonuspulse" },
+        { "u_spawn_item": "warptoken", "count": { "global_val": "totalbonus", "default": 1 } },
         { "run_eocs": "EOC_innawood_bonus_exp_warpshards" }
       ]
     }
@@ -61,6 +71,10 @@
         { "math": [ "u_missionswon++" ] },
         { "math": [ "totalbonus = 3 + total_difficulty_bonus" ] },
         {
+          "if": { "math": [ "challenge_mode_active == 1" ] },
+          "then": [ { "math": [ "totalbonus = totalbonus * challenge_mode_reward_multiplier" ] } ]
+        },
+        {
           "u_message": "It's done.  They're all dead.  Warp shards filter in from seams in reality.  Your reward rains down on you.",
           "type": "mixed"
         },
@@ -90,6 +104,10 @@
       "effect": [
         { "math": [ "u_missionswon++" ] },
         { "math": [ "totalbonus = 4 + total_difficulty_bonus" ] },
+        {
+          "if": { "math": [ "challenge_mode_active == 1" ] },
+          "then": [ { "math": [ "totalbonus = totalbonus * challenge_mode_reward_multiplier" ] } ]
+        },
         {
           "u_message": "It's done.  They're all dead.  Warp shards filter in from seams in reality.  Your reward rains down on you.",
           "type": "mixed"
@@ -129,6 +147,10 @@
         { "math": [ "u_missionswon++" ] },
         { "math": [ "totalbonus = 4 + total_difficulty_bonus" ] },
         {
+          "if": { "math": [ "challenge_mode_active == 1" ] },
+          "then": [ { "math": [ "totalbonus = totalbonus * challenge_mode_reward_multiplier" ] } ]
+        },
+        {
           "u_message": "It's done.  They're all dead.  Warp shards filter in from seams in reality.  Your reward rains down on you.",
           "type": "mixed"
         },
@@ -166,6 +188,10 @@
       "effect": [
         { "math": [ "u_missionswon++" ] },
         { "math": [ "totalbonus = 5 + total_difficulty_bonus" ] },
+        {
+          "if": { "math": [ "challenge_mode_active == 1" ] },
+          "then": [ { "math": [ "totalbonus = totalbonus * challenge_mode_reward_multiplier" ] } ]
+        },
         {
           "u_message": "It's done.  They're all dead.  Warp shards filter in from seams in reality.  Your reward rains down on you.",
           "type": "mixed"
@@ -213,6 +239,10 @@
         { "math": [ "u_missionswon++" ] },
         { "math": [ "totalbonus = 5 + total_difficulty_bonus" ] },
         {
+          "if": { "math": [ "challenge_mode_active == 1" ] },
+          "then": [ { "math": [ "totalbonus = totalbonus * challenge_mode_reward_multiplier" ] } ]
+        },
+        {
           "u_message": "It's done.  They're all dead.  Warp shards filter in from seams in reality.  Your reward rains down on you.",
           "type": "mixed"
         },
@@ -259,6 +289,10 @@
         { "math": [ "u_missionswon++" ] },
         { "math": [ "totalbonus = 8 + total_difficulty_bonus" ] },
         {
+          "if": { "math": [ "challenge_mode_active == 1" ] },
+          "then": [ { "math": [ "totalbonus = totalbonus * challenge_mode_reward_multiplier" ] } ]
+        },
+        {
           "u_message": "It's done.  They're all dead.  Warp shards filter in from seams in reality.  Your reward rains down on you.",
           "type": "mixed"
         },
@@ -286,6 +320,10 @@
       "effect": [
         { "math": [ "u_missionswon++" ] },
         { "math": [ "totalbonus = 10 + total_difficulty_bonus" ] },
+        {
+          "if": { "math": [ "challenge_mode_active == 1" ] },
+          "then": [ { "math": [ "totalbonus = totalbonus * challenge_mode_reward_multiplier" ] } ]
+        },
         {
           "u_message": "It's done.  They're all dead.  Warp shards filter in from seams in reality.  Your reward rains down on you.",
           "type": "mixed"
@@ -316,6 +354,10 @@
       "effect": [
         { "math": [ "u_missionswon++" ] },
         { "math": [ "totalbonus = 10 + total_difficulty_bonus" ] },
+        {
+          "if": { "math": [ "challenge_mode_active == 1" ] },
+          "then": [ { "math": [ "totalbonus = totalbonus * challenge_mode_reward_multiplier" ] } ]
+        },
         {
           "u_message": "It's done.  They're all dead.  Warp shards filter in from seams in reality.  Your reward rains down on you.",
           "type": "mixed"
@@ -355,6 +397,10 @@
         { "math": [ "u_missionswon++" ] },
         { "math": [ "totalbonus = 12 + total_difficulty_bonus" ] },
         {
+          "if": { "math": [ "challenge_mode_active == 1" ] },
+          "then": [ { "math": [ "totalbonus = totalbonus * challenge_mode_reward_multiplier" ] } ]
+        },
+        {
           "u_message": "It's done.  They're all dead.  Warp shards filter in from seams in reality.  Your reward rains down on you.",
           "type": "mixed"
         },
@@ -393,6 +439,10 @@
         { "math": [ "u_missionswon++" ] },
         { "math": [ "totalbonus = 12 + total_difficulty_bonus" ] },
         {
+          "if": { "math": [ "challenge_mode_active == 1" ] },
+          "then": [ { "math": [ "totalbonus = totalbonus * challenge_mode_reward_multiplier" ] } ]
+        },
+        {
           "u_message": "It's done.  They're all dead.  Warp shards filter in from seams in reality.  Your reward rains down on you.",
           "type": "mixed"
         },
@@ -420,6 +470,10 @@
       "effect": [
         { "math": [ "u_missionswon++" ] },
         { "math": [ "totalbonus = 9 + total_difficulty_bonus" ] },
+        {
+          "if": { "math": [ "challenge_mode_active == 1" ] },
+          "then": [ { "math": [ "totalbonus = totalbonus * challenge_mode_reward_multiplier" ] } ]
+        },
         {
           "u_message": "It's done.  They're all dead.  Warp shards filter in from seams in reality.  Your reward rains down on you.",
           "type": "mixed"
@@ -452,6 +506,10 @@
         { "math": [ "u_missionswon++" ] },
         { "math": [ "totalbonus = 12 + total_difficulty_bonus" ] },
         {
+          "if": { "math": [ "challenge_mode_active == 1" ] },
+          "then": [ { "math": [ "totalbonus = totalbonus * challenge_mode_reward_multiplier" ] } ]
+        },
+        {
           "u_message": "It's done.  They're all dead.  Warp shards filter in from seams in reality.  Your reward rains down on you.",
           "type": "mixed"
         },
@@ -478,6 +536,10 @@
         { "math": [ "u_missionswon++" ] },
         { "math": [ "totalbonus = 9 + total_difficulty_bonus" ] },
         {
+          "if": { "math": [ "challenge_mode_active == 1" ] },
+          "then": [ { "math": [ "totalbonus = totalbonus * challenge_mode_reward_multiplier" ] } ]
+        },
+        {
           "u_message": "It's done.  They're all dead.  Warp shards filter in from seams in reality.  Your reward rains down on you.",
           "type": "mixed"
         },
@@ -503,6 +565,10 @@
       "effect": [
         { "math": [ "u_missionswon++" ] },
         { "math": [ "totalbonus = 6 + total_difficulty_bonus" ] },
+        {
+          "if": { "math": [ "challenge_mode_active == 1" ] },
+          "then": [ { "math": [ "totalbonus = totalbonus * challenge_mode_reward_multiplier" ] } ]
+        },
         {
           "u_message": "It's done.  They're all dead.  Warp shards filter in from seams in reality.  Your reward rains down on you.",
           "type": "mixed"
@@ -536,6 +602,10 @@
         { "math": [ "u_missionswon++" ] },
         { "math": [ "totalbonus = 12 + total_difficulty_bonus" ] },
         {
+          "if": { "math": [ "challenge_mode_active == 1" ] },
+          "then": [ { "math": [ "totalbonus = totalbonus * challenge_mode_reward_multiplier" ] } ]
+        },
+        {
           "u_message": "It's done.  They're all dead.  Warp shards filter in from seams in reality.  Your reward rains down on you.",
           "type": "mixed"
         },
@@ -555,7 +625,21 @@
     "difficulty": 0,
     "value": 0,
     "invisible_on_complete": true,
-    "end": { "effect": [ { "math": [ "slaughterswon++" ] }, { "u_spawn_item": "warptoken", "count": 1 } ] }
+    "end": {
+      "effect": [
+        { "math": [ "slaughterswon++" ] },
+        { "math": [ "totalbonus = 1" ] },
+        {
+          "if": { "math": [ "challenge_mode_active == 1" ] },
+          "then": [ { "math": [ "totalbonus = totalbonus * challenge_mode_reward_multiplier" ] } ]
+        },
+        {
+          "u_message": "It's done.  They're all dead.  Warp shards filter in from seams in reality.  Your reward rains down on you.",
+          "type": "mixed"
+        },
+        { "u_spawn_item": "warptoken", "count": { "global_val": "totalbonus", "default": 1 } }
+      ]
+    }
   },
   {
     "id": "MISSION_BONUS_SLAUGHTER_ZED2",
@@ -568,7 +652,21 @@
     "difficulty": 0,
     "value": 0,
     "invisible_on_complete": true,
-    "end": { "effect": [ { "math": [ "slaughterswon++" ] }, { "u_spawn_item": "warptoken", "count": 3 } ] }
+    "end": {
+      "effect": [
+        { "math": [ "slaughterswon++" ] },
+        { "math": [ "totalbonus = 3" ] },
+        {
+          "if": { "math": [ "challenge_mode_active == 1" ] },
+          "then": [ { "math": [ "totalbonus = totalbonus * challenge_mode_reward_multiplier" ] } ]
+        },
+        {
+          "u_message": "It's done.  They're all dead.  Warp shards filter in from seams in reality.  Your reward rains down on you.",
+          "type": "mixed"
+        },
+        { "u_spawn_item": "warptoken", "count": { "global_val": "totalbonus", "default": 1 } }
+      ]
+    }
   },
   {
     "id": "MISSION_BONUS_SLAUGHTER_ZED3",
@@ -581,7 +679,21 @@
     "difficulty": 0,
     "value": 0,
     "invisible_on_complete": true,
-    "end": { "effect": [ { "math": [ "slaughterswon++" ] }, { "u_spawn_item": "warptoken", "count": 5 } ] }
+    "end": {
+      "effect": [
+        { "math": [ "slaughterswon++" ] },
+        { "math": [ "totalbonus = 5" ] },
+        {
+          "if": { "math": [ "challenge_mode_active == 1" ] },
+          "then": [ { "math": [ "totalbonus = totalbonus * challenge_mode_reward_multiplier" ] } ]
+        },
+        {
+          "u_message": "It's done.  They're all dead.  Warp shards filter in from seams in reality.  Your reward rains down on you.",
+          "type": "mixed"
+        },
+        { "u_spawn_item": "warptoken", "count": { "global_val": "totalbonus", "default": 1 } }
+      ]
+    }
   },
   {
     "id": "MISSION_BONUS_SLAUGHTER_MIGO",
@@ -594,7 +706,21 @@
     "difficulty": 0,
     "value": 0,
     "invisible_on_complete": true,
-    "end": { "effect": [ { "math": [ "slaughterswon++" ] }, { "u_spawn_item": "warptoken", "count": 3 } ] }
+    "end": {
+      "effect": [
+        { "math": [ "slaughterswon++" ] },
+        { "math": [ "totalbonus = 3" ] },
+        {
+          "if": { "math": [ "challenge_mode_active == 1" ] },
+          "then": [ { "math": [ "totalbonus = totalbonus * challenge_mode_reward_multiplier" ] } ]
+        },
+        {
+          "u_message": "It's done.  They're all dead.  Warp shards filter in from seams in reality.  Your reward rains down on you.",
+          "type": "mixed"
+        },
+        { "u_spawn_item": "warptoken", "count": { "global_val": "totalbonus", "default": 1 } }
+      ]
+    }
   },
   {
     "id": "MISSION_BONUS_SLAUGHTER_NETHER",
@@ -607,7 +733,21 @@
     "difficulty": 0,
     "value": 0,
     "invisible_on_complete": true,
-    "end": { "effect": [ { "math": [ "slaughterswon++" ] }, { "u_spawn_item": "warptoken", "count": 4 } ] }
+    "end": {
+      "effect": [
+        { "math": [ "slaughterswon++" ] },
+        { "math": [ "totalbonus = 4" ] },
+        {
+          "if": { "math": [ "challenge_mode_active == 1" ] },
+          "then": [ { "math": [ "totalbonus = totalbonus * challenge_mode_reward_multiplier" ] } ]
+        },
+        {
+          "u_message": "It's done.  They're all dead.  Warp shards filter in from seams in reality.  Your reward rains down on you.",
+          "type": "mixed"
+        },
+        { "u_spawn_item": "warptoken", "count": { "global_val": "totalbonus", "default": 1 } }
+      ]
+    }
   },
   {
     "id": "MISSION_BONUS_SLAUGHTER_BIRD",
@@ -620,7 +760,21 @@
     "difficulty": 0,
     "value": 0,
     "invisible_on_complete": true,
-    "end": { "effect": [ { "math": [ "slaughterswon++" ] }, { "u_spawn_item": "warptoken", "count": 1 } ] }
+    "end": {
+      "effect": [
+        { "math": [ "slaughterswon++" ] },
+        { "math": [ "totalbonus = 1" ] },
+        {
+          "if": { "math": [ "challenge_mode_active == 1" ] },
+          "then": [ { "math": [ "totalbonus = totalbonus * challenge_mode_reward_multiplier" ] } ]
+        },
+        {
+          "u_message": "It's done.  They're all dead.  Warp shards filter in from seams in reality.  Your reward rains down on you.",
+          "type": "mixed"
+        },
+        { "u_spawn_item": "warptoken", "count": { "global_val": "totalbonus", "default": 1 } }
+      ]
+    }
   },
   {
     "id": "MISSION_BONUS_SLAUGHTER_MAMMAL",
@@ -633,7 +787,21 @@
     "difficulty": 0,
     "value": 0,
     "invisible_on_complete": true,
-    "end": { "effect": [ { "math": [ "slaughterswon++" ] }, { "u_spawn_item": "warptoken", "count": 1 } ] }
+    "end": {
+      "effect": [
+        { "math": [ "slaughterswon++" ] },
+        { "math": [ "totalbonus = 1" ] },
+        {
+          "if": { "math": [ "challenge_mode_active == 1" ] },
+          "then": [ { "math": [ "totalbonus = totalbonus * challenge_mode_reward_multiplier" ] } ]
+        },
+        {
+          "u_message": "It's done.  They're all dead.  Warp shards filter in from seams in reality.  Your reward rains down on you.",
+          "type": "mixed"
+        },
+        { "u_spawn_item": "warptoken", "count": { "global_val": "totalbonus", "default": 1 } }
+      ]
+    }
   },
   {
     "type": "mapgen",
@@ -679,7 +847,7 @@
         "  x  "
       ],
       "terrain": { "x": [ "t_carpet_green" ], "o": [ "t_carpet_purple" ] },
-      "items": { "o": [ { "item": "warp_mission_goal", "chance": 100 } ] },
+      "furniture": { "o": "f_warpshardrewardstatue" },
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
     }
   }

--- a/data/mods/Sky_Island/missions/raid_upgrades/challenge.json
+++ b/data/mods/Sky_Island/missions/raid_upgrades/challenge.json
@@ -1,0 +1,79 @@
+[
+  {
+    "id": "SKYISLAND_UPGRADE_challenge_mode",
+    "type": "mission_definition",
+    "name": "Unlock: Challenge Mode",
+    "description": "Completing this mission will unlock a permanent upgrade for all future expeditions.\n\nCraft an Eternal Obelisk from weapons and armor.  The Heart of the Island has already placed the recipe inside your mind.\n\nEFFECT: You will be able to enable a challenge mode for expeditions, applying a random modifier in exchange for increased rewards.",
+    "goal": "MGOAL_FIND_ITEM",
+    "item": "upgradekey_challenge_mode",
+    "count": 1,
+    "difficulty": 0,
+    "value": 0,
+    "has_generic_rewards": false,
+    "start": {
+      "effect": [
+        { "u_learn_recipe": "upgradekey_challenge_mode" },
+        {
+          "u_message": "Somehow, you understand the statue is calling out for something that can strengthen its power.\nA new recipe has been learned.  Craft this artifact to permanently upgrade the island.\n\nEFFECT: You will be able to enable a challenge mode for expeditions, applying a random modifier in exchange for increased rewards.",
+          "popup": true
+        }
+      ]
+    },
+    "end": {
+      "effect": [
+        { "math": [ "challenge_mode_available = 1" ] },
+        { "u_forget_recipe": "upgradekey_challenge_mode" },
+        {
+          "u_message": "You feel a burning sensation sweep through your body as your connection to the warpstream grows before splitting in two.  You can feel that there is another, more dangerous place that you can travel to.\n\nYou can now enable challenge mode for your expeditions.  A random modifier will be applied to the expedition in exchange for increased rewards.",
+          "type": "mixed"
+        }
+      ]
+    }
+  },
+  {
+    "id": "upgradekey_challenge_mode",
+    "type": "ITEM",
+    "category": "spare_parts",
+    "name": { "str": "Eternal Obelisk" },
+    "description": "This strange metaphysical artifact will empower the island and unlock a permanent upgrade for all future runs.  Will be used automatically upon crafting, and can only be used once.\n\nASSOCIATED UPGRADE: Challenge Mode",
+    "volume": "25000 ml",
+    "weight": "15000 g",
+    "longest_side": "90 cm",
+    "material": [ "stone" ],
+    "symbol": "V",
+    "color": "white"
+  },
+  {
+    "result": "upgradekey_challenge_mode",
+    "type": "recipe",
+    "activity_level": "NO_EXERCISE",
+    "category": "CC_WARP",
+    "subcategory": "CSC_WARP_UPGRADES",
+    "skill_used": "survival",
+    "difficulty": 0,
+    "time": "15 m",
+    "flags": [ "SECRET", "BLIND_EASY" ],
+    "reversible": false,
+    "tools": [ [ [ "fakeitem_statue", -1 ] ] ],
+    "components": [
+      [ [ "warptoken", 50 ] ],
+      [ [ "m107a1", 1 ], [ "m2browning", 1 ], [ "as50", 1 ] ],
+      [ [ "xedra_enviro_suit", 1 ], [ "xedra_enviro_suit_casual", 1 ] ],
+      [
+        [ "lc_chainmail_vest", 1 ],
+        [ "hc_chainmail_vest", 1 ],
+        [ "mc_chainmail_vest", 1 ],
+        [ "ch_chainmail_vest", 1 ],
+        [ "qt_chainmail_vest", 1 ]
+      ],
+      [
+        [ "lab_postit_bio", 2 ],
+        [ "lab_postit_blob", 2 ],
+        [ "lab_postit_migo", 2 ],
+        [ "lab_postit_portal", 2 ],
+        [ "lab_postit_tech", 2 ]
+      ],
+      [ [ "lab_file_bio", 2 ], [ "lab_file_portal", 2 ], [ "lab_file_psych", 2 ], [ "lab_file_sec", 2 ] ]
+    ]
+  }
+]

--- a/data/mods/Sky_Island/region_settings.json
+++ b/data/mods/Sky_Island/region_settings.json
@@ -70,5 +70,37 @@
       "subway_connection": "subway_tunnel",
       "rail_connection": "local_railroad"
     }
+  },
+  {
+    "type": "weather_generator",
+    "id": "sky_island_raid_weather_hot",
+    "copy-from": "default",
+    "base_temperature": 26,
+    "spring_temp_manual_mod": 15,
+    "summer_temp_manual_mod": 0,
+    "autumn_temp_manual_mod": 15,
+    "winter_temp_manual_mod": 30
+  },
+  {
+    "type": "region_settings",
+    "id": "sky_island_raid_region_hot",
+    "copy-from": "dimension_sky_island_region",
+    "weather": "sky_island_raid_weather_hot"
+  },
+  {
+    "type": "weather_generator",
+    "id": "sky_island_raid_weather_cold",
+    "copy-from": "default",
+    "base_temperature": -4,
+    "spring_temp_manual_mod": -15,
+    "summer_temp_manual_mod": -30,
+    "autumn_temp_manual_mod": -15,
+    "winter_temp_manual_mod": 0
+  },
+  {
+    "type": "region_settings",
+    "id": "sky_island_raid_region_cold",
+    "copy-from": "dimension_sky_island_region",
+    "weather": "sky_island_raid_weather_cold"
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Sky Island] Challenge Mode"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Adds an unlockable challenge mode for raids.
An entirely voluntary toggle that the player controls once they unlock it to make raids more challenging while providing greater rewards.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
A new upgrade created to unlock challenge mode
- Locked behind island rank 2, hardest missions unlocked, and stability 6 upgrade
- Requires trash loot from labs, 50 warp shards, activity suit, a 50 cal rifle, and some sort of chainmail vest

Obelisk selector EOCs updated to accommodate challenge mode
- Raid length selection step (first step) now has a toggle and status indicator for challenge mode
- New EOC fired before the dimension shift EOC to do pre raid checks and changes for the raid

Post raid EOC added to clear all effects from challenge mode

All mission rewards updated to include a multiplier for challenge mode when active
- Warp shards mission had to be changed to accommodate this, now finding the area simply rewards shards directly instead of having to pick them up
  - yes this makes the mission marginally easier but math cant be used in item groups
  
Completed raid material token rewards multiplied as well

Challenge mode modifiers
- Hot dimension
  - Dimension is hotter and all seasons have a flat modifier applied to make them all as hot as summer
  - ~ 43c year round and 26c underground

- Cold dimension
  - Dimension is colder and all seasons have a flat modifier applied to make them all as cold as winter
  - ~ -15c year round and -4c underground 

- Slow dimension
  - A 20% speed reduction is applied to the player
  
- Reduced pulse length 
  - Pulse length is reduced by 2/3 (15m -> 5m)
  
When challenge mode is active, a single modifier is picked at random when the raid is started. All modifiers are currently weighted the same. All modifiers provide the same bonus of 1.5x for all rewards.


#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Checked all requirements must be met to unlock challenge mode.
Challenge mode toggle remains unusable while the upgrade is not complete and remains inactive.
Toggling challenge mode toggles the indicator as required. When inactive no modifiers are applied and when active a random modifer is applied.
When returning to the island, any currently applied modifer on the character is cleared (currently only the speed modifier, the rest don't apply anything the player to function.)


<img width="515" height="277" alt="image" src="https://github.com/user-attachments/assets/dbca809b-0e44-4a2a-a498-ace25efb33f1" />
<img width="1029" height="453" alt="image" src="https://github.com/user-attachments/assets/d8d036dd-ab7e-4253-b4e7-dea3a4c8cad9" />

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Depends on #86025 to be merged first since it edits one of the new files added. Reviewing this before then will be difficult since it includes the churn from that PR currently
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
