### PR TITLE
[alt-map-key] Add new overmap terrain

### DIFF
--- a/data/mods/alt_map_key/overmap_terrain_brown.json
+++ b/data/mods/alt_map_key/overmap_terrain_brown.json
@@ -1266,5 +1266,37 @@
     "name": "standing stones",
     "sym": "S",
     "color": "brown"
+  },
+  {
+    "type": "overmap_terrain",
+    "id": [ "inner_cabins_cabin" ],
+    "copy-from": "inner_cabins_cabin",
+    "name": "cabin",
+    "sym": "C",
+    "color": "brown"
+  },
+  {
+    "type": "overmap_terrain",
+    "id": [ "inner_cabins_cabin_roof" ],
+    "copy-from": "inner_cabins_cabin_roof",
+    "name": "cabin roof",
+    "sym": "C",
+    "color": "brown"
+  },
+  {
+    "type": "overmap_terrain",
+    "id": [ "inner_cabins_empty_cabin" ],
+    "copy-from": "inner_cabins_empty_cabin",
+    "name": "cabin",
+    "sym": "C",
+    "color": "brown"
+  },
+  {
+    "type": "overmap_terrain",
+    "id": [ "inner_cabins_empty_cabin_roof" ],
+    "copy-from": "inner_cabins_empty_cabin_roof",
+    "name": "cabin roof",
+    "sym": "C",
+    "color": "brown"
   }
 ]


### PR DESCRIPTION
#### Summary
Mods "[alt-map-key] Add new overmap terrain"


#### Purpose of change
Adding new overmap terrain

#### Describe the solution
Add new inner cabins reverb from #85971

#### Describe alternatives you've considered


#### Testing
<img width="355" height="235" alt="image" src="https://github.com/user-attachments/assets/0c8474e7-c362-430b-bd7c-eb4da70930bb" />


#### Additional context



<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
