### PR TITLE
NPC needs: local resource acquisition (drink, eat, wear from ground)

### DIFF
--- a/src/npc.h
+++ b/src/npc.h
@@ -1130,6 +1130,23 @@ class npc : public Character
         npc_action address_needs( float danger );
         bool wear_warmest_item();
         bool take_shelter_nearby();
+        // Local resource acquisition: find helpers return scored candidates
+        // for callers to iterate best-first, skipping unpathable targets.
+        struct scored_item {
+            item_location loc;
+            float score;
+        };
+        struct scored_water_source {
+            tripoint_bub_ms pos;
+            int dist;
+        };
+        std::vector<scored_water_source> find_nearby_water_sources() const;
+        std::vector<scored_item> find_nearby_food();
+        std::vector<scored_item> find_nearby_warm_clothing();
+        bool drink_from_water_source( const tripoint_bub_ms &water_pos );
+        bool consume_food_at( item_location loc );
+        bool wear_item_at( item_location loc );
+        bool move_to_and_verify( const tripoint_bub_ms &target );
         npc_action address_player();
         npc_action long_term_goal_action();
         int evaluate_sleep_spot( tripoint_bub_ms p );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -183,6 +183,8 @@ static const itype_id itype_lsd( "lsd" );
 static const itype_id itype_oxygen_tank( "oxygen_tank" );
 static const itype_id itype_smoxygen_tank( "smoxygen_tank" );
 static const itype_id itype_thorazine( "thorazine" );
+static const itype_id itype_water( "water" );
+static const itype_id itype_water_clean( "water_clean" );
 
 static const json_character_flag json_flag_CANNOT_ATTACK( "CANNOT_ATTACK" );
 static const json_character_flag json_flag_CANNOT_MOVE( "CANNOT_MOVE" );
@@ -191,7 +193,6 @@ static const npc_class_id NC_EVAC_SHOPKEEP( "NC_EVAC_SHOPKEEP" );
 
 static const skill_id skill_firstaid( "firstaid" );
 
-static const string_id<behavior::node_t> behavior_node_t_npc_homeostasis( "npc_homeostasis" );
 static const string_id<behavior::node_t> behavior_node_t_npc_needs( "npc_needs" );
 
 static const trait_id trait_IGNORE_SOUND( "IGNORE_SOUND" );
@@ -2567,21 +2568,18 @@ healing_options npc::patient_assessment( const Character &c )
 
 npc_action npc::address_needs( float danger )
 {
-    // Tick warmth subtree as gate. If not "idle", NPC needs warmth.
-    // Try all supported warmth actions in order. start_fire goal is not
-    // dispatched yet (no fire-starting action code); when it is, switch
-    // to respecting the specific goal string.
+    // Check if NPC needs warmth via the oracle predicate directly.
+    // The full BT subtree is too narrow for gating -- it only knows about
+    // inventory items and indoor tiles, not ground items. The predicate
+    // just checks bodypart temperature.
     bool needs_warmth = false;
     {
         behavior::character_oracle_t oracle( this );
-        behavior::tree warmth_tree;
-        warmth_tree.add( &behavior_node_t_npc_homeostasis.obj() );
-        std::string warmth_goal = warmth_tree.tick( &oracle );
-        needs_warmth = warmth_goal != "idle";
+        needs_warmth = oracle.needs_warmth_badly( "" ) == behavior::status_t::running;
         if( needs_warmth ) {
             add_msg_debug( debugmode::DF_NPC_NEEDS,
-                           "NPC %s: warmth subtree = %s (gate open, trying wear then shelter)",
-                           get_name(), warmth_goal );
+                           "NPC %s: needs warmth (trying wear, ground wear, shelter)",
+                           get_name() );
         }
     }
 
@@ -2659,6 +2657,16 @@ npc_action npc::address_needs( float danger )
     if( needs_warmth && wear_warmest_item() ) {
         return npc_noop;
     }
+    // Warmth: adjacent ground clothing, instant (no movement).
+    if( needs_warmth ) {
+        for( scored_item &c : find_nearby_warm_clothing() ) {
+            if( square_dist( pos_bub(), c.loc.pos_bub( here ) ) <= 1 ) {
+                if( wear_item_at( c.loc ) ) {
+                    return npc_noop;
+                }
+            }
+        }
+    }
 
     // Extreme thirst or hunger, bypass safety check.
     if( get_thirst() > 80 ||
@@ -2668,6 +2676,22 @@ npc_action npc::address_needs( float danger )
         }
         if( consume_food() ) {
             return npc_noop;
+        }
+        // Adjacent ground food, instant.
+        for( scored_item &c : find_nearby_food() ) {
+            if( square_dist( pos_bub(), c.loc.pos_bub( here ) ) <= 1 ) {
+                if( consume_food_at( c.loc ) ) {
+                    return npc_noop;
+                }
+            }
+        }
+        // Adjacent water terrain, instant.
+        for( scored_water_source &ws : find_nearby_water_sources() ) {
+            if( square_dist( pos_bub(), ws.pos ) <= 1 ) {
+                if( drink_from_water_source( ws.pos ) ) {
+                    return npc_noop;
+                }
+            }
         }
     }
     //Hallucinations have a chance of disappearing each turn
@@ -2683,7 +2707,46 @@ npc_action npc::address_needs( float danger )
     if( needs_warmth && take_shelter_nearby() ) {
         return npc_noop;
     }
+    // Warmth: path to distant ground clothing.
+    if( needs_warmth ) {
+        for( scored_item &c : find_nearby_warm_clothing() ) {
+            if( move_to_and_verify( c.loc.pos_bub( here ) ) ) {
+                return npc_noop;
+            }
+        }
+    }
 
+    // Extreme food/water pathing: the pre-gate block only consumed adjacent
+    // resources. If extreme need persists and we passed the danger gate,
+    // path to distant ground food or water deterministically.
+    if( get_thirst() > 80 ||
+        get_stored_kcal() + stomach.get_calories() < get_healthy_kcal() * 0.75 ) {
+        for( scored_item &c : find_nearby_food() ) {
+            if( square_dist( pos_bub(), c.loc.pos_bub( here ) ) <= 1 ) {
+                if( consume_food_at( c.loc ) ) {
+                    return npc_noop;
+                }
+            } else {
+                if( move_to_and_verify( c.loc.pos_bub( here ) ) ) {
+                    return npc_noop;
+                }
+            }
+        }
+        for( scored_water_source &ws : find_nearby_water_sources() ) {
+            if( square_dist( pos_bub(), ws.pos ) <= 1 ) {
+                if( drink_from_water_source( ws.pos ) ) {
+                    return npc_noop;
+                }
+            } else {
+                if( move_to_and_verify( ws.pos ) ) {
+                    return npc_noop;
+                }
+            }
+        }
+    }
+
+    // Normal food/drink: camp -> inventory -> ground food -> terrain water.
+    // All under the same random gate so ground never outranks camp/inventory.
     if( one_in( 3 ) && ( get_thirst() > NPC_THIRST_CONSUME ||
                          get_hunger() > NPC_HUNGER_CONSUME ) ) {
         if( consume_food_from_camp() ) {
@@ -2691,6 +2754,28 @@ npc_action npc::address_needs( float danger )
         }
         if( consume_food() ) {
             return npc_noop;
+        }
+        for( scored_item &c : find_nearby_food() ) {
+            if( square_dist( pos_bub(), c.loc.pos_bub( here ) ) <= 1 ) {
+                if( consume_food_at( c.loc ) ) {
+                    return npc_noop;
+                }
+            } else {
+                if( move_to_and_verify( c.loc.pos_bub( here ) ) ) {
+                    return npc_noop;
+                }
+            }
+        }
+        for( scored_water_source &ws : find_nearby_water_sources() ) {
+            if( square_dist( pos_bub(), ws.pos ) <= 1 ) {
+                if( drink_from_water_source( ws.pos ) ) {
+                    return npc_noop;
+                }
+            } else {
+                if( move_to_and_verify( ws.pos ) ) {
+                    return npc_noop;
+                }
+            }
         }
     }
 
@@ -5614,6 +5699,169 @@ bool npc::take_shelter_nearby()
         }
     }
     return false;
+}
+
+std::vector<npc::scored_water_source> npc::find_nearby_water_sources() const
+{
+    static const std::set<itype_id> allowed = {
+        itype_water, itype_water_clean
+    };
+    std::vector<scored_water_source> results;
+    const map &here = get_map();
+    for( const tripoint_bub_ms &p : closest_points_first( pos_bub(), 6 ) ) {
+        if( !sees( here, p ) ) {
+            continue;
+        }
+        const ter_t &t = here.ter( p ).obj();
+        if( t.liquid_source_item_id.is_null() ) {
+            continue;
+        }
+        if( t.liquid_source_count != std::make_pair( 0, 0 ) ) {
+            continue;
+        }
+        if( allowed.count( t.liquid_source_item_id ) == 0 ) {
+            continue;
+        }
+        results.push_back( { p, rl_dist( pos_bub(), p ) } );
+    }
+    std::sort( results.begin(), results.end(),
+    []( const scored_water_source & a, const scored_water_source & b ) {
+        return a.dist < b.dist;
+    } );
+    return results;
+}
+
+std::vector<npc::scored_item> npc::find_nearby_food()
+{
+    std::vector<scored_item> results;
+    if( is_player_ally() && !rules.has_flag( ally_rule::allow_pick_up ) ) {
+        return results;
+    }
+    int want_hunger = std::max( 0, get_hunger() );
+    int want_quench = std::max( 0, get_thirst() );
+    bool thirst_dominant = get_thirst() > get_hunger() * 2;
+    map &here = get_map();
+
+    for( const tripoint_bub_ms &p : closest_points_first( pos_bub(), 6 ) ) {
+        if( is_player_ally() && g->check_zone( zone_type_NO_NPC_PICKUP, p ) ) {
+            continue;
+        }
+        if( !here.sees_some_items( p, *this ) || !sees( here, p ) ) {
+            continue;
+        }
+        for( item &it : here.i_at( p ) ) {
+            if( !it.is_food() ) {
+                continue;
+            }
+            if( thirst_dominant && it.get_comestible() &&
+                it.get_comestible()->quench <= 0 ) {
+                continue;
+            }
+            if( !would_take_that( it, p ) ) {
+                continue;
+            }
+            float w = rate_food( *this, it, want_hunger, want_quench );
+            if( w > 0.0f && will_eat( it ).success() ) {
+                results.push_back( {
+                    item_location( map_cursor( p ), &it ), w
+                } );
+            }
+        }
+    }
+    std::sort( results.begin(), results.end(),
+    []( const scored_item & a, const scored_item & b ) {
+        return a.score > b.score;
+    } );
+    return results;
+}
+
+std::vector<npc::scored_item> npc::find_nearby_warm_clothing()
+{
+    std::vector<scored_item> results;
+    if( is_player_ally() && !rules.has_flag( ally_rule::allow_pick_up ) ) {
+        return results;
+    }
+    map &here = get_map();
+    for( const tripoint_bub_ms &p : closest_points_first( pos_bub(), 6 ) ) {
+        if( is_player_ally() && g->check_zone( zone_type_NO_NPC_PICKUP, p ) ) {
+            continue;
+        }
+        if( !here.sees_some_items( p, *this ) || !sees( here, p ) ) {
+            continue;
+        }
+        for( item &it : here.i_at( p ) ) {
+            if( it.get_warmth() <= 0 || !can_wear( it ).success() ) {
+                continue;
+            }
+            if( !would_take_that( it, p ) ) {
+                continue;
+            }
+            results.push_back( {
+                item_location( map_cursor( p ), &it ),
+                static_cast<float>( it.get_warmth() )
+            } );
+        }
+    }
+    std::sort( results.begin(), results.end(),
+    []( const scored_item & a, const scored_item & b ) {
+        return a.score > b.score;
+    } );
+    return results;
+}
+
+bool npc::drink_from_water_source( const tripoint_bub_ms &water_pos )
+{
+    if( get_thirst() <= 0 ) {
+        return false;
+    }
+    const units::volume want = std::max( 0_ml,
+                                         units::from_milliliter( get_thirst() * 5 ) );
+    const units::volume room = stomach.stomach_remaining( *this );
+    const units::volume intake = std::min( want, room );
+    if( intake <= 0_ml ) {
+        return false;
+    }
+    stomach.ingest( { intake, 0_ml, {} } );
+    add_msg_debug( debugmode::DF_NPC_NEEDS,
+                   "NPC %s: drank from terrain at %s", get_name(),
+                   water_pos.to_string_writable() );
+    return true;
+}
+
+bool npc::consume_food_at( item_location loc )
+{
+    if( !loc.get_item() ) {
+        return false;
+    }
+    const time_duration &t = get_consume_time( *loc );
+    if( consume( loc ) != trinary::NONE ) {
+        mod_moves( -to_moves<int>( t ) );
+        return true;
+    }
+    return false;
+}
+
+bool npc::wear_item_at( item_location loc )
+{
+    if( !loc.get_item() ) {
+        return false;
+    }
+    return wear( loc, false ).has_value();
+}
+
+bool npc::move_to_and_verify( const tripoint_bub_ms &target )
+{
+    const std::optional<tripoint_bub_ms> dest = nearest_passable( target, pos_bub() );
+    if( !dest ) {
+        return false;
+    }
+    update_path( *dest );
+    if( path.empty() && rl_dist( pos_bub(), *dest ) > 1 ) {
+        return false;
+    }
+    const tripoint_bub_ms before = pos_bub();
+    move_to_next();
+    return pos_bub() != before;
 }
 
 bool npc::adjust_worn()

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -1,3 +1,4 @@
+#include <cstddef>
 #include <functional>
 #include <map>
 #include <memory>
@@ -34,9 +35,12 @@
 #include "item.h"
 #include "item_group.h"
 #include "item_location.h"
+#include "itype.h"
 #include "map.h"
 #include "map_helpers.h"
+#include "map_iterator.h"
 #include "map_scale_constants.h"
+#include "map_selector.h"
 #include "memory_fast.h"
 #include "messages.h"
 #include "monster.h"
@@ -56,6 +60,7 @@
 #include "translation.h"
 #include "type_id.h"
 #include "units.h"
+#include "value_ptr.h"
 #include "veh_type.h"
 #include "vehicle.h"
 #include "viewer.h"
@@ -78,6 +83,7 @@ static const item_group_id Item_spawn_data_test_NPC_guns( "test_NPC_guns" );
 
 static const itype_id itype_2x4( "2x4" );
 static const itype_id itype_M24( "M24" );
+static const itype_id itype_apron_leather( "apron_leather" );
 static const itype_id itype_backpack( "backpack" );
 static const itype_id itype_bat( "bat" );
 static const itype_id itype_debug_backpack( "debug_backpack" );
@@ -94,7 +100,12 @@ static const itype_id itype_sandwich_cheese_grilled( "sandwich_cheese_grilled" )
 static const itype_id itype_space_cake( "space_cake" );
 static const itype_id itype_sweater( "sweater" );
 
+static const ter_str_id ter_t_concrete_wall( "t_concrete_wall" );
 static const ter_str_id ter_t_floor( "t_floor" );
+static const ter_str_id ter_t_swater_sh( "t_swater_sh" );
+static const ter_str_id ter_t_wall_glass( "t_wall_glass" );
+static const ter_str_id ter_t_water_dispenser( "t_water_dispenser" );
+static const ter_str_id ter_t_water_sh( "t_water_sh" );
 
 static const trait_id trait_SAPROPHAGE( "SAPROPHAGE" );
 static const trait_id trait_SAPROVORE( "SAPROVORE" );
@@ -107,6 +118,7 @@ static const vproto_id vehicle_prototype_none( "none" );
 
 static const zone_type_id zone_type_CAMP_FOOD( "CAMP_FOOD" );
 static const zone_type_id zone_type_CAMP_STORAGE( "CAMP_STORAGE" );
+static const zone_type_id zone_type_NO_NPC_PICKUP( "NO_NPC_PICKUP" );
 
 static void on_load_test( npc &who, const time_duration &from, const time_duration &to )
 {
@@ -1303,5 +1315,632 @@ TEST_CASE( "npc_nonally_sleeps_when_tired", "[npc][needs]" )
 
         CHECK_FALSE( guy.has_effect( effect_sleep ) );
         CHECK_FALSE( guy.has_effect( effect_lying_down ) );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helper-level tests for local resource acquisition
+// ---------------------------------------------------------------------------
+
+TEST_CASE( "npc_find_nearby_water_sources", "[npc][needs]" )
+{
+    clear_map_without_vision();
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy, true );
+    set_time_to_day();
+    map &here = get_map();
+    const tripoint_bub_ms adj = guy.pos_bub() + point::east;
+
+    SECTION( "finds adjacent fresh shallow water" ) {
+        here.ter_set( adj, ter_t_water_sh );
+        std::vector<npc::scored_water_source> sources = guy.find_nearby_water_sources();
+        REQUIRE( !sources.empty() );
+        CHECK( sources[0].pos == adj );
+    }
+
+    SECTION( "ignores salt water" ) {
+        here.ter_set( adj, ter_t_swater_sh );
+        CHECK( guy.find_nearby_water_sources().empty() );
+    }
+
+    SECTION( "finds water within 6 tiles, returns exact position" ) {
+        tripoint_bub_ms water_at = guy.pos_bub() + tripoint( 5, 0, 0 );
+        here.ter_set( water_at, ter_t_water_sh );
+        std::vector<npc::scored_water_source> sources = guy.find_nearby_water_sources();
+        REQUIRE( !sources.empty() );
+        CHECK( sources[0].pos == water_at );
+    }
+
+    SECTION( "ignores water beyond 6 tiles" ) {
+        here.ter_set( guy.pos_bub() + tripoint( 7, 0, 0 ), ter_t_water_sh );
+        CHECK( guy.find_nearby_water_sources().empty() );
+    }
+
+    SECTION( "sorted by distance, closest first" ) {
+        tripoint_bub_ms near = guy.pos_bub() + tripoint::east;
+        tripoint_bub_ms far = guy.pos_bub() + tripoint( 4, 0, 0 );
+        here.ter_set( far, ter_t_water_sh );
+        here.ter_set( near, ter_t_water_sh );
+        std::vector<npc::scored_water_source> sources = guy.find_nearby_water_sources();
+        REQUIRE( sources.size() >= 2 );
+        CHECK( sources[0].pos == near );
+        CHECK( sources[0].dist <= sources[1].dist );
+    }
+
+    SECTION( "ignores finite water sources" ) {
+        here.ter_set( adj, ter_t_water_dispenser );
+        CHECK( guy.find_nearby_water_sources().empty() );
+    }
+
+    SECTION( "ignores water behind walls (no LOS)" ) {
+        // Place water behind a wall -- NPC can't see it
+        tripoint_bub_ms wall_pos = guy.pos_bub() + tripoint::east;
+        tripoint_bub_ms water_behind = guy.pos_bub() + tripoint( 2, 0, 0 );
+        here.ter_set( wall_pos, ter_t_concrete_wall );
+        here.ter_set( water_behind, ter_t_water_sh );
+        here.build_map_cache( 0 );
+        REQUIRE_FALSE( guy.sees( here, water_behind ) );
+        CHECK( guy.find_nearby_water_sources().empty() );
+    }
+}
+
+TEST_CASE( "npc_drink_from_water_source", "[npc][needs]" )
+{
+    clear_map_without_vision();
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy, true );
+    guy.stomach.empty();
+    set_time_to_day();
+    map &here = get_map();
+    const tripoint_bub_ms adj = guy.pos_bub() + point::east;
+    here.ter_set( adj, ter_t_water_sh );
+    std::vector<npc::scored_water_source> sources = guy.find_nearby_water_sources();
+    REQUIRE( !sources.empty() );
+    const tripoint_bub_ms water_pos = sources[0].pos;
+
+    SECTION( "drinking fills stomach, lowers thirst, no movement" ) {
+        guy.set_thirst( 200 );
+        const int thirst_before = guy.get_thirst();
+        const tripoint_bub_ms pos_before = guy.pos_bub();
+        const units::volume water_before = guy.stomach.get_water();
+        REQUIRE( guy.drink_from_water_source( water_pos ) );
+        CHECK( guy.stomach.get_water() > water_before );
+        CHECK( guy.get_thirst() < thirst_before );
+        CHECK( guy.pos_bub() == pos_before );
+    }
+
+    SECTION( "full stomach returns false, no water added" ) {
+        const units::volume room = guy.stomach.stomach_remaining( guy );
+        guy.stomach.ingest( { room, 0_ml, {} } );
+        const units::volume water_before = guy.stomach.get_water();
+        guy.set_thirst( 600 );
+        CHECK_FALSE( guy.drink_from_water_source( water_pos ) );
+        CHECK( guy.stomach.get_water() == water_before );
+    }
+
+    SECTION( "zero thirst returns false" ) {
+        guy.set_thirst( 0 );
+        CHECK_FALSE( guy.drink_from_water_source( water_pos ) );
+    }
+}
+
+TEST_CASE( "npc_find_nearby_food", "[npc][needs]" )
+{
+    clear_map_without_vision();
+    clear_avatar();
+    get_player_character().camps.clear();
+    get_weather().forced_temperature = 20_C;
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy, true );
+    guy.set_hunger( 300 );
+    guy.set_thirst( 100 );
+    guy.set_stored_kcal( 5000 );
+    set_time_to_day();
+    map &here = get_map();
+    const tripoint_bub_ms adj = guy.pos_bub() + point::east;
+    REQUIRE_FALSE( guy.is_player_ally() );
+
+    SECTION( "finds food on adjacent tile, returns correct item" ) {
+        here.add_item_or_charges( adj, item( itype_sandwich_cheese_grilled ) );
+        std::vector<npc::scored_item> food = guy.find_nearby_food();
+        REQUIRE( !food.empty() );
+        CHECK( food[0].score > 0.0f );
+        CHECK( food[0].loc.get_item()->typeId() == itype_sandwich_cheese_grilled );
+        CHECK( food[0].loc.pos_bub( here ) == adj );
+    }
+
+    SECTION( "results sorted by descending score" ) {
+        // Two different foods; verify the list is sorted descending by score.
+        here.add_item_or_charges( adj, item( itype_honeycomb ) );
+        tripoint_bub_ms adj2 = guy.pos_bub() + point::west;
+        here.add_item_or_charges( adj2, item( itype_sandwich_cheese_grilled ) );
+        std::vector<npc::scored_item> food = guy.find_nearby_food();
+        REQUIRE( food.size() >= 2 );
+        CHECK( food[0].score >= food[1].score );
+    }
+
+    SECTION( "does not find food beyond 6 tiles" ) {
+        tripoint_bub_ms far = guy.pos_bub() + tripoint( 7, 0, 0 );
+        here.add_item_or_charges( far, item( itype_sandwich_cheese_grilled ) );
+        CHECK( guy.find_nearby_food().empty() );
+    }
+
+    SECTION( "ally without allow_pick_up returns empty" ) {
+        guy.set_fac( faction_your_followers );
+        guy.set_attitude( NPCATT_FOLLOW );
+        REQUIRE( guy.is_player_ally() );
+        guy.rules.clear_flag( ally_rule::allow_pick_up );
+        here.add_item_or_charges( adj, item( itype_sandwich_cheese_grilled ) );
+        CHECK( guy.find_nearby_food().empty() );
+    }
+
+    SECTION( "ally skips food in NO_NPC_PICKUP zone" ) {
+        guy.set_fac( faction_your_followers );
+        guy.set_attitude( NPCATT_FOLLOW );
+        REQUIRE( guy.is_player_ally() );
+        const tripoint_abs_ms abs_adj = here.get_abs( adj );
+        mapgen_place_zone( abs_adj, abs_adj, zone_type_NO_NPC_PICKUP,
+                           faction_your_followers, {}, "no_pickup" );
+        here.add_item_or_charges( adj, item( itype_sandwich_cheese_grilled ) );
+        CHECK( guy.find_nearby_food().empty() );
+    }
+
+    SECTION( "thirst-dominant filter skips dry food" ) {
+        guy.set_thirst( 400 );
+        guy.set_hunger( 50 );
+        item dry_food( itype_meat_cooked );
+        REQUIRE( dry_food.get_comestible() );
+        REQUIRE( dry_food.get_comestible()->quench <= 0 );
+        here.add_item_or_charges( adj, dry_food );
+        CHECK( guy.find_nearby_food().empty() );
+    }
+}
+
+TEST_CASE( "npc_find_nearby_warm_clothing", "[npc][needs]" )
+{
+    clear_map_without_vision();
+    set_time_to_day();
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy, true );
+    guy.worn.wear_item( guy, item( itype_backpack ), false, false );
+    map &here = get_map();
+    here.build_map_cache( 0 );
+    const tripoint_bub_ms adj = guy.pos_bub() + point::east;
+    REQUIRE_FALSE( guy.is_player_ally() );
+
+    SECTION( "finds sweater on adjacent tile, correct item and warmth score" ) {
+        here.add_item_or_charges( adj, item( itype_sweater ) );
+        std::vector<npc::scored_item> warm = guy.find_nearby_warm_clothing();
+        REQUIRE( !warm.empty() );
+        CHECK( warm[0].loc.get_item()->typeId() == itype_sweater );
+        CHECK( warm[0].loc.pos_bub( here ) == adj );
+        CHECK( warm[0].score == static_cast<float>( item( itype_sweater ).get_warmth() ) );
+    }
+
+    SECTION( "results sorted by descending warmth" ) {
+        here.add_item_or_charges( adj, item( itype_apron_leather ) );
+        tripoint_bub_ms adj2 = guy.pos_bub() + point::west;
+        here.add_item_or_charges( adj2, item( itype_sweater ) );
+        std::vector<npc::scored_item> warm = guy.find_nearby_warm_clothing();
+        REQUIRE( warm.size() >= 2 );
+        CHECK( warm[0].score >= warm[1].score );
+        CHECK( warm[0].loc.get_item()->typeId() == itype_sweater );
+    }
+
+    SECTION( "ally without allow_pick_up returns empty" ) {
+        guy.set_fac( faction_your_followers );
+        guy.set_attitude( NPCATT_FOLLOW );
+        REQUIRE( guy.is_player_ally() );
+        guy.rules.clear_flag( ally_rule::allow_pick_up );
+        here.add_item_or_charges( adj, item( itype_sweater ) );
+        CHECK( guy.find_nearby_warm_clothing().empty() );
+    }
+}
+
+TEST_CASE( "npc_move_to_and_verify", "[npc][needs]" )
+{
+    clear_map_without_vision();
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy, true );
+    map &here = get_map();
+
+    SECTION( "moves toward passable target, distance decreases" ) {
+        tripoint_bub_ms target = guy.pos_bub() + tripoint( 3, 0, 0 );
+        REQUIRE( here.passable( target ) );
+        const int dist_before = rl_dist( guy.pos_bub(), target );
+        REQUIRE( guy.move_to_and_verify( target ) );
+        CHECK( rl_dist( guy.pos_bub(), target ) < dist_before );
+    }
+
+    SECTION( "impassable target: nearest_passable finds adjacent passable tile" ) {
+        tripoint_bub_ms target = guy.pos_bub() + tripoint( 3, 0, 0 );
+        here.ter_set( target, ter_t_wall_glass );
+        REQUIRE( here.impassable( target ) );
+        REQUIRE( here.passable( target + tripoint::west ) );
+        REQUIRE( guy.move_to_and_verify( target ) );
+        CHECK( guy.pos_bub() != target );
+        CHECK( here.passable( guy.pos_bub() ) );
+        CHECK( rl_dist( guy.pos_bub(), target ) < 3 );
+    }
+
+    SECTION( "unreachable target returns false, NPC stays" ) {
+        tripoint_bub_ms target = guy.pos_bub() + tripoint( 3, 0, 0 );
+        for( const tripoint_bub_ms &wall : here.points_in_radius( target, 1 ) ) {
+            if( wall != target ) {
+                here.ter_set( wall, ter_t_wall_glass );
+            }
+        }
+        REQUIRE( here.impassable( target + tripoint::west ) );
+        const tripoint_bub_ms before = guy.pos_bub();
+        CHECK_FALSE( guy.move_to_and_verify( target ) );
+        CHECK( guy.pos_bub() == before );
+    }
+}
+
+TEST_CASE( "npc_ownership_blocks_ground_food", "[npc][needs]" )
+{
+    clear_map_without_vision();
+    clear_avatar();
+    get_weather().forced_temperature = 20_C;
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy, true );
+    guy.set_hunger( 300 );
+    guy.set_thirst( 100 );
+    guy.set_stored_kcal( 5000 );
+    set_time_to_day();
+    map &here = get_map();
+    const tripoint_bub_ms adj = guy.pos_bub() + point::east;
+    REQUIRE_FALSE( guy.is_player_ally() );
+    // Place player close enough to see NPC and adj tile
+    get_player_character().setpos( here, guy.pos_bub() + tripoint( 0, -2, 0 ) );
+    REQUIRE( get_player_view().sees( here, guy.pos_bub( here ) ) );
+    REQUIRE( get_player_view().sees( here, adj ) );
+
+    SECTION( "high-trust NPC skips player-owned food (caught stealing)" ) {
+        // stealing_threshold = 10 + 100/5 - 5 - 0 = 25 > 0
+        // would_always_steal = false; player sees NPC -> won't steal
+        guy.get_faction()->trusts_u = 100;
+        guy.personality.aggression = 5;
+        guy.personality.collector = 0;
+        item owned_food( itype_sandwich_cheese_grilled );
+        owned_food.set_owner( get_player_character() );
+        here.add_item_or_charges( adj, owned_food );
+        CHECK( guy.find_nearby_food().empty() );
+    }
+
+    SECTION( "aggressive NPC takes player-owned food (always steals)" ) {
+        // stealing_threshold = 10 + 0/5 - 20 - 0 = -10 < 0
+        // would_always_steal = true, ignores visibility
+        guy.get_faction()->trusts_u = 0;
+        guy.personality.aggression = 20;
+        guy.personality.collector = 0;
+        item owned_food( itype_sandwich_cheese_grilled );
+        owned_food.set_owner( get_player_character() );
+        here.add_item_or_charges( adj, owned_food );
+        std::vector<npc::scored_item> food = guy.find_nearby_food();
+        CHECK_FALSE( food.empty() );
+    }
+}
+
+TEST_CASE( "npc_consume_food_at_helper", "[npc][needs]" )
+{
+    clear_map_without_vision();
+    get_weather().forced_temperature = 20_C;
+    set_time_to_day();
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy, true );
+    guy.set_hunger( 300 );
+    guy.set_stored_kcal( 5000 );
+    map &here = get_map();
+    const tripoint_bub_ms adj = guy.pos_bub() + point::east;
+
+    SECTION( "consumes ground food, item removed from map" ) {
+        item &spawned = here.add_item_or_charges( adj, item( itype_sandwich_cheese_grilled ) );
+        const size_t count_before = here.i_at( adj ).size();
+        item_location loc( map_cursor( adj ), &spawned );
+        REQUIRE( guy.consume_food_at( loc ) );
+        CHECK( here.i_at( adj ).size() < count_before );
+    }
+
+    SECTION( "null item_location returns false" ) {
+        item_location empty;
+        CHECK_FALSE( guy.consume_food_at( empty ) );
+    }
+}
+
+TEST_CASE( "npc_wear_item_at_helper", "[npc][needs]" )
+{
+    clear_map_without_vision();
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy, true );
+    guy.worn.wear_item( guy, item( itype_backpack ), false, false );
+    map &here = get_map();
+    const tripoint_bub_ms adj = guy.pos_bub() + point::east;
+
+    SECTION( "wears ground sweater, item removed from map" ) {
+        item &spawned = here.add_item_or_charges( adj, item( itype_sweater ) );
+        const size_t count_before = here.i_at( adj ).size();
+        item_location loc( map_cursor( adj ), &spawned );
+        REQUIRE( guy.wear_item_at( loc ) );
+        CHECK( guy.is_wearing( itype_sweater ) );
+        CHECK( here.i_at( adj ).size() < count_before );
+    }
+
+    SECTION( "null item_location returns false" ) {
+        item_location empty;
+        CHECK_FALSE( guy.wear_item_at( empty ) );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Integration tests: address_needs with ground resources
+// ---------------------------------------------------------------------------
+
+TEST_CASE( "npc_address_needs_ground_water", "[npc][needs]" )
+{
+    clear_map_without_vision();
+    clear_avatar();
+    get_player_character().camps.clear();
+    set_time_to_day();
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy, true );
+    guy.set_hunger( 0 );
+    guy.set_thirst( 0 );
+    guy.set_stored_kcal( guy.get_healthy_kcal() );
+    guy.set_all_parts_temp_conv( BODYTEMP_NORM );
+    guy.set_all_parts_temp_cur( BODYTEMP_NORM );
+    guy.stomach.empty();
+    guy.guts.empty();
+    REQUIRE_FALSE( guy.is_player_ally() );
+    map &here = get_map();
+    const tripoint_bub_ms adj = guy.pos_bub() + point::east;
+
+    SECTION( "extreme thirst: adjacent water consumed before danger gate" ) {
+        guy.set_thirst( 200 );
+        REQUIRE( guy.get_thirst() > 80 );
+        here.ter_set( adj, ter_t_water_sh );
+        const tripoint_bub_ms before = guy.pos_bub();
+
+        guy.address_needs( NPC_DANGER_VERY_LOW + 1 );
+
+        CHECK( guy.stomach.get_water() > 0_ml );
+        CHECK( guy.pos_bub() == before );
+    }
+
+    SECTION( "non-adjacent water: blocked by danger gate" ) {
+        guy.set_thirst( 200 );
+        tripoint_bub_ms water_at = guy.pos_bub() + tripoint( 3, 0, 0 );
+        here.ter_set( water_at, ter_t_water_sh );
+        REQUIRE( square_dist( guy.pos_bub(), water_at ) > 1 );
+        const tripoint_bub_ms before = guy.pos_bub();
+
+        guy.address_needs( NPC_DANGER_VERY_LOW + 1 );
+
+        CHECK( guy.stomach.get_water() == 0_ml );
+        CHECK( guy.pos_bub() == before );
+    }
+
+    SECTION( "non-adjacent water: NPC paths toward it (extreme thirst, low danger)" ) {
+        guy.set_thirst( 200 );
+        REQUIRE( guy.get_thirst() > 80 );
+        tripoint_bub_ms water_at = guy.pos_bub() + tripoint( 3, 0, 0 );
+        here.ter_set( water_at, ter_t_water_sh );
+        const int dist_before = rl_dist( guy.pos_bub(), water_at );
+
+        guy.address_needs( 0 );
+
+        CHECK( rl_dist( guy.pos_bub(), water_at ) < dist_before );
+    }
+
+    SECTION( "blocked nearest water skipped, reachable farther water reached" ) {
+        guy.set_thirst( 200 );
+        REQUIRE( guy.get_thirst() > 80 );
+        // Nearest water behind glass walls (unreachable)
+        tripoint_bub_ms blocked_at = guy.pos_bub() + tripoint( 2, 0, 0 );
+        for( const tripoint_bub_ms &w : here.points_in_radius( blocked_at, 1 ) ) {
+            if( w != blocked_at ) {
+                here.ter_set( w, ter_t_wall_glass );
+            }
+        }
+        here.ter_set( blocked_at, ter_t_water_sh );
+        // Farther water on open ground (reachable)
+        tripoint_bub_ms open_at = guy.pos_bub() + tripoint( 0, 3, 0 );
+        here.ter_set( open_at, ter_t_water_sh );
+        REQUIRE( here.passable( open_at ) );
+        const int dist_to_open = rl_dist( guy.pos_bub(), open_at );
+
+        guy.address_needs( 0 );
+
+        CHECK( rl_dist( guy.pos_bub(), open_at ) < dist_to_open );
+    }
+}
+
+TEST_CASE( "npc_address_needs_ground_food", "[npc][needs]" )
+{
+    clear_map_without_vision();
+    clear_avatar();
+    get_player_character().camps.clear();
+    get_weather().forced_temperature = 20_C;
+    set_time_to_day();
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy, true );
+    guy.set_hunger( 0 );
+    guy.set_thirst( 0 );
+    guy.set_stored_kcal( guy.get_healthy_kcal() );
+    guy.set_all_parts_temp_conv( BODYTEMP_NORM );
+    guy.set_all_parts_temp_cur( BODYTEMP_NORM );
+    guy.stomach.empty();
+    guy.guts.empty();
+    REQUIRE_FALSE( guy.is_player_ally() );
+    map &here = get_map();
+    const tripoint_bub_ms adj = guy.pos_bub() + point::east;
+
+    SECTION( "extreme hunger: adjacent food consumed before danger gate" ) {
+        guy.set_stored_kcal( 2000 );
+        guy.set_hunger( 300 );
+        guy.set_thirst( 100 );
+        here.add_item_or_charges( adj, item( itype_sandwich_cheese_grilled ) );
+        const size_t items_before = here.i_at( adj ).size();
+        const tripoint_bub_ms before = guy.pos_bub();
+
+        guy.address_needs( NPC_DANGER_VERY_LOW + 1 );
+
+        CHECK( here.i_at( adj ).size() < items_before );
+        CHECK( guy.pos_bub() == before );
+    }
+
+    SECTION( "non-adjacent food: blocked by danger gate" ) {
+        guy.set_stored_kcal( 2000 );
+        guy.set_hunger( 300 );
+        guy.set_thirst( 100 );
+        tripoint_bub_ms food_at = guy.pos_bub() + tripoint( 3, 0, 0 );
+        here.add_item_or_charges( food_at, item( itype_sandwich_cheese_grilled ) );
+        const tripoint_bub_ms before = guy.pos_bub();
+
+        guy.address_needs( NPC_DANGER_VERY_LOW + 1 );
+
+        CHECK( guy.pos_bub() == before );
+    }
+
+    SECTION( "non-adjacent food: NPC paths at low danger (extreme hunger)" ) {
+        guy.set_stored_kcal( 2000 );
+        guy.set_hunger( 300 );
+        guy.set_thirst( 100 );
+        REQUIRE( guy.get_stored_kcal() + guy.stomach.get_calories() <
+                 guy.get_healthy_kcal() * 0.75 );
+        tripoint_bub_ms food_at = guy.pos_bub() + tripoint( 3, 0, 0 );
+        here.add_item_or_charges( food_at, item( itype_sandwich_cheese_grilled ) );
+        const int dist_before = rl_dist( guy.pos_bub(), food_at );
+
+        guy.address_needs( 0 );
+
+        CHECK( rl_dist( guy.pos_bub(), food_at ) < dist_before );
+    }
+
+    SECTION( "unreachable food: NPC does not stall" ) {
+        guy.set_stored_kcal( 2000 );
+        guy.set_hunger( 300 );
+        guy.set_thirst( 100 );
+        tripoint_bub_ms food_at = guy.pos_bub() + tripoint( 3, 0, 0 );
+        for( const tripoint_bub_ms &w : here.points_in_radius( food_at, 1 ) ) {
+            if( w != food_at ) {
+                here.ter_set( w, ter_t_wall_glass );
+            }
+        }
+        here.add_item_or_charges( food_at, item( itype_sandwich_cheese_grilled ) );
+        REQUIRE( here.sees_some_items( food_at, guy ) );
+        REQUIRE( guy.sees( here, food_at ) );
+        const tripoint_bub_ms before = guy.pos_bub();
+
+        guy.address_needs( 0 );
+
+        CHECK( guy.pos_bub() == before );
+    }
+
+    SECTION( "blocked best candidate skipped, reachable second candidate reached" ) {
+        guy.set_stored_kcal( 2000 );
+        guy.set_hunger( 300 );
+        guy.set_thirst( 100 );
+        // High-value food behind glass (unreachable)
+        tripoint_bub_ms blocked_at = guy.pos_bub() + tripoint( 3, 0, 0 );
+        for( const tripoint_bub_ms &w : here.points_in_radius( blocked_at, 1 ) ) {
+            if( w != blocked_at ) {
+                here.ter_set( w, ter_t_wall_glass );
+            }
+        }
+        here.add_item_or_charges( blocked_at, item( itype_sandwich_cheese_grilled ) );
+        REQUIRE( here.sees_some_items( blocked_at, guy ) );
+        REQUIRE( guy.sees( here, blocked_at ) );
+        // Low-value food on open ground (reachable)
+        tripoint_bub_ms open_at = guy.pos_bub() + tripoint( 0, 3, 0 );
+        REQUIRE( here.passable( open_at ) );
+        here.add_item_or_charges( open_at, item( itype_honeycomb ) );
+        const int dist_to_open = rl_dist( guy.pos_bub(), open_at );
+
+        guy.address_needs( 0 );
+
+        CHECK( rl_dist( guy.pos_bub(), open_at ) < dist_to_open );
+    }
+}
+
+TEST_CASE( "npc_address_needs_ground_clothing", "[npc][needs]" )
+{
+    clear_map_without_vision();
+    clear_avatar();
+    get_player_character().camps.clear();
+    set_time_to_day();
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy, true );
+    guy.set_hunger( 0 );
+    guy.set_thirst( 0 );
+    guy.set_stored_kcal( guy.get_healthy_kcal() );
+    guy.set_all_parts_temp_conv( BODYTEMP_NORM );
+    guy.set_all_parts_temp_cur( BODYTEMP_NORM );
+    guy.stomach.empty();
+    guy.guts.empty();
+    REQUIRE_FALSE( guy.is_player_ally() );
+    map &here = get_map();
+    const tripoint_bub_ms adj = guy.pos_bub() + point::east;
+
+    SECTION( "freezing NPC wears adjacent sweater from ground" ) {
+        guy.set_all_parts_temp_conv( BODYTEMP_VERY_COLD );
+        guy.worn.wear_item( guy, item( itype_backpack ), false, false );
+        here.add_item_or_charges( adj, item( itype_sweater ) );
+        const tripoint_bub_ms before = guy.pos_bub();
+
+        guy.address_needs( 0 );
+
+        CHECK( guy.is_wearing( itype_sweater ) );
+        CHECK( guy.pos_bub() == before );
+    }
+
+    SECTION( "adjacent sweater worn even during combat, no movement" ) {
+        guy.set_all_parts_temp_conv( BODYTEMP_VERY_COLD );
+        guy.worn.wear_item( guy, item( itype_backpack ), false, false );
+        here.add_item_or_charges( adj, item( itype_sweater ) );
+        const tripoint_bub_ms before = guy.pos_bub();
+
+        guy.address_needs( NPC_DANGER_VERY_LOW + 1 );
+
+        CHECK( guy.is_wearing( itype_sweater ) );
+        CHECK( guy.pos_bub() == before );
+    }
+
+    SECTION( "non-adjacent sweater: blocked by danger gate" ) {
+        guy.set_all_parts_temp_conv( BODYTEMP_VERY_COLD );
+        tripoint_bub_ms sweater_at = guy.pos_bub() + tripoint( 3, 0, 0 );
+        here.add_item_or_charges( sweater_at, item( itype_sweater ) );
+        const tripoint_bub_ms before = guy.pos_bub();
+
+        guy.address_needs( NPC_DANGER_VERY_LOW + 1 );
+
+        CHECK_FALSE( guy.is_wearing( itype_sweater ) );
+        CHECK( guy.pos_bub() == before );
+    }
+
+    SECTION( "non-adjacent sweater: NPC paths at low danger, distance decreases" ) {
+        guy.set_all_parts_temp_conv( BODYTEMP_VERY_COLD );
+        tripoint_bub_ms sweater_at = guy.pos_bub() + tripoint( 3, 0, 0 );
+        here.add_item_or_charges( sweater_at, item( itype_sweater ) );
+        const int dist_before = rl_dist( guy.pos_bub(), sweater_at );
+        REQUIRE( dist_before > 1 );
+
+        guy.address_needs( 0 );
+
+        CHECK( rl_dist( guy.pos_bub(), sweater_at ) < dist_before );
+        CHECK_FALSE( guy.is_wearing( itype_sweater ) );
+    }
+
+    SECTION( "prefers inventory over ground" ) {
+        guy.set_all_parts_temp_conv( BODYTEMP_VERY_COLD );
+        guy.worn.wear_item( guy, item( itype_backpack ), false, false );
+        guy.i_add( item( itype_sweater ) );
+        here.add_item_or_charges( adj, item( itype_sweater ) );
+        const size_t ground_before = here.i_at( adj ).size();
+
+        guy.address_needs( 0 );
+
+        CHECK( guy.is_wearing( itype_sweater ) );
+        CHECK( here.i_at( adj ).size() == ground_before );
     }
 }

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -51,6 +51,7 @@
 #include "point.h"
 #include "rng.h"
 #include "type_id.h"
+#include "units.h"
 #include "weather.h"
 #include "weather_type.h"
 #include "worldfactory.h"
@@ -285,6 +286,7 @@ struct CataListener : Catch::TestEventListenerBase {
         weather_manager &weather = get_weather();
         weather.weather_override = WEATHER_NULL; // NOLINT(cata-tests-must-restore-global-state)
         weather.windspeed_override.reset();
+        weather.forced_temperature.reset(); // NOLINT(cata-tests-must-restore-global-state)
         weather.set_nextweather( calendar::turn );
         weather.clear_temp_cache();
     }


### PR DESCRIPTION
#### Summary
Features "NPCs drink from water, eat food, and wear clothes found on the ground"

#### Purpose of change

NPCs could only consume what was in their inventory or at a camp larder. With an empty inventory and no camp, they just stood there and died. This is the first layer of environmental interaction -- the "feral animal" milestone from #28681.

Depends on #86016.

#### Describe the solution

Seven reusable find/act helpers on `npc`, designed so both the current legacy `address_needs()` and future BT dispatch can call them:

**Find helpers** return scored candidate lists. Callers iterate best-first and skip unpathable targets:
- `find_nearby_water_sources()` -- scans visible terrain within 6 tiles for infinite fresh water. Allowlist: `water`, `water_clean`. Sorted by distance. Respects LOS. Skips salt, murky, sewage, and finite sources (wells need charge tracking -- follow-up).
- `find_nearby_food()` -- scans visible ground items within 6 tiles, scored by `rate_food()`, filtered by `will_eat()`. Thirst-dominant filter skips dry food when thirst >> hunger.
- `find_nearby_warm_clothing()` -- same structure, scored by warmth, filtered by `can_wear()`.

All ground-item helpers mirror `find_item()` governance: ally `allow_pick_up` rule, `NO_NPC_PICKUP` zones, ownership via `would_take_that()`, visibility via `sees_some_items()` + `sees()`.

**Act helpers:**
- `drink_from_water_source()` -- routes through `stomach.ingest()`, same pattern as camp water. No parasite effects yet.
- `consume_food_at()` / `wear_item_at()` -- thin wrappers that verify the item still exists, then consume/wear via `item_location`.
- `move_to_and_verify()` -- uses `nearest_passable()` for impassable targets, checks path non-empty, verifies the NPC actually moved.

**Danger-gate split** in `address_needs()`:
- Before gate (adjacent only, instant): wear ground clothing, eat adjacent food, drink adjacent water. No movement during combat.
- After gate (pathing allowed): path to distant clothing, food, water.
- Extreme needs path deterministically after the danger gate. Normal needs stay under the existing `one_in(3)` gate alongside camp/inventory so ground resources never outrank carried food.

Warmth gate switched from full BT subtree tick to direct `needs_warmth_badly()` predicate -- the subtree only knows about inventory items and indoor tiles, not ground items.

#### Describe alternatives you've considered

Could have wired ground acquisition outside the `one_in(3)` gate for normal needs, but that lets NPCs prefer ground food over camp/inventory on turns where the gate doesn't fire. Keeping them together preserves the deterministic preference order.

Could have used the full BT subtree as the warmth gate (like #86004), but the subtree's `can_wear_warmer_clothes` predicate only checks inventory -- ground clothing would never trigger it.

#### Testing

11 new test cases, ~30 sections, 200+ assertions. Structured as helper-level tests first, integration tests second.

Helper tests: water source finding (fresh/salt/distance/ordering/finite/LOS), drinking (fills stomach, thirst drops, full stomach blocks), food finding (correct item, ordering, range, ally rules, NO_NPC_PICKUP zones, thirst-dominant filter), clothing finding (correct item, warmth ordering, ally rules), movement (passable target, impassable target via nearest_passable, unreachable target), ownership (high-trust NPC skips, aggressive NPC steals), consume/wear wrappers (item removed from map, null safety).

Integration tests: extreme thirst adjacent water before danger gate, non-adjacent water blocked by danger, non-adjacent water pathed at low danger, blocked-nearest-water fallback to reachable, extreme hunger adjacent food, non-adjacent food blocked/pathed, unreachable food skipped, blocked-best food fallback to reachable, freezing NPC wears adjacent ground sweater (including during combat), non-adjacent sweater blocked/pathed, inventory preferred over ground.

All 30 existing `[npc]` tests pass.

#### Additional context

Known limitations for follow-up:
- No parasite/contamination effects from dirty water (stomach.ingest bypasses item consumption path)
- Finite water sources (wells) excluded -- need charge tracking through the real consume path
- Water source allowlist is conservative (water, water_clean only)
- Food scoring inherits all rate_food() quirks (quench surplus penalty on fresh items with low thirst)

Related to #28681.