### PR TITLE
[MoM] Add Selective Autosomnia Vitakinetic power

### DIFF
--- a/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
+++ b/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
@@ -1781,6 +1781,17 @@ Powers causing telepathic damage have a 5% chance to down the target, a 33% chan
 *Prerequisites*: Revitalizing Meditation 6, Allay Infection 8 *or* Detoxification 8<br />
 </details>
 <details>
+<summary><h3>Selective Autosomnia (C)</h3></summary>
+
+*Difficulty*: 7<br />
+*Target*: Self<br />
+*Duration*: 32 minutes and 30 seconds to 1 hour and 19 minutes and 40 seconds, plus 5 minutes and 40 seconds to 13 minutes and 10 seconds per power level<br />
+*Stamina Cost*: 9500, minus 205 per level to a minimum of 5550<br />
+*Channeling Time*: 150 moves, minus 5 moves per level to a minimum of 50<br />
+*Effects*: Selectively put parts of the psion's brain to sleep in sequence, allowing rest to occur while remaining conscious. However, concentration suffers somewhat, providing a penalty to learning focus (-15) and social skills (50% of normal).<br />
+*Prerequisites*: Wakeful Rest 10, Revitalizing Meditation 6<br />
+</details>
+<details>
 <summary><h3>Banish Illness</h3></summary>
 
 *Difficulty*: 8<br />

--- a/data/mods/MindOverMatter/effectoncondition/eoc_learn_recipes.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_learn_recipes.json
@@ -1098,6 +1098,7 @@
           "EOC_CHECK_GAMEBEGIN_VITAKIN_RECIPE_HEALING_TRANCE",
           "EOC_CHECK_GAMEBEGIN_VITAKIN_RECIPE_ATTACK_TOUCH",
           "EOC_CHECK_GAMEBEGIN_VITAKIN_RECIPE_BLOOD_PURGE",
+          "EOC_CHECK_GAMEBEGIN_VITAKIN_RECIPE_NO_NEED_FOR_SLEEP",
           "EOC_CHECK_GAMEBEGIN_VITAKIN_RECIPE_BANISH_ILLNESS",
           "EOC_CHECK_GAMEBEGIN_VITAKIN_RECIPE_SUPER_HEAL",
           "EOC_CHECK_GAMEBEGIN_VITAKIN_RECIPE_LIMB_RESTORE",
@@ -1183,6 +1184,12 @@
     "id": "EOC_CHECK_GAMEBEGIN_VITAKIN_RECIPE_BLOOD_PURGE",
     "condition": { "and": [ { "u_has_trait": "VITAKINETIC" }, { "math": [ "u_spell_level('vita_blood_purge') >= 0" ] } ] },
     "effect": [ { "u_learn_recipe": "practice_vita_blood_purge" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CHECK_GAMEBEGIN_VITAKIN_RECIPE_NO_NEED_FOR_SLEEP",
+    "condition": { "and": [ { "u_has_trait": "VITAKINETIC" }, { "math": [ "u_spell_level('vita_no_need_for_sleep') >= 0" ] } ] },
+    "effect": [ { "u_learn_recipe": "practice_vita_no_need_for_sleep" } ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/MindOverMatter/effectoncondition/eoc_power_effects.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_power_effects.json
@@ -352,6 +352,7 @@
           "EOC_VITAKIN_REMOVE_CONCENTRATED_HEALING",
           "EOC_VITAKIN_REMOVE_HEALTH_POWER",
           "EOC_VITAKIN_REMOVE_CURE_DISEASE",
+          "EOC_VITAKIN_REMOVE_NO_NEED_FOR_SLEEP",
           "EOC_VITAKIN_REMOVE_SUPER_HEAL",
           "EOC_VITAKIN_REMOVE_RETURN_FROM_DEATH"
         ]
@@ -448,6 +449,7 @@
           "EOC_VITAKIN_REMOVE_CONCENTRATED_HEALING",
           "EOC_VITAKIN_REMOVE_HEALTH_POWER",
           "EOC_VITAKIN_REMOVE_CURE_DISEASE",
+          "EOC_VITAKIN_REMOVE_NO_NEED_FOR_SLEEP",
           "EOC_VITAKIN_REMOVE_SUPER_HEAL",
           "EOC_VITAKIN_REMOVE_RETURN_FROM_DEATH",
           "EOC_MOM_NO_EFFECT"
@@ -518,6 +520,7 @@
           "Leukocyte Accumulation",
           "Healthy Glow",
           "Immunostimulus",
+          "Selective Autosomnia",
           "Anabolic Rejuvenation",
           "Accelerated Resuscitation",
           "cancel"
@@ -610,6 +613,7 @@
           "EOC_VITAKIN_REMOVE_CONCENTRATED_HEALING",
           "EOC_VITAKIN_REMOVE_HEALTH_POWER",
           "EOC_VITAKIN_REMOVE_CURE_DISEASE",
+          "EOC_VITAKIN_REMOVE_NO_NEED_FOR_SLEEP",
           "EOC_VITAKIN_REMOVE_SUPER_HEAL",
           "EOC_VITAKIN_REMOVE_RETURN_FROM_DEATH"
         ]

--- a/data/mods/MindOverMatter/effects/effects_psionic.json
+++ b/data/mods/MindOverMatter/effects/effects_psionic.json
@@ -3074,9 +3074,16 @@
     "type": "effect_type",
     "id": "effect_vitakin_no_need_for_sleep",
     "name": [ "Selective Autosomnia" ],
-    "desc": [ "You are healing extraordinarily quickly." ],
+    "desc": [ "Parts of your brain are sleeping while other parts remain awake." ],
     "apply_message": "",
-    "remove_message": "You yawn involuntarily."
+    "remove_message": "You yawn involuntarily.",
+    "base_mods": { "sleepiness_min": [ -1 ], "sleepiness_chance": [ 1 ], "sleepiness_tick": [ 60 ] },
+    "enchantments": [
+      {
+        "values": [ { "value": "SLEEPINESS", "multiply": -1 }, { "value": "LEARNING_FOCUS", "add": -15 } ],
+        "skills": [ { "value": "speech", "multiply": -0.5 } ]
+      }
+    ]
   },
   {
     "type": "effect_type",

--- a/data/mods/MindOverMatter/effects/effects_psionic.json
+++ b/data/mods/MindOverMatter/effects/effects_psionic.json
@@ -3072,6 +3072,14 @@
   },
   {
     "type": "effect_type",
+    "id": "effect_vitakin_no_need_for_sleep",
+    "name": [ "Selective Autosomnia" ],
+    "desc": [ "You are healing extraordinarily quickly." ],
+    "apply_message": "",
+    "remove_message": "You yawn involuntarily."
+  },
+  {
+    "type": "effect_type",
     "id": "effect_vita_super_heal",
     "name": [ "Anabolic Rejuvenation" ],
     "desc": [ "You are healing extraordinarily quickly." ],

--- a/data/mods/MindOverMatter/powers/learning_eocs/vitakinesis.json
+++ b/data/mods/MindOverMatter/powers/learning_eocs/vitakinesis.json
@@ -384,6 +384,45 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_VITAKIN_LEARNING_NO_NEED_FOR_SLEEP",
+    "recurrence": [
+      { "math": [ "jmath_vitakinesis_learning_eocs_modifiers(global_tier_three_power_learning_time_low)" ] },
+      { "math": [ "jmath_vitakinesis_learning_eocs_modifiers(global_tier_three_power_learning_time_high)" ] }
+    ],
+    "condition": {
+      "and": [
+        { "u_has_trait": "VITAKINETIC" },
+        { "math": [ "u_vitamin('vitamin_psi_learning_counter') == 1" ] },
+        {
+          "or": [
+            { "test_eoc": "EOC_CONDITION_ODDS_OF_RANDOM_TIER_THREE_POWER_INSIGHT" },
+            {
+              "and": [
+                { "math": [ "u_spell_level('vita_sleeping_trance') >= 10" ] },
+                { "math": [ "u_spell_level('vita_healing_trance') >= 6" ] }
+              ]
+            }
+          ]
+        },
+        { "test_eoc": "EOC_PSI_LEARNING_BANNED_EFFECTS" },
+        { "math": [ "u_spell_level('vita_no_need_for_sleep') <= 0" ] },
+        { "not": { "u_know_recipe": "practice_vita_no_need_for_sleep" } }
+      ]
+    },
+    "deactivate_condition": {
+      "or": [ { "not": { "u_has_trait": "VITAKINETIC" } }, { "math": [ "u_spell_level('vita_no_need_for_sleep') >= 1" ] } ]
+    },
+    "effect": [
+      { "math": [ "u_vitamin('vitamin_psi_learning_counter') = 0" ] },
+      { "u_learn_recipe": "practice_vita_no_need_for_sleep" },
+      {
+        "u_message": "Use of your powers has led to an insight.  You could put parts of your brain to sleep while leaving the rest of it awake, allowing you to remain conscious while sitting gaining the benefits of rest, if you can figure out the proper technique.",
+        "popup": true
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_VITAKIN_LEARNING_BANISH_ILLNESS",
     "recurrence": [
       { "math": [ "jmath_vitakinesis_learning_eocs_modifiers(global_tier_three_power_learning_time_low)" ] },

--- a/data/mods/MindOverMatter/powers/telepathy.json
+++ b/data/mods/MindOverMatter/powers/telepathy.json
@@ -3,7 +3,7 @@
     "id": "telepathic_concentration",
     "type": "SPELL",
     "name": "[Ψ]Concentration Trance (C)",
-    "description": "Focus your own mind into a trance state, increasing learning speed.\n\nThis power <color_yellow>is maintained by concentration</color> and <color_red>may fail</color> if <color_yellow>concentration is interrupted</color>.  It is <color_red>canceled by engaging in combat</color>.",
+    "description": "Focus your own mind into a trance state, increasing learning speed.\n\nThis power <color_yellow>is maintained by concentration</color> and <color_red>may fail</color> if <color_yellow>concentration is interrupted</color>.  It is <color_red>canceled by engaging in combat</color>.\n\nThis power <color_red>cannot be used</color> together with the Vitakinetic power Selective Autosomnia.",
     "message": "",
     "teachable": false,
     "valid_targets": [ "self" ],

--- a/data/mods/MindOverMatter/powers/telepathy_concentration_eoc.json
+++ b/data/mods/MindOverMatter/powers/telepathy_concentration_eoc.json
@@ -5,7 +5,7 @@
     "condition": { "not": { "u_has_effect": "effect_telepathic_learning_bonus" } },
     "effect": [
       { "u_message": "Your vision narrows to what is directly in front of you as you concentrate.", "type": "good" },
-      { "run_eocs": "EOC_POWER_MAINTENANCE_PLUS_ONE" },
+      { "run_eocs": [ "EOC_POWER_MAINTENANCE_PLUS_ONE", "EOC_VITAKIN_REMOVE_NO_NEED_FOR_SLEEP" ] },
       { "u_add_effect": "effect_telepathic_learning_bonus", "duration": "PERMANENT" },
       {
         "run_eocs": "EOC_TELEPATH_CONCENTRATION_DRAIN",

--- a/data/mods/MindOverMatter/powers/vitakinesis.json
+++ b/data/mods/MindOverMatter/powers/vitakinesis.json
@@ -594,12 +594,12 @@
     "effect_str": "EOC_VITAKIN_NO_NEED_FOR_SLEEP",
     "min_duration": {
       "math": [
-        "( ( u_spell_level('vita_no_need_for_sleep') * 21000) + 195000) * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling"
+        "( ( u_spell_level('vita_no_need_for_sleep') * 34000) + 195000) * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling"
       ]
     },
     "max_duration": {
       "math": [
-        "( ( u_spell_level('vita_no_need_for_sleep') * 59000) + 418000) * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling"
+        "( ( u_spell_level('vita_no_need_for_sleep') * 79000) + 418000) * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling"
       ]
     },
     "base_energy_cost": 9500,

--- a/data/mods/MindOverMatter/powers/vitakinesis.json
+++ b/data/mods/MindOverMatter/powers/vitakinesis.json
@@ -576,6 +576,40 @@
     "casting_time_increment": -8
   },
   {
+    "id": "vita_no_need_for_sleep",
+    "type": "SPELL",
+    "name": "[Ψ]Selective Autosomnia",
+    "description": "You can selectively allow portions of your brain to sleep, allowing you to receive all the benefits of sleep without the disadvantages of complete unconsciousness.  This does make it slightly harder for you to focus, however.\n\nThis power <color_yellow>is maintained by concentration</color> and <color_red>may fail</color> if <color_yellow>concentration is interrupted</color>.\n\nThis power <color_red>cannot be used</color> together with the Telepathic power Concentration Trance.",
+    "message": "",
+    "teachable": false,
+    "valid_targets": [ "self" ],
+    "spell_class": "VITAKINETIC",
+    "magic_type": "mom_psionics",
+    "skill": "metaphysics",
+    "flags": [ "PSIONIC", "SILENT", "NO_HANDS", "NO_LEGS", "RANDOM_DURATION", "NO_EXPLOSION_SFX" ],
+    "shape": "blast",
+    "difficulty": 7,
+    "max_level": { "math": [ "int_to_level(1)" ] },
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_VITAKIN_NO_NEED_FOR_SLEEP",
+    "min_duration": {
+      "math": [
+        "( ( u_spell_level('vita_no_need_for_sleep') * 21000) + 195000) * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling"
+      ]
+    },
+    "max_duration": {
+      "math": [
+        "( ( u_spell_level('vita_no_need_for_sleep') * 59000) + 418000) * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling"
+      ]
+    },
+    "base_energy_cost": 9500,
+    "final_energy_cost": 5550,
+    "energy_increment": -205,
+    "base_casting_time": 150,
+    "final_casting_time": 50,
+    "casting_time_increment": -5
+  },
+  {
     "id": "vita_blood_purge_no_mutagens",
     "type": "SPELL",
     "name": { "str": "[Ψ]Blood Purge Additional Purging", "//~": "NO_I18N" },

--- a/data/mods/MindOverMatter/powers/vitakinesis_concentration_eoc.json
+++ b/data/mods/MindOverMatter/powers/vitakinesis_concentration_eoc.json
@@ -480,6 +480,77 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_VITAKIN_NO_NEED_FOR_SLEEP",
+    "condition": { "not": { "u_has_effect": "effect_vitakin_no_need_for_sleep" } },
+    "effect": [
+      { "u_message": "You blink suddenly.", "type": "good" },
+      { "u_add_effect": "effect_vitakin_no_need_for_sleep", "duration": "PERMANENT" },
+      { "run_eocs": [ "EOC_POWER_MAINTENANCE_PLUS_ONE", "EOC_TELEPATH_REMOVE_TELEPATHIC_CONCENTRATION" ] },
+      {
+        "run_eocs": "EOC_VITAKIN_NO_NEED_FOR_SLEEP_DRAIN",
+        "time_in_future": [
+          {
+            "math": [
+              "( ( u_spell_level('vita_no_need_for_sleep') * 210.00) + 1950.00) * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling"
+            ]
+          },
+          {
+            "math": [
+              "( ( u_spell_level('vita_no_need_for_sleep') * 590.00) + 4180.00) * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling"
+            ]
+          }
+        ]
+      }
+    ],
+    "false_effect": [ { "run_eocs": "EOC_VITAKIN_REMOVE_NO_NEED_FOR_SLEEP" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_VITAKIN_REMOVE_NO_NEED_FOR_SLEEP",
+    "condition": { "u_has_effect": "effect_vitakin_no_need_for_sleep" },
+    "effect": [ { "run_eocs": [ "EOC_POWER_MAINTENANCE_MINUS_ONE" ] }, { "u_lose_effect": "effect_vitakin_no_need_for_sleep" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_VITAKIN_NO_NEED_FOR_SLEEP_DRAIN",
+    "condition": { "u_has_effect": "effect_vitakin_no_need_for_sleep" },
+    "effect": [
+      { "math": [ "u_latest_channeled_power_difficulty = 7" ] },
+      { "run_eocs": [ "EOC_PSIONICS_GAIN_NETHER_ATTUNEMENT_2", "EOC_PSI_MAINTENANCE_CALORIE_COST_CALCULATOR" ] },
+      { "math": [ "u_spell_exp('vita_no_need_for_sleep') += psionic_power_experience_formula()" ] },
+      { "run_eocs": "EOC_POWER_MAINTENANCE_CONCENTRATION_CHECK" },
+      {
+        "if": { "math": [ "u_val('sleep_deprivation') >= 250" ] },
+        "then": { "math": [ "u_val('sleep_deprivation') -= 250" ] }
+      },
+      {
+        "if": { "math": [ "u_val('sleep_deprivation') >= 100" ] },
+        "then": { "math": [ "u_val('sleep_deprivation') -= 100" ] }
+      },
+      {
+        "if": { "math": [ "u_val('sleep_deprivation') >= 50" ] },
+        "then": { "math": [ "u_val('sleep_deprivation') -= 50" ] }
+      },
+      {
+        "run_eocs": "EOC_VITAKIN_NO_NEED_FOR_SLEEP_DRAIN",
+        "time_in_future": [
+          {
+            "math": [
+              "( ( u_spell_level('vita_no_need_for_sleep') * 210.00) + 1950.00) * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling"
+            ]
+          },
+          {
+            "math": [
+              "( ( u_spell_level('vita_no_need_for_sleep') * 590.00) + 4180.00) * scaling_factor(u_val('intelligence') ) * u_nether_attunement_power_scaling"
+            ]
+          }
+        ]
+      }
+    ],
+    "false_effect": [  ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_VITAKIN_SUPER_HEAL_INITIATE",
     "condition": { "not": { "u_has_effect": "effect_vita_super_heal" } },
     "effect": [

--- a/data/mods/MindOverMatter/recipes/practice/vitakinesis_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/vitakinesis_practice.json
@@ -23,6 +23,7 @@
       "practice_vita_healing_trance",
       "practice_vita_attack_touch",
       "practice_vita_blood_purge",
+      "practice_vita_no_need_for_sleep",
       "practice_vita_banish_illness",
       "practice_vita_super_heal",
       "practice_vita_limb_restore",
@@ -648,6 +649,60 @@
     "condition": {
       "and": [
         { "compare_string": [ "vita_attack_touch", { "u_val": "latest_studied_power_name" } ] },
+        { "test_eoc": "EOC_CONDITION_PSI_REQUIRED_FOR_LEARNING_NEW_POWER" }
+      ]
+    },
+    "effect": [ { "run_eocs": "EOC_PRACTICE_PSIONICS_FINAL_LEARNING_CHECK" } ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "name": "contemplation: selective autosomnia",
+    "id": "practice_vita_no_need_for_sleep",
+    "description": "Contemplate your powers and improve your ability to sleep while remaining awake.\n\nPower Difficulty: 7\n\nCurrent Power Level: <u_spell_level:vita_no_need_for_sleep>",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "metaphysics",
+    "difficulty": 0,
+    "time": "0 s",
+    "autolearn": false,
+    "proficiencies": [ { "proficiency": "prof_contemplation_vitakinesis", "required": false } ],
+    "tools": [
+      [ [ "matrix_crystal_drained", -1 ], [ "black_nether_crystal_pseudo_tool", -1 ], [ "matrix_crystal_vitakinesis", -1 ] ]
+    ],
+    "components": [ [ [ "matrix_crystal_vitakin_dust", 1 ] ] ],
+    "flags": [ "SECRET", "BLIND_EASY", "NO_MANIP", "AFFECTED_BY_PAIN", "NO_BENCH", "NO_ENCHANTMENT" ],
+    "result_eocs": [
+      {
+        "id": "EOC_PRACTICE_VITAKIN_NO_NEED_FOR_SLEEP",
+        "condition": { "u_has_trait": "VITAKINETIC" },
+        "effect": [
+          { "set_string_var": "vita_no_need_for_sleep", "target_var": { "u_val": "latest_studied_power_name" } },
+          { "run_eocs": "EOC_PSI_STUDYING_VITAKIN_POWER_SETUP" },
+          {
+            "if": { "math": [ "u_spell_level('vita_no_need_for_sleep') >= 1" ] },
+            "then": { "run_eocs": [ "EOC_PSI_STUDYING_POWER_BEGIN", "EOC_PSI_STUDYING_POWER_SIDE_EFFECTS" ] },
+            "else": [
+              { "run_eocs": [ "EOC_PSI_STUDYING_POWER_INITIAL_SETUP", "EOC_PSI_PRACTICE_FOCUS_MOD" ] },
+              {
+                "run_eocs": "EOC_PRACTICE_VITAKIN_NO_NEED_FOR_SLEEP_LEARNING",
+                "time_in_future": [
+                  { "math": [ "learn_new_power_lower_time_bound(u_latest_studied_power_difficulty)" ] },
+                  { "math": [ "learn_new_power_upper_time_bound(u_latest_studied_power_difficulty)" ] }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PRACTICE_VITAKIN_NO_NEED_FOR_SLEEP_LEARNING",
+    "condition": {
+      "and": [
+        { "compare_string": [ "vita_no_need_for_sleep", { "u_val": "latest_studied_power_name" } ] },
         { "test_eoc": "EOC_CONDITION_PSI_REQUIRED_FOR_LEARNING_NEW_POWER" }
       ]
     },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[MoM] Add Selective Autosomnia Vitakinetic power"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Now that not needing to sleep doesn't remove weariness gain, I can implement this.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the Difficulty 7 Selective Autosomnia power, where you have portions of your brain rest while keeping other parts awake. This effectively means you do not have to sleep at all while the power is maintained (your sleepiness will go down and will not increase), but it also means your brain does not function at 100% because parts of it are asleep (penalty to social skill and to learning focus). You cannot have Concentration Trance and Selective Autosomnia active simultaneously. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Learned the power, used the power, did not get tired at all for 24 hours. 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
