### PR TITLE
Fix map (the item) location recording, improve name display and search

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -716,7 +716,12 @@
   {
     "id": "HINT_THE_LOCATION",
     "type": "json_flag",
-    "//": "Same as PRESERVE_SPAWN_LOC, but also shows a snippet of how far the character from the `spawn_location`: 1 OMT or less is `(from here)`, less than 6 OMT is `(from nearby)`, less than 30 OMT is `(from this area)`, anything more is (from far away)"
+    "//": "Shows a snippet of how far the character from the `spawn_location`: 1 OMT or less is `(from here)`, less than 6 OMT is `(from nearby)`, less than 30 OMT is `(from this area)`, anything more is (from far away)"
+  },
+  {
+    "id": "LOCATION_PRECISE_CLOSEST_CITY",
+    "type": "json_flag",
+    "//": "Shows a snippet with the name of the closest city to the `spawn_location`"
   },
   {
     "id": "PROVIDES_TECHNIQUES",

--- a/data/json/items/book/abstract.json
+++ b/data/json/items/book/abstract.json
@@ -496,7 +496,7 @@
     "description": "seeing this is a bug.",
     "weight": "30 g",
     "volume": "250 ml",
-    "flags": [ "PAPER_SHAPED" ],
+    "flags": [ "PRESERVE_SPAWN_LOC", "LOCATION_PRECISE_CLOSEST_CITY", "PAPER_SHAPED" ],
     "price": "10 USD",
     "price_postapoc": "10 USD",
     "material": [ "paper" ],

--- a/data/json/items/book/maps.json
+++ b/data/json/items/book/maps.json
@@ -8,7 +8,7 @@
     "color": "blue",
     "volume": "10 ml",
     "weight": "10 g",
-    "flags": [ "CREDIT_CARD_SHAPED" ],
+    "extend": { "flags": [ "CREDIT_CARD_SHAPED" ] },
     "use_action": {
       "type": "reveal_map",
       "radius": 90,
@@ -523,7 +523,7 @@
     "price": "0 cent",
     "price_postapoc": "0 cent",
     "material": [ "paper" ],
-    "flags": [ "PAPER_SHAPED" ],
+    "flags": [ "PRESERVE_SPAWN_LOC", "LOCATION_PRECISE_CLOSEST_CITY", "PAPER_SHAPED" ],
     "weight": "3 g",
     "volume": "5 ml",
     "use_action": {
@@ -567,6 +567,7 @@
     "category": "maps",
     "symbol": ",",
     "color": "white",
+    "looks_like": "book_binder",
     "description": "A small notebook with \"X.E.D.R.A\" embossed on the cover.  It's filled with notes scribbled by pencil.",
     "price": "0 cent",
     "price_postapoc": "0 cent",

--- a/data/json/items/id_cards.json
+++ b/data/json/items/id_cards.json
@@ -57,7 +57,7 @@
     "name": { "str": "visitor's pass", "str_pl": "visitor's passes" },
     "description": "A visitor's pass to some sort of facility.  The reverse side describes the protocol for using it; this could grant access at a card reader, if you can find one.  It also lists the addresses of nearby facilities; activate it to add their locations to your map.",
     "price": "600 USD",
-    "extend": { "flags": [ "SCIENCE_CARD_VISITOR" ] },
+    "extend": { "flags": [ "SCIENCE_CARD_VISITOR", "PRESERVE_SPAWN_LOC", "LOCATION_PRECISE_CLOSEST_CITY" ] },
     "price_postapoc": "2 USD 50 cent",
     "category": "keys",
     "use_action": {
@@ -116,7 +116,7 @@
     "copy-from": "id_science",
     "name": { "str": "transport freight employee badge" },
     "description": "An employee badge for a freight hauler.  The reverse side describes the protocol for using it; this could grant access at transport freight card readers.  It also lists the addresses of nearby facilities; activate it to add their locations to your map.",
-    "flags": [ "SCIENCE_CARD_TRANSPORT_1", "CREDIT_CARD_SHAPED" ],
+    "flags": [ "SCIENCE_CARD_TRANSPORT_1", "CREDIT_CARD_SHAPED", "PRESERVE_SPAWN_LOC", "LOCATION_PRECISE_CLOSEST_CITY" ],
     "use_action": {
       "type": "reveal_map",
       "radius": 300,

--- a/data/mods/MindOverMatter/items/files_and_post_it.json
+++ b/data/mods/MindOverMatter/items/files_and_post_it.json
@@ -315,7 +315,7 @@
     "copy-from": "card_plastic_abstract",
     "description": "A visitor's pass to some sort of facility.  The reverse side describes the protocol for using it; this could grant one-time access at a card reader, if you can find one.  It also lists the addresses of nearby facilities; activate it to add their locations to your map.  There is a prominent symbol stamped on it with the word \"PHAVIAN\" underneath.",
     "price": "600 USD",
-    "flags": [ "CREDIT_CARD_SHAPED", "SCIENCE_CARD_VISITOR" ],
+    "flags": [ "CREDIT_CARD_SHAPED", "SCIENCE_CARD_VISITOR", "PRESERVE_SPAWN_LOC", "LOCATION_PRECISE_CLOSEST_CITY" ],
     "price_postapoc": "2 USD 50 cent",
     "material": [ "plastic" ],
     "weight": "5 g",

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -259,6 +259,7 @@ const flag_id flag_POLEARM( "POLEARM" );
 const flag_id flag_POWERARMOR_COMPATIBLE( "POWERARMOR_COMPATIBLE" );
 const flag_id flag_POWERED( "POWERED" );
 const flag_id flag_PREDATOR_FUN( "PREDATOR_FUN" );
+const flag_id flag_PRESERVE_SPAWN_LOC( "PRESERVE_SPAWN_LOC" );
 const flag_id flag_PRIMITIVE_RANGED_WEAPON( "PRIMITIVE_RANGED_WEAPON" );
 const flag_id flag_PROCESSING( "PROCESSING" );
 const flag_id flag_PROCESSING_RESULT( "PROCESSING_RESULT" );

--- a/src/flag.h
+++ b/src/flag.h
@@ -269,6 +269,7 @@ extern const flag_id flag_POLEARM;
 extern const flag_id flag_POWERARMOR_COMPATIBLE;
 extern const flag_id flag_POWERED;
 extern const flag_id flag_PREDATOR_FUN;
+extern const flag_id flag_PRESERVE_SPAWN_LOC;
 extern const flag_id flag_PRIMITIVE_RANGED_WEAPON;
 extern const flag_id flag_PROCESSING;
 extern const flag_id flag_PROCESSING_RESULT;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -678,6 +678,27 @@ bool _stacks_location_hint( item const &lhs, item const &rhs )
     return false;
 }
 
+bool _stacks_location_precise_closest_city( item const &lhs, item const &rhs )
+{
+    static const std::string omt_loc_var = "spawn_location";
+    const tripoint_abs_ms this_loc( lhs.get_var( omt_loc_var, tripoint_abs_ms::invalid ) );
+    const tripoint_abs_ms that_loc( rhs.get_var( omt_loc_var, tripoint_abs_ms::invalid ) );
+    if( this_loc == that_loc ) {
+        return true;
+    } else if( this_loc != tripoint_abs_ms::invalid && that_loc != tripoint_abs_ms::invalid ) {
+        const tripoint_abs_omt this_omt = project_to<coords::omt>( this_loc );
+        const tripoint_abs_sm this_sm = project_to<coords::sm>( this_omt );
+        const city_reference this_city = overmap_buffer.closest_city( this_sm );
+
+        const tripoint_abs_omt that_omt = project_to<coords::omt>( that_loc );
+        const tripoint_abs_sm that_sm = project_to<coords::sm>( that_omt );
+        const city_reference that_city = overmap_buffer.closest_city( that_sm );
+
+        return this_city.city == that_city.city;
+    }
+    return false;
+}
+
 bool _stacks_rot( item const &lhs, item const &rhs, bool combine_liquid )
 {
     // Stack items that fall into the same "bucket" of freshness.
@@ -882,6 +903,8 @@ stacking_info item::stacks_with( const item &rhs, bool check_components, bool co
     bits.set( tname::segments::VARS, map_equal_ignoring_keys( item_vars, rhs.item_vars, ignore_keys ) );
     bits.set( tname::segments::ETHEREAL, _stacks_ethereal( *this, rhs ) );
     bits.set( tname::segments::LOCATION_HINT, _stacks_location_hint( *this, rhs ) );
+    bits.set( tname::segments::LOCATION_PRECISE_CLOSEST_CITY,
+              _stacks_location_precise_closest_city( *this, rhs ) );
 
     bool const this_goes_bad = goes_bad();
     bool const that_goes_bad = rhs.goes_bad();

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -22,7 +22,6 @@
 #include "character.h"
 #include "character_id.h"
 #include "character_martial_arts.h"
-#include "city.h"
 #include "color.h"
 #include "coordinates.h"
 #include "craft_command.h"
@@ -1628,17 +1627,6 @@ std::string item::display_name( unsigned int quantity ) const
             }
             cable = string_format( " (%s)", colorize( string_format( _( "%d/%d cable%s" ),
                                    link_max_len - link_len, link_max_len, extensions ), cable_color ) );
-        }
-    }
-    // HACK: This is a hack to prevent possible crashing when displaying maps as items during character creation
-    if( is_map() && calendar::turn != calendar::turn_zero ) {
-        tripoint_abs_omt map_pos_omt =
-            project_to<coords::omt>( get_var( "reveal_map_center", player_character.pos_abs() ) );
-        tripoint_abs_sm map_pos =
-            project_to<coords::sm>( map_pos_omt );
-        const city *c = overmap_buffer.closest_city( map_pos ).city;
-        if( c != nullptr ) {
-            name = string_format( "%s %s", c->name, name );
         }
     }
 
@@ -4586,6 +4574,22 @@ void item::mod_charges( int mod )
         charges = INFINITE_CHARGES - 1; // Highly unlikely, but finite charges should not become infinite.
     } else {
         charges += mod;
+    }
+}
+
+void item::preserve_location( const tripoint_abs_ms &location )
+{
+    if( has_flag( flag_PRESERVE_SPAWN_LOC ) && !has_var( "spawn_location" ) ) {
+        // TODO migrate from old reveal_map_center, can be removed somewhere in the future
+        if( has_var( "reveal_map_center" ) ) {
+            set_var( "spawn_location", get_var( "reveal_map_center", tripoint_abs_ms::invalid ) );
+            remove_var( "reveal_map_center" );
+        } else {
+            set_var( "spawn_location", location );
+        }
+    }
+    for( item *subitem : all_items_ptr() ) {
+        subitem->preserve_location( location );
     }
 }
 

--- a/src/item.h
+++ b/src/item.h
@@ -1113,6 +1113,12 @@ class item : public visitable
         void mod_charges( int mod );
 
         /**
+         * Store items current location into spawn_location, if flag PRESERVE_SPAWN_LOC is present. Works
+         * recursively.
+         */
+        void preserve_location( const tripoint_abs_ms &location );
+
+        /**
          * Returns rate of rot (rot/h) at the given temperature
          */
         float calc_hourly_rotpoints_at_temp( const units::temperature &temp ) const;

--- a/src/item_tname.cpp
+++ b/src/item_tname.cpp
@@ -15,6 +15,7 @@
 #include "avatar.h"
 #include "calendar.h"
 #include "cata_utility.h"
+#include "city.h"
 #include "color.h"
 #include "coordinates.h"
 #include "debug.h"
@@ -30,6 +31,7 @@
 #include "itype.h"
 #include "mutation.h"
 #include "options.h"
+#include "overmapbuffer.h"
 #include "point.h"
 #include "recipe.h"
 #include "relic.h"
@@ -43,6 +45,7 @@
 #include "value_ptr.h"
 
 static const flag_id json_flag_HINT_THE_LOCATION( "HINT_THE_LOCATION" );
+static const flag_id json_flag_LOCATION_PRECISE_CLOSEST_CITY( "LOCATION_PRECISE_CLOSEST_CITY" );
 
 static const itype_id itype_barrel_small( "barrel_small" );
 static const itype_id itype_disassembly( "disassembly" );
@@ -339,6 +342,24 @@ std::string location_hint( item const &it, unsigned int /* quantity */,
             return _( " (from this area)" );
         }
         return _( " (from far away)" );
+    }
+    return {};
+}
+
+std::string location_closest_city( item const &it, unsigned int /* quantity */,
+                                   segment_bitset const &/* segments */ )
+{
+    if( it.has_flag( json_flag_LOCATION_PRECISE_CLOSEST_CITY ) ) {
+        const tripoint_abs_ms map_pos_ms = it.get_var( "spawn_location", tripoint_abs_ms::invalid );
+        city_reference closest_city = city_reference::invalid;
+        if( !map_pos_ms.is_invalid() ) {
+            const tripoint_abs_omt map_pos_omt = project_to<coords::omt>( map_pos_ms );
+            const tripoint_abs_sm map_pos = project_to<coords::sm>( map_pos_omt );
+            closest_city = overmap_buffer.closest_city( map_pos );
+        }
+        if( closest_city.city != nullptr ) {
+            return string_format( ", %s", closest_city.city->name );
+        }
     }
     return {};
 }
@@ -692,6 +713,7 @@ constexpr std::array<decl_f_print_segment *, num_segments> get_segs_array()
     arr[static_cast<size_t>( tname::segments::FOOD_IRRADIATED ) ] = food_irradiated;
     arr[static_cast<size_t>( tname::segments::TEMPERATURE ) ] = temperature;
     arr[static_cast<size_t>( tname::segments::LOCATION_HINT ) ] = location_hint;
+    arr[static_cast<size_t>( tname::segments::LOCATION_PRECISE_CLOSEST_CITY ) ] = location_closest_city;
     arr[static_cast<size_t>( tname::segments::CLOTHING_SIZE ) ] = clothing_size;
     arr[static_cast<size_t>( tname::segments::ETHEREAL ) ] = ethereal;
     arr[static_cast<size_t>( tname::segments::FILTHY ) ] = filthy;
@@ -759,6 +781,7 @@ std::string enum_to_string<tname::segments>( tname::segments seg )
         case tname::segments::FOOD_IRRADIATED: return "FOOD_IRRADIATED";
         case tname::segments::TEMPERATURE: return "TEMPERATURE";
         case tname::segments::LOCATION_HINT: return "LOCATION_HINT";
+        case tname::segments::LOCATION_PRECISE_CLOSEST_CITY: return "LOCATION_PRECISE_CLOSEST_CITY";
         case tname::segments::CLOTHING_SIZE: return "CLOTHING_SIZE";
         case tname::segments::ETHEREAL: return "ETHEREAL";
         case tname::segments::FILTHY: return "FILTHY";

--- a/src/item_tname.h
+++ b/src/item_tname.h
@@ -41,6 +41,7 @@ enum class segments : std::size_t {
     FOOD_IRRADIATED,
     TEMPERATURE,
     LOCATION_HINT,
+    LOCATION_PRECISE_CLOSEST_CITY,
     CLOTHING_SIZE,
     ETHEREAL,
     FILTHY,

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1373,8 +1373,21 @@ std::optional<int> reveal_map_actor::use( Character *p, item &it, map *,
         p->add_msg_if_player( _( "It's too dark to read." ) );
         return std::nullopt;
     }
-    const tripoint_abs_omt center( coords::project_to<coords::omt>( it.get_var( "reveal_map_center",
-                                   p->pos_abs() ) ) );
+
+    const tripoint_abs_ms map_pos_ms = it.get_var( "spawn_location", tripoint_abs_ms::invalid );
+    city_reference closest_city = city_reference::invalid;
+    if( !map_pos_ms.is_invalid() ) {
+        const tripoint_abs_omt map_pos_omt = project_to<coords::omt>( map_pos_ms );
+        const tripoint_abs_sm map_pos = project_to<coords::sm>( map_pos_omt );
+        closest_city = overmap_buffer.closest_city( map_pos );
+    }
+    if( closest_city.city == nullptr ) {
+        p->add_msg_if_player( _( "The %s is unreadable." ), it.tname() );
+        return std::nullopt;
+    }
+
+    const tripoint_abs_omt center( project_to<coords::omt>( closest_city.abs_sm_pos ) );
+
     // Clear highlight on previously revealed OMTs before revealing new ones
     p->map_revealed_omts.clear();
     for( const auto &omt : omt_types ) {
@@ -1382,13 +1395,14 @@ std::optional<int> reveal_map_actor::use( Character *p, item &it, map *,
             reveal_targets( tripoint_abs_omt( center.xy(), z ), omt, 0 );
         }
     }
-    if( !message.empty() ) {
-        p->add_msg_if_player( m_good, "%s", message );
-    }
+
     if( p->map_revealed_omts.empty() ) {
         p->add_msg_if_player( _( "You didn't learn anything new from the %s." ), it.tname() );
+    } else if( !message.empty() ) {
+        p->add_msg_if_player( m_good, "%s", message );
     }
     it.mark_as_used_by_player( *p );
+
     return 0;
 }
 

--- a/src/iuse_actor.h
+++ b/src/iuse_actor.h
@@ -472,8 +472,8 @@ class reveal_map_actor : public iuse_actor
          * The radius of the overmap area that gets revealed.
          * This is in overmap terrain coordinates.
          * A radius of 1 means all terrains directly around center are revealed.
-         * The center is location of nearest city defined in `reveal_map_center` variable of
-         * activated item (or current player global omt location if variable is not set).
+         * The center is location of nearest city defined in `spawn_location` variable of
+         * activated item. Skip if location is missing.
          */
         int radius = 0;
         /**

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -150,7 +150,6 @@ static const flag_id json_flag_JETPACK( "JETPACK" );
 static const flag_id json_flag_LEVITATION( "LEVITATION" );
 static const flag_id json_flag_PHASE_BACK( "PHASE_BACK" );
 static const flag_id json_flag_PLOWABLE( "PLOWABLE" );
-static const flag_id json_flag_PRESERVE_SPAWN_LOC( "PRESERVE_SPAWN_LOC" );
 static const flag_id json_flag_PROXIMITY( "PROXIMITY" );
 static const flag_id json_flag_UNDODGEABLE( "UNDODGEABLE" );
 
@@ -5805,18 +5804,7 @@ item &map::add_item( const tripoint_bub_ms &p, item new_item, int copies )
         new_item.active = true;
     }
 
-    if( new_item.is_map() && !new_item.has_var( "reveal_map_center" ) ) {
-        new_item.set_var( "reveal_map_center", get_abs( p ) );
-    }
-
-    std::list<item *> all_items = new_item.all_items_ptr();
-    all_items.emplace_back( &new_item );
-    for( item *it : all_items ) {
-        if( it->has_flag( json_flag_PRESERVE_SPAWN_LOC ) &&
-            !it->has_var( "spawn_location" ) ) {
-            it->set_var( "spawn_location", get_abs( p ) );
-        }
-    };
+    new_item.preserve_location( get_abs( p ) );
 
     if( new_item.has_flag( flag_ACTIVATE_ON_PLACE ) ) {
         new_item.activate();

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -7057,6 +7057,7 @@ std::vector<item *> map::place_items(
         }
 
         e->randomize_rot();
+        e->preserve_location( project_to<coords::ms>( get_abs_sub() ) );
         e->set_owner( faction_id( faction ) );
     }
     return res;

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -161,7 +161,6 @@ static const flag_id json_flag_DISABLE_FLIGHT( "DISABLE_FLIGHT" );
 static const flag_id json_flag_FILTHY( "FILTHY" );
 static const flag_id json_flag_GRAB( "GRAB" );
 static const flag_id json_flag_GRAB_FILTER( "GRAB_FILTER" );
-static const flag_id json_flag_PRESERVE_SPAWN_LOC( "PRESERVE_SPAWN_LOC" );
 
 static const itype_id itype_beartrap( "beartrap" );
 static const itype_id itype_milk( "milk" );
@@ -3290,7 +3289,7 @@ void monster::generate_inventory( bool disableDrops )
     no_extra_death_drops = disableDrops;
 }
 
-void monster::drop_items_on_death( map *here, item *corpse )
+void monster::drop_items_on_death( map *here, item *corpse ) const
 {
     if( is_hallucination() ) {
         return;
@@ -3305,6 +3304,7 @@ void monster::drop_items_on_death( map *here, item *corpse )
 
     for( item &e : new_items ) {
         e.randomize_rot();
+        e.preserve_location( pos_abs() );
     }
 
     // for non corpses this is much simpler
@@ -3353,25 +3353,6 @@ void monster::drop_items_on_death( map *here, item *corpse )
             }
         }
     }
-
-    // Check if item has PRESERVE_SPAWN_LOC and set it if necessary
-    // This probably needs to be encapsulated in some generic function
-    for( item &it : new_items ) {
-        if( it.has_flag( json_flag_PRESERVE_SPAWN_LOC ) &&
-            !it.has_var( "spawn_location" ) ) {
-            it.set_var( "spawn_location", pos_abs().to_string_writable() );
-        }
-
-        // since efiles are not in standard pocket, check it separately
-        if( it.has_pocket_type( pocket_type::E_FILE_STORAGE ) ) {
-            for( item *it_software : it.all_items_top( pocket_type::E_FILE_STORAGE ) ) {
-                if( it_software->has_flag( json_flag_PRESERVE_SPAWN_LOC ) &&
-                    !it_software->has_var( "spawn_location" ) ) {
-                    it_software->set_var( "spawn_location", pos_abs().to_string_writable() );
-                }
-            }
-        }
-    };
 }
 
 void monster::spawn_dissectables_on_death( item *corpse ) const

--- a/src/monster.h
+++ b/src/monster.h
@@ -474,7 +474,7 @@ class monster : public Creature
         void reset_stats() override;
 
         void die( map *here, Creature *killer ) override; //this is the die from Creature, it calls kill_mo
-        void drop_items_on_death( map *here, item *corpse );
+        void drop_items_on_death( map *here, item *corpse ) const;
         void spawn_dissectables_on_death( item *corpse ) const; //spawn dissectable CBMs into CORPSE pocket
         //spawn monster's inventory without killing it
         void generate_inventory( bool disableDrops = true );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -6438,6 +6438,8 @@ std::optional<vehicle_stack::iterator> vehicle::add_item( map &here, vehicle_par
         itm_copy.spill_contents( bub_part_pos( here, vp ) );
     }
 
+    itm_copy.preserve_location( pos_abs() );
+
     const vehicle_stack::iterator new_pos = vp.items.insert( itm_copy );
     active_items.add( *new_pos, vp.mount );
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Fix map (the item) location recording, improve name display and search"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/83566

Maps do not properly set the `reveal_map_center`, causing them to "mutate" their names to the closest city. That also means you can stock maps spawned in a place, and then move somewhere else to reveal another area instead.  Somehow I just noticed no my last run, and didn't make the work to track how far the issue goes.

There are minor things that bothered me also, and are addressed here: first, maps display as "<City> map", but `reveal_map_center` is set to spawn loc, which means not two maps will have the same center. Last, the display and search functions doesn't account for the actual location, i.e., "<City> road map" will apear as just "road map" in few places in the UI and search will never find the "<City>" part, which creates a confusing UX.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

I start progressively addressing the issues on each commit. At first, I removed the default fallback to player position, so if a map doesn't have the actual center location recorded, it would be described as "unreadable" and be clear there is an issue with the item. The reveal action would just do nothing (besides a default message).

Then, for recorded locations, I use the same logic that's used for display to find the closest city, and use the city position as the origin of the reveal action. This way, no mater where a given maps is spawned, if it is spawned under the "<City A>" it will reveal the same radius.

As I continue to debug and familiarize with the code, I noticed we already have a mechanic to record spawn location, used by TLC cards. So, I move the code to use `spawn_location` var and gave maps the `PRESERVE_SPAWN_LOC`.  Any improvement or fixes to `spawn_location` should benefit maps.

Which happens next, when I found a map in a car with missing location (payoff from the name change above). I've copied the code present at `map::add_item`, and maps worked.

This covers all the functional aspects of the feature. A last change I did was to move city name presentation to `tname`. The city name position was change in format that I expect should be more translatable, for example `New England road map`, would become `road map, New England`.  As a nice side-effect here, many places that didn't present the city name (just the base item name) now work as expected, and search works too! (example, I can search `New England` to find both a road map and a trail guide. Before this change, the search doesn't see the `New England` part.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

- Split this PR with the separate pieces. I can do it if required, but keep everything together as they're related.
- Keep two location vars, duplicating fixes to item spawn.
- Have the city center search function be computed at spawn time, but that would not be intended for non-map cases. As I centralize with a single spawn_location, then decided to keep city loc resolution at read-time. 
- Code used to spawn preserving loc, which was copied to vehicle, has a comment about extracting to a function. I didn't know where to put the function, so I just duplicate it. 

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

I'm not familiar with unit testing in C++, so all my tests were playing the game. Explored, find trail heads, kills zombies, found cars... looked for opportunities that would spawn maps and see how they behave.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Maps generated before this change would not have the var set if they're on your inventory. Throwing on the floor or in a vehicle will set them to that location.

Here some presentation screenshots:

<img width="337" height="217" alt="Screenshot 2026-03-23 at 18 55 27" src="https://github.com/user-attachments/assets/49cddf77-5fa1-4978-a22f-ffdfd0252862" />

That's from a trailhead display case. Notice that, before this change, it would show just as `trail guide`.


<img width="413" height="328" alt="Screenshot 2026-03-23 at 19 12 35" src="https://github.com/user-attachments/assets/8d10afd2-8827-4c27-a5cf-0938497521d6" />

Creating a new char. As I didn't reintroduced the hack from calendar, here it appears as `(unreadable)`. If this suffix is just omited, them presentation in this case would improve. Decided to keep this way, for now, to stress that something is wrong with these items in during gameplay.


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
