### PR TITLE
NPC needs: top-level decision BT diagnostic

### DIFF
--- a/data/json/npcs/npc_behavior.json
+++ b/data/json/npcs/npc_behavior.json
@@ -1,6 +1,56 @@
 [
   {
     "type": "behavior",
+    "id": "npc_decision",
+    "strategy": "fallback",
+    "children": [ "npc_combat", "npc_investigate", "npc_priorities" ]
+  },
+  {
+    "type": "behavior",
+    "id": "npc_combat",
+    "strategy": "fallback",
+    "conditions": [ { "predicate": "npc_in_danger" } ],
+    "children": [ "npc_flee", "npc_fight" ]
+  },
+  {
+    "type": "behavior",
+    "id": "npc_flee",
+    "conditions": [ { "predicate": "npc_should_flee" } ],
+    "goal": "flee"
+  },
+  {
+    "type": "behavior",
+    "id": "npc_fight",
+    "conditions": [ { "predicate": "npc_has_target" } ],
+    "goal": "fight"
+  },
+  {
+    "type": "behavior",
+    "id": "npc_investigate",
+    "conditions": [ { "predicate": "npc_has_sound_alerts" } ],
+    "goal": "investigate_sound"
+  },
+  {
+    "type": "behavior",
+    "id": "npc_priorities",
+    "strategy": "utility",
+    "children": [ "npc_needs", "npc_duty" ]
+  },
+  {
+    "type": "behavior",
+    "id": "npc_duty",
+    "strategy": "sequential",
+    "children": [ "npc_return_to_post" ],
+    "score": "npc_duty_urgency"
+  },
+  {
+    "type": "behavior",
+    "id": "npc_return_to_post",
+    "conditions": [ { "predicate": "npc_displaced_from_post" } ],
+    "goal": "return_to_guard_pos"
+  },
+  {
+    "type": "behavior",
     "id": "npc_needs",
     "strategy": "utility",
     "children": [ "npc_homeostasis", "npc_thirst", "npc_hunger", "npc_sleepiness" ]

--- a/src/behavior_oracle.cpp
+++ b/src/behavior_oracle.cpp
@@ -48,6 +48,11 @@ predicate_map = {{
         { "npc_has_food", make_function( &character_oracle_t::has_food ) },
         { "npc_needs_sleep_badly", make_function( &character_oracle_t::needs_sleep_badly ) },
         { "npc_can_sleep", make_function( &character_oracle_t::can_sleep ) },
+        { "npc_in_danger", make_function( &character_oracle_t::in_danger ) },
+        { "npc_should_flee", make_function( &character_oracle_t::should_flee ) },
+        { "npc_has_target", make_function( &character_oracle_t::has_target ) },
+        { "npc_has_sound_alerts", make_function( &character_oracle_t::has_sound_alerts ) },
+        { "npc_displaced_from_post", make_function( &character_oracle_t::displaced_from_post ) },
         { "monster_not_hallucination", make_function( &monster_oracle_t::not_hallucination ) },
         { "monster_items_available", make_function( &monster_oracle_t::items_available ) },
         { "monster_split_possible", make_function( &monster_oracle_t::split_possible ) },
@@ -61,7 +66,8 @@ score_predicate_map = {{
         { "npc_thirst_urgency", make_score_function( &character_oracle_t::thirst_urgency ) },
         { "npc_hunger_urgency", make_score_function( &character_oracle_t::hunger_urgency ) },
         { "npc_warmth_urgency", make_score_function( &character_oracle_t::warmth_urgency ) },
-        { "npc_sleepiness_urgency", make_score_function( &character_oracle_t::sleepiness_urgency ) }
+        { "npc_sleepiness_urgency", make_score_function( &character_oracle_t::sleepiness_urgency ) },
+        { "npc_duty_urgency", make_score_function( &character_oracle_t::duty_urgency ) }
     }
 };
 

--- a/src/character_health.cpp
+++ b/src/character_health.cpp
@@ -2881,7 +2881,7 @@ void Character::on_hurt( Creature *source, bool disturb /*= true*/ )
     }
 
     if( disturb ) {
-        if( has_effect( effect_sleep ) && !has_bionic( bio_sleep_shutdown ) ) {
+        if( in_sleep_state() && !has_bionic( bio_sleep_shutdown ) ) {
             wake_up();
         }
         if( uistate.distraction_attack && !is_npc() && !has_effect( effect_narcosis ) ) {

--- a/src/character_oracle.cpp
+++ b/src/character_oracle.cpp
@@ -3,14 +3,17 @@
 #include <algorithm>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include "behavior.h"
 #include "bodypart.h"
 #include "character.h"
+#include "coordinates.h"
 #include "item.h"
 #include "itype.h"
 #include "npc.h"
+#include "point.h"
 #include "ret_val.h"
 #include "type_id.h"
 #include "units.h"
@@ -18,7 +21,10 @@
 #include "weather.h"
 
 static const efftype_id effect_meth( "meth" );
+static const efftype_id effect_npc_run_away( "npc_run_away" );
 static const flag_id json_flag_FIRESTARTER( "FIRESTARTER" );
+static const json_character_flag json_flag_CANNOT_MOVE( "CANNOT_MOVE" );
+static const trait_id trait_IGNORE_SOUND( "IGNORE_SOUND" );
 
 namespace behavior
 {
@@ -183,6 +189,87 @@ float character_oracle_t::sleepiness_urgency( std::string_view ) const
     // 0 = rested, 1 = forced unconsciousness (MASSIVE_SLEEPINESS = 1000).
     static constexpr float cap = 1000.0f;
     return std::clamp( subject->get_sleepiness() / cap, 0.0f, 1.0f );
+}
+
+// Top-level decision predicates. These need NPC-specific state (ai_cache,
+// attitude) so they dynamic_cast from Character to npc.
+
+status_t character_oracle_t::in_danger( std::string_view ) const
+{
+    const npc *n = dynamic_cast<const npc *>( subject );
+    if( !n ) {
+        return status_t::failure;
+    }
+    return n->get_ai_danger() > 0 ? status_t::running : status_t::failure;
+}
+
+status_t character_oracle_t::should_flee( std::string_view ) const
+{
+    const npc *n = dynamic_cast<const npc *>( subject );
+    if( !n ) {
+        return status_t::failure;
+    }
+    if( n->has_effect( effect_npc_run_away ) ) {
+        return status_t::running;
+    }
+    if( n->get_attitude() == NPCATT_FLEE_TEMP ) {
+        return status_t::running;
+    }
+    return status_t::failure;
+}
+
+status_t character_oracle_t::has_target( std::string_view ) const
+{
+    const npc *n = dynamic_cast<const npc *>( subject );
+    if( !n ) {
+        return status_t::failure;
+    }
+    return n->get_ai_target().lock() ? status_t::running : status_t::failure;
+}
+
+status_t character_oracle_t::has_sound_alerts( std::string_view ) const
+{
+    const npc *n = dynamic_cast<const npc *>( subject );
+    if( !n ) {
+        return status_t::failure;
+    }
+    // Mirror the live cascade gates in npc::move() sound investigation:
+    // companions don't investigate, immobile NPCs can't investigate,
+    // IGNORE_SOUND NPCs treat sounds as non-actionable.
+    if( n->is_walking_with() || n->has_flag( json_flag_CANNOT_MOVE ) ||
+        n->has_trait( trait_IGNORE_SOUND ) ) {
+        return status_t::failure;
+    }
+    return n->has_ai_sound_alerts() ? status_t::running : status_t::failure;
+}
+
+status_t character_oracle_t::displaced_from_post( std::string_view ) const
+{
+    const npc *n = dynamic_cast<const npc *>( subject );
+    if( !n ) {
+        return status_t::failure;
+    }
+    if( n->has_flag( json_flag_CANNOT_MOVE ) ) {
+        return status_t::failure;
+    }
+    std::optional<tripoint_abs_ms> gp = n->get_effective_guard_pos();
+    if( !gp ) {
+        return status_t::failure;
+    }
+    return n->pos_abs() != *gp ? status_t::running : status_t::failure;
+}
+
+float character_oracle_t::duty_urgency( std::string_view ) const
+{
+    const npc *n = dynamic_cast<const npc *>( subject );
+    if( !n ) {
+        return 0.0f;
+    }
+    std::optional<tripoint_abs_ms> gp = n->get_effective_guard_pos();
+    if( !gp || n->pos_abs() == *gp ) {
+        return 0.0f;
+    }
+    return 0.5f;
 }
 
 } // namespace behavior

--- a/src/character_oracle.h
+++ b/src/character_oracle.h
@@ -32,12 +32,21 @@ class character_oracle_t : public oracle_t
         status_t needs_sleep_badly( std::string_view ) const;
         status_t can_sleep( std::string_view ) const;
         /**
+         * Top-level decision predicates (NPC-specific via dynamic_cast).
+         */
+        status_t in_danger( std::string_view ) const;
+        status_t should_flee( std::string_view ) const;
+        status_t has_target( std::string_view ) const;
+        status_t has_sound_alerts( std::string_view ) const;
+        status_t displaced_from_post( std::string_view ) const;
+        /**
          * Score predicates for utility strategy (return 0-1 urgency).
          */
         float thirst_urgency( std::string_view ) const;
         float hunger_urgency( std::string_view ) const;
         float warmth_urgency( std::string_view ) const;
         float sleepiness_urgency( std::string_view ) const;
+        float duty_urgency( std::string_view ) const;
     private:
         const Character *subject;
 };

--- a/src/npc.h
+++ b/src/npc.h
@@ -1366,6 +1366,31 @@ class npc : public Character
             return ai_cache.current_attack_evaluation;
         }
 
+        // Accessors for BT oracle predicates (character_oracle_t)
+        float get_ai_danger() const {
+            return ai_cache.danger;
+        }
+        weak_ptr_fast<Creature> get_ai_target() const {
+            return ai_cache.target;
+        }
+        bool has_ai_sound_alerts() const {
+            return !ai_cache.sound_alerts.empty();
+        }
+        std::optional<tripoint_abs_ms> get_ai_guard_pos() const {
+            return ai_cache.guard_pos;
+        }
+        // Effective guard position: ai_cache (ephemeral, from sound investigation)
+        // falls back to persistent guard_pos (from mission/dialogue assignment).
+        std::optional<tripoint_abs_ms> get_effective_guard_pos() const {
+            if( ai_cache.guard_pos ) {
+                return ai_cache.guard_pos;
+            }
+            return guard_pos;
+        }
+        void push_ai_sound_alert( const tripoint_abs_ms &pos, sounds::sound_t type, int vol ) {
+            ai_cache.sound_alerts.push_back( { pos, type, vol } );
+        }
+
         // Where we last saw the player
         std::optional<tripoint_abs_ms> last_player_seen_pos;
         // Player orders a friendly NPC to move to this position

--- a/src/npc_decision_category.h
+++ b/src/npc_decision_category.h
@@ -1,0 +1,18 @@
+#pragma once
+#ifndef CATA_SRC_NPC_DECISION_CATEGORY_H
+#define CATA_SRC_NPC_DECISION_CATEGORY_H
+
+#include <string>
+
+// Decision categories for BT/cascade convergence diagnostic.
+// Used by the top-level npc_decision behavior tree to compare
+// BT goal selection against the legacy npc::move() cascade.
+enum class decision_category : int {
+    combat, investigate, needs, duty, idle, unmodeled
+};
+
+const char *category_name( decision_category cat );
+decision_category bt_goal_to_category( const std::string &goal );
+const char *classify_comparison( decision_category bt, decision_category cascade );
+
+#endif // CATA_SRC_NPC_DECISION_CATEGORY_H

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -80,6 +80,7 @@
 #include "mtype.h"
 #include "npc.h"
 #include "npc_attack.h"
+#include "npc_decision_category.h"
 #include "npc_opinion.h"
 #include "npctalk.h"
 #include "omdata.h"
@@ -194,6 +195,7 @@ static const npc_class_id NC_EVAC_SHOPKEEP( "NC_EVAC_SHOPKEEP" );
 
 static const skill_id skill_firstaid( "firstaid" );
 
+static const string_id<behavior::node_t> behavior_node_t_npc_decision( "npc_decision" );
 static const string_id<behavior::node_t> behavior_node_t_npc_needs( "npc_needs" );
 
 static const trait_id trait_IGNORE_SOUND( "IGNORE_SOUND" );
@@ -241,6 +243,80 @@ enum npc_action : int {
     npc_worker_downtime,
     num_npc_actions
 };
+
+const char *category_name( decision_category cat )
+{
+    switch( cat ) {
+        case decision_category::combat:
+            return "combat";
+        case decision_category::investigate:
+            return "investigate";
+        case decision_category::needs:
+            return "needs";
+        case decision_category::duty:
+            return "duty";
+        case decision_category::idle:
+            return "idle";
+        case decision_category::unmodeled:
+            return "unmodeled";
+    }
+    return "unmodeled";
+}
+
+decision_category bt_goal_to_category( const std::string &goal )
+{
+    if( goal == "fight" || goal == "flee" ) {
+        return decision_category::combat;
+    }
+    if( goal == "investigate_sound" ) {
+        return decision_category::investigate;
+    }
+    if( goal == "drink_water" || goal == "eat_food" || goal == "go_to_sleep" ||
+        goal == "wear_warmer_clothes" || goal == "take_shelter" || goal == "start_fire" ) {
+        return decision_category::needs;
+    }
+    if( goal == "return_to_guard_pos" ) {
+        return decision_category::duty;
+    }
+    if( goal == "idle" ) {
+        return decision_category::idle;
+    }
+    return decision_category::unmodeled;
+}
+
+const char *classify_comparison( decision_category bt, decision_category cascade )
+{
+    if( bt == decision_category::unmodeled || cascade == decision_category::unmodeled ) {
+        return "unmodeled";
+    }
+    return bt == cascade ? "converged" : "DIVERGED";
+}
+
+static decision_category cascade_action_to_category( npc_action action )
+{
+    switch( action ) {
+        case npc_melee:
+        case npc_shoot:
+        case npc_do_attack:
+        case npc_reach_attack:
+        case npc_aim:
+        case npc_flee:
+        case npc_avoid_friendly_fire:
+            return decision_category::combat;
+        case npc_investigate_sound:
+            return decision_category::investigate;
+        case npc_sleep:
+            return decision_category::needs;
+        case npc_return_to_guard_pos:
+            return decision_category::duty;
+        case npc_undecided:
+        case npc_pause:
+            return decision_category::idle;
+        default:
+            return decision_category::unmodeled;
+    }
+}
+
 
 namespace
 {
@@ -1451,6 +1527,19 @@ void npc::move()
         }
     }
 
+    // Top-level decision BT: evaluate before side-effecting cascade for convergence
+    // diagnostic. Placed after regen_ai_cache, act_on_danger_assessment, and
+    // guaranteed_hostile attitude mutation so the oracle sees final state.
+    std::string bt_decision_goal;
+    decision_category bt_decision_cat = decision_category::unmodeled;
+    if( debug_mode && debugmode::enabled_filters.count( debugmode::DF_NPC_NEEDS ) ) {
+        behavior::character_oracle_t decision_oracle( this );
+        behavior::tree decision_tree;
+        decision_tree.add( &behavior_node_t_npc_decision.obj() );
+        bt_decision_goal = decision_tree.tick( &decision_oracle );
+        bt_decision_cat = bt_goal_to_category( bt_decision_goal );
+    }
+
     /* This bypasses the logic to determine the npc action, but this all needs to be rewritten
      * anyway.
      * NPC won't avoid dangerous terrain while accompanying the player inside a vehicle to keep
@@ -1676,6 +1765,17 @@ void npc::move()
     }
 
     add_msg_debug( debugmode::DF_NPC, "%s chose action %s.", get_name(), npc_action_name( action ) );
+
+    if( !bt_decision_goal.empty() ) {
+        decision_category cascade_cat = cascade_action_to_category( action );
+        add_msg_debug( debugmode::DF_NPC_NEEDS,
+                       "NPC %s: BT=%s(%s) cascade=%s(%s) %s",
+                       get_name(),
+                       category_name( bt_decision_cat ), bt_decision_goal,
+                       category_name( cascade_cat ), npc_action_name( action ),
+                       classify_comparison( bt_decision_cat, cascade_cat ) );
+    }
+
     execute_action( action );
 }
 

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -629,7 +629,7 @@ void sounds::process_sound_markers( Character *you )
         // Secure the flag before wake_up() clears the effect
         bool slept_through = you->has_effect( effect_slept_through_alarm );
         // See if we need to wake someone up
-        if( you->has_effect( effect_sleep ) ) {
+        if( you->in_sleep_state() ) {
             if( ( ( !( you->has_trait( trait_HEAVYSLEEPER ) ||
                        you->has_trait( trait_HEAVYSLEEPER2 ) ) && dice( 2, 15 ) < heard_volume ) ||
                   ( you->has_trait( trait_HEAVYSLEEPER ) && dice( 3, 15 ) < heard_volume ) ||

--- a/tests/behavior_test.cpp
+++ b/tests/behavior_test.cpp
@@ -1,6 +1,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <tuple>
@@ -13,10 +14,14 @@
 #include "bodypart.h"
 #include "calendar.h"
 #include "cata_catch.h"
+#include "character.h"
 #include "character_attire.h"
 #include "character_oracle.h"
 #include "coordinates.h"
+#include "creature.h"
+#include "npc_decision_category.h"
 #include "flexbuffer_json.h"
+#include "game.h"
 #include "item.h"
 #include "json_loader.h"
 #include "item_group.h"
@@ -35,12 +40,16 @@
 #include "player_helpers.h"
 #include "pocket_type.h"
 #include "point.h"
+#include "sounds.h"
 #include "type_id.h"
 #include "units.h"
 #include "weather.h"
 #include "weighted_list.h"
 
 static const efftype_id effect_meth( "meth" );
+static const efftype_id effect_npc_run_away( "npc_run_away" );
+
+static const faction_id faction_your_followers( "your_followers" );
 
 static const item_group_id Item_spawn_data_test_bottle_water( "test_bottle_water" );
 
@@ -54,13 +63,18 @@ static const itype_id itype_sandwich_cheese_grilled( "sandwich_cheese_grilled" )
 static const itype_id itype_sweater( "sweater" );
 static const itype_id itype_water_clean( "water_clean" );
 
+static const mtype_id mon_zombie( "mon_zombie" );
+
 static const nested_mapgen_id nested_mapgen_test_seedling( "test_seedling" );
 
+static const string_id<behavior::node_t> behavior_node_t_npc_decision( "npc_decision" );
 static const string_id<behavior::node_t> behavior_node_t_npc_needs( "npc_needs" );
 
 static const ter_str_id ter_t_floor( "t_floor" );
 static const ter_str_id ter_t_ponywall( "t_ponywall" );
 static const ter_str_id ter_t_wall( "t_wall" );
+
+static const trait_id trait_IGNORE_SOUND( "IGNORE_SOUND" );
 
 namespace behavior
 {
@@ -899,4 +913,302 @@ TEST_CASE( "npc_urgency_score_predicates", "[npc][behavior]" )
     SECTION( "predicates registered in predicate_map" ) {
         CHECK( behavior::predicate_map.count( "npc_needs_sleep_badly" ) == 1 );
     }
+}
+
+TEST_CASE( "npc_decision_combat_predicates", "[npc][behavior]" )
+{
+    clear_map();
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy );
+    // Allied faction ensures assess_danger considers zombies as threats,
+    // matching npc_attack_test setup.
+    guy.set_fac( faction_your_followers );
+    behavior::character_oracle_t oracle( &guy );
+
+    SECTION( "in_danger running with hostile creature nearby" ) {
+        map &here = get_map();
+        // Player underground so they don't interfere with NPC threat assessment
+        get_player_character().setpos( here, guy.pos_bub() + tripoint( 0, 0, -2 ) );
+        monster *zed = g->place_critter_at( mon_zombie,
+                                            guy.pos_bub() + point::east );
+        REQUIRE( zed != nullptr );
+        REQUIRE( zed->attitude_to( guy ) == Creature::Attitude::HOSTILE );
+        guy.recalc_sight_limits();
+        REQUIRE( guy.sees( here, *zed ) );
+        guy.regen_ai_cache();
+        REQUIRE( guy.get_ai_danger() > 0 );
+        CHECK( oracle.in_danger( "" ) == behavior::status_t::running );
+    }
+    SECTION( "in_danger failure when no danger" ) {
+        guy.recalc_sight_limits();
+        guy.regen_ai_cache();
+        CHECK( oracle.in_danger( "" ) == behavior::status_t::failure );
+    }
+    SECTION( "should_flee running with run_away effect" ) {
+        guy.add_effect( effect_npc_run_away, 10_turns );
+        CHECK( oracle.should_flee( "" ) == behavior::status_t::running );
+    }
+    SECTION( "should_flee running with FLEE_TEMP attitude" ) {
+        guy.set_attitude( NPCATT_FLEE_TEMP );
+        CHECK( oracle.should_flee( "" ) == behavior::status_t::running );
+    }
+    SECTION( "should_flee failure without effect or attitude" ) {
+        CHECK( oracle.should_flee( "" ) == behavior::status_t::failure );
+    }
+    SECTION( "has_target running with hostile creature" ) {
+        map &here = get_map();
+        get_player_character().setpos( here, guy.pos_bub() + tripoint( 0, 0, -2 ) );
+        monster *zed = g->place_critter_at( mon_zombie,
+                                            guy.pos_bub() + point::east );
+        REQUIRE( zed != nullptr );
+        guy.recalc_sight_limits();
+        REQUIRE( guy.sees( here, *zed ) );
+        guy.regen_ai_cache();
+        REQUIRE( guy.get_ai_danger() > 0 );
+        CHECK( oracle.has_target( "" ) == behavior::status_t::running );
+    }
+    SECTION( "has_target failure when no target" ) {
+        guy.recalc_sight_limits();
+        guy.regen_ai_cache();
+        CHECK( oracle.has_target( "" ) == behavior::status_t::failure );
+    }
+    SECTION( "has_sound_alerts failure when quiet" ) {
+        CHECK( oracle.has_sound_alerts( "" ) == behavior::status_t::failure );
+    }
+}
+
+TEST_CASE( "npc_decision_sound_alert_predicates", "[npc][behavior]" )
+{
+    clear_map();
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy );
+    behavior::character_oracle_t oracle( &guy );
+
+    SECTION( "has_sound_alerts running when alerts present" ) {
+        guy.push_ai_sound_alert( guy.pos_abs() + tripoint( 10, 0, 0 ),
+                                 sounds::sound_t::combat, 20 );
+        CHECK( oracle.has_sound_alerts( "" ) == behavior::status_t::running );
+    }
+    SECTION( "has_sound_alerts suppressed for walking companion" ) {
+        guy.set_attitude( NPCATT_FOLLOW );
+        REQUIRE( guy.is_walking_with() );
+        guy.push_ai_sound_alert( guy.pos_abs() + tripoint( 10, 0, 0 ),
+                                 sounds::sound_t::combat, 20 );
+        CHECK( oracle.has_sound_alerts( "" ) == behavior::status_t::failure );
+    }
+    SECTION( "has_sound_alerts suppressed for IGNORE_SOUND trait" ) {
+        guy.set_mutation( trait_IGNORE_SOUND );
+        REQUIRE( guy.has_trait( trait_IGNORE_SOUND ) );
+        guy.push_ai_sound_alert( guy.pos_abs() + tripoint( 10, 0, 0 ),
+                                 sounds::sound_t::combat, 20 );
+        CHECK( oracle.has_sound_alerts( "" ) == behavior::status_t::failure );
+    }
+}
+
+TEST_CASE( "npc_decision_duty_predicates", "[npc][behavior]" )
+{
+    clear_map_without_vision();
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy );
+    behavior::character_oracle_t oracle( &guy );
+
+    SECTION( "displaced running when guard_pos set elsewhere" ) {
+        guy.set_guard_pos( guy.pos_abs() + tripoint( 10, 0, 0 ) );
+        CHECK( oracle.displaced_from_post( "" ) == behavior::status_t::running );
+    }
+    SECTION( "displaced failure when no guard_pos" ) {
+        CHECK( oracle.displaced_from_post( "" ) == behavior::status_t::failure );
+    }
+    SECTION( "displaced failure when at guard_pos" ) {
+        guy.set_guard_pos( guy.pos_abs() );
+        CHECK( oracle.displaced_from_post( "" ) == behavior::status_t::failure );
+    }
+    SECTION( "displaced detects persistent guard_pos from mission" ) {
+        // Refugee Center guards have npc::guard_pos set by dialogue,
+        // not ai_cache.guard_pos. The predicate must check both.
+        guy.guard_pos = guy.pos_abs() + tripoint( 10, 0, 0 );
+        CHECK( oracle.displaced_from_post( "" ) == behavior::status_t::running );
+    }
+    SECTION( "duty_urgency zero without post" ) {
+        CHECK( oracle.duty_urgency( "" ) == Approx( 0.0f ) );
+    }
+    SECTION( "duty_urgency nonzero when displaced" ) {
+        guy.set_guard_pos( guy.pos_abs() + tripoint( 5, 0, 0 ) );
+        CHECK( oracle.duty_urgency( "" ) > 0.0f );
+    }
+}
+
+TEST_CASE( "npc_decision_tree_priorities", "[npc][behavior]" )
+{
+    clear_map();
+    behavior::tree npc_decision;
+    npc_decision.add( &behavior_node_t_npc_decision.obj() );
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy );
+    guy.set_fac( faction_your_followers );
+    behavior::character_oracle_t oracle( &guy );
+
+    SECTION( "combat beats any need" ) {
+        map &here = get_map();
+        get_player_character().setpos( here, guy.pos_bub() + tripoint( 0, 0, -2 ) );
+        monster *zed = g->place_critter_at( mon_zombie,
+                                            guy.pos_bub() + point::east );
+        REQUIRE( zed != nullptr );
+        guy.recalc_sight_limits();
+        guy.regen_ai_cache();
+        REQUIRE( guy.get_ai_danger() > 0 );
+        guy.set_stored_kcal( 1000 );
+        guy.set_hunger( 500 );
+        guy.i_add( item( itype_sandwich_cheese_grilled ) );
+        REQUIRE( oracle.needs_food_badly( "" ) == behavior::status_t::running );
+        CHECK( npc_decision.tick( &oracle ) == "fight" );
+    }
+    SECTION( "flee beats fight" ) {
+        map &here = get_map();
+        get_player_character().setpos( here, guy.pos_bub() + tripoint( 0, 0, -2 ) );
+        monster *zed = g->place_critter_at( mon_zombie,
+                                            guy.pos_bub() + point::east );
+        REQUIRE( zed != nullptr );
+        guy.recalc_sight_limits();
+        guy.regen_ai_cache();
+        REQUIRE( guy.get_ai_danger() > 0 );
+        guy.add_effect( effect_npc_run_away, 10_turns );
+        CHECK( npc_decision.tick( &oracle ) == "flee" );
+    }
+    SECTION( "investigation beats needs" ) {
+        guy.push_ai_sound_alert( guy.pos_abs() + tripoint( 10, 0, 0 ),
+                                 sounds::sound_t::combat, 20 );
+        REQUIRE( oracle.has_sound_alerts( "" ) == behavior::status_t::running );
+        guy.set_stored_kcal( 1000 );
+        guy.set_hunger( 500 );
+        guy.i_add( item( itype_sandwich_cheese_grilled ) );
+        REQUIRE( oracle.needs_food_badly( "" ) == behavior::status_t::running );
+        CHECK( npc_decision.tick( &oracle ) == "investigate_sound" );
+    }
+    SECTION( "feasible extreme need beats duty" ) {
+        guy.set_thirst( 1000 );
+        const item_group::ItemList water = item_group::items_from(
+                                               Item_spawn_data_test_bottle_water );
+        guy.i_add( water.front() );
+        REQUIRE( oracle.needs_water_badly( "" ) == behavior::status_t::running );
+        REQUIRE( oracle.has_water( "" ) == behavior::status_t::running );
+        guy.set_guard_pos( guy.pos_abs() + tripoint( 10, 0, 0 ) );
+        REQUIRE( oracle.thirst_urgency( "" ) > oracle.duty_urgency( "" ) );
+        CHECK( npc_decision.tick( &oracle ) == "drink_water" );
+    }
+    SECTION( "infeasible need does not inflate score over duty" ) {
+        // Sleepiness 800 -> urgency 0.8, but on meth -> can_sleep fails.
+        // Thirst 200 -> below needs_water_badly threshold -> not running.
+        // No feasible need runs, so duty should win.
+        guy.set_sleepiness( 800 );
+        guy.add_effect( effect_meth, 1_hours );
+        guy.set_thirst( 200 );
+        guy.set_guard_pos( guy.pos_abs() + tripoint( 10, 0, 0 ) );
+        REQUIRE( oracle.needs_sleep_badly( "" ) == behavior::status_t::running );
+        REQUIRE( oracle.can_sleep( "" ) == behavior::status_t::failure );
+        CHECK( npc_decision.tick( &oracle ) == "return_to_guard_pos" );
+    }
+    SECTION( "duty wins when needs are below threshold" ) {
+        guy.set_thirst( 200 );
+        guy.set_guard_pos( guy.pos_abs() + tripoint( 10, 0, 0 ) );
+        CHECK( npc_decision.tick( &oracle ) == "return_to_guard_pos" );
+    }
+    SECTION( "exhausted guard sleeps over duty" ) {
+        // sleepiness 600 -> urgency 0.6 > duty 0.5. Policy: exhaustion
+        // is dangerous (microsleeps), guard should sleep.
+        guy.set_sleepiness( 600 );
+        REQUIRE( oracle.needs_sleep_badly( "" ) == behavior::status_t::running );
+        REQUIRE( oracle.can_sleep( "" ) == behavior::status_t::running );
+        guy.set_guard_pos( guy.pos_abs() + tripoint( 10, 0, 0 ) );
+        CHECK( npc_decision.tick( &oracle ) == "go_to_sleep" );
+    }
+    SECTION( "tired but not exhausted guard stays on duty" ) {
+        // sleepiness 400 -> needs_sleep_badly running, but can_sleep fails
+        // (EXHAUSTED=575). No feasible sleep -> duty wins.
+        guy.set_sleepiness( 400 );
+        REQUIRE( oracle.needs_sleep_badly( "" ) == behavior::status_t::running );
+        REQUIRE( oracle.can_sleep( "" ) == behavior::status_t::failure );
+        guy.set_guard_pos( guy.pos_abs() + tripoint( 10, 0, 0 ) );
+        CHECK( npc_decision.tick( &oracle ) == "return_to_guard_pos" );
+    }
+    SECTION( "idle when nothing fires" ) {
+        CHECK( npc_decision.tick( &oracle ) == "idle" );
+    }
+}
+
+TEST_CASE( "npc_decision_category_mapping", "[npc][behavior]" )
+{
+    SECTION( "bt goals map to expected categories" ) {
+        CHECK( bt_goal_to_category( "fight" ) == decision_category::combat );
+        CHECK( bt_goal_to_category( "flee" ) == decision_category::combat );
+        CHECK( bt_goal_to_category( "investigate_sound" ) == decision_category::investigate );
+        CHECK( bt_goal_to_category( "drink_water" ) == decision_category::needs );
+        CHECK( bt_goal_to_category( "eat_food" ) == decision_category::needs );
+        CHECK( bt_goal_to_category( "go_to_sleep" ) == decision_category::needs );
+        CHECK( bt_goal_to_category( "wear_warmer_clothes" ) == decision_category::needs );
+        CHECK( bt_goal_to_category( "take_shelter" ) == decision_category::needs );
+        CHECK( bt_goal_to_category( "start_fire" ) == decision_category::needs );
+        CHECK( bt_goal_to_category( "return_to_guard_pos" ) == decision_category::duty );
+        CHECK( bt_goal_to_category( "idle" ) == decision_category::idle );
+        CHECK( bt_goal_to_category( "something_unknown" ) == decision_category::unmodeled );
+    }
+    SECTION( "tri-state outcome classification" ) {
+        using dc = decision_category;
+        CHECK( std::string( classify_comparison( dc::combat, dc::combat ) ) == "converged" );
+        CHECK( std::string( classify_comparison( dc::needs, dc::duty ) ) == "DIVERGED" );
+        CHECK( std::string( classify_comparison( dc::needs, dc::unmodeled ) ) == "unmodeled" );
+        CHECK( std::string( classify_comparison( dc::unmodeled, dc::combat ) ) == "unmodeled" );
+        CHECK( std::string( classify_comparison( dc::unmodeled, dc::unmodeled ) ) == "unmodeled" );
+        CHECK( std::string( classify_comparison( dc::idle, dc::idle ) ) == "converged" );
+        CHECK( std::string( classify_comparison( dc::duty, dc::needs ) ) == "DIVERGED" );
+    }
+}
+
+TEST_CASE( "npc_decision_bt_contract_guard_duty", "[npc][behavior]" )
+{
+    clear_map();
+    behavior::tree npc_decision;
+    npc_decision.add( &behavior_node_t_npc_decision.obj() );
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy );
+    guy.set_fac( faction_your_followers );
+    guy.set_mission( NPC_MISSION_GUARD );
+    behavior::character_oracle_t oracle( &guy );
+
+    SECTION( "displaced guard with mild hunger: BT chooses duty" ) {
+        guy.set_guard_pos( guy.pos_abs() + tripoint( 10, 0, 0 ) );
+        guy.set_hunger( 100 );
+        CHECK( npc_decision.tick( &oracle ) == "return_to_guard_pos" );
+    }
+    SECTION( "displaced guard with extreme thirst and water: BT chooses need" ) {
+        guy.set_guard_pos( guy.pos_abs() + tripoint( 10, 0, 0 ) );
+        guy.set_thirst( 1000 );
+        const item_group::ItemList water = item_group::items_from(
+                                               Item_spawn_data_test_bottle_water );
+        guy.i_add( water.front() );
+        REQUIRE( oracle.needs_water_badly( "" ) == behavior::status_t::running );
+        REQUIRE( oracle.has_water( "" ) == behavior::status_t::running );
+        CHECK( npc_decision.tick( &oracle ) == "drink_water" );
+    }
+    SECTION( "displaced exhausted guard: BT chooses sleep over duty" ) {
+        guy.set_guard_pos( guy.pos_abs() + tripoint( 10, 0, 0 ) );
+        guy.set_sleepiness( 600 );
+        REQUIRE( oracle.needs_sleep_badly( "" ) == behavior::status_t::running );
+        REQUIRE( oracle.can_sleep( "" ) == behavior::status_t::running );
+        CHECK( npc_decision.tick( &oracle ) == "go_to_sleep" );
+    }
+    SECTION( "guard at post with no needs: BT returns idle" ) {
+        guy.set_guard_pos( guy.pos_abs() );
+        CHECK( npc_decision.tick( &oracle ) == "idle" );
+    }
+}
+
+TEST_CASE( "npc_decision_predicates_registered", "[npc][behavior]" )
+{
+    CHECK( behavior::predicate_map.count( "npc_in_danger" ) == 1 );
+    CHECK( behavior::predicate_map.count( "npc_should_flee" ) == 1 );
+    CHECK( behavior::predicate_map.count( "npc_has_target" ) == 1 );
+    CHECK( behavior::predicate_map.count( "npc_has_sound_alerts" ) == 1 );
+    CHECK( behavior::predicate_map.count( "npc_displaced_from_post" ) == 1 );
+    CHECK( behavior::score_predicate_map.count( "npc_duty_urgency" ) == 1 );
 }


### PR DESCRIPTION
#### Summary
Infrastructure "Add top-level NPC decision behavior tree as convergence diagnostic"

#### Purpose of change

The NPC needs BT (#85927-#86052) wired food/water/sleep/warmth actions into `address_needs()`, which fires before the guard-return check in `npc::move()`. Guards now leave their posts to eat and sleep. The root cause: needs and duty live in separate systems that can't negotiate priority.

This PR adds a top-level decision BT that covers combat, investigation, needs, and duty as competing goals. It evaluates alongside the legacy cascade each turn and logs a symmetric category comparison -- no behavior changes yet.

Depends on #86052.

Related to #28681.

#### Describe the solution

`npc_decision` tree: `fallback(combat, investigate, utility(needs, duty))`.

Combat and investigation have strict priority via fallback -- if danger or sound alerts are present, those always win. Below that, needs and duty compete via utility scoring. The existing `npc_needs` subtree (warmth/thirst/hunger/sleep) participates with child scores bubbling up naturally -- no parent score override, so infeasible needs (e.g. sleepiness blocked by meth) don't inflate urgency. `duty_urgency` is a flat 0.5 when the NPC is displaced from their guard post, meaning extreme needs beat duty but mild needs don't.

Five new oracle predicates: `in_danger`, `should_flee` (checks both run_away effect and FLEE_TEMP attitude), `has_target`, `has_sound_alerts` (suppressed for companions, immobile NPCs, and IGNORE_SOUND), `displaced_from_post` (checks both ephemeral `ai_cache.guard_pos` and persistent `npc::guard_pos`, suppressed when CANNOT_MOVE). One new score: `duty_urgency`.

Diagnostic logging under `DF_NPC_NEEDS`: evaluates BT after state normalization (danger assessment + attitude mutation) but before any side-effecting action selection, then compares against cascade outcome via symmetric category mapping. Three-state result: converged, DIVERGED, or unmodeled (when either side maps to an action the comparison can't classify).

Social branch dropped from first pass -- `address_player()` depends on visibility, distance, patience, and can return 5+ different actions. Too noisy for trustworthy diagnostic.

#### Describe alternatives you've considered

Could have patched `address_needs()` with `is_guarding()` checks to prevent guards from eating/sleeping. But that's another special case on a system already buckling under special cases -- followers, patrollers, and camp workers would each need their own gate. The BT approach lets all these roles compete via scoring instead.

Could have used utility at the root (combat competes with needs by score), but combat should always win when present. Fallback at root preserves that guarantee while utility handles the needs-vs-duty negotiation where scoring actually matters.

#### Testing

7 test cases, 354 total assertions across `[npc][behavior]`. Combat predicates tested with hostile zombies via `regen_ai_cache()`. Sound alert predicates tested via direct push (handle_sound has too many interacting filters for reliable unit tests). Duty predicates tested with both `set_guard_pos` and persistent `guard_pos`. Tree priority tests cover: combat beats needs, flee beats fight, investigation beats needs, feasible extreme need beats duty, infeasible need doesn't inflate over duty, duty beats mild needs, exhausted guard sleeps (intended policy -- microsleeps degrade combat), tired-but-not-exhausted guard stays on duty. Category mapping and tri-state classification tested directly. Guard contract tests in realistic mission-assigned NPC scenarios.

Gameplay-tested at Refugee Center: combat convergence confirmed, guard duty divergence from address_needs regression identified and logged correctly.

#### Additional context

The persistent vs ephemeral `guard_pos` split was discovered during gameplay testing -- Refugee Center guards have `npc::guard_pos` set by dialogue, not `ai_cache.guard_pos`. The predicate now checks both via `get_effective_guard_pos()`.