### PR TITLE
Avoid creating curses windows for hidden ImGui windows

### DIFF
--- a/src/third-party/imtui/imtui-impl-ncurses.cpp
+++ b/src/third-party/imtui/imtui-impl-ncurses.cpp
@@ -397,7 +397,7 @@ void create_destroy_curses_windows( std::vector<WINDOW *> &windows )
     int imguiWinIdx = 0;
     for( ; imguiWinIdx < GImGui->Windows.Size; imguiWinIdx++ ) {
         ImGuiWindow *imwin = GImGui->Windows[imguiWinIdx];
-        if( imwin->Collapsed || !imwin->Active ) {
+        if( imwin->Collapsed || !imwin->Active || imwin->Hidden ) {
             continue;
         }
         if( windows.size() <= cursesWinIdx ) {
@@ -439,6 +439,7 @@ void ImTui_ImplNcurses_DrawScreen( bool active )
     for( WINDOW *cursesWin : rd->imtui_wins ) {
         int nx = g_screen.nx;
         int ny = g_screen.ny;
+        bool any_content = false;
 
         for( int y = getbegy( cursesWin ); y <= ( getbegy( cursesWin ) + getmaxy( cursesWin ) ); ++y ) {
             constexpr int no_lastp = 0x7FFFFFFF;
@@ -463,6 +464,9 @@ void ImTui_ImplNcurses_DrawScreen( bool active )
                 strTmp[0] = cell.ch;
                 waddwstr( cursesWin, strTmp );
 
+                if( cell.ch != 0 ) {
+                    any_content = true;
+                }
                 if( cell.chwidth > 1 ) {
                     x += ( cell.chwidth - 1 );
                 }
@@ -472,7 +476,9 @@ void ImTui_ImplNcurses_DrawScreen( bool active )
             }
         }
 
-        wnoutrefresh( cursesWin );
+        if( any_content ) {
+            wnoutrefresh( cursesWin );
+        }
     }
 
 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Avoid creating curses windows for hidden ImGui windows"

#### Purpose of change
Full disclosure: The fix and the analysis is from Claude (AI).

The curses interface has a bug where the close dialog creates an extra 4x4 blank space nearby. It seems to be sensitive to terminal size and it may not happen at all with a smaller window. The blank square doesn't appear every time but around 80% of the time.

This bugfix prevents the blank window creation. Likely related to #82161 and #82239.

Play area without the dialog open:
![cataclysm-map-clear](https://github.com/user-attachments/assets/a2172355-5b11-49ea-ba09-c5e098d1ef2e)

Dialog open, exhibiting the 4x4 blank square:
![cataclysm-close-dialog-bug](https://github.com/user-attachments/assets/8c40eb5e-2141-4d9a-ae08-c4e49d2b818b)


#### Describe the solution
The bug is due to the ncurses adapter creating windows for hidden ImGui window. This adds `imwin-Hidden` to a check for skipping an ImGui window in a loop.

As an additional guard, this patch will skip `wnoutrefresh` for empty windows.

#### Describe alternatives you've considered
Not fixing the bug.


#### Testing
I opened the quit dialog several times and the blank square didn't show up anymore.

#### Additional context
Full analysis from Claude:

## The Causal Chain (verified end-to-end)

### Step 1: ImGui's render pass skips Hidden windows

`ImGui::Render()` calls `AddRootWindowToDrawData()` only for windows passing `IsWindowActiveAndVisible()`, defined as:

```cpp
// imgui.cpp:4991
return (window->Active) && (!window->Hidden);
```

Hidden windows produce **zero** draw commands.

### Step 2: ImTui's text rasterizer clears the screen and writes only visible content

```cpp
// imtui-impl-text.cpp:158-159
screen.resize(displayw, displayh);
screen.clear();              // memset(data, 0, nx*ny*sizeof(TCell))
```

Then it iterates `drawData->CmdLists` and rasterizes text + triangles into `g_screen`. Regions belonging to Hidden windows stay zeroed (`ch=0, fg=0, bg=0`).

### Step 3: The ncurses adapter creates curses windows for Hidden ImGui windows (THE BUG)

```cpp
// imtui-impl-ncurses.cpp:400
if( imwin->Collapsed || !imwin->Active ) {
    continue;                 // ← Missing: || imwin->Hidden
}
```

This creates a curses WINDOW via `newwin()` for every Active, non-Collapsed ImGui window, **including Hidden ones**. The predicate disagrees with `IsWindowActiveAndVisible()`.

### Step 4: DrawScreen blits zeroed TScreen cells to the curses window — which does nothing

```cpp
strTmp[0] = cell.ch;         // cell.ch == 0 (NUL)
waddwstr( cursesWin, strTmp );  // L"\0" → empty string → cursor doesn't advance
```

`waddwstr` with a NUL-terminated empty wide string writes nothing. The curses window retains its `newwin()` default content: **space characters**.

### Step 5: wnoutrefresh marks the space-filled window for display

```cpp
wnoutrefresh( cursesWin );    // Marks the space-filled region for terminal update
```

When `doupdate()` eventually runs, this region overwrites whatever the game map had drawn there. Result: a blank rectangle of spaces.

### Step 6: Why only during the quit dialog?

During normal gameplay, no ImGui windows are Active — `GImGui->Windows` contains only deactivated entries. `create_destroy_curses_windows` creates zero curses windows. No overwrite occurs.

When the quit dialog opens (`query_popup` → `cataimgui::window`), it activates the ImGui subsystem. ImGui internally creates supporting windows (tooltip containers, nav overlays, popup backdrops) which may be `Active=true` but
`Hidden=true` (they exist but have nothing to display). These get spurious curses windows.

### Step 7: Why ~80% and not 100%?

The `Hidden` flag depends on frame-countdown fields:
```cpp
// imgui.cpp:7744-7745
bool hidden_regular = (window->HiddenFramesCanSkipItems > 0)
                   || (window->HiddenFramesCannotSkipItems > 0);
window->Hidden = hidden_regular || (window->HiddenFramesForRenderOnly > 0);
```

These counters decrement each frame. Whether a particular internal ImGui window is in the `Active && Hidden` state at the moment of `ImGui::Render()` depends on the exact frame at which the quit dialog was opened. Some frames catch the transient state; others don't.

---

## The Fix

### Primary: align the predicate (one-line change)

```diff
--- a/src/third-party/imtui/imtui-impl-ncurses.cpp
+++ b/src/third-party/imtui/imtui-impl-ncurses.cpp
@@ -397,7 +397,7 @@ void create_destroy_curses_windows( std::vector<WINDOW *> &windows )
     for( ; imguiWinIdx < GImGui->Windows.Size; imguiWinIdx++ ) {
         ImGuiWindow *imwin = GImGui->Windows[imguiWinIdx];
-        if( imwin->Collapsed || !imwin->Active ) {
+        if( imwin->Collapsed || !imwin->Active || imwin->Hidden ) {
             continue;
         }
```

This makes `create_destroy_curses_windows` consistent with `IsWindowActiveAndVisible()` and `any_window_shown()`.

### Defense-in-depth: skip wnoutrefresh for empty windows

```diff
--- a/src/third-party/imtui/imtui-impl-ncurses.cpp
+++ b/src/third-party/imtui/imtui-impl-ncurses.cpp
@@ -439,6 +439,7 @@ void ImTui_ImplNcurses_DrawScreen( bool active )
     for( WINDOW *cursesWin : rd->imtui_wins ) {
         int nx = g_screen.nx;
         int ny = g_screen.ny;
+        bool any_content = false;
 
         for( int y = getbegy( cursesWin ); y <= ( getbegy( cursesWin ) + getmaxy( cursesWin ) ); ++y ) {
             constexpr int no_lastp = 0x7FFFFFFF;
@@ -463,6 +464,9 @@ void ImTui_ImplNcurses_DrawScreen( bool active )
                 strTmp[0] = cell.ch;
                 waddwstr( cursesWin, strTmp );
 
+                if( cell.ch != 0 ) {
+                    any_content = true;
+                }
                 if( cell.chwidth > 1 ) {
                     x += ( cell.chwidth - 1 );
                 }
@@ -472,7 +476,9 @@ void ImTui_ImplNcurses_DrawScreen( bool active )
             }
         }
 
-        wnoutrefresh( cursesWin );
+        if( any_content ) {
+            wnoutrefresh( cursesWin );
+        }
     }
 
 }
```

This catches edge cases where a window is Active && !Hidden but still produces no draw commands (possible during frame transitions). It converts the inversive failure → graceful: instead of silently overwriting with blanks, the window simply doesn't refresh.

---

## Relation to #82239 and #82161

Both issues report rendering failures in the ImTui curses backend. They share the same structural root: the `create_destroy_curses_windows` function's model of ImGui window visibility is incomplete.

**#82239 (whole menus invisible):** This is likely the converse problem. The linear index mapping between `GImGui->Windows` and the curses window vector is fragile. Hidden windows getting spurious curses windows shift the
index mapping, potentially causing visible windows to get recycled curses windows at wrong positions. When ImGui reorders its window list (e.g., when bringing a window to front), the mapping breaks further. The primary fix (skipping Hidden windows) will also reduce this index-misalignment by keeping the curses window count closer to the actual visible window count.

**#82161 (highlighting halos, invisible text):** The "halo" effect around highlighted options is likely from ImGui's rectangle-fill triangles (`drawTriangle` writing `cell.ch = ' '` with a highlight background color) bleeding outside the intended bounds. The invisible text is likely from color pair mismanagement — the `colPairs` array uses `uint16_t` indices (`b * 256 + f`) which works for 256-color terminals but may produce collisions or incorrect pairs under certain terminal configurations. These are separate issues from the blank square but share the same architectural weakness: the ImTui→ncurses boundary has low constraint propagation (few constraints prevent incorrect rendering) and inversive failure modes.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
