### PR TITLE
Cover no_faction NPCs in Refugee Center back bay zones and water access

### DIFF
--- a/data/json/mapgen/refugee_center/refugee_center.json
+++ b/data/json/mapgen/refugee_center/refugee_center.json
@@ -101,7 +101,9 @@
         { "type": "NPC_NO_INVESTIGATE", "faction": "old_guard", "x": [ 69, 71 ], "y": [ 2, 23 ] },
         { "type": "NPC_NO_INVESTIGATE", "faction": "old_guard", "x": [ 72, 95 ], "y": [ 0, 23 ] },
         { "type": "NPC_NO_INVESTIGATE", "faction": "lobby_beggars", "x": [ 69, 71 ], "y": [ 2, 23 ] },
-        { "type": "NPC_NO_INVESTIGATE", "faction": "lobby_beggars", "x": [ 72, 95 ], "y": [ 0, 23 ] }
+        { "type": "NPC_NO_INVESTIGATE", "faction": "lobby_beggars", "x": [ 72, 95 ], "y": [ 0, 23 ] },
+        { "type": "NPC_NO_INVESTIGATE", "faction": "no_faction", "x": [ 69, 71 ], "y": [ 2, 23 ] },
+        { "type": "NPC_NO_INVESTIGATE", "faction": "no_faction", "x": [ 72, 95 ], "y": [ 0, 23 ] }
       ],
       "place_vehicles": [
         { "vehicle": "schoolbus", "x": 19, "y": 13, "chance": 75, "rotation": 270 },

--- a/data/json/npcs/factions.json
+++ b/data/json/npcs/factions.json
@@ -423,6 +423,7 @@
         "kill on sight": false,
         "watch your back": false,
         "share my stuff": false,
+        "share public goods": true,
         "guard your stuff": false,
         "lets you in": false,
         "defends your space": false,


### PR DESCRIPTION
#### Summary
Bugfixes "Prevent no_faction NPCs from investigating zombie sounds in Refugee Center back bay"

#### Purpose of change

no_faction NPCs (arsonist, scavenger mercs) investigate sounds from the back bay, break barricades, open doors, and immediately fall asleep. 

Fixes #86061.

They also die of dehydration because free_merchants won't share camp water with them.

#### Describe the solution

Add no_faction to the existing NPC_NO_INVESTIGATE zones covering the back bay. Matches the four already listed factions.

Add share_public_goods from free_merchants to no_faction so they can access camp water. Matches the existing lobby_beggars relationship.

#### Describe alternatives you've considered

Could give these NPCs their own faction, but no_faction is probably intentional for their independent role  

#### Testing

Observed that Arsonist died of dehydration at her post after 1-3 hours. Scavenger mercs walked into the back bay and broke barricades.

#### Additional context

Related to #86056