### PR TITLE
Paint dawn, dusk, and beacons

### DIFF
--- a/data/json/vehicleparts/lights.json
+++ b/data/json/vehicleparts/lights.json
@@ -159,6 +159,7 @@
     "description": "A blue light from the top of an emergency services vehicle.",
     "color": "blue",
     "broken_color": "blue",
+    "light_color": [ 30, 60, 255 ],
     "extend": { "flags": [ "EVENTURN" ] }
   },
   {
@@ -169,6 +170,7 @@
     "description": "A red light from the top of an emergency services vehicle.",
     "color": "red",
     "broken_color": "red",
+    "light_color": [ 255, 30, 30 ],
     "extend": { "flags": [ "ODDTURN" ] }
   }
 ]

--- a/data/mods/TEST_DATA/fields.json
+++ b/data/mods/TEST_DATA/fields.json
@@ -103,5 +103,25 @@
     "id": "test_fd_migration_new_id",
     "type": "field_type",
     "intensity_levels": [ { "name": "migrated" } ]
+  },
+  {
+    "id": "fd_test_green_glow",
+    "type": "field_type",
+    "intensity_levels": [
+      {
+        "name": "green glow",
+        "sym": "*",
+        "color": "green",
+        "light_emitted": 8,
+        "light_color": [ 0, 255, 0 ],
+        "translucency": 10
+      }
+    ],
+    "description_affix": "illuminated_by",
+    "priority": 4,
+    "half_life": "30 minutes",
+    "phase": "plasma",
+    "display_items": false,
+    "display_field": true
   }
 ]

--- a/data/mods/TEST_DATA/terrain.json
+++ b/data/mods/TEST_DATA/terrain.json
@@ -276,5 +276,23 @@
     "coverage": 60,
     "roof": "t_flat_roof",
     "flags": [ "BARRICADABLE_WINDOW" ]
+  },
+  {
+    "type": "terrain",
+    "id": "t_test_red_light",
+    "copy-from": "t_utility_light",
+    "name": "test red light",
+    "description": "Test terrain: utility light that emits red-colored light.",
+    "light_emitted": 10,
+    "light_color": [ 255, 0, 0 ]
+  },
+  {
+    "type": "terrain",
+    "id": "t_test_blue_light",
+    "copy-from": "t_utility_light",
+    "name": "test blue light",
+    "description": "Test terrain: utility light that emits blue-colored light.",
+    "light_emitted": 10,
+    "light_color": [ 0, 0, 255 ]
   }
 ]

--- a/data/mods/TEST_DATA/vehicle_parts.json
+++ b/data/mods/TEST_DATA/vehicle_parts.json
@@ -38,5 +38,12 @@
     "symbol": ";",
     "color": "light_gray",
     "melee_damage": { "bash": 4 }
+  },
+  {
+    "type": "vehicle_part",
+    "id": "test_red_headlight",
+    "copy-from": "headlight",
+    "name": { "str": "test red headlight" },
+    "light_color": [ 255, 0, 0 ]
   }
 ]

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1826,6 +1826,96 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
                     }
                 }
             }
+            // Colored light overlay. Draws a tinted rect over tiles that have
+            // colored light energy in the cache (emergency beacons, colored fields,
+            // etc). Only the chromatic (saturated) component produces a tint --
+            // white light (equal RGB) is ignored. Alpha scales with the ratio of
+            // colored energy to total scalar light so the effect is subtle under
+            // bright ambient and vivid in darkness.
+            const level_cache &cur_cache = here.access_cache( cur_zlevel );
+            for( const tile_render_info &p : here.draw_points_cache[cur_zlevel][row] ) {
+                const tile_render_info::sprite *const
+                var = std::get_if<tile_render_info::sprite>( &p.var );
+                if( !var || var->ll == lit_level::DARK || var->ll == lit_level::BLANK ||
+                    var->ll == lit_level::MEMORIZED ) {
+                    continue;
+                }
+                const light_color_rgb &lc =
+                    cur_cache.light_color_cache[p.com.pos.x()][p.com.pos.y()];
+                if( !lc.is_colored() ) {
+                    continue;
+                }
+                // Subtract the achromatic (white) component to isolate saturated color.
+                const float min_ch = std::min( { lc.r, lc.g, lc.b } );
+                const float sat_r = lc.r - min_ch;
+                const float sat_g = lc.g - min_ch;
+                const float sat_b = lc.b - min_ch;
+                const float sat_mag = std::max( { sat_r, sat_g, sat_b } );
+                if( sat_mag < 0.01f ) {
+                    continue; // pure white light, no tint
+                }
+                // Alpha: saturated energy relative to total scalar light at this tile
+                const float scalar = cur_cache.lm[p.com.pos.x()][p.com.pos.y()].max();
+                const float ratio = scalar > 0.1f ? std::min( 1.0f, sat_mag / scalar ) : 0.0f;
+                const Uint8 alpha = static_cast<Uint8>( ratio * 80.0f );
+                if( alpha == 0 ) {
+                    continue;
+                }
+                // Normalize saturated color to full brightness for the SDL tint.
+                const SDL_Color tint = {
+                    static_cast<Uint8>( sat_r / sat_mag * 255.0f ),
+                    static_cast<Uint8>( sat_g / sat_mag * 255.0f ),
+                    static_cast<Uint8>( sat_b / sat_mag * 255.0f ),
+                    alpha
+                };
+                const point screen = player_to_screen( p.com.pos.xy() );
+                const SDL_Rect draw_rect = {
+                    screen.x, screen.y - p.com.height_3d, tile_width, tile_height
+                };
+                SetRenderDrawBlendMode( renderer, SDL_BLENDMODE_BLEND );
+                geometry->rect( renderer, draw_rect, tint );
+                SetRenderDrawBlendMode( renderer, SDL_BLENDMODE_NONE );
+            }
+        }
+        // Dawn/dusk warm color temperature overlay on outside tiles.
+        // Sun altitude drives hue: deep orange (25 deg HSV) at the horizon,
+        // gold (45 deg HSV) as the sun climbs. Sine ease gives a smooth
+        // fade in/out instead of a sudden switch at the twilight boundary.
+        if( cur_zlevel >= 0 && is_twilight( calendar::turn ) ) {
+            const units::angle alt = sun_azimuth_altitude( calendar::turn ).second;
+            // lo/hi: nautical twilight range in degrees below horizon
+            constexpr float lo = -6.0f;
+            constexpr float hi = -1.0f;
+            const float progress = std::clamp(
+                                       static_cast<float>( to_degrees( alt ) - lo ) / ( hi - lo ), 0.0f, 1.0f );
+            const float hue = 25.0f + progress * 20.0f;
+            const float ease = std::sin( progress * 3.14159f );
+            const Uint8 sun_alpha = static_cast<Uint8>( ease * 25.0f );
+            if( sun_alpha > 0 ) {
+                const light_color_rgb sun_rgb = light_color_rgb::from_hsv( hue, 0.8f, 1.0f );
+                const SDL_Color sun_tint = {
+                    static_cast<Uint8>( sun_rgb.r * 255.0f ),
+                    static_cast<Uint8>( sun_rgb.g * 255.0f ),
+                    static_cast<Uint8>( sun_rgb.b * 255.0f ),
+                    sun_alpha
+                };
+                const auto &outside_cache = here.access_cache( cur_zlevel ).outside_cache;
+                SetRenderDrawBlendMode( renderer, SDL_BLENDMODE_BLEND );
+                for( int sun_row = cur_any_tile_range.p_min.y; sun_row < cur_any_tile_range.p_max.y;
+                     sun_row++ ) {
+                    for( const tile_render_info &p : here.draw_points_cache[cur_zlevel][sun_row] ) {
+                        if( !outside_cache[p.com.pos.x()][p.com.pos.y()] ) {
+                            continue;
+                        }
+                        const point screen = player_to_screen( p.com.pos.xy() );
+                        const SDL_Rect draw_rect = {
+                            screen.x, screen.y - p.com.height_3d, tile_width, tile_height
+                        };
+                        geometry->rect( renderer, draw_rect, sun_tint );
+                    }
+                }
+                SetRenderDrawBlendMode( renderer, SDL_BLENDMODE_NONE );
+            }
         }
         cur_zlevel += 1;
     }

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2995,16 +2995,17 @@ bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEG
     }
 
     //draw it!
-    draw_tile_at( display_tile, screen_pos, loc_rand, rota, ll,
-                  nv_color_active, retract, height_3d, offset );
+    const tile_render_params rp{ ll, nv_color_active };
+    draw_tile_at( display_tile, screen_pos, loc_rand, rota, rp,
+                  retract, height_3d, offset );
 
     return true;
 }
 
 bool cata_tiles::draw_sprite_at(
     const tile_type &tile, const weighted_int_list<std::vector<int>> &svlist,
-    const point &p, unsigned int loc_rand, bool rota_fg, int rota, lit_level ll,
-    bool apply_night_vision_goggles, int retract, int &height_3d, const point &offset )
+    const point &p, unsigned int loc_rand, bool rota_fg, int rota,
+    const tile_render_params &rp, int retract, int &height_3d, const point &offset )
 {
     const std::vector<int> *picked = svlist.pick( loc_rand );
     if( !picked ) {
@@ -3041,12 +3042,12 @@ bool cata_tiles::draw_sprite_at(
 
     //use night vision colors when in use
     //then use low light tile if available
-    if( ll == lit_level::MEMORIZED ) {
+    if( rp.ll == lit_level::MEMORIZED ) {
         if( const texture *ptr = tileset_ptr->get_memory_tile( sprite_index ) ) {
             sprite_tex = ptr;
         }
-    } else if( apply_night_vision_goggles ) {
-        if( ll != lit_level::LOW ) {
+    } else if( rp.use_night_vision_tiles ) {
+        if( rp.ll != lit_level::LOW ) {
             if( const texture *ptr = tileset_ptr->get_overexposed_tile( sprite_index ) ) {
                 sprite_tex = ptr;
             }
@@ -3055,7 +3056,7 @@ bool cata_tiles::draw_sprite_at(
                 sprite_tex = ptr;
             }
         }
-    } else if( ll == lit_level::LOW ) {
+    } else if( rp.ll == lit_level::LOW ) {
         if( const texture *ptr = tileset_ptr->get_shadow_tile( sprite_index ) ) {
             sprite_tex = ptr;
         }
@@ -3160,14 +3161,14 @@ bool cata_tiles::draw_sprite_at(
 
 bool cata_tiles::draw_tile_at(
     const tile_type &tile, const point &p, unsigned int loc_rand, int rota,
-    lit_level ll, bool apply_night_vision_goggles, int retract, int &height_3d,
+    const tile_render_params &rp, int retract, int &height_3d,
     const point &offset )
 {
     int fake_int = height_3d;
-    draw_sprite_at( tile, tile.bg, p, loc_rand, /*fg:*/ false, rota, ll,
-                    apply_night_vision_goggles, retract, fake_int, offset );
-    draw_sprite_at( tile, tile.fg, p, loc_rand, /*fg:*/ true, rota, ll,
-                    apply_night_vision_goggles, retract, height_3d, offset );
+    draw_sprite_at( tile, tile.bg, p, loc_rand, /*fg:*/ false, rota, rp,
+                    retract, fake_int, offset );
+    draw_sprite_at( tile, tile.fg, p, loc_rand, /*fg:*/ true, rota, rp,
+                    retract, height_3d, offset );
     return true;
 }
 

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -156,6 +156,16 @@ class texture
 };
 
 /**
+ * Bundles per-tile rendering state so the draw path carries all lighting
+ * decisions in one place. Future fields (light color tint, per-tile
+ * brightness) extend this struct without adding parameters to every function.
+ */
+struct tile_render_params {
+    lit_level ll;
+    bool use_night_vision_tiles = false;
+};
+
+/**
 * Holds weighted map of sprites for contextual tile layering
 * e.g. different sprites for item "pen" on "f_desk"
 */
@@ -548,10 +558,10 @@ class cata_tiles
                                   const std::string &variant, const point &offset );
         bool draw_sprite_at(
             const tile_type &tile, const weighted_int_list<std::vector<int>> &svlist,
-            const point &, unsigned int loc_rand, bool rota_fg, int rota, lit_level ll,
-            bool apply_night_vision_goggles, int retract, int &height_3d, const point &offset );
+            const point &, unsigned int loc_rand, bool rota_fg, int rota,
+            const tile_render_params &rp, int retract, int &height_3d, const point &offset );
         bool draw_tile_at( const tile_type &tile, const point &, unsigned int loc_rand, int rota,
-                           lit_level ll, bool apply_night_vision_goggles, int retract, int &height_3d,
+                           const tile_render_params &rp, int retract, int &height_3d,
                            const point &offset );
 
         /* Tile Picking */

--- a/src/field_type.cpp
+++ b/src/field_type.cpp
@@ -241,6 +241,14 @@ void field_type::load( const JsonObject &jo, std::string_view )
                   fallback_intensity_level.monster_spawn_group );
         optional( jao, was_loaded, "light_emitted", intensity_level.light_emitted,
                   fallback_intensity_level.light_emitted );
+        if( jao.has_array( "light_color" ) ) {
+            JsonArray jarr = jao.get_array( "light_color" );
+            intensity_level.light_color.r = jarr.get_int( 0 ) / 255.0f;
+            intensity_level.light_color.g = jarr.get_int( 1 ) / 255.0f;
+            intensity_level.light_color.b = jarr.get_int( 2 ) / 255.0f;
+        } else {
+            intensity_level.light_color = fallback_intensity_level.light_color;
+        }
         optional( jao, was_loaded, "light_override", intensity_level.local_light_override,
                   fallback_intensity_level.local_light_override );
         optional( jao, was_loaded, "translucency", intensity_level.translucency,

--- a/src/field_type.h
+++ b/src/field_type.h
@@ -13,6 +13,8 @@
 #include <utility>
 #include <vector>
 
+#include "lightmap.h"
+
 #include "calendar.h"
 #include "catacharset.h"
 #include "color.h"
@@ -116,6 +118,7 @@ struct field_intensity_level {
     int monster_spawn_radius = 0;
     mongroup_id monster_spawn_group;
     float light_emitted = 0.0f;
+    light_color_rgb light_color;
     float local_light_override = -1.0f;
     float translucency = 0.0f;
     int concentration = 0;

--- a/src/level_cache.cpp
+++ b/src/level_cache.cpp
@@ -14,7 +14,8 @@ level_cache::level_cache()
     constexpr four_quadrants four_zeros( 0.0f );
     std::fill_n( &lm[0][0], map_dimensions, four_zeros );
     std::fill_n( &sm[0][0], map_dimensions, 0.0f );
-    std::fill_n( &light_source_buffer[0][0], map_dimensions, 0.0f );
+    std::fill_n( &light_color_cache[0][0], map_dimensions, light_color_rgb{} );
+    std::fill_n( &light_source_buffer[0][0], map_dimensions, buffered_light_source{} );
     std::fill_n( &outside_cache[0][0], map_dimensions, false );
     std::fill_n( &floor_cache[0][0], map_dimensions, false );
     std::fill_n( &transparency_cache[0][0], map_dimensions, 0.0f );

--- a/src/level_cache.h
+++ b/src/level_cache.h
@@ -8,16 +8,14 @@
 #include <unordered_map>
 #include <utility>
 
-#include <stdint.h>
-
 #include "coordinates.h"
+#include "lightmap.h"
 #include "map_scale_constants.h"
 #include "mdarray.h"
 #include "shadowcasting.h"
 
 // IWYU pragma: no_forward_declare four_quadrants
 class vehicle;
-enum class lit_level : uint8_t;
 
 struct level_cache {
     public:
@@ -34,9 +32,16 @@ struct level_cache {
 
         cata::mdarray<four_quadrants, point_bub_ms> lm;
         cata::mdarray<float, point_bub_ms> sm;
-        // To prevent redundant ray casting into neighbors: precalculate bulk light source positions.
-        // This is only valid for the duration of generate_lightmap
-        cata::mdarray<float, point_bub_ms> light_source_buffer;
+        // Accumulated colored light energy per tile. Populated during generate_lightmap
+        // alongside lm/sm. Zero = uncolored (white) light only.
+        cata::mdarray<light_color_rgb, point_bub_ms> light_color_cache;
+        // Bulk light source buffer. Scalar luminance uses max() for dedup;
+        // color accumulates additively. Only valid during generate_lightmap.
+        struct buffered_light_source {
+            float luminance = 0.0f;
+            light_color_rgb color;
+        };
+        cata::mdarray<buffered_light_source, point_bub_ms> light_source_buffer;
 
         // Cache of natural light level is useful if it needs to be in sync with the light cache.
         float natural_light_level_cache;

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -454,18 +454,19 @@ void map::generate_lightmap( const int zlev )
     bool top_floor = zlev == OVERMAP_DEPTH;
     lm.fill( four_quadrants{} );
     sm.fill( 0 );
+    map_cache.light_color_cache.fill( light_color_rgb{} );
 
     /* Bulk light sources wastefully cast rays into neighbors; a burning hospital can produce
          significant slowdown, so for stuff like fire and lava:
      * Step 1: Store the position and luminance in buffer via add_light_source, for efficient
-         checking of neighbors.
+         checking of neighbors. Color rides the same buffer additively.
      * Step 2: After everything else, iterate buffer and apply_light_source only in non-redundant
-         directions
+         directions, propagating both scalar light and color in the same octant decisions.
      * Step 3: ????
      * Step 4: Profit!
      */
     auto &light_source_buffer = map_cache.light_source_buffer;
-    light_source_buffer.fill( 0 );
+    light_source_buffer.fill( level_cache::buffered_light_source{} );
 
     constexpr std::array<int, 4> dir_x = { {  0, -1, 1, 0 } };    //    [0]
     constexpr std::array<int, 4> dir_y = { { -1,  0, 0, 1 } };    // [1][X][2]
@@ -529,22 +530,21 @@ void map::generate_lightmap( const int zlev )
 
                     const ter_id &terrain = cur_submap->get_ter( { sx, sy } );
                     if( terrain->light_emitted > 0 ) {
-                        add_light_source( p, terrain->light_emitted );
+                        add_light_source( p, terrain->light_emitted, terrain->light_color );
                     }
                     const furn_id &furniture = cur_submap->get_furn( {sx, sy } );
                     if( furniture->light_emitted > 0 ) {
-                        add_light_source( p, furniture->light_emitted );
+                        add_light_source( p, furniture->light_emitted, furniture->light_color );
                     }
 
                     for( const auto &fld : cur_submap->get_field( { sx, sy } ) ) {
                         const field_entry *cur = &fld.second;
-                        const int light_emitted = cur->get_intensity_level().light_emitted;
-                        if( light_emitted > 0 ) {
-                            add_light_source( p, light_emitted );
+                        const field_intensity_level &fil = cur->get_intensity_level();
+                        if( fil.light_emitted > 0 ) {
+                            add_light_source( p, fil.light_emitted, fil.light_color );
                         }
-                        const float light_override = cur->get_intensity_level().local_light_override;
-                        if( light_override >= 0.0f ) {
-                            lm_override.emplace_back( p, light_override );
+                        if( fil.local_light_override >= 0.0f ) {
+                            lm_override.emplace_back( p, fil.local_light_override );
                         }
                     }
                 }
@@ -601,16 +601,16 @@ void map::generate_lightmap( const int zlev )
 
             if( vp.has_flag( VPFLAG_CONE_LIGHT ) ) {
                 if( veh_luminance > lit_level::LIT ) {
-                    add_light_source( src, M_SQRT2 ); // Add a little surrounding light
+                    add_light_source( src, M_SQRT2, vp.light_color ); // Add a little surrounding light
                     apply_light_arc( src, v->face.dir() + pt->direction, veh_luminance,
-                                     45_degrees );
+                                     45_degrees, vp.light_color );
                 }
 
             } else if( vp.has_flag( VPFLAG_WIDE_CONE_LIGHT ) ) {
                 if( veh_luminance > lit_level::LIT ) {
-                    add_light_source( src, M_SQRT2 ); // Add a little surrounding light
+                    add_light_source( src, M_SQRT2, vp.light_color ); // Add a little surrounding light
                     apply_light_arc( src, v->face.dir() + pt->direction, veh_luminance,
-                                     90_degrees );
+                                     90_degrees, vp.light_color );
                 }
 
             } else if( vp.has_flag( VPFLAG_HALF_CIRCLE_LIGHT ) ) {
@@ -620,11 +620,13 @@ void map::generate_lightmap( const int zlev )
                     tripoint_bub_ms offset = src;
                     offset.x() = src.x() + tdir.dx();
                     offset.y() = src.y() + tdir.dy();
-                    add_light_source( offset, M_SQRT2 ); // Add a little surrounding light
-                    apply_light_arc( offset, v->face.dir() + pt->direction, vp.bonus, 180_degrees );
+                    add_light_source( offset, M_SQRT2, vp.light_color ); // Add a little surrounding light
+                    apply_light_arc( offset, v->face.dir() + pt->direction, vp.bonus, 180_degrees,
+                                     vp.light_color );
                 } else {
-                    add_light_source( src, M_SQRT2 ); // Add a little surrounding light
-                    apply_light_arc( src, v->face.dir() + pt->direction, vp.bonus, 180_degrees );
+                    add_light_source( src, M_SQRT2, vp.light_color ); // Add a little surrounding light
+                    apply_light_arc( src, v->face.dir() + pt->direction, vp.bonus, 180_degrees,
+                                     vp.light_color );
                 }
 
             } else if( vp.has_flag( VPFLAG_CIRCLE_LIGHT ) ) {
@@ -633,11 +635,11 @@ void map::generate_lightmap( const int zlev )
                     ( !odd_turn && vp.has_flag( VPFLAG_EVENTURN ) ) ||
                     ( !( vp.has_flag( VPFLAG_EVENTURN ) || vp.has_flag( VPFLAG_ODDTURN ) ) ) ) {
 
-                    add_light_source( src, vp.bonus );
+                    add_light_source( src, vp.bonus, vp.light_color );
                 }
 
             } else {
-                add_light_source( src, vp.bonus );
+                add_light_source( src, vp.bonus, vp.light_color );
             }
         }
 
@@ -658,20 +660,42 @@ void map::generate_lightmap( const int zlev )
     const tripoint_bub_ms cache_start( 0, 0, zlev );
     const tripoint_bub_ms cache_end( LIGHTMAP_CACHE_X, LIGHTMAP_CACHE_Y, zlev );
     for( const tripoint_bub_ms &p : points_in_rectangle( cache_start, cache_end ) ) {
-        if( light_source_buffer[p.x()][p.y()] > 0.0 ) {
-            apply_light_source( p, light_source_buffer[p.x()][p.y()] );
+        if( light_source_buffer[p.x()][p.y()].luminance > 0.0 ) {
+            apply_light_source( p, light_source_buffer[p.x()][p.y()].luminance );
         }
     }
+
     for( const std::pair<tripoint_bub_ms, float> &elem : lm_override ) {
         lm[elem.first.x()][elem.first.y()].fill( elem.second );
     }
 }
 
-void map::add_light_source( const tripoint_bub_ms &p, float luminance )
+void map::add_light_source( const tripoint_bub_ms &p, float luminance,
+                            const light_color_rgb &color )
 {
-    auto &light_source_buffer = get_cache( p.z() ).light_source_buffer;
-    light_source_buffer[p.x()][p.y()] = std::max( luminance, light_source_buffer[p.x()][p.y()] );
+    auto &buf = get_cache( p.z() ).light_source_buffer[p.x()][p.y()];
+    if( luminance > buf.luminance ) {
+        buf.luminance = luminance;
+    }
+    // Color accumulates additively, weighted by luminance so brighter sources
+    // dominate the hue. Luminance itself uses max() for the buffer dedup that
+    // prevents redundant ray casting into neighbors (see apply_light_source).
+    if( color.is_colored() ) {
+        buf.color += color * luminance;
+    }
 }
+
+// Set before each castLight sequence, read by update_light_color callback.
+static light_color_rgb g_current_source_color;
+
+// castLight callback for color propagation. Additive accumulation lets
+// multiple sources contribute; the rendering pass extracts the saturated
+// component to build the final tint.
+static void update_light_color( light_color_rgb &tile_color, const float &intensity, quadrant )
+{
+    tile_color += g_current_source_color * intensity;
+}
+
 
 // Tile light/transparency: 3D
 
@@ -1221,12 +1245,11 @@ static bool light_check( const float &transparency, const float &intensity )
 void map::apply_light_source( const tripoint_bub_ms &p, float luminance )
 {
     level_cache &cache = get_cache( p.z() );
-    cata::mdarray<four_quadrants, point_bub_ms> &lm = cache.lm;
-    cata::mdarray<float, point_bub_ms> &sm = cache.sm;
-    cata::mdarray<float, point_bub_ms> &transparency_cache =
-        cache.transparency_cache;
-    cata::mdarray<float, point_bub_ms> &light_source_buffer =
-        cache.light_source_buffer;
+    auto &lm = cache.lm;
+    auto &sm = cache.sm;
+    auto &transparency_cache = cache.transparency_cache;
+    auto &light_source_buffer = cache.light_source_buffer;
+    auto &light_color_cache = cache.light_color_cache;
 
     const point_bub_ms p2( p.xy() );
 
@@ -1241,10 +1264,21 @@ void map::apply_light_source( const tripoint_bub_ms &p, float luminance )
         luminance = 1.49f;
     }
 
+    // Color propagation: the buffer stores accumulated (color * luminance).
+    // Dividing by luminance recovers the average color, which castLight then
+    // re-scales by the per-tile attenuated intensity -- same falloff as scalar.
+    const auto &buf = light_source_buffer[p2.x()][p2.y()];
+    const bool has_color = buf.color.is_colored();
+    if( has_color ) {
+        g_current_source_color = buf.color * ( 1.0f / buf.luminance );
+        // Set source tile color directly
+        light_color_cache[p2.x()][p2.y()] += g_current_source_color * luminance;
+    }
+
     /* If we're a 5 luminance fire , we skip casting rays into ey && sx if we have
          neighboring fires to the north and west that were applied via light_source_buffer
        If there's a 1 luminance candle east in buffer, we still cast rays into ex since it's smaller
-       If there's a 100 luminance magnesium flare south added via apply_light_source instead od
+       If there's a 100 luminance magnesium flare south added via apply_light_source instead of
          add_light_source, it's unbuffered so we'll still cast rays into sy.
 
           ey
@@ -1258,45 +1292,87 @@ void map::apply_light_source( const tripoint_bub_ms &p, float luminance )
            sy
     */
     const int peer_inbounds = LIGHTMAP_CACHE_X - 1;
-    bool north = p2.y() != 0 && light_source_buffer[p2.x()][p2.y() - 1] < luminance;
-    bool south = p2.y() != peer_inbounds && light_source_buffer[p2.x()][p2.y() + 1] < luminance;
-    bool east = p2.x() != peer_inbounds && light_source_buffer[p2.x() + 1][p2.y()] < luminance;
-    bool west = p2.x() != 0 && light_source_buffer[p2.x() - 1][p2.y()] < luminance;
+    bool north = p2.y() != 0 && light_source_buffer[p2.x()][p2.y() - 1].luminance < luminance;
+    bool south = p2.y() != peer_inbounds &&
+                 light_source_buffer[p2.x()][p2.y() + 1].luminance < luminance;
+    bool east = p2.x() != peer_inbounds &&
+                light_source_buffer[p2.x() + 1][p2.y()].luminance < luminance;
+    bool west = p2.x() != 0 && light_source_buffer[p2.x() - 1][p2.y()].luminance < luminance;
 
     if( north ) {
         castLight < 1, 0, 0, -1, float, four_quadrants, light_calc, light_check,
                   update_light_quadrants, accumulate_transparency > (
                       lm, transparency_cache, p2, 0, luminance );
+        if( has_color ) {
+            castLight < 1, 0, 0, -1, float, light_color_rgb, light_calc, light_check,
+                      update_light_color, accumulate_transparency > (
+                          light_color_cache, transparency_cache, p2, 0, luminance );
+        }
         castLight < -1, 0, 0, -1, float, four_quadrants, light_calc, light_check,
                   update_light_quadrants, accumulate_transparency > (
                       lm, transparency_cache, p2, 0, luminance );
+        if( has_color ) {
+            castLight < -1, 0, 0, -1, float, light_color_rgb, light_calc, light_check,
+                      update_light_color, accumulate_transparency > (
+                          light_color_cache, transparency_cache, p2, 0, luminance );
+        }
     }
 
     if( east ) {
         castLight < 0, -1, 1, 0, float, four_quadrants, light_calc, light_check,
                   update_light_quadrants, accumulate_transparency > (
                       lm, transparency_cache, p2, 0, luminance );
+        if( has_color ) {
+            castLight < 0, -1, 1, 0, float, light_color_rgb, light_calc, light_check,
+                      update_light_color, accumulate_transparency > (
+                          light_color_cache, transparency_cache, p2, 0, luminance );
+        }
         castLight < 0, -1, -1, 0, float, four_quadrants, light_calc, light_check,
                   update_light_quadrants, accumulate_transparency > (
                       lm, transparency_cache, p2, 0, luminance );
+        if( has_color ) {
+            castLight < 0, -1, -1, 0, float, light_color_rgb, light_calc, light_check,
+                      update_light_color, accumulate_transparency > (
+                          light_color_cache, transparency_cache, p2, 0, luminance );
+        }
     }
 
     if( south ) {
         castLight<1, 0, 0, 1, float, four_quadrants, light_calc, light_check,
                   update_light_quadrants, accumulate_transparency>(
                       lm, transparency_cache, p2, 0, luminance );
+        if( has_color ) {
+            castLight<1, 0, 0, 1, float, light_color_rgb, light_calc, light_check,
+                      update_light_color, accumulate_transparency>(
+                          light_color_cache, transparency_cache, p2, 0, luminance );
+        }
         castLight < -1, 0, 0, 1, float, four_quadrants, light_calc, light_check,
                   update_light_quadrants, accumulate_transparency > (
                       lm, transparency_cache, p2, 0, luminance );
+        if( has_color ) {
+            castLight < -1, 0, 0, 1, float, light_color_rgb, light_calc, light_check,
+                      update_light_color, accumulate_transparency > (
+                          light_color_cache, transparency_cache, p2, 0, luminance );
+        }
     }
 
     if( west ) {
         castLight<0, 1, 1, 0, float, four_quadrants, light_calc, light_check,
                   update_light_quadrants, accumulate_transparency>(
                       lm, transparency_cache, p2, 0, luminance );
+        if( has_color ) {
+            castLight<0, 1, 1, 0, float, light_color_rgb, light_calc, light_check,
+                      update_light_color, accumulate_transparency>(
+                          light_color_cache, transparency_cache, p2, 0, luminance );
+        }
         castLight < 0, 1, -1, 0, float, four_quadrants, light_calc, light_check,
                   update_light_quadrants, accumulate_transparency > (
                       lm, transparency_cache, p2, 0, luminance );
+        if( has_color ) {
+            castLight < 0, 1, -1, 0, float, light_color_rgb, light_calc, light_check,
+                      update_light_color, accumulate_transparency > (
+                          light_color_cache, transparency_cache, p2, 0, luminance );
+        }
     }
 }
 
@@ -1341,7 +1417,7 @@ void map::apply_directional_light( const tripoint_bub_ms &p, int direction, floa
 }
 
 void map::apply_light_arc( const tripoint_bub_ms &p, const units::angle &angle, float luminance,
-                           const units::angle &wideangle )
+                           const units::angle &wideangle, const light_color_rgb &color )
 {
     if( luminance <= LIGHT_SOURCE_LOCAL ) {
         return;
@@ -1355,6 +1431,15 @@ void map::apply_light_arc( const tripoint_bub_ms &p, const units::angle &angle, 
     cata::mdarray<four_quadrants, point_bub_ms> &lm = cache.lm;
     cata::mdarray<float, point_bub_ms> &transparency_cache =
         cache.transparency_cache;
+    cata::mdarray<light_color_rgb, point_bub_ms> &light_color_cache =
+        cache.light_color_cache;
+
+    const bool has_color = color.is_colored();
+    if( has_color ) {
+        g_current_source_color = color;
+        // Source tile gets only the local halo intensity, matching scalar path
+        light_color_cache[p2.x()][p2.y()] += color * LIGHT_SOURCE_LOCAL;
+    }
 
     const units::angle wangle = wideangle / 2.0;
     // Normalize so oangle is between 0 and 360 degrees
@@ -1381,49 +1466,46 @@ void map::apply_light_arc( const tripoint_bub_ms &p, const units::angle &angle, 
         start_angle = std::max( 45_degrees * start, oangle );
         end_angle = std::min( 45_degrees * end, cangle );
 
+        // Helper macro: cast scalar light, then color through the same octant.
+        // The template parameters encode the octant direction.
+#define CAST_ARC_OCTANT( xx, xy, yx, yy, s1, s2 ) \
+    castLight < xx, xy, yx, yy, float, four_quadrants, light_calc, light_check, \
+    update_light_quadrants, accumulate_transparency > ( \
+            lm, transparency_cache, p2, 0, luminance, 1, s1, s2 ); \
+    if( has_color ) { \
+        castLight < xx, xy, yx, yy, float, light_color_rgb, light_calc, light_check, \
+        update_light_color, accumulate_transparency > ( \
+                light_color_cache, transparency_cache, p2, 0, luminance, 1, s1, s2 ); \
+    }
+
         // i is positive
         switch( i % 8 ) {
             case 0:
-                castLight < 0, -1, -1, 0, float, four_quadrants, light_calc, light_check,
-                          update_light_quadrants, accumulate_transparency > (
-                              lm, transparency_cache, p2, 0, luminance, 1, tan( end_angle ), tan( start_angle ) );
+                CAST_ARC_OCTANT( 0, -1, -1, 0, tan( end_angle ), tan( start_angle ) );
                 break;
             case 1:
-                castLight < -1, 0, 0, -1, float, four_quadrants, light_calc, light_check,
-                          update_light_quadrants, accumulate_transparency > (
-                              lm, transparency_cache, p2, 0, luminance, 1, cot( start_angle ), cot( end_angle ) );
+                CAST_ARC_OCTANT( -1, 0, 0, -1, cot( start_angle ), cot( end_angle ) );
                 break;
             case 2:
-                castLight < 1, 0, 0, -1, float, four_quadrants, light_calc, light_check,
-                          update_light_quadrants, accumulate_transparency > (
-                              lm, transparency_cache, p2, 0, luminance, 1, -cot( end_angle ), -cot( start_angle ) );
+                CAST_ARC_OCTANT( 1, 0, 0, -1, -cot( end_angle ), -cot( start_angle ) );
                 break;
             case 3:
-                castLight < 0, 1, -1, 0, float, four_quadrants, light_calc, light_check,
-                          update_light_quadrants, accumulate_transparency > (
-                              lm, transparency_cache, p2, 0, luminance, 1, -tan( start_angle ), -tan( end_angle ) );
+                CAST_ARC_OCTANT( 0, 1, -1, 0, -tan( start_angle ), -tan( end_angle ) );
                 break;
             case 4:
-                castLight < 0, 1, 1, 0, float, four_quadrants, light_calc, light_check,
-                          update_light_quadrants, accumulate_transparency >(
-                              lm, transparency_cache, p2, 0, luminance, 1, tan( end_angle ), tan( start_angle ) );
+                CAST_ARC_OCTANT( 0, 1, 1, 0, tan( end_angle ), tan( start_angle ) );
                 break;
             case 5:
-                castLight < 1, 0, 0, 1, float, four_quadrants, light_calc, light_check,
-                          update_light_quadrants, accumulate_transparency >(
-                              lm, transparency_cache, p2, 0, luminance, 1, cot( start_angle ), cot( end_angle ) );
+                CAST_ARC_OCTANT( 1, 0, 0, 1, cot( start_angle ), cot( end_angle ) );
                 break;
             case 6:
-                castLight < -1, 0, 0, 1, float, four_quadrants, light_calc, light_check,
-                          update_light_quadrants, accumulate_transparency > (
-                              lm, transparency_cache, p2, 0, luminance, 1, -cot( end_angle ), -cot( start_angle ) );
+                CAST_ARC_OCTANT( -1, 0, 0, 1, -cot( end_angle ), -cot( start_angle ) );
                 break;
             case 7:
-                castLight < 0, -1, 1, 0, float, four_quadrants, light_calc, light_check,
-                          update_light_quadrants, accumulate_transparency > (
-                              lm, transparency_cache, p2, 0, luminance, 1, -tan( start_angle ), -tan( end_angle ) );
+                CAST_ARC_OCTANT( 0, -1, 1, 0, -tan( start_angle ), -tan( end_angle ) );
                 break;
         }
+#undef CAST_ARC_OCTANT
         i++;
     }
 }

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -668,6 +668,39 @@ void map::generate_lightmap( const int zlev )
     for( const std::pair<tripoint_bub_ms, float> &elem : lm_override ) {
         lm[elem.first.x()][elem.first.y()].fill( elem.second );
     }
+
+    // 3x3 box blur on the color cache softens residual octant boundary seams.
+    // Even with per-channel max in update_light_color, attenuation differences
+    // between adjacent octants can leave visible intensity steps.
+    {
+        auto &light_color_cache = map_cache.light_color_cache;
+        static auto blur_buf =
+            std::make_unique<cata::mdarray<light_color_rgb, point_bub_ms>>();
+        blur_buf->fill( light_color_rgb{} );
+        for( int x = 1; x < MAPSIZE_X - 1; ++x ) {
+            for( int y = 1; y < MAPSIZE_Y - 1; ++y ) {
+                if( !light_color_cache[x][y].is_colored() ) {
+                    continue;
+                }
+                light_color_rgb sum;
+                int count = 0;
+                for( int dx = -1; dx <= 1; ++dx ) {
+                    for( int dy = -1; dy <= 1; ++dy ) {
+                        sum += light_color_cache[x + dx][y + dy];
+                        ++count;
+                    }
+                }
+                ( *blur_buf )[x][y] = sum * ( 1.0f / count );
+            }
+        }
+        for( int x = 1; x < MAPSIZE_X - 1; ++x ) {
+            for( int y = 1; y < MAPSIZE_Y - 1; ++y ) {
+                if( ( *blur_buf )[x][y].is_colored() ) {
+                    light_color_cache[x][y] = ( *blur_buf )[x][y];
+                }
+            }
+        }
+    }
 }
 
 void map::add_light_source( const tripoint_bub_ms &p, float luminance,
@@ -685,15 +718,48 @@ void map::add_light_source( const tripoint_bub_ms &p, float luminance,
     }
 }
 
+light_color_rgb light_color_rgb::from_hsv( float h, float s, float v )
+{
+    const float c = v * s;
+    const float x = c * ( 1.0f - std::abs( std::fmod( h / 60.0f, 2.0f ) - 1.0f ) );
+    const float m = v - c;
+    float r1 = 0.0f;
+    float g1 = 0.0f;
+    float b1 = 0.0f;
+    if( h < 60.0f ) {
+        r1 = c;
+        g1 = x;
+    } else if( h < 120.0f ) {
+        r1 = x;
+        g1 = c;
+    } else if( h < 180.0f ) {
+        g1 = c;
+        b1 = x;
+    } else if( h < 240.0f ) {
+        g1 = x;
+        b1 = c;
+    } else if( h < 300.0f ) {
+        r1 = x;
+        b1 = c;
+    } else {
+        r1 = c;
+        b1 = x;
+    }
+    return { r1 + m, g1 + m, b1 + m };
+}
+
 // Set before each castLight sequence, read by update_light_color callback.
 static light_color_rgb g_current_source_color;
 
-// castLight callback for color propagation. Additive accumulation lets
-// multiple sources contribute; the rendering pass extracts the saturated
-// component to build the final tint.
+// castLight callback for color propagation. Per-channel max prevents octant
+// boundary seams (two adjacent octants hitting the same tile would double
+// the color with +=, but scalar light uses max() so it stays clean).
 static void update_light_color( light_color_rgb &tile_color, const float &intensity, quadrant )
 {
-    tile_color += g_current_source_color * intensity;
+    const light_color_rgb contrib = g_current_source_color * intensity;
+    tile_color.r = std::max( tile_color.r, contrib.r );
+    tile_color.g = std::max( tile_color.g, contrib.g );
+    tile_color.b = std::max( tile_color.b, contrib.b );
 }
 
 

--- a/src/lightmap.h
+++ b/src/lightmap.h
@@ -53,6 +53,26 @@ constexpr inline int LIGHT_RANGE( float b )
                              LIGHT_TRANSPARENCY_OPEN_AIR ) );
 }
 
+// Per-tile accumulated light color energy (float RGB).
+// Stored as raw energy, not display-ready; the renderer converts to uint8.
+struct light_color_rgb {
+    float r = 0.0f;
+    float g = 0.0f;
+    float b = 0.0f;
+    bool is_colored() const {
+        return r > 0.0f || g > 0.0f || b > 0.0f;
+    }
+    light_color_rgb &operator+=( const light_color_rgb &rhs ) {
+        r += rhs.r;
+        g += rhs.g;
+        b += rhs.b;
+        return *this;
+    }
+    light_color_rgb operator*( float scale ) const {
+        return { r * scale, g * scale, b * scale };
+    }
+};
+
 enum class lit_level : uint8_t {
     DARK = 0,
     LOW, // Hard to see

--- a/src/lightmap.h
+++ b/src/lightmap.h
@@ -71,6 +71,9 @@ struct light_color_rgb {
     light_color_rgb operator*( float scale ) const {
         return { r * scale, g * scale, b * scale };
     }
+
+    // Create from HSV. h in [0,360), s and v in [0,1].
+    static light_color_rgb from_hsv( float h, float s, float v );
 };
 
 enum class lit_level : uint8_t {

--- a/src/map.h
+++ b/src/map.h
@@ -2101,11 +2101,14 @@ class map
         void apply_light_source( const tripoint_bub_ms &p, float luminance );
         // ...this, which will apply the light after at the end of generate_lightmap, and prevent redundant
         // light rays from causing massive slowdowns, if there's a huge amount of light.
-        void add_light_source( const tripoint_bub_ms &p, float luminance );
+        // Color rides the same buffer; omit for white (uncolored) light.
+        void add_light_source( const tripoint_bub_ms &p, float luminance,
+                               const light_color_rgb &color = {} );
         // Handle just cardinal directions and 45 deg angles.
         void apply_directional_light( const tripoint_bub_ms &p, int direction, float luminance );
         void apply_light_arc( const tripoint_bub_ms &p, const units::angle &angle, float luminance,
-                              const units::angle &wideangle = 30_degrees );
+                              const units::angle &wideangle = 30_degrees,
+                              const light_color_rgb &color = {} );
         void apply_light_ray( cata::mdarray<bool, point_bub_ms, MAPSIZE_X, MAPSIZE_Y> &lit,
                               const tripoint_bub_ms &s, const tripoint_bub_ms &e, float luminance );
         void add_light_from_items( const tripoint_bub_ms &p, const item_stack &items );

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -1224,6 +1224,12 @@ void map_data_common_t::load( const JsonObject &jo, const std::string &src )
 
     optional( jo, was_loaded, "lockpick_message", lockpick_message, translation() );
     optional( jo, was_loaded, "light_emitted", light_emitted );
+    if( jo.has_array( "light_color" ) ) {
+        JsonArray jarr = jo.get_array( "light_color" );
+        light_color.r = jarr.get_int( 0 ) / 255.0f;
+        light_color.g = jarr.get_int( 1 ) / 255.0f;
+        light_color.b = jarr.get_int( 2 ) / 255.0f;
+    }
 
     if( jo.has_object( "shoot" ) ) {
         shoot = cata::make_value<map_shoot_info>();

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -21,6 +21,7 @@
 #include "enum_bitset.h"
 #include "game_constants.h"
 #include "iexamine.h"
+#include "lightmap.h"
 #include "requirements.h"
 #include "translation.h"
 #include "type_id.h"
@@ -558,6 +559,7 @@ struct map_data_common_t {
         void examine( Character &, const tripoint_bub_ms & ) const;
 
         int light_emitted = 0;
+        light_color_rgb light_color;
         // The amount of movement points required to pass this terrain by default.
         int movecost = 0;
         int heat_radiation = 0;

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -262,6 +262,12 @@ void vpart_info::load( const JsonObject &jo, const std::string_view src )
     optional( jo, was_loaded, "folded_volume", folded_volume, std::nullopt );
     optional( jo, was_loaded, "size", size, 0_ml );
     optional( jo, was_loaded, "bonus", bonus, 0 );
+    if( jo.has_array( "light_color" ) ) {
+        JsonArray jarr = jo.get_array( "light_color" );
+        light_color.r = jarr.get_int( 0 ) / 255.0f;
+        light_color.g = jarr.get_int( 1 ) / 255.0f;
+        light_color.b = jarr.get_int( 2 ) / 255.0f;
+    }
     optional( jo, was_loaded, "cargo_weight_modifier", cargo_weight_modifier, 100 );
     optional( jo, was_loaded, "categories", categories, string_reader{} );
     optional( jo, was_loaded, "flags", flags, string_reader{} );

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -16,6 +16,7 @@
 
 #include "calendar.h"
 #include "color.h"
+#include "lightmap.h"
 #include "coordinates.h"
 #include "memory_fast.h"
 #include "point.h"
@@ -483,6 +484,7 @@ class vpart_info
         // recharging (charging speed in watts)
         // funnel (water collection area in mm^2)
         int bonus = 0;
+        light_color_rgb light_color;
 
         /** cargo weight modifier (percentage) */
         int cargo_weight_modifier = 100;

--- a/tests/light_color_test.cpp
+++ b/tests/light_color_test.cpp
@@ -1,0 +1,386 @@
+#include <memory> // IWYU pragma: keep
+#include <vector>
+
+#include "calendar.h"
+#include "cata_catch.h"
+#include "character.h"
+#include "coordinates.h"
+#include "game.h"
+#include "level_cache.h"
+#include "lightmap.h"
+#include "map.h"
+#include "map_helpers.h"
+#include "map_scale_constants.h"
+#include "mdarray.h"
+#include "options_helpers.h"
+#include "player_helpers.h"
+#include "point.h"
+#include "shadowcasting.h"
+#include "type_id.h"
+#include "units.h"
+#include "veh_type.h"
+#include "vehicle.h"
+#include "vpart_position.h"
+#include "vpart_range.h"
+#include "weather_type.h"
+
+static const field_type_str_id field_fd_test_green_glow( "fd_test_green_glow" );
+static const ter_str_id ter_t_brick_wall( "t_brick_wall" );
+static const ter_str_id ter_t_flat_roof( "t_flat_roof" );
+static const ter_str_id ter_t_floor( "t_floor" );
+static const ter_str_id ter_t_test_blue_light( "t_test_blue_light" );
+static const ter_str_id ter_t_test_red_light( "t_test_red_light" );
+static const ter_str_id ter_t_utility_light( "t_utility_light" );
+static const vpart_id vpart_test_red_headlight( "test_red_headlight" );
+static const vproto_id vehicle_prototype_car( "car" );
+
+static const time_point midnight = calendar::turn_zero + 0_hours;
+
+// Helper: build full lightmap cache at a given z-level
+static void rebuild_lightmap( int zlev )
+{
+    map &here = get_map();
+    for( int z = -2; z <= OVERMAP_HEIGHT; z++ ) {
+        here.invalidate_map_cache( z );
+    }
+    here.invalidate_visibility_cache();
+    here.build_map_cache( zlev );
+    here.invalidate_visibility_cache();
+    here.update_visibility_cache( zlev );
+    here.build_map_cache( zlev );
+}
+
+// Helper: standard dark-map test setup
+static void setup_dark_map()
+{
+    clear_avatar();
+    clear_map_without_vision( -2, OVERMAP_HEIGHT );
+    g->reset_light_level();
+    calendar::turn = midnight;
+    get_player_character().recalc_sight_limits();
+}
+
+// Helper: get light color at a map position
+static light_color_rgb get_light_color_at( const tripoint_bub_ms &pos )
+{
+    const map &here = get_map();
+    const level_cache &cache = here.access_cache( pos.z() );
+    return cache.light_color_cache[pos.x()][pos.y()];
+}
+
+// Helper: place terrain at a position with a roof above
+static void place_ter_roofed( const tripoint_bub_ms &pos, const ter_str_id &ter )
+{
+    map &here = get_map();
+    here.ter_set( pos, ter.id() );
+    here.ter_set( pos + tripoint::above, ter_t_flat_roof.id() );
+}
+
+TEST_CASE( "colored_light_source_populates_cache", "[light_color]" )
+{
+    setup_dark_map();
+    scoped_weather_override weather_clear( WEATHER_CLEAR );
+
+    const tripoint_bub_ms src = get_player_character().pos_bub() + tripoint::east * 3;
+    place_ter_roofed( src, ter_t_test_red_light );
+
+    rebuild_lightmap( 0 );
+
+    const light_color_rgb color = get_light_color_at( src );
+    CHECK( color.r > 0.0f );
+    CHECK( color.g == 0.0f );
+    CHECK( color.b == 0.0f );
+}
+
+TEST_CASE( "colored_light_attenuates_with_distance", "[light_color]" )
+{
+    setup_dark_map();
+    scoped_weather_override weather_clear( WEATHER_CLEAR );
+
+    const tripoint_bub_ms src = get_player_character().pos_bub() + tripoint::east * 5;
+    place_ter_roofed( src, ter_t_test_red_light );
+
+    // Surround with floor so transparency is uniform
+    for( int dx = -4; dx <= 4; dx++ ) {
+        for( int dy = -4; dy <= 4; dy++ ) {
+            tripoint_bub_ms p = src + tripoint( dx, dy, 0 );
+            if( p != src ) {
+                place_ter_roofed( p, ter_t_floor );
+            }
+        }
+    }
+
+    rebuild_lightmap( 0 );
+
+    // Skip the source tile itself (octant overlap makes it complicated).
+    // Check attenuation at increasing distances from the source.
+    const float r_at_1 = get_light_color_at( src + tripoint::east ).r;
+    const float r_at_2 = get_light_color_at( src + tripoint::east * 2 ).r;
+    const float r_at_3 = get_light_color_at( src + tripoint::east * 3 ).r;
+
+    CHECK( r_at_1 > 0.0f );
+    CHECK( r_at_1 > r_at_2 );
+    CHECK( r_at_2 > r_at_3 );
+    CHECK( r_at_3 > 0.0f );
+}
+
+TEST_CASE( "wall_blocks_colored_light", "[light_color]" )
+{
+    setup_dark_map();
+    scoped_weather_override weather_clear( WEATHER_CLEAR );
+
+    const tripoint_bub_ms src = get_player_character().pos_bub() + tripoint::east * 3;
+    place_ter_roofed( src, ter_t_test_red_light );
+
+    // Wall one tile east of the source
+    const tripoint_bub_ms wall_pos = src + tripoint::east;
+    place_ter_roofed( wall_pos, ter_t_brick_wall );
+
+    // Target is behind the wall
+    const tripoint_bub_ms target = src + tripoint::east * 2;
+    place_ter_roofed( target, ter_t_floor );
+
+    rebuild_lightmap( 0 );
+
+    const light_color_rgb behind_wall = get_light_color_at( target );
+    CHECK( behind_wall.r == 0.0f );
+    CHECK( behind_wall.g == 0.0f );
+    CHECK( behind_wall.b == 0.0f );
+}
+
+TEST_CASE( "two_colored_sources_both_contribute", "[light_color]" )
+{
+    // Two differently colored sources illuminate their own areas independently.
+    setup_dark_map();
+    scoped_weather_override weather_clear( WEATHER_CLEAR );
+
+    const tripoint_bub_ms center = get_player_character().pos_bub() + tripoint::east * 5;
+
+    // Red source 3 tiles west of center
+    const tripoint_bub_ms red_pos = center + tripoint::west * 3;
+    place_ter_roofed( red_pos, ter_t_test_red_light );
+
+    // Blue source 3 tiles east of center
+    const tripoint_bub_ms blue_pos = center + tripoint::east * 3;
+    place_ter_roofed( blue_pos, ter_t_test_blue_light );
+
+    // Fill area with floor
+    for( int dx = -5; dx <= 5; dx++ ) {
+        for( int dy = -2; dy <= 2; dy++ ) {
+            tripoint_bub_ms p = center + tripoint( dx, dy, 0 );
+            if( p != red_pos && p != blue_pos ) {
+                place_ter_roofed( p, ter_t_floor );
+            }
+        }
+    }
+
+    rebuild_lightmap( 0 );
+
+    const light_color_rgb mid = get_light_color_at( center );
+    CHECK( mid.r > 0.0f );
+    CHECK( mid.b > 0.0f );
+}
+
+TEST_CASE( "overlapping_same_color_sources_accumulate", "[light_color]" )
+{
+    // Two same-colored sources on opposite sides of a point produce more
+    // color at the midpoint than one source alone: each source reaches
+    // center from different octants with different attenuation paths.
+    setup_dark_map();
+    scoped_weather_override weather_clear( WEATHER_CLEAR );
+
+    const tripoint_bub_ms center = get_player_character().pos_bub() + tripoint::east * 5;
+
+    // First: measure color from a single red source
+    place_ter_roofed( center + tripoint::west * 2, ter_t_test_red_light );
+    for( int dx = -3; dx <= 3; dx++ ) {
+        for( int dy = -3; dy <= 3; dy++ ) {
+            tripoint_bub_ms p = center + tripoint( dx, dy, 0 );
+            if( get_map().ter( p ) != ter_t_test_red_light.id() ) {
+                place_ter_roofed( p, ter_t_floor );
+            }
+        }
+    }
+    rebuild_lightmap( 0 );
+    const float single_r = get_light_color_at( center ).r;
+    CHECK( single_r > 0.0f );
+
+    // Second: add another red source on the other side
+    place_ter_roofed( center + tripoint::east * 2, ter_t_test_red_light );
+    rebuild_lightmap( 0 );
+    const float double_r = get_light_color_at( center ).r;
+
+    // Two sources should produce strictly more color than one
+    CHECK( double_r > single_r );
+}
+
+TEST_CASE( "uncolored_source_produces_no_color", "[light_color]" )
+{
+    setup_dark_map();
+    scoped_weather_override weather_clear( WEATHER_CLEAR );
+
+    const tripoint_bub_ms src = get_player_character().pos_bub() + tripoint::east * 3;
+    place_ter_roofed( src, ter_t_utility_light );
+
+    rebuild_lightmap( 0 );
+
+    const light_color_rgb color = get_light_color_at( src );
+    CHECK( color.r == 0.0f );
+    CHECK( color.g == 0.0f );
+    CHECK( color.b == 0.0f );
+}
+
+TEST_CASE( "colored_light_footprint_matches_scalar", "[light_color]" )
+{
+    // Invariant: wherever the scalar lightmap shows source contribution above
+    // ambient, color should be present. Checked by comparing against a control
+    // tile with NO source (purely ambient). Single isolated source, dark map.
+    setup_dark_map();
+    scoped_weather_override weather_clear( WEATHER_CLEAR );
+
+    const tripoint_bub_ms src = get_player_character().pos_bub() + tripoint::east * 5;
+    place_ter_roofed( src, ter_t_test_red_light );
+
+    // Control tile far from source, same z-level, gives us the ambient lm value
+    const tripoint_bub_ms control = get_player_character().pos_bub() + tripoint::west * 10;
+    place_ter_roofed( control, ter_t_floor );
+
+    rebuild_lightmap( 0 );
+
+    const map &here = get_map();
+    const level_cache &cache = here.access_cache( 0 );
+    const float ambient = cache.lm[control.x()][control.y()].max();
+
+    // Check tiles near the source: if lm is meaningfully above ambient, color
+    // should be present. And if lm equals ambient, color may or may not be
+    // present (color castLight can reach tiles where scalar is ambient-masked).
+    int tiles_with_both = 0;
+    for( int dx = -4; dx <= 4; dx++ ) {
+        for( int dy = -4; dy <= 4; dy++ ) {
+            const point p( src.x() + dx, src.y() + dy );
+            if( p.x < 0 || p.x >= MAPSIZE_X || p.y < 0 || p.y >= MAPSIZE_Y ) {
+                continue;
+            }
+            const float scalar = cache.lm[p.x][p.y].max();
+            const bool has_color = cache.light_color_cache[p.x][p.y].is_colored();
+
+            // If scalar is well above ambient, color must be present
+            if( scalar > ambient + 1.0f ) {
+                CAPTURE( dx, dy, scalar, ambient, cache.light_color_cache[p.x][p.y].r );
+                CHECK( has_color );
+                tiles_with_both++;
+            }
+        }
+    }
+    // Sanity: we found at least some tiles with both scalar and color
+    CHECK( tiles_with_both > 10 );
+}
+
+TEST_CASE( "light_color_cache_clears_on_rebuild", "[light_color]" )
+{
+    setup_dark_map();
+    scoped_weather_override weather_clear( WEATHER_CLEAR );
+
+    const tripoint_bub_ms src = get_player_character().pos_bub() + tripoint::east * 3;
+    place_ter_roofed( src, ter_t_test_red_light );
+
+    rebuild_lightmap( 0 );
+    CHECK( get_light_color_at( src ).r > 0.0f );
+
+    // Remove the light source
+    place_ter_roofed( src, ter_t_floor );
+
+    rebuild_lightmap( 0 );
+    CHECK( get_light_color_at( src ).r == 0.0f );
+}
+
+TEST_CASE( "field_colored_light_propagates", "[light_color]" )
+{
+    setup_dark_map();
+    scoped_weather_override weather_clear( WEATHER_CLEAR );
+
+    const tripoint_bub_ms src = get_player_character().pos_bub() + tripoint::east * 3;
+    place_ter_roofed( src, ter_t_floor );
+
+    // Place a green-glowing field
+    map &here = get_map();
+    here.add_field( src, field_fd_test_green_glow.id(), 1 );
+
+    rebuild_lightmap( 0 );
+
+    const light_color_rgb color = get_light_color_at( src );
+    CHECK( color.g > 0.0f );
+    CHECK( color.r == 0.0f );
+    CHECK( color.b == 0.0f );
+
+    // Check propagation to an adjacent tile
+    const light_color_rgb adjacent = get_light_color_at( src + tripoint::east );
+    CHECK( adjacent.g > 0.0f );
+}
+
+TEST_CASE( "vehicle_cone_light_carries_color", "[light_color]" )
+{
+    setup_dark_map();
+    scoped_weather_override weather_clear( WEATHER_CLEAR );
+
+    map &here = get_map();
+    const tripoint_bub_ms veh_pos = get_player_character().pos_bub() + tripoint::east * 5;
+
+    for( int dx = -10; dx <= 10; dx++ ) {
+        for( int dy = -10; dy <= 10; dy++ ) {
+            place_ter_roofed( veh_pos + tripoint( dx, dy, 0 ), ter_t_floor );
+        }
+    }
+
+    vehicle *veh = here.add_vehicle( vehicle_prototype_car, veh_pos, 0_degrees, 100, 0 );
+    REQUIRE( veh != nullptr );
+
+    // Replace one stock headlight with our red test headlight
+    std::vector<point_rel_ms> hl_mounts;
+    for( const vpart_reference &vpr : veh->get_any_parts( VPFLAG_CONE_LIGHT ) ) {
+        hl_mounts.push_back( vpr.part().mount );
+        veh->remove_part( vpr.part() );
+    }
+    veh->part_removal_cleanup( here );
+    REQUIRE( !hl_mounts.empty() );
+
+    const int part_idx = veh->install_part( here, hl_mounts.front(), vpart_test_red_headlight );
+    REQUIRE( part_idx >= 0 );
+
+    vehicle_part &installed = veh->part( part_idx );
+    installed.enabled = true;
+    REQUIRE( installed.info().has_flag( VPFLAG_CONE_LIGHT ) );
+
+    rebuild_lightmap( 0 );
+
+    // Find the brightest colored tile near the headlight. The cone direction
+    // depends on vehicle facing + part mount direction, so scan rather than
+    // hardcoding an offset.
+    const tripoint_bub_ms hl_pos = veh->bub_part_pos( here, installed );
+    const level_cache &cache = here.access_cache( 0 );
+    float best_r = 0.0f;
+    tripoint best_offset;
+    for( int dx = -6; dx <= 6; dx++ ) {
+        for( int dy = -6; dy <= 6; dy++ ) {
+            const tripoint_bub_ms p = hl_pos + tripoint( dx, dy, 0 );
+            if( !here.inbounds( p ) ) {
+                continue;
+            }
+            const float r = cache.light_color_cache[p.x()][p.y()].r;
+            if( r > best_r ) {
+                best_r = r;
+                best_offset = tripoint( dx, dy, 0 );
+            }
+        }
+    }
+    REQUIRE( best_r > 0.0f );
+
+    // The opposite direction should have less (or no) color
+    const tripoint_bub_ms behind = hl_pos - best_offset;
+    REQUIRE( here.inbounds( behind ) );
+    const light_color_rgb behind_color = get_light_color_at( behind );
+    CAPTURE( best_r, best_offset.x, best_offset.y );
+    CAPTURE( behind_color.r, behind_color.g, behind_color.b );
+
+    CHECK( best_r > behind_color.r );
+}


### PR DESCRIPTION
#### Summary
Features "Colored light rendering overlay, dawn/dusk tint"

#### Purpose of change

All light in CDDA is scalar - fire, emergency beacons, flares, glowsticks all emit the same white glow. This adds colored light so police beacons flash red/blue and dawn/dusk gets a warm orange tint instead of the usual binary day/night switch.

Also lays groundwork for richer rendering: the `tile_render_params` struct gives future effects a clean place to plug in without touching every draw call.

#### Describe the solution

Three commits, each standalone:

tile_render_params - bundles `lit_level` + NV toggle into a struct threaded through `draw_sprite_at` / `draw_tile_at`. Pure refactor, no behavior change.

light_color data layer -- terrain, furniture, fields, and vehicle parts gain an optional `light_color` JSON field (`[R,G,B]`, 0-255). Color reuses the existing scalar light buffer and shadow casting: `add_light_source` accumulates color weighted by luminance, `apply_light_source` propagates it through the same octant-pruning decisions, `apply_light_arc` carries it through cone/arc casting. Stored as float-precision accumulated energy in `level_cache`; the renderer quantizes when reading.

Rendering overlay - draws per-tile colored rects after all 11 sprite layers using `SDL_BLENDMODE_BLEND`. Chromatic (saturated) component of the cached color drives tint hue; white component is discarded. Alpha scales with colored-to-total light ratio. Octant seam artifacts addressed with per-channel max in the castLight callback plus a 3x3 box blur.

Dawn/dusk tint: outside tiles get a warm orange-to-gold overlay during twilight. The sun altitude range (-6 to -1 degrees below horizon) comes from the nautical twilight definition; the hue range (HSV 25-45) was eyeballed to match the color temperature shift you get in real sunsets. A sine curve fades it in and out so it doesn't pop on/off.

Emergency beacons (`light_red`, `light_blue`) get `light_color` as starter content.

#### Describe alternatives you've considered

Full RGB lightmap (replacing `four_quadrants` with per-channel floats) - 3x the memory and shadow casting cost, way more invasive for what amounts to a subtle visual feature. The overlay approach reuses existing scalar propagation and only adds cost for tiles that actually have colored sources. So essentially it's free until you start placing colored lights.

#### Testing

10 new test cases covering source cache population, distance attenuation, wall blocking, two-color blending, same-color accumulation, uncolored source passthrough, footprint-matches-scalar invariant, cache clearing, field propagation, vehicle cone directionality. All pass.

Memory: +429 KB per z-level (~34% of level_cache). CPU: zero overhead for uncolored sources, ~2x casting cost per colored source (mitigated by octant pruning). Rendering overlay adds under 1ms per frame.

<img width="1249" height="1429" alt="image" src="https://github.com/user-attachments/assets/88670f4a-6370-4754-8e36-fb5eedbf77f4" />


#### Additional context

Known v1 limitation: same-tile mixed-color sources can borrow range from the stronger source due to the max-luminance buffer merge model. In practice this doesn't matter because beacons flash one color per turn and fire tiles are all one color, but worth mentioning for anyone who decides to put a red candle on top of a blue portal.

The dawn/dusk tint is purely cosmetic and not tied to any gameplay mechanic. It just looked sad without it.