### PR TITLE
No kill xp for spawncampers

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -3186,6 +3186,14 @@
   },
   {
     "type": "effect_type",
+    "id": "revived_marker",
+    "//COMMENT": "Hardcoded dummy effect to track a monster as revived. Applied and checked in C++ only.",
+    "name": [ "Revived" ],
+    "desc": [ "" ],
+    "show_in_info": false
+  },
+  {
+    "type": "effect_type",
     "id": "slimed",
     "name": [ "Slimed" ],
     "desc": [ "You're covered in thick goo!" ],

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4875,7 +4875,7 @@ bool game::revive_corpse( const tripoint_bub_ms &p, item &it, int radius )
     }
 
     if( it.get_var( "times_combatted", 0.0 ) > 0.0 ) {
-        critter.times_combatted_player = it.get_var( "times_combatted", 0.0 );
+        critter.times_combatted_player = std::numeric_limits<short>::max();
     }
 
     // Add a permanent effect marking this as a revived creature. Everytime they revive they will have this effect forever.

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -263,6 +263,7 @@ static const efftype_id effect_no_sight( "no_sight" );
 static const efftype_id effect_onfire( "onfire" );
 static const efftype_id effect_pet( "pet" );
 static const efftype_id effect_psi_stunned( "psi_stunned" );
+static const efftype_id effect_revived_marker( "revived_marker" );
 static const efftype_id effect_ridden( "ridden" );
 static const efftype_id effect_riding( "riding" );
 static const efftype_id effect_stunned( "stunned" );
@@ -4876,6 +4877,10 @@ bool game::revive_corpse( const tripoint_bub_ms &p, item &it, int radius )
     if( it.get_var( "times_combatted", 0.0 ) > 0.0 ) {
         critter.times_combatted_player = it.get_var( "times_combatted", 0.0 );
     }
+
+    // Add a permanent effect marking this as a revived creature. Everytime they revive they will have this effect forever.
+    critter.add_effect( effect_source(), effect_revived_marker, calendar::INDEFINITELY_LONG_DURATION,
+                        true );
 
     return place_critter_around( newmon_ptr, tripoint_bub_ms( p ), radius );
 }

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -136,6 +136,7 @@ static const efftype_id effect_pet( "pet" );
 static const efftype_id effect_photophobia( "photophobia" );
 static const efftype_id effect_poison( "poison" );
 static const efftype_id effect_psi_stunned( "psi_stunned" );
+static const efftype_id effect_revived_marker( "revived_marker" );
 static const efftype_id effect_ridden( "ridden" );
 static const efftype_id effect_run( "run" );
 static const efftype_id effect_spooked( "spooked" );
@@ -3028,8 +3029,10 @@ void monster::die( map *here, Creature *nkiller )
             ch = get_killer()->get_summoner()->as_character();
         }
         if( !is_hallucination() && ch != nullptr ) {
+            // Revived creatures never grant any kill xp.
+            const int kill_xp = has_effect( effect_revived_marker ) ? 0 : compute_kill_xp( type->id );
             cata::event e = cata::event::make<event_type::character_kills_monster>( ch->getID(), type->id,
-                            compute_kill_xp( type->id ) );
+                            kill_xp );
             get_event_bus().send_with_talker( ch, this, e );
         }
     }


### PR DESCRIPTION
#### Summary
Bugfixes "No kill xp for spawncampers"

#### Purpose of change
> I leaved 13 bodies of zombie deer to return and kill them for skill xp

I misread this as "kill xp". Oh well - that's still an exploit.

#### Describe the solution
Squash this exploit.

Revived creatures have an invisible marker that ensures they never give kill xp.

#### Describe alternatives you've considered


#### Testing
First kill:
<img width="1273" height="198" alt="image" src="https://github.com/user-attachments/assets/6d2c0477-a7ea-463f-8eef-e34d34d50ff1" />

Revived effect successfully applied:
<img width="1867" height="1129" alt="image" src="https://github.com/user-attachments/assets/d517e589-07f8-42d2-86bd-4f1684a4ed23" />

Second kill:
<img width="1396" height="202" alt="image" src="https://github.com/user-attachments/assets/1e419854-0ce9-4eae-9723-4d772b9439f9" />


#### Additional context
