### PR TITLE
[Sky Island] Add two new challenge mode modifiers

### DIFF
--- a/data/mods/Sky_Island/effectoncondition/challenge_mode.json
+++ b/data/mods/Sky_Island/effectoncondition/challenge_mode.json
@@ -11,6 +11,7 @@
         "then": [
           {
             "weighted_list_eocs": [
+              [ "EOC_raid_challenge_mode_horde_chase", 100 ],
               [ "EOC_raid_challenge_mode_megacity_dimension", 100 ],
               [ "EOC_raid_challenge_mode_hot_dimension", 100 ],
               [ "EOC_raid_challenge_mode_cold_dimension", 100 ],
@@ -28,6 +29,8 @@
     "//": "Clear modifier effects and reset weights for selecting forest/houses as mission/extract targets post raid",
     "effect": [
       { "u_lose_effect": [ "challenge_mode_speed_reduction" ] },
+      { "u_lose_trait": "CHALLENGE_MODE_HORDES" },
+      { "math": [ "target_fields_weight = 15" ] },
       { "math": [ "target_forests_weight = hardmissions" ] },
       { "math": [ "target_houses_weight = hardermissions" ] }
     ]
@@ -126,6 +129,48 @@
         "time_in_future": 1
       },
       { "u_add_effect": "challenge_mode_speed_reduction", "duration": "PERMANENT" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_raid_challenge_mode_horde_chase",
+    "effect": [
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_raid_challenge_mode_horde_chase_warning",
+            "effect": [
+              {
+                "u_message": "Something is different about this dimension.  It feels like everything is following you.",
+                "popup": true
+              }
+            ]
+          },
+          "EOC_raid_challenge_mode_horde_chase_action"
+        ],
+        "time_in_future": 1
+      },
+      { "u_add_trait": "CHALLENGE_MODE_HORDES" },
+      { "math": [ "target_fields_weight = 0" ] },
+      { "math": [ "target_forests_weight = 0" ] },
+      { "math": [ "target_houses_weight = 100" ] }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_raid_challenge_mode_horde_chase_recurrence",
+    "recurrence": [ "1 minutes", "5 minutes" ],
+    "condition": { "u_has_trait": "CHALLENGE_MODE_HORDES" },
+    "deactivate_condition": { "not": { "u_has_trait": "CHALLENGE_MODE_HORDES" } },
+    "effect": [ { "run_eocs": [ "EOC_raid_challenge_mode_horde_chase_action" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_raid_challenge_mode_horde_chase_action",
+    "effect": [
+      { "u_location_variable": { "context_val": "your_pos" } },
+      { "signal_hordes": { "context_val": "your_pos" }, "signal_power": { "math": [ "5000" ] } },
+      { "u_message": "Your skin itches, you can feel them closing in.", "type": "bad" }
     ]
   }
 ]

--- a/data/mods/Sky_Island/effectoncondition/challenge_mode.json
+++ b/data/mods/Sky_Island/effectoncondition/challenge_mode.json
@@ -11,6 +11,7 @@
         "then": [
           {
             "weighted_list_eocs": [
+              [ "EOC_raid_challenge_mode_megacity_dimension", 100 ],
               [ "EOC_raid_challenge_mode_hot_dimension", 100 ],
               [ "EOC_raid_challenge_mode_cold_dimension", 100 ],
               [ "EOC_raid_challenge_mode_reduced_pulselength", 100 ],
@@ -24,7 +25,31 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_raid_challenge_mode_post_raid",
-    "effect": [ { "u_lose_effect": [ "challenge_mode_speed_reduction" ] } ]
+    "//": "Clear modifier effects and reset weights for selecting forest/houses as mission/extract targets post raid",
+    "effect": [
+      { "u_lose_effect": [ "challenge_mode_speed_reduction" ] },
+      { "math": [ "target_forests_weight = hardmissions" ] },
+      { "math": [ "target_houses_weight = hardermissions" ] }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_raid_challenge_mode_megacity_dimension",
+    "//": "Disable targeting forests for missions/extract since there is none in this dimension",
+    "effect": [
+      {
+        "run_eocs": {
+          "id": "EOC_raid_challenge_mode_megacity_dimension_warning",
+          "effect": [ { "u_message": "Something is different about this dimension.  The city appears to never end.", "popup": true } ]
+        },
+        "time_in_future": 1
+      },
+      {
+        "set_string_var": "sky_island_raid_region_mega_city",
+        "target_var": { "global_val": "sky_island_target_region_settings" }
+      },
+      { "math": [ "target_forests_weight = 0" ] }
+    ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/Sky_Island/effectoncondition/raid_missions.json
+++ b/data/mods/Sky_Island/effectoncondition/raid_missions.json
@@ -6,7 +6,7 @@
     "effect": [
       {
         "weighted_list_eocs": [
-          [ "EOC_Location1e", 15 ],
+          [ "EOC_Location1e", { "global_val": "target_fields_weight", "default": 15 } ],
           [ "EOC_Location2e", { "global_val": "target_forests_weight", "default": 0 } ],
           [ "EOC_Location3e", { "global_val": "target_houses_weight", "default": 0 } ]
         ]
@@ -20,7 +20,7 @@
     "effect": [
       {
         "weighted_list_eocs": [
-          [ "EOC_Location1m", 15 ],
+          [ "EOC_Location1m", { "global_val": "target_fields_weight", "default": 15 } ],
           [ "EOC_Location2m", { "global_val": "target_forests_weight", "default": 0 } ],
           [ "EOC_Location3m", { "global_val": "target_houses_weight", "default": 0 } ]
         ]

--- a/data/mods/Sky_Island/effectoncondition/raid_missions.json
+++ b/data/mods/Sky_Island/effectoncondition/raid_missions.json
@@ -7,8 +7,8 @@
       {
         "weighted_list_eocs": [
           [ "EOC_Location1e", 15 ],
-          [ "EOC_Location2e", { "global_val": "hardmissions", "default": 0 } ],
-          [ "EOC_Location3e", { "global_val": "hardermissions", "default": 0 } ]
+          [ "EOC_Location2e", { "global_val": "target_forests_weight", "default": 0 } ],
+          [ "EOC_Location3e", { "global_val": "target_houses_weight", "default": 0 } ]
         ]
       }
     ]
@@ -21,8 +21,8 @@
       {
         "weighted_list_eocs": [
           [ "EOC_Location1m", 15 ],
-          [ "EOC_Location2m", { "global_val": "hardmissions", "default": 0 } ],
-          [ "EOC_Location3m", { "global_val": "hardermissions", "default": 0 } ]
+          [ "EOC_Location2m", { "global_val": "target_forests_weight", "default": 0 } ],
+          [ "EOC_Location3m", { "global_val": "target_houses_weight", "default": 0 } ]
         ]
       }
     ]

--- a/data/mods/Sky_Island/missions/raid_upgrades/missions.json
+++ b/data/mods/Sky_Island/missions/raid_upgrades/missions.json
@@ -428,6 +428,8 @@
       "effect": [
         { "math": [ "hardmissions = 10" ] },
         { "math": [ "hardermissions = 5" ] },
+        { "math": [ "target_forests_weight = hardmissions" ] },
+        { "math": [ "target_houses_weight = hardermissions" ] },
         { "u_forget_recipe": "upgradekey_hardmissions1" },
         {
           "u_message": "Greater trespasses against the flow of the warpstream reveal themselves to you.  This interference cannot go unpunished.\nThe missions you are randomly assigned in each expedition are more varied, and can now pull from harder and more rewarding challenges.",
@@ -495,6 +497,8 @@
         { "math": [ "hardmissions = 15" ] },
         { "math": [ "hardermissions = 15" ] },
         { "math": [ "hardestmissions = 10" ] },
+        { "math": [ "target_forests_weight = hardmissions" ] },
+        { "math": [ "target_houses_weight = hardermissions" ] },
         { "u_forget_recipe": "upgradekey_hardmissions2" },
         {
           "u_message": "The greatest trespasses against the island now glimmer in the dark, guiding your hand as a tool of order.  Return these chaotic energies to the tranquility of the warpstream.\nThe missions you are randomly assigned in each expedition are even more varied, and can now pull from the hardest and most rewarding challenges.",

--- a/data/mods/Sky_Island/mutations.json
+++ b/data/mods/Sky_Island/mutations.json
@@ -128,5 +128,14 @@
         "ench_effects": [ { "effect": "effect_island_steady", "intensity": 1 } ]
       }
     ]
+  },
+  {
+    "type": "mutation",
+    "id": "CHALLENGE_MODE_HORDES",
+    "name": { "str": "Inverted Warp" },
+    "points": 0,
+    "purifiable": false,
+    "valid": false,
+    "description": "Instead of protecting you when you ended up here, the warpstream inverted itself and is now summoning zombies to your location."
   }
 ]

--- a/data/mods/Sky_Island/region_settings.json
+++ b/data/mods/Sky_Island/region_settings.json
@@ -102,5 +102,36 @@
     "id": "sky_island_raid_region_cold",
     "copy-from": "dimension_sky_island_region",
     "weather": "sky_island_raid_weather_cold"
+  },
+  {
+    "id": "MEGACITY_FLAG",
+    "type": "json_flag",
+    "name": ""
+  },
+  {
+    "type": "region_settings",
+    "id": "sky_island_raid_region_mega_city",
+    "copy-from": "dimension_sky_island_region",
+    "place_swamps": false,
+    "rivers": null,
+    "ocean": null,
+    "forests": null,
+    "lakes": null,
+    "highways": null,
+    "cities": "sky_island_raid_region_mega_city_settings",
+    "//": "Stop generation of all specials, just city buildings",
+    "feature_flag_settings": { "extend": { "whitelist": [ "MEGACITY_FLAG" ] } }
+  },
+  {
+    "type": "region_settings_city",
+    "id": "sky_island_raid_region_mega_city_settings",
+    "copy-from": "default",
+    "is_megacity": true,
+    "city_size": 16,
+    "city_spacing": 0,
+    "shop_radius": 200,
+    "shop_sigma": 0,
+    "park_radius": 0,
+    "park_sigma": 0
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Sky Island] Add two new challenge mode modifiers"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Adds two new challenge mode modifiers:
Hordes will chase you until you leave
Megacity dimension

#### Describe the solution
A new `region_settings` with `region_settings_city` object created to generate megacities and a new EOC is added to the challenge mode list to activate this modifier.

A new trait and paired recurring EOC created to signal hordes every 1-5 minutes while inside of the raid dimension. A new EOC is created and added to the challenge mode list to trigger this modifier.

The variable that controls weights for where to spawn missions and extracts was changed to new ones that are updated pre and post raids to accommodate changing where these things can spawn.

Megacities disable spawning of missions and extracts in forests since there are none.
Hordes disables field and forest targets so the player is forced into populated areas.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
<details>
<summary>images</summary>
Megacities
<img width="1234" height="963" alt="image" src="https://github.com/user-attachments/assets/93453265-910a-45ac-919d-e3af48b11fbf" />

Hordes
<img width="638" height="99" alt="image" src="https://github.com/user-attachments/assets/7111d2cd-0a99-44ea-bca4-20329b86793e" />
<img width="681" height="623" alt="image" src="https://github.com/user-attachments/assets/01c870fe-51ed-4108-b89a-e905b25430e7" />

</details>

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
