### PR TITLE
[alt-map-key] Add new overmap terrain

### DIFF
--- a/data/mods/alt_map_key/overmap_terrain_terrain.json
+++ b/data/mods/alt_map_key/overmap_terrain_terrain.json
@@ -152,6 +152,14 @@
   },
   {
     "type": "overmap_terrain",
+    "id": [ "inner_cabins_void_exit" ],
+    "copy-from": "inner_cabins_void_exit",
+    "name": "retracting pond",
+    "sym": "#",
+    "color": "blue"
+  },
+  {
+    "type": "overmap_terrain",
     "id": "hot_springs",
     "copy-from": "hot_springs",
     "name": "hot spring",


### PR DESCRIPTION
#### Summary
Mods "[alt-map-key] Add new overmap terrain"


#### Purpose of change
Adding new overmap terrain

#### Describe the solution
Add new retracting pond from #86058

#### Describe alternatives you've considered


#### Testing
<img width="171" height="181" alt="image" src="https://github.com/user-attachments/assets/189388d2-6549-4d97-b9e3-06b9aa8ab35f" />



#### Additional context



<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
