### PR TITLE
Correct movement mode cycling logic for horses

### DIFF
--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -1330,21 +1330,25 @@ void avatar::reset_move_mode()
 
 void avatar::cycle_move_mode()
 {
-    const move_mode_id next = current_movement_mode()->cycle();
-    set_movement_mode( next );
-    // if a movemode is disabled then just cycle to the next one
-    if( !movement_mode_is( next ) ) {
-        set_movement_mode( next->cycle() );
+    move_mode_id next = current_movement_mode()->cycle();
+    while( next != current_movement_mode() ) {
+        if( can_switch_to( next ) ) {
+            set_movement_mode( next );
+            return;
+        }
+        next = next->cycle();
     }
 }
 
 void avatar::cycle_move_mode_reverse()
 {
-    const move_mode_id prev = current_movement_mode()->cycle_reverse();
-    set_movement_mode( prev );
-    // if a movemode is disabled then just cycle to the previous one
-    if( !movement_mode_is( prev ) ) {
-        set_movement_mode( prev->cycle_reverse() );
+    move_mode_id prev = current_movement_mode()->cycle_reverse();
+    while( prev != current_movement_mode() ) {
+        if( can_switch_to( prev ) ) {
+            set_movement_mode( prev );
+            return;
+        }
+        prev = prev->cycle_reverse();
     }
 }
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2197,6 +2197,10 @@ steed_type Character::get_steed_type() const
 
 bool Character::can_switch_to( const move_mode_id &mode ) const
 {
+    if( get_steed_type() == steed_type::ANIMAL &&
+        ( mode->type() == move_mode_type::PRONE || mode->type() == move_mode_type::CROUCHING ) ) {
+        return false;
+    }
     // Only running modes are restricted at the moment and only when its your legs doing the running
     return get_steed_type() != steed_type::NONE || mode->type() != move_mode_type::RUNNING || can_run();
 }

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -141,9 +141,6 @@ json_flag_TEMPORARY_SHAPESHIFT_NO_HANDS( "TEMPORARY_SHAPESHIFT_NO_HANDS" );
 
 static const material_id material_glass( "glass" );
 
-static const move_mode_id move_mode_run( "run" );
-static const move_mode_id move_mode_walk( "walk" );
-
 static const quality_id qual_CUT( "CUT" );
 
 static const skill_id skill_melee( "melee" );
@@ -1834,13 +1831,7 @@ static void fire()
 static void open_movement_mode_menu()
 {
     avatar &player_character = get_avatar();
-    std::vector<move_mode_id> modes;
-    const bool riding_animal = player_character.get_steed_type() == steed_type::ANIMAL;
-    if( riding_animal ) {
-        modes = { move_mode_walk, move_mode_run };
-    } else {
-        modes = move_modes_by_speed();
-    }
+    std::vector<move_mode_id> modes = move_modes_by_speed();
     const int cycle = 1027;
     uilist as_m;
 
@@ -1853,7 +1844,7 @@ static void open_movement_mode_menu()
                                    curr->name() );
     }
     as_m.entries.emplace_back( cycle,
-                               player_character.can_switch_to( player_character.current_movement_mode()->cycle() ),
+                               true, // cycling movement is controlled in relevant functions, always allow
                                hotkey_for_action( ACTION_OPEN_MOVEMENT, /*maximum_modifier_count=*/1 ),
                                _( "Cycle move mode" ) );
     // This should select the middle move mode
@@ -1862,15 +1853,7 @@ static void open_movement_mode_menu()
 
     if( as_m.ret != UILIST_CANCEL ) {
         if( as_m.ret == cycle ) {
-            if( riding_animal ) {
-                if( player_character.current_movement_mode() == move_mode_walk ) {
-                    player_character.set_movement_mode( move_mode_run );
-                } else {
-                    player_character.set_movement_mode( move_mode_walk );
-                }
-            } else {
-                player_character.cycle_move_mode();
-            }
+            player_character.cycle_move_mode();
         } else {
             player_character.set_movement_mode( modes[as_m.ret] );
         }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Correct movement mode cycling logic for horses"

#### Purpose of change
#85021 introduced some good mechanics for riding animals but missed movement cycling via keybind

#### Describe the solution
Moved logic to control what movement modes are allowed on a horse out to `Character::can_switch_to` instead of inside of `open_movement_mode_menu`

Adjusted `open_movement_mode_menu` to always allow the cycling option, all handling of cycling movement modes are handled elsewhere

All movement mode cycling operations are controlled by `avatar::cycle_move_mode` and `avatar::cycle_move_mode_reverse`. These functions will attempt to cycle through the whole movement mode loop to find the next valid option. They will return upon returning back to the already active mode if no other options are found


#### Describe alternatives you've considered
Adding a guard in `avatar::cycle_move_mode` and `avatar::cycle_move_mode_reverse` loops to break out if it looped too many times but movement modes are constructed in a circular double linked list already so I skipped on the extra logic 

#### Testing
Cycling movement modes via keybind or the movement mode selection menu will only cycle between walk and run.
Walk and run remain the only selectable movement modes in the movement mode menu
All movement mode options remain working as normal when on foot.

#### Additional context



<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
