### PR TITLE
[Sky Island] Red Exit Room red glow

### DIFF
--- a/data/mods/Sky_Island/furniture_and_terrain.json
+++ b/data/mods/Sky_Island/furniture_and_terrain.json
@@ -99,7 +99,8 @@
     "name": "red glowing wall",
     "description": "A red wall emitting otherworldly glow, enough to be noticeable at night.",
     "color": "red",
-    "light_emitted": 120
+    "light_emitted": 120,
+    "light_color": [ 149, 36, 20 ]
   },
   {
     "id": "fakeitem_statue",


### PR DESCRIPTION

#### Summary
None
#### Purpose of change

Since that colored light pr got merged, i can make the red room glow red.

#### Describe the solution

give it the thing that colors the light

#### Describe alternatives you've considered
None

#### Testing
![Screenshot_20260325_232414](https://github.com/user-attachments/assets/af0a1036-7b24-4294-bf13-effc77c637ff)


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
