### PR TITLE
Rural church of nether strings glows

### DIFF
--- a/data/json/emit.json
+++ b/data/json/emit.json
@@ -147,6 +147,14 @@
     "chance": 15
   },
   {
+    "id": "emit_twisting_mass_dust",
+    "type": "emit",
+    "field": "fd_twisting_mass_dust",
+    "intensity": 3,
+    "qty": 10,
+    "chance": 15
+  },
+  {
     "id": "emit_toxic_cloud",
     "type": "emit",
     "//": "Small cloud of toxic gas emitted infrequently",

--- a/data/json/field_type.json
+++ b/data/json/field_type.json
@@ -979,6 +979,28 @@
     "looks_like": "fd_smoke"
   },
   {
+    "id": "fd_twisting_mass_dust",
+    "type": "field_type",
+    "intensity_levels": [
+      {
+        "name": "magenta sparkles",
+        "color": "magenta",
+        "sym": "*",
+        "light_emitted": 160,
+        "light_color": [ 255, 0, 255 ],
+        "concentration": 1
+      }
+    ],
+    "priority": 9,
+    "half_life": "10 seconds",
+    "accelerated_decay": true,
+    "dirty_transparency_cache": true,
+    "phase": "gas",
+    "display_items": true,
+    "display_field": true,
+    "looks_like": "fd_tindalos_rift"
+  },
+  {
     "id": "fd_fire_vent",
     "type": "field_type",
     "legacy_enum_id": 17,

--- a/data/json/monsters/nether.json
+++ b/data/json/monsters/nether.json
@@ -2461,6 +2461,7 @@
     "vision_night": 5,
     "harvest": "exempt",
     "death_function": { "message": "The %s shatters into innumerable, impossibly small fragments!", "corpse_type": "NO_CORPSE" },
+    "emit_fields": [ { "emit_id": "emit_twisting_mass_dust", "delay": "1 s" } ],
     "grab_strength": 35,
     "special_attacks": [ { "id": "ranged_pull", "range": 5, "cooldown": 20, "grab_data": { "pull_weight_ratio": 3.0 } } ],
     "flags": [ "SEES", "NO_BREATHE", "RANGED_ATTACKER", "BASHES", "GROUP_BASH" ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Features "Church of Strings actually glows"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

The nether strings in the rural church always glowed.  Now they can actually glow magenta.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Adds a field they emit that glows very brightly.  Now even in the day, it's clear something funky is going on.

<img width="787" height="602" alt="magenta_sparkles" src="https://github.com/user-attachments/assets/83f37661-d4d4-41a3-ae90-e225f07851c7" />


<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

n/a, this matches my vision of what they looked like

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Checked the church

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
