### PR TITLE
Give fire light emission color

### DIFF
--- a/data/json/field_type.json
+++ b/data/json/field_type.json
@@ -342,8 +342,20 @@
         "translucency": 0.7,
         "convection_temperature_mod": 300
       },
-      { "name": { "ctxt": "noun", "str": "fire" }, "color": "light_red", "light_emitted": 60, "light_color": [ 255, 180, 80 ], "translucency": 0.4 },
-      { "name": "raging fire", "color": "red", "light_emitted": 160, "light_color": [ 255, 255, 210 ], "translucency": 0.1 }
+      {
+        "name": { "ctxt": "noun", "str": "fire" },
+        "color": "light_red",
+        "light_emitted": 60,
+        "light_color": [ 255, 180, 80 ],
+        "translucency": 0.4
+      },
+      {
+        "name": "raging fire",
+        "color": "red",
+        "light_emitted": 160,
+        "light_color": [ 255, 255, 210 ],
+        "translucency": 0.1
+      }
     ],
     "description_affix": "on",
     "decay_amount_factor": 3,

--- a/data/json/field_type.json
+++ b/data/json/field_type.json
@@ -338,11 +338,12 @@
         "color": "yellow",
         "dangerous": true,
         "light_emitted": 20,
+        "light_color": [ 255, 120, 40 ],
         "translucency": 0.7,
         "convection_temperature_mod": 300
       },
-      { "name": { "ctxt": "noun", "str": "fire" }, "color": "light_red", "light_emitted": 60, "translucency": 0.4 },
-      { "name": "raging fire", "color": "red", "light_emitted": 160, "translucency": 0.1 }
+      { "name": { "ctxt": "noun", "str": "fire" }, "color": "light_red", "light_emitted": 60, "light_color": [ 255, 180, 80 ], "translucency": 0.4 },
+      { "name": "raging fire", "color": "red", "light_emitted": 160, "light_color": [ 255, 255, 210 ], "translucency": 0.1 }
     ],
     "description_affix": "on",
     "decay_amount_factor": 3,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Features "Fire emits colored light"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fire could use some color

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Gave fire colored light, spanning from reddish, to yellow, to almost white.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Different colors.  Happy to tweak these, or have someone else tweak them.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Tested various stages of fire.  Screenshots below.  I did not notice any obvious performance issues.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Small fire inside (delicate glow): <details><img width="517" height="482" alt="fire1" src="https://github.com/user-attachments/assets/08c21ad9-3444-47ba-9e12-11d78712d2f4" /></details>

Large fire inside (starts to get brighter/whiter): <details><img width="347" height="348" alt="fire2" src="https://github.com/user-attachments/assets/fd39b727-6b4e-4378-9341-43659a0c12df" /></details>

Small fire outside during day, not much light: <details><img width="412" height="343" alt="fire3" src="https://github.com/user-attachments/assets/95f76bf4-7dd3-47da-82f4-55e8109e830b" /></details>

Small fire outside during dusk light: <details><img width="377" height="323" alt="fire4" src="https://github.com/user-attachments/assets/bb7f76bb-d731-48fb-a12d-47cb9700bda8" /></details>

Large fire outside during day: <details><img width="591" height="472" alt="fire5" src="https://github.com/user-attachments/assets/a04bd3a1-281b-46ad-ad4d-0032af049e08" /></details>

Large fire outside during night: <details><img width="837" height="687" alt="fire6" src="https://github.com/user-attachments/assets/05a8c993-1e43-44bb-9ec2-f1257dbf7580" /></details>

Raging fires are almost white: <details><img width="463" height="402" alt="fire7" src="https://github.com/user-attachments/assets/3abd58f5-2514-438c-a81f-246da84d3cca" /></details>

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
