### PR TITLE
[XEDRA Evolved] Balefire colored light

### DIFF
--- a/data/mods/Xedra_Evolved/furniture_and_terrain/furniture.json
+++ b/data/mods/Xedra_Evolved/furniture_and_terrain/furniture.json
@@ -121,6 +121,7 @@
     "color": "light_blue",
     "coverage": 30,
     "light_emitted": 55,
+    "light_color": [ 94, 175, 237 ],
     "flags": [ "TRANSPARENT", "NOITEM", "BLOCKSDOOR" ],
     "bash": {
       "str_min": 20,


### PR DESCRIPTION

#### Summary
None

#### Purpose of change
Now that the colored light pr got merged, give the balefire blue colored lights

#### Describe the solution

Give it so.

#### Describe alternatives you've considered

None

#### Testing
![Screenshot_20260326_012521](https://github.com/user-attachments/assets/9a135594-6781-4233-81c4-4baac1fde04e)


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
