### PR TITLE
Fix find_parent debugmsg on every charged-item pickup

### DIFF
--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -303,7 +303,8 @@ static bool pick_one_up( item_location &loc, int quantity, bool &got_water, bool
             if( ret.success() ) {
                 if( added_it == item_location::nowhere ) {
                     newit.charges = last_charges - newit.charges;
-                    newit.on_pickup( player_character );
+                    // Don't call on_pickup on this local copy -- the real items
+                    // already got it via add_stash -> fill_with (#85439).
                     if( newit.charges != 0 ) {
                         auto &entry = mapPickup[newit.tname()];
                         entry.second += newit.charges;

--- a/tests/item_pickup_test.cpp
+++ b/tests/item_pickup_test.cpp
@@ -1,3 +1,5 @@
+#include <climits>
+#include <functional>
 #include <list>
 #include <optional>
 #include <string>
@@ -6,6 +8,7 @@
 #include "avatar.h"
 #include "cata_catch.h"
 #include "coordinates.h"
+#include "debug.h"
 #include "item.h"
 #include "item_location.h"
 #include "map.h"
@@ -20,6 +23,7 @@
 
 static const itype_id itype_backpack_hiking( "backpack_hiking" );
 static const itype_id itype_debug_modular_m4_carbine( "debug_modular_m4_carbine" );
+static const itype_id itype_nail( "nail" );
 static const itype_id itype_rope_6( "rope_6" );
 
 // This test case exists by way of documenting and exhibiting some potentially unexpected behavior
@@ -198,5 +202,144 @@ TEST_CASE( "pickup_m4_with_a_rope_in_a_hiking_backpack", "[pickup][container]" )
             }
         }
     }
+}
+
+// Helper: count total charges of a given item type on a map tile
+static int ground_charges_of( map &here, const tripoint_bub_ms &pos,
+                              const itype_id &type )
+{
+    int total = 0;
+    for( const item &it : here.i_at( pos ) ) {
+        if( it.typeId() == type ) {
+            total += it.charges;
+        }
+    }
+    return total;
+}
+
+// Regression tests for #85439: charged-item pickup that merges into existing
+// stacks must not call on_pickup() on the detached local copy in pick_one_up().
+// The real items already get on_pickup() via item_pocket::fill_with().
+TEST_CASE( "charged_item_pickup_full_merge_no_debugmsg", "[pickup][charges]" )
+{
+    avatar &they = get_avatar();
+    map &here = get_map();
+    clear_avatar();
+    clear_map_without_vision();
+
+    const tripoint_bub_ms ground = they.pos_bub();
+
+    // Wear a backpack so we have somewhere to stash items
+    item backpack_on_ground( itype_backpack_hiking );
+    they.wear_item( backpack_on_ground );
+
+    // Pre-seed inventory with some nails
+    item seed_nails( itype_nail );
+    seed_nails.charges = 10;
+    they.i_add( seed_nails );
+
+    const int inv_before = they.charges_of( itype_nail );
+    REQUIRE( inv_before == 10 );
+
+    // Prime inv_search_cache -- the bug only fires when cache entries exist
+    they.cache_has_item_with( itype_nail );
+
+    // Place more nails on the ground (small enough to fully absorb)
+    item ground_nails( itype_nail );
+    ground_nails.charges = 5;
+    here.add_item( ground, ground_nails );
+
+    const int ground_before = ground_charges_of( here, ground, itype_nail );
+    REQUIRE( ground_before == 5 );
+    const int total_before = inv_before + ground_before;
+
+    // Build pickup list from items on the ground
+    item_location nail_loc( map_cursor( they.pos_abs() ),
+                            &here.i_at( ground ).only_item() );
+    const drop_locations to_pick_up = { std::make_pair( nail_loc, 0 ) };
+
+    std::string dmsg = capture_debugmsg_during( [&]() {
+        they.pick_up( to_pick_up );
+        process_activity( they );
+    } );
+
+    const int inv_after = they.charges_of( itype_nail );
+    const int ground_after = ground_charges_of( here, ground, itype_nail );
+
+    CHECK( dmsg.empty() );
+    CHECK( inv_after + ground_after == total_before );
+    CHECK( inv_after == 15 );
+    CHECK( ground_after == 0 );
+}
+
+TEST_CASE( "charged_item_pickup_partial_merge_no_debugmsg", "[pickup][charges]" )
+{
+    avatar &they = get_avatar();
+    map &here = get_map();
+    clear_avatar();
+    clear_map_without_vision();
+
+    const tripoint_bub_ms ground = they.pos_bub();
+
+    // Wear a backpack so we have somewhere to stash items
+    item backpack_on_ground( itype_backpack_hiking );
+    they.wear_item( backpack_on_ground );
+
+    // Determine total nail capacity of the empty backpack
+    item probe_nail( itype_nail );
+    probe_nail.charges = 1;
+    int remaining = INT_MAX;
+    they.can_stash_partial( probe_nail, remaining );
+    const int total_capacity = INT_MAX - remaining;
+    REQUIRE( total_capacity > 100 );
+
+    // Fill backpack to (capacity - margin) via i_add_or_fill
+    const int margin = 50;
+    item prefill_nails( itype_nail );
+    prefill_nails.charges = total_capacity - margin;
+    they.i_add_or_fill( prefill_nails, true, nullptr, nullptr,
+                        /*allow_drop=*/false, /*allow_wield=*/false );
+
+    const int inv_before = they.charges_of( itype_nail );
+    REQUIRE( inv_before > 0 );
+
+    // Prime inv_search_cache -- the bug only fires when cache entries exist
+    they.cache_has_item_with( itype_nail );
+
+    // Re-probe remaining capacity after prefill
+    int post_fill_remaining = INT_MAX;
+    they.can_stash_partial( probe_nail, post_fill_remaining );
+    const int can_still_fit = INT_MAX - post_fill_remaining;
+
+    // Place more nails on ground than remaining capacity
+    const int ground_count = can_still_fit + 50;
+    REQUIRE( can_still_fit > 0 );
+    REQUIRE( ground_count > can_still_fit );
+    const int expected_transferred = can_still_fit;
+    const int expected_remaining = ground_count - expected_transferred;
+
+    item ground_nails( itype_nail );
+    ground_nails.charges = ground_count;
+    here.add_item( ground, ground_nails );
+
+    const int ground_before = ground_charges_of( here, ground, itype_nail );
+    REQUIRE( ground_before == ground_count );
+
+    // Build pickup list
+    item_location nail_loc( map_cursor( they.pos_abs() ),
+                            &here.i_at( ground ).only_item() );
+    const drop_locations to_pick_up = { std::make_pair( nail_loc, 0 ) };
+
+    std::string dmsg = capture_debugmsg_during( [&]() {
+        they.pick_up( to_pick_up );
+        process_activity( they );
+    } );
+
+    const int inv_after = they.charges_of( itype_nail );
+    const int ground_after = ground_charges_of( here, ground, itype_nail );
+
+    CHECK( dmsg.empty() );
+    CHECK( inv_after == inv_before + expected_transferred );
+    CHECK( ground_after == expected_remaining );
 }
 


### PR DESCRIPTION
#### Summary
Bugfixes "Fix find_parent debugmsg on every charged-item pickup"

#### Purpose of change

Fixes #85439

Picking up charged items that merge into existing inventory stacks fires a `find_parent` debugmsg when `inv_search_cache` has been populated (normal gameplay).

#### Describe the solution

`pick_one_up()` calls `i_add_or_fill()` which distributes charges via `add_stash` -> `item_pocket::fill_with`. That path already calls `on_pickup()` on the actual items in the character's tree.

After that, `pick_one_up` was calling `on_pickup()` again on the stack-local copy -- which was never inserted into the tree, so `form_loc_recursive` -> `find_parent` fails.

Fix: remove the redundant `on_pickup()` on the local copy. One line.

#### Describe alternatives you've considered

Making `form_loc_recursive` tolerate missing items would paper over the real problem.

#### Testing

Two new regression tests (fail without this fix): full merge and partial merge (data-driven capacity via `can_stash_partial`, exact charge conservation).

Verified with saves from #85439. All existing `[pickup]` tests pass.