### PR TITLE
Sealed Condiment bottles prevent spoilage

### DIFF
--- a/data/json/items/containers/containers.json
+++ b/data/json/items/containers/containers.json
@@ -742,7 +742,7 @@
         "max_contains_volume": "500 ml",
         "max_item_volume": "17 ml",
         "max_contains_weight": "1 kg",
-        "sealed_data": { "spoil_multiplier": 0.5 },
+        "sealed_data": { "spoil_multiplier": 0.0 },
         "moves": 400
       }
     ],


### PR DESCRIPTION
Partially reverts #83348. Condiment bottles will not spoil, but spoil normally once open.

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Condiment Bottles Prevent Spoilage When Sealed"
Fixes #86075 and partially reverts #83348. Spoilage in sealed condiment bottles is set to 0, and opened containers have no benefit to spoilage. 
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I discussed it with @esotericist in the bug report in #86075.  Also, as we discussed in that issue, condiment bottles IRL give best by dates in the scale of a year or longer, and only caution one to refrigerate them once opened. With mayo's in game spoiling in weeks nominally, this made for some bizarre circumstances. I believe the change originally made to the condiment bottle was either trying to match it to plastic bottles, or mistakenly changed the wrong line when making a change.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Condiment bottles have a sealed spoil modifier of 0, and as before there is no spoil modifier when opened. I think one could do some further research on the opened modifier, but I believe this aligns it with other bottles in game.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Obviously, I considered doing nothing, and I also considered various modifiers on the bottle once opened. That said, there isn't a great body of research on how long condiments stay good in a condiment bottle compared to say being on a plate on the table. With that In mind I think removing the modifier once opened is fine. If this results in strangeness in opened condiment spoilage, I believe that is best approached by modifying the spoilage timer on the condiments individually rather than the bottles.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
<img width="634" height="340" alt="image" src="https://github.com/user-attachments/assets/0442f91d-ecfa-492d-9aaf-5bf8574e8b85" />
I added the correct binaries, revealed 3 OM tiles, teleported to a supermarket, found a sealed condiment bottle, and it looks to be behaving as desired.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
