### PR TITLE
Fix liquid handling freeze and zone sort spillable container bypass

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -13130,8 +13130,9 @@ bool zone_sort_activity_actor::stage_think( player_activity &act, Character &you
 
         // check if there is valid destination for any item of the tile
         bool pickup_failure;
+        bool spillable_skipped = false;
         bool has_items_to_work_on = zone_sorting::has_items_to_sort( you, src, zone_unload_options,
-                                    other_activity_items, items, &pickup_failure );
+                                    other_activity_items, items, &pickup_failure, &spillable_skipped );
 
         if( pickup_failure && !pickup_failure_reported ) {
             pickup_failure_reported = true;
@@ -13139,6 +13140,12 @@ bool zone_sort_activity_actor::stage_think( player_activity &act, Character &you
                                     _( "At least one item to be sorted is too large/heavy for %s to sort.  "
                                        "Emptying the inventory and freeing up the hands will allow for more efficient sorting." ),
                                     you.disp_name() );
+        }
+
+        if( spillable_skipped && !spillable_skip_reported ) {
+            spillable_skip_reported = true;
+            you.add_msg_if_player( m_info,
+                                   _( "Some open containers were not sorted to avoid spilling." ) );
         }
 
         if( !has_items_to_work_on ) {

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -4116,6 +4116,7 @@ class zone_sort_activity_actor : public zone_activity_actor
         // Place(s) that the current stuff can be dropped off at.
         std::vector<tripoint_abs_ms> dropoff_coords;
         bool pickup_failure_reported = false;
+        bool spillable_skip_reported = false; // NOLINT(cata-serialize)
         // Tracks whether current batch used virtual pickup (items left on cart).
         // Batch-scoped: captured and cleared in pre-loop section of stage_do.
         bool virtual_pickup_active = false;

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -903,12 +903,23 @@ bool route_to_destination( Character &you, player_activity &act,
 
 bool sort_skip_item( Character &you, const item *it,
                      const std::vector<item_location> &other_activity_items,
-                     bool ignore_favorite, const tripoint_abs_ms &src )
+                     bool ignore_favorite, const tripoint_abs_ms &src,
+                     bool *spillable_skipped )
 {
     const zone_manager &mgr = zone_manager::get_manager();
 
     // skip unpickable liquid
     if( !it->made_of_from_type( phase_id::SOLID ) ) {
+        return true;
+    }
+
+    // skip nonempty spillable containers -- picking them up triggers the
+    // interactive liquid dialog, which is inappropriate during automated
+    // sorting.  Normal pickup also refuses these (pickup.cpp, ACT_INSERT_ITEM).
+    if( it->is_bucket_nonempty() ) {
+        if( spillable_skipped ) {
+            *spillable_skipped = true;
+        }
         return true;
     }
 
@@ -1040,7 +1051,8 @@ bool ignore_zone_position( Character &you, const tripoint_abs_ms &src,
 bool has_items_to_sort( Character &you, const tripoint_abs_ms &src,
                         unload_sort_options zone_unload_options,
                         const std::vector<item_location> &other_activity_items,
-                        const zone_items &items, bool *pickup_failure )
+                        const zone_items &items, bool *pickup_failure,
+                        bool *spillable_skipped )
 {
     const zone_manager &mgr = zone_manager::get_manager();
     const faction_id fac_id = _fac_id( you );
@@ -1104,7 +1116,7 @@ bool has_items_to_sort( Character &you, const tripoint_abs_ms &src,
         }
 
         if( sort_skip_item( you, it, other_activity_items,
-                            zone_unload_options.ignore_favorite, src ) ) {
+                            zone_unload_options.ignore_favorite, src, spillable_skipped ) ) {
             continue;
         }
 

--- a/src/activity_item_handling.h
+++ b/src/activity_item_handling.h
@@ -76,7 +76,8 @@ bool route_to_destination( Character &you, player_activity &act,
 */
 bool sort_skip_item( Character &you, const item *it,
                      const std::vector<item_location> &other_activity_items,
-                     bool ignore_favorite, const tripoint_abs_ms &src );
+                     bool ignore_favorite, const tripoint_abs_ms &src,
+                     bool *spillable_skipped = nullptr );
 
 /**
 * Sets sorting options given nearby UNLOAD_ALL zones
@@ -104,7 +105,8 @@ bool ignore_zone_position( Character &you, const tripoint_abs_ms &src, bool igno
 bool has_items_to_sort( Character &you, const tripoint_abs_ms &src,
                         zone_sorting::unload_sort_options zone_unload_options,
                         const std::vector<item_location> &other_activity_items,
-                        const zone_sorting::zone_items &items, bool *pickup_failure );
+                        const zone_sorting::zone_items &items, bool *pickup_failure,
+                        bool *spillable_skipped = nullptr );
 bool can_unload( item *it );
 void add_item( const std::optional<vpart_reference> &vp, const tripoint_bub_ms &src_bub,
                const item &it );

--- a/src/handle_liquid.cpp
+++ b/src/handle_liquid.cpp
@@ -493,11 +493,13 @@ static bool handle_item_target( Character &player_character, item &liquid, liqui
     // not on ground or similar. TODO: implement storing arbitrary container locations.
     if( target.item_loc && create_activity() ) {
         serialize_liquid_target( player_character.activity, target.item_loc );
+        return true;
     } else if( player_character.pour_into( target.item_loc, liquid, true, silent ) ) {
         target.item_loc.make_active();
         player_character.mod_moves( -100 );
+        return true;
     }
-    return true;
+    return false;
 }
 
 static bool handle_vehicle_target( Character &player_character, item &liquid,

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -812,7 +812,9 @@ void item_pocket::handle_liquid_or_spill( Character &guy, const item *avoid )
         if( iter->made_of( phase_id::LIQUID ) ) {
             liquid_dest_opt liquid_target;
             while( iter->charges > 0 && liquid_handler::handle_liquid( *iter, liquid_target, avoid, 1 ) ) {
-                // query until completely handled or explicitly canceled
+                // Reset so the next iteration re-prompts for a target,
+                // matching consume_liquid (handle_liquid.cpp).
+                liquid_target.dest_opt = LD_NULL;
             }
             if( iter->charges == 0 ) {
                 iter = contents.erase( iter );

--- a/tests/clzones_test.cpp
+++ b/tests/clzones_test.cpp
@@ -11,15 +11,18 @@
 #include "activity_actor.h"
 #include "activity_actor_definitions.h"
 #include "activity_item_handling.h"
-#include "clone_ptr.h"
 #include "avatar.h"
+#include "cached_options.h"
 #include "calendar.h"
 #include "cata_catch.h"
+#include "cata_scope_helpers.h"
 #include "character_attire.h"
+#include "clone_ptr.h"
 #include "clzones.h"
 #include "coordinates.h"
 #include "enums.h"
 #include "item.h"
+#include "item_location.h"
 #include "item_pocket.h"
 #include "map.h"
 #include "map_helpers.h"
@@ -47,6 +50,7 @@ static const itype_id itype_chem_washing_soda( "chem_washing_soda" );
 static const itype_id itype_test_apple( "test_apple" );
 static const itype_id itype_test_bitter_almond( "test_bitter_almond" );
 static const itype_id itype_test_heavy_boulder( "test_heavy_boulder" );
+static const itype_id itype_test_liquid_1ml( "test_liquid_1ml" );
 static const itype_id itype_test_milk( "test_milk" );
 static const itype_id
 itype_test_watertight_open_sealed_container_250ml( "test_watertight_open_sealed_container_250ml" );
@@ -59,6 +63,7 @@ static const vproto_id vehicle_prototype_test_shopping_cart( "test_shopping_cart
 static const vproto_id vehicle_prototype_test_turret_rig( "test_turret_rig" );
 
 static const zone_type_id zone_type_LOOT_CHEMICAL( "LOOT_CHEMICAL" );
+static const zone_type_id zone_type_LOOT_DEFAULT( "LOOT_DEFAULT" );
 static const zone_type_id zone_type_LOOT_DRINK( "LOOT_DRINK" );
 static const zone_type_id zone_type_LOOT_FOOD( "LOOT_FOOD" );
 static const zone_type_id zone_type_LOOT_PDRINK( "LOOT_PDRINK" );
@@ -2242,7 +2247,9 @@ TEST_CASE( "zone_sort_unload_liquid_container_hang", "[zones][items][activities]
     const tripoint_abs_ms start_abs = here.get_abs( start_pos );
     dummy.set_pos_abs_only( start_abs );
 
-    const tripoint_bub_ms chem_pos = start_pos + tripoint( 3, 0, 0 );
+    // Adjacent destination so process_activity completes without routing
+    // (non-adjacent would leave stale destination_point for later tests).
+    const tripoint_bub_ms chem_pos = start_pos + tripoint::east;
     here.ter_set( chem_pos, ter_t_floor );
     create_tile_zone( "Unsorted", zone_type_LOOT_UNSORTED, start_abs );
     create_tile_zone( "Unload All", zone_type_UNLOAD_ALL, start_abs );
@@ -2651,4 +2658,263 @@ TEST_CASE( "zone_sort_viewport_lifecycle", "[zones][viewport][activities]" )
             CHECK( actor->viewport_saved_zoom == 16 );  // DEFAULT_TILESET_ZOOM
         }
     }
+}
+
+// Issue #86095: zone sort should skip nonempty spillable containers to avoid
+// triggering the interactive liquid dialog during automated sorting.
+
+TEST_CASE( "zone_sort_skips_spillable_container_in_mixed_source",
+           "[zones][items][activities][sorting]" )
+{
+    avatar &dummy = get_avatar();
+    map &here = get_map();
+
+    clear_avatar();
+    clear_map_without_vision();
+    dummy.clear_destination();
+
+    restore_on_out_of_scope<test_mode_spilling_action_t> restore_spill( test_mode_spilling_action );
+    test_mode_spilling_action = test_mode_spilling_action_t::spill_all;
+
+    const tripoint_bub_ms start_pos = tripoint_bub_ms::zero + tripoint::east;
+    const tripoint_abs_ms start_abs = here.get_abs( start_pos );
+    dummy.set_pos_abs_only( start_abs );
+    dummy.worn.wear_item( dummy, item( itype_backpack ), false, false );
+
+    const tripoint_bub_ms dest_pos = start_pos + tripoint( 3, 0, 0 );
+    here.ter_set( dest_pos, ter_t_floor );
+
+    create_tile_zone( "Unsorted", zone_type_LOOT_UNSORTED, start_abs );
+    create_tile_zone( "Food", zone_type_LOOT_FOOD, here.get_abs( dest_pos ) );
+    // LOOT_DEFAULT so the spillable container has a valid destination
+    // (its category won't match LOOT_FOOD)
+    create_tile_zone( "Default", zone_type_LOOT_DEFAULT, here.get_abs( dest_pos ) );
+
+    // Spillable container with liquid
+    item container( itype_test_watertight_open_sealed_container_250ml );
+    item liquid( itype_test_liquid_1ml );
+    liquid.charges = 5;
+    REQUIRE( container.put_in( liquid, pocket_type::CONTAINER ).success() );
+    REQUIRE( container.is_bucket_nonempty() );
+    here.add_item_or_charges( start_pos, container );
+
+    // Normal food item alongside the spillable container
+    here.add_item_or_charges( start_pos, item( itype_test_apple ) );
+
+    here.invalidate_map_cache( 0 );
+    here.build_map_cache( 0, true );
+
+    dummy.assign_activity( zone_sort_activity_actor() );
+
+    // Teleport-and-resume: route_to_destination nulls the activity and sets
+    // destination_point for non-adjacent travel. Teleport there and restart.
+    int teleports = 0;
+    const int max_teleports = 30;
+    do {
+        int turns = 0;
+        while( dummy.activity && turns < 200 ) {
+            dummy.mod_moves( dummy.get_speed() );
+            while( dummy.get_moves() > 0 && dummy.activity ) {
+                dummy.activity.do_turn( dummy );
+            }
+            turns++;
+        }
+        if( dummy.destination_point ) {
+            dummy.setpos( here, here.get_bub( *dummy.destination_point ) );
+            if( dummy.has_destination_activity() ) {
+                dummy.start_destination_activity();
+            } else {
+                dummy.clear_destination();
+            }
+            teleports++;
+        }
+    } while( ( dummy.activity || dummy.destination_point ) && teleports < max_teleports );
+
+    REQUIRE( teleports < max_teleports );
+
+    // Spillable container must remain at source with liquid intact
+    bool found_container_with_liquid = false;
+    for( const item &it : here.i_at( start_pos ) ) {
+        if( it.typeId() == itype_test_watertight_open_sealed_container_250ml ) {
+            found_container_with_liquid = it.has_item_with( []( const item & nested ) {
+                return nested.typeId() == itype_test_liquid_1ml;
+            } );
+        }
+    }
+    CHECK( found_container_with_liquid );
+
+    // Apple should have been sorted to destination
+    CHECK( count_items_or_charges( dest_pos, itype_test_apple, std::nullopt ) == 1 );
+}
+
+TEST_CASE( "zone_sort_completes_when_only_spillable_items_at_source",
+           "[zones][items][activities][sorting]" )
+{
+    avatar &dummy = get_avatar();
+    map &here = get_map();
+
+    clear_avatar();
+    clear_map_without_vision();
+    dummy.clear_destination();
+
+    restore_on_out_of_scope<test_mode_spilling_action_t> restore_spill( test_mode_spilling_action );
+    test_mode_spilling_action = test_mode_spilling_action_t::spill_all;
+
+    const tripoint_bub_ms start_pos = tripoint_bub_ms::zero + tripoint::east;
+    const tripoint_abs_ms start_abs = here.get_abs( start_pos );
+    dummy.set_pos_abs_only( start_abs );
+    dummy.worn.wear_item( dummy, item( itype_backpack ), false, false );
+
+    const tripoint_bub_ms dest_pos = start_pos + tripoint( 3, 0, 0 );
+    here.ter_set( dest_pos, ter_t_floor );
+
+    create_tile_zone( "Unsorted", zone_type_LOOT_UNSORTED, start_abs );
+    create_tile_zone( "Default", zone_type_LOOT_DEFAULT, here.get_abs( dest_pos ) );
+
+    // Only a spillable container at source
+    item container( itype_test_watertight_open_sealed_container_250ml );
+    item liquid( itype_test_liquid_1ml );
+    liquid.charges = 5;
+    REQUIRE( container.put_in( liquid, pocket_type::CONTAINER ).success() );
+    REQUIRE( container.is_bucket_nonempty() );
+    here.add_item_or_charges( start_pos, container );
+
+    dummy.assign_activity( zone_sort_activity_actor() );
+    process_activity( dummy );
+
+    // Container must remain at source with liquid inside
+    bool found_container_with_liquid = false;
+    for( const item &it : here.i_at( start_pos ) ) {
+        if( it.typeId() == itype_test_watertight_open_sealed_container_250ml ) {
+            found_container_with_liquid = it.has_item_with( []( const item & nested ) {
+                return nested.typeId() == itype_test_liquid_1ml;
+            } );
+        }
+    }
+    CHECK( found_container_with_liquid );
+
+    CHECK( !dummy.activity );
+}
+
+// Direct characterization: has_items_to_sort must return false when a source
+// tile contains only nonempty spillable containers (the THINK-layer skip).
+TEST_CASE( "has_items_to_sort_returns_false_for_spillable_only_source",
+           "[zones][items][sorting]" )
+{
+    avatar &dummy = get_avatar();
+    map &here = get_map();
+
+    clear_avatar();
+    clear_map_without_vision();
+    dummy.clear_destination();
+
+    const tripoint_bub_ms start_pos = tripoint_bub_ms::zero + tripoint::east;
+    const tripoint_abs_ms start_abs = here.get_abs( start_pos );
+    dummy.set_pos_abs_only( start_abs );
+
+    const tripoint_bub_ms dest_pos = start_pos + tripoint( 3, 0, 0 );
+    here.ter_set( dest_pos, ter_t_floor );
+
+    create_tile_zone( "Unsorted", zone_type_LOOT_UNSORTED, start_abs );
+    create_tile_zone( "Default", zone_type_LOOT_DEFAULT, here.get_abs( dest_pos ) );
+
+    item container( itype_test_watertight_open_sealed_container_250ml );
+    item liquid( itype_test_liquid_1ml );
+    liquid.charges = 5;
+    REQUIRE( container.put_in( liquid, pocket_type::CONTAINER ).success() );
+    REQUIRE( container.is_bucket_nonempty() );
+    here.add_item_or_charges( start_pos, container );
+
+    zone_sorting::zone_items items = zone_sorting::populate_items( start_pos );
+    REQUIRE( !items.empty() );
+
+    zone_sorting::unload_sort_options zone_unload_options =
+        zone_sorting::set_unload_options( dummy, start_abs, true );
+
+    std::vector<item_location> other_activity_items;
+    bool pickup_failure = false;
+
+    bool result = zone_sorting::has_items_to_sort( dummy, start_abs, zone_unload_options,
+                  other_activity_items, items, &pickup_failure );
+
+    CHECK_FALSE( result );
+}
+
+TEST_CASE( "zone_sort_sealed_liquid_container_is_sorted_normally",
+           "[zones][items][activities][sorting]" )
+{
+    avatar &dummy = get_avatar();
+    map &here = get_map();
+
+    clear_avatar();
+    clear_map_without_vision();
+    dummy.clear_destination();
+
+    const tripoint_bub_ms start_pos = tripoint_bub_ms::zero + tripoint::east;
+    const tripoint_abs_ms start_abs = here.get_abs( start_pos );
+    dummy.set_pos_abs_only( start_abs );
+    dummy.worn.wear_item( dummy, item( itype_backpack ), false, false );
+
+    const tripoint_bub_ms dest_pos = start_pos + tripoint( 3, 0, 0 );
+    const tripoint_abs_ms dest_abs = here.get_abs( dest_pos );
+    here.ter_set( dest_pos, ter_t_floor );
+
+    create_tile_zone( "Unsorted", zone_type_LOOT_UNSORTED, start_abs );
+    create_tile_zone( "Default", zone_type_LOOT_DEFAULT, dest_abs );
+
+    item container( itype_test_watertight_open_sealed_container_250ml );
+    item liquid( itype_test_liquid_1ml );
+    liquid.charges = 5;
+    REQUIRE( container.put_in( liquid, pocket_type::CONTAINER ).success() );
+    REQUIRE( container.seal() );
+    REQUIRE( !container.is_bucket_nonempty() );
+
+    // Verify zone classification recognizes this item
+    const zone_manager &mgr = zone_manager::get_manager();
+    REQUIRE( mgr.get_near_zone_type_for_item( container, start_abs ) == zone_type_LOOT_DEFAULT );
+
+    here.add_item_or_charges( start_pos, container );
+
+    here.invalidate_map_cache( 0 );
+    here.build_map_cache( 0, true );
+
+    dummy.assign_activity( zone_sort_activity_actor() );
+
+    int teleports = 0;
+    const int max_teleports = 30;
+    do {
+        int turns = 0;
+        while( dummy.activity && turns < 200 ) {
+            dummy.mod_moves( dummy.get_speed() );
+            while( dummy.get_moves() > 0 && dummy.activity ) {
+                dummy.activity.do_turn( dummy );
+            }
+            turns++;
+        }
+        if( dummy.destination_point ) {
+            dummy.setpos( here, here.get_bub( *dummy.destination_point ) );
+            if( dummy.has_destination_activity() ) {
+                dummy.start_destination_activity();
+            } else {
+                dummy.clear_destination();
+            }
+            teleports++;
+        }
+    } while( ( dummy.activity || dummy.destination_point ) && teleports < max_teleports );
+
+    REQUIRE( teleports < max_teleports );
+
+    // Sealed container should be at destination with liquid intact
+    bool found_at_dest = false;
+    for( const item &it : here.i_at( dest_pos ) ) {
+        if( it.typeId() == itype_test_watertight_open_sealed_container_250ml ) {
+            found_at_dest = it.has_item_with( []( const item & nested ) {
+                return nested.typeId() == itype_test_liquid_1ml;
+            } );
+        }
+    }
+    CHECK( found_at_dest );
+
+    CHECK( count_items_or_charges( start_pos, itype_test_watertight_open_sealed_container_250ml,
+                                   std::nullopt ) == 0 );
 }

--- a/tests/liquid_handler_test.cpp
+++ b/tests/liquid_handler_test.cpp
@@ -1,0 +1,109 @@
+#include "avatar.h"
+#include "cached_options.h"
+#include "cata_catch.h"
+#include "cata_scope_helpers.h"
+#include "coordinates.h"
+#include "handle_liquid.h"
+#include "item.h"
+#include "item_location.h"
+#include "map.h"
+#include "map_helpers.h"
+#include "map_selector.h"
+#include "player_helpers.h"
+#include "pocket_type.h"
+#include "point.h"
+#include "ret_val.h"
+#include "type_id.h"
+
+// *INDENT-OFF*
+static const itype_id itype_test_liquid_1ml( "test_liquid_1ml" );
+static const itype_id itype_test_watertight_open_sealed_container_250ml( "test_watertight_open_sealed_container_250ml" );
+// *INDENT-ON*
+
+// handle_liquid should return false when a pre-set LD_ITEM target is full
+// and pour_into fails. Before the fix, handle_item_target unconditionally
+// returned true, causing infinite loops in callers like handle_liquid_or_spill.
+TEST_CASE( "handle_liquid_returns_false_when_target_container_is_full",
+           "[liquid][handler]" )
+{
+    avatar &dummy = get_avatar();
+    map &here = get_map();
+
+    clear_avatar();
+    clear_map_without_vision();
+
+    const tripoint_bub_ms player_pos = dummy.pos_bub();
+    const tripoint_bub_ms container_pos = player_pos + tripoint::east;
+
+    // Create a container and fill it to capacity
+    item container( itype_test_watertight_open_sealed_container_250ml );
+    item filler( itype_test_liquid_1ml );
+    filler.charges = 250;
+    REQUIRE( container.fill_with( filler, 250 ) > 0 );
+    // Verify it's actually full
+    REQUIRE( container.get_remaining_capacity_for_liquid( item( itype_test_liquid_1ml ), true ) == 0 );
+
+    // Place the full container on the map and get an item_location for it
+    here.add_item_or_charges( container_pos, container );
+    map_stack items_at = here.i_at( container_pos );
+    REQUIRE( !items_at.empty() );
+    item_location cont_loc( map_cursor( container_pos ), &items_at.only_item() );
+    REQUIRE( cont_loc.get_item() != nullptr );
+
+    // Create liquid to pour
+    item liquid( itype_test_liquid_1ml );
+    liquid.charges = 10;
+
+    // Pre-set the liquid target to the full container
+    liquid_dest_opt target;
+    target.dest_opt = LD_ITEM;
+    target.item_loc = cont_loc;
+
+    const int moves_before = dummy.get_moves();
+    const int charges_before = liquid.charges;
+
+    bool result = liquid_handler::handle_liquid( liquid, target, nullptr, 0 );
+
+    CHECK_FALSE( result );
+    CHECK( liquid.charges == charges_before );
+    CHECK( dummy.get_moves() == moves_before );
+}
+
+// Regression guard: on_pickup with a spillable container should handle all
+// liquid without hanging. Exercises the real item_pocket::on_pickup ->
+// handle_liquid_or_spill production path.
+TEST_CASE( "on_pickup_spillable_container_handles_all_liquid",
+           "[liquid][spill]" )
+{
+    avatar &dummy = get_avatar();
+    map &here = get_map();
+
+    clear_avatar();
+    clear_map_without_vision();
+
+    restore_on_out_of_scope<test_mode_spilling_action_t> restore_spill( test_mode_spilling_action );
+    test_mode_spilling_action = test_mode_spilling_action_t::spill_all;
+
+    // Create a spillable container with liquid
+    item container( itype_test_watertight_open_sealed_container_250ml );
+    item liquid( itype_test_liquid_1ml );
+    liquid.charges = 5;
+    REQUIRE( container.put_in( liquid, pocket_type::CONTAINER ).success() );
+    REQUIRE( container.is_bucket_nonempty() );
+
+    // Call the real on_pickup path
+    container.on_pickup( dummy );
+
+    // All liquid should have been handled (spilled to ground in test mode)
+    CHECK( container.is_container_empty() );
+
+    // Liquid should be on the ground at player position
+    bool found_liquid = false;
+    for( const item &ground_item : here.i_at( dummy.pos_bub() ) ) {
+        if( ground_item.typeId() == itype_test_liquid_1ml ) {
+            found_liquid = true;
+            break;
+        }
+    }
+    CHECK( found_liquid );
+}


### PR DESCRIPTION
#### Summary
Bugfixes "Fix zone sorting freeze and liquid loss with spillable containers"

#### Purpose of change

Fixes #86095. Zone sort picks up open containers with liquid via `try_add`, which triggers the interactive liquid dialog through `on_pickup`. If the player pours into a too-small container, `handle_item_target` returns true unconditionally and the caller loop retries forever. If the player pours back into the original ground container, zone sort deletes it afterward, taking the liquid with it.

Normal pickup and ACT_INSERT_ITEM both refuse nonempty spillable containers already. Zone sort was the odd one out.

#### Describe the solution

Three independent fixes:

**handle_item_target return value** -- return false when both `create_activity` and `pour_into` fail, matching `handle_vehicle_target`. Direct cause of the infinite loop.

**dest_opt reset in handle_liquid_or_spill** -- add LD_NULL reset after each `handle_liquid` call, matching the existing pattern in `consume_liquid`. Without this a stale LD_ITEM target causes premature exit instead of re-prompting. Looks like the commit that added liquid_target reuse updated consume_liquid but missed this one.

**Zone sort skip** -- sort_skip_item now checks `is_bucket_nonempty()` and skips those items. has_items_to_sort propagates a spillable flag so stage_think can show a one-time info message. Sealed containers are unaffected.

#### Describe alternatives you've considered

Considered virtual pickup (leave on ground, transfer at destination like cart-at-source), but that bypasses carry/drag/mass checks and needs more touch points than it looks. Skip-and-message is simpler and consistent with how other pickup paths handle spillables.

#### Testing

New tests verify handle_liquid returns false for a full pre-set target, and that on_pickup handles all liquid without hanging.

Zone sort tests cover the mixed-source skip (spillable stays, normal item sorts), spillable-only completion, direct has_items_to_sort characterization, and sealed container delivery.

Also narrowed the existing unload-hang test to adjacent destination to stop it leaking stale destination_point between tests.

Full zone sort, liquid, unseal_and_spill, and pocket suites all pass.

#### Additional context

The dest_opt reset is not directly testable through the existing test_mode_spilling_action infrastructure (only offers LD_GROUND which handles all charges atomically). It matches what consume_liquid already does, so it seemed like the right thing to include.