### PR TITLE
Wrap SDL surface operations behind abstraction layer

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -437,7 +437,7 @@ static SDL_Surface_Ptr apply_color_filter( const SDL_Surface_Ptr &original,
     cata_assert( original );
     SDL_Surface_Ptr surf = create_surface_32( original->w, original->h );
     cata_assert( surf );
-    throwErrorIf( SDL_BlitSurface( original.get(), nullptr, surf.get(), nullptr ) != 0,
+    throwErrorIf( BlitSurface( original, nullptr, surf, nullptr ) != 0,
                   "SDL_BlitSurface failed" );
 
     SDL_Color *pix = static_cast<SDL_Color *>( surf->pixels );
@@ -533,10 +533,10 @@ void tileset_cache::loader::load_tileset( const cata_path &img_path, const bool 
     tile_atlas_width = tile_atlas->w;
 
     if( R >= 0 && R <= 255 && G >= 0 && G <= 255 && B >= 0 && B <= 255 ) {
-        const Uint32 key = SDL_MapRGB( tile_atlas->format, 0, 0, 0 );
-        throwErrorIf( SDL_SetColorKey( tile_atlas.get(), SDL_TRUE, key ) != 0,
+        const Uint32 key = MapRGB( tile_atlas, 0, 0, 0 );
+        throwErrorIf( SetColorKey( tile_atlas, SDL_TRUE, key ) != 0,
                       "SDL_SetColorKey failed" );
-        throwErrorIf( SDL_SetSurfaceRLE( tile_atlas.get(), 1 ), "SDL_SetSurfaceRLE failed" );
+        throwErrorIf( SetSurfaceRLE( tile_atlas, 1 ), "SDL_SetSurfaceRLE failed" );
     }
 
     SDL_RendererInfo info;
@@ -616,8 +616,8 @@ void tileset_cache::loader::load_tileset( const cata_path &img_path, const bool 
             smaller_surf = ::create_surface_32( w, h );
             cata_assert( smaller_surf );
             const SDL_Rect inp{ sub_rect.x, sub_rect.y, w, h };
-            throwErrorIf( SDL_BlitSurface( tile_atlas.get(), &inp, smaller_surf.get(),
-                                           nullptr ) != 0, "SDL_BlitSurface failed" );
+            throwErrorIf( BlitSurface( tile_atlas, &inp, smaller_surf,
+                                       nullptr ) != 0, "SDL_BlitSurface failed" );
         }
         const SDL_Surface_Ptr &surf_to_use = smaller_surf ? smaller_surf : tile_atlas;
         cata_assert( surf_to_use );
@@ -4524,8 +4524,8 @@ void tileset_cache::loader::ensure_default_item_highlight()
 
     const SDL_Surface_Ptr surface = create_surface_32( ts.tile_width, ts.tile_height );
     cata_assert( surface );
-    throwErrorIf( SDL_FillRect( surface.get(), nullptr, SDL_MapRGBA( surface->format, 0, 0, 127,
-                                highlight_alpha ) ) != 0, "SDL_FillRect failed" );
+    throwErrorIf( FillRect( surface, nullptr, MapRGBA( surface, 0, 0, 127,
+                            highlight_alpha ) ) != 0, "SDL_FillRect failed" );
     ts.tile_values.emplace_back( CreateTextureFromSurface( renderer, surface ),
                                  SDL_Rect{ 0, 0, ts.tile_width, ts.tile_height } );
     ts.tile_ids[ITEM_HIGHLIGHT].fg.add( std::vector<int>( {index} ), 1 );

--- a/src/sdl_font.cpp
+++ b/src/sdl_font.cpp
@@ -47,7 +47,7 @@
     return faceIndex;
 }
 
-std::unique_ptr<Font> Font::load_font( SDL_Renderer_Ptr &renderer, SDL_PixelFormat_Ptr &format,
+std::unique_ptr<Font> Font::load_font( SDL_Renderer_Ptr &renderer, Uint32 pixel_format,
                                        const std::string &typeface, int fontsize, int width,
                                        int height,
                                        const palette_array &palette,
@@ -57,17 +57,17 @@ std::unique_ptr<Font> Font::load_font( SDL_Renderer_Ptr &renderer, SDL_PixelForm
         // Seems to be an image file, not a font.
         // Try to load as bitmap font from user font dir, then from font dir.
         try {
-            return std::unique_ptr<Font>( std::make_unique<BitmapFont>( renderer, format, width, height,
+            return std::unique_ptr<Font>( std::make_unique<BitmapFont>( renderer, pixel_format, width, height,
                                           palette,
                                           typeface ) );
         } catch( std::exception & ) {
             try {
-                return std::unique_ptr<Font>( std::make_unique<BitmapFont>( renderer, format, width, height,
+                return std::unique_ptr<Font>( std::make_unique<BitmapFont>( renderer, pixel_format, width, height,
                                               palette,
                                               PATH_INFO::user_font() + typeface ) );
             } catch( std::exception & ) {
                 try {
-                    return std::unique_ptr<Font>( std::make_unique<BitmapFont>( renderer, format, width, height,
+                    return std::unique_ptr<Font>( std::make_unique<BitmapFont>( renderer, pixel_format, width, height,
                                                   palette,
                                                   PATH_INFO::fontdir() + typeface ) );
                 } catch( std::exception &err ) {
@@ -336,12 +336,12 @@ SDL_Texture_Ptr CachedTTFFont::create_glyph( const SDL_Renderer_Ptr &renderer,
     }
 
     // Copy without altering the source
-    SDL_SetSurfaceBlendMode( sglyph.get(), SDL_BLENDMODE_NONE );
-    if( !printErrorIf( SDL_BlitSurface( sglyph.get(), &src_rect, surface.get(), &dst_rect ) != 0,
+    SetSurfaceBlendMode( sglyph, SDL_BLENDMODE_NONE );
+    if( !printErrorIf( BlitSurface( sglyph, &src_rect, surface, &dst_rect ) != 0,
                        "SDL_BlitSurface failed" ) ) {
         sglyph = std::move( surface );
     }
-    SDL_SetSurfaceBlendMode( sglyph.get(), SDL_BLENDMODE_BLEND );
+    SetSurfaceBlendMode( sglyph, SDL_BLENDMODE_BLEND );
 
     return CreateTextureFromSurface( renderer, sglyph );
 }
@@ -388,7 +388,7 @@ void CachedTTFFont::OutputChar( const SDL_Renderer_Ptr &renderer, const Geometry
 }
 
 BitmapFont::BitmapFont(
-    SDL_Renderer_Ptr &renderer, SDL_PixelFormat_Ptr &format,
+    SDL_Renderer_Ptr &renderer, Uint32 pixel_format,
     const int w, const int h,
     const palette_array &palette,
     const std::string &typeface_path )
@@ -400,20 +400,20 @@ BitmapFont::BitmapFont(
     if( asciiload->w * asciiload->h < ( width * height * 256 ) ) {
         throw std::runtime_error( "bitmap for font is to small" );
     }
-    Uint32 key = SDL_MapRGB( asciiload->format, 0xFF, 0, 0xFF );
-    SDL_SetColorKey( asciiload.get(), SDL_TRUE, key );
+    Uint32 key = MapRGB( asciiload, 0xFF, 0, 0xFF );
+    SetColorKey( asciiload, SDL_TRUE, key );
     std::array<SDL_Surface_Ptr, std::tuple_size<decltype( ascii )>::value> ascii_surf;
-    ascii_surf[0].reset( SDL_ConvertSurface( asciiload.get(), format.get(), 0 ) );
-    SDL_SetSurfaceRLE( ascii_surf[0].get(), 1 );
+    ascii_surf[0] = ConvertSurfaceFormat( asciiload, pixel_format );
+    SetSurfaceRLE( ascii_surf[0], 1 );
     asciiload.reset();
 
     for( size_t a = 1; a < std::tuple_size<decltype( ascii )>::value; ++a ) {
-        ascii_surf[a].reset( SDL_ConvertSurface( ascii_surf[0].get(), format.get(), 0 ) );
-        SDL_SetSurfaceRLE( ascii_surf[a].get(), 1 );
+        ascii_surf[a] = ConvertSurfaceFormat( ascii_surf[0], pixel_format );
+        SetSurfaceRLE( ascii_surf[a], 1 );
     }
 
     for( size_t a = 0; a < std::tuple_size<decltype( ascii )>::value - 1; ++a ) {
-        SDL_LockSurface( ascii_surf[a].get() );
+        throwErrorIf( LockSurface( ascii_surf[a] ) != 0, "SDL_LockSurface failed" );
         int size = ascii_surf[a]->h * ascii_surf[a]->w;
         Uint32 *pixels = static_cast<Uint32 *>( ascii_surf[a]->pixels );
         Uint32 color = ( windowsPalette[a].r << 16 ) | ( windowsPalette[a].g << 8 ) | windowsPalette[a].b;
@@ -422,7 +422,7 @@ BitmapFont::BitmapFont(
                 pixels[i] = color;
             }
         }
-        SDL_UnlockSurface( ascii_surf[a].get() );
+        UnlockSurface( ascii_surf[a] );
     }
     tilewidth = ascii_surf[0]->w / width;
 
@@ -582,7 +582,7 @@ void BitmapFont::OutputChar( const SDL_Renderer_Ptr &renderer, const GeometryRen
 }
 
 FontFallbackList::FontFallbackList(
-    SDL_Renderer_Ptr &renderer, SDL_PixelFormat_Ptr &format,
+    SDL_Renderer_Ptr &renderer, Uint32 pixel_format,
     const int w, const int h,
     const palette_array &palette,
     const std::vector<font_config> &typefaces,
@@ -590,7 +590,8 @@ FontFallbackList::FontFallbackList(
     : Font( w, h, palette )
 {
     for( const font_config &font_config : typefaces ) {
-        std::unique_ptr<Font> font = Font::load_font( renderer, format, font_config.path, fontsize, w, h,
+        std::unique_ptr<Font> font = Font::load_font( renderer, pixel_format, font_config.path, fontsize, w,
+                                     h,
                                      palette, fontblending );
         if( !font ) {
             throw std::runtime_error( "Cannot load font " + font_config.path );

--- a/src/sdl_font.h
+++ b/src/sdl_font.h
@@ -54,7 +54,7 @@ class Font
 
         /// Try to load a font by typeface (Bitmap or Truetype).
         static std::unique_ptr<Font> load_font(
-            SDL_Renderer_Ptr &renderer, SDL_PixelFormat_Ptr &format,
+            SDL_Renderer_Ptr &renderer, Uint32 pixel_format,
             const std::string &typeface, int fontsize, int fontwidth,
             int fontheight,
             const palette_array &palette,
@@ -127,7 +127,7 @@ class BitmapFont : public Font
 {
     public:
         BitmapFont(
-            SDL_Renderer_Ptr &renderer, SDL_PixelFormat_Ptr &format,
+            SDL_Renderer_Ptr &renderer, Uint32 pixel_format,
             int w, int h,
             const palette_array &palette,
             const std::string &typeface_path );
@@ -154,7 +154,7 @@ class FontFallbackList : public Font
 {
     public:
         FontFallbackList(
-            SDL_Renderer_Ptr &renderer, SDL_PixelFormat_Ptr &format,
+            SDL_Renderer_Ptr &renderer, Uint32 pixel_format,
             int w, int h,
             const palette_array &palette,
             const std::vector<font_config> &typefaces,

--- a/src/sdl_geometry.cpp
+++ b/src/sdl_geometry.cpp
@@ -46,9 +46,9 @@ ColorModulatedGeometryRenderer::ColorModulatedGeometryRenderer( const SDL_Render
         return;
     }
 
-    FillRect( alt_surf, nullptr, SDL_MapRGB( alt_surf->format, 255, 255, 255 ) );
+    FillRect( alt_surf, nullptr, MapRGB( alt_surf, 255, 255, 255 ) );
 
-    tex.reset( SDL_CreateTextureFromSurface( renderer.get(), alt_surf.get() ) );
+    tex = CreateTextureFromSurface( renderer, alt_surf );
     alt_surf.reset();
 
     SetTextureBlendMode( tex, SDL_BLENDMODE_BLEND );

--- a/src/sdl_wrappers.cpp
+++ b/src/sdl_wrappers.cpp
@@ -105,13 +105,15 @@ void RenderFillRect( const SDL_Renderer_Ptr &renderer, const SDL_Rect *const rec
     printErrorIf( SDL_RenderFillRect( renderer.get(), rect ) != 0, "SDL_RenderFillRect failed" );
 }
 
-void FillRect( const SDL_Surface_Ptr &surface, const SDL_Rect *const rect, Uint32 color )
+int FillRect( const SDL_Surface_Ptr &surface, const SDL_Rect *const rect, Uint32 color )
 {
     if( !surface ) {
         dbg( D_ERROR ) << "Tried to use a null surface";
-        return;
+        return -1;
     }
-    printErrorIf( SDL_FillRect( surface.get(), rect, color ) != 0, "SDL_FillRect failed" );
+    const int ret = SDL_FillRect( surface.get(), rect, color );
+    printErrorIf( ret != 0, "SDL_FillRect failed" );
+    return ret;
 }
 
 void SetTextureBlendMode( const SDL_Texture_Ptr &texture, SDL_BlendMode blendMode )
@@ -248,6 +250,105 @@ bool RenderIsClipEnabled( const SDL_Renderer_Ptr &renderer )
         return false;
     }
     return SDL_RenderIsClipEnabled( renderer.get() ) == SDL_TRUE;
+}
+
+int BlitSurface( const SDL_Surface_Ptr &src, const SDL_Rect *const srcrect,
+                 const SDL_Surface_Ptr &dst, SDL_Rect *const dstrect )
+{
+    if( !src ) {
+        dbg( D_ERROR ) << "Tried to blit from a null surface";
+        return -1;
+    }
+    if( !dst ) {
+        dbg( D_ERROR ) << "Tried to blit to a null surface";
+        return -1;
+    }
+    return SDL_BlitSurface( src.get(), srcrect, dst.get(), dstrect );
+}
+
+Uint32 MapRGB( const SDL_Surface_Ptr &surface, const Uint8 r, const Uint8 g, const Uint8 b )
+{
+    if( !surface ) {
+        dbg( D_ERROR ) << "Tried to map color on a null surface";
+        return 0;
+    }
+    return SDL_MapRGB( surface->format, r, g, b );
+}
+
+Uint32 MapRGBA( const SDL_Surface_Ptr &surface, const Uint8 r, const Uint8 g, const Uint8 b,
+                const Uint8 a )
+{
+    if( !surface ) {
+        dbg( D_ERROR ) << "Tried to map color on a null surface";
+        return 0;
+    }
+    return SDL_MapRGBA( surface->format, r, g, b, a );
+}
+
+int SetColorKey( const SDL_Surface_Ptr &surface, const int flag, const Uint32 key )
+{
+    if( !surface ) {
+        dbg( D_ERROR ) << "Tried to set colorkey on a null surface";
+        return -1;
+    }
+    return SDL_SetColorKey( surface.get(), flag, key );
+}
+
+int SetSurfaceRLE( const SDL_Surface_Ptr &surface, const int flag )
+{
+    if( !surface ) {
+        dbg( D_ERROR ) << "Tried to set RLE on a null surface";
+        return -1;
+    }
+    return SDL_SetSurfaceRLE( surface.get(), flag );
+}
+
+int SetSurfaceBlendMode( const SDL_Surface_Ptr &surface, const SDL_BlendMode blendMode )
+{
+    if( !surface ) {
+        dbg( D_ERROR ) << "Tried to set blend mode on a null surface";
+        return -1;
+    }
+    return SDL_SetSurfaceBlendMode( surface.get(), blendMode );
+}
+
+SDL_Surface_Ptr ConvertSurfaceFormat( const SDL_Surface_Ptr &surface, const Uint32 pixel_format )
+{
+    if( !surface ) {
+        dbg( D_ERROR ) << "Tried to convert a null surface";
+        return SDL_Surface_Ptr();
+    }
+    SDL_Surface_Ptr result( SDL_ConvertSurfaceFormat( surface.get(), pixel_format, 0 ) );
+    printErrorIf( !result, "SDL_ConvertSurfaceFormat failed" );
+    return result;
+}
+
+int LockSurface( const SDL_Surface_Ptr &surface )
+{
+    if( !surface ) {
+        dbg( D_ERROR ) << "Tried to lock a null surface";
+        return -1;
+    }
+    return SDL_LockSurface( surface.get() );
+}
+
+void UnlockSurface( const SDL_Surface_Ptr &surface )
+{
+    if( !surface ) {
+        dbg( D_ERROR ) << "Tried to unlock a null surface";
+        return;
+    }
+    SDL_UnlockSurface( surface.get() );
+}
+
+Uint32 GetSurfacePixelFormat( const SDL_Surface_Ptr &surface )
+{
+    if( !surface ) {
+        dbg( D_ERROR ) << "Tried to get pixel format of a null surface";
+        return 0;
+    }
+    // SDL3: surface->format is the enum directly (no intermediate struct).
+    return surface->format->format;
 }
 #endif // defined(TILES)
 #endif // defined(TILES) || defined(SDL_SOUND)

--- a/src/sdl_wrappers.h
+++ b/src/sdl_wrappers.h
@@ -40,13 +40,6 @@ struct SDL_Window_deleter {
 };
 using SDL_Window_Ptr = std::unique_ptr<SDL_Window, SDL_Window_deleter>;
 
-struct SDL_PixelFormat_deleter {
-    void operator()( SDL_PixelFormat *const format ) {
-        SDL_FreeFormat( format );
-    }
-};
-using SDL_PixelFormat_Ptr = std::unique_ptr<SDL_PixelFormat, SDL_PixelFormat_deleter>;
-
 struct SDL_Texture_deleter {
     void operator()( SDL_Texture *const ptr ) {
         SDL_DestroyTexture( ptr );
@@ -97,7 +90,7 @@ SDL_Texture_Ptr CreateTextureFromSurface( const SDL_Renderer_Ptr &renderer,
 void SetRenderDrawColor( const SDL_Renderer_Ptr &renderer, Uint8 r, Uint8 g, Uint8 b, Uint8 a );
 void RenderDrawPoint( const SDL_Renderer_Ptr &renderer, const point &p );
 void RenderFillRect( const SDL_Renderer_Ptr &renderer, const SDL_Rect *rect );
-void FillRect( const SDL_Surface_Ptr &surface, const SDL_Rect *rect, Uint32 color );
+int FillRect( const SDL_Surface_Ptr &surface, const SDL_Rect *rect, Uint32 color );
 void SetTextureBlendMode( const SDL_Texture_Ptr &texture, SDL_BlendMode blendMode );
 bool SetTextureColorMod( const SDL_Texture_Ptr &texture, Uint32 r, Uint32 g, Uint32 b );
 void SetRenderDrawBlendMode( const SDL_Renderer_Ptr &renderer, SDL_BlendMode blendMode );
@@ -114,6 +107,19 @@ void RenderCopyEx( const SDL_Renderer_Ptr &renderer, SDL_Texture *texture,
 void RenderSetClipRect( const SDL_Renderer_Ptr &renderer, const SDL_Rect *rect );
 void RenderGetClipRect( const SDL_Renderer_Ptr &renderer, SDL_Rect *rect );
 bool RenderIsClipEnabled( const SDL_Renderer_Ptr &renderer );
+int BlitSurface( const SDL_Surface_Ptr &src, const SDL_Rect *srcrect,
+                 const SDL_Surface_Ptr &dst, SDL_Rect *dstrect );
+Uint32 MapRGB( const SDL_Surface_Ptr &surface, Uint8 r, Uint8 g, Uint8 b );
+Uint32 MapRGBA( const SDL_Surface_Ptr &surface, Uint8 r, Uint8 g, Uint8 b, Uint8 a );
+int SetColorKey( const SDL_Surface_Ptr &surface, int flag, Uint32 key );
+int SetSurfaceRLE( const SDL_Surface_Ptr &surface, int flag );
+int SetSurfaceBlendMode( const SDL_Surface_Ptr &surface, SDL_BlendMode blendMode );
+SDL_Surface_Ptr ConvertSurfaceFormat( const SDL_Surface_Ptr &surface, Uint32 pixel_format );
+int LockSurface( const SDL_Surface_Ptr &surface );
+void UnlockSurface( const SDL_Surface_Ptr &surface );
+// Returns the pixel format enum (SDL_PIXELFORMAT_*) for the surface.
+// SDL3: surface->format is the enum directly; SDL2: surface->format->format.
+Uint32 GetSurfacePixelFormat( const SDL_Surface_Ptr &surface );
 /**@}*/
 
 void StartTextInput();

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -135,7 +135,7 @@ static Font_Ptr overmap_font;
 
 static SDL_Window_Ptr window;
 static SDL_Renderer_Ptr renderer;
-static SDL_PixelFormat_Ptr format;
+static Uint32 pixel_format = SDL_PIXELFORMAT_UNKNOWN;
 static SDL_Texture_Ptr display_buffer;
 static GeometryRenderer_Ptr geometry;
 #if defined(__ANDROID__)
@@ -337,9 +337,8 @@ static void WinCreate()
         TERMINAL_HEIGHT = WindowHeight / fontheight / scaling_factor;
     }
 #endif
-    const Uint32 wformat = SDL_GetWindowPixelFormat( ::window.get() );
-    format.reset( SDL_AllocFormat( wformat ) );
-    throwErrorIf( !format, "SDL_AllocFormat failed" );
+    pixel_format = SDL_GetWindowPixelFormat( ::window.get() );
+    throwErrorIf( pixel_format == SDL_PIXELFORMAT_UNKNOWN, "SDL_GetWindowPixelFormat failed" );
 
     int renderer_id = -1;
 #if !defined(__ANDROID__)
@@ -453,7 +452,6 @@ static void WinDestroy()
     tilecontext.reset();
     gamepad::quit();
     geometry.reset();
-    format.reset();
     display_buffer.reset();
     renderer.reset();
     ::window.reset();
@@ -3961,14 +3959,14 @@ void catacurses::init_interface()
     }
 #endif // SOUND
 
-    font = std::make_unique<FontFallbackList>( renderer, format, fl.fontwidth, fl.fontheight,
+    font = std::make_unique<FontFallbackList>( renderer, pixel_format, fl.fontwidth, fl.fontheight,
             windowsPalette, fl.typeface, fl.fontsize, fl.fontblending );
-    gui_font = std::make_unique<FontFallbackList>( renderer, format, fl.fontwidth, fl.fontheight,
+    gui_font = std::make_unique<FontFallbackList>( renderer, pixel_format, fl.fontwidth, fl.fontheight,
                windowsPalette, fl.gui_typeface, fl.fontsize, fl.fontblending );
-    map_font = std::make_unique<FontFallbackList>( renderer, format, fl.map_fontwidth,
+    map_font = std::make_unique<FontFallbackList>( renderer, pixel_format, fl.map_fontwidth,
                fl.map_fontheight,
                windowsPalette, fl.map_typeface, fl.map_fontsize, fl.fontblending );
-    overmap_font = std::make_unique<FontFallbackList>( renderer, format, fl.overmap_fontwidth,
+    overmap_font = std::make_unique<FontFallbackList>( renderer, pixel_format, fl.overmap_fontwidth,
                    fl.overmap_fontheight,
                    windowsPalette, fl.overmap_typeface, fl.overmap_fontsize, fl.fontblending );
     stdscr = newwin( get_terminal_height(), get_terminal_width(), point::zero );
@@ -4405,7 +4403,7 @@ bool save_screenshot( const std::string &file_path )
     SDL_Surface_Ptr surface = CreateRGBSurface( 0, viewport.w, viewport.h, 32, 0, 0, 0, 0 );
 
     // Get data from SDL_Renderer and save them into surface
-    if( printErrorIf( SDL_RenderReadPixels( renderer.get(), nullptr, surface->format->format,
+    if( printErrorIf( SDL_RenderReadPixels( renderer.get(), nullptr, GetSurfacePixelFormat( surface ),
                                             surface->pixels, surface->pitch ) != 0,
                       "save_screenshot: cannot read data from SDL_Renderer." ) ) {
         return false;


### PR DESCRIPTION
#### Summary
Infrastructure "Wrap SDL surface operations behind abstraction layer"

#### Purpose of change

Continuation of #86055. Several SDL2 surface functions are called directly in rendering and font code, scattering the SDL API surface across the codebase. More importantly, many of these calls use `SDL_PixelFormat` structs that are removed in SDL3 (where pixel format becomes a simple enum).

#### Describe the solution

Add nine new wrappers to `sdl_wrappers.h/cpp`: `BlitSurface`, `MapRGB`, `MapRGBA`, `SetColorKey`, `SetSurfaceRLE`, `SetSurfaceBlendMode`, `ConvertSurfaceFormat`, `LockSurface`, `UnlockSurface`.

Replace the `SDL_PixelFormat_Ptr` struct threading through the font pipeline (`Font::load_font`, `BitmapFont`, `FontFallbackList`) with a `Uint32` pixel format enum. SDL2 already has `SDL_ConvertSurfaceFormat` that takes the enum directly, so `SDL_AllocFormat` and the `SDL_PixelFormat_Ptr` RAII type are no longer needed. This is the seam that SDL3 actually needs -- format-as-enum rather than format-as-struct.

Surface wrappers return `int` (matching SDL convention) so callers keep their existing throw-vs-log error handling. `FillRect` (existing wrapper) changed from `void` to `int` for the same reason.

#### Describe alternatives you've considered

N/A

#### Testing

Ran the game, loaded a world, verified tile rendering and bitmap font rendering look identical. No behavior change -- purely mechanical wrapper substitution plus the format pipeline cleanup.

#### Additional context

Next in the series: TTF font wrappers (separate PR), then gamepad abstraction (separate PR).