### PR TITLE
Wrap TTF font operations behind SDL abstraction layer

### DIFF
--- a/src/sdl_font.cpp
+++ b/src/sdl_font.cpp
@@ -25,17 +25,17 @@
     // return face index that has this size or below
     static int test_face_size( const std::string &f, int size, int faceIndex )
 {
-    const TTF_Font_Ptr fnt( TTF_OpenFontIndex( f.c_str(), size, faceIndex ) );
+    const TTF_Font_Ptr fnt = OpenFontIndex( f.c_str(), size, faceIndex );
     if( fnt ) {
-        const char *style = TTF_FontFaceStyleName( fnt.get() );
+        const char *style = FontFaceStyleName( fnt );
         if( style != nullptr ) {
-            int faces = TTF_FontFaces( fnt.get() );
+            int faces = FontFaces( fnt );
             for( int i = faces - 1; i >= 0; i-- ) {
-                const TTF_Font_Ptr tf( TTF_OpenFontIndex( f.c_str(), size, i ) );
+                const TTF_Font_Ptr tf = OpenFontIndex( f.c_str(), size, i );
                 const char *ts = nullptr;
                 if( tf ) {
-                    if( nullptr != ( ts = TTF_FontFaceStyleName( tf.get() ) ) ) {
-                        if( 0 == strcasecmp( ts, style ) && TTF_FontHeight( tf.get() ) <= size ) {
+                    if( nullptr != ( ts = FontFaceStyleName( tf ) ) ) {
+                        if( 0 == strcasecmp( ts, style ) && FontHeight( tf ) <= size ) {
                             return i;
                         }
                     }
@@ -295,11 +295,11 @@ CachedTTFFont::CachedTTFFont(
         strcasecmp( typeface.substr( typeface.length() - 4 ).c_str(), ".fon" ) == 0 ) {
         faceIndex = test_face_size( typeface, fontsize, faceIndex );
     }
-    font.reset( TTF_OpenFontIndex( typeface.c_str(), fontsize, faceIndex ) );
+    font = OpenFontIndex( typeface.c_str(), fontsize, faceIndex );
     if( !font ) {
         throw std::runtime_error( TTF_GetError() );
     }
-    TTF_SetFontStyle( font.get(), TTF_STYLE_NORMAL );
+    SetFontStyle( font, TTF_STYLE_NORMAL );
 }
 
 SDL_Texture_Ptr CachedTTFFont::create_glyph( const SDL_Renderer_Ptr &renderer,
@@ -307,8 +307,9 @@ SDL_Texture_Ptr CachedTTFFont::create_glyph( const SDL_Renderer_Ptr &renderer,
         int &ch_width,
         const int color )
 {
-    const auto function = fontblending ? TTF_RenderUTF8_Blended : TTF_RenderUTF8_Solid;
-    SDL_Surface_Ptr sglyph( function( font.get(), ch.c_str(), windowsPalette[color] ) );
+    SDL_Surface_Ptr sglyph = fontblending
+                             ? RenderUTF8_Blended( font, ch.c_str(), windowsPalette[color] )
+                             : RenderUTF8_Solid( font, ch.c_str(), windowsPalette[color] );
     if( !sglyph ) {
         dbg( D_ERROR ) << "Failed to create glyph for " << ch << ": " << TTF_GetError();
         return nullptr;
@@ -349,13 +350,13 @@ SDL_Texture_Ptr CachedTTFFont::create_glyph( const SDL_Renderer_Ptr &renderer,
 bool CachedTTFFont::isGlyphProvided( const std::string &ch ) const
 {
     // Just return false if the glyph is not provided by the font
-    if( !TTF_GlyphIsProvided( font.get(), UTF8_getch( ch ) ) ) {
+    if( !CanRenderGlyph( font, UTF8_getch( ch ) ) ) {
         return false;
     }
 
     // Test whether the glyph can actually be rendered
     constexpr SDL_Color white{255, 255, 255, 0};
-    SDL_Surface_Ptr surface( TTF_RenderUTF8_Solid( font.get(), ch.c_str(), white ) );
+    SDL_Surface_Ptr surface = RenderUTF8_Solid( font, ch.c_str(), white );
     return static_cast<bool>( surface );
 }
 

--- a/src/sdl_wrappers.cpp
+++ b/src/sdl_wrappers.cpp
@@ -350,5 +350,82 @@ Uint32 GetSurfacePixelFormat( const SDL_Surface_Ptr &surface )
     // SDL3: surface->format is the enum directly (no intermediate struct).
     return surface->format->format;
 }
+
+TTF_Font_Ptr OpenFontIndex( const char *const file, const int ptsize, const int64_t index )
+{
+    // NOLINTNEXTLINE(cata-no-long)
+    TTF_Font_Ptr result( TTF_OpenFontIndex( file, ptsize, static_cast<long>( index ) ) );
+    // Callers check the result and may call TTF_GetError themselves.
+    return result;
+}
+
+const char *FontFaceStyleName( const TTF_Font_Ptr &font )
+{
+    if( !font ) {
+        dbg( D_ERROR ) << "Tried to query style name of a null font";
+        return nullptr;
+    }
+    return TTF_FontFaceStyleName( font.get() );
+}
+
+int FontFaces( const TTF_Font_Ptr &font )
+{
+    if( !font ) {
+        dbg( D_ERROR ) << "Tried to query face count of a null font";
+        return 0;
+    }
+    return TTF_FontFaces( font.get() );
+}
+
+int FontHeight( const TTF_Font_Ptr &font )
+{
+    if( !font ) {
+        dbg( D_ERROR ) << "Tried to query height of a null font";
+        return 0;
+    }
+    return TTF_FontHeight( font.get() );
+}
+
+void SetFontStyle( const TTF_Font_Ptr &font, const int style )
+{
+    if( !font ) {
+        dbg( D_ERROR ) << "Tried to set style on a null font";
+        return;
+    }
+    TTF_SetFontStyle( font.get(), style );
+}
+
+SDL_Surface_Ptr RenderUTF8_Solid( const TTF_Font_Ptr &font, const char *const text,
+                                  const SDL_Color fg )
+{
+    if( !font ) {
+        dbg( D_ERROR ) << "Tried to render with a null font";
+        return SDL_Surface_Ptr();
+    }
+    return SDL_Surface_Ptr( TTF_RenderUTF8_Solid( font.get(), text, fg ) );
+}
+
+SDL_Surface_Ptr RenderUTF8_Blended( const TTF_Font_Ptr &font, const char *const text,
+                                    const SDL_Color fg )
+{
+    if( !font ) {
+        dbg( D_ERROR ) << "Tried to render with a null font";
+        return SDL_Surface_Ptr();
+    }
+    return SDL_Surface_Ptr( TTF_RenderUTF8_Blended( font.get(), text, fg ) );
+}
+
+bool CanRenderGlyph( const TTF_Font_Ptr &font, const Uint32 ch )
+{
+    if( !font ) {
+        return false;
+    }
+    // SDL2: TTF_GlyphIsProvided only takes Uint16, so clamp for now.
+    // SDL3_ttf will use Uint32 natively via glyph metrics.
+    if( ch > 0xFFFF ) {
+        return false;
+    }
+    return TTF_GlyphIsProvided( font.get(), static_cast<Uint16>( ch ) ) != 0;
+}
 #endif // defined(TILES)
 #endif // defined(TILES) || defined(SDL_SOUND)

--- a/src/sdl_wrappers.h
+++ b/src/sdl_wrappers.h
@@ -120,6 +120,17 @@ void UnlockSurface( const SDL_Surface_Ptr &surface );
 // Returns the pixel format enum (SDL_PIXELFORMAT_*) for the surface.
 // SDL3: surface->format is the enum directly; SDL2: surface->format->format.
 Uint32 GetSurfacePixelFormat( const SDL_Surface_Ptr &surface );
+TTF_Font_Ptr OpenFontIndex( const char *file, int ptsize, int64_t index );
+const char *FontFaceStyleName( const TTF_Font_Ptr &font );
+int FontFaces( const TTF_Font_Ptr &font );
+int FontHeight( const TTF_Font_Ptr &font );
+void SetFontStyle( const TTF_Font_Ptr &font, int style );
+SDL_Surface_Ptr RenderUTF8_Solid( const TTF_Font_Ptr &font, const char *text, SDL_Color fg );
+SDL_Surface_Ptr RenderUTF8_Blended( const TTF_Font_Ptr &font, const char *text, SDL_Color fg );
+// Project-level helper: can this font produce a glyph for the given codepoint?
+// In SDL3_ttf there is no direct TTF_GlyphIsProvided equivalent; this will be
+// emulated via glyph metrics or a render attempt.
+bool CanRenderGlyph( const TTF_Font_Ptr &font, Uint32 ch );
 /**@}*/
 
 void StartTextInput();


### PR DESCRIPTION
#### Summary
Infrastructure "Wrap TTF font operations behind SDL abstraction layer"

#### Purpose of change

Depends on #86103. SDL3_ttf redesigns the font rendering API: `TTF_RenderUTF8_*` becomes `TTF_RenderText_*`, `TTF_OpenFontIndex` becomes `TTF_OpenFontWithProperties`, `TTF_FontFaceStyleName` becomes `TTF_GetFontStyleName`, and `TTF_GlyphIsProvided` has no direct equivalent. Wrapping these now means SDL3 migration only touches `sdl_wrappers.cpp`.

#### Describe the solution

Add eight new wrappers to `sdl_wrappers.h/cpp`: `OpenFontIndex`, `FontFaceStyleName`, `FontFaces`, `FontHeight`, `SetFontStyle`, `RenderUTF8_Solid`, `RenderUTF8_Blended`, and `CanRenderGlyph`.

`CanRenderGlyph` is a project-level helper rather than a mechanical wrapper. SDL2's `TTF_GlyphIsProvided` only takes `Uint16`, but the project uses `uint32_t` codepoints (`UTF8_getch`). The wrapper takes `Uint32` and handles the narrowing internally. In SDL3_ttf, this will be emulated via glyph metrics or a render attempt.

`TTF_GetError()` is left unwrapped for now -- SDL3_ttf drops it in favor of `SDL_GetError()`, a trivial change when the time comes.

#### Describe alternatives you've considered

N/A

#### Testing

Ran the game, verified TTF and bitmap font rendering look identical.

#### Additional context

Part of the SDL abstraction series: #86055 (rendering), #86103 (surfaces), this PR (TTF), gamepad (next).