### PR TITLE
Centralize gamepad SDL boundary inside the gamepad module

### DIFF
--- a/src/sdl_gamepad.cpp
+++ b/src/sdl_gamepad.cpp
@@ -98,6 +98,8 @@ void init()
         return;
     }
 
+    // SDL3: SDL_NumJoysticks is replaced by SDL_GetJoysticks (returns array).
+    // SDL3: SDL_GameControllerOpen becomes SDL_OpenGamepad and takes instance ID, not device index.
     if( SDL_NumJoysticks() > 0 ) {
         controller = SDL_GameControllerOpen( 0 );
         if( controller ) {
@@ -122,9 +124,10 @@ void quit()
     }
 }
 
-SDL_GameController *get_controller()
+// SDL3: SDL_GameControllerGetAxis becomes SDL_GetGamepadAxis.
+static Sint16 get_controller_axis( SDL_GameControllerAxis axis )
 {
-    return controller;
+    return SDL_GameControllerGetAxis( controller, axis );
 }
 
 static int one_of_two( const std::array<int, 2> &arr, int val )
@@ -324,7 +327,7 @@ static void send_direction_movement()
     }
 }
 
-bool handle_axis_event( SDL_Event &event )
+static bool handle_axis_event( SDL_Event &event )
 {
     if( event.type != SDL_CONTROLLERAXISMOTION ) {
         return false;
@@ -406,10 +409,8 @@ bool handle_axis_event( SDL_Event &event )
         if( axis_idx >= 0 ) {
             // Get current values for both axes of this stick
             const point val(
-                SDL_GameControllerGetAxis( controller,
-                                           static_cast<SDL_GameControllerAxis>( sticks_axis[i][0] ) ),
-                SDL_GameControllerGetAxis( controller,
-                                           static_cast<SDL_GameControllerAxis>( sticks_axis[i][1] ) ) );
+                get_controller_axis( static_cast<SDL_GameControllerAxis>( sticks_axis[i][0] ) ),
+                get_controller_axis( static_cast<SDL_GameControllerAxis>( sticks_axis[i][1] ) ) );
 
             // Calculate magnitude (distance from center)
             double magnitude = std::sqrt( static_cast<double>( val.x ) * val.x +
@@ -515,7 +516,7 @@ bool handle_axis_event( SDL_Event &event )
 }
 
 
-void handle_button_event( SDL_Event &event )
+static void handle_button_event( SDL_Event &event )
 {
     int button = event.cbutton.button;
     Uint32 now = event.cbutton.timestamp;
@@ -649,7 +650,10 @@ void handle_button_event( SDL_Event &event )
     }
 }
 
-void handle_device_event( SDL_Event &event )
+// SDL3: SDL_CONTROLLERDEVICEADDED/REMOVED become SDL_EVENT_GAMEPAD_ADDED/REMOVED.
+// SDL3: event.cdevice.which for ADDED is an instance ID (not device index).
+// SDL3: SDL_GameControllerOpen becomes SDL_OpenGamepad.
+static void handle_device_event( SDL_Event &event )
 {
     if( event.type == SDL_CONTROLLERDEVICEADDED ) {
         if( controller == nullptr ) {
@@ -667,7 +671,7 @@ void handle_device_event( SDL_Event &event )
     }
 }
 
-void handle_scheduler_event( SDL_Event &event )
+static void handle_scheduler_event( SDL_Event &event )
 {
     Uint32 now = event.user.timestamp;
     for( size_t i = 0; i < all_tasks.size(); ++i ) {
@@ -761,6 +765,46 @@ tripoint direction_to_offset( direction dir )
         case direction::NONE:
         default:
             return tripoint::zero;
+    }
+}
+
+// SDL3: SDL_CONTROLLERBUTTONDOWN/UP become SDL_EVENT_GAMEPAD_BUTTON_DOWN/UP.
+// SDL3: SDL_CONTROLLERAXISMOTION becomes SDL_EVENT_GAMEPAD_AXIS_MOTION.
+// SDL3: SDL_CONTROLLERDEVICEADDED/REMOVED become SDL_EVENT_GAMEPAD_ADDED/REMOVED.
+// SDL3: event.caxis/cbutton/cdevice become event.gaxis/gbutton/gdevice.
+bool is_gamepad_event( const SDL_Event &event )
+{
+    switch( event.type ) {
+        case SDL_CONTROLLERBUTTONDOWN:
+        case SDL_CONTROLLERBUTTONUP:
+        case SDL_CONTROLLERAXISMOTION:
+        case SDL_CONTROLLERDEVICEADDED:
+        case SDL_CONTROLLERDEVICEREMOVED:
+        case SDL_GAMEPAD_SCHEDULER:
+            return true;
+        default:
+            return false;
+    }
+}
+
+bool handle_event( SDL_Event &event )
+{
+    switch( event.type ) {
+        case SDL_CONTROLLERBUTTONDOWN:
+        case SDL_CONTROLLERBUTTONUP:
+            handle_button_event( event );
+            return false;
+        case SDL_CONTROLLERAXISMOTION:
+            return handle_axis_event( event );
+        case SDL_CONTROLLERDEVICEADDED:
+        case SDL_CONTROLLERDEVICEREMOVED:
+            handle_device_event( event );
+            return false;
+        case SDL_GAMEPAD_SCHEDULER:
+            handle_scheduler_event( event );
+            return false;
+        default:
+            return false;
     }
 }
 

--- a/src/sdl_gamepad.h
+++ b/src/sdl_gamepad.h
@@ -30,12 +30,12 @@ enum class direction : int {
 
 void init();
 void quit();
-// Returns true if the selected direction changed (UI needs refresh)
-bool handle_axis_event( SDL_Event &event );
-void handle_button_event( SDL_Event &event );
-void handle_device_event( SDL_Event &event );
-void handle_scheduler_event( SDL_Event &event );
-SDL_GameController *get_controller();
+// Returns true if this event type belongs to the gamepad module.
+bool is_gamepad_event( const SDL_Event &event );
+// Dispatch any gamepad-related SDL event. Returns true if UI needs refresh.
+// Handles button, axis, device hotplug, and scheduler events internally.
+bool handle_event( SDL_Event &event );
+
 
 direction get_left_stick_direction();
 direction get_right_stick_direction();

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -3341,24 +3341,6 @@ static void CheckMessages()
                 break;
             }
 #endif
-            case SDL_CONTROLLERBUTTONDOWN:
-            case SDL_CONTROLLERBUTTONUP:
-                gamepad::handle_button_event( ev );
-                break;
-            case SDL_CONTROLLERAXISMOTION:
-                if( gamepad::handle_axis_event( ev ) ) {
-                    // Direction indicator changed, need to redraw
-                    needupdate = true;
-                    ui_manager::redraw_invalidated();
-                }
-                break;
-            case SDL_CONTROLLERDEVICEADDED:
-            case SDL_CONTROLLERDEVICEREMOVED:
-                gamepad::handle_device_event( ev );
-                break;
-            case SDL_GAMEPAD_SCHEDULER:
-                gamepad::handle_scheduler_event( ev );
-                break;
             case SDL_MOUSEMOTION:
                 if( ! mouse.enabled ) {
                     break;
@@ -3677,6 +3659,14 @@ static void CheckMessages()
 
             case SDL_QUIT:
                 quit = true;
+                break;
+            default:
+                if( gamepad::is_gamepad_event( ev ) ) {
+                    if( gamepad::handle_event( ev ) ) {
+                        needupdate = true;
+                        ui_manager::redraw_invalidated();
+                    }
+                }
                 break;
         }
         if( text_refresh && !is_repeat ) {
@@ -4131,7 +4121,7 @@ input_event input_manager::get_input_event( const keyboard_mode preferred_keyboa
 
 bool gamepad_available()
 {
-    return gamepad::get_controller() != nullptr;
+    return gamepad::is_active();
 }
 
 void rescale_tileset( int size )


### PR DESCRIPTION
#### Summary
Infrastructure "Centralize gamepad SDL boundary inside the gamepad module"

#### Purpose of change

Depends on #86105. SDL3 completely renames the gamepad API (`SDL_GameController` -> `SDL_Gamepad`, different event constants, instance IDs instead of device indices). Currently `sdltiles.cpp` knows about `SDL_CONTROLLERBUTTONDOWN`, `SDL_CONTROLLERAXISMOTION`, etc. directly in its event switch. This PR moves that knowledge into the gamepad module where it belongs.

#### Describe the solution

Replace the four separate public event handlers (`handle_axis_event`, `handle_button_event`, `handle_device_event`, `handle_scheduler_event`) with a single `handle_event(SDL_Event &)` that returns true when UI needs refresh. The old handlers become file-static.

Remove `get_controller()` from the public API. The only external caller was `gamepad_available()` in sdltiles.cpp, which did a null check. Replaced with the already-existing `is_active()`.

Added `// SDL3:` comments at semantic boundaries where the API changes matter (device index vs instance ID, event struct renames, function renames).

#### Describe alternatives you've considered

N/A

#### Testing

Ran the game, verified no regressions in keyboard/mouse input. Don't have a gamepad connected to test controller input directly, but the code paths are unchanged -- only the dispatch location moved.

#### Additional context

Part of the SDL abstraction series: #86055 (rendering), #86103 (surfaces), #86105 (TTF), this PR (gamepad).