### PR TITLE
Fuse color shadowcasting, skip idle blur, LUT for castLight distances

### DIFF
--- a/src/level_cache.h
+++ b/src/level_cache.h
@@ -27,6 +27,9 @@ struct level_cache {
         bool outside_cache_dirty = false;
         bool floor_cache_dirty = false;
         bool seen_cache_dirty = false;
+        // True when at least one light source on this z-level has non-white color.
+        // Used to skip the color blur pass when all lights are white.
+        bool has_colored_lights = false;
         // This is a single value indicating that the entire level is floored.
         bool no_floor_gaps = false;
 

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -670,7 +670,7 @@ void map::generate_lightmap( const int zlev )
     }
 
     // 3x3 box blur on the color cache softens residual octant boundary seams.
-    // Even with per-channel max in update_light_color, attenuation differences
+    // Even with per-channel max in the color write, attenuation differences
     // between adjacent octants can leave visible intensity steps.
     {
         auto &light_color_cache = map_cache.light_color_cache;
@@ -747,21 +747,6 @@ light_color_rgb light_color_rgb::from_hsv( float h, float s, float v )
     }
     return { r1 + m, g1 + m, b1 + m };
 }
-
-// Set before each castLight sequence, read by update_light_color callback.
-static light_color_rgb g_current_source_color;
-
-// castLight callback for color propagation. Per-channel max prevents octant
-// boundary seams (two adjacent octants hitting the same tile would double
-// the color with +=, but scalar light uses max() so it stays clean).
-static void update_light_color( light_color_rgb &tile_color, const float &intensity, quadrant )
-{
-    const light_color_rgb contrib = g_current_source_color * intensity;
-    tile_color.r = std::max( tile_color.r, contrib.r );
-    tile_color.g = std::max( tile_color.g, contrib.g );
-    tile_color.b = std::max( tile_color.b, contrib.b );
-}
-
 
 // Tile light/transparency: 3D
 
@@ -976,23 +961,29 @@ template<int xx, int xy, int yx, int yy, typename T, typename Out,
          T( *calc )( const T &, const T &, const int & ),
          bool( *check )( const T &, const T & ),
          void( *update_output )( Out &, const T &, quadrant ),
-         T( *accumulate )( const T &, const T &, const int & )>
+         T( *accumulate )( const T &, const T &, const int & ),
+         bool with_color = false>
 void castLight( cata::mdarray<Out, point_bub_ms> &output_cache,
                 const cata::mdarray<T, point_bub_ms> &input_array,
                 const point_bub_ms &offset, int offsetDistance,
                 T numerator = VISIBILITY_FULL,
                 int row = 1, float start = 1.0f, float end = 0.0f,
-                T cumulative_transparency = T( LIGHT_TRANSPARENCY_OPEN_AIR ) );
+                T cumulative_transparency = T( LIGHT_TRANSPARENCY_OPEN_AIR ),
+                light_color_rgb source_color = {},
+                cata::mdarray<light_color_rgb, point_bub_ms> *color_cache = nullptr );
 
 template<int xx, int xy, int yx, int yy, typename T, typename Out,
          T( *calc )( const T &, const T &, const int & ),
          bool( *check )( const T &, const T & ),
          void( *update_output )( Out &, const T &, quadrant ),
-         T( *accumulate )( const T &, const T &, const int & )>
+         T( *accumulate )( const T &, const T &, const int & ),
+         bool with_color>
 void castLight( cata::mdarray<Out, point_bub_ms> &output_cache,
                 const cata::mdarray<T, point_bub_ms> &input_array,
                 const point_bub_ms &offset, const int offsetDistance, const T numerator,
-                const int row, float start, const float end, T cumulative_transparency )
+                const int row, float start, const float end, T cumulative_transparency,
+                const light_color_rgb source_color,
+                cata::mdarray<light_color_rgb, point_bub_ms> *color_cache )
 {
     constexpr quadrant quad = quadrant_from_x_y( -xx - xy, -yx - yy );
     float newStart = 0.0f;
@@ -1040,16 +1031,25 @@ void castLight( cata::mdarray<Out, point_bub_ms> &output_cache,
                 update_output( output_cache[current.x][current.y], last_intensity, quad );
             }
 
+            if constexpr( with_color ) {
+                const light_color_rgb contrib = source_color * last_intensity;
+                auto &cc = ( *color_cache )[current.x][current.y];
+                cc.r = std::max( cc.r, contrib.r );
+                cc.g = std::max( cc.g, contrib.g );
+                cc.b = std::max( cc.b, contrib.b );
+            }
+
             if( new_transparency == current_transparency ) {
                 newStart = leadingEdge;
                 continue;
             }
             // Only cast recursively if previous span was not opaque.
             if( check( current_transparency, last_intensity ) ) {
-                castLight<xx, xy, yx, yy, T, Out, calc, check, update_output, accumulate>(
+                castLight<xx, xy, yx, yy, T, Out, calc, check, update_output, accumulate, with_color>(
                     output_cache, input_array, offset, offsetDistance,
                     numerator, distance + 1, start, trailingEdge,
-                    accumulate( cumulative_transparency, current_transparency, distance ) );
+                    accumulate( cumulative_transparency, current_transparency, distance ),
+                    source_color, color_cache );
             }
             // The new span starts at the leading edge of the previous square if it is opaque,
             // and at the trailing edge of the current square if it is transparent.
@@ -1335,10 +1335,11 @@ void map::apply_light_source( const tripoint_bub_ms &p, float luminance )
     // re-scales by the per-tile attenuated intensity -- same falloff as scalar.
     const auto &buf = light_source_buffer[p2.x()][p2.y()];
     const bool has_color = buf.color.is_colored();
+    light_color_rgb source_color;
     if( has_color ) {
-        g_current_source_color = buf.color * ( 1.0f / buf.luminance );
+        source_color = buf.color * ( 1.0f / buf.luminance );
         // Set source tile color directly
-        light_color_cache[p2.x()][p2.y()] += g_current_source_color * luminance;
+        light_color_cache[p2.x()][p2.y()] += source_color * luminance;
     }
 
     /* If we're a 5 luminance fire , we skip casting rays into ey && sx if we have
@@ -1365,81 +1366,40 @@ void map::apply_light_source( const tripoint_bub_ms &p, float luminance )
                 light_source_buffer[p2.x() + 1][p2.y()].luminance < luminance;
     bool west = p2.x() != 0 && light_source_buffer[p2.x() - 1][p2.y()].luminance < luminance;
 
+    // Helper macro: cast scalar light through one octant, fusing the color
+    // write into the same traversal when the source has color.
+#define CAST_LIGHT_OCTANT( _xx, _xy, _yx, _yy ) \
+    if( has_color ) { \
+        castLight<_xx, _xy, _yx, _yy, float, four_quadrants, light_calc, light_check, \
+        update_light_quadrants, accumulate_transparency, true>( \
+                lm, transparency_cache, p2, 0, luminance, 1, 1.0f, 0.0f, \
+                LIGHT_TRANSPARENCY_OPEN_AIR, source_color, &light_color_cache ); \
+    } else { \
+        castLight<_xx, _xy, _yx, _yy, float, four_quadrants, light_calc, light_check, \
+        update_light_quadrants, accumulate_transparency>( \
+                lm, transparency_cache, p2, 0, luminance ); \
+    }
+
     if( north ) {
-        castLight < 1, 0, 0, -1, float, four_quadrants, light_calc, light_check,
-                  update_light_quadrants, accumulate_transparency > (
-                      lm, transparency_cache, p2, 0, luminance );
-        if( has_color ) {
-            castLight < 1, 0, 0, -1, float, light_color_rgb, light_calc, light_check,
-                      update_light_color, accumulate_transparency > (
-                          light_color_cache, transparency_cache, p2, 0, luminance );
-        }
-        castLight < -1, 0, 0, -1, float, four_quadrants, light_calc, light_check,
-                  update_light_quadrants, accumulate_transparency > (
-                      lm, transparency_cache, p2, 0, luminance );
-        if( has_color ) {
-            castLight < -1, 0, 0, -1, float, light_color_rgb, light_calc, light_check,
-                      update_light_color, accumulate_transparency > (
-                          light_color_cache, transparency_cache, p2, 0, luminance );
-        }
+        CAST_LIGHT_OCTANT( 1, 0, 0, -1 )
+        CAST_LIGHT_OCTANT( -1, 0, 0, -1 )
     }
 
     if( east ) {
-        castLight < 0, -1, 1, 0, float, four_quadrants, light_calc, light_check,
-                  update_light_quadrants, accumulate_transparency > (
-                      lm, transparency_cache, p2, 0, luminance );
-        if( has_color ) {
-            castLight < 0, -1, 1, 0, float, light_color_rgb, light_calc, light_check,
-                      update_light_color, accumulate_transparency > (
-                          light_color_cache, transparency_cache, p2, 0, luminance );
-        }
-        castLight < 0, -1, -1, 0, float, four_quadrants, light_calc, light_check,
-                  update_light_quadrants, accumulate_transparency > (
-                      lm, transparency_cache, p2, 0, luminance );
-        if( has_color ) {
-            castLight < 0, -1, -1, 0, float, light_color_rgb, light_calc, light_check,
-                      update_light_color, accumulate_transparency > (
-                          light_color_cache, transparency_cache, p2, 0, luminance );
-        }
+        CAST_LIGHT_OCTANT( 0, -1, 1, 0 )
+        CAST_LIGHT_OCTANT( 0, -1, -1, 0 )
     }
 
     if( south ) {
-        castLight<1, 0, 0, 1, float, four_quadrants, light_calc, light_check,
-                  update_light_quadrants, accumulate_transparency>(
-                      lm, transparency_cache, p2, 0, luminance );
-        if( has_color ) {
-            castLight<1, 0, 0, 1, float, light_color_rgb, light_calc, light_check,
-                      update_light_color, accumulate_transparency>(
-                          light_color_cache, transparency_cache, p2, 0, luminance );
-        }
-        castLight < -1, 0, 0, 1, float, four_quadrants, light_calc, light_check,
-                  update_light_quadrants, accumulate_transparency > (
-                      lm, transparency_cache, p2, 0, luminance );
-        if( has_color ) {
-            castLight < -1, 0, 0, 1, float, light_color_rgb, light_calc, light_check,
-                      update_light_color, accumulate_transparency > (
-                          light_color_cache, transparency_cache, p2, 0, luminance );
-        }
+        CAST_LIGHT_OCTANT( 1, 0, 0, 1 )
+        CAST_LIGHT_OCTANT( -1, 0, 0, 1 )
     }
 
     if( west ) {
-        castLight<0, 1, 1, 0, float, four_quadrants, light_calc, light_check,
-                  update_light_quadrants, accumulate_transparency>(
-                      lm, transparency_cache, p2, 0, luminance );
-        if( has_color ) {
-            castLight<0, 1, 1, 0, float, light_color_rgb, light_calc, light_check,
-                      update_light_color, accumulate_transparency>(
-                          light_color_cache, transparency_cache, p2, 0, luminance );
-        }
-        castLight < 0, 1, -1, 0, float, four_quadrants, light_calc, light_check,
-                  update_light_quadrants, accumulate_transparency > (
-                      lm, transparency_cache, p2, 0, luminance );
-        if( has_color ) {
-            castLight < 0, 1, -1, 0, float, light_color_rgb, light_calc, light_check,
-                      update_light_color, accumulate_transparency > (
-                          light_color_cache, transparency_cache, p2, 0, luminance );
-        }
+        CAST_LIGHT_OCTANT( 0, 1, 1, 0 )
+        CAST_LIGHT_OCTANT( 0, 1, -1, 0 )
     }
+#undef CAST_LIGHT_OCTANT
 }
 
 void map::apply_directional_light( const tripoint_bub_ms &p, int direction, float luminance )
@@ -1502,7 +1462,6 @@ void map::apply_light_arc( const tripoint_bub_ms &p, const units::angle &angle, 
 
     const bool has_color = color.is_colored();
     if( has_color ) {
-        g_current_source_color = color;
         // Source tile gets only the local halo intensity, matching scalar path
         light_color_cache[p2.x()][p2.y()] += color * LIGHT_SOURCE_LOCAL;
     }
@@ -1532,16 +1491,18 @@ void map::apply_light_arc( const tripoint_bub_ms &p, const units::angle &angle, 
         start_angle = std::max( 45_degrees * start, oangle );
         end_angle = std::min( 45_degrees * end, cangle );
 
-        // Helper macro: cast scalar light, then color through the same octant.
-        // The template parameters encode the octant direction.
-#define CAST_ARC_OCTANT( xx, xy, yx, yy, s1, s2 ) \
-    castLight < xx, xy, yx, yy, float, four_quadrants, light_calc, light_check, \
-    update_light_quadrants, accumulate_transparency > ( \
-            lm, transparency_cache, p2, 0, luminance, 1, s1, s2 ); \
+        // Helper macro: cast scalar light through one octant, fusing the
+        // color write into the same traversal when the source has color.
+#define CAST_ARC_OCTANT( _xx, _xy, _yx, _yy, s1, s2 ) \
     if( has_color ) { \
-        castLight < xx, xy, yx, yy, float, light_color_rgb, light_calc, light_check, \
-        update_light_color, accumulate_transparency > ( \
-                light_color_cache, transparency_cache, p2, 0, luminance, 1, s1, s2 ); \
+        castLight<_xx, _xy, _yx, _yy, float, four_quadrants, light_calc, light_check, \
+        update_light_quadrants, accumulate_transparency, true>( \
+                lm, transparency_cache, p2, 0, luminance, 1, s1, s2, \
+                LIGHT_TRANSPARENCY_OPEN_AIR, color, &light_color_cache ); \
+    } else { \
+        castLight<_xx, _xy, _yx, _yy, float, four_quadrants, light_calc, light_check, \
+        update_light_quadrants, accumulate_transparency>( \
+                lm, transparency_cache, p2, 0, luminance, 1, s1, s2 ); \
     }
 
         // i is positive

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -1,6 +1,7 @@
 #include "lightmap.h" // IWYU pragma: associated
 #include "shadowcasting.h" // IWYU pragma: associated
 
+#include <array>
 #include <bitset>
 #include <cmath>
 #include <cstdlib>
@@ -455,6 +456,7 @@ void map::generate_lightmap( const int zlev )
     lm.fill( four_quadrants{} );
     sm.fill( 0 );
     map_cache.light_color_cache.fill( light_color_rgb{} );
+    map_cache.has_colored_lights = false;
 
     /* Bulk light sources wastefully cast rays into neighbors; a burning hospital can produce
          significant slowdown, so for stuff like fire and lava:
@@ -672,7 +674,7 @@ void map::generate_lightmap( const int zlev )
     // 3x3 box blur on the color cache softens residual octant boundary seams.
     // Even with per-channel max in the color write, attenuation differences
     // between adjacent octants can leave visible intensity steps.
-    {
+    if( map_cache.has_colored_lights ) {
         auto &light_color_cache = map_cache.light_color_cache;
         static auto blur_buf =
             std::make_unique<cata::mdarray<light_color_rgb, point_bub_ms>>();
@@ -957,6 +959,30 @@ static constexpr quadrant quadrant_from_x_y( int x, int y )
            ( ( y > 0 ) ? quadrant::NE : quadrant::SE );
 }
 
+// Precomputed 2D Euclidean distances for castLight inner loop.
+// Eliminates sqrt calls from the hottest code path.
+static const auto &trig_dist_2d_lut()
+{
+    static const auto lut = []() {
+        constexpr int N = MAX_VIEW_DISTANCE + 1;
+        std::array<std::array<int, N>, N> t{};
+        for( int x = 0; x < N; ++x ) {
+            for( int y = 0; y < N; ++y ) {
+                t[x][y] = static_cast<int>(
+                              std::sqrt( static_cast<double>( x * x + y * y ) ) );
+            }
+        }
+        return t;
+    }
+    ();
+    return lut;
+}
+
+int trig_dist_2d( point delta )
+{
+    return trig_dist_2d_lut()[std::abs( delta.x )][std::abs( delta.y )];
+}
+
 template<int xx, int xy, int yx, int yy, typename T, typename Out,
          T( *calc )( const T &, const T &, const int & ),
          bool( *check )( const T &, const T & ),
@@ -1019,7 +1045,9 @@ void castLight( cata::mdarray<Out, point_bub_ms> &output_cache,
                 current_transparency = input_array[ current.x ][ current.y ];
             }
 
-            const int dist = rl_dist( tripoint::zero, delta ) + offsetDistance;
+            const int dist = ( trigdist
+                               ? trig_dist_2d_lut()[std::abs( delta.x )][std::abs( delta.y )]
+                               : std::max( std::abs( delta.x ), std::abs( delta.y ) ) ) + offsetDistance;
             last_intensity = calc( numerator, cumulative_transparency, dist );
 
             T new_transparency = input_array[ current.x ][ current.y ];
@@ -1340,6 +1368,7 @@ void map::apply_light_source( const tripoint_bub_ms &p, float luminance )
         source_color = buf.color * ( 1.0f / buf.luminance );
         // Set source tile color directly
         light_color_cache[p2.x()][p2.y()] += source_color * luminance;
+        cache.has_colored_lights = true;
     }
 
     /* If we're a 5 luminance fire , we skip casting rays into ey && sx if we have
@@ -1464,6 +1493,7 @@ void map::apply_light_arc( const tripoint_bub_ms &p, const units::angle &angle, 
     if( has_color ) {
         // Source tile gets only the local halo intensity, matching scalar path
         light_color_cache[p2.x()][p2.y()] += color * LIGHT_SOURCE_LOCAL;
+        cache.has_colored_lights = true;
     }
 
     const units::angle wangle = wideangle / 2.0;

--- a/src/lightmap.h
+++ b/src/lightmap.h
@@ -8,6 +8,7 @@
 #include <stdint.h>
 
 #include "map_scale_constants.h"
+#include "point.h"
 
 constexpr float LIGHT_SOURCE_LOCAL = 0.1f;
 constexpr float LIGHT_SOURCE_BRIGHT = 10.0f;
@@ -108,5 +109,8 @@ inline std::ostream &operator<<( std::ostream &os, const lit_level &ll )
 {
     return os << static_cast<int>( ll );
 }
+
+// Exposed for testing: precomputed 2D integer euclidean distance.
+int trig_dist_2d( point delta );
 
 #endif // CATA_SRC_LIGHTMAP_H

--- a/tests/light_color_test.cpp
+++ b/tests/light_color_test.cpp
@@ -384,3 +384,136 @@ TEST_CASE( "vehicle_cone_light_carries_color", "[light_color]" )
 
     CHECK( best_r > behind_color.r );
 }
+
+TEST_CASE( "fused_color_output_matches_golden_values", "[light_color]" )
+{
+    // Golden values captured from pre-fusion code. These pin the exact
+    // per-tile RGB and scalar lightmap output for a single red point light
+    // on a dark roofed map with uniform floor.
+    setup_dark_map();
+    scoped_weather_override weather_clear( WEATHER_CLEAR );
+
+    const tripoint_bub_ms src = get_player_character().pos_bub() + tripoint::east * 5;
+
+    for( int dx = -6; dx <= 6; dx++ ) {
+        for( int dy = -6; dy <= 6; dy++ ) {
+            place_ter_roofed( src + tripoint( dx, dy, 0 ), ter_t_floor );
+        }
+    }
+    place_ter_roofed( src, ter_t_test_red_light );
+
+    rebuild_lightmap( 0 );
+
+    const map &here = get_map();
+    const level_cache &cache = here.access_cache( 0 );
+
+    // Golden 7x7 patch (inner tiles with actual color data): { delta, expected_r, expected_lm_max }
+    // g and b are always 0 for a pure red source.
+    struct golden_entry {
+        point d;
+        float r;
+        float lm;
+    };
+    // NOLINTBEGIN(cata-use-named-point-constants)
+    static const std::vector<golden_entry> golden = {
+        { { -3, -3 }, 1.438203f, 3.500000f },
+        { { -2, -3 }, 2.298876f, 3.500000f },
+        { { -1, -3 }, 2.582018f, 3.500000f },
+        { { 0, -3 }, 2.582018f, 3.500000f },
+        { { 1, -3 }, 2.582018f, 3.500000f },
+        { { 2, -3 }, 2.298876f, 3.500000f },
+        { { 3, -3 }, 1.438203f, 3.500000f },
+        { { -3, -2 }, 2.298876f, 3.500000f },
+        { { -2, -2 }, 4.239466f, 4.723102f },
+        { { -1, -2 }, 5.266641f, 4.723102f },
+        { { 0, -2 }, 5.821768f, 4.723102f },
+        { { 1, -2 }, 5.266641f, 4.723102f },
+        { { 2, -2 }, 4.239465f, 4.723102f },
+        { { 3, -2 }, 2.298876f, 3.500000f },
+        { { -3, -1 }, 2.582018f, 3.500000f },
+        { { -2, -1 }, 5.266641f, 4.723102f },
+        { { -1, -1 }, 6.974808f, 9.719253f },
+        { { 0, -1 }, 8.085064f, 9.719253f },
+        { { 1, -1 }, 6.974808f, 9.719253f },
+        { { 2, -1 }, 5.266640f, 4.723102f },
+        { { 3, -1 }, 2.582018f, 3.500000f },
+        { { -3, 0 }, 2.582018f, 3.500000f },
+        { { -2, 0 }, 5.821769f, 4.723102f },
+        { { -1, 0 }, 8.085064f, 9.719253f },
+        { { 0, 0 }, 9.750447f, 10.000000f },
+        { { 1, 0 }, 8.085064f, 9.719253f },
+        { { 2, 0 }, 5.821768f, 4.723102f },
+        { { 3, 0 }, 2.582018f, 3.500000f },
+        { { -3, 1 }, 2.582018f, 3.500000f },
+        { { -2, 1 }, 5.266641f, 4.723102f },
+        { { -1, 1 }, 6.974808f, 9.719253f },
+        { { 0, 1 }, 8.085063f, 9.719253f },
+        { { 1, 1 }, 6.974808f, 9.719253f },
+        { { 2, 1 }, 5.266640f, 4.723102f },
+        { { 3, 1 }, 2.582018f, 3.500000f },
+        { { -3, 2 }, 2.298876f, 3.500000f },
+        { { -2, 2 }, 4.239466f, 4.723102f },
+        { { -1, 2 }, 5.266641f, 4.723102f },
+        { { 0, 2 }, 5.821768f, 4.723102f },
+        { { 1, 2 }, 5.266641f, 4.723102f },
+        { { 2, 2 }, 4.239466f, 4.723102f },
+        { { 3, 2 }, 2.298876f, 3.500000f },
+        { { -3, 3 }, 1.438203f, 3.500000f },
+        { { -2, 3 }, 2.298876f, 3.500000f },
+        { { -1, 3 }, 2.582018f, 3.500000f },
+        { { 0, 3 }, 2.582018f, 3.500000f },
+        { { 1, 3 }, 2.582018f, 3.500000f },
+        { { 2, 3 }, 2.298876f, 3.500000f },
+        { { 3, 3 }, 1.438203f, 3.500000f },
+    };
+    // NOLINTEND(cata-use-named-point-constants)
+
+    for( const golden_entry &g : golden ) {
+        const point p = g.d + point( src.x(), src.y() );
+        CAPTURE( g.d );
+        CHECK( cache.light_color_cache[p.x][p.y].r == Approx( g.r ).margin( 0.01f ) );
+        CHECK( cache.light_color_cache[p.x][p.y].g == Approx( 0.0f ).margin( 0.01f ) );
+        CHECK( cache.light_color_cache[p.x][p.y].b == Approx( 0.0f ).margin( 0.01f ) );
+        CHECK( cache.lm[p.x][p.y].max() == Approx( g.lm ).margin( 0.01f ) );
+    }
+}
+
+// Manual-only capture helper for regenerating golden values.
+// Run with: ./tests/cata_test "[golden_capture]"
+TEST_CASE( "capture_golden_values_for_point_light", "[.][golden_capture]" )
+{
+    setup_dark_map();
+    scoped_weather_override weather_clear( WEATHER_CLEAR );
+
+    const tripoint_bub_ms src = get_player_character().pos_bub() + tripoint::east * 5;
+
+    for( int dx = -6; dx <= 6; dx++ ) {
+        for( int dy = -6; dy <= 6; dy++ ) {
+            place_ter_roofed( src + tripoint( dx, dy, 0 ), ter_t_floor );
+        }
+    }
+    place_ter_roofed( src, ter_t_test_red_light );
+
+    rebuild_lightmap( 0 );
+
+    const map &here = get_map();
+    const level_cache &cache = here.access_cache( 0 );
+
+    // NOLINTNEXTLINE(cata-text-style)
+    printf( "\n=== GOLDEN VALUES: 9x9 patch centered on red light ===\n" );
+    // NOLINTNEXTLINE(cata-text-style)
+    printf( "// { dx, dy, r, g, b, lm_max }\n" );
+    for( int dy = -4; dy <= 4; dy++ ) {
+        for( int dx = -4; dx <= 4; dx++ ) {
+            // NOLINTNEXTLINE(cata-combine-locals-into-point)
+            const int x = src.x() + dx;
+            const int y = src.y() + dy;
+            const auto &c = cache.light_color_cache[x][y];
+            const float lm = cache.lm[x][y].max();
+            // NOLINTNEXTLINE(cata-text-style)
+            printf( "{ %2d, %2d, %10.6ff, %10.6ff, %10.6ff, %10.6ff },\n",
+                    dx, dy, c.r, c.g, c.b, lm );
+        }
+    }
+}
+

--- a/tests/light_color_test.cpp
+++ b/tests/light_color_test.cpp
@@ -1,13 +1,14 @@
-#include <memory> // IWYU pragma: keep
 #include <vector>
 
 #include "calendar.h"
 #include "cata_catch.h"
+#include "cata_scope_helpers.h"
 #include "character.h"
 #include "coordinates.h"
 #include "game.h"
 #include "level_cache.h"
 #include "lightmap.h"
+#include "line.h"
 #include "map.h"
 #include "map_helpers.h"
 #include "map_scale_constants.h"
@@ -517,3 +518,256 @@ TEST_CASE( "capture_golden_values_for_point_light", "[.][golden_capture]" )
     }
 }
 
+// Manual-only capture helper for arc golden values.
+// Run with: ./tests/cata_test "[golden_arc_capture]"
+TEST_CASE( "capture_golden_values_for_arc_light", "[.][golden_arc_capture]" )
+{
+    setup_dark_map();
+    scoped_weather_override weather_clear( WEATHER_CLEAR );
+
+    map &here = get_map();
+    const tripoint_bub_ms veh_pos = get_player_character().pos_bub() + tripoint::east * 5;
+
+    for( int dx = -10; dx <= 10; dx++ ) {
+        for( int dy = -10; dy <= 10; dy++ ) {
+            place_ter_roofed( veh_pos + tripoint( dx, dy, 0 ), ter_t_floor );
+        }
+    }
+
+    vehicle *veh = here.add_vehicle( vehicle_prototype_car, veh_pos, 0_degrees, 100, 0 );
+    REQUIRE( veh != nullptr );
+
+    std::vector<point_rel_ms> hl_mounts;
+    for( const vpart_reference &vpr : veh->get_any_parts( VPFLAG_CONE_LIGHT ) ) {
+        hl_mounts.push_back( vpr.part().mount );
+        veh->remove_part( vpr.part() );
+    }
+    veh->part_removal_cleanup( here );
+    REQUIRE( !hl_mounts.empty() );
+
+    const int part_idx = veh->install_part( here, hl_mounts.front(), vpart_test_red_headlight );
+    REQUIRE( part_idx >= 0 );
+
+    vehicle_part &installed = veh->part( part_idx );
+    installed.enabled = true;
+
+    rebuild_lightmap( 0 );
+
+    const tripoint_bub_ms hl_pos = veh->bub_part_pos( here, installed );
+    const level_cache &cache = here.access_cache( 0 );
+
+    // NOLINTNEXTLINE(cata-text-style)
+    printf( "\n=== ARC GOLDEN: hl_pos=(%d,%d), mount=(%d,%d) ===\n",
+            hl_pos.x(), hl_pos.y(), hl_mounts.front().x(), hl_mounts.front().y() );
+    // NOLINTNEXTLINE(cata-text-style)
+    printf( "// { dx, dy, r, lm_max }\n" );
+    for( int dy = -5; dy <= 5; dy++ ) {
+        for( int dx = -5; dx <= 5; dx++ ) {
+            // NOLINTNEXTLINE(cata-combine-locals-into-point)
+            const int x = hl_pos.x() + dx;
+            const int y = hl_pos.y() + dy;
+            if( x < 0 || x >= MAPSIZE_X || y < 0 || y >= MAPSIZE_Y ) {
+                continue;
+            }
+            const float r = cache.light_color_cache[x][y].r;
+            const float lm = cache.lm[x][y].max();
+            if( r > 0.0f || ( dx >= -2 && dx <= 2 && dy >= -2 && dy <= 2 ) ) {
+                // NOLINTNEXTLINE(cata-text-style)
+                printf( "{ %2d, %2d, %10.6ff, %10.6ff },\n", dx, dy, r, lm );
+            }
+        }
+    }
+}
+
+TEST_CASE( "white_only_map_has_no_colored_light", "[light_color]" )
+{
+    setup_dark_map();
+    scoped_weather_override weather_clear( WEATHER_CLEAR );
+
+    const tripoint_bub_ms src = get_player_character().pos_bub() + tripoint::east * 3;
+    place_ter_roofed( src, ter_t_utility_light );
+
+    rebuild_lightmap( 0 );
+
+    const map &here = get_map();
+    const level_cache &cache = here.access_cache( 0 );
+
+    CHECK_FALSE( cache.has_colored_lights );
+
+    // Entire color cache should be zero
+    bool any_color = false;
+    for( int x = 0; x < MAPSIZE_X && !any_color; x++ ) {
+        for( int y = 0; y < MAPSIZE_Y && !any_color; y++ ) {
+            if( cache.light_color_cache[x][y].is_colored() ) {
+                any_color = true;
+            }
+        }
+    }
+    CHECK_FALSE( any_color );
+}
+
+TEST_CASE( "colored_terrain_sets_has_colored_lights", "[light_color]" )
+{
+    setup_dark_map();
+    scoped_weather_override weather_clear( WEATHER_CLEAR );
+
+    const tripoint_bub_ms src = get_player_character().pos_bub() + tripoint::east * 3;
+    place_ter_roofed( src, ter_t_test_red_light );
+
+    rebuild_lightmap( 0 );
+
+    const level_cache &cache = get_map().access_cache( 0 );
+    CHECK( cache.has_colored_lights );
+}
+
+TEST_CASE( "colored_vehicle_cone_sets_has_colored_lights", "[light_color]" )
+{
+    setup_dark_map();
+    scoped_weather_override weather_clear( WEATHER_CLEAR );
+
+    map &here = get_map();
+    const tripoint_bub_ms veh_pos = get_player_character().pos_bub() + tripoint::east * 5;
+
+    for( int dx = -10; dx <= 10; dx++ ) {
+        for( int dy = -10; dy <= 10; dy++ ) {
+            place_ter_roofed( veh_pos + tripoint( dx, dy, 0 ), ter_t_floor );
+        }
+    }
+
+    vehicle *veh = here.add_vehicle( vehicle_prototype_car, veh_pos, 0_degrees, 100, 0 );
+    REQUIRE( veh != nullptr );
+
+    // Replace one stock headlight with our red test headlight
+    std::vector<point_rel_ms> hl_mounts;
+    for( const vpart_reference &vpr : veh->get_any_parts( VPFLAG_CONE_LIGHT ) ) {
+        hl_mounts.push_back( vpr.part().mount );
+        veh->remove_part( vpr.part() );
+    }
+    veh->part_removal_cleanup( here );
+    REQUIRE( !hl_mounts.empty() );
+
+    const int part_idx = veh->install_part( here, hl_mounts.front(), vpart_test_red_headlight );
+    REQUIRE( part_idx >= 0 );
+
+    vehicle_part &installed = veh->part( part_idx );
+    installed.enabled = true;
+
+    rebuild_lightmap( 0 );
+
+    const level_cache &cache = here.access_cache( 0 );
+    CHECK( cache.has_colored_lights );
+}
+
+TEST_CASE( "lut_wiring_respects_trigdist_option", "[light_color]" )
+{
+    setup_dark_map();
+    scoped_weather_override weather_clear( WEATHER_CLEAR );
+
+    restore_on_out_of_scope restore_trigdist( trigdist );
+
+    const tripoint_bub_ms src = get_player_character().pos_bub() + tripoint::east * 5;
+    // Place light and floor
+    for( int dx = -6; dx <= 6; dx++ ) {
+        for( int dy = -6; dy <= 6; dy++ ) {
+            place_ter_roofed( src + tripoint( dx, dy, 0 ), ter_t_floor );
+        }
+    }
+    place_ter_roofed( src, ter_t_utility_light );
+
+    // Tile at (3,3) from source: Euclidean truncates to 4, Chebyshev gives 3
+    const tripoint_bub_ms target = src + tripoint( 3, 3, 0 );
+    place_ter_roofed( target, ter_t_floor );
+
+    trigdist = true;
+    rebuild_lightmap( 0 );
+    const float lm_trig = get_map().access_cache( 0 ).lm[target.x()][target.y()].max();
+
+    trigdist = false;
+    rebuild_lightmap( 0 );
+    const float lm_cheb = get_map().access_cache( 0 ).lm[target.x()][target.y()].max();
+
+    // Euclidean distance at (3,3) truncates to 4, Chebyshev gives 3.
+    // Higher distance means more attenuation, so trigdist should be dimmer.
+    CAPTURE( lm_trig, lm_cheb );
+    CHECK( lm_trig < lm_cheb );
+}
+
+TEST_CASE( "fused_arc_color_output_matches_golden_values", "[light_color]" )
+{
+    // Golden values captured from pre-fusion code (master) for a vehicle
+    // with a red headlight cone. Pins forward-beam color propagation from
+    // apply_light_arc / CAST_ARC_OCTANT.
+    setup_dark_map();
+    scoped_weather_override weather_clear( WEATHER_CLEAR );
+
+    map &here = get_map();
+    const tripoint_bub_ms veh_pos = get_player_character().pos_bub() + tripoint::east * 5;
+
+    for( int dx = -10; dx <= 10; dx++ ) {
+        for( int dy = -10; dy <= 10; dy++ ) {
+            place_ter_roofed( veh_pos + tripoint( dx, dy, 0 ), ter_t_floor );
+        }
+    }
+
+    vehicle *veh = here.add_vehicle( vehicle_prototype_car, veh_pos, 0_degrees, 100, 0 );
+    REQUIRE( veh != nullptr );
+
+    std::vector<point_rel_ms> hl_mounts;
+    for( const vpart_reference &vpr : veh->get_any_parts( VPFLAG_CONE_LIGHT ) ) {
+        hl_mounts.push_back( vpr.part().mount );
+        veh->remove_part( vpr.part() );
+    }
+    veh->part_removal_cleanup( here );
+    REQUIRE( !hl_mounts.empty() );
+
+    const int part_idx = veh->install_part( here, hl_mounts.front(), vpart_test_red_headlight );
+    REQUIRE( part_idx >= 0 );
+
+    vehicle_part &installed = veh->part( part_idx );
+    installed.enabled = true;
+
+    rebuild_lightmap( 0 );
+
+    const tripoint_bub_ms hl_pos = veh->bub_part_pos( here, installed );
+    const level_cache &cache = here.access_cache( 0 );
+
+    // Golden entries from pre-fusion master code.
+    // Mount is (2,-1), beam goes roughly east. Offsets relative to hl_pos.
+    struct golden_entry {
+        point d;
+        float r;
+        float lm;
+    };
+    // Near-source halo and forward beam
+    static const std::vector<golden_entry> golden = {
+        // Forward beam (dx=2..5, dy=-1..1) -- the core arc propagation path
+        { {  2, -1 }, 3104.943359f, 3778.481689f },
+        { {  2,  0 }, 4657.414551f, 3778.481689f },
+        { {  2,  1 }, 3104.943359f, 3778.481689f },
+        { {  3, -1 }, 1957.029907f, 2418.360840f },
+        { {  3,  0 }, 2645.568115f, 2418.360840f },
+        { {  3,  1 }, 1957.029907f, 2418.360840f },
+        { {  4, -1 }, 1562.625610f, 1739.861816f },
+        { {  4,  0 }, 1831.332275f, 1739.861816f },
+        { {  4,  1 }, 1562.625610f, 1739.861816f },
+        { {  5, -1 }, 1381.454834f, 1335.774170f },
+        { {  5,  0 }, 1381.454834f, 1335.774170f },
+        { {  5,  1 }, 1381.454834f, 1335.774170f },
+        // Behind the headlight -- no color
+        { { -2, -1 },    0.000000f,    3.500000f },
+        { { -2,  0 },    0.000000f,    3.500000f },
+        { { -2,  1 },    0.000000f,    3.500000f },
+    };
+
+    for( const golden_entry &g : golden ) {
+        const point p = g.d + point( hl_pos.x(), hl_pos.y() );
+        CAPTURE( g.d );
+        CHECK( cache.light_color_cache[p.x][p.y].r == Approx( g.r ).margin( 0.01f ) );
+        CHECK( cache.lm[p.x][p.y].max() == Approx( g.lm ).margin( 0.01f ) );
+    }
+
+    // Asymmetry: forward beam center must be brighter than behind
+    const float forward_r = cache.light_color_cache[hl_pos.x() + 4][hl_pos.y()].r;
+    const float behind_r = cache.light_color_cache[hl_pos.x() - 2][hl_pos.y()].r;
+    CHECK( forward_r > behind_r );
+}

--- a/tests/shadowcasting_test.cpp
+++ b/tests/shadowcasting_test.cpp
@@ -1,5 +1,6 @@
 #include <array>
 #include <chrono>
+#include <cmath>
 #include <cstdio>
 #include <functional>
 #include <memory>
@@ -1134,6 +1135,18 @@ TEST_CASE( "shadowcasting_float_quad_performance", "[.]" )
 {
     shadowcasting_float_quad( 1000000 );
     shadowcasting_float_quad( 1000000, 100 );
+}
+
+TEST_CASE( "trig_dist_lut_matches_sqrt", "[shadowcasting]" )
+{
+    for( int dx = 0; dx <= MAX_VIEW_DISTANCE; dx++ ) {
+        for( int dy = 0; dy <= MAX_VIEW_DISTANCE; dy++ ) {
+            const int expected = static_cast<int>(
+                                     std::sqrt( static_cast<double>( dx * dx + dy * dy ) ) );
+            CAPTURE( dx, dy );
+            CHECK( trig_dist_2d( point( dx, dy ) ) == expected );
+        }
+    }
 }
 
 // I'm not sure this will ever work.


### PR DESCRIPTION
#### Summary
Performance "Fuse color shadowcasting, skip idle blur, LUT for castLight distances"

#### Purpose of change

Colored light sources (terrain, furniture, fields, vehicle headlights with `light_color`) were roughly 2x as expensive as white ones because castLight ran twice per octant -- once for scalar intensity, once for color propagation. On a stress-test map with 576 dense colored lights, lighting ate ~80% of CPU.

#### Describe the solution

Three changes, two commits:

Fuse dual-pass color shadowcasting -- added a `bool with_color` template parameter to `castLight`. When true, an `if constexpr` block writes color alongside scalar intensity in the same traversal. Deleted the `g_current_source_color` global and `update_light_color` callback. Refactored `apply_light_source` and `apply_light_arc` (via helper macros) to use the fused path for colored sources and the original path for white ones.

Skip color blur when no colored lights -- the 3x3 box blur on `light_color_cache` ran every frame unconditionally (zeroing a 576KB buffer + iterating 132x132 tiles). Added `level_cache::has_colored_lights` flag, set in `apply_light_source` and `apply_light_arc`, checked before the blur.

LUT for castLight distances -- `rl_dist(tripoint::zero, delta)` in the castLight inner loop called `sqrt` on every tile visit. Replaced with a precomputed 61x61 int LUT (15KB, fits in L1) for `trigdist` mode, and inline `std::max` for Chebyshev mode.

#### Describe alternatives you've considered

Could have merged the two output caches into a combined struct and used a single template instantiation, but that requires allocating a temporary combined cache and copying results back -- the overhead would eat the gains.

Could have optimized `trig_dist` globally in line.h, but that would add a static LUT to every translation unit. Keeping it local to lightmap.cpp targets the hottest callsite without polluting widely-included headers.

#### Testing

Perf profiling on stress-test maps (576 light sources, 2x2 OMT, matched walks on the new binary):
- Lighting CPU share (colored): ~31% (down from ~80% pre-optimization)
- Color overhead vs white: ~21% more samples (down from ~36%)

New test coverage:
- Golden-value regression tests pinning exact RGB and scalar lightmap output for a point light and a vehicle cone light (captured from pre-fusion code)
- `has_colored_lights` flag tests for both buffered sources and arc lights
- Exhaustive LUT correctness (all 3721 inputs match `(int)sqrt(...)`)
- trigdist wiring test verifying the branch produces different attenuation at an off-axis tile where Euclidean and Chebyshev distances diverge
- All existing `[light_color]`, `[shadowcasting]`, and `[vision]` tests pass

#### Additional context

None