### PR TITLE
Hub sells their advanced headgear at appropriate times

### DIFF
--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
@@ -98,10 +98,16 @@
         "strict": true,
         "condition": {
           "and": [
-            { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_3" } ] },
+            { "math": [ "ancilla_autodoc_placed == 1" ] },
             { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_ivas" } ] }
           ]
         }
+      },
+      {
+        "group": "NC_ROBOFAC_INTERCOM_MVAS",
+        "rigid": true,
+        "strict": true,
+        "condition": { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_ivas" } ] }
       }
     ],
     "shopkeeper_blacklist": "robofac_blacklist"
@@ -146,6 +152,14 @@
       { "item": "robofac_lens_mask_filter", "prob": 70, "count": [ 1, 2 ] },
       { "item": "robofac_lens_mask_gas", "prob": 70, "count": [ 1, 2 ] },
       { "item": "robofac_lens_mask_papr", "prob": 70, "count": [ 1, 2 ] }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "NC_ROBOFAC_INTERCOM_MVAS",
+    "subtype": "collection",
+    "entries": [
+      { "item": "robofac_head_rig_ar", "prob": 100, "count": 1 }
     ]
   },
   {

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
@@ -158,9 +158,7 @@
     "type": "item_group",
     "id": "NC_ROBOFAC_INTERCOM_MVAS",
     "subtype": "collection",
-    "entries": [
-      { "item": "robofac_head_rig_ar", "prob": 100, "count": 1 }
-    ]
+    "entries": [ { "item": "robofac_head_rig_ar", "prob": 100, "count": 1 } ]
   },
   {
     "id": "robofac_blacklist",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Hub didn't wait for the AutoDoc to sell the LENS (oversight).  Also, they didn't sell extra copies of the visual augmentation headgear (I just didn't add that, when I added that headgear).

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Hub 01 now sells the Hub 01 visual augmentation headgear after completing the mission to get/make it (Augmented Reality).

Hub 01 now sells the LENS if Augmented Reality was completed and the AutoDoc clinic has spawned.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

n/a

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Checked that it eventually showed up in inventory

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Deleted the requirement for Light Retrieval to be finished, because it was unnecessary - Light Retrieval is already required to do Augmented Reality!

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
