### PR TITLE
document _has_item_with_flag

### DIFF
--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -1013,6 +1013,24 @@ check do you memorize `meat_hunk` recipe
 { "u_know_recipe": "meat_hunk" }
 ```
 
+### `u_has_item_with_flag`, `npc_has_item_with_flag`
+- type: string or [variable object](#variable-object)
+- return true if alpha or beta talker has any item with specific flag
+
+#### Valid talkers:
+
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------ | --------- | ---- | ------- | --- | ---- |
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+
+#### Examples
+
+check do you have anything with `RAD_DETECT` flag
+```jsonc
+{ "u_has_item_with_flag": "RAD_DETECT" }
+```
+
+
 ### `u_has_worn_with_flag`, `npc_has_worn_with_flag`
 - type: string or [variable object](#variable-object)
 - return true if alpha or beta talker wear some item with specific flag


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Figured i will need a _has_item_with_flag condition for one of my next additions (maybe?); implemented it, then got hit with error that said the function with such name already exists; apparently there was such function already, but it was not used and, as always, not documented anywhere
#### Describe the solution
At least document it