### PR TITLE
NPC sleep: no-bash pathfinding, NPC_NO_GO zone

### DIFF
--- a/data/json/mapgen/refugee_center/refugee_center.json
+++ b/data/json/mapgen/refugee_center/refugee_center.json
@@ -103,7 +103,18 @@
         { "type": "NPC_NO_INVESTIGATE", "faction": "lobby_beggars", "x": [ 69, 71 ], "y": [ 2, 23 ] },
         { "type": "NPC_NO_INVESTIGATE", "faction": "lobby_beggars", "x": [ 72, 95 ], "y": [ 0, 23 ] },
         { "type": "NPC_NO_INVESTIGATE", "faction": "no_faction", "x": [ 69, 71 ], "y": [ 2, 23 ] },
-        { "type": "NPC_NO_INVESTIGATE", "faction": "no_faction", "x": [ 72, 95 ], "y": [ 0, 23 ] }
+        { "type": "NPC_NO_INVESTIGATE", "faction": "no_faction", "x": [ 72, 95 ], "y": [ 0, 23 ] },
+        { "type": "NPC_NO_GO", "faction": "free_merchants", "x": [ 69, 71 ], "y": [ 2, 23 ] },
+        { "type": "NPC_NO_GO", "faction": "free_merchants", "x": [ 72, 95 ], "y": [ 0, 23 ] },
+        { "type": "NPC_NO_GO", "faction": "wasteland_scavengers", "x": [ 69, 71 ], "y": [ 2, 23 ] },
+        { "type": "NPC_NO_GO", "faction": "wasteland_scavengers", "x": [ 72, 95 ], "y": [ 0, 23 ] },
+        { "type": "NPC_NO_GO", "faction": "old_guard", "x": [ 69, 71 ], "y": [ 2, 23 ] },
+        { "type": "NPC_NO_GO", "faction": "old_guard", "x": [ 72, 95 ], "y": [ 0, 23 ] },
+        { "type": "NPC_NO_GO", "faction": "lobby_beggars", "x": [ 24, 47 ], "y": [ 0, 23 ] },
+        { "type": "NPC_NO_GO", "faction": "lobby_beggars", "x": [ 48, 71 ], "y": [ 0, 23 ] },
+        { "type": "NPC_NO_GO", "faction": "lobby_beggars", "x": [ 72, 95 ], "y": [ 0, 23 ] },
+        { "type": "NPC_NO_GO", "faction": "no_faction", "x": [ 69, 71 ], "y": [ 2, 23 ] },
+        { "type": "NPC_NO_GO", "faction": "no_faction", "x": [ 72, 95 ], "y": [ 0, 23 ] }
       ],
       "place_vehicles": [
         { "vehicle": "schoolbus", "x": 19, "y": 13, "chance": 75, "rotation": 270 },
@@ -200,7 +211,12 @@
         { "type": "NPC_INVESTIGATE_ONLY", "faction": "wasteland_scavengers", "x": [ 72, 95 ], "y": [ 0, 23 ] },
         { "type": "NPC_NO_INVESTIGATE", "faction": "free_merchants", "x": [ 24, 32 ], "y": [ 3, 20 ] },
         { "type": "NPC_NO_INVESTIGATE", "faction": "wasteland_scavengers", "x": [ 24, 32 ], "y": [ 3, 20 ] },
-        { "type": "NPC_INVESTIGATE_ONLY", "faction": "lobby_beggars", "x": [ 51, 68 ], "y": [ 21, 23 ] }
+        { "type": "NPC_INVESTIGATE_ONLY", "faction": "lobby_beggars", "x": [ 51, 68 ], "y": [ 21, 23 ] },
+        { "type": "NPC_NO_GO", "faction": "lobby_beggars", "x": [ 24, 47 ], "y": [ 0, 23 ] },
+        { "type": "NPC_NO_GO", "faction": "lobby_beggars", "x": [ 48, 50 ], "y": [ 0, 23 ] },
+        { "type": "NPC_NO_GO", "faction": "lobby_beggars", "x": [ 51, 68 ], "y": [ 0, 20 ] },
+        { "type": "NPC_NO_GO", "faction": "lobby_beggars", "x": [ 69, 71 ], "y": [ 0, 23 ] },
+        { "type": "NPC_NO_GO", "faction": "lobby_beggars", "x": [ 72, 95 ], "y": [ 0, 23 ] }
       ],
       "items": {
         "D": { "item": "SUS_trash_trashcan", "chance": 60 },
@@ -284,6 +300,11 @@
         { "type": "NPC_INVESTIGATE_ONLY", "faction": "old_guard", "x": [ 48, 59 ], "y": [ 2, 19 ] },
         { "type": "NPC_INVESTIGATE_ONLY", "faction": "old_guard", "x": [ 48, 48 ], "y": [ 0, 0 ] },
         { "type": "NPC_INVESTIGATE_ONLY", "faction": "lobby_beggars", "x": [ 51, 68 ], "y": [ 0, 4 ] },
+        { "type": "NPC_NO_GO", "faction": "lobby_beggars", "x": [ 24, 47 ], "y": [ 0, 23 ] },
+        { "type": "NPC_NO_GO", "faction": "lobby_beggars", "x": [ 48, 50 ], "y": [ 0, 23 ] },
+        { "type": "NPC_NO_GO", "faction": "lobby_beggars", "x": [ 51, 68 ], "y": [ 5, 23 ] },
+        { "type": "NPC_NO_GO", "faction": "lobby_beggars", "x": [ 69, 71 ], "y": [ 0, 23 ] },
+        { "type": "NPC_NO_GO", "faction": "lobby_beggars", "x": [ 72, 95 ], "y": [ 0, 23 ] },
         { "type": "LOOT_UNSORTED", "faction": "free_merchants", "x": [ 72, 72 ], "y": [ 0, 0 ] },
         { "type": "LOOT_CURRENCY", "faction": "free_merchants", "x": [ 71, 71 ], "y": [ 2, 2 ] },
         { "type": "LOOT_WOOD", "faction": "free_merchants", "x": [ 71, 71 ], "y": [ 1, 1 ] },

--- a/data/json/zone_field_type.json
+++ b/data/json/zone_field_type.json
@@ -315,6 +315,13 @@
     "display_field": true
   },
   {
+    "id": "fd_npc_no_go_zone",
+    "type": "field_type",
+    "intensity_levels": [ { "name": "NPC no-go zone", "sym": "X", "dangerous": false } ],
+    "priority": 1,
+    "display_field": true
+  },
+  {
     "id": "fd_npc_retreat_zone",
     "type": "field_type",
     "intensity_levels": [ { "name": "NPC retreat zone", "sym": "5", "dangerous": false } ],

--- a/data/json/zones.json
+++ b/data/json/zones.json
@@ -105,6 +105,14 @@
     "description": "Friendly NPCs will investigate unseen sounds only if they come from inside this area."
   },
   {
+    "id": "NPC_NO_GO",
+    "type": "LOOT_ZONE",
+    "name": "NPC No-Go Area",
+    "hidden": true,
+    "display_field": "fd_npc_no_go_zone",
+    "description": "NPCs of this faction will not seek needs-driven targets inside this zone."
+  },
+  {
     "id": "NPC_RETREAT",
     "type": "LOOT_ZONE",
     "name": "NPC Retreat",

--- a/src/npc.h
+++ b/src/npc.h
@@ -1096,6 +1096,11 @@ class npc : public Character
         // Movement; the following are defined in npcmove.cpp
         void move(); // Picks an action & a target and calls execute_action
         void execute_action( npc_action action ); // Performs action
+        // Returns true if p is in an NPC_NO_GO zone for this NPC's faction.
+        bool is_no_go_position( const tripoint_abs_ms &p ) const;
+        // Returns true if p is a valid sleep target: not in NPC_NO_GO and
+        // reachable without bashing. Does not check occupancy.
+        bool is_valid_sleep_candidate( const tripoint_bub_ms &p ) const;
         void process_turn() override;
 
         using Character::invoke_item;

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -204,6 +204,7 @@ static const trait_id trait_SAPROPHAGE( "SAPROPHAGE" );
 static const trait_id trait_SAPROVORE( "SAPROVORE" );
 
 static const zone_type_id zone_type_NO_NPC_PICKUP( "NO_NPC_PICKUP" );
+static const zone_type_id zone_type_NPC_NO_GO( "NPC_NO_GO" );
 static const zone_type_id zone_type_NPC_RETREAT( "NPC_RETREAT" );
 
 static constexpr float MAX_FLOAT = 5000000000.0f;
@@ -1847,7 +1848,9 @@ void npc::execute_action( npc_action action )
             // TODO: Allow stims when not too tired
             // Find a nice spot to sleep
             tripoint_bub_ms best_spot = pos_bub();
-            int best_sleepy = evaluate_sleep_spot( best_spot );
+            int best_sleepy = is_valid_sleep_candidate( pos_bub() )
+                              ? evaluate_sleep_spot( best_spot )
+                              : INT_MIN;
 
             // first build a list of positions to search
             std::vector<tripoint_bub_ms> search_positions;
@@ -1876,7 +1879,7 @@ void npc::execute_action( npc_action action )
                 // For non-mutants, very_comfortable-1 is the expected value of an ideal normal bed.
                 if( best_sleepy < comfort_data::COMFORT_VERY_COMFORTABLE - 1 ) {
                     const int sleepy = evaluate_sleep_spot( p );
-                    if( sleepy > best_sleepy ) {
+                    if( sleepy > best_sleepy && is_valid_sleep_candidate( p ) ) {
                         best_sleepy = sleepy;
                         best_spot = p;
                     }
@@ -1886,7 +1889,7 @@ void npc::execute_action( npc_action action )
             if( is_walking_with() ) {
                 complain_about( "napping", 30_minutes, chat_snippets().snip_warn_sleep.translated() );
             }
-            update_path( best_spot );
+            update_path( best_spot, true );
             // TODO: Handle empty path better
             if( best_spot == pos_bub() || path.empty() ) {
                 move_pause();
@@ -3248,6 +3251,24 @@ bool npc::update_path( const tripoint_bub_ms &p, const bool no_bashing, bool for
 void npc::set_guard_pos( const tripoint_abs_ms &p )
 {
     ai_cache.guard_pos = p;
+}
+
+bool npc::is_no_go_position( const tripoint_abs_ms &p ) const
+{
+    return zone_manager::get_manager().has( zone_type_NPC_NO_GO, p, fac_id );
+}
+
+bool npc::is_valid_sleep_candidate( const tripoint_bub_ms &p ) const
+{
+    const map &here = get_map();
+    if( is_no_go_position( here.get_abs( p ) ) ) {
+        return false;
+    }
+    if( p == pos_bub() ) {
+        return true;
+    }
+    return !here.route( pos_bub(), pathfinding_target::point( p ),
+                        get_pathfinding_settings( true ), get_path_avoid() ).empty();
 }
 
 bool npc::can_open_door( const tripoint_bub_ms &p, const bool inside ) const
@@ -5837,6 +5858,9 @@ std::vector<npc::scored_water_source> npc::find_nearby_water_sources() const
     std::vector<scored_water_source> results;
     const map &here = get_map();
     for( const tripoint_bub_ms &p : closest_points_first( pos_bub(), 6 ) ) {
+        if( is_no_go_position( here.get_abs( p ) ) ) {
+            continue;
+        }
         if( !sees( here, p ) ) {
             continue;
         }
@@ -5888,6 +5912,9 @@ std::vector<npc::scored_item> npc::find_nearby_food()
     };
 
     for( const tripoint_bub_ms &p : closest_points_first( pos_bub(), 6 ) ) {
+        if( is_no_go_position( here.get_abs( p ) ) ) {
+            continue;
+        }
         if( is_player_ally() && g->check_zone( zone_type_NO_NPC_PICKUP, p ) ) {
             continue;
         }
@@ -5955,6 +5982,9 @@ std::vector<npc::scored_item> npc::find_nearby_warm_clothing()
     };
 
     for( const tripoint_bub_ms &p : closest_points_first( pos_bub(), 6 ) ) {
+        if( is_no_go_position( here.get_abs( p ) ) ) {
+            continue;
+        }
         if( is_player_ally() && g->check_zone( zone_type_NO_NPC_PICKUP, p ) ) {
             continue;
         }
@@ -6073,6 +6103,9 @@ std::vector<npc::scored_shelter> npc::find_nearby_shelters() const
         if( p == cur ) {
             continue;
         }
+        if( is_no_go_position( here.get_abs( p ) ) ) {
+            continue;
+        }
         if( !here.has_flag( ter_furn_flag::TFLAG_INDOORS, p ) ) {
             continue;
         }
@@ -6099,6 +6132,9 @@ std::vector<npc::scored_water_source> npc::find_nearby_harvestable() const
     std::vector<scored_water_source> results;
     const map &here = get_map();
     for( const tripoint_bub_ms &p : closest_points_first( pos_bub(), 6 ) ) {
+        if( is_no_go_position( here.get_abs( p ) ) ) {
+            continue;
+        }
         // Detect both harvest-system terrain (fruit trees, berry bushes)
         // and examine-action foraging (underbrush -> shrub_wildveggies).
         const bool harvestable = here.is_harvestable( p ) ||

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -83,6 +83,10 @@ static const efftype_id effect_wet( "wet" );
 
 static const faction_id faction_your_followers( "your_followers" );
 
+static const furn_str_id furn_f_bed( "f_bed" );
+static const furn_str_id furn_f_locker( "f_locker" );
+static const furn_str_id furn_f_makeshift_bed( "f_makeshift_bed" );
+
 static const item_group_id Item_spawn_data_SUS_trash_forest_manmade( "SUS_trash_forest_manmade" );
 static const item_group_id Item_spawn_data_test_NPC_guns( "test_NPC_guns" );
 
@@ -109,6 +113,7 @@ static const itype_id itype_sweater( "sweater" );
 static const itype_id itype_water_clean( "water_clean" );
 
 static const ter_str_id ter_t_concrete_wall( "t_concrete_wall" );
+static const ter_str_id ter_t_door_c( "t_door_c" );
 static const ter_str_id ter_t_floor( "t_floor" );
 static const ter_str_id ter_t_ponywall( "t_ponywall" );
 static const ter_str_id ter_t_swater_sh( "t_swater_sh" );
@@ -133,6 +138,7 @@ static const vproto_id vehicle_prototype_test_shopping_cart( "test_shopping_cart
 static const zone_type_id zone_type_CAMP_FOOD( "CAMP_FOOD" );
 static const zone_type_id zone_type_CAMP_STORAGE( "CAMP_STORAGE" );
 static const zone_type_id zone_type_NO_NPC_PICKUP( "NO_NPC_PICKUP" );
+static const zone_type_id zone_type_NPC_NO_GO( "NPC_NO_GO" );
 
 static void on_load_test( npc &who, const time_duration &from, const time_duration &to )
 {
@@ -2527,4 +2533,273 @@ TEST_CASE( "npc_harvest_scavenging", "[npc][needs]" )
     // backlog triggers ACT_NULL when driving do_turn() directly in tests.
     // Completion coverage for forage_activity_actor should go in
     // player_activities_test.cpp or harvest_test.cpp.
+}
+
+// Helper: place double-thick glass enclosure around a point (seals diagonal gaps)
+static void enclose_in_glass( map &here, const tripoint_bub_ms &center )
+{
+    for( int r = 1; r <= 2; ++r ) {
+        for( const tripoint_bub_ms &w : here.points_in_radius( center, r ) ) {
+            if( w != center ) {
+                here.ter_set( w, ter_t_wall_glass );
+            }
+        }
+    }
+}
+
+// Helper: set up a sleepy non-ally NPC ready to call move().
+// Mirrors npc_nonally_sleeps_when_tired setup.
+static void make_npc_sleepy( npc &guy )
+{
+    guy.set_sleepiness( 800 );
+    guy.set_hunger( 0 );
+    guy.set_thirst( 0 );
+    guy.set_stored_kcal( guy.get_healthy_kcal() );
+    guy.set_all_parts_temp_conv( BODYTEMP_NORM );
+    guy.set_all_parts_temp_cur( BODYTEMP_NORM );
+    guy.set_mission( NPC_MISSION_SHELTER );
+    guy.set_moves( 100 );
+}
+
+TEST_CASE( "npc_sleep_spot_reachability", "[npc][needs]" )
+{
+    clear_map_without_vision();
+    calendar::turn = calendar::turn_zero + 1_hours;
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy, true );
+    REQUIRE_FALSE( guy.is_player_ally() );
+    map &here = get_map();
+
+    SECTION( "reachable worse bed beats unreachable better bed" ) {
+        // Good bed behind glass walls (unreachable without bashing)
+        const tripoint_bub_ms walled_bed = guy.pos_bub() + tripoint( 5, 0, 0 );
+        here.ter_set( walled_bed, ter_t_floor );
+        here.furn_set( walled_bed, furn_f_bed );
+        enclose_in_glass( here, walled_bed );
+        // Worse bed on open ground (reachable)
+        const tripoint_bub_ms open_bed = guy.pos_bub() + tripoint( 0, 3, 0 );
+        here.ter_set( open_bed, ter_t_floor );
+        here.furn_set( open_bed, furn_f_makeshift_bed );
+
+        const int dist_walled_before = rl_dist( guy.pos_bub(), walled_bed );
+        const int dist_open_before = rl_dist( guy.pos_bub(), open_bed );
+
+        make_npc_sleepy( guy );
+        guy.move();
+
+        CHECK( rl_dist( guy.pos_bub(), open_bed ) < dist_open_before );
+        CHECK( rl_dist( guy.pos_bub(), walled_bed ) >= dist_walled_before );
+    }
+
+    SECTION( "bed behind closed door is reachable" ) {
+        const tripoint_bub_ms door = guy.pos_bub() + tripoint( 2, 0, 0 );
+        here.ter_set( door, ter_t_door_c );
+        const tripoint_bub_ms bed = guy.pos_bub() + tripoint( 3, 0, 0 );
+        here.ter_set( bed, ter_t_floor );
+        here.furn_set( bed, furn_f_bed );
+
+        const int dist_before = rl_dist( guy.pos_bub(), bed );
+
+        make_npc_sleepy( guy );
+        guy.move();
+
+        CHECK( rl_dist( guy.pos_bub(), bed ) < dist_before );
+    }
+
+    SECTION( "bed behind bashable furniture is unreachable" ) {
+        // Seal bed behind double-thick locker enclosure (same pattern as glass
+        // wall tests -- single thickness has diagonal gaps A* can exploit).
+        const tripoint_bub_ms blocked_bed = guy.pos_bub() + tripoint( 5, 0, 0 );
+        here.ter_set( blocked_bed, ter_t_floor );
+        here.furn_set( blocked_bed, furn_f_bed );
+        for( int r = 1; r <= 2; ++r ) {
+            for( const tripoint_bub_ms &w : here.points_in_radius( blocked_bed, r ) ) {
+                if( w != blocked_bed ) {
+                    here.furn_set( w, furn_f_locker );
+                }
+            }
+        }
+        // Alternative on open ground
+        const tripoint_bub_ms open_bed = guy.pos_bub() + tripoint( 0, 3, 0 );
+        here.ter_set( open_bed, ter_t_floor );
+        here.furn_set( open_bed, furn_f_makeshift_bed );
+
+        const int dist_blocked_before = rl_dist( guy.pos_bub(), blocked_bed );
+        const int dist_open_before = rl_dist( guy.pos_bub(), open_bed );
+
+        make_npc_sleepy( guy );
+        guy.move();
+
+        CHECK( rl_dist( guy.pos_bub(), open_bed ) < dist_open_before );
+        CHECK( rl_dist( guy.pos_bub(), blocked_bed ) >= dist_blocked_before );
+    }
+
+    SECTION( "no reachable bed: NPC sleeps in place" ) {
+        const tripoint_bub_ms walled_bed = guy.pos_bub() + tripoint( 5, 0, 0 );
+        here.ter_set( walled_bed, ter_t_floor );
+        here.furn_set( walled_bed, furn_f_bed );
+        enclose_in_glass( here, walled_bed );
+
+        const tripoint_bub_ms before = guy.pos_bub();
+
+        make_npc_sleepy( guy );
+        guy.move();
+
+        CHECK( guy.pos_bub() == before );
+        CHECK( ( guy.has_effect( effect_sleep ) || guy.has_effect( effect_lying_down ) ) );
+    }
+}
+
+TEST_CASE( "npc_no_go_zone_blocks_needs", "[npc][needs]" )
+{
+    clear_map_without_vision();
+    clear_avatar();
+    get_player_character().camps.clear();
+    calendar::turn = calendar::turn_zero + 1_hours;
+    get_weather().forced_temperature = 20_C;
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy, true );
+    guy.set_hunger( 0 );
+    guy.set_thirst( 0 );
+    guy.set_stored_kcal( guy.get_healthy_kcal() );
+    guy.set_all_parts_temp_conv( BODYTEMP_NORM );
+    guy.set_all_parts_temp_cur( BODYTEMP_NORM );
+    guy.stomach.empty();
+    guy.guts.empty();
+    REQUIRE_FALSE( guy.is_player_ally() );
+    map &here = get_map();
+
+    // NPC_NO_GO zone covering tiles east of NPC (x >= npc_x + 1)
+    const tripoint_abs_ms zone_start = guy.pos_abs() + tripoint( 1, -10, 0 );
+    const tripoint_abs_ms zone_end = guy.pos_abs() + tripoint( 20, 10, 0 );
+    zone_manager &mgr = zone_manager::get_manager();
+    mgr.add( "test_no_go", zone_type_NPC_NO_GO, guy.get_fac_id(),
+             false, true, zone_start, zone_end );
+    mgr.cache_data();
+
+    SECTION( "sleep: best bed in NPC_NO_GO is skipped" ) {
+        // Good bed in no-go zone
+        const tripoint_bub_ms zoned_bed = guy.pos_bub() + tripoint( 3, 0, 0 );
+        here.ter_set( zoned_bed, ter_t_floor );
+        here.furn_set( zoned_bed, furn_f_bed );
+        // Worse bed outside zone (west)
+        const tripoint_bub_ms open_bed = guy.pos_bub() + tripoint( 0, -3, 0 );
+        here.ter_set( open_bed, ter_t_floor );
+        here.furn_set( open_bed, furn_f_makeshift_bed );
+
+        const int dist_zoned_before = rl_dist( guy.pos_bub(), zoned_bed );
+        const int dist_open_before = rl_dist( guy.pos_bub(), open_bed );
+
+        make_npc_sleepy( guy );
+        guy.move();
+
+        CHECK( rl_dist( guy.pos_bub(), open_bed ) < dist_open_before );
+        CHECK( rl_dist( guy.pos_bub(), zoned_bed ) >= dist_zoned_before );
+    }
+
+    SECTION( "food: adjacent ground food in NPC_NO_GO not consumed" ) {
+        guy.set_stored_kcal( 2000 );
+        guy.set_hunger( 300 );
+        guy.set_thirst( 100 );
+        const tripoint_bub_ms food_at = guy.pos_bub() + point::east;
+        here.add_item_or_charges( food_at, item( itype_sandwich_cheese_grilled ) );
+        const size_t items_before = here.i_at( food_at ).size();
+        const tripoint_bub_ms before = guy.pos_bub();
+
+        guy.address_needs( 0 );
+
+        CHECK( here.i_at( food_at ).size() == items_before );
+        CHECK( guy.pos_bub() == before );
+    }
+
+    SECTION( "water: adjacent water in NPC_NO_GO not used" ) {
+        guy.set_thirst( 200 );
+        REQUIRE( guy.get_thirst() > 80 );
+        const tripoint_bub_ms water_at = guy.pos_bub() + point::east;
+        here.ter_set( water_at, ter_t_water_sh );
+
+        guy.address_needs( 0 );
+
+        CHECK( guy.stomach.get_water() == 0_ml );
+    }
+
+    SECTION( "shelter: indoor tile in NPC_NO_GO skipped" ) {
+        guy.set_all_parts_temp_conv( BODYTEMP_VERY_COLD );
+        const tripoint_bub_ms shelter = guy.pos_bub() + tripoint( 3, 0, 0 );
+        here.ter_set( shelter, ter_t_floor );
+        here.build_map_cache( 0 );
+        const tripoint_bub_ms before = guy.pos_bub();
+
+        guy.address_needs( 0 );
+
+        CHECK( guy.pos_bub() == before );
+    }
+
+    SECTION( "harvest: harvestable in NPC_NO_GO skipped" ) {
+        guy.set_stored_kcal( 2000 );
+        guy.set_hunger( 300 );
+        guy.set_thirst( 100 );
+        const tripoint_bub_ms harvest_at = guy.pos_bub() + tripoint( 3, 0, 0 );
+        here.ter_set( harvest_at, ter_t_underbrush );
+        here.build_map_cache( 0 );
+        const tripoint_bub_ms before = guy.pos_bub();
+
+        guy.address_needs( 0 );
+
+        CHECK( guy.pos_bub() == before );
+    }
+
+    SECTION( "clothing: warm clothing in NPC_NO_GO not picked up" ) {
+        guy.set_all_parts_temp_conv( BODYTEMP_VERY_COLD );
+        const tripoint_bub_ms cloth_at = guy.pos_bub() + point::east;
+        here.add_item_or_charges( cloth_at, item( itype_sweater ) );
+        const size_t items_before = here.i_at( cloth_at ).size();
+
+        guy.address_needs( 0 );
+
+        CHECK( here.i_at( cloth_at ).size() == items_before );
+    }
+
+    // Cleanup: remove test zone so it doesn't leak into other tests
+    mgr.clear();
+    mgr.cache_data();
+}
+
+TEST_CASE( "npc_is_no_go_position", "[npc][needs]" )
+{
+    clear_map_without_vision();
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy, true );
+
+    const tripoint_abs_ms inside = guy.pos_abs() + tripoint( 3, 0, 0 );
+    const tripoint_abs_ms outside = guy.pos_abs() + tripoint( -3, 0, 0 );
+
+    zone_manager &mgr = zone_manager::get_manager();
+    mgr.add( "test_no_go", zone_type_NPC_NO_GO, guy.get_fac_id(),
+             false, true,
+             guy.pos_abs() + tripoint( 1, -5, 0 ),
+             guy.pos_abs() + tripoint( 10, 5, 0 ) );
+    mgr.cache_data();
+
+    SECTION( "true for matching faction zone" ) {
+        CHECK( guy.is_no_go_position( inside ) );
+    }
+
+    SECTION( "false outside zone" ) {
+        CHECK_FALSE( guy.is_no_go_position( outside ) );
+    }
+
+    SECTION( "false for different faction" ) {
+        // Zone is for guy's faction; a different NPC with different faction
+        // should not be blocked
+        npc &other = spawn_npc( { 55, 50 }, "test_talker" );
+        clear_character( other, true );
+        // Set a different faction
+        other.set_fac( faction_your_followers );
+        REQUIRE( other.get_fac_id() != guy.get_fac_id() );
+        CHECK_FALSE( other.is_no_go_position( inside ) );
+    }
+
+    mgr.clear();
+    mgr.cache_data();
 }


### PR DESCRIPTION
#### Summary
Bugfixes "Prevent NPCs from bashing through barricades to reach beds"

#### Purpose of change

NPCs at the Refugee Center bash through back bay barricades at night because the sleep spot search picks the highest-comfort tile in a 60-tile radius, then pathfinds with bashing enabled. The back bay beds win on comfort, so NPCs break in and either clear the area or die trying.

Fixes #86110. Related to #86063 and #86061.

#### Describe the solution

No-bash sleep pathfinding. New `is_valid_sleep_candidate()` validates each sleep spot candidate using the real pathfinder with `no_bashing=true` before accepting it. Beds behind walls or bashable furniture get skipped. Beds behind openable doors still work. The vehicle-boardable sleep path is untouched.

NPC_NO_GO zone type. New mapgen-only zone (hidden from player menu) that blocks all needs-driven target selection: sleep, food, water, shelter, clothing, harvest. Checked in every `find_nearby_*` helper so future callers get the filter automatically. Does not eject NPCs already standing in the zone.

RC mapgen uses both: NPC_NO_GO for the back bay (all 5 factions, mirroring existing NPC_NO_INVESTIGATE rectangles) and beggar lobby confinement (beggars restricted to their lobby area across all building strips).

#### Describe alternatives you've considered

Custom BFS flood-fill for reachability, but that creates a second pathability model that diverges from real NPC movement rules. Using the actual pathfinder with no_bashing is honest and gets doors, fields, and avoid rules for free.

Could have reused NPC_NO_INVESTIGATE for this, but that's scope creep for a sound investigation zone.

#### Testing

Sleep reachability tests: walled bed skipped for open bed, door-accessible bed works, locker-enclosed bed skipped, no-reachable-bed sleeps in place. NPC_NO_GO tests: blocks sleep, food, water, shelter, harvest, clothing targets. Faction matching works correctly.

Gameplay tested at Refugee Center: started RC scenario, waited through the night. NPCs found beds in their own areas without bashing barricades. Beggars stayed in the lobby.

#### Additional context

NPC_NO_GO is hidden from the zone menu -- intended for mapgen use only. Sleep memory (NPCs remembering their bed) deferred to a follow-up, bed assignment is a separate infrastructure piece.