### PR TITLE
Actually move NPCs to the new overmap when dimension shifting

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -9683,8 +9683,11 @@ bool game::travel_to_dimension( const std::string &new_prefix,
 {
     map &here = get_map();
     avatar &player = get_avatar();
+    std::vector<npc_ptr> moving_npcs;
+    moving_npcs.reserve( npc_travellers.size() );
     if( !npc_travellers.empty() ) {
         int traveller_count = npc_travellers.size();
+        overmap &old_om = overmap_buffer.get( project_to<coords::om>( player.pos_abs().xy() ) );
         for( auto it = critter_tracker->active_npc.begin(); it != critter_tracker->active_npc.end(); ) {
             // skip unloading a traveller
             bool skip = false;
@@ -9701,7 +9704,9 @@ bool game::travel_to_dimension( const std::string &new_prefix,
                 ( *it )->on_unload();
                 it = critter_tracker->active_npc.erase( it );
             } else {
-                it++;
+                if( const npc_ptr ptr = old_om.erase_npc( ( *it++ )->getID() ) ) {
+                    moving_npcs.push_back( ptr );
+                }
             }
         }
     } else {
@@ -9750,7 +9755,11 @@ bool game::travel_to_dimension( const std::string &new_prefix,
     // Clear the overmap
     overmap_buffer.clear();
     // load/create new overmap
-    overmap_buffer.get( point_abs_om{} );
+    overmap &new_om = overmap_buffer.get( project_to<coords::om>( player.pos_abs().xy() ) );
+    // insert travelled NPCs
+    for( const npc_ptr &guy : moving_npcs ) {
+        new_om.insert_npc( guy );
+    }
     // clear map memory from the previous dimension
     player.clear_map_memory();
     // Load map memory in new dimension, if there is any


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Actually move NPCs to the new overmap when dimension shifting"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
#83032 introduced NPCs moving with dimension shifts. Unfortunately the NPCs coming along did not *really* come along, the original was left where it was before and the dimensional NPC was bugged. This fixes that.

#### Describe the solution
Before the overmap_buffer is cleared, we grab the overmap the player is currently on.
Then when we iterate over the NPCs and prevent unloading of the travellers, we remove them from that overmap and store them in a vector.
Once the overmap_buffer is cleared and a new overmap created in the new dimension, we insert the traveller NPC pointers into the new overmap.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested with some debug EOCs and then with Sky Island EOCs (with the condition removed to stop NPC travel)
NPCs move back and forth and verified that if you travel back to the main dimension without bringing the NPC you brought, there is no more original untouched copy there.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I will have a followup PR for Sky Island to re-enable the dimension travel with NPCs
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
