### PR TITLE
Fix renamed terrain fixture in light_color_test

### DIFF
--- a/tests/light_color_test.cpp
+++ b/tests/light_color_test.cpp
@@ -585,7 +585,7 @@ TEST_CASE( "white_only_map_has_no_colored_light", "[light_color]" )
     scoped_weather_override weather_clear( WEATHER_CLEAR );
 
     const tripoint_bub_ms src = get_player_character().pos_bub() + tripoint::east * 3;
-    place_ter_roofed( src, ter_t_utility_light );
+    place_ter_roofed( src, ter_test_t_utility_light );
 
     rebuild_lightmap( 0 );
 
@@ -672,7 +672,7 @@ TEST_CASE( "lut_wiring_respects_trigdist_option", "[light_color]" )
             place_ter_roofed( src + tripoint( dx, dy, 0 ), ter_t_floor );
         }
     }
-    place_ter_roofed( src, ter_t_utility_light );
+    place_ter_roofed( src, ter_test_t_utility_light );
 
     // Tile at (3,3) from source: Euclidean truncates to 4, Chebyshev gives 3
     const tripoint_bub_ms target = src + tripoint( 3, 3, 0 );


### PR DESCRIPTION
#### Summary
Infrastructure "Fix build break from renamed test terrain fixture"

#### Purpose of change

Two call sites in light_color_test.cpp still used the old name `ter_t_utility_light` after it was renamed to `ter_test_t_utility_light` in the declaration section.

#### Describe the solution

Updated the two remaining references to use the new name.

#### Describe alternatives you've considered

None, straightforward rename.

#### Testing

Build passes.

#### Additional context

None.