### PR TITLE
[Xedra Evolved] Salamander fae ban only broken once per water application

### DIFF
--- a/data/mods/Xedra_Evolved/effects/effects.json
+++ b/data/mods/Xedra_Evolved/effects/effects.json
@@ -1318,6 +1318,13 @@
   },
   {
     "type": "effect_type",
+    "id": "effect_salamander_wet_rate_limiter",
+    "name": [ "" ],
+    "desc": [ "" ],
+    "rating": "bad"
+  },
+  {
+    "type": "effect_type",
     "id": "effect_broke_fae_ban",
     "name": [ "Broken Ban" ],
     "desc": [ "You've broken one of the ancient laws that bind the fae and are suffering thereby." ],

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_fae_bans.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/paraclesian_fae_bans.json
@@ -328,18 +328,45 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_SALAMANDER_FAE_BAN_GET_WET",
+    "id": "EOC_SALAMANDER_FAE_BAN_GET_WET_HEAD",
+    "//": "We need separate foot/head EoCs to prevent the event from firing every single time any bodypart gets hit, thus rocketing to 10 in the first second of rain.",
     "eoc_type": "EVENT",
     "required_event": "character_gains_effect",
     "condition": {
       "and": [
         { "or": [ { "u_has_trait": "THRESH_SALAMANDER" }, { "u_has_trait": "SALAMANDER_SKIN_2" } ] },
-        { "compare_string": [ "wet", { "context_val": "effect" } ] }
+        { "compare_string": [ "wet", { "context_val": "effect" } ] },
+        { "compare_string": [ "head", { "context_val": "bodypart" } ] },
+        { "not": { "u_has_effect": "effect_salamander_wet_rate_limiter" } }
       ]
     },
     "effect": [
       { "run_eocs": "EOC_PARACLESIAN_BROKE_FAE_BAN" },
       { "run_eocs": "EOC_PARACLESIAN_BROKE_FAE_BAN_PAIN", "time_in_future": 1 },
+      { "u_add_effect": "effect_salamander_wet_rate_limiter", "duration": 60 },
+      {
+        "u_message": "Accursed water!  The touch of it burns you like acid, reminding you of your nature.  Your flames must not be dowsed.",
+        "type": "bad"
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_SALAMANDER_FAE_BAN_GET_WET_FOOT",
+    "eoc_type": "EVENT",
+    "required_event": "character_gains_effect",
+    "condition": {
+      "and": [
+        { "or": [ { "u_has_trait": "THRESH_SALAMANDER" }, { "u_has_trait": "SALAMANDER_SKIN_2" } ] },
+        { "compare_string": [ "wet", { "context_val": "effect" } ] },
+        { "compare_string": [ "foot_l", { "context_val": "bodypart" } ] },
+        { "not": { "u_has_effect": "effect_salamander_wet_rate_limiter" } }
+      ]
+    },
+    "effect": [
+      { "run_eocs": "EOC_PARACLESIAN_BROKE_FAE_BAN" },
+      { "run_eocs": "EOC_PARACLESIAN_BROKE_FAE_BAN_PAIN", "time_in_future": 1 },
+      { "u_add_effect": "effect_salamander_wet_rate_limiter", "duration": 60 },
       {
         "u_message": "Accursed water!  The touch of it burns you like acid, reminding you of your nature.  Your flames must not be dowsed.",
         "type": "bad"


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Xedra Evolved] Salamander fae ban only broken once per water application"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Standing in rain for one (1) second and being rocketed to 10 fae ban was a problem. 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Use two EoCs, one that checks your head for wetness and one that checks your foot for wetness. Add a rate limiter so you can only have the damage occur once every minute. 

In testing I was able to stand in the rain after the initial ban application with no problem, but in the game that won't be the case because the ban only applies after you gain traits that means you take damage from water.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Walked into rain, did not immediately gain 10 stacks of fae ban. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
