### PR TITLE
sub2000 10 round mag fix

### DIFF
--- a/data/json/items/gun/9mm.json
+++ b/data/json/items/gun/9mm.json
@@ -532,7 +532,7 @@
       {
         "magazine_well": "250 ml",
         "pocket_type": "MAGAZINE_WELL",
-        "item_restriction": [ "glockmag", "glockbigmag", "glock17_17", "glock17_22", "glock_drum_50rd", "glock_drum_100rd" ]
+        "item_restriction": [ "glockmag", "glockbigmag", "glock17_17", "glock17_22", "glock_drum_50rd", "glock_drum_100rd", "glockmag_10", "glock17_10"]
       }
     ]
   },

--- a/data/json/items/gun/9mm.json
+++ b/data/json/items/gun/9mm.json
@@ -532,7 +532,16 @@
       {
         "magazine_well": "250 ml",
         "pocket_type": "MAGAZINE_WELL",
-        "item_restriction": [ "glockmag", "glockbigmag", "glock17_17", "glock17_22", "glock_drum_50rd", "glock_drum_100rd", "glockmag_10", "glock17_10"]
+        "item_restriction": [
+          "glockmag",
+          "glockbigmag",
+          "glock17_17",
+          "glock17_22",
+          "glock_drum_50rd",
+          "glock_drum_100rd",
+          "glockmag_10",
+          "glock17_10"
+        ]
       }
     ]
   },


### PR DESCRIPTION


#### Summary
bugfixes "sub2000 10 round mag fix"


#### Purpose of change
the ingame sub2000 can not be used with the pinned 10 round glock mags. it should be able to be.

#### Describe the solution

single json line change

#### Describe alternatives you've considered

NA

#### Testing

made edit, spawned sub2000, spawned glock mags. they worked.

#### Additional context
this issue might exist elsewhere? find out if i run into it.
