### PR TITLE
Add a `phase_move` event

### DIFF
--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -1837,6 +1837,7 @@ Every event EOC passes context vars with each of their key value pairs that the 
 | opens_portal | Triggers when TOGGLE PORTAL option is activated via ("old lab" finale's?) computer | NONE | avatar / NONE |
 | opens_spellbook | Triggers when player opens the spell menu OR when NPC evaluates spell as best weapon(in preparation to use it) | { "character", `character_id` } | character / NONE |
 | opens_temple | Triggers when `pedestal_temple` examine action is used to consume a petrified eye | NONE | avatar / NONE |
+| phase_move | Triggers after a phasing enchant movement is completed | { "distance_traveled", `int` },<br/> { "is_bionic", `bool` }, | avatar / NONE |
 | player_fails_conduct | | { "conduct", `achievement_id` },<br/> { "achievements_enabled", `bool` }, | avatar / NONE |
 | player_gets_achievement | | { "achievement", `achievement_id` },<br/> { "achievements_enabled", `bool` }, | avatar / NONE |
 | player_levels_spell | triggers when player changes it's spell level, either by casting a spell, reading spell book, or using EoC. Spawning a new character with spells defined by using `spells` in chargen option will also run an event | { "character", `character_id` },<br/>{ "spell", `spell_id` },<br/>{ "new_level", `int` },{ "spell_class", `trait_id` } | character / NONE |

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -106,6 +106,7 @@ std::string enum_to_string<event_type>( event_type data )
         case event_type::opens_portal: return "opens_portal";
         case event_type::opens_spellbook: return "opens_spellbook";
         case event_type::opens_temple: return "opens_temple";
+        case event_type::phase_move: return "phase_move";
         case event_type::player_fails_conduct: return "player_fails_conduct";
         case event_type::player_gets_achievement: return "player_gets_achievement";
         case event_type::player_levels_spell: return "player_levels_spell";
@@ -146,7 +147,7 @@ DEFINE_EVENT_HELPER_FIELDS( event_spec_empty )
 DEFINE_EVENT_HELPER_FIELDS( event_spec_character )
 DEFINE_EVENT_HELPER_FIELDS( event_spec_character_item )
 
-static_assert( static_cast<int>( event_type::num_event_types ) == 108,
+static_assert( static_cast<int>( event_type::num_event_types ) == 109,
                "This static_assert is a reminder to add a definition below when you add a new "
                "event_type.  If your event_spec specialization inherits from another struct for "
                "its fields definition then you probably don't need a definition here." );
@@ -222,6 +223,7 @@ DEFINE_EVENT_FIELDS( u_var_changed )
 DEFINE_EVENT_FIELDS( vehicle_moves )
 DEFINE_EVENT_FIELDS( character_butchered_corpse )
 DEFINE_EVENT_FIELDS( dimension_travel )
+DEFINE_EVENT_FIELDS( phase_move )
 
 } // namespace event_detail
 

--- a/src/event.h
+++ b/src/event.h
@@ -114,6 +114,7 @@ enum class event_type : int {
     opens_portal,
     opens_spellbook,
     opens_temple,
+    phase_move,
     player_fails_conduct,
     player_gets_achievement,
     player_levels_spell,
@@ -197,7 +198,7 @@ struct event_spec_character_item {
 // NOTE: Events are saved to the character file for later memorializing them. It's currently unsafe to ever remove any of these.
 // Removal will cause any save file with one of the saved events to be unable to load.
 // FIXME.
-static_assert( static_cast<int>( event_type::num_event_types ) == 108,
+static_assert( static_cast<int>( event_type::num_event_types ) == 109,
                "This static_assert is to remind you to add a specialization for your new "
                "event_type below" );
 
@@ -840,6 +841,15 @@ struct event_spec<event_type::opens_portal> : event_spec_empty {};
 
 template<>
 struct event_spec<event_type::opens_temple> : event_spec_empty {};
+
+template<>
+struct event_spec<event_type::phase_move> {
+    static constexpr std::array<event_field, 2> fields = {{
+            { "distance_traveled", cata_variant_type::int_ },
+            { "is_bionic", cata_variant_type::bool_ },
+        }
+    };
+};
 
 template<>
 struct event_spec<event_type::releases_subspace_specimens> : event_spec_empty {};

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8517,6 +8517,7 @@ bool game::phasing_move( const tripoint_bub_ms &dest_loc, const bool via_ramp )
         u.grab( object_type::NONE );
         on_move_effects();
         here.creature_on_trap( u );
+        get_event_bus().send<event_type::phase_move>( tunneldist, true );
         return true;
     }
 
@@ -8581,6 +8582,8 @@ bool game::phasing_move_enchant( const tripoint_bub_ms &dest_loc, const int phas
         u.grab( object_type::NONE );
         on_move_effects();
         here.creature_on_trap( u );
+
+        get_event_bus().send<event_type::phase_move>( tunneldist, false );
         return true;
     }
 

--- a/src/memorial_logger.cpp
+++ b/src/memorial_logger.cpp
@@ -1011,6 +1011,11 @@ void memorial_logger::notify( const cata::event &e )
                  pgettext( "memorial_female", "Opened a strange temple." ) );
             break;
         }
+        case event_type::phase_move: {
+            add( pgettext( "memorial_male", "Phased through an obstacle." ),
+                 pgettext( "memorial_female", "Phased through an obstacle." ) );
+            break;
+        }
         case event_type::player_fails_conduct: {
             add( pgettext( "memorial_male", "Lost the conduct %s%s." ),
                  pgettext( "memorial_female", "Lost the conduct %s%s." ),


### PR DESCRIPTION
#### Summary
Infrastructure "Add a `phase_move` event"

#### Purpose of change
Adds a new event for when a character completes a phase enchant movement. i.e. Ephemeral Walk in MoM or the Probability Travel CBM

#### Describe the solution
Added a new event to the event enum `event_type::phase_move`, a related `event_spec` struct, and section to the memorial logger. 
Added a call to the event bus at the end of a successful movement in `game::phasing_move_enchant` and `game::phasing_move`
An `is_bionic` context var is available to test if it was from a bionic and used `game::phasing_move` 


#### Describe alternatives you've considered

#### Testing
Using a debug EOC to catpure the event and display the move distance 
<img width="1065" height="352" alt="image" src="https://github.com/user-attachments/assets/2a085382-5938-4710-b0e8-a5b58e9bc387" />
```jsonc
[
  {
    "type": "effect_on_condition",
    "id": "DEBUG_EOC_PHASE_MOVE",
    "eoc_type": "EVENT",
    "required_event": "phase_move",
    "effect": [ { "u_message": "Phase Move - Traveled: <context_val:distance_traveled> - Is Bionic: <context_val:is_bionic>" } ]
  }
]
```

#### Additional context
As requested by @Standing-Storm 


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
