### PR TITLE
[alt-map-key] Add new overmap terrain

### DIFF
--- a/data/mods/alt_map_key/overmap_terrain_pink.json
+++ b/data/mods/alt_map_key/overmap_terrain_pink.json
@@ -1,6 +1,14 @@
 [
   {
     "type": "overmap_terrain",
+    "id": [ "inner_cabins_depths_entrance" ],
+    "copy-from": "inner_cabins_depths_entrance",
+    "name": "cabin",
+    "sym": "C",
+    "color": "pink"
+  },
+  {
+    "type": "overmap_terrain",
     "id": [ "shipwreck_river_1", "shipwreck_river_2", "shipwreck_river_3", "shipwreck_river_4" ],
     "copy-from": "shipwreck_river_1",
     "name": "shipwreck",


### PR DESCRIPTION
#### Summary
Mods "[alt-map-key] Add new overmap terrain"


#### Purpose of change
Adding new overmap terrain

#### Describe the solution
Add new cabin from #86080

#### Describe alternatives you've considered


#### Testing
<img width="217" height="174" alt="image" src="https://github.com/user-attachments/assets/e70da9fb-2406-4512-b6c4-a726751c5135" />



#### Additional context



<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
