### PR TITLE
Portal storm + string church = string dimension

### DIFF
--- a/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
@@ -630,7 +630,17 @@
     "condition": { "and": [ { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_PORTAL_PROOF" }, { "not": "u_driving" } ] },
     "effect": [
       {
-        "if": { "u_has_item": "inert_glowing_string" },
+        "if": {
+          "or": [
+            { "u_has_item": "inert_glowing_string" },
+            { "u_at_om_location": "xedra_rural_church_parking" },
+            { "u_at_om_location": "xedra_rural_church" },
+            { "u_at_om_location": "xedra_rural_church_steeple" },
+            { "u_at_om_location": "xedra_rural_church_steeple_roof" },
+            { "u_at_om_location": "xedra_rural_church_basement" },
+            { "u_near_om_location": "xedra_rural_church", "range": 2 }
+          ]
+        },
         "then": { "run_eocs": "EOC_PORTAL_STRING_DIMENSION" },
         "else": [
           { "u_location_variable": { "context_val": "loc" } },

--- a/data/json/effects_on_condition/nether_eocs/string_dimension.json
+++ b/data/json/effects_on_condition/nether_eocs/string_dimension.json
@@ -10,7 +10,7 @@
         "region_type": "string_dimension",
         "npc_travel_filter": "none",
         "fail_message": "You experience brief vertigo, but nothing dangerous seems to happen.",
-        "success_message": "Your glowing string flashes brightly, and your surroundings warp and fold into an ever-expanding plane of light."
+        "success_message": "Your surroundings warp and fold into an ever-expanding plane of light."
       },
       {
         "u_location_variable": { "context_val": "nearest_floor" },
@@ -65,7 +65,10 @@
       },
       { "custom_light_level": 125, "length": "9999 days", "key": "string_dimension_lights_on" }
     ],
-    "false_effect": { "u_message": "Your glowing string rattles in its container.  There is almost a futile sadness to its struggle." }
+    "false_effect": {
+      "if": { "u_has_item": "inert_glowing_string" },
+      "then": { "u_message": "Your glowing string rattles in its container.  There is almost a futile sadness to its struggle." }
+    }
   },
   {
     "type": "effect_on_condition",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "The barricaded rural church can serve as an entrance to the string dimension"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Interdimensional space is "thin" at the stringy rural church, since it's filled with strange nether creatures.  Being there during a portal storm should have consequences.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Being outside the stringy church during a portal storm can take you to the string dimension.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

The church also changing over time, to get more stringy itself.  Still thinking about this as a future thing.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Stood outside barricaded rural church for 2 portal storms.  Portaled to string dimension during the second.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
