### PR TITLE
portaling to the string dimension doesn't instakill you

### DIFF
--- a/data/json/effects_on_condition/nether_eocs/string_dimension.json
+++ b/data/json/effects_on_condition/nether_eocs/string_dimension.json
@@ -13,7 +13,8 @@
         "success_message": "Your glowing string flashes brightly, and your surroundings warp and fold into an ever-expanding plane of light."
       },
       {
-        "u_location_variable": { "context_val": "nearest_floor" },
+        "u_location_variable": { "context_val": "nearest_sd_floor" },
+        "target_params": { "om_terrain": "string_dimension_crossroads", "z": 0, "min_distance": 0, "search_range": 100, "random": true },
         "terrain": "t_string_xy",
         "target_max_radius": 20,
         "min_radius": 0,
@@ -23,7 +24,7 @@
         "if": { "compare_string": [ "yes", { "u_val": "general_yrax_u_met_apeirohedra" } ] },
         "then": { "run_eocs": "EOC_YRAX_WARP_IN", "time_in_future": [ "3 seconds", "6 seconds" ] }
       },
-      { "u_teleport": { "context_val": "nearest_floor" } },
+      { "u_teleport": { "context_val": "nearest_sd_floor" } },
       { "math": [ "u_string_dimension_visits += 1" ] },
       { "math": [ "u_ire -= 5" ] },
       {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Portaling to the string dimension always places you on a walkable surface"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Portaling to the string dimension at z=0 worked great.  At negative z levels, you got stuck in void.  At positive z levels, you fell to your death.  Neither was intended.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Target an actual walkable OMT

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

n/a

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

warped to SD from multiple z levels.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
