### PR TITLE
The inner cabins cellar depths are dimly illuminated

### DIFF
--- a/data/json/furniture_and_terrain/terrain-reverberations.json
+++ b/data/json/furniture_and_terrain/terrain-reverberations.json
@@ -71,5 +71,17 @@
     "connect_groups": "WALL",
     "connects_to": "WALL",
     "flags": [ "TRANSPARENT", "FLAT", "ROAD", "SUPPORTS_ROOF" ]
+  },
+  {
+    "type": "terrain",
+    "id": "t_inner_cabins_nether_glass_floor",
+    "name": "black glass",
+    "description": "An endless expanse of black glass, illuminated by dim, otherworldly light.",
+    "symbol": " ",
+    "color": "black",
+    "move_cost": 2,
+    "light_emitted": 5,
+    "light_color": [ 150, 75, 0 ],
+    "flags": [ "TRANSPARENT", "FLAT", "ROAD" ]
   }
 ]

--- a/data/json/mapgen/reverberations/cabins_inner_depths.json
+++ b/data/json/mapgen/reverberations/cabins_inner_depths.json
@@ -637,7 +637,7 @@
         "                        ",
         "                        "
       ],
-      "terrain": { " ": "t_nether_glass_floor" },
+      "terrain": { " ": "t_inner_cabins_nether_glass_floor" },
       "place_nested": [ { "chunks": [ "inner_cabins_depths_nest" ], "x": 0, "y": 0 } ]
     }
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Inner cabins cellar depths have dim lighting"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Atmosphere for the WIP inner cabins

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

The inner cabins nether glass emits dim, brown light.  The interplay of black and brown make it so when a light is on, it almost appears darker between the cellars.

Headlamp off:<details><img width="978" height="760" alt="DIMLY-LIT" src="https://github.com/user-attachments/assets/2fa288fb-56d1-49ed-ad51-8bc45b4144d5" /></details>

Headlamp on:<details><img width="1081" height="893" alt="DIMLY-LIT-2" src="https://github.com/user-attachments/assets/9ce9e67c-d491-4d19-ba3f-672eae56019b" /></details>

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

not being lit

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Traveled to inner cabins, walked around a bit with various lights.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
