### PR TITLE
Fix dawn/dusk tint ignoring visibility, roofs and windows

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1833,6 +1833,7 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
             // colored energy to total scalar light so the effect is subtle under
             // bright ambient and vivid in darkness.
             const level_cache &cur_cache = here.access_cache( cur_zlevel );
+            SetRenderDrawBlendMode( renderer, SDL_BLENDMODE_BLEND );
             for( const tile_render_info &p : here.draw_points_cache[cur_zlevel][row] ) {
                 const tile_render_info::sprite *const
                 var = std::get_if<tile_render_info::sprite>( &p.var );
@@ -1872,50 +1873,9 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
                 const SDL_Rect draw_rect = {
                     screen.x, screen.y - p.com.height_3d, tile_width, tile_height
                 };
-                SetRenderDrawBlendMode( renderer, SDL_BLENDMODE_BLEND );
                 geometry->rect( renderer, draw_rect, tint );
-                SetRenderDrawBlendMode( renderer, SDL_BLENDMODE_NONE );
             }
-        }
-        // Dawn/dusk warm color temperature overlay on outside tiles.
-        // Sun altitude drives hue: deep orange (25 deg HSV) at the horizon,
-        // gold (45 deg HSV) as the sun climbs. Sine ease gives a smooth
-        // fade in/out instead of a sudden switch at the twilight boundary.
-        if( cur_zlevel >= 0 && is_twilight( calendar::turn ) ) {
-            const units::angle alt = sun_azimuth_altitude( calendar::turn ).second;
-            // lo/hi: nautical twilight range in degrees below horizon
-            constexpr float lo = -6.0f;
-            constexpr float hi = -1.0f;
-            const float progress = std::clamp(
-                                       static_cast<float>( to_degrees( alt ) - lo ) / ( hi - lo ), 0.0f, 1.0f );
-            const float hue = 25.0f + progress * 20.0f;
-            const float ease = std::sin( progress * 3.14159f );
-            const Uint8 sun_alpha = static_cast<Uint8>( ease * 25.0f );
-            if( sun_alpha > 0 ) {
-                const light_color_rgb sun_rgb = light_color_rgb::from_hsv( hue, 0.8f, 1.0f );
-                const SDL_Color sun_tint = {
-                    static_cast<Uint8>( sun_rgb.r * 255.0f ),
-                    static_cast<Uint8>( sun_rgb.g * 255.0f ),
-                    static_cast<Uint8>( sun_rgb.b * 255.0f ),
-                    sun_alpha
-                };
-                const auto &outside_cache = here.access_cache( cur_zlevel ).outside_cache;
-                SetRenderDrawBlendMode( renderer, SDL_BLENDMODE_BLEND );
-                for( int sun_row = cur_any_tile_range.p_min.y; sun_row < cur_any_tile_range.p_max.y;
-                     sun_row++ ) {
-                    for( const tile_render_info &p : here.draw_points_cache[cur_zlevel][sun_row] ) {
-                        if( !outside_cache[p.com.pos.x()][p.com.pos.y()] ) {
-                            continue;
-                        }
-                        const point screen = player_to_screen( p.com.pos.xy() );
-                        const SDL_Rect draw_rect = {
-                            screen.x, screen.y - p.com.height_3d, tile_width, tile_height
-                        };
-                        geometry->rect( renderer, draw_rect, sun_tint );
-                    }
-                }
-                SetRenderDrawBlendMode( renderer, SDL_BLENDMODE_NONE );
-            }
+            SetRenderDrawBlendMode( renderer, SDL_BLENDMODE_NONE );
         }
         cur_zlevel += 1;
     }

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -69,6 +69,40 @@ std::string four_quadrants::to_string() const
                           ( *this )[quadrant::SW], ( *this )[quadrant::NW] );
 }
 
+// Dawn/dusk tint: cached per turn, returns the warm color for twilight
+// or an empty color outside twilight. Only depends on calendar::turn.
+static light_color_rgb cached_twilight_color()
+{
+    static time_point cached_turn = calendar::before_time_starts;
+    static light_color_rgb cached_color;
+    if( cached_turn == calendar::turn ) {
+        return cached_color;
+    }
+    cached_turn = calendar::turn;
+    if( !is_twilight( calendar::turn ) ) {
+        cached_color = {};
+        return cached_color;
+    }
+    const units::angle alt = sun_azimuth_altitude( calendar::turn ).second;
+    constexpr float lo = -6.0f;
+    constexpr float hi = -1.0f;
+    const float progress = std::clamp(
+                               static_cast<float>( to_degrees( alt ) - lo ) / ( hi - lo ), 0.0f, 1.0f );
+    const float hue = 25.0f + progress * 20.0f;
+    const float ease = std::sin( progress * M_PI );
+    const float tint_strength = ease * 0.35f;
+    cached_color = light_color_rgb::from_hsv( hue, 0.8f, 1.0f ) * tint_strength;
+    return cached_color;
+}
+
+light_color_rgb dawn_dusk_color_for_lightmap( std::string_view dimension )
+{
+    if( !dimension.empty() ) {
+        return {};
+    }
+    return cached_twilight_color();
+}
+
 void map::add_item_light_recursive( const tripoint_bub_ms &p, const item &it )
 {
     float ilum = 0.0f; // brightness
@@ -485,6 +519,35 @@ void map::generate_lightmap( const int zlev )
 
     build_sunlight_cache( zlev );
 
+    // Dawn/dusk tint: color sunlit tiles during twilight. At this point lm
+    // contains only sunlight (no artificial sources yet), so any excess over
+    // the indoor baseline is sunlight that reached the tile.
+    const light_color_rgb ddc =
+        dawn_dusk_color_for_lightmap( g->get_dimension_prefix() );
+    if( ddc.is_colored() ) {
+        const float outside_light = g->natural_light_level( 0 );
+        const float inside_light = ( zlev >= 0 && outside_light > LIGHT_SOURCE_BRIGHT )
+                                   ? LIGHT_AMBIENT_DIM * 0.8f : LIGHT_AMBIENT_LOW;
+        auto &lcc = map_cache.light_color_cache;
+        bool wrote_any = false;
+        for( int x = 0; x < MAPSIZE_X; ++x ) {
+            for( int y = 0; y < MAPSIZE_Y; ++y ) {
+                const float sun = lm[x][y].max() - inside_light;
+                if( sun > 0.5f ) {
+                    const light_color_rgb contrib = ddc * sun;
+                    auto &cc = lcc[x][y];
+                    cc.r = std::max( cc.r, contrib.r );
+                    cc.g = std::max( cc.g, contrib.g );
+                    cc.b = std::max( cc.b, contrib.b );
+                    wrote_any = true;
+                }
+            }
+        }
+        if( wrote_any ) {
+            map_cache.has_colored_lights = true;
+        }
+    }
+
     apply_character_light( get_player_character() );
     for( npc &guy : g->all_npcs() ) {
         apply_character_light( guy );
@@ -517,10 +580,17 @@ void map::generate_lightmap( const int zlev )
                                     std::min( natural_light, lm[neighbour.x()][neighbour.y()].max() );
                                 if( light_transparency( p ) > LIGHT_TRANSPARENCY_SOLID ) {
                                     update_light_quadrants( lm[p.x()][p.y()], source_light, quadrant::default_ );
-                                    apply_directional_light( p, dir_d[i], source_light );
+                                    apply_directional_light( p, dir_d[i], source_light, ddc );
                                 } else {
                                     update_light_quadrants( lm[p.x()][p.y()], source_light, dir_quadrants[i][0] );
                                     update_light_quadrants( lm[p.x()][p.y()], source_light, dir_quadrants[i][1] );
+                                    if( ddc.is_colored() ) {
+                                        const light_color_rgb contrib = ddc * source_light;
+                                        auto &cc = map_cache.light_color_cache[p.x()][p.y()];
+                                        cc.r = std::max( cc.r, contrib.r );
+                                        cc.g = std::max( cc.g, contrib.g );
+                                        cc.b = std::max( cc.b, contrib.b );
+                                    }
                                 }
                             }
                         }
@@ -1431,7 +1501,8 @@ void map::apply_light_source( const tripoint_bub_ms &p, float luminance )
 #undef CAST_LIGHT_OCTANT
 }
 
-void map::apply_directional_light( const tripoint_bub_ms &p, int direction, float luminance )
+void map::apply_directional_light( const tripoint_bub_ms &p, int direction,
+                                   float luminance, const light_color_rgb &color )
 {
     const point_bub_ms p2( p.xy() );
 
@@ -1439,36 +1510,45 @@ void map::apply_directional_light( const tripoint_bub_ms &p, int direction, floa
     cata::mdarray<four_quadrants, point_bub_ms> &lm = cache.lm;
     cata::mdarray<float, point_bub_ms> &transparency_cache =
         cache.transparency_cache;
+    cata::mdarray<light_color_rgb, point_bub_ms> &light_color_cache =
+        cache.light_color_cache;
+
+    const bool has_color = color.is_colored();
+    if( has_color ) {
+        const light_color_rgb contrib = color * luminance;
+        auto &cc = light_color_cache[p2.x()][p2.y()];
+        cc.r = std::max( cc.r, contrib.r );
+        cc.g = std::max( cc.g, contrib.g );
+        cc.b = std::max( cc.b, contrib.b );
+        cache.has_colored_lights = true;
+    }
+
+#define CAST_DIR_OCTANT( _xx, _xy, _yx, _yy ) \
+    if( has_color ) { \
+        castLight<_xx, _xy, _yx, _yy, float, four_quadrants, light_calc, light_check, \
+        update_light_quadrants, accumulate_transparency, true>( \
+                lm, transparency_cache, p2, 0, luminance, 1, 1.0f, 0.0f, \
+                LIGHT_TRANSPARENCY_OPEN_AIR, color, &light_color_cache ); \
+    } else { \
+        castLight<_xx, _xy, _yx, _yy, float, four_quadrants, light_calc, light_check, \
+        update_light_quadrants, accumulate_transparency>( \
+                lm, transparency_cache, p2, 0, luminance ); \
+    }
 
     if( direction == 90 ) {
-        castLight < 1, 0, 0, -1, float, four_quadrants, light_calc, light_check,
-                  update_light_quadrants, accumulate_transparency > (
-                      lm, transparency_cache, p2, 0, luminance );
-        castLight < -1, 0, 0, -1, float, four_quadrants, light_calc, light_check,
-                  update_light_quadrants, accumulate_transparency > (
-                      lm, transparency_cache, p2, 0, luminance );
+        CAST_DIR_OCTANT( 1, 0, 0, -1 )
+        CAST_DIR_OCTANT( -1, 0, 0, -1 )
     } else if( direction == 0 ) {
-        castLight < 0, -1, 1, 0, float, four_quadrants, light_calc, light_check,
-                  update_light_quadrants, accumulate_transparency > (
-                      lm, transparency_cache, p2, 0, luminance );
-        castLight < 0, -1, -1, 0, float, four_quadrants, light_calc, light_check,
-                  update_light_quadrants, accumulate_transparency > (
-                      lm, transparency_cache, p2, 0, luminance );
+        CAST_DIR_OCTANT( 0, -1, 1, 0 )
+        CAST_DIR_OCTANT( 0, -1, -1, 0 )
     } else if( direction == 270 ) {
-        castLight<1, 0, 0, 1, float, four_quadrants, light_calc, light_check,
-                  update_light_quadrants, accumulate_transparency>(
-                      lm, transparency_cache, p2, 0, luminance );
-        castLight < -1, 0, 0, 1, float, four_quadrants, light_calc, light_check,
-                  update_light_quadrants, accumulate_transparency > (
-                      lm, transparency_cache, p2, 0, luminance );
+        CAST_DIR_OCTANT( 1, 0, 0, 1 )
+        CAST_DIR_OCTANT( -1, 0, 0, 1 )
     } else if( direction == 180 ) {
-        castLight<0, 1, 1, 0, float, four_quadrants, light_calc, light_check,
-                  update_light_quadrants, accumulate_transparency>(
-                      lm, transparency_cache, p2, 0, luminance );
-        castLight < 0, 1, -1, 0, float, four_quadrants, light_calc, light_check,
-                  update_light_quadrants, accumulate_transparency > (
-                      lm, transparency_cache, p2, 0, luminance );
+        CAST_DIR_OCTANT( 0, 1, 1, 0 )
+        CAST_DIR_OCTANT( 0, 1, -1, 0 )
     }
+#undef CAST_DIR_OCTANT
 }
 
 void map::apply_light_arc( const tripoint_bub_ms &p, const units::angle &angle, float luminance,

--- a/src/lightmap.h
+++ b/src/lightmap.h
@@ -4,6 +4,7 @@
 
 #include <cmath> // IWYU pragma: keep
 #include <ostream>
+#include <string_view>
 
 #include <stdint.h>
 
@@ -76,6 +77,10 @@ struct light_color_rgb {
     // Create from HSV. h in [0,360), s and v in [0,1].
     static light_color_rgb from_hsv( float h, float s, float v );
 };
+
+// Returns the warm dawn/dusk tint color, or empty when not applicable
+// (alternate dimension, outside twilight). Cached per turn.
+light_color_rgb dawn_dusk_color_for_lightmap( std::string_view dimension );
 
 enum class lit_level : uint8_t {
     DARK = 0,

--- a/src/map.h
+++ b/src/map.h
@@ -2105,7 +2105,8 @@ class map
         void add_light_source( const tripoint_bub_ms &p, float luminance,
                                const light_color_rgb &color = {} );
         // Handle just cardinal directions and 45 deg angles.
-        void apply_directional_light( const tripoint_bub_ms &p, int direction, float luminance );
+        void apply_directional_light( const tripoint_bub_ms &p, int direction, float luminance,
+                                      const light_color_rgb &color = {} );
         void apply_light_arc( const tripoint_bub_ms &p, const units::angle &angle, float luminance,
                               const units::angle &wideangle = 30_degrees,
                               const light_color_rgb &color = {} );

--- a/tests/light_color_test.cpp
+++ b/tests/light_color_test.cpp
@@ -1,3 +1,4 @@
+#include <string_view>
 #include <vector>
 
 #include "calendar.h"
@@ -27,10 +28,12 @@
 
 static const field_type_str_id field_fd_test_green_glow( "fd_test_green_glow" );
 static const ter_str_id ter_t_brick_wall( "t_brick_wall" );
+static const ter_str_id ter_t_door_o( "t_door_o" );
 static const ter_str_id ter_t_flat_roof( "t_flat_roof" );
 static const ter_str_id ter_t_floor( "t_floor" );
 static const ter_str_id ter_t_test_blue_light( "t_test_blue_light" );
 static const ter_str_id ter_t_test_red_light( "t_test_red_light" );
+static const ter_str_id ter_t_wall( "t_wall" );
 static const ter_str_id ter_test_t_utility_light( "test_t_utility_light" );
 static const vpart_id vpart_test_red_headlight( "test_red_headlight" );
 static const vproto_id vehicle_prototype_car( "car" );
@@ -770,4 +773,182 @@ TEST_CASE( "fused_arc_color_output_matches_golden_values", "[light_color]" )
     const float forward_r = cache.light_color_cache[hl_pos.x() + 4][hl_pos.y()].r;
     const float behind_r = cache.light_color_cache[hl_pos.x() - 2][hl_pos.y()].r;
     CHECK( forward_r > behind_r );
+}
+
+// --- Dawn/dusk tint (DDT) tests ---
+
+// Helper: set time and reset stale light caches before rebuilding lightmap.
+// rebuild_lightmap() alone does not call g->reset_light_level(), so
+// natural_light_level() would return stale cached values after a turn change.
+static void set_time_and_rebuild( const time_point &when, int zlev = 0 )
+{
+    calendar::turn = when;
+    g->reset_light_level();
+    get_player_character().recalc_sight_limits();
+    rebuild_lightmap( zlev );
+}
+
+TEST_CASE( "dawn_dusk_tint_on_outside_tiles", "[light_color][dawn_dusk]" )
+{
+    setup_dark_map();
+    scoped_weather_override weather_clear( WEATHER_CLEAR );
+
+    const time_point dawn = sunrise( calendar::turn_zero ) - 15_minutes;
+    set_time_and_rebuild( dawn );
+
+    const level_cache &cache = get_map().access_cache( 0 );
+    // Pick a few outside tiles near the player. After clear_map, z=0 is
+    // open ground so all tiles should receive full sunlight.
+    const tripoint_bub_ms center = get_player_character().pos_bub();
+    for( int dx = -3; dx <= 3; dx += 3 ) {
+        for( int dy = -3; dy <= 3; dy += 3 ) {
+            const point p( center.x() + dx, center.y() + dy );
+            CAPTURE( dx, dy );
+            const light_color_rgb &c = cache.light_color_cache[p.x][p.y];
+            CHECK( c.r > 0.0f );
+            // Warm hue: red > green > blue
+            CHECK( c.r > c.g );
+            CHECK( c.g > c.b );
+        }
+    }
+}
+
+TEST_CASE( "no_dawn_dusk_tint_at_midnight", "[light_color][dawn_dusk]" )
+{
+    setup_dark_map();
+    scoped_weather_override weather_clear( WEATHER_CLEAR );
+
+    set_time_and_rebuild( midnight );
+
+    const level_cache &cache = get_map().access_cache( 0 );
+    const tripoint_bub_ms center = get_player_character().pos_bub();
+    for( int d = -3; d <= 3; d += 3 ) {
+        const light_color_rgb &c = cache.light_color_cache[center.x() + d][center.y()];
+        CAPTURE( d );
+        CHECK_FALSE( c.is_colored() );
+    }
+}
+
+TEST_CASE( "no_dawn_dusk_tint_at_noon", "[light_color][dawn_dusk]" )
+{
+    setup_dark_map();
+    scoped_weather_override weather_clear( WEATHER_CLEAR );
+
+    const time_point noon = calendar::turn_zero + 12_hours;
+    set_time_and_rebuild( noon );
+
+    const level_cache &cache = get_map().access_cache( 0 );
+    const tripoint_bub_ms center = get_player_character().pos_bub();
+    for( int d = -3; d <= 3; d += 3 ) {
+        const light_color_rgb &c = cache.light_color_cache[center.x() + d][center.y()];
+        CAPTURE( d );
+        CHECK_FALSE( c.is_colored() );
+    }
+}
+
+TEST_CASE( "dawn_dusk_tint_blocked_by_roof", "[light_color][dawn_dusk]" )
+{
+    setup_dark_map();
+    scoped_weather_override weather_clear( WEATHER_CLEAR );
+
+    map &here = get_map();
+    const tripoint_bub_ms center = get_player_character().pos_bub();
+    // Build a sealed 5x5 walled box with roof, offset from player
+    const tripoint_bub_ms room_origin = center + tripoint( 8, 0, 0 );
+    for( int dx = 0; dx < 5; dx++ ) {
+        for( int dy = 0; dy < 5; dy++ ) {
+            const tripoint_bub_ms pos = room_origin + tripoint( dx, dy, 0 );
+            if( dx == 0 || dx == 4 || dy == 0 || dy == 4 ) {
+                here.ter_set( pos, ter_t_wall.id() );
+            } else {
+                here.ter_set( pos, ter_t_floor.id() );
+            }
+            here.ter_set( pos + tripoint::above, ter_t_flat_roof.id() );
+        }
+    }
+
+    const time_point dawn = sunrise( calendar::turn_zero ) - 15_minutes;
+    set_time_and_rebuild( dawn );
+
+    const level_cache &cache = here.access_cache( 0 );
+    // Interior tile (sealed room, under roof) should have no tint
+    const tripoint_bub_ms inside = room_origin + tripoint( 2, 2, 0 );
+    CHECK_FALSE( cache.light_color_cache[inside.x()][inside.y()].is_colored() );
+    // Outside tile far from room should have tint
+    CHECK( cache.light_color_cache[center.x()][center.y()].r > 0.0f );
+}
+
+TEST_CASE( "dawn_dusk_tint_penetrates_through_opening", "[light_color][dawn_dusk]" )
+{
+    setup_dark_map();
+    scoped_weather_override weather_clear( WEATHER_CLEAR );
+
+    map &here = get_map();
+    const tripoint_bub_ms center = get_player_character().pos_bub();
+    // Build a 7-tile east-west corridor: open west end, walled east end.
+    // Walls on north/south sides, flat roof above.
+    //
+    // Layout (y is north-south, x is east-west):
+    //   W W W W W W W W W
+    //   O . . . . . . . W    <- corridor, O = open door on west wall
+    //   W W W W W W W W W
+    const tripoint_bub_ms corridor_sw = center + tripoint( 6, -1, 0 );
+    constexpr int corridor_len = 9;
+    for( int dx = 0; dx < corridor_len; dx++ ) {
+        for( int dy = 0; dy < 3; dy++ ) {
+            const tripoint_bub_ms pos = corridor_sw + tripoint( dx, dy, 0 );
+            if( dy == 0 || dy == 2 || dx == corridor_len - 1 ) {
+                here.ter_set( pos, ter_t_wall.id() );
+            } else if( dx == 0 ) {
+                here.ter_set( pos, ter_t_door_o.id() );
+            } else {
+                here.ter_set( pos, ter_t_floor.id() );
+            }
+            // Roof above
+            here.ter_set( pos + tripoint::above, ter_t_flat_roof.id() );
+        }
+    }
+
+    const time_point dawn = sunrise( calendar::turn_zero ) - 15_minutes;
+    set_time_and_rebuild( dawn );
+
+    const level_cache &cache = here.access_cache( 0 );
+    // Corridor interior at y=corridor_sw.y()+1 (the middle row)
+    const int cy = corridor_sw.y() + 1;
+    const int x_open = corridor_sw.x();       // open door
+    const int x_near = corridor_sw.x() + 2;   // 2 tiles inside
+    const int x_deep = corridor_sw.x() + 5;   // 5 tiles inside
+
+    const float r_open = cache.light_color_cache[x_open][cy].r;
+    const float r_near = cache.light_color_cache[x_near][cy].r;
+    const float r_deep = cache.light_color_cache[x_deep][cy].r;
+
+    CAPTURE( r_open, r_near, r_deep );
+
+    // Opening tile must be tinted
+    CHECK( r_open > 0.0f );
+    // Near-inside tile must still have tint (directional ray cast)
+    CHECK( r_near > 0.0f );
+    // Gradient: opening brighter than deep inside
+    CHECK( r_open > r_deep );
+}
+
+TEST_CASE( "no_dawn_dusk_tint_in_alternate_dimension", "[light_color][dawn_dusk]" )
+{
+    setup_dark_map();
+    scoped_weather_override weather_clear( WEATHER_CLEAR );
+
+    // Set time to twilight so cached_twilight_color() returns a colored value
+    const time_point dawn = sunrise( calendar::turn_zero ) - 15_minutes;
+    calendar::turn = dawn;
+    g->reset_light_level();
+
+    // Default dimension: should produce tint
+    const light_color_rgb default_dim = dawn_dusk_color_for_lightmap( "" );
+    CHECK( default_dim.is_colored() );
+    CHECK( default_dim.r > 0.0f );
+
+    // Alternate dimension: no tint
+    const light_color_rgb nether = dawn_dusk_color_for_lightmap( "nether" );
+    CHECK_FALSE( nether.is_colored() );
 }


### PR DESCRIPTION
#### Summary
Bugfixes "Fix dawn/dusk tint ignoring visibility, roofs and windows"

#### Purpose of change

The dawn/dusk tint from #86066 was a renderer-side overlay that painted every `outside_cache` tile during twilight. It ignored visibility range (tinting DARK/MEMORIZED tiles), roofs (no `floor_cache` check), didn't enter buildings through windows/doors, and showed up in alternate dimensions.

#### Describe the solution

Move the tint into the lightmap so it rides actual sunlight propagation.

After `build_sunlight_cache` returns, `lm` contains only sunlight. Iterate tiles and write max-based dawn/dusk tint color proportional to sunlight excess over the indoor baseline -- so roofed/sealed tiles get nothing and outside tiles get the full warm hue.

Make `apply_directional_light` color-aware (same fused-castLight pattern as `apply_light_arc`) so when the horizontal projection loop pushes sunlight through transparent openings, the dawn/dusk tint follows through the full ray-cast footprint inside buildings.

Cache the twilight color per turn (only depends on sun altitude). Gate on default dimension and z >= 0.

Remove the renderer overlay from `cata_tiles.cpp`. Also moved `SetRenderDrawBlendMode` out of the per-tile colored light loop since it was toggling for every tile.

#### Describe alternatives you've considered

Could have patched the renderer overlay to also check `lit_level` and `floor_cache`, but that still wouldn't handle window penetration -- the whole point is that sunlight enters buildings through the lightmap, not through `outside_cache`.

#### Testing

New test cases covering: outside tint at dawn, no tint at midnight/noon, sealed roofed room blocks tint, tint penetrates through an open doorway with gradient assertion, dimension gate. All existing `[light_color]`, `[sun]`, and `[shadowcasting]` tests pass. Verified in-game.

#### Additional context

Follow-up to #86066 and #86107.