### PR TITLE
NPC duty/sleep shift scheduling, Hub intercom shift rotation

### DIFF
--- a/data/json/effects_on_condition/npc_eocs/robofac_npc_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/robofac_npc_eocs.json
@@ -59,7 +59,10 @@
     "type": "effect_on_condition",
     "id": "EOC_ROBOFAC_LOCK_INTERCOM",
     "global": true,
-    "effect": [ { "mapgen_update": "remove_robofac_intercom", "om_terrain": "robofachq_surface_entrance" } ]
+    "effect": [
+      { "mapgen_update": "remove_robofac_intercom", "om_terrain": "robofachq_surface_entrance" },
+      { "math": [ "hub01_intercom_locked = 1" ] }
+    ]
   },
   {
     "type": "mapgen",

--- a/data/json/mapgen/refugee_center/refugee_center.json
+++ b/data/json/mapgen/refugee_center/refugee_center.json
@@ -157,8 +157,8 @@
         { "class": "evac_broker", "x": 50, "y": 20 },
         { "class": "evac_teamster", "x": 54, "y": 4 },
         { "class": "guard", "x": 60, "y": 9 },
-        { "class": "guard", "x": 54, "y": 20 },
-        { "class": "guard", "x": 63, "y": 15 }
+        { "class": "night_guard", "x": 54, "y": 20 },
+        { "class": "night_guard", "x": 63, "y": 15 }
       ],
       "place_monsters": [ { "monster": "GROUP_VANILLA_ONLY_HUMANS", "x": [ 74, 87 ], "y": [ 4, 20 ], "density": 0.6 } ]
     }
@@ -245,7 +245,7 @@
         { "class": "refugee_UyenTran", "x": 69, "y": 4 },
         { "class": "refugee_RhyzaeaJohnny", "x": 69, "y": 2 },
         { "class": "refugee_FatimaalJadir", "x": 72, "y": 3 },
-        { "class": "guard", "x": 62, "y": 21 },
+        { "class": "night_guard", "x": 62, "y": 21 },
         { "class": "refugee_beggar5", "x": 64, "y": 22 }
       ]
     }
@@ -333,10 +333,10 @@
       "place_npcs": [
         { "class": "scavenger_merc", "x": 48, "y": 5 },
         { "class": "guard", "x": 39, "y": 4, "unique_id": "GUARD1" },
-        { "class": "guard", "x": 36, "y": 7, "unique_id": "GUARD2" },
+        { "class": "night_guard", "x": 36, "y": 7, "unique_id": "GUARD2" },
         { "class": "arsonist", "x": 38, "y": 19 },
         { "class": "old_guard_rep", "x": 47, "y": 10 },
-        { "class": "guard", "x": 45, "y": 3, "unique_id": "GUARD3" },
+        { "class": "night_guard", "x": 45, "y": 3, "unique_id": "GUARD3" },
         { "class": "free_merchants_merchant", "x": 71, "y": 0 },
         { "class": "science_rep", "x": 48, "y": 0 },
         { "class": "guard", "x": 52, "y": 4, "unique_id": "GUARD4" },
@@ -345,8 +345,8 @@
         { "class": "refugee_beggar3", "x": 64, "y": 0 },
         { "class": "refugee_beggar4", "x": 61, "y": 2 },
         { "class": "guard", "x": 73, "y": 3, "unique_id": "GUARD5" },
-        { "class": "guard", "x": 89, "y": 3, "unique_id": "GUARD6" },
-        { "class": "guard", "x": 88, "y": 19, "unique_id": "GUARD7" }
+        { "class": "night_guard", "x": 89, "y": 3, "unique_id": "GUARD6" },
+        { "class": "night_guard", "x": 88, "y": 19, "unique_id": "GUARD7" }
       ],
       "place_variables": [
         { "name": "GUARD1_First", "x": 39, "y": 4 },

--- a/data/json/mapgen/robofachq_static.json
+++ b/data/json/mapgen/robofachq_static.json
@@ -191,7 +191,7 @@
         ",,,,,,,,,,,,,,,,,|$,,,(B  [   |?ñt  Y||eeee||yyyyyyyyyyyyyy___________|||,,,,,,,,,,,,,,,,,,,,,,,",
         ",,,,,,,,,,,,,,,,,|$,,,(hdh=   |^     ||Eeee||9  y  8 y  99|___________|||,,,,,,,,,,,,,,,,,,,,,,,",
         ",,,,,,,,,,,,,,,,,|$,,||||||[[||  a   ||||||||99 y 88 y 999|55555555555|||,,,,,,,,,,,,,,,,,,,,,,,",
-        ",,,,,,,,,,,,,,,,,|$,,,(  h h  ||||||+||||||Q|||||||||||||||MMMMMMMMMMM|||,,,,,,,,,,,,,,,,,,,,,,,",
+        ",,,,,,,,,,,,,,,,,|$,,,(  h h  ||||||+||||||||||||||||||||||MMMMMMMMMMM|||,,,,,,,,,,,,,,,,,,,,,,,",
         ",,,,,,,,,,,,,,,,,|$,,,(  6dd  2 7|; Y||||||||||||||||||||||mmmmmmmmmmm|||,,,,,,,,,,,,,,,,,,,,,,,",
         ",,,,,,,,,,,,,,,,,|$,,,(B h  ^^|77|i  |,,,,,,,,,,,,,,,,,,|||||||||||||||||||,,,,,,,,,,,,,,,,,,,,,",
         ",,,,,,,,,,,,,,,,,|||u|||||||||||||||||,,,,,,,,,,,,,,,,,,|||||||||||||||||,|,,,,,,,,,,,,,,,,,,,,,",
@@ -253,8 +253,7 @@
         "i": { "item": "cleaning", "chance": 50 },
         "B": [ { "item": "textbooks", "chance": 50 }, { "item": "manuals", "chance": 50 } ],
         "7": { "item": "SUS_office_filing_cabinet", "chance": 100, "repeat": [ 10, 30 ] }
-      },
-      "npcs": { "Q": { "class": "robofac_intercom" } }
+      }
     }
   },
   {
@@ -436,9 +435,9 @@
         "#|iii    |====[[||=====|===[=|===[|[==||==[=||2||2|||[=======||  |||=====||||||2|||2||||########",
         "#|||||||||      ^|  hd^|^   H|    |    |^   |f ff f|  d  dh dh|  |Y      Y^|;2Y  |  Y2;|########",
         "#########|dd     [   dh|h   t|h h |    | d  |f ff f|  dh d  d |  2  hhhhh ^|||  |||  |||########",
-        "#########| h     [  hh |6dd H|ddd |6dd |hd  |f ff f| Y       Y|  2  ttttt ^|;2Y i|i Y2;|########",
+        "#########| V     [  hh |6dd H|ddd |6dd |hd  |f ff f| Y       Y|  2  ttttt ^|;2Y i|i Y2;|########",
         "#########|dd   dd|Y    |h  YB|Yh  |Yhd |^  Y|f    f|  d  d  dh|  |  hhh h ^|||  i|i  |||########",
-        "#########|Yh    h|BBBB^|^^BBB|A6^^|    |BBBB|ffffff|  dh d  d |^^|Y   h  Y^|;2Y i|i Y2;|########",
+        "#########| X    S|BBBB^|^^BBB|A6^^|    |BBBB|ffffff|  dh d  d |^^|Y   h  Y^|;2Y i|i Y2;|########",
         "#########|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||########",
         "################################################################################################"
       ],
@@ -462,7 +461,10 @@
         "H": "f_armchair",
         "L": "f_locker",
         "f": "f_filing_cabinet",
-        "A": "f_indoor_flagpole"
+        "A": "f_indoor_flagpole",
+        "S": "f_chair",
+        "V": "f_chair",
+        "X": "f_chair"
       },
       "item": { "A": { "item": "american_flag" } },
       "items": {
@@ -492,7 +494,13 @@
         ]
       },
       "monster": { "T": { "monster": "mon_robofac_laserturret_mk1" } },
-      "npcs": { "G": { "class": "hub_security" }, "Q": { "class": "hub_security_head" } },
+      "npcs": {
+        "G": { "class": "hub_security" },
+        "Q": { "class": "hub_security_head" },
+        "S": { "class": "robofac_intercom_supply" },
+        "V": { "class": "robofac_intercom_day" },
+        "X": { "class": "robofac_intercom_night" }
+      },
       "liquids": { "W": { "liquid": "water_clean", "amount": [ 0, 80 ] } }
     }
   },

--- a/data/json/mutations/npc_only.json
+++ b/data/json/mutations/npc_only.json
@@ -61,6 +61,36 @@
   },
   {
     "type": "mutation",
+    "id": "NPC_STASIS",
+    "name": { "str": "In Stasis" },
+    "description": "This NPC is in stasis and will not act, move, or accumulate needs until activated.",
+    "points": 0,
+    "player_display": false,
+    "purifiable": false,
+    "valid": false
+  },
+  {
+    "type": "mutation",
+    "id": "INTERCOM_OPERATOR",
+    "name": { "str": "Intercom Operator" },
+    "description": "This NPC operates an intercom system.",
+    "points": 0,
+    "player_display": false,
+    "purifiable": false,
+    "valid": false
+  },
+  {
+    "type": "mutation",
+    "id": "TRADE_BACKEND",
+    "name": { "str": "Trade Backend" },
+    "description": "This NPC serves as a backend trade actor for delegated shopkeeping.",
+    "points": 0,
+    "player_display": false,
+    "purifiable": false,
+    "valid": false
+  },
+  {
+    "type": "mutation",
     "id": "GETS_RANDOM_MISSION",
     "name": { "str": "Assign Random Mission", "//~": "NO_I18N" },
     "description": { "str": "This is an AI tag to give a static NPC a random mission.  If you see this, it's a bug.", "//~": "NO_I18N" },

--- a/data/json/npcs/exodii/exodii_Luliya.json
+++ b/data/json/npcs/exodii/exodii_Luliya.json
@@ -20,7 +20,8 @@
       { "trait": "EXODII_BODY_2" },
       { "trait": "IGNORE_SOUND" },
       { "trait": "NO_BASH" },
-      { "trait": "RETURN_TO_START_POS" }
+      { "trait": "RETURN_TO_START_POS" },
+      { "trait": "NPC_STASIS" }
     ],
     "common": false,
     "bonus_str": { "rng": [ 0, 6 ] },
@@ -122,7 +123,8 @@
     "speaker_effect": {
       "effect": [
         { "u_add_var": "general_meeting_u_met_luliya", "value": "yes" },
-        { "math": [ "u_timer_meeting_luliya_music_timer = time('now')" ] }
+        { "math": [ "u_timer_meeting_luliya_music_timer = time('now')" ] },
+        { "npc_lose_trait": "NPC_STASIS" }
       ]
     },
     "responses": [

--- a/data/json/npcs/exodii/exodii_merchant_definitions.json
+++ b/data/json/npcs/exodii/exodii_merchant_definitions.json
@@ -16,6 +16,7 @@
     "id": "NC_EXODII_TYPE_1_Merchant",
     "name": { "str": "Cyborg, type 1" },
     "job_description": "I'm a cyborg.",
+    "work_hours": [ 6, 22 ],
     "traits": [
       { "trait": "EXODII_BODY_1" },
       { "trait": "IGNORE_SOUND" },

--- a/data/json/npcs/exodii/exodii_weaponmaster.json
+++ b/data/json/npcs/exodii/exodii_weaponmaster.json
@@ -16,6 +16,7 @@
     "id": "NC_EXODII_TYPE_9_Weaponmaster",
     "name": { "str": "Cyborg, type 9" },
     "job_description": "I'm a cyborg.",
+    "work_hours": [ 6, 22 ],
     "traits": [
       { "trait": "EXODII_BODY_9" },
       { "trait": "IGNORE_SOUND" },

--- a/data/json/npcs/npc_behavior.json
+++ b/data/json/npcs/npc_behavior.json
@@ -39,15 +39,21 @@
   {
     "type": "behavior",
     "id": "npc_duty",
-    "strategy": "sequential",
-    "children": [ "npc_return_to_post" ],
+    "strategy": "fallback",
+    "children": [ "npc_return_to_post", "npc_hold_post" ],
     "score": "npc_duty_urgency"
   },
   {
     "type": "behavior",
     "id": "npc_return_to_post",
-    "conditions": [ { "predicate": "npc_displaced_from_post" } ],
+    "conditions": [ { "predicate": "npc_on_shift" }, { "predicate": "npc_displaced_from_post" } ],
     "goal": "return_to_guard_pos"
+  },
+  {
+    "type": "behavior",
+    "id": "npc_hold_post",
+    "conditions": [ { "predicate": "npc_on_shift" } ],
+    "goal": "hold_position"
   },
   {
     "type": "behavior",

--- a/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_guard_generic.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_guard_generic.json
@@ -11,6 +11,17 @@
     "faction": "free_merchants"
   },
   {
+    "type": "npc",
+    "id": "night_guard",
+    "//": "Night shift guard for the Free Merchants faction.",
+    "name_suffix": "Guard",
+    "class": "NC_FREE_MERCH_GUARD_NIGHT",
+    "attitude": 0,
+    "mission": 8,
+    "chat": "TALK_GUARD",
+    "faction": "free_merchants"
+  },
+  {
     "id": "TALK_GUARD",
     "type": "talk_topic",
     "dynamic_line": [

--- a/data/json/npcs/refugee_center/surface_staff/generic_class_definitions.json
+++ b/data/json/npcs/refugee_center/surface_staff/generic_class_definitions.json
@@ -53,6 +53,7 @@
     "id": "NC_FREE_MERCH_GUARD",
     "name": { "str": "Guard" },
     "job_description": "I'm on a guard shift.",
+    "work_hours": [ 9, 21 ],
     "weapon_override": "NC_FREE_MERCH_GUARD_wield_phase1",
     "worn_override": "NC_FREE_MERCH_GUARD_worn_phase1",
     "traits": [
@@ -69,5 +70,13 @@
       { "skill": "stabbing", "bonus": { "rng": [ 2, 4 ] } },
       { "skill": "melee", "bonus": { "rng": [ 2, 4 ] } }
     ]
+  },
+  {
+    "type": "npc_class",
+    "id": "NC_FREE_MERCH_GUARD_NIGHT",
+    "copy-from": "NC_FREE_MERCH_GUARD",
+    "name": { "str": "Night Guard" },
+    "job_description": "I'm on the night watch.",
+    "work_hours": [ 21, 9 ]
   }
 ]

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
@@ -16,8 +16,8 @@
   },
   {
     "type": "npc_class",
-    "id": "NC_ROBOFAC_INTERCOM",
-    "name": { "str": "intercom" },
+    "id": "NC_ROBOFAC_INTERCOM_BASE",
+    "name": { "str": "intercom (base)" },
     "job_description": ".",
     "common": false,
     "bonus_str": { "rng": [ 8, 10 ] },
@@ -26,7 +26,14 @@
     "skills": [ { "skill": "speech", "level": { "dice": [ 2, 2 ] } } ],
     "carry_override": "EMPTY_GROUP",
     "worn_override": "EMPTY_GROUP",
-    "weapon_override": "EMPTY_GROUP",
+    "weapon_override": "EMPTY_GROUP"
+  },
+  {
+    "type": "npc_class",
+    "id": "NC_ROBOFAC_INTERCOM",
+    "copy-from": "NC_ROBOFAC_INTERCOM_BASE",
+    "name": { "str": "intercom" },
+    "job_description": ".",
     "shopkeeper_item_group": [
       { "group": "NC_ROBOFAC_INTERCOM_trade", "rigid": true },
       {
@@ -86,6 +93,7 @@
         "rigid": true,
         "condition": {
           "or": [
+            { "compare_string": [ "yes", { "global_val": "hub01_intercom_bought_protective_gear" } ] },
             { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_npc_bought_protective_gear" } ] },
             { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_3" } ] }
           ]
@@ -111,6 +119,87 @@
       }
     ],
     "shopkeeper_blacklist": "robofac_blacklist"
+  },
+  {
+    "type": "npc_class",
+    "id": "NC_ROBOFAC_INTERCOM_DAY",
+    "copy-from": "NC_ROBOFAC_INTERCOM_BASE",
+    "name": { "str": "intercom (day)" },
+    "job_description": ".",
+    "work_hours": [ 6, 18 ],
+    "worn_override": "NC_ROBOFAC_SCIENTIST_worn",
+    "traits": [
+      { "group": "NPC_starting_traits" },
+      { "group": "Appearance_demographics" },
+      { "trait": "RETURN_TO_START_POS" },
+      { "trait": "INTERCOM_OPERATOR" },
+      { "trait": "IGNORE_SOUND" }
+    ]
+  },
+  {
+    "type": "npc_class",
+    "id": "NC_ROBOFAC_INTERCOM_NIGHT",
+    "copy-from": "NC_ROBOFAC_INTERCOM_BASE",
+    "name": { "str": "intercom (night)" },
+    "job_description": ".",
+    "work_hours": [ 18, 6 ],
+    "worn_override": "NC_ROBOFAC_SCIENTIST_worn",
+    "traits": [
+      { "group": "NPC_starting_traits" },
+      { "group": "Appearance_demographics" },
+      { "trait": "RETURN_TO_START_POS" },
+      { "trait": "INTERCOM_OPERATOR" },
+      { "trait": "IGNORE_SOUND" }
+    ]
+  },
+  {
+    "type": "npc",
+    "id": "robofac_intercom_day",
+    "//": "Day shift operator for Hub 01 intercom. Placed at z=-1 ops room.",
+    "name_suffix": "Intercom Operator",
+    "class": "NC_ROBOFAC_INTERCOM_DAY",
+    "attitude": 0,
+    "mission": 3,
+    "chat": "TALK_ROBOFAC_INTERCOM",
+    "faction": "robofac"
+  },
+  {
+    "type": "npc",
+    "id": "robofac_intercom_night",
+    "//": "Night shift operator for Hub 01 intercom. Placed at z=-1 ops room.",
+    "name_suffix": "Intercom Operator",
+    "class": "NC_ROBOFAC_INTERCOM_NIGHT",
+    "attitude": 0,
+    "mission": 3,
+    "chat": "TALK_ROBOFAC_INTERCOM",
+    "faction": "robofac"
+  },
+  {
+    "type": "npc_class",
+    "id": "NC_ROBOFAC_INTERCOM_SUPPLY",
+    "copy-from": "NC_ROBOFAC_INTERCOM",
+    "name": { "str": "Hub 01 representative" },
+    "job_description": ".",
+    "worn_override": "NC_ROBOFAC_SCIENTIST_worn",
+    "traits": [
+      { "group": "NPC_starting_traits" },
+      { "group": "Appearance_demographics" },
+      { "trait": "RETURN_TO_START_POS" },
+      { "trait": "IGNORE_SOUND" },
+      { "trait": "NO_BASH" },
+      { "trait": "TRADE_BACKEND" }
+    ]
+  },
+  {
+    "type": "npc",
+    "id": "robofac_intercom_supply",
+    "//": "Backend trade actor for Hub 01 intercom. Holds shared shop inventory.",
+    "name_suffix": "Hub 01 Representative",
+    "class": "NC_ROBOFAC_INTERCOM_SUPPLY",
+    "attitude": 0,
+    "mission": 3,
+    "chat": "TALK_ROBOFAC_INTERCOM",
+    "faction": "robofac"
   },
   {
     "type": "item_group",
@@ -183,17 +272,21 @@
     "id": "TALK_ROBOFAC_INTERCOM",
     "type": "talk_topic",
     "dynamic_line": {
-      "compare_string": [ "yes", { "npc_val": "dialogue_intercom_npc_intercom_trade" } ],
-      "yes": [
-        "&The intercom is silent.",
-        "&The intercom crackles on.",
-        "&The intercom's red LED blinks on.",
-        "&The intercom says something unintelligible."
-      ],
+      "math": [ "hub01_intercom_locked == 1" ],
+      "yes": "&The intercom is dead.  No light, no static, nothing.",
       "no": {
-        "compare_string": [ "yes", { "u_val": "dialogue_intercom_u_discovered_robofac_intercom" } ],
-        "yes": "&The intercom is silent.",
-        "no": "&An intercom is embedded into the wall here, just next to the card reader.  It's a metal box about as big as a dinner plate, with a speaker shaped like a downwards curve and a large camera prominently featured in the center.  You see a single metal button with a dark LED next to it.  The intercom is silent."
+        "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_1" } ],
+        "yes": [
+          "&The intercom is silent.",
+          "&The intercom crackles on.",
+          "&The intercom's red LED blinks on.",
+          "&The intercom says something unintelligible."
+        ],
+        "no": {
+          "compare_string": [ "yes", { "u_val": "dialogue_intercom_u_discovered_robofac_intercom" } ],
+          "yes": "&The intercom is silent.",
+          "no": "&An intercom is embedded into the wall here, just next to the card reader.  It's a metal box about as big as a dinner plate, with a speaker shaped like a downwards curve and a large camera prominently featured in the center.  You see a single metal button with a dark LED next to it.  The intercom is silent."
+        }
       }
     },
     "speaker_effect": {
@@ -202,8 +295,23 @@
     },
     "responses": [
       {
+        "text": "[Leave the dead intercom.]",
+        "condition": { "math": [ "hub01_intercom_locked == 1" ] },
+        "topic": "TALK_DONE"
+      },
+      {
         "text": "[Identify yourself before the intercom.]",
-        "condition": { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_npc_intercom_trade" } ] },
+        "condition": {
+          "and": [
+            { "not": { "math": [ "hub01_intercom_locked == 1" ] } },
+            {
+              "or": [
+                { "compare_string": [ "yes", { "global_val": "hub01_intercom_trade_unlocked" } ] },
+                { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_npc_intercom_trade" } ] }
+              ]
+            }
+          ]
+        },
         "topic": "TALK_ROBOFAC_INTERCOM_SERVICES",
         "effect": {
           "run_eocs": [
@@ -225,7 +333,15 @@
         "topic": "TALK_ROBOFAC_INTERCOM_INTRO",
         "condition": {
           "and": [
-            { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_npc_intercom_trade" } ] } },
+            { "not": { "math": [ "hub01_intercom_locked == 1" ] } },
+            {
+              "not": {
+                "or": [
+                  { "compare_string": [ "yes", { "global_val": "hub01_intercom_trade_unlocked" } ] },
+                  { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_npc_intercom_trade" } ] }
+                ]
+              }
+            },
             { "not": { "u_has_mission": "MISSION_ROBOFAC_INTERCOM_1" } },
             { "not": { "compare_string": [ "yes", { "u_val": "u_informed_robofac_of_exodii" } ] } }
           ]
@@ -236,7 +352,15 @@
         "topic": "MISSION_ROBOFAC_INTERCOM_1_INQUIRE",
         "condition": {
           "and": [
-            { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_npc_intercom_trade" } ] } },
+            { "not": { "math": [ "hub01_intercom_locked == 1" ] } },
+            {
+              "not": {
+                "or": [
+                  { "compare_string": [ "yes", { "global_val": "hub01_intercom_trade_unlocked" } ] },
+                  { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_npc_intercom_trade" } ] }
+                ]
+              }
+            },
             { "u_has_mission": "MISSION_ROBOFAC_INTERCOM_1" }
           ]
         }
@@ -246,9 +370,17 @@
         "topic": "TALK_ROBOFAC_INTERCOM_INTRO_3",
         "condition": {
           "and": [
+            { "not": { "math": [ "hub01_intercom_locked == 1" ] } },
             { "compare_string": [ "yes", { "u_val": "u_informed_robofac_of_exodii" } ] },
             { "not": { "compare_string": [ "yes", { "u_val": "u_give_robofac_exodii_info" } ] } },
-            { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_npc_intercom_trade" } ] } }
+            {
+              "not": {
+                "or": [
+                  { "compare_string": [ "yes", { "global_val": "hub01_intercom_trade_unlocked" } ] },
+                  { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_npc_intercom_trade" } ] }
+                ]
+              }
+            }
           ]
         }
       },
@@ -257,16 +389,29 @@
         "topic": "TALK_ROBOFAC_INTERCOM_INTRO_4",
         "condition": {
           "and": [
+            { "not": { "math": [ "hub01_intercom_locked == 1" ] } },
             { "compare_string": [ "yes", { "u_val": "u_give_robofac_exodii_info" } ] },
             { "not": { "u_has_mission": "MISSION_ROBOFAC_INTERCOM_1" } },
-            { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_npc_intercom_trade" } ] } }
+            {
+              "not": {
+                "or": [
+                  { "compare_string": [ "yes", { "global_val": "hub01_intercom_trade_unlocked" } ] },
+                  { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_npc_intercom_trade" } ] }
+                ]
+              }
+            }
           ]
         }
       },
       {
         "text": "[Bang on the metal door.]",
         "topic": "TALK_ROBOFAC_INTERCOM",
-        "condition": { "not": { "compare_string": [ "yes", { "u_val": "dialogue_intercom_u_met_robofac_intercom" } ] } }
+        "condition": {
+          "and": [
+            { "not": { "math": [ "hub01_intercom_locked == 1" ] } },
+            { "not": { "compare_string": [ "yes", { "u_val": "dialogue_intercom_u_met_robofac_intercom" } ] } }
+          ]
+        }
       },
       { "text": "[Leave.]", "topic": "TALK_DONE" }
     ],
@@ -342,7 +487,14 @@
           "and": [
             { "compare_string": [ "yes", { "u_val": "global_portal_storms_u_heard_of_portal_storms" } ] },
             { "not": { "compare_string": [ "yes", { "u_val": "global_portal_storms_u_witnessed_portal_storm" } ] } },
-            { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_told_about_portal_storms" } ] } }
+            {
+              "not": {
+                "or": [
+                  { "compare_string": [ "yes", { "global_val": "hub01_intercom_told_portal_storms" } ] },
+                  { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_told_about_portal_storms" } ] }
+                ]
+              }
+            }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_PORTAL_STORMS"
@@ -352,7 +504,14 @@
         "condition": {
           "and": [
             { "compare_string": [ "yes", { "u_val": "global_portal_storms_u_witnessed_portal_storm" } ] },
-            { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_told_about_portal_storms" } ] } }
+            {
+              "not": {
+                "or": [
+                  { "compare_string": [ "yes", { "global_val": "hub01_intercom_told_portal_storms" } ] },
+                  { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_told_about_portal_storms" } ] }
+                ]
+              }
+            }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_PORTAL_STORMS"
@@ -430,7 +589,14 @@
         "condition": {
           "and": [
             { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_1" } ] },
-            { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_told_about_prototype" } ] } }
+            {
+              "not": {
+                "or": [
+                  { "compare_string": [ "yes", { "global_val": "hub01_intercom_told_prototype" } ] },
+                  { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_told_about_prototype" } ] }
+                ]
+              }
+            }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_PROTOTYPE_ASK"
@@ -440,7 +606,14 @@
         "condition": {
           "and": [
             { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_1" } ] },
-            { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_told_about_armor" } ] } }
+            {
+              "not": {
+                "or": [
+                  { "compare_string": [ "yes", { "global_val": "hub01_intercom_told_armor" } ] },
+                  { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_told_about_armor" } ] }
+                ]
+              }
+            }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_ARMOR_ASK"
@@ -482,7 +655,14 @@
         "condition": {
           "and": [
             { "u_has_mission": "MISSION_ROBOFAC_INTERCOM_3" },
-            { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_npc_bought_protective_gear" } ] } }
+            {
+              "not": {
+                "or": [
+                  { "compare_string": [ "yes", { "global_val": "hub01_intercom_bought_protective_gear" } ] },
+                  { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_npc_bought_protective_gear" } ] }
+                ]
+              }
+            }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_BUY_PROTECTIVE_GEAR"
@@ -492,7 +672,14 @@
         "condition": {
           "and": [
             { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_2" } ] },
-            { "not": { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_sold_local_map" } ] } }
+            {
+              "not": {
+                "or": [
+                  { "compare_string": [ "yes", { "global_val": "hub01_intercom_sold_local_map" } ] },
+                  { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_sold_local_map" } ] }
+                ]
+              }
+            }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_BUY_LOCAL_MAP"
@@ -504,7 +691,14 @@
             { "u_has_faction_trust": 5 },
             { "u_has_mission": "MISSION_ISHERWOOD_CHRIS_1_GET_GEAR" },
             { "math": [ "isherwood_gear_status < 1" ] },
-            { "not": { "compare_string": [ "yes", { "npc_val": "npc_dialogue_exodii_npc_bought_riot_gear" } ] } }
+            {
+              "not": {
+                "or": [
+                  { "compare_string": [ "yes", { "global_val": "hub01_intercom_bought_riot_gear" } ] },
+                  { "compare_string": [ "yes", { "npc_val": "npc_dialogue_exodii_npc_bought_riot_gear" } ] }
+                ]
+              }
+            }
           ]
         },
         "topic": "TALK_ROBOFAC_INTERCOM_BUY_RIOT_GEAR"
@@ -513,7 +707,12 @@
         "text": "I'm here and I've got the goods.",
         "condition": {
           "and": [
-            { "compare_string": [ "yes", { "npc_val": "npc_dialogue_intercom_u_pay_back_on_cash" } ] },
+            {
+              "or": [
+                { "compare_string": [ "yes", { "global_val": "hub01_intercom_pay_back_on_cash" } ] },
+                { "compare_string": [ "yes", { "npc_val": "npc_dialogue_intercom_u_pay_back_on_cash" } ] }
+              ]
+            },
             { "u_has_items": { "item": "RobofacCoin", "count": 8 } },
             { "u_has_mission": "MISSION_HUB01_PAY_BACK_RIOT_GEAR" }
           ]
@@ -524,7 +723,12 @@
         "text": "Cost of the armor plus everything left in the tower.",
         "condition": {
           "and": [
-            { "compare_string": [ "yes", { "npc_val": "npc_dialogue_intercom_u_pay_back_on_specimens" } ] },
+            {
+              "or": [
+                { "compare_string": [ "yes", { "global_val": "hub01_intercom_pay_back_on_specimens" } ] },
+                { "compare_string": [ "yes", { "npc_val": "npc_dialogue_intercom_u_pay_back_on_specimens" } ] }
+              ]
+            },
             { "math": [ "isherwood_barry_rescued == 1" ] },
             { "u_has_mission": "MISSION_HUB01_PAY_BACK_RIOT_GEAR" }
           ]
@@ -983,6 +1187,7 @@
     "speaker_effect": {
       "effect": [
         { "npc_add_var": "dialogue_intercom_npc_intercom_trade", "value": "yes" },
+        { "set_string_var": "yes", "target_var": { "global_val": "hub01_intercom_trade_unlocked" } },
         { "u_add_var": "dialogue_intercom_completed_robofac_intercom_1", "value": "yes" },
         { "finish_mission": "MISSION_ROBOFAC_INTERCOM_1", "success": true }
       ],
@@ -1114,7 +1319,10 @@
     "type": "talk_topic",
     "dynamic_line": "Understand that I'm not an expert about this.\"  The voice sighs.  You hear the person on the other side typing on a keyboard for several seconds.  \"I will explain it as best I can, but again, I'm not a professional.  Whatever caused the apocalypse, it… broke something about the way our world works.  I'm sure you've noticed that 'normal' physics don't always apply anymore.  We are, as of right now, uncertain if our models were wrong, or if this is something fundamentally different to our reality.\"\n\n\"From what we've observed, these events are what happen at the peak of a cyclical effect.  This is gross oversimplification, and I don't know the science behind it, but… I guess the simplest way to think of it is that 'our' reality is moving closer and further from this other place, or model, or so on.  Like a yo-yo.  When these two things are closest together, we get portal storms.  Otherwise, things are… I wouldn't say normal, not anymore, but they are as close to normal as we get now.\"\n\n\"Reading a footnote here… we're looking to gather data about these storms using a device developed specifically for the purpose.  I'll add that to your contracts list, if you want to know more about it.",
     "speaker_effect": {
-      "effect": [ { "npc_add_var": "dialogue_intercom_told_about_portal_storms", "value": "yes" } ],
+      "effect": [
+        { "npc_add_var": "dialogue_intercom_told_about_portal_storms", "value": "yes" },
+        { "set_string_var": "yes", "target_var": { "global_val": "hub01_intercom_told_portal_storms" } }
+      ],
       "sentinel": "told_about_portal_storms"
     },
     "responses": [
@@ -1163,7 +1371,13 @@
     "id": "TALK_ROBOFAC_INTERCOM_ARMOR_ASK",
     "type": "talk_topic",
     "dynamic_line": "We've been working on specialized gear for potential agents in the field, given the hardware we have available.  Given the risks we've observed from here, it seemed astute.  It seems we still have some work to do.",
-    "speaker_effect": { "effect": { "npc_add_var": "dialogue_intercom_told_about_armor", "value": "yes" }, "sentinel": "told_about_armor" },
+    "speaker_effect": {
+      "effect": [
+        { "npc_add_var": "dialogue_intercom_told_about_armor", "value": "yes" },
+        { "set_string_var": "yes", "target_var": { "global_val": "hub01_intercom_told_armor" } }
+      ],
+      "sentinel": "told_about_armor"
+    },
     "responses": [
       { "text": "…", "topic": "TALK_ROBOFAC_INTERCOM_ARMOR_NEUTRAL" },
       {
@@ -1211,7 +1425,10 @@
     "type": "talk_topic",
     "dynamic_line": "It was a modified Wraitheon chassis, with a custom AI.  We'd hoped that it would interact with the outside world for us, but you know how well that went.  That particular line of study is now on hiatus, given that the project lead… well, you know.",
     "speaker_effect": {
-      "effect": { "npc_add_var": "dialogue_intercom_told_about_prototype", "value": "yes" },
+      "effect": [
+        { "npc_add_var": "dialogue_intercom_told_about_prototype", "value": "yes" },
+        { "set_string_var": "yes", "target_var": { "global_val": "hub01_intercom_told_prototype" } }
+      ],
       "sentinel": "told_about_prototype"
     },
     "responses": [ { "text": "Right.", "topic": "TALK_ROBOFAC_INTERCOM_SERVICES" } ]

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
@@ -203,7 +203,12 @@
             {
               "not": { "compare_string": [ "yes", { "u_val": "dialogue_intercom_completed_robofac_intercom_portal_sm_1" } ] }
             },
-            { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_told_about_portal_storms" } ] }
+            {
+              "or": [
+                { "compare_string": [ "yes", { "global_val": "hub01_intercom_told_portal_storms" } ] },
+                { "compare_string": [ "yes", { "npc_val": "dialogue_intercom_told_about_portal_storms" } ] }
+              ]
+            }
           ]
         },
         "topic": "MISSION_ROBOFAC_INTERCOM_PORTAL_SM_1_OFFER"

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_prototypes.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_prototypes.json
@@ -564,16 +564,28 @@
         "effect": [
           {
             "if": { "compare_string": [ "phase_immersion_suit", { "u_val": "dialogue_hub_rnd_u_current_project" } ] },
-            "then": [ { "npc_add_var": "phase_suit_reverse_engineered", "value": "yes" }, { "u_spawn_item": "phase_immersion_suit" } ]
+            "then": [
+              { "npc_add_var": "phase_suit_reverse_engineered", "value": "yes" },
+              { "set_string_var": "yes", "target_var": { "global_val": "hub01_phase_suit_reverse_engineered" } },
+              { "u_spawn_item": "phase_immersion_suit" }
+            ]
           },
           {
             "if": { "compare_string": [ "rm13_armor", { "u_val": "dialogue_hub_rnd_u_current_project" } ] },
-            "then": [ { "npc_add_var": "rm13_reverse_engineered", "value": "yes" }, { "u_spawn_item": "rm13_armor" } ]
+            "then": [
+              { "npc_add_var": "rm13_reverse_engineered", "value": "yes" },
+              { "set_string_var": "yes", "target_var": { "global_val": "hub01_rm13_reverse_engineered" } },
+              { "u_spawn_item": "rm13_armor" }
+            ]
           },
           {
             "if": { "compare_string": [ "combat_exoskeleton_light_salvaged", { "u_val": "dialogue_hub_rnd_u_current_project" } ] },
             "then": [
               { "npc_add_var": "combat_exoskeleton_reverse_engineered", "value": "yes" },
+              {
+                "set_string_var": "yes",
+                "target_var": { "global_val": "hub01_combat_exoskeleton_reverse_engineered" }
+              },
               { "u_spawn_item": "combat_exoskeleton_light" }
             ]
           },
@@ -597,7 +609,11 @@
       {
         "math": [ "has_var(n_phase_suit_reverse_engineered)" ],
         "yes": "Certainly; for a fee of ten coins, repairs and adjustments could be completed in two weeks.  We'll also pull suit metrics and haptic data to better understand the situation on the ground.  I'd ask you to make sure everything has been removed from the suit before giving it to us.",
-        "no": "&The camera starts scanning the armor, after a moment the intercom cracks back to life.  \"This technology is currently not within our database, we can probably repair it but we'll need to reverse-engineer it first.  We estimate the repairs to take around a month and a half, and they'll have an increased fee of 12 coins.  Please make sure everything has been removed from the suit before giving it to us.\""
+        "no": {
+          "compare_string": [ "yes", { "global_val": "hub01_phase_suit_reverse_engineered" } ],
+          "yes": "Certainly; for a fee of ten coins, repairs and adjustments could be completed in two weeks.  We'll also pull suit metrics and haptic data to better understand the situation on the ground.  I'd ask you to make sure everything has been removed from the suit before giving it to us.",
+          "no": "&The camera starts scanning the armor, after a moment the intercom cracks back to life.  \"This technology is currently not within our database, we can probably repair it but we'll need to reverse-engineer it first.  We estimate the repairs to take around a month and a half, and they'll have an increased fee of 12 coins.  Please make sure everything has been removed from the suit before giving it to us.\""
+        }
       }
     ],
     "responses": [
@@ -606,7 +622,12 @@
         "condition": {
           "and": [
             { "u_has_items": { "item": "RobofacCoin", "count": 10 } },
-            { "math": [ "has_var(n_phase_suit_reverse_engineered)" ] }
+            {
+              "or": [
+                { "math": [ "has_var(n_phase_suit_reverse_engineered)" ] },
+                { "compare_string": [ "yes", { "global_val": "hub01_phase_suit_reverse_engineered" } ] }
+              ]
+            }
           ]
         },
         "effect": [
@@ -624,7 +645,8 @@
         "condition": {
           "and": [
             { "u_has_items": { "item": "RobofacCoin", "count": 12 } },
-            { "math": [ "!has_var(n_phase_suit_reverse_engineered)" ] }
+            { "not": { "math": [ "has_var(n_phase_suit_reverse_engineered)" ] } },
+            { "not": { "compare_string": [ "yes", { "global_val": "hub01_phase_suit_reverse_engineered" } ] } }
           ]
         },
         "effect": [
@@ -647,14 +669,26 @@
       {
         "math": [ "has_var(n_rm13_reverse_engineered)" ],
         "yes": "Yes, that is within our capabilities.  For ten coins, repairs and adjustments can be completed in two weeks; we will recharge the internal battery as well.  Please note that if you have made any modifications to the armor, it will be reverted to factory standard as part of the repairs.",
-        "no": "&The camera starts scanning the armor, after a moment the intercom cracks back to life.  \"This technology is currently not within our database, we can probably repair it but we'll need to reverse-engineer it first.  We estimate the repairs to take around a month and a half, and they'll have an increased fee of 12 coins.  Please make sure everything has been removed from the suit before giving it to us.\""
+        "no": {
+          "compare_string": [ "yes", { "global_val": "hub01_rm13_reverse_engineered" } ],
+          "yes": "Yes, that is within our capabilities.  For ten coins, repairs and adjustments can be completed in two weeks; we will recharge the internal battery as well.  Please note that if you have made any modifications to the armor, it will be reverted to factory standard as part of the repairs.",
+          "no": "&The camera starts scanning the armor, after a moment the intercom cracks back to life.  \"This technology is currently not within our database, we can probably repair it but we'll need to reverse-engineer it first.  We estimate the repairs to take around a month and a half, and they'll have an increased fee of 12 coins.  Please make sure everything has been removed from the suit before giving it to us.\""
+        }
       }
     ],
     "responses": [
       {
         "text": "[10 HGC] Alright.",
         "condition": {
-          "and": [ { "u_has_items": { "item": "RobofacCoin", "count": 10 } }, { "math": [ "has_var(n_rm13_reverse_engineered)" ] } ]
+          "and": [
+            { "u_has_items": { "item": "RobofacCoin", "count": 10 } },
+            {
+              "or": [
+                { "math": [ "has_var(n_rm13_reverse_engineered)" ] },
+                { "compare_string": [ "yes", { "global_val": "hub01_rm13_reverse_engineered" } ] }
+              ]
+            }
+          ]
         },
         "effect": [
           { "u_consume_item": "RobofacCoin", "count": 10, "popup": true },
@@ -669,7 +703,11 @@
       {
         "text": "[12 HGC] Fine.",
         "condition": {
-          "and": [ { "u_has_items": { "item": "RobofacCoin", "count": 12 } }, { "math": [ "!has_var(n_rm13_reverse_engineered)" ] } ]
+          "and": [
+            { "u_has_items": { "item": "RobofacCoin", "count": 12 } },
+            { "not": { "math": [ "has_var(n_rm13_reverse_engineered)" ] } },
+            { "not": { "compare_string": [ "yes", { "global_val": "hub01_rm13_reverse_engineered" } ] } }
+          ]
         },
         "effect": [
           { "u_consume_item": "RobofacCoin", "count": 12, "popup": true },
@@ -691,7 +729,11 @@
       {
         "math": [ "has_var(n_combat_exoskeleton_reverse_engineered)" ],
         "yes": "Certainly, it'll cost you 10 coins and should be ready in two weeks.  Remember to take off any attachments and batteries before turning it in.",
-        "no": "One moment,\" the respondent audibly leaves for a moment and after a short period the intercom cracks with life.  \"We have never attempted repairs on a military exoskeleton, we will have to reverse-engineer it first, expect this to take around a month and a half, it will also cost you 12 coins.  Please make sure to take off any attachments and batteries before turning it in."
+        "no": {
+          "compare_string": [ "yes", { "global_val": "hub01_combat_exoskeleton_reverse_engineered" } ],
+          "yes": "Certainly, it'll cost you 10 coins and should be ready in two weeks.  Remember to take off any attachments and batteries before turning it in.",
+          "no": "One moment,\" the respondent audibly leaves for a moment and after a short period the intercom cracks with life.  \"We have never attempted repairs on a military exoskeleton, we will have to reverse-engineer it first, expect this to take around a month and a half, it will also cost you 12 coins.  Please make sure to take off any attachments and batteries before turning it in."
+        }
       }
     ],
     "responses": [
@@ -700,7 +742,12 @@
         "condition": {
           "and": [
             { "u_has_items": { "item": "RobofacCoin", "count": 10 } },
-            { "math": [ "has_var(n_combat_exoskeleton_reverse_engineered)" ] }
+            {
+              "or": [
+                { "math": [ "has_var(n_combat_exoskeleton_reverse_engineered)" ] },
+                { "compare_string": [ "yes", { "global_val": "hub01_combat_exoskeleton_reverse_engineered" } ] }
+              ]
+            }
           ]
         },
         "effect": [
@@ -717,7 +764,10 @@
         "condition": {
           "and": [
             { "u_has_items": { "item": "RobofacCoin", "count": 12 } },
-            { "math": [ "!has_var(n_combat_exoskeleton_reverse_engineered)" ] }
+            { "not": { "math": [ "has_var(n_combat_exoskeleton_reverse_engineered)" ] } },
+            {
+              "not": { "compare_string": [ "yes", { "global_val": "hub01_combat_exoskeleton_reverse_engineered" } ] }
+            }
           ]
         },
         "effect": [

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_trades.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_trades.json
@@ -12,7 +12,8 @@
           { "u_spawn_item": "mask_gas_half" },
           { "u_spawn_item": "robofac_enviro_suit" },
           { "u_spawn_item": "gasfilter_med", "count": 1 },
-          { "npc_add_var": "dialogue_intercom_npc_bought_protective_gear", "value": "yes" }
+          { "npc_add_var": "dialogue_intercom_npc_bought_protective_gear", "value": "yes" },
+          { "set_string_var": "yes", "target_var": { "global_val": "hub01_intercom_bought_protective_gear" } }
         ],
         "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"
       },
@@ -36,7 +37,8 @@
         "effect": [
           { "u_consume_item": "RobofacCoin", "count": 1, "popup": true },
           { "mapgen_update": "robofachq_surface_entrance", "reveal_radius": 40 },
-          { "npc_add_var": "dialogue_intercom_sold_local_map", "value": "yes" }
+          { "npc_add_var": "dialogue_intercom_sold_local_map", "value": "yes" },
+          { "set_string_var": "yes", "target_var": { "global_val": "hub01_intercom_sold_local_map" } }
         ],
         "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"
       },
@@ -116,14 +118,19 @@
       "math": [ "portal_storm_small_data_sold >= 3" ],
       "yes": "Extrapolating trends from these recordings has become difficult.  Research has requested we only accept higher quality data from now on.",
       "no": {
-        "compare_string": [ "yes", { "npc_val": "dialogue_intercom_accepted_nre_recording" } ],
-        "no": "Excellent; this should be enough to work with.  Here's your agreed-upon reward.\"  The tray slides shut, and quickly reopens with your payment.  \"Given your performance and our constant need for new data, you are free to keep the recorder for further use.  We are willing to pay for any future data that you're able to record.",
-        "yes": "&\"Thank you.\"  The recording changes hands."
+        "compare_string": [ "yes", { "global_val": "hub01_intercom_accepted_nre_recording" } ],
+        "yes": "&\"Thank you.\"  The recording changes hands.",
+        "no": {
+          "compare_string": [ "yes", { "npc_val": "dialogue_intercom_accepted_nre_recording" } ],
+          "yes": "&\"Thank you.\"  The recording changes hands.",
+          "no": "Excellent; this should be enough to work with.  Here's your agreed-upon reward.\"  The tray slides shut, and quickly reopens with your payment.  \"Given your performance and our constant need for new data, you are free to keep the recorder for further use.  We are willing to pay for any future data that you're able to record."
+        }
       }
     },
     "speaker_effect": {
       "effect": [
         { "npc_add_var": "dialogue_intercom_accepted_nre_recording", "value": "yes" },
+        { "set_string_var": "yes", "target_var": { "global_val": "hub01_intercom_accepted_nre_recording" } },
         { "finish_mission": "MISSION_ROBOFAC_INTERCOM_PORTAL_SM_1", "success": true }
       ],
       "sentinel": "nre_trade"
@@ -136,14 +143,19 @@
       "math": [ "portal_storm_medium_data_sold >= 15" ],
       "yes": "Extrapolating trends from these recordings has become difficult.  Research has requested we only accept higher quality data from now on.",
       "no": {
-        "compare_string": [ "yes", { "npc_val": "dialogue_intercom_accepted_nre_recording" } ],
-        "no": "Great!  This looks like a very high-quality recording.  Because this data is much better, we are willing to pay five times what we paid for the base data collected.\"  The tray slides shut, and quickly reopens with your payment.  \"Given your performance and our constant need for new data, you are free to keep the recorder for further use.  We are willing to pay for any future data that you're able to record.",
-        "yes": "&\"Excellent.\"  The recording changes hands."
+        "compare_string": [ "yes", { "global_val": "hub01_intercom_accepted_nre_recording" } ],
+        "yes": "&\"Excellent.\"  The recording changes hands.",
+        "no": {
+          "compare_string": [ "yes", { "npc_val": "dialogue_intercom_accepted_nre_recording" } ],
+          "yes": "&\"Excellent.\"  The recording changes hands.",
+          "no": "Great!  This looks like a very high-quality recording.  Because this data is much better, we are willing to pay five times what we paid for the base data collected.\"  The tray slides shut, and quickly reopens with your payment.  \"Given your performance and our constant need for new data, you are free to keep the recorder for further use.  We are willing to pay for any future data that you're able to record."
+        }
       }
     },
     "speaker_effect": {
       "effect": [
         { "npc_add_var": "dialogue_intercom_accepted_nre_recording", "value": "yes" },
+        { "set_string_var": "yes", "target_var": { "global_val": "hub01_intercom_accepted_nre_recording" } },
         { "finish_mission": "MISSION_ROBOFAC_INTERCOM_PORTAL_SM_1", "success": true }
       ],
       "sentinel": "nre_trade"
@@ -153,13 +165,18 @@
     "id": "TALK_ROBOFAC_INTERCOM_SELL_PORTAL_STORM_DATA_Large",
     "type": "talk_topic",
     "dynamic_line": {
-      "compare_string": [ "yes", { "npc_val": "dialogue_intercom_accepted_nre_recording" } ],
-      "no": "Uh… please allow me a second to check this in.\"  The tray slides shut, and the intercom turns off.  Roughly a minute later, it turns back on.  \"Well, it looks like this is a real treasure trove of information.  In fact, you've made quite an impression on R&D, and probably just saved us a few weeks of research at the least.  They demanded you be given a pretty significant accomplishment bonus, so… well, there you go.\"  The tray slides open, revealing an impressive pile of coins.\n\n\"Given your performance and our constant need for new data, you are free to keep the recorder for further use.  We are willing to pay for any future data that you're able to record.",
-      "yes": "Fantastic.\"  The recording changes hands.  \"At this rate, we'll have some real results soon."
+      "compare_string": [ "yes", { "global_val": "hub01_intercom_accepted_nre_recording" } ],
+      "yes": "Fantastic.\"  The recording changes hands.  \"At this rate, we'll have some real results soon.",
+      "no": {
+        "compare_string": [ "yes", { "npc_val": "dialogue_intercom_accepted_nre_recording" } ],
+        "yes": "Fantastic.\"  The recording changes hands.  \"At this rate, we'll have some real results soon.",
+        "no": "Uh… please allow me a second to check this in.\"  The tray slides shut, and the intercom turns off.  Roughly a minute later, it turns back on.  \"Well, it looks like this is a real treasure trove of information.  In fact, you've made quite an impression on R&D, and probably just saved us a few weeks of research at the least.  They demanded you be given a pretty significant accomplishment bonus, so… well, there you go.\"  The tray slides open, revealing an impressive pile of coins.\n\n\"Given your performance and our constant need for new data, you are free to keep the recorder for further use.  We are willing to pay for any future data that you're able to record."
+      }
     },
     "speaker_effect": {
       "effect": [
         { "npc_add_var": "dialogue_intercom_accepted_nre_recording", "value": "yes" },
+        { "set_string_var": "yes", "target_var": { "global_val": "hub01_intercom_accepted_nre_recording" } },
         { "finish_mission": "MISSION_ROBOFAC_INTERCOM_PORTAL_SM_1", "success": true }
       ],
       "sentinel": "nre_trade"
@@ -179,7 +196,8 @@
           { "u_spawn_item": "helmet_riot", "count": 5 },
           { "u_spawn_item": "armor_riot_arm", "count": 5 },
           { "u_spawn_item": "armor_riot_leg", "count": 5 },
-          { "npc_add_var": "npc_dialogue_exodii_npc_bought_riot_gear", "value": "yes" }
+          { "npc_add_var": "npc_dialogue_exodii_npc_bought_riot_gear", "value": "yes" },
+          { "set_string_var": "yes", "target_var": { "global_val": "hub01_intercom_bought_riot_gear" } }
         ],
         "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"
       },
@@ -198,12 +216,18 @@
     "responses": [
       {
         "text": "I can pay you what I owe in cash and looted gear.",
-        "effect": [ { "npc_add_var": "npc_dialogue_intercom_u_pay_back_on_cash", "value": "yes" } ],
+        "effect": [
+          { "npc_add_var": "npc_dialogue_intercom_u_pay_back_on_cash", "value": "yes" },
+          { "set_string_var": "yes", "target_var": { "global_val": "hub01_intercom_pay_back_on_cash" } }
+        ],
         "topic": "TALK_ROBOFAC_INTERCOM_BUY_RIOT_GEAR_ON_CREDIT_ACCEPT"
       },
       {
         "text": "If you give me this deal you can have all the alien corpses, their stuff and their tower",
-        "effect": [ { "npc_add_var": "npc_dialogue_intercom_u_pay_back_on_specimens", "value": "yes" } ],
+        "effect": [
+          { "npc_add_var": "npc_dialogue_intercom_u_pay_back_on_specimens", "value": "yes" },
+          { "set_string_var": "yes", "target_var": { "global_val": "hub01_intercom_pay_back_on_specimens" } }
+        ],
         "topic": "TALK_ROBOFAC_INTERCOM_BUY_RIOT_GEAR_ON_CREDIT_ACCEPT"
       },
       { "text": "I'll have to give it some thought.", "topic": "TALK_ROBOFAC_INTERCOM_SERVICES" }
@@ -213,7 +237,7 @@
     "id": "TALK_ROBOFAC_INTERCOM_BUY_RIOT_GEAR_ON_CREDIT_ACCEPT",
     "type": "talk_topic",
     "dynamic_line": {
-      "compare_string": [ "yes", { "npc_val": "npc_dialogue_intercom_u_pay_back_on_specimens" } ],
+      "compare_string": [ "yes", { "global_val": "hub01_intercom_pay_back_on_specimens" } ],
       "yes": "Well it might be more interesting than straight gear.  Tell us when it's available for inspection.  We expect you back in 20 days or less.",
       "no": "20 days then for payment."
     },
@@ -226,7 +250,8 @@
           { "u_spawn_item": "armor_riot_arm", "count": 5 },
           { "u_spawn_item": "armor_riot_leg", "count": 5 },
           { "assign_mission": "MISSION_HUB01_PAY_BACK_RIOT_GEAR" },
-          { "npc_add_var": "npc_dialogue_exodii_npc_bought_riot_gear", "value": "yes" }
+          { "npc_add_var": "npc_dialogue_exodii_npc_bought_riot_gear", "value": "yes" },
+          { "set_string_var": "yes", "target_var": { "global_val": "hub01_intercom_bought_riot_gear" } }
         ],
         "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"
       },
@@ -357,61 +382,121 @@
     "id": "TALK_ROBOFAC_INTERCOM_SELL_BROKEN_YRAX_TRIFACET",
     "type": "talk_topic",
     "dynamic_line": "We already have a similar model in better condition but this one is useful as a reference.",
-    "speaker_effect": { "effect": [ { "npc_add_var": "dialogue_intercom_accepted_yrax_robot", "value": "yes" } ], "sentinel": "yrax_trade" }
+    "speaker_effect": {
+      "effect": [
+        { "npc_add_var": "dialogue_intercom_accepted_yrax_robot", "value": "yes" },
+        { "set_string_var": "yes", "target_var": { "global_val": "hub01_intercom_accepted_yrax_robot" } }
+      ],
+      "sentinel": "yrax_trade"
+    }
   },
   {
     "id": "TALK_ROBOFAC_INTERCOM_SELL_BROKEN_YRAX_TRIAKIS",
     "type": "talk_topic",
     "dynamic_line": "We can probably gain some insight from studying this unit, but it appears seriously damaged.",
-    "speaker_effect": { "effect": [ { "npc_add_var": "dialogue_intercom_accepted_yrax_robot", "value": "yes" } ], "sentinel": "yrax_trade" }
+    "speaker_effect": {
+      "effect": [
+        { "npc_add_var": "dialogue_intercom_accepted_yrax_robot", "value": "yes" },
+        { "set_string_var": "yes", "target_var": { "global_val": "hub01_intercom_accepted_yrax_robot" } }
+      ],
+      "sentinel": "yrax_trade"
+    }
   },
   {
     "id": "TALK_ROBOFAC_INTERCOM_SELL_BROKEN_GOLDEN_MONOLITH",
     "type": "talk_topic",
     "dynamic_line": "That is quite a lot of broken metal, let's hope R&D can at least salvage some materials.",
-    "speaker_effect": { "effect": [ { "npc_add_var": "dialogue_intercom_accepted_yrax_robot", "value": "yes" } ], "sentinel": "yrax_trade" }
+    "speaker_effect": {
+      "effect": [
+        { "npc_add_var": "dialogue_intercom_accepted_yrax_robot", "value": "yes" },
+        { "set_string_var": "yes", "target_var": { "global_val": "hub01_intercom_accepted_yrax_robot" } }
+      ],
+      "sentinel": "yrax_trade"
+    }
   },
   {
     "id": "TALK_ROBOFAC_INTERCOM_SELL_BROKEN_YRAX_DELTA",
     "type": "talk_topic",
     "dynamic_line": "We don't need all of your glossy scrap.",
-    "speaker_effect": { "effect": [ { "npc_add_var": "dialogue_intercom_accepted_yrax_robot", "value": "yes" } ], "sentinel": "yrax_trade" }
+    "speaker_effect": {
+      "effect": [
+        { "npc_add_var": "dialogue_intercom_accepted_yrax_robot", "value": "yes" },
+        { "set_string_var": "yes", "target_var": { "global_val": "hub01_intercom_accepted_yrax_robot" } }
+      ],
+      "sentinel": "yrax_trade"
+    }
   },
   {
     "id": "TALK_ROBOFAC_INTERCOM_SELL_BROKEN_YRAX_QUADRAPHRACT_LEG",
     "type": "talk_topic",
     "dynamic_line": "We witnessed it as a part of larger construct.",
-    "speaker_effect": { "effect": [ { "npc_add_var": "dialogue_intercom_accepted_yrax_robot", "value": "yes" } ], "sentinel": "yrax_trade" }
+    "speaker_effect": {
+      "effect": [
+        { "npc_add_var": "dialogue_intercom_accepted_yrax_robot", "value": "yes" },
+        { "set_string_var": "yes", "target_var": { "global_val": "hub01_intercom_accepted_yrax_robot" } }
+      ],
+      "sentinel": "yrax_trade"
+    }
   },
   {
     "id": "TALK_ROBOFAC_INTERCOM_SELL_BROKEN_YRAX_QUADRAPHRACT",
     "type": "talk_topic",
     "dynamic_line": "I'm impressed you managed to drag it inside.  We gonna need to fix the lift after this one.",
-    "speaker_effect": { "effect": [ { "npc_add_var": "dialogue_intercom_accepted_yrax_robot", "value": "yes" } ], "sentinel": "yrax_trade" }
+    "speaker_effect": {
+      "effect": [
+        { "npc_add_var": "dialogue_intercom_accepted_yrax_robot", "value": "yes" },
+        { "set_string_var": "yes", "target_var": { "global_val": "hub01_intercom_accepted_yrax_robot" } }
+      ],
+      "sentinel": "yrax_trade"
+    }
   },
   {
     "id": "TALK_ROBOFAC_INTERCOM_SELL_BOT_YRAX_TRIFACET",
     "type": "talk_topic",
     "dynamic_line": "I believe we already have similar model already but is nice to have more, it will allow us be more active in our research.",
-    "speaker_effect": { "effect": [ { "npc_add_var": "dialogue_intercom_accepted_yrax_robot", "value": "yes" } ], "sentinel": "yrax_trade" }
+    "speaker_effect": {
+      "effect": [
+        { "npc_add_var": "dialogue_intercom_accepted_yrax_robot", "value": "yes" },
+        { "set_string_var": "yes", "target_var": { "global_val": "hub01_intercom_accepted_yrax_robot" } }
+      ],
+      "sentinel": "yrax_trade"
+    }
   },
   {
     "id": "TALK_ROBOFAC_INTERCOM_SELL_BOT_YRAX_TRIAKIS",
     "type": "talk_topic",
     "dynamic_line": "Oh what an interesting piece.  R&D will have a field day with it.",
-    "speaker_effect": { "effect": [ { "npc_add_var": "dialogue_intercom_accepted_yrax_robot", "value": "yes" } ], "sentinel": "yrax_trade" }
+    "speaker_effect": {
+      "effect": [
+        { "npc_add_var": "dialogue_intercom_accepted_yrax_robot", "value": "yes" },
+        { "set_string_var": "yes", "target_var": { "global_val": "hub01_intercom_accepted_yrax_robot" } }
+      ],
+      "sentinel": "yrax_trade"
+    }
   },
   {
     "id": "TALK_ROBOFAC_INTERCOM_SELL_BOT_GOLDEN_MONOLITH",
     "type": "talk_topic",
     "dynamic_line": "I assume you were trying to figure out limits of the hm12.  I guess they are right here.",
-    "speaker_effect": { "effect": [ { "npc_add_var": "dialogue_intercom_accepted_yrax_robot", "value": "yes" } ], "sentinel": "yrax_trade" }
+    "speaker_effect": {
+      "effect": [
+        { "npc_add_var": "dialogue_intercom_accepted_yrax_robot", "value": "yes" },
+        { "set_string_var": "yes", "target_var": { "global_val": "hub01_intercom_accepted_yrax_robot" } }
+      ],
+      "sentinel": "yrax_trade"
+    }
   },
   {
     "id": "TALK_ROBOFAC_INTERCOM_SELL_BOT_YRAX_DELTA",
     "type": "talk_topic",
     "dynamic_line": "I doubt we can get a lot of information from this drone but thanks.",
-    "speaker_effect": { "effect": [ { "npc_add_var": "dialogue_intercom_accepted_yrax_robot", "value": "yes" } ], "sentinel": "yrax_trade" }
+    "speaker_effect": {
+      "effect": [
+        { "npc_add_var": "dialogue_intercom_accepted_yrax_robot", "value": "yes" },
+        { "set_string_var": "yes", "target_var": { "global_val": "hub01_intercom_accepted_yrax_robot" } }
+      ],
+      "sentinel": "yrax_trade"
+    }
   },
   {
     "id": [
@@ -773,6 +858,7 @@
     "speaker_effect": {
       "effect": [
         { "npc_add_var": "dialogue_intercom_accepted_HEW_recording", "value": "yes" },
+        { "set_string_var": "yes", "target_var": { "global_val": "hub01_intercom_accepted_HEW_recording" } },
         { "finish_mission": "MISSION_ROBOFAC_INTERCOM_MWS_4", "success": true }
       ]
     }
@@ -784,14 +870,19 @@
       "math": [ "HEW_portal_storm_data_sold >= 15" ],
       "yes": "Research has requested we no longer pay for portal storm recordings.  You have done enough.",
       "no": {
-        "compare_string": [ "yes", { "npc_val": "dialogue_intercom_accepted_HEW_recording" } ],
-        "no": "Excellent.  Here's your agreed-upon reward.\"  The tray slides shut, and quickly reopens with your payment.",
-        "yes": "&\"Thank you.\"  The recording changes hands."
+        "compare_string": [ "yes", { "global_val": "hub01_intercom_accepted_HEW_recording" } ],
+        "yes": "&\"Thank you.\"  The recording changes hands.",
+        "no": {
+          "compare_string": [ "yes", { "npc_val": "dialogue_intercom_accepted_HEW_recording" } ],
+          "yes": "&\"Thank you.\"  The recording changes hands.",
+          "no": "Excellent.  Here's your agreed-upon reward.\"  The tray slides shut, and quickly reopens with your payment."
+        }
       }
     },
     "speaker_effect": {
       "effect": [
         { "npc_add_var": "dialogue_intercom_accepted_HEW_recording", "value": "yes" },
+        { "set_string_var": "yes", "target_var": { "global_val": "hub01_intercom_accepted_HEW_recording" } },
         { "finish_mission": "MISSION_ROBOFAC_INTERCOM_MWS_4", "success": true }
       ]
     }
@@ -803,6 +894,7 @@
     "speaker_effect": {
       "effect": [
         { "npc_add_var": "dialogue_intercom_accepted_HEW_recording", "value": "yes" },
+        { "set_string_var": "yes", "target_var": { "global_val": "hub01_intercom_accepted_HEW_recording" } },
         { "finish_mission": "MISSION_ROBOFAC_INTERCOM_MWS_4", "success": true }
       ]
     }
@@ -814,6 +906,7 @@
     "speaker_effect": {
       "effect": [
         { "npc_add_var": "dialogue_intercom_accepted_HEW_recording", "value": "yes" },
+        { "set_string_var": "yes", "target_var": { "global_val": "hub01_intercom_accepted_HEW_recording" } },
         { "finish_mission": "MISSION_ROBOFAC_INTERCOM_MWS_4", "success": true }
       ]
     }
@@ -825,6 +918,7 @@
     "speaker_effect": {
       "effect": [
         { "npc_add_var": "dialogue_intercom_accepted_HEW_recording", "value": "yes" },
+        { "set_string_var": "yes", "target_var": { "global_val": "hub01_intercom_accepted_HEW_recording" } },
         { "finish_mission": "MISSION_ROBOFAC_INTERCOM_MWS_4", "success": true }
       ]
     }
@@ -836,6 +930,7 @@
     "speaker_effect": {
       "effect": [
         { "npc_add_var": "dialogue_intercom_accepted_HEW_recording", "value": "yes" },
+        { "set_string_var": "yes", "target_var": { "global_val": "hub01_intercom_accepted_HEW_recording" } },
         { "finish_mission": "MISSION_ROBOFAC_INTERCOM_MWS_4", "success": true }
       ]
     }
@@ -847,6 +942,7 @@
     "speaker_effect": {
       "effect": [
         { "npc_add_var": "dialogue_intercom_accepted_HEW_recording", "value": "yes" },
+        { "set_string_var": "yes", "target_var": { "global_val": "hub01_intercom_accepted_HEW_recording" } },
         { "finish_mission": "MISSION_ROBOFAC_INTERCOM_MWS_4", "success": true }
       ]
     }
@@ -858,6 +954,7 @@
     "speaker_effect": {
       "effect": [
         { "npc_add_var": "dialogue_intercom_accepted_HEW_recording", "value": "yes" },
+        { "set_string_var": "yes", "target_var": { "global_val": "hub01_intercom_accepted_HEW_recording" } },
         { "finish_mission": "MISSION_ROBOFAC_INTERCOM_MWS_4", "success": true }
       ]
     }
@@ -869,6 +966,7 @@
     "speaker_effect": {
       "effect": [
         { "npc_add_var": "dialogue_intercom_accepted_HEW_recording", "value": "yes" },
+        { "set_string_var": "yes", "target_var": { "global_val": "hub01_intercom_accepted_HEW_recording" } },
         { "finish_mission": "MISSION_ROBOFAC_INTERCOM_MWS_4", "success": true }
       ]
     }
@@ -880,6 +978,7 @@
     "speaker_effect": {
       "effect": [
         { "npc_add_var": "dialogue_intercom_accepted_HEW_recording", "value": "yes" },
+        { "set_string_var": "yes", "target_var": { "global_val": "hub01_intercom_accepted_HEW_recording" } },
         { "finish_mission": "MISSION_ROBOFAC_INTERCOM_MWS_4", "success": true }
       ]
     }
@@ -891,6 +990,7 @@
     "speaker_effect": {
       "effect": [
         { "npc_add_var": "dialogue_intercom_accepted_HEW_recording", "value": "yes" },
+        { "set_string_var": "yes", "target_var": { "global_val": "hub01_intercom_accepted_HEW_recording" } },
         { "finish_mission": "MISSION_ROBOFAC_INTERCOM_MWS_4", "success": true }
       ]
     }
@@ -902,6 +1002,7 @@
     "speaker_effect": {
       "effect": [
         { "npc_add_var": "dialogue_intercom_accepted_HEW_recording", "value": "yes" },
+        { "set_string_var": "yes", "target_var": { "global_val": "hub01_intercom_accepted_HEW_recording" } },
         { "finish_mission": "MISSION_ROBOFAC_INTERCOM_MWS_4", "success": true }
       ]
     }
@@ -913,6 +1014,7 @@
     "speaker_effect": {
       "effect": [
         { "npc_add_var": "dialogue_intercom_accepted_HEW_recording", "value": "yes" },
+        { "set_string_var": "yes", "target_var": { "global_val": "hub01_intercom_accepted_HEW_recording" } },
         { "finish_mission": "MISSION_ROBOFAC_INTERCOM_MWS_4", "success": true }
       ]
     }
@@ -928,6 +1030,7 @@
     "speaker_effect": {
       "effect": [
         { "npc_add_var": "dialogue_intercom_accepted_HEW_recording", "value": "yes" },
+        { "set_string_var": "yes", "target_var": { "global_val": "hub01_intercom_accepted_HEW_recording" } },
         { "finish_mission": "MISSION_ROBOFAC_INTERCOM_MWS_4", "success": true }
       ]
     }
@@ -939,6 +1042,7 @@
     "speaker_effect": {
       "effect": [
         { "npc_add_var": "dialogue_intercom_accepted_HEW_recording", "value": "yes" },
+        { "set_string_var": "yes", "target_var": { "global_val": "hub01_intercom_accepted_HEW_recording" } },
         { "finish_mission": "MISSION_ROBOFAC_INTERCOM_MWS_4", "success": true }
       ]
     }
@@ -950,6 +1054,7 @@
     "speaker_effect": {
       "effect": [
         { "npc_add_var": "dialogue_intercom_accepted_HEW_recording", "value": "yes" },
+        { "set_string_var": "yes", "target_var": { "global_val": "hub01_intercom_accepted_HEW_recording" } },
         { "finish_mission": "MISSION_ROBOFAC_INTERCOM_MWS_4", "success": true }
       ]
     }
@@ -961,6 +1066,7 @@
     "speaker_effect": {
       "effect": [
         { "npc_add_var": "dialogue_intercom_accepted_HEW_recording", "value": "yes" },
+        { "set_string_var": "yes", "target_var": { "global_val": "hub01_intercom_accepted_HEW_recording" } },
         { "finish_mission": "MISSION_ROBOFAC_INTERCOM_MWS_4", "success": true }
       ]
     }
@@ -972,6 +1078,7 @@
     "speaker_effect": {
       "effect": [
         { "npc_add_var": "dialogue_intercom_accepted_HEW_recording", "value": "yes" },
+        { "set_string_var": "yes", "target_var": { "global_val": "hub01_intercom_accepted_HEW_recording" } },
         { "finish_mission": "MISSION_ROBOFAC_INTERCOM_MWS_4", "success": true }
       ]
     }
@@ -983,6 +1090,7 @@
     "speaker_effect": {
       "effect": [
         { "npc_add_var": "dialogue_intercom_accepted_HEW_recording", "value": "yes" },
+        { "set_string_var": "yes", "target_var": { "global_val": "hub01_intercom_accepted_HEW_recording" } },
         { "finish_mission": "MISSION_ROBOFAC_INTERCOM_MWS_4", "success": true }
       ]
     }
@@ -1002,6 +1110,7 @@
     "speaker_effect": {
       "effect": [
         { "npc_add_var": "dialogue_intercom_accepted_HEW_recording", "value": "yes" },
+        { "set_string_var": "yes", "target_var": { "global_val": "hub01_intercom_accepted_HEW_recording" } },
         { "finish_mission": "MISSION_ROBOFAC_INTERCOM_MWS_4", "success": true }
       ]
     }

--- a/src/avatar.h
+++ b/src/avatar.h
@@ -226,7 +226,9 @@ class avatar : public Character
 
         // Dialogue and bartering--see npctalk.cpp
         void talk_to( std::unique_ptr<talker> talk_with, bool radio_contact = false,
-                      bool is_computer = false, bool is_not_conversation = false, const std::string &debug_topic = "" );
+                      bool is_computer = false, bool is_not_conversation = false,
+                      const std::string &debug_topic = "",
+                      const std::string &remote_name = "" );
 
         /**
          * Try to disarm the NPC. May result in fail attempt, you receiving the weapon and instantly wielding it,
@@ -308,6 +310,9 @@ class avatar : public Character
 
         // Set in npc::talk_to_you for use in further NPC interactions
         bool dialogue_by_radio = false;
+        // When set, overrides the NPC display name in dialogue and trade
+        // windows (e.g. "the intercom" for remote intercom conversations).
+        std::string dialogue_remote_name;
         // Preferred aim mode - ranged.cpp aim mode defaults to this if possible
         std::string preferred_aiming_mode;
 

--- a/src/behavior_oracle.cpp
+++ b/src/behavior_oracle.cpp
@@ -53,6 +53,7 @@ predicate_map = {{
         { "npc_has_target", make_function( &character_oracle_t::has_target ) },
         { "npc_has_sound_alerts", make_function( &character_oracle_t::has_sound_alerts ) },
         { "npc_displaced_from_post", make_function( &character_oracle_t::displaced_from_post ) },
+        { "npc_on_shift", make_function( &character_oracle_t::on_shift ) },
         { "monster_not_hallucination", make_function( &monster_oracle_t::not_hallucination ) },
         { "monster_items_available", make_function( &monster_oracle_t::items_available ) },
         { "monster_split_possible", make_function( &monster_oracle_t::split_possible ) },

--- a/src/character_health.cpp
+++ b/src/character_health.cpp
@@ -211,6 +211,7 @@ static const trait_id trait_HEAVYSLEEPER2( "HEAVYSLEEPER2" );
 static const trait_id trait_HIBERNATE( "HIBERNATE" );
 static const trait_id trait_MASOCHIST( "MASOCHIST" );
 static const trait_id trait_M_SKIN3( "M_SKIN3" );
+static const trait_id trait_NPC_STASIS( "NPC_STASIS" );
 static const trait_id trait_PACIFIST( "PACIFIST" );
 static const trait_id trait_PROF_FOODP( "PROF_FOODP" );
 static const trait_id trait_PYROMANIA( "PYROMANIA" );
@@ -1422,6 +1423,10 @@ bool Character::needs_food() const
 
 void Character::update_needs( int rate_multiplier )
 {
+    // Stasis NPCs don't accumulate any needs.
+    if( has_trait( trait_NPC_STASIS ) ) {
+        return;
+    }
     const int current_stim = get_stim();
     // Hunger, thirst, & sleepiness up every 5 minutes
     effect &sleep = get_effect( effect_sleep );

--- a/src/character_oracle.cpp
+++ b/src/character_oracle.cpp
@@ -8,11 +8,13 @@
 
 #include "behavior.h"
 #include "bodypart.h"
+#include "calendar.h"
 #include "character.h"
 #include "coordinates.h"
 #include "item.h"
 #include "itype.h"
 #include "npc.h"
+#include "npc_class.h"
 #include "point.h"
 #include "ret_val.h"
 #include "type_id.h"
@@ -125,9 +127,9 @@ status_t character_oracle_t::has_food( std::string_view ) const
 
 status_t character_oracle_t::needs_sleep_badly( std::string_view ) const
 {
-    // DEAD_TIRED (383) = microsleeps start, 38% of MASSIVE_SLEEPINESS.
-    // Parallels needs_water_badly at 43% of death threshold.
-    if( subject->get_sleepiness() >= static_cast<int>( sleepiness_levels::DEAD_TIRED ) ) {
+    // TIRED (191): low enough that off-shift NPCs go to bed early.
+    // On-shift duty (0.45) easily beats sleep urgency at this level (0.191).
+    if( subject->get_sleepiness() >= static_cast<int>( sleepiness_levels::TIRED ) ) {
         return status_t::running;
     }
     return status_t::success;
@@ -178,7 +180,7 @@ status_t character_oracle_t::can_sleep( std::string_view ) const
     if( subject->has_effect( effect_meth ) ) {
         return status_t::failure;
     }
-    if( subject->get_sleepiness() >= static_cast<int>( sleepiness_levels::EXHAUSTED ) ) {
+    if( subject->get_sleepiness() >= static_cast<int>( sleepiness_levels::TIRED ) ) {
         return status_t::running;
     }
     return status_t::failure;
@@ -259,6 +261,17 @@ status_t character_oracle_t::displaced_from_post( std::string_view ) const
     return n->pos_abs() != *gp ? status_t::running : status_t::failure;
 }
 
+status_t character_oracle_t::on_shift( std::string_view ) const
+{
+    const npc *n = dynamic_cast<const npc *>( subject );
+    if( !n || !n->get_effective_guard_pos() ) {
+        return status_t::failure;
+    }
+    const auto &[start, end] = n->myclass.obj().get_work_hours();
+    const int hour = to_hours<int>( time_past_midnight( calendar::turn ) );
+    return is_within_work_hours( hour, start, end ) ? status_t::running : status_t::failure;
+}
+
 float character_oracle_t::duty_urgency( std::string_view ) const
 {
     const npc *n = dynamic_cast<const npc *>( subject );
@@ -266,10 +279,27 @@ float character_oracle_t::duty_urgency( std::string_view ) const
         return 0.0f;
     }
     std::optional<tripoint_abs_ms> gp = n->get_effective_guard_pos();
-    if( !gp || n->pos_abs() == *gp ) {
+    if( !gp ) {
         return 0.0f;
     }
-    return 0.5f;
+    const auto &[start, end] = n->myclass.obj().get_work_hours();
+    const int hour = to_hours<int>( time_past_midnight( calendar::turn ) );
+    const bool on = is_within_work_hours( hour, start, end );
+
+    if( n->pos_abs() == *gp ) {
+        // At post: on-shift returns a baseline that resists moderate
+        // tiredness. Off-shift returns 0 so needs (sleep) can win.
+        return on ? 0.45f : 0.0f;
+    }
+    // Off-shift: no duty pull at all. Guard stays where they are
+    // (bed, shelter, wherever) until their shift starts.
+    if( !on ) {
+        return 0.0f;
+    }
+    // Displaced on-shift: distance-based with a floor so the NPC
+    // strongly prefers returning even when close to post.
+    const int dist = rl_dist( n->pos_abs(), *gp );
+    return std::max( 0.45f, std::min( 0.5f, dist * 0.05f ) );
 }
 
 } // namespace behavior

--- a/src/character_oracle.h
+++ b/src/character_oracle.h
@@ -39,6 +39,7 @@ class character_oracle_t : public oracle_t
         status_t has_target( std::string_view ) const;
         status_t has_sound_alerts( std::string_view ) const;
         status_t displaced_from_post( std::string_view ) const;
+        status_t on_shift( std::string_view ) const;
         /**
          * Score predicates for utility strategy (return 0-1 urgency).
          */

--- a/src/dialogue.h
+++ b/src/dialogue.h
@@ -295,6 +295,10 @@ struct dialogue: public const_dialogue {
 
         std::string dynamic_line( const talk_topic &topic );
         void apply_speaker_effects( const talk_topic &the_topic );
+        // Display name for the NPC in conversation history. Uses
+        // remote_name from dialogue_window when set (intercom etc.),
+        // falls back to NPC display name, empty if not a conversation.
+        std::string speaker_name( const dialogue_window &d_win ) const;
 
         /**
          * Possible responses from the player character, filled in @ref gen_responses.

--- a/src/dialogue_win.cpp
+++ b/src/dialogue_win.cpp
@@ -64,7 +64,7 @@ void dialogue_window::draw( const std::string &npc_name )
                                         line );
         }
     } else {
-        if( !is_computer && !is_not_conversation ) {
+        if( !is_computer && !is_not_conversation && !is_remote ) {
             std::string formatted_text = formatted_hotkey( ctxt.get_desc( "LOOK_AT", 1 ),
                                          cur_color ).append( _( "Look at" ) );
             print_colored_text( d_win, point( actions_xoffset, ycurrent ), cur_color, c_magenta,

--- a/src/dialogue_win.h
+++ b/src/dialogue_win.h
@@ -52,6 +52,11 @@ class dialogue_window
         void clear_history_highlights();
         bool is_computer = false;
         bool is_not_conversation = false;
+        // Remote conversation (intercom, radio). Hides physical-presence
+        // actions (Look at, Assess, etc.) but keeps normal dialogue style.
+        // If remote_name is set, it replaces the NPC name in the header.
+        bool is_remote = false;
+        std::string remote_name;
         bool show_dynamic_line_conditionals = true;
         bool show_dynamic_line_effects = true;
         bool show_response_conditionals = true;

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -67,6 +67,7 @@
 #include "mtype.h"
 #include "mutation.h"
 #include "npc.h"
+#include "npc_class.h"
 #include "omdata.h"
 #include "options.h"
 #include "output.h"
@@ -134,6 +135,8 @@ static const efftype_id effect_strong_antibiotic_visible( "strong_antibiotic_vis
 static const efftype_id effect_teleglow( "teleglow" );
 static const efftype_id effect_tetanus( "tetanus" );
 static const efftype_id effect_weak_antibiotic( "weak_antibiotic" );
+
+static const faction_id faction_robofac( "robofac" );
 
 static const furn_str_id furn_f_arcfurnace_empty( "f_arcfurnace_empty" );
 static const furn_str_id furn_f_arcfurnace_full( "f_arcfurnace_full" );
@@ -300,6 +303,7 @@ static const trait_id trait_ESPER_ADVANCEMENT_OKAY( "ESPER_ADVANCEMENT_OKAY" );
 static const trait_id trait_ESPER_STARTER_ADVANCEMENT_OKAY( "ESPER_STARTER_ADVANCEMENT_OKAY" );
 static const trait_id trait_ILLITERATE( "ILLITERATE" );
 static const trait_id trait_INSECT_ARMS_OK( "INSECT_ARMS_OK" );
+static const trait_id trait_INTERCOM_OPERATOR( "INTERCOM_OPERATOR" );
 static const trait_id trait_M_DEFENDER( "M_DEFENDER" );
 static const trait_id trait_M_DEPENDENT( "M_DEPENDENT" );
 static const trait_id trait_M_FERTILE( "M_FERTILE" );
@@ -1447,16 +1451,48 @@ void iexamine::intercom_balthazar( Character &you, const tripoint_bub_ms &examp 
     }
 }
 
+npc *find_intercom_operator( const trait_id &marker_trait,
+                             const faction_id &fac_id )
+{
+    npc *fallback = nullptr;
+    for( npc *guy : g->get_npcs_if( [&marker_trait, &fac_id]( const npc & n ) {
+    return n.has_trait( marker_trait ) &&
+               n.get_faction() && n.get_faction()->id == fac_id &&
+               !n.in_sleep_state();
+    } ) ) {
+        if( !guy->myclass.is_null() ) {
+            const auto &[start, end] = guy->myclass.obj().get_work_hours();
+            const int hour = to_hours<int>( time_past_midnight( calendar::turn ) );
+            if( is_within_work_hours( hour, start, end ) ) {
+                return guy;
+            }
+        }
+        if( !fallback ) {
+            fallback = guy;
+        }
+    }
+    return fallback;
+}
+
 void iexamine::intercom( Character &you, const tripoint_bub_ms &examp )
 {
-    const std::vector<npc *> intercom_npcs = g->get_npcs_if( [examp]( const npc & guy ) {
-        return guy.myclass == NC_ROBOFAC_INTERCOM && rl_dist( guy.pos_bub(), examp ) < 10;
-    } );
-    if( intercom_npcs.empty() ) {
+    // Prefer trait-based operators (new worlds with shift rotation)
+    npc *op = find_intercom_operator( trait_INTERCOM_OPERATOR, faction_robofac );
+    if( !op ) {
+        // Legacy fallback: old class-based NPC (existing saves).
+        // Preserves original 10-tile distance check.
+        const std::vector<npc *> legacy = g->get_npcs_if( [examp]( const npc & n ) {
+            return n.myclass == NC_ROBOFAC_INTERCOM && rl_dist( n.pos_bub(), examp ) < 10;
+        } );
+        if( !legacy.empty() ) {
+            op = legacy.front();
+        }
+    }
+    if( !op ) {
         you.add_msg_if_player( m_info, _( "No one responds." ) );
     } else {
-        // TODO: This needs to be converted a talker_console or something
-        get_avatar().talk_to( get_talker_for( *intercom_npcs.front() ), false );
+        get_avatar().talk_to( get_talker_for( *op ), false, false, false, "",
+                              _( "the intercom" ) );
     }
 }
 

--- a/src/iexamine.h
+++ b/src/iexamine.h
@@ -19,6 +19,7 @@ class JsonObject;
 class item;
 class item_location;
 class map;
+class npc;
 class time_point;
 class vpart_reference;
 struct itype;
@@ -195,5 +196,11 @@ struct iexamine_functions {
 };
 
 iexamine_functions iexamine_functions_from_string( const std::string &function_name );
+
+// Find the best available intercom operator for a faction.
+// Prefers on-shift, awake operators. Falls back to any awake operator.
+// Returns nullptr if no operator is found.
+npc *find_intercom_operator( const trait_id &marker_trait,
+                             const faction_id &fac_id );
 
 #endif // CATA_SRC_IEXAMINE_H

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -89,11 +89,14 @@
 #include "vpart_position.h"
 #include "weather.h"
 
+static const activity_id ACT_TRY_SLEEP( "ACT_TRY_SLEEP" );
+
 static const efftype_id effect_bouldering( "bouldering" );
 static const efftype_id effect_controlled( "controlled" );
 static const efftype_id effect_drunk( "drunk" );
 static const efftype_id effect_high( "high" );
 static const efftype_id effect_infection( "infection" );
+static const efftype_id effect_lying_down( "lying_down" );
 static const efftype_id effect_mending( "mending" );
 static const efftype_id effect_npc_flee_player( "npc_flee_player" );
 static const efftype_id effect_npc_suspend( "npc_suspend" );
@@ -162,9 +165,11 @@ static const skill_id skill_unarmed( "unarmed" );
 static const trait_id trait_BEE( "BEE" );
 static const trait_id trait_DEBUG_MIND_CONTROL( "DEBUG_MIND_CONTROL" );
 static const trait_id trait_HALLUCINATION( "HALLUCINATION" );
+static const trait_id trait_INTERCOM_OPERATOR( "INTERCOM_OPERATOR" );
 static const trait_id trait_NO_BASH( "NO_BASH" );
 static const trait_id trait_PROF_DICEMASTER( "PROF_DICEMASTER" );
 static const trait_id trait_TERRIFYING( "TERRIFYING" );
+static const trait_id trait_TRADE_BACKEND( "TRADE_BACKEND" );
 
 static void starting_clothes( npc &who, const npc_class_id &type, bool male );
 static void starting_inv( npc &who, const npc_class_id &type );
@@ -2303,6 +2308,82 @@ bool npc::is_shopkeeper() const
     return !is_player_ally() && !myclass->get_shopkeeper_items().empty();
 }
 
+npc &npc::get_trade_delegate()
+{
+    if( !has_trait( trait_INTERCOM_OPERATOR ) ) {
+        return *this;
+    }
+    const faction_id fac = get_fac_id();
+    for( npc *guy : g->get_npcs_if( [&fac]( const npc & n ) {
+    return n.has_trait( trait_TRADE_BACKEND ) &&
+               n.get_fac_id() == fac;
+    } ) ) {
+        return *guy;
+    }
+    return *this;
+}
+
+void npc::reconcile_schedule()
+{
+    if( myclass.is_null() ) {
+        return;
+    }
+    const auto &[shift_start, shift_end] = myclass.obj().get_work_hours();
+    if( shift_start == 0 && shift_end == 24 ) {
+        return;
+    }
+    const int hour = to_hours<int>( time_past_midnight( calendar::turn ) );
+    const bool on_shift = is_within_work_hours( hour, shift_start, shift_end );
+
+    if( on_shift && in_sleep_state() ) {
+        remove_effect( effect_sleep );
+        remove_effect( effect_lying_down );
+        remove_effect( effect_npc_suspend );
+        if( activity.id() == ACT_TRY_SLEEP ) {
+            activity.set_to_null();
+        }
+        if( !needs_food() ) {
+            set_sleepiness( 0 );
+        }
+        ai_cache.committed_goal.clear();
+    } else if( !on_shift && !in_sleep_state() && !needs_food() ) {
+        if( get_sleepiness() < static_cast<int>( sleepiness_levels::TIRED ) ) {
+            set_sleepiness( sleepiness_levels::TIRED );
+        }
+    }
+}
+
+void npc::reconcile_schedule_on_load()
+{
+    reconcile_schedule();
+
+    if( needs_food() || myclass.is_null() ) {
+        return;
+    }
+    const auto &[shift_start, shift_end] = myclass.obj().get_work_hours();
+    if( shift_start == 0 && shift_end == 24 ) {
+        return;
+    }
+    const int hour = to_hours<int>( time_past_midnight( calendar::turn ) );
+    const int minute = to_minutes<int>( time_past_midnight( calendar::turn ) ) % 60;
+    const int now_mins = hour * 60 + minute;
+    const int start_mins = shift_start * 60;
+    const int end_mins = shift_end * 60;
+    const bool wraps = shift_start > shift_end;
+    const bool on_shift = wraps ? ( now_mins >= start_mins || now_mins < end_mins )
+                          : ( now_mins >= start_mins && now_mins < end_mins );
+    const int shift_len = wraps ? ( 24 * 60 - start_mins + end_mins )
+                          : ( end_mins - start_mins );
+
+    if( on_shift && shift_len > 0 ) {
+        int mins_in = wraps && now_mins < start_mins
+                      ? ( 24 * 60 - start_mins + now_mins )
+                      : ( now_mins - start_mins );
+        int expected = mins_in * static_cast<int>( sleepiness_levels::TIRED ) / shift_len;
+        set_sleepiness( expected );
+    }
+}
+
 int npc::minimum_item_value() const
 {
     // TODO: Base on inventory
@@ -3297,6 +3378,7 @@ void npc::npc_update_body()
         update_body( last_updated, calendar::turn );
         last_updated = calendar::turn;
         update_bodytemp_and_wetness();
+        reconcile_schedule();
     }
 }
 
@@ -3393,6 +3475,7 @@ void npc::on_load( map *here )
         hallucination = true;
     }
     effect_on_conditions::load_existing_character( *this );
+    reconcile_schedule_on_load();
     shop_restock();
 }
 

--- a/src/npc.h
+++ b/src/npc.h
@@ -556,6 +556,9 @@ struct npc_short_term_cache {
     std::vector<weak_ptr_fast<Creature>> friends;
     std::vector<sphere> dangerous_explosives;
     std::map<direction, float> threat_map;
+    // BT goal commitment: persists across turns until completed or
+    // overridden by a higher-priority goal. Empty = no commitment.
+    std::string committed_goal;
     // Cache of locations the NPC has searched recently in npc::find_item()
     lru_cache<tripoint_abs_ms, int> searched_tiles;
     // returns the value of the distance between a friendly creature and the closest enemy to that
@@ -942,6 +945,16 @@ class npc : public Character
         time_point restock_time() const;
         std::string get_restock_interval() const;
         bool is_shopkeeper() const;
+        // Return the NPC who should actually handle trade for this NPC.
+        // Default: self. Intercom operators delegate to the supply clerk.
+        npc &get_trade_delegate();
+        // Reconcile shift-based schedule state. Wakes sleeping NPCs at
+        // shift start, floors sleepiness off-shift for !needs_food() NPCs.
+        // Called from npc_update_body() (in-bubble) and on_load() (off-bubble).
+        void reconcile_schedule();
+        // reconcile_schedule() plus coarse sleepiness correction for
+        // !needs_food() NPCs based on shift position. For on_load() only.
+        void reconcile_schedule_on_load();
         // Use and assessment of items
         // The minimum value to want to pick up an item
         int minimum_item_value() const;
@@ -1384,6 +1397,12 @@ class npc : public Character
         std::optional<tripoint_abs_ms> get_ai_guard_pos() const {
             return ai_cache.guard_pos;
         }
+        const std::string &get_committed_goal() const {
+            return ai_cache.committed_goal;
+        }
+        void set_committed_goal( const std::string &goal ) {
+            ai_cache.committed_goal = goal;
+        }
         // Effective guard position: ai_cache (ephemeral, from sound investigation)
         // falls back to persistent guard_pos (from mission/dialogue assignment).
         std::optional<tripoint_abs_ms> get_effective_guard_pos() const {
@@ -1391,6 +1410,14 @@ class npc : public Character
                 return ai_cache.guard_pos;
             }
             return guard_pos;
+        }
+        void clear_ai_guard_pos() {
+            ai_cache.guard_pos = std::nullopt;
+        }
+        // Set cache guard_pos without touching persistent guard_pos.
+        // Used for temporary anchors like sound investigation targets.
+        void set_ai_guard_pos( const tripoint_abs_ms &p ) {
+            ai_cache.guard_pos = p;
         }
         void push_ai_sound_alert( const tripoint_abs_ms &pos, sounds::sound_t type, int vol ) {
             ai_cache.sound_alerts.push_back( { pos, type, vol } );

--- a/src/npc_class.cpp
+++ b/src/npc_class.cpp
@@ -271,6 +271,10 @@ void npc_class::load( const JsonObject &jo, std::string_view )
     optional( jo, was_loaded, SHOPKEEPER_WHITELIST, shop_whitelist_id,
               shopkeeper_whitelist_id::NULL_ID() );
     optional( jo, was_loaded, "restock_interval", restock_interval, 6_days );
+    if( jo.has_array( "work_hours" ) ) {
+        JsonArray arr = jo.get_array( "work_hours" );
+        work_hours_ = { arr.get_int( 0 ), arr.get_int( 1 ) };
+    }
     optional( jo, was_loaded, "worn_override", worn_override );
     optional( jo, was_loaded, "carry_override", carry_override );
     optional( jo, was_loaded, "weapon_override", weapon_override );
@@ -424,6 +428,20 @@ faction_price_rule const *npc_class::get_price_rules( item const &it, npc const 
 const time_duration &npc_class::get_shop_restock_interval() const
 {
     return restock_interval;
+}
+
+const std::pair<int, int> &npc_class::get_work_hours() const
+{
+    return work_hours_;
+}
+
+bool is_within_work_hours( int hour, int start, int end )
+{
+    if( start <= end ) {
+        return hour >= start && hour < end;
+    }
+    // wraps midnight
+    return hour >= start || hour < end;
 }
 
 int npc_class::roll_strength() const

--- a/src/npc_class.h
+++ b/src/npc_class.h
@@ -104,6 +104,9 @@ class npc_class
         shopkeeper_blacklist_id shop_blacklist_id = shopkeeper_blacklist_id::NULL_ID();
         shopkeeper_whitelist_id shop_whitelist_id = shopkeeper_whitelist_id::NULL_ID();
         time_duration restock_interval = 6_days;
+        // Work shift hours [start, end). Default [0,24] = always on duty.
+        // Wraps midnight: [22,6] means 10pm-6am.
+        std::pair<int, int> work_hours_ = { 0, 24 };
 
     public:
         npc_class_id id;
@@ -151,6 +154,7 @@ class npc_class
             return !shop_whitelist_id.is_null();
         };
         const time_duration &get_shop_restock_interval() const;
+        const std::pair<int, int> &get_work_hours() const;
         faction_price_rule const *get_price_rules( item const &it, npc const &guy ) const;
 
         bool is_common() const;
@@ -170,5 +174,9 @@ class npc_class
 
         static void check_consistency();
 };
+
+// Check if an hour falls within [start, end) work hours,
+// handling midnight wrap (e.g., [22, 6) means 10pm to 6am).
+bool is_within_work_hours( int hour, int start, int end );
 
 #endif // CATA_SRC_NPC_CLASS_H

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -175,6 +175,7 @@ static const efftype_id effect_npc_flee_player( "npc_flee_player" );
 static const efftype_id effect_npc_player_still_looking( "npc_player_still_looking" );
 static const efftype_id effect_npc_run_away( "npc_run_away" );
 static const efftype_id effect_psi_stunned( "psi_stunned" );
+static const efftype_id effect_sleep( "sleep" );
 static const efftype_id effect_stumbled_into_invisible( "stumbled_into_invisible" );
 static const efftype_id effect_stunned( "stunned" );
 
@@ -199,6 +200,7 @@ static const string_id<behavior::node_t> behavior_node_t_npc_decision( "npc_deci
 static const string_id<behavior::node_t> behavior_node_t_npc_needs( "npc_needs" );
 
 static const trait_id trait_IGNORE_SOUND( "IGNORE_SOUND" );
+static const trait_id trait_NPC_STASIS( "NPC_STASIS" );
 static const trait_id trait_RETURN_TO_START_POS( "RETURN_TO_START_POS" );
 static const trait_id trait_SAPROPHAGE( "SAPROPHAGE" );
 static const trait_id trait_SAPROVORE( "SAPROVORE" );
@@ -276,7 +278,7 @@ decision_category bt_goal_to_category( const std::string &goal )
         goal == "wear_warmer_clothes" || goal == "take_shelter" || goal == "start_fire" ) {
         return decision_category::needs;
     }
-    if( goal == "return_to_guard_pos" ) {
+    if( goal == "return_to_guard_pos" || goal == "hold_position" ) {
         return decision_category::duty;
     }
     if( goal == "idle" ) {
@@ -1386,9 +1388,14 @@ void npc::regen_ai_cache()
     auto i = std::begin( ai_cache.sound_alerts );
     creature_tracker &creatures = get_creature_tracker();
     if( has_trait( trait_RETURN_TO_START_POS ) ) {
-        if( !ai_cache.guard_pos ) {
-            ai_cache.guard_pos = pos_abs();
+        if( !guard_pos ) {
+            guard_pos = pos_abs();
         }
+    }
+    // Any NPC with persistent guard_pos gets it re-filled into cache.
+    // Covers RETURN_TO_START_POS, dialogue-assigned guards, and any future source.
+    if( !ai_cache.guard_pos && guard_pos ) {
+        ai_cache.guard_pos = guard_pos;
     }
     while( i != std::end( ai_cache.sound_alerts ) ) {
         if( sees( here,  here.get_bub( tripoint_abs_ms( i->abs_pos ) ) ) ) {
@@ -1483,6 +1490,11 @@ void npc::move()
     // NPCs under operation or casting spells should just stay still
     if( activity.id() == ACT_OPERATION || activity.id() == ACT_SPELLCASTING ) {
         execute_action( npc_player_activity );
+        return;
+    }
+    // Stasis NPCs are completely inert until activated via dialogue.
+    if( has_trait( trait_NPC_STASIS ) ) {
+        move_pause();
         return;
     }
     act_on_danger_assessment();
@@ -1588,56 +1600,133 @@ void npc::move()
         action = method_of_attack();
     } else if( !ai_cache.sound_alerts.empty() && !is_walking_with() &&
                !has_flag( json_flag_CANNOT_MOVE ) ) {
-        tripoint_abs_ms cur_s_abs_pos = ai_cache.s_abs_pos;
-        if( !ai_cache.guard_pos ) {
-            ai_cache.guard_pos = pos_abs();
-        }
-        if( ai_cache.sound_alerts.size() > 1 ) {
-            std::sort( ai_cache.sound_alerts.begin(), ai_cache.sound_alerts.end(),
-                       compare_sound_alert );
-            if( ai_cache.sound_alerts.size() > 10 ) {
-                ai_cache.sound_alerts.resize( 10 );
-            }
-        }
-        if( has_trait( trait_IGNORE_SOUND ) ) { //Do not investigate sounds - clear sound alerts as below
+        if( has_trait( trait_IGNORE_SOUND ) ) {
+            // Discard alerts and fall through to BT/needs below.
+            // Hard-coding npc_return_to_guard_pos here would fight the
+            // BT sleep goal when ambient sounds keep refilling the queue.
             ai_cache.sound_alerts.clear();
-            action = npc_return_to_guard_pos;
         } else {
+            tripoint_abs_ms cur_s_abs_pos = ai_cache.s_abs_pos;
+            if( !ai_cache.guard_pos ) {
+                ai_cache.guard_pos = pos_abs();
+            }
+            if( ai_cache.sound_alerts.size() > 1 ) {
+                std::sort( ai_cache.sound_alerts.begin(), ai_cache.sound_alerts.end(),
+                           compare_sound_alert );
+                if( ai_cache.sound_alerts.size() > 10 ) {
+                    ai_cache.sound_alerts.resize( 10 );
+                }
+            }
             action = npc_investigate_sound;
-        }
-        if( ai_cache.sound_alerts.front().abs_pos != cur_s_abs_pos ) {
-            ai_cache.stuck = 0;
-            ai_cache.s_abs_pos = ai_cache.sound_alerts.front().abs_pos;
-        } else if( ai_cache.stuck > 10 ) {
-            ai_cache.stuck = 0;
-            if( ai_cache.sound_alerts.size() == 1 ) {
-                ai_cache.sound_alerts.clear();
-                action = npc_return_to_guard_pos;
-            } else {
-                ai_cache.s_abs_pos = ai_cache.sound_alerts.at( 1 ).abs_pos;
+            if( ai_cache.sound_alerts.front().abs_pos != cur_s_abs_pos ) {
+                ai_cache.stuck = 0;
+                ai_cache.s_abs_pos = ai_cache.sound_alerts.front().abs_pos;
+            } else if( ai_cache.stuck > 10 ) {
+                ai_cache.stuck = 0;
+                if( ai_cache.sound_alerts.size() == 1 ) {
+                    ai_cache.sound_alerts.clear();
+                    action = npc_return_to_guard_pos;
+                } else {
+                    ai_cache.s_abs_pos = ai_cache.sound_alerts.at( 1 ).abs_pos;
+                }
+            }
+            if( action == npc_investigate_sound ) {
+                add_msg_debug( debugmode::DF_NPC, "NPC %s: investigating sound at x(%d) y(%d)", get_name(),
+                               ai_cache.s_abs_pos.x(), ai_cache.s_abs_pos.y() );
             }
         }
-        if( action == npc_investigate_sound ) {
-            add_msg_debug( debugmode::DF_NPC, "NPC %s: investigating sound at x(%d) y(%d)", get_name(),
-                           ai_cache.s_abs_pos.x(), ai_cache.s_abs_pos.y() );
-        }
-    } else {
+    }
+    if( action == npc_undecided ) {
         // No present danger
         cleanup_on_no_danger();
 
-        action = address_needs();
+        // Duty NPCs with a guard post: let BT arbitrate needs vs duty.
+        // The BT evaluates every turn but committed goals persist until
+        // completed or overridden by a higher-priority category
+        // (combat > investigation > needs/duty > idle).
+        bool bt_dispatched = false;
+        if( ( mission == NPC_MISSION_SHOPKEEP || mission == NPC_MISSION_GUARD ||
+              mission == NPC_MISSION_GUARD_PATROL ) && get_effective_guard_pos() ) {
+            bt_dispatched = true;
+            behavior::character_oracle_t oracle( this );
+            behavior::tree decision_tree;
+            decision_tree.add( &behavior_node_t_npc_decision.obj() );
+            std::string new_goal = decision_tree.tick( &oracle );
+
+            // Goal commitment: prevent flip-flopping between goals.
+            std::string &committed = ai_cache.committed_goal;
+            if( !committed.empty() ) {
+                // Check if committed goal is completed.
+                bool completed_goal = false;
+                if( committed == "return_to_guard_pos" ) {
+                    std::optional<tripoint_abs_ms> gp = get_effective_guard_pos();
+                    completed_goal = gp && pos_abs() == *gp;
+                } else if( committed == "hold_position" ) {
+                    // Persists only while BT keeps returning hold_position.
+                    // Off-shift (BT returns idle) or displaced (return_to_guard_pos):
+                    // the commitment clears and the fresh goal takes over.
+                    completed_goal = ( new_goal != "hold_position" );
+                } else if( committed == "go_to_sleep" ) {
+                    completed_goal = has_effect( effect_sleep ) ||
+                                     get_sleepiness() < static_cast<int>( sleepiness_levels::TIRED );
+                    // BT no longer wants sleep specifically: context changed
+                    // (shift started, or a more urgent need appeared).
+                    // If genuinely exhausted, BT still returns go_to_sleep
+                    // and commitment persists.
+                    if( !completed_goal ) {
+                        completed_goal = ( new_goal != "go_to_sleep" );
+                    }
+                }
+                if( completed_goal ) {
+                    committed.clear();
+                } else {
+                    // Override only if new goal is strictly higher priority.
+                    decision_category new_cat = bt_goal_to_category( new_goal );
+                    decision_category old_cat = bt_goal_to_category( committed );
+                    if( new_cat < old_cat ) {
+                        committed = new_goal;
+                    } else {
+                        new_goal = committed;
+                    }
+                }
+            } else if( new_goal != "idle" ) {
+                committed = new_goal;
+            }
+
+            // Dispatch based on the (possibly committed) goal.
+            if( new_goal == "return_to_guard_pos" ) {
+                if( !ai_cache.guard_pos ) {
+                    ai_cache.guard_pos = get_effective_guard_pos();
+                }
+                action = npc_return_to_guard_pos;
+            } else if( new_goal == "hold_position" || new_goal == "idle" ) {
+                // At post (on shift or idle). High danger parameter
+                // prevents address_needs from sending NPC to wander.
+                action = address_needs( NPC_DANGER_VERY_LOW + 1 );
+            } else {
+                // Needs goal (sleep, eat, drink, etc.). Full address_needs.
+                action = address_needs();
+            }
+        } else {
+            action = address_needs();
+        }
         print_action( "address_needs %s", action );
 
         if( action == npc_undecided ) {
             action = address_player();
             print_action( "address_player %s", action );
         }
-        if( action == npc_undecided && ai_cache.sound_alerts.empty() && ai_cache.guard_pos &&
+        if( action == npc_undecided && !bt_dispatched && ai_cache.sound_alerts.empty() &&
             !has_flag( json_flag_CANNOT_MOVE ) ) {
-            tripoint_abs_ms return_guard_pos = *ai_cache.guard_pos;
-            add_msg_debug( debugmode::DF_NPC, "NPC %s: returning to guard spot at x(%d) y(%d)", get_name(),
-                           return_guard_pos.x(), return_guard_pos.y() );
-            action = npc_return_to_guard_pos;
+            std::optional<tripoint_abs_ms> effective = get_effective_guard_pos();
+            if( effective && pos_abs() != *effective ) {
+                if( !ai_cache.guard_pos ) {
+                    ai_cache.guard_pos = effective;
+                }
+                add_msg_debug( debugmode::DF_NPC, "NPC %s: returning to guard spot at x(%d) y(%d)",
+                               get_name(), effective->x(), effective->y() );
+                action = npc_return_to_guard_pos;
+            }
         }
     }
 
@@ -1832,11 +1921,14 @@ void npc::execute_action( npc_action action )
         break;
 
         case npc_return_to_guard_pos: {
-            const tripoint_bub_ms local_guard_pos = here.get_bub( *ai_cache.guard_pos );
+            const tripoint_abs_ms effective = ai_cache.guard_pos ? *ai_cache.guard_pos
+                                              : ( guard_pos ? *guard_pos : pos_abs() );
+            const tripoint_bub_ms local_guard_pos = here.get_bub( effective );
             update_path( local_guard_pos );
             if( pos_bub() == local_guard_pos || path.empty() ) {
                 move_pause();
                 ai_cache.guard_pos = std::nullopt;
+                // Persistent guard_pos stays; regen_ai_cache re-fills cache next turn.
                 path.clear();
             } else {
                 move_to_next();
@@ -1846,52 +1938,66 @@ void npc::execute_action( npc_action action )
 
         case npc_sleep: {
             // TODO: Allow stims when not too tired
-            // Find a nice spot to sleep
-            tripoint_bub_ms best_spot = pos_bub();
-            int best_sleepy = is_valid_sleep_candidate( pos_bub() )
-                              ? evaluate_sleep_spot( best_spot )
-                              : INT_MIN;
-
-            // first build a list of positions to search
-            std::vector<tripoint_bub_ms> search_positions;
-
-            if( is_walking_with() && player_character.in_vehicle && player_character.in_sleep_state() ) {
-                const optional_vpart_position player_part_pos = here.veh_at( player_character.pos_bub() );
-                if( player_part_pos ) {
-                    vehicle *player_vehicle = &player_part_pos->vehicle();
-                    for( const vpart_reference &part : player_vehicle->get_avail_parts( VPFLAG_BOARDABLE ) ) {
-                        search_positions.push_back( player_vehicle->bub_part_pos( here, part.part() ) );
-                    }
+            // If we already have a path to a good sleep spot, keep following
+            // it instead of re-searching. Re-searching every turn causes
+            // oscillation when two beds are equidistant.
+            bool keep_existing_path = false;
+            if( !path.empty() ) {
+                const tripoint_bub_ms &dest = path.back();
+                if( is_valid_sleep_candidate( dest ) && g->is_empty( dest ) &&
+                    evaluate_sleep_spot( dest ) > INT_MIN ) {
+                    keep_existing_path = true;
                 }
             }
 
-            if( search_positions.empty() ) {
-                search_positions = closest_points_first( pos_bub(), MAX_VIEW_DISTANCE );
-            }
+            if( !keep_existing_path ) {
+                // Find a nice spot to sleep
+                tripoint_bub_ms best_spot = pos_bub();
+                int best_sleepy = is_valid_sleep_candidate( pos_bub() )
+                                  ? evaluate_sleep_spot( best_spot )
+                                  : INT_MIN;
 
+                // first build a list of positions to search
+                std::vector<tripoint_bub_ms> search_positions;
 
-            // then search through all positions to find the best sleep spot
-            for( const tripoint_bub_ms &p : search_positions ) {
-                if( !could_move_onto( p ) || !g->is_empty( p ) ) {
-                    continue;
-                }
-
-                // For non-mutants, very_comfortable-1 is the expected value of an ideal normal bed.
-                if( best_sleepy < comfort_data::COMFORT_VERY_COMFORTABLE - 1 ) {
-                    const int sleepy = evaluate_sleep_spot( p );
-                    if( sleepy > best_sleepy && is_valid_sleep_candidate( p ) ) {
-                        best_sleepy = sleepy;
-                        best_spot = p;
+                if( is_walking_with() && player_character.in_vehicle && player_character.in_sleep_state() ) {
+                    const optional_vpart_position player_part_pos = here.veh_at( player_character.pos_bub() );
+                    if( player_part_pos ) {
+                        vehicle *player_vehicle = &player_part_pos->vehicle();
+                        for( const vpart_reference &part : player_vehicle->get_avail_parts( VPFLAG_BOARDABLE ) ) {
+                            search_positions.push_back( player_vehicle->bub_part_pos( here, part.part() ) );
+                        }
                     }
                 }
+
+                if( search_positions.empty() ) {
+                    search_positions = closest_points_first( pos_bub(), MAX_VIEW_DISTANCE );
+                }
+
+                // then search through all positions to find the best sleep spot
+                for( const tripoint_bub_ms &p : search_positions ) {
+                    if( !could_move_onto( p ) || !g->is_empty( p ) ) {
+                        continue;
+                    }
+
+                    // For non-mutants, very_comfortable-1 is the expected value of an ideal normal bed.
+                    if( best_sleepy < comfort_data::COMFORT_VERY_COMFORTABLE - 1 ) {
+                        const int sleepy = evaluate_sleep_spot( p );
+                        if( sleepy > best_sleepy && is_valid_sleep_candidate( p ) ) {
+                            best_sleepy = sleepy;
+                            best_spot = p;
+                        }
+                    }
+                }
+
+                update_path( best_spot, true );
             }
 
             if( is_walking_with() ) {
                 complain_about( "napping", 30_minutes, chat_snippets().snip_warn_sleep.translated() );
             }
-            update_path( best_spot, true );
             // TODO: Handle empty path better
-            if( best_spot == pos_bub() || path.empty() ) {
+            if( path.empty() ) {
                 move_pause();
                 if( !in_sleep_state() ) {
                     activate_bionic_by_id( bio_soporific );
@@ -3250,6 +3356,7 @@ bool npc::update_path( const tripoint_bub_ms &p, const bool no_bashing, bool for
 
 void npc::set_guard_pos( const tripoint_abs_ms &p )
 {
+    guard_pos = p;
     ai_cache.guard_pos = p;
 }
 

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1643,7 +1643,8 @@ static std::string bye_message( const npc *npc_actor )
 }
 
 void avatar::talk_to( std::unique_ptr<talker> talk_with, bool radio_contact,
-                      bool is_computer, bool is_not_conversation, const std::string &debug_topic )
+                      bool is_computer, bool is_not_conversation, const std::string &debug_topic,
+                      const std::string &remote_name )
 {
     const bool has_mind_control = has_trait( trait_DEBUG_MIND_CONTROL );
     const bool force_topic = !debug_topic.empty();
@@ -1653,6 +1654,7 @@ void avatar::talk_to( std::unique_ptr<talker> talk_with, bool radio_contact,
     dialogue d( get_talker_for( *this ), std::move( talk_with ), {} );
     d.by_radio = radio_contact;
     dialogue_by_radio = radio_contact;
+    dialogue_remote_name = remote_name;
     d.actor( true )->check_missions();
     for( mission *&mission : d.actor( true )->assigned_missions() ) {
         if( mission->get_assigned_player_id() == getID() ) {
@@ -1672,6 +1674,10 @@ void avatar::talk_to( std::unique_ptr<talker> talk_with, bool radio_contact,
     dialogue_window d_win;
     d_win.is_computer = is_computer;
     d_win.is_not_conversation = is_not_conversation;
+    if( !remote_name.empty() ) {
+        d_win.is_remote = true;
+        d_win.remote_name = remote_name;
+    }
     // Main dialogue loop
     do {
         d.actor( true )->update_missions( d.missions_assigned );
@@ -1689,6 +1695,7 @@ void avatar::talk_to( std::unique_ptr<talker> talk_with, bool radio_contact,
             d.add_topic( next );
         }
     } while( !d.done );
+    dialogue_remote_name.clear();
 
     if( activity.id() == ACT_AIM && !has_weapon() ) {
         cancel_activity();
@@ -1704,6 +1711,17 @@ void avatar::talk_to( std::unique_ptr<talker> talk_with, bool radio_contact,
                                             string_format( _( "%s talked to you." ),
                                                     d.actor( true )->disp_name() ) );
     }
+}
+
+std::string dialogue::speaker_name( const dialogue_window &d_win ) const
+{
+    if( d_win.is_not_conversation ) {
+        return "";
+    }
+    if( !d_win.remote_name.empty() ) {
+        return d_win.remote_name;
+    }
+    return actor( true )->disp_name();
 }
 
 std::string dialogue::dynamic_line( const talk_topic &the_topic )
@@ -2959,12 +2977,13 @@ talk_topic dialogue::opt( dialogue_window &d_win, const talk_topic &topic )
         d_win.add_to_history( challenge );
     } else if( challenge[0] == '*' ) {
         // Prepend name
-        challenge = string_format( pgettext( "npc does something", "%s %s" ), actor( true )->disp_name(),
+        challenge = string_format( pgettext( "npc does something", "%s %s" ),
+                                   speaker_name( d_win ),
                                    challenge.substr( 1 ) );
         d_win.add_to_history( challenge );
     } else {
         npc *npc_actor = actor( true )->get_npc();
-        d_win.add_to_history( challenge, d_win.is_not_conversation ? "" : actor( true )->disp_name(),
+        d_win.add_to_history( challenge, speaker_name( d_win ),
                               npc_actor ? npc_actor->basic_symbol_color() : c_red );
     }
     if( debug_mode ) {
@@ -3015,7 +3034,7 @@ talk_topic dialogue::opt( dialogue_window &d_win, const talk_topic &topic )
     generate_response_lines();
 
     ui.on_redraw( [&]( const ui_adaptor & ) {
-        d_win.draw( d_win.is_not_conversation ? "" : actor( true )->disp_name() );
+        d_win.draw( speaker_name( d_win ) );
     } );
 
     size_t response_ind = response_hotkeys.size();

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -224,7 +224,7 @@ void spawn_animal( npc &p, const mtype_id &mon )
 
 void talk_function::start_trade( npc &p )
 {
-    npc_trading::trade( p, 0, _( "Trade" ) );
+    npc_trading::trade( p.get_trade_delegate(), 0, _( "Trade" ) );
 }
 
 void talk_function::sort_loot( npc &p )

--- a/src/pathfinding.cpp
+++ b/src/pathfinding.cpp
@@ -322,13 +322,21 @@ int map::cost_to_pass( const tripoint_bub_ms &cur, const tripoint_bub_ms &p,
     }
 
     // If it's a door and we can open it from the tile we're on, cool.
+    // But only if opening actually makes the tile passable. Shutters over
+    // reinforced glass open to reveal impassable glass -- no point opening.
     if( allow_open_doors && ( terrain.open || furniture.open ) &&
         ( ( !terrain.has_flag( ter_furn_flag::TFLAG_OPENCLOSE_INSIDE ) &&
             !furniture.has_flag( ter_furn_flag::TFLAG_OPENCLOSE_INSIDE ) ) ||
           !is_outside( cur ) ) ) {
-        // Only try to open INSIDE doors from the inside
-        // To open and then move onto the tile
-        return 4;
+        // Check that opening leads to a passable tile (or a tile that can
+        // itself be opened, like curtains over a window).
+        const ter_t &opened_ter = terrain.open ? *terrain.open : terrain;
+        const furn_t &opened_furn = furniture.open ? *furniture.open : furniture;
+        if( opened_ter.movecost > 0 || opened_furn.open || opened_ter.open ) {
+            // Only try to open INSIDE doors from the inside
+            // To open and then move onto the tile
+            return 4;
+        }
     }
 
     // Otherwise, if we can bash, we'll consider that.
@@ -348,9 +356,13 @@ int map::cost_to_pass( const tripoint_bub_ms &cur, const tripoint_bub_ms &p,
     }
 
     // If we can open doors generally but couldn't open this one, maybe we can
-    // try from another direction.
-    if( allow_open_doors && terrain.open && furniture.open ) {
-        return PF_IMPASSABLE_FROM_HERE;
+    // try from another direction. But only if opening would actually help.
+    if( allow_open_doors && ( terrain.open || furniture.open ) ) {
+        const ter_t &opened_ter = terrain.open ? *terrain.open : terrain;
+        const furn_t &opened_furn = furniture.open ? *furniture.open : furniture;
+        if( opened_ter.movecost > 0 || opened_furn.open || opened_ter.open ) {
+            return PF_IMPASSABLE_FROM_HERE;
+        }
     }
 
     return PF_IMPASSABLE;

--- a/src/trade_ui.cpp
+++ b/src/trade_ui.cpp
@@ -9,6 +9,7 @@
 #include <set>
 #include <unordered_set>
 
+#include "avatar.h"
 #include "character.h"
 #include "clzones.h"
 #include "color.h"
@@ -36,6 +37,8 @@ static const flag_id json_flag_NO_UNWIELD( "NO_UNWIELD" );
 
 static const item_category_id item_category_ITEMS_WORN( "ITEMS_WORN" );
 static const item_category_id item_category_WEAPON_HELD( "WEAPON_HELD" );
+
+static const trait_id trait_TRADE_BACKEND( "TRADE_BACKEND" );
 
 namespace
 {
@@ -127,7 +130,9 @@ trade_ui::trade_ui( party_t &you, npc &trader, currency_t cost, std::string titl
 {
     _panes[_you]->add_character_items( you );
     _panes[_you]->add_nearby_items( 1 );
-    _panes[_trader]->add_character_items( trader );
+    if( !trader.has_trait( trait_TRADE_BACKEND ) ) {
+        _panes[_trader]->add_character_items( trader );
+    }
     if( trader.is_shopkeeper() ) {
         _panes[_trader]->categorize_map_items( true );
 
@@ -334,7 +339,8 @@ void trade_ui::_draw_header()
                                   format_money( std::abs( _balance ) ) );
     }
     center_print( _header_w, 2, trade_color, cost_str );
-    mvwprintz( _header_w, { 1, 3 }, c_white, _parties[_trader]->get_name() );
+    const std::string &rname = get_avatar().dialogue_remote_name;
+    mvwprintz( _header_w, { 1, 3 }, c_white, rname.empty() ? _parties[_trader]->get_name() : rname );
     right_print( _header_w, 3, 1, c_white, _( "You" ) );
     center_print( _header_w, header_size - 1, c_white,
                   string_format( _( "%s to switch panes" ),

--- a/tests/behavior_test.cpp
+++ b/tests/behavior_test.cpp
@@ -360,14 +360,13 @@ TEST_CASE( "check_npc_behavior_tree", "[npc][behavior]" )
 
         CHECK( npc_needs.tick( &oracle ) == "start_fire" );
     }
-    SECTION( "Dead tired but not exhausted -- sleep not feasible" ) {
-        // needs_sleep_badly fires at DEAD_TIRED (383) but can_sleep
-        // requires EXHAUSTED (575). Between the two, the need exists
-        // but the NPC pushes through.
+    SECTION( "Dead tired -- sleep is feasible" ) {
+        // can_sleep threshold matches needs_sleep_badly at DEAD_TIRED.
+        // Utility scoring handles duty priority, not can_sleep gating.
         test_npc.set_sleepiness( 500 );
         REQUIRE( oracle.needs_sleep_badly( "" ) == behavior::status_t::running );
-        REQUIRE( oracle.can_sleep( "" ) == behavior::status_t::failure );
-        CHECK( npc_needs.tick( &oracle ) == "idle" );
+        REQUIRE( oracle.can_sleep( "" ) == behavior::status_t::running );
+        CHECK( npc_needs.tick( &oracle ) == "go_to_sleep" );
     }
     SECTION( "Exhausted -- sleep is feasible" ) {
         test_npc.set_sleepiness( 600 );
@@ -1032,9 +1031,37 @@ TEST_CASE( "npc_decision_duty_predicates", "[npc][behavior]" )
     SECTION( "duty_urgency zero without post" ) {
         CHECK( oracle.duty_urgency( "" ) == Approx( 0.0f ) );
     }
-    SECTION( "duty_urgency nonzero when displaced" ) {
+    SECTION( "on_shift follows work_hours from npc_class" ) {
+        // Default work_hours [0,24] means always on shift.
+        guy.set_guard_pos( guy.pos_abs() );
+        calendar::turn = calendar::turn_zero + 14_hours;
+        CHECK( oracle.on_shift( "" ) == behavior::status_t::running );
+        calendar::turn = calendar::turn_zero + 2_hours;
+        CHECK( oracle.on_shift( "" ) == behavior::status_t::running );
+    }
+    SECTION( "on_shift requires guard_pos" ) {
+        CHECK( oracle.on_shift( "" ) == behavior::status_t::failure );
+    }
+    SECTION( "duty_urgency on-shift at post" ) {
+        // Default work_hours [0,24]: always on shift.
+        guy.set_guard_pos( guy.pos_abs() );
+        calendar::turn = calendar::turn_zero + 12_hours;
+        CHECK( oracle.duty_urgency( "" ) == Approx( 0.45f ) );
+    }
+    SECTION( "duty_urgency on-shift scales with distance" ) {
+        calendar::turn = calendar::turn_zero + 12_hours;
+
+        guy.set_guard_pos( guy.pos_abs() + tripoint::east );
+        CHECK( oracle.duty_urgency( "" ) == Approx( 0.45f ) );
+
         guy.set_guard_pos( guy.pos_abs() + tripoint( 5, 0, 0 ) );
-        CHECK( oracle.duty_urgency( "" ) > 0.0f );
+        CHECK( oracle.duty_urgency( "" ) == Approx( 0.45f ) );
+
+        guy.set_guard_pos( guy.pos_abs() + tripoint( 10, 0, 0 ) );
+        CHECK( oracle.duty_urgency( "" ) == Approx( 0.5f ) );
+
+        guy.set_guard_pos( guy.pos_abs() + tripoint( 20, 0, 0 ) );
+        CHECK( oracle.duty_urgency( "" ) == Approx( 0.5f ) );
     }
 }
 
@@ -1123,15 +1150,28 @@ TEST_CASE( "npc_decision_tree_priorities", "[npc][behavior]" )
         CHECK( npc_decision.tick( &oracle ) == "go_to_sleep" );
     }
     SECTION( "tired but not exhausted guard stays on duty" ) {
-        // sleepiness 400 -> needs_sleep_badly running, but can_sleep fails
-        // (EXHAUSTED=575). No feasible sleep -> duty wins.
+        // sleepiness 400 -> can_sleep passes (DEAD_TIRED=383), but
+        // sleepiness_urgency(0.4) < duty_urgency(0.5) -> duty wins.
+        // Default work_hours [0,24] means always on shift.
         guy.set_sleepiness( 400 );
         REQUIRE( oracle.needs_sleep_badly( "" ) == behavior::status_t::running );
-        REQUIRE( oracle.can_sleep( "" ) == behavior::status_t::failure );
+        REQUIRE( oracle.can_sleep( "" ) == behavior::status_t::running );
         guy.set_guard_pos( guy.pos_abs() + tripoint( 10, 0, 0 ) );
         CHECK( npc_decision.tick( &oracle ) == "return_to_guard_pos" );
     }
+    SECTION( "on-shift at post beats DEAD_TIRED sleep" ) {
+        // At post during shift: duty 0.45 > sleepiness_urgency 0.383.
+        // Default work_hours [0,24], so NPC is always on shift.
+        guy.set_sleepiness( 383 );
+        REQUIRE( oracle.needs_sleep_badly( "" ) == behavior::status_t::running );
+        REQUIRE( oracle.can_sleep( "" ) == behavior::status_t::running );
+        guy.set_guard_pos( guy.pos_abs() );
+        CHECK( npc_decision.tick( &oracle ) == "hold_position" );
+    }
     SECTION( "idle when nothing fires" ) {
+        // Ensure no stale guard_pos from spawn (random traits may set it).
+        guy.guard_pos = std::nullopt;
+        guy.clear_ai_guard_pos();
         CHECK( npc_decision.tick( &oracle ) == "idle" );
     }
 }
@@ -1197,9 +1237,11 @@ TEST_CASE( "npc_decision_bt_contract_guard_duty", "[npc][behavior]" )
         REQUIRE( oracle.can_sleep( "" ) == behavior::status_t::running );
         CHECK( npc_decision.tick( &oracle ) == "go_to_sleep" );
     }
-    SECTION( "guard at post with no needs: BT returns idle" ) {
+    SECTION( "guard at post on shift: BT returns hold_position" ) {
         guy.set_guard_pos( guy.pos_abs() );
-        CHECK( npc_decision.tick( &oracle ) == "idle" );
+        // Default work_hours [0,24] = always on shift. At post, on shift
+        // means hold_position (duty 0.45 beats any sub-threshold need).
+        CHECK( npc_decision.tick( &oracle ) == "hold_position" );
     }
 }
 
@@ -1210,5 +1252,6 @@ TEST_CASE( "npc_decision_predicates_registered", "[npc][behavior]" )
     CHECK( behavior::predicate_map.count( "npc_has_target" ) == 1 );
     CHECK( behavior::predicate_map.count( "npc_has_sound_alerts" ) == 1 );
     CHECK( behavior::predicate_map.count( "npc_displaced_from_post" ) == 1 );
+    CHECK( behavior::predicate_map.count( "npc_on_shift" ) == 1 );
     CHECK( behavior::score_predicate_map.count( "npc_duty_urgency" ) == 1 );
 }

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -21,6 +21,7 @@
 #include "cata_scope_helpers.h"
 #include "character.h"
 #include "character_attire.h"
+#include "character_id.h"
 #include "character_oracle.h"
 #include "clzones.h"
 #include "common_types.h"
@@ -45,6 +46,7 @@
 #include "map_selector.h"
 #include "memory_fast.h"
 #include "messages.h"
+#include "iexamine.h"
 #include "monster.h"
 #include "npc.h"
 #include "npctalk.h"
@@ -81,6 +83,7 @@ static const efftype_id effect_meth( "meth" );
 static const efftype_id effect_sleep( "sleep" );
 static const efftype_id effect_wet( "wet" );
 
+static const faction_id faction_robofac( "robofac" );
 static const faction_id faction_your_followers( "your_followers" );
 
 static const furn_str_id furn_f_bed( "f_bed" );
@@ -112,6 +115,11 @@ static const itype_id itype_space_cake( "space_cake" );
 static const itype_id itype_sweater( "sweater" );
 static const itype_id itype_water_clean( "water_clean" );
 
+static const npc_class_id NC_ROBOFAC_INTERCOM_DAY( "NC_ROBOFAC_INTERCOM_DAY" );
+static const npc_class_id NC_ROBOFAC_INTERCOM_NIGHT( "NC_ROBOFAC_INTERCOM_NIGHT" );
+static const npc_class_id NC_ROBOFAC_INTERCOM_SUPPLY( "NC_ROBOFAC_INTERCOM_SUPPLY" );
+static const npc_class_id test_shop_class( "test_shop_class" );
+
 static const ter_str_id ter_t_concrete_wall( "t_concrete_wall" );
 static const ter_str_id ter_t_door_c( "t_door_c" );
 static const ter_str_id ter_t_floor( "t_floor" );
@@ -123,8 +131,12 @@ static const ter_str_id ter_t_wall_glass( "t_wall_glass" );
 static const ter_str_id ter_t_water_dispenser( "t_water_dispenser" );
 static const ter_str_id ter_t_water_sh( "t_water_sh" );
 
+static const trait_id trait_IGNORE_SOUND( "IGNORE_SOUND" );
+static const trait_id trait_INTERCOM_OPERATOR( "INTERCOM_OPERATOR" );
+static const trait_id trait_RETURN_TO_START_POS( "RETURN_TO_START_POS" );
 static const trait_id trait_SAPROPHAGE( "SAPROPHAGE" );
 static const trait_id trait_SAPROVORE( "SAPROVORE" );
+static const trait_id trait_TRADE_BACKEND( "TRADE_BACKEND" );
 static const trait_id trait_WEB_WEAVER( "WEB_WEAVER" );
 
 static const vpart_id vpart_cargo_lock( "cargo_lock" );
@@ -2802,4 +2814,862 @@ TEST_CASE( "npc_is_no_go_position", "[npc][needs]" )
 
     mgr.clear();
     mgr.cache_data();
+}
+
+TEST_CASE( "npc_persistent_guard_pos_authority", "[npc][needs]" )
+{
+    clear_map_without_vision();
+    calendar::turn = calendar::turn_zero + 1_hours;
+    map &here = get_map();
+
+    SECTION( "RETURN_TO_START_POS sets persistent guard_pos on first spawn" ) {
+        npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+        clear_character( guy, true );
+        guy.set_mutation( trait_RETURN_TO_START_POS );
+        REQUIRE( guy.has_trait( trait_RETURN_TO_START_POS ) );
+
+        guy.regen_ai_cache();
+
+        CHECK( guy.guard_pos.has_value() );
+        CHECK( *guy.guard_pos == guy.pos_abs() );
+    }
+
+    SECTION( "cache loss re-fills from persistent, not current position" ) {
+        npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+        clear_character( guy, true );
+        guy.set_mutation( trait_RETURN_TO_START_POS );
+
+        guy.regen_ai_cache();
+        const tripoint_abs_ms original_post = guy.pos_abs();
+        REQUIRE( guy.guard_pos == original_post );
+
+        // Move NPC away from post
+        guy.setpos( here, guy.pos_bub() + tripoint( 5, 0, 0 ) );
+        REQUIRE( guy.pos_abs() != original_post );
+
+        // Simulate cache loss
+        guy.clear_ai_guard_pos();
+        REQUIRE_FALSE( guy.get_ai_guard_pos().has_value() );
+
+        guy.regen_ai_cache();
+
+        CHECK( guy.get_ai_guard_pos().has_value() );
+        CHECK( *guy.get_ai_guard_pos() == original_post );
+    }
+
+    SECTION( "set_guard_pos writes both persistent and cache" ) {
+        npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+        clear_character( guy, true );
+        const tripoint_abs_ms duty_post = guy.pos_abs() + tripoint( 10, 0, 0 );
+
+        guy.set_guard_pos( duty_post );
+
+        CHECK( guy.guard_pos == duty_post );
+        CHECK( guy.get_ai_guard_pos() == duty_post );
+
+        // Simulate cache loss and rebuild
+        guy.clear_ai_guard_pos();
+        guy.regen_ai_cache();
+
+        CHECK( guy.get_ai_guard_pos() == duty_post );
+    }
+
+    SECTION( "sound anchor temporarily overrides cache, persistent survives" ) {
+        npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+        clear_character( guy, true );
+        const tripoint_abs_ms permanent_post = guy.pos_abs();
+        guy.guard_pos = permanent_post;
+        guy.regen_ai_cache();
+        REQUIRE( guy.get_ai_guard_pos() == permanent_post );
+
+        // Sound investigation writes a temporary anchor to ai_cache
+        // without touching persistent guard_pos.
+        const tripoint_abs_ms sound_anchor = guy.pos_abs() + tripoint( 10, 0, 0 );
+        guy.set_ai_guard_pos( sound_anchor );
+        CHECK( guy.get_ai_guard_pos() == sound_anchor );
+        CHECK( guy.guard_pos == permanent_post );
+
+        // NPC reaches sound source; cache cleared by execute_action.
+        guy.clear_ai_guard_pos();
+        REQUIRE_FALSE( guy.get_ai_guard_pos().has_value() );
+        // Persistent still untouched.
+        CHECK( guy.guard_pos == permanent_post );
+
+        // Generic refill re-populates cache from persistent.
+        guy.regen_ai_cache();
+        CHECK( guy.get_ai_guard_pos() == permanent_post );
+    }
+}
+
+TEST_CASE( "npc_shopkeeper_sleep_wake_return", "[npc][needs]" )
+{
+    clear_map_without_vision();
+    clear_avatar();
+    calendar::turn = calendar::turn_zero + 1_hours;
+    map &here = get_map();
+    // Move player underground so they don't interact with NPC at all
+    get_player_character().setpos( here, tripoint_bub_ms( 50, 50, -2 ) );
+
+    SECTION( "shopkeeper returns to post after sleep and cache loss" ) {
+        npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+        clear_character( guy, true );
+        guy.set_mutation( trait_RETURN_TO_START_POS );
+        guy.set_mission( NPC_MISSION_SHOPKEEP );
+        REQUIRE_FALSE( guy.is_player_ally() );
+
+        guy.regen_ai_cache();
+        const tripoint_abs_ms post = guy.pos_abs();
+        REQUIRE( guy.guard_pos == post );
+
+        // Place a bed nearby and make NPC sleepy
+        const tripoint_bub_ms bed_pos = guy.pos_bub() + tripoint( 3, 0, 0 );
+        here.ter_set( bed_pos, ter_t_floor );
+        here.furn_set( bed_pos, furn_f_bed );
+
+        guy.set_sleepiness( 800 );
+        guy.set_hunger( 0 );
+        guy.set_thirst( 0 );
+        guy.set_stored_kcal( guy.get_healthy_kcal() );
+        guy.set_all_parts_temp_conv( BODYTEMP_NORM );
+        guy.set_all_parts_temp_cur( BODYTEMP_NORM );
+
+        // Move toward bed until asleep or 10 turns
+        for( int i = 0; i < 10 && !guy.has_effect( effect_sleep ); ++i ) {
+            guy.set_moves( 100 );
+            guy.move();
+        }
+        REQUIRE( guy.has_effect( effect_sleep ) );
+        REQUIRE( guy.pos_abs() != post );
+
+        // Simulate cache loss while at bed
+        guy.clear_ai_guard_pos();
+        REQUIRE_FALSE( guy.get_ai_guard_pos().has_value() );
+
+        // Regen re-fills from persistent post, not bed position
+        guy.regen_ai_cache();
+        CHECK( guy.get_ai_guard_pos() == post );
+
+        // Wake up and return
+        guy.remove_effect( effect_sleep );
+        guy.remove_effect( effect_lying_down );
+        guy.set_sleepiness( 0 );
+
+        for( int i = 0; i < 20; ++i ) {
+            guy.set_moves( 100 );
+            guy.move();
+            if( guy.pos_abs() == post ) {
+                break;
+            }
+        }
+        CHECK( guy.pos_abs() == post );
+
+        // Stay at post on subsequent turns
+        for( int i = 0; i < 3; ++i ) {
+            guy.set_moves( 100 );
+            guy.move();
+        }
+        CHECK( guy.pos_abs() == post );
+    }
+
+    SECTION( "shopkeeper at post with no needs stays put" ) {
+        npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+        clear_character( guy, true );
+        guy.set_mutation( trait_RETURN_TO_START_POS );
+        guy.set_mission( NPC_MISSION_SHOPKEEP );
+        guy.set_hunger( 0 );
+        guy.set_thirst( 0 );
+        guy.set_stored_kcal( guy.get_healthy_kcal() );
+        guy.set_all_parts_temp_conv( BODYTEMP_NORM );
+        guy.set_all_parts_temp_cur( BODYTEMP_NORM );
+        guy.regen_ai_cache();
+        const tripoint_abs_ms post = guy.pos_abs();
+
+        for( int i = 0; i < 3; ++i ) {
+            guy.set_moves( 100 );
+            guy.move();
+        }
+        CHECK( guy.pos_abs() == post );
+    }
+
+    SECTION( "NO_NPC_FOOD caps unscheduled NPC at TIRED" ) {
+        override_option no_food( "NO_NPC_FOOD", "true" );
+        npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+        clear_character( guy, true );
+        guy.set_sleepiness( sleepiness_levels::TIRED );
+        REQUIRE_FALSE( guy.needs_food() );
+        guy.update_needs( 1 );
+        CHECK( guy.get_sleepiness() <= static_cast<int>( sleepiness_levels::TIRED ) );
+    }
+
+    SECTION( "DEAD_TIRED shopkeeper commits to sleep, no oscillation" ) {
+        npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+        clear_character( guy, true );
+        guy.set_mutation( trait_RETURN_TO_START_POS );
+        guy.set_mission( NPC_MISSION_SHOPKEEP );
+        guy.set_hunger( 0 );
+        guy.set_thirst( 0 );
+        guy.set_stored_kcal( guy.get_healthy_kcal() );
+        guy.set_all_parts_temp_conv( BODYTEMP_NORM );
+        guy.set_all_parts_temp_cur( BODYTEMP_NORM );
+        guy.regen_ai_cache();
+        const tripoint_abs_ms post = guy.pos_abs();
+        here.furn_set( guy.pos_bub() + tripoint( 3, 0, 0 ), furn_f_bed );
+        // Sleepiness 800: sleep_urgency 0.8 beats on-shift duty 0.45,
+        // so BT says go_to_sleep. While walking to bed (1-3 tiles from
+        // post), goal commitment prevents flipping to return_to_guard_pos.
+        guy.set_sleepiness( 800 );
+
+        bool oscillated = false;
+        bool reached_sleep = false;
+        for( int i = 0; i < 20; ++i ) {
+            guy.set_moves( 100 );
+            guy.move();
+            if( guy.has_effect( effect_sleep ) ||
+                guy.has_effect( effect_lying_down ) ) {
+                reached_sleep = true;
+                break;
+            }
+            if( i > 0 && guy.pos_abs() == post ) {
+                oscillated = true;
+                break;
+            }
+        }
+        CHECK_FALSE( oscillated );
+        CHECK( reached_sleep );
+    }
+
+    SECTION( "shopkeeper at post sleeps when tired" ) {
+        npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+        clear_character( guy, true );
+        guy.set_mutation( trait_RETURN_TO_START_POS );
+        guy.set_mission( NPC_MISSION_SHOPKEEP );
+        guy.set_hunger( 0 );
+        guy.set_thirst( 0 );
+        guy.set_stored_kcal( guy.get_healthy_kcal() );
+        guy.set_all_parts_temp_conv( BODYTEMP_NORM );
+        guy.set_all_parts_temp_cur( BODYTEMP_NORM );
+        guy.regen_ai_cache();
+        // Well above TIRED threshold -- BT says go_to_sleep.
+        guy.set_sleepiness( 800 );
+
+        guy.set_moves( 100 );
+        guy.move();
+
+        CHECK( ( guy.has_effect( effect_sleep ) || guy.has_effect( effect_lying_down ) ) );
+    }
+
+    SECTION( "tired-but-not-exhausted shopkeeper stays on duty" ) {
+        npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+        clear_character( guy, true );
+        guy.set_mutation( trait_RETURN_TO_START_POS );
+        guy.set_mission( NPC_MISSION_SHOPKEEP );
+        guy.regen_ai_cache();
+        const tripoint_abs_ms post = guy.pos_abs();
+
+        // Displace 10 tiles from post. duty_urgency = min(0.5, 10*0.05) = 0.5.
+        // sleepiness_urgency = 400/1000 = 0.4. Duty wins.
+        guy.setpos( here, guy.pos_bub() + tripoint( 10, 0, 0 ) );
+        REQUIRE( guy.pos_abs() != post );
+        const int dist_to_post = rl_dist( guy.pos_bub(), here.get_bub( post ) );
+
+        guy.set_sleepiness( 400 );
+        guy.set_moves( 100 );
+        guy.move();
+
+        // Should move toward post, not sleep
+        CHECK( rl_dist( guy.pos_bub(), here.get_bub( post ) ) < dist_to_post );
+        CHECK_FALSE( guy.has_effect( effect_sleep ) );
+        CHECK_FALSE( guy.has_effect( effect_lying_down ) );
+    }
+}
+
+// Helper: set up an NPC as an intercom operator with a given faction and shift.
+static npc &spawn_intercom_operator( const point_bub_ms &pos, const npc_class_id &cls,
+                                     const faction_id &fac )
+{
+    npc &guy = spawn_npc( pos, "test_talker" );
+    clear_character( guy, true );
+    guy.set_mutation( trait_INTERCOM_OPERATOR );
+    guy.myclass = cls;
+    guy.set_fac( fac );
+    return guy;
+}
+
+TEST_CASE( "find_intercom_operator_shift_selection", "[npc][intercom]" )
+{
+    clear_map_without_vision();
+
+    // Real intercom class IDs with work_hours from JSON.
+    // NC_ROBOFAC_INTERCOM_DAY [6,18], NC_ROBOFAC_INTERCOM_NIGHT [18,6].
+    SECTION( "noon selects day operator" ) {
+        calendar::turn = calendar::turn_zero + 12_hours;
+        npc &day = spawn_intercom_operator( { 50, 50 }, NC_ROBOFAC_INTERCOM_DAY, faction_robofac );
+        npc &night = spawn_intercom_operator( { 52, 50 }, NC_ROBOFAC_INTERCOM_NIGHT, faction_robofac );
+
+        npc *result = find_intercom_operator( trait_INTERCOM_OPERATOR, faction_robofac );
+        REQUIRE( result != nullptr );
+        CHECK( result->getID() == day.getID() );
+        ( void )night; // suppress unused
+    }
+    SECTION( "midnight selects night operator" ) {
+        calendar::turn = calendar::turn_zero + 0_hours;
+        npc &day = spawn_intercom_operator( { 50, 50 }, NC_ROBOFAC_INTERCOM_DAY, faction_robofac );
+        npc &night = spawn_intercom_operator( { 52, 50 }, NC_ROBOFAC_INTERCOM_NIGHT, faction_robofac );
+
+        npc *result = find_intercom_operator( trait_INTERCOM_OPERATOR, faction_robofac );
+        REQUIRE( result != nullptr );
+        CHECK( result->getID() == night.getID() );
+        ( void )day;
+    }
+    SECTION( "boundary 06:00 selects day (start-inclusive)" ) {
+        calendar::turn = calendar::turn_zero + 6_hours;
+        npc &day = spawn_intercom_operator( { 50, 50 }, NC_ROBOFAC_INTERCOM_DAY, faction_robofac );
+        spawn_intercom_operator( { 52, 50 }, NC_ROBOFAC_INTERCOM_NIGHT, faction_robofac );
+
+        npc *result = find_intercom_operator( trait_INTERCOM_OPERATOR, faction_robofac );
+        REQUIRE( result != nullptr );
+        CHECK( result->getID() == day.getID() );
+    }
+    SECTION( "boundary 18:00 selects night (day end-exclusive)" ) {
+        calendar::turn = calendar::turn_zero + 18_hours;
+        spawn_intercom_operator( { 50, 50 }, NC_ROBOFAC_INTERCOM_DAY, faction_robofac );
+        npc &night = spawn_intercom_operator( { 52, 50 }, NC_ROBOFAC_INTERCOM_NIGHT, faction_robofac );
+
+        npc *result = find_intercom_operator( trait_INTERCOM_OPERATOR, faction_robofac );
+        REQUIRE( result != nullptr );
+        CHECK( result->getID() == night.getID() );
+    }
+    SECTION( "fallback to awake off-shift when on-shift is asleep" ) {
+        calendar::turn = calendar::turn_zero + 12_hours;
+        npc &day = spawn_intercom_operator( { 50, 50 }, NC_ROBOFAC_INTERCOM_DAY, faction_robofac );
+        npc &night = spawn_intercom_operator( { 52, 50 }, NC_ROBOFAC_INTERCOM_NIGHT, faction_robofac );
+
+        // Put the on-shift (day) operator to sleep
+        day.add_effect( effect_sleep, 1_hours );
+
+        npc *result = find_intercom_operator( trait_INTERCOM_OPERATOR, faction_robofac );
+        REQUIRE( result != nullptr );
+        // Day is asleep, night is awake -- falls back to night
+        CHECK( result->getID() == night.getID() );
+    }
+    SECTION( "no operators returns nullptr" ) {
+        calendar::turn = calendar::turn_zero + 12_hours;
+        npc *result = find_intercom_operator( trait_INTERCOM_OPERATOR, faction_robofac );
+        CHECK( result == nullptr );
+    }
+    SECTION( "wrong faction not selected" ) {
+        calendar::turn = calendar::turn_zero + 12_hours;
+        spawn_intercom_operator( { 50, 50 }, NC_ROBOFAC_INTERCOM_DAY, faction_your_followers );
+
+        npc *result = find_intercom_operator( trait_INTERCOM_OPERATOR, faction_robofac );
+        CHECK( result == nullptr );
+    }
+}
+
+// --- Schedule reconciliation tests ---
+
+static npc &spawn_scheduled_npc( const point_bub_ms &pos, const npc_class_id &cls )
+{
+    npc &guy = spawn_npc( pos, "test_talker" );
+    clear_character( guy, true );
+    guy.myclass = cls;
+    guy.set_mutation( trait_RETURN_TO_START_POS );
+    guy.set_mission( NPC_MISSION_SHOPKEEP );
+    guy.set_hunger( 0 );
+    guy.set_thirst( 0 );
+    guy.set_stored_kcal( guy.get_healthy_kcal() );
+    guy.set_all_parts_temp_conv( BODYTEMP_NORM );
+    guy.set_all_parts_temp_cur( BODYTEMP_NORM );
+    return guy;
+}
+
+TEST_CASE( "schedule_reconciliation_no_npc_food", "[npc][schedule]" )
+{
+    clear_map_without_vision();
+    override_option no_food( "NO_NPC_FOOD", "true" );
+
+    SECTION( "wakes and zeroes sleepiness at shift start" ) {
+        calendar::turn = calendar::turn_zero + 12_hours;
+        npc &guy = spawn_scheduled_npc( { 50, 50 }, NC_ROBOFAC_INTERCOM_DAY );
+        guy.set_sleepiness( 100 );
+        guy.add_effect( effect_sleep, 1_hours );
+        REQUIRE( guy.in_sleep_state() );
+        REQUIRE_FALSE( guy.needs_food() );
+
+        guy.reconcile_schedule();
+
+        CHECK_FALSE( guy.in_sleep_state() );
+        CHECK( guy.get_sleepiness() == 0 );
+    }
+
+    SECTION( "floors sleepiness at off-shift transition" ) {
+        calendar::turn = calendar::turn_zero + 20_hours;
+        npc &guy = spawn_scheduled_npc( { 50, 50 }, NC_ROBOFAC_INTERCOM_DAY );
+        guy.set_sleepiness( 100 );
+        REQUIRE_FALSE( guy.needs_food() );
+
+        guy.reconcile_schedule();
+
+        CHECK( guy.get_sleepiness() >= static_cast<int>( sleepiness_levels::TIRED ) );
+    }
+
+    SECTION( "on_load sets sleepiness proportional to shift" ) {
+        // 12:00 is 6 hours into a [6,18] shift (12h total).
+        // Expected: TIRED * 6/12 = TIRED/2
+        calendar::turn = calendar::turn_zero + 12_hours;
+        npc &guy = spawn_scheduled_npc( { 50, 50 }, NC_ROBOFAC_INTERCOM_DAY );
+        guy.set_sleepiness( 0 );
+        REQUIRE_FALSE( guy.needs_food() );
+
+        guy.reconcile_schedule_on_load();
+
+        int expected = static_cast<int>( sleepiness_levels::TIRED ) / 2;
+        CHECK( guy.get_sleepiness() >= expected - 5 );
+        CHECK( guy.get_sleepiness() <= expected + 5 );
+    }
+
+    SECTION( "loaded NPC covers full shift then sleeps" ) {
+        // Start just before shift end so we don't need a massive time jump.
+        calendar::turn = calendar::turn_zero + 17_hours + 59_minutes;
+        map &here = get_map();
+        clear_avatar();
+        get_player_character().setpos( here, tripoint_bub_ms( 50, 50, -2 ) );
+        npc &guy = spawn_scheduled_npc( { 50, 50 }, NC_ROBOFAC_INTERCOM_DAY );
+        guy.update_body( calendar::turn, calendar::turn );
+        guy.regen_ai_cache();
+        const tripoint_abs_ms post = guy.pos_abs();
+        REQUIRE( guy.guard_pos == post );
+
+        // Place a bed 3 tiles away for sleep target.
+        const tripoint_bub_ms bed_pos = guy.pos_bub() + tripoint( 3, 0, 0 );
+        here.ter_set( bed_pos, ter_t_floor );
+        here.furn_set( bed_pos, furn_f_bed );
+
+        // On-shift: NPC should stay at post.
+        for( int i = 0; i < 5; ++i ) {
+            guy.set_moves( 100 );
+            guy.move();
+        }
+        CHECK( guy.pos_abs() == post );
+        CHECK_FALSE( guy.in_sleep_state() );
+
+        // Cross shift boundary. Small time jump (2 minutes).
+        calendar::turn = calendar::turn_zero + 18_hours + 10_seconds;
+        guy.update_body( calendar::turn - 10_seconds, calendar::turn );
+        guy.npc_update_body();
+
+        CHECK( guy.get_sleepiness() >= static_cast<int>( sleepiness_levels::TIRED ) );
+
+        // BT should now send NPC to sleep.
+        bool reached_sleep = false;
+        for( int i = 0; i < 20; ++i ) {
+            guy.set_moves( 100 );
+            guy.move();
+            if( guy.has_effect( effect_sleep ) ||
+                guy.has_effect( effect_lying_down ) ) {
+                reached_sleep = true;
+                break;
+            }
+        }
+        CHECK( reached_sleep );
+    }
+}
+
+TEST_CASE( "schedule_reconciliation_normal_needs", "[npc][schedule]" )
+{
+    clear_map_without_vision();
+
+    SECTION( "wakes but preserves sleepiness at shift start" ) {
+        calendar::turn = calendar::turn_zero + 12_hours;
+        npc &guy = spawn_scheduled_npc( { 50, 50 }, NC_ROBOFAC_INTERCOM_DAY );
+        guy.set_sleepiness( 100 );
+        guy.add_effect( effect_sleep, 1_hours );
+        REQUIRE( guy.in_sleep_state() );
+        REQUIRE( guy.needs_food() );
+
+        guy.reconcile_schedule();
+
+        CHECK_FALSE( guy.in_sleep_state() );
+        CHECK( guy.get_sleepiness() == 100 );
+    }
+
+    SECTION( "does not floor sleepiness off-shift" ) {
+        calendar::turn = calendar::turn_zero + 20_hours;
+        npc &guy = spawn_scheduled_npc( { 50, 50 }, NC_ROBOFAC_INTERCOM_DAY );
+        guy.set_sleepiness( 50 );
+        REQUIRE( guy.needs_food() );
+
+        guy.reconcile_schedule();
+
+        CHECK( guy.get_sleepiness() == 50 );
+    }
+
+    SECTION( "on_load does not overwrite sleepiness" ) {
+        calendar::turn = calendar::turn_zero + 12_hours;
+        npc &guy = spawn_scheduled_npc( { 50, 50 }, NC_ROBOFAC_INTERCOM_DAY );
+        guy.set_sleepiness( 300 );
+        REQUIRE( guy.needs_food() );
+
+        guy.reconcile_schedule_on_load();
+
+        CHECK( guy.get_sleepiness() == 300 );
+    }
+
+    SECTION( "leaves sleeping NPC alone off-shift" ) {
+        calendar::turn = calendar::turn_zero + 22_hours;
+        npc &guy = spawn_scheduled_npc( { 50, 50 }, NC_ROBOFAC_INTERCOM_DAY );
+        guy.add_effect( effect_sleep, 1_hours );
+        REQUIRE( guy.in_sleep_state() );
+
+        guy.reconcile_schedule();
+
+        CHECK( guy.in_sleep_state() );
+    }
+}
+
+TEST_CASE( "npc_update_body_calls_reconcile_schedule", "[npc][schedule]" )
+{
+    clear_map_without_vision();
+    override_option no_food( "NO_NPC_FOOD", "true" );
+
+    // Align to a 10-second boundary so once_every(10_seconds) fires.
+    calendar::turn = calendar::turn_zero + 12_hours;
+    npc &guy = spawn_scheduled_npc( { 50, 50 }, NC_ROBOFAC_INTERCOM_DAY );
+    guy.add_effect( effect_sleep, 1_hours );
+    guy.update_body( calendar::turn, calendar::turn );
+    REQUIRE( guy.in_sleep_state() );
+
+    // Advance exactly to the next 10-second boundary.
+    calendar::turn += 10_seconds;
+    guy.npc_update_body();
+
+    CHECK_FALSE( guy.in_sleep_state() );
+}
+
+// --- Trade delegate tests ---
+
+TEST_CASE( "trade_delegate", "[npc][trade]" )
+{
+    clear_map_without_vision();
+
+    SECTION( "default is self" ) {
+        npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+        clear_character( guy, true );
+
+        CHECK( &guy.get_trade_delegate() == &guy );
+    }
+
+    SECTION( "intercom operator returns supply clerk" ) {
+        npc &op = spawn_npc( { 50, 50 }, "test_talker" );
+        clear_character( op, true );
+        op.set_mutation( trait_INTERCOM_OPERATOR );
+        op.set_fac( faction_robofac );
+
+        npc &clerk = spawn_npc( { 52, 50 }, "test_talker" );
+        clear_character( clerk, true );
+        clerk.set_mutation( trait_TRADE_BACKEND );
+        clerk.set_fac( faction_robofac );
+
+        CHECK( &op.get_trade_delegate() == &clerk );
+    }
+
+    SECTION( "no clerk falls back to self" ) {
+        npc &op = spawn_npc( { 50, 50 }, "test_talker" );
+        clear_character( op, true );
+        op.set_mutation( trait_INTERCOM_OPERATOR );
+        op.set_fac( faction_robofac );
+
+        CHECK( &op.get_trade_delegate() == &op );
+    }
+
+    SECTION( "ignores non-backend shopkeepers" ) {
+        npc &op = spawn_npc( { 50, 50 }, "test_talker" );
+        clear_character( op, true );
+        op.set_mutation( trait_INTERCOM_OPERATOR );
+        op.set_fac( faction_robofac );
+
+        // The intended backend.
+        npc &clerk = spawn_npc( { 52, 50 }, "test_talker" );
+        clear_character( clerk, true );
+        clerk.set_mutation( trait_TRADE_BACKEND );
+        clerk.set_fac( faction_robofac );
+
+        // Another robofac shopkeeper (no TRADE_BACKEND).
+        npc &other = spawn_npc( { 54, 50 }, "test_talker" );
+        clear_character( other, true );
+        other.myclass = test_shop_class;
+        other.set_fac( faction_robofac );
+
+        CHECK( &op.get_trade_delegate() == &clerk );
+    }
+
+    SECTION( "both operators share the same backend" ) {
+        npc &day = spawn_npc( { 50, 50 }, "test_talker" );
+        clear_character( day, true );
+        day.set_mutation( trait_INTERCOM_OPERATOR );
+        day.set_fac( faction_robofac );
+
+        npc &night = spawn_npc( { 52, 50 }, "test_talker" );
+        clear_character( night, true );
+        night.set_mutation( trait_INTERCOM_OPERATOR );
+        night.set_fac( faction_robofac );
+
+        npc &clerk = spawn_npc( { 54, 50 }, "test_talker" );
+        clear_character( clerk, true );
+        clerk.set_mutation( trait_TRADE_BACKEND );
+        clerk.set_fac( faction_robofac );
+
+        CHECK( &day.get_trade_delegate() == &clerk );
+        CHECK( &night.get_trade_delegate() == &clerk );
+        CHECK( &day.get_trade_delegate() == &night.get_trade_delegate() );
+    }
+}
+
+TEST_CASE( "intercom_shopkeeper_isolation", "[npc][trade][intercom]" )
+{
+    clear_map_without_vision();
+    SECTION( "operators are not shopkeepers, clerk is" ) {
+        npc &day = spawn_npc( { 50, 50 }, "test_talker" );
+        clear_character( day, true );
+        day.myclass = NC_ROBOFAC_INTERCOM_DAY;
+        day.set_fac( faction_robofac );
+
+        npc &night = spawn_npc( { 52, 50 }, "test_talker" );
+        clear_character( night, true );
+        night.myclass = NC_ROBOFAC_INTERCOM_NIGHT;
+        night.set_fac( faction_robofac );
+
+        npc &clerk = spawn_npc( { 54, 50 }, "test_talker" );
+        clear_character( clerk, true );
+        clerk.myclass = NC_ROBOFAC_INTERCOM_SUPPLY;
+        clerk.set_fac( faction_robofac );
+
+        CHECK_FALSE( day.is_shopkeeper() );
+        CHECK_FALSE( night.is_shopkeeper() );
+        CHECK( clerk.is_shopkeeper() );
+    }
+
+    SECTION( "shop_restock is no-op for non-shopkeeper operator" ) {
+        npc &day = spawn_npc( { 50, 50 }, "test_talker" );
+        clear_character( day, true );
+        day.myclass = NC_ROBOFAC_INTERCOM_DAY;
+        day.set_fac( faction_robofac );
+        day.restock = calendar::turn_zero;
+
+        day.shop_restock();
+
+        // restock timestamp should be unchanged: shop_restock() is a
+        // no-op for non-shopkeepers (is_shopkeeper() returns false).
+        CHECK( day.restock == calendar::turn_zero );
+    }
+}
+
+TEST_CASE( "shift_start_clears_stale_sleep_commitment", "[npc][schedule]" )
+{
+    clear_map_without_vision();
+    clear_avatar();
+    map &here = get_map();
+    get_player_character().setpos( here, tripoint_bub_ms( 50, 50, -2 ) );
+    SECTION( "already sleeping at shift start, duty wins after wake" ) {
+        // Sleepiness 400: urgency 0.4, below on-shift duty at post (0.45).
+        // reconcile_schedule clears the stale go_to_sleep commitment so
+        // the BT picks duty instead of sending the NPC back to bed.
+        calendar::turn = calendar::turn_zero + 12_hours;
+        npc &guy = spawn_scheduled_npc( { 50, 50 }, NC_ROBOFAC_INTERCOM_DAY );
+        guy.set_sleepiness( 400 );
+        guy.add_effect( effect_sleep, 1_hours );
+        guy.add_effect( effect_lying_down, 1_hours );
+        guy.set_committed_goal( "go_to_sleep" );
+        guy.regen_ai_cache();
+        const tripoint_abs_ms post = guy.pos_abs();
+
+        REQUIRE( guy.in_sleep_state() );
+        REQUIRE( guy.needs_food() );
+        REQUIRE( guy.guard_pos == post );
+
+        guy.reconcile_schedule();
+
+        CHECK_FALSE( guy.in_sleep_state() );
+        CHECK( guy.get_sleepiness() == 400 );
+        CHECK( guy.get_committed_goal().empty() );
+
+        // Gameplay outcome: NPC stays at post instead of heading to bed.
+        for( int i = 0; i < 3; ++i ) {
+            guy.set_moves( 100 );
+            guy.move();
+        }
+        CHECK( guy.pos_abs() == post );
+        CHECK_FALSE( guy.in_sleep_state() );
+    }
+
+    SECTION( "walking toward bed at shift start" ) {
+        // Off-shift, NPC committed to sleep but not sleeping yet.
+        calendar::turn = calendar::turn_zero + 5_hours + 50_minutes;
+        npc &guy = spawn_scheduled_npc( { 50, 50 }, NC_ROBOFAC_INTERCOM_DAY );
+        guy.set_sleepiness( 400 );  // sleep_urgency 0.4 < duty_urgency 0.45
+        guy.regen_ai_cache();
+        guy.set_committed_goal( "go_to_sleep" );
+
+        REQUIRE_FALSE( guy.in_sleep_state() );
+        REQUIRE( guy.needs_food() );
+
+        // Advance to on-shift.
+        calendar::turn = calendar::turn_zero + 6_hours + 10_minutes;
+        guy.set_moves( 100 );
+        guy.move();
+
+        // BT returns hold_position (duty 0.45 > sleep 0.4).
+        // go_to_sleep completes because new_goal != "go_to_sleep".
+        CHECK( guy.get_committed_goal() != "go_to_sleep" );
+    }
+
+    SECTION( "committed sleep yields to a different needs goal" ) {
+        // Off-shift so duty is irrelevant. Sleepiness below TIRED (191)
+        // so can_sleep fails and sleep branch is not running. Thirst is
+        // high with water available, so BT returns drink_water (same
+        // needs category, but different goal).
+        calendar::turn = calendar::turn_zero + 20_hours; // off-shift [6,18]
+        npc &guy = spawn_scheduled_npc( { 50, 50 }, NC_ROBOFAC_INTERCOM_DAY );
+        guy.set_sleepiness( 100 );  // below TIRED (191): can_sleep fails
+        guy.set_thirst( 600 );       // thirst_urgency = 0.5
+        guy.i_add( item( itype_water_clean, calendar::turn ) );
+        guy.regen_ai_cache();
+        guy.set_committed_goal( "go_to_sleep" );
+
+        REQUIRE( guy.get_committed_goal() == "go_to_sleep" );
+
+        guy.set_moves( 100 );
+        guy.move();
+
+        // BT returns drink_water. Same needs category, but goal-level
+        // completion fires because new_goal != "go_to_sleep".
+        CHECK( guy.get_committed_goal() != "go_to_sleep" );
+    }
+}
+
+TEST_CASE( "hold_position_commitment_completes_off_shift", "[npc][schedule]" )
+{
+    clear_map_without_vision();
+    clear_avatar();
+    map &here = get_map();
+    get_player_character().setpos( here, tripoint_bub_ms( 50, 50, -2 ) );
+    // Near end of shift.
+    calendar::turn = calendar::turn_zero + 17_hours + 50_minutes;
+    npc &guy = spawn_scheduled_npc( { 50, 50 }, NC_ROBOFAC_INTERCOM_DAY );
+    // Low needs so BT returns idle off-shift, not go_to_sleep.
+    guy.set_sleepiness( 0 );
+    guy.set_hunger( 0 );
+    guy.set_thirst( 0 );
+    guy.set_stored_kcal( guy.get_healthy_kcal() );
+    guy.set_all_parts_temp_conv( BODYTEMP_NORM );
+    guy.set_all_parts_temp_cur( BODYTEMP_NORM );
+    guy.update_body( calendar::turn, calendar::turn );
+    guy.regen_ai_cache();
+    REQUIRE( guy.guard_pos == guy.pos_abs() );
+    REQUIRE( guy.needs_food() );
+
+    guy.set_committed_goal( "hold_position" );
+
+    // Advance past shift end.
+    calendar::turn = calendar::turn_zero + 18_hours + 10_minutes;
+
+    guy.set_moves( 100 );
+    guy.move();
+
+    // BT returns idle (off-shift, no urgent needs). hold_position
+    // should complete because BT no longer returns hold_position.
+    CHECK( guy.get_committed_goal() != "hold_position" );
+}
+
+TEST_CASE( "intercom_operators_have_IGNORE_SOUND", "[npc][schedule]" )
+{
+    clear_map_without_vision();
+
+    npc &day = spawn_npc( { 50, 50 }, "robofac_intercom_day" );
+    CHECK( day.has_trait( trait_IGNORE_SOUND ) );
+
+    npc &night = spawn_npc( { 52, 50 }, "robofac_intercom_night" );
+    CHECK( night.has_trait( trait_IGNORE_SOUND ) );
+}
+
+TEST_CASE( "off_shift_displaced_npc_does_not_return_to_post", "[npc][schedule]" )
+{
+    clear_map_without_vision();
+    clear_avatar();
+    map &here = get_map();
+    get_player_character().setpos( here, tripoint_bub_ms( 50, 50, -2 ) );
+    // Off-shift, low needs so BT returns "idle".
+    calendar::turn = calendar::turn_zero + 20_hours;
+    npc &guy = spawn_scheduled_npc( { 50, 50 }, NC_ROBOFAC_INTERCOM_DAY );
+    guy.set_sleepiness( 0 );
+    guy.set_hunger( 0 );
+    guy.set_thirst( 0 );
+    guy.set_stored_kcal( guy.get_healthy_kcal() );
+    guy.set_all_parts_temp_conv( BODYTEMP_NORM );
+    guy.set_all_parts_temp_cur( BODYTEMP_NORM );
+    guy.update_body( calendar::turn, calendar::turn );
+    guy.regen_ai_cache();
+
+    const tripoint_abs_ms post = guy.pos_abs();
+    REQUIRE( guy.guard_pos == post );
+    REQUIRE( guy.needs_food() );
+
+    // Displace the NPC 5 tiles from their guard post.
+    guy.setpos( here, tripoint_bub_ms( 55, 50, 0 ) );
+    // Pin overmap goal to current OMT so the is_stationary path
+    // yields npc_pause rather than npc_goto_destination.
+    guy.goal = guy.pos_abs_omt();
+    guy.regen_ai_cache();
+    const tripoint_abs_ms displaced = guy.pos_abs();
+
+    REQUIRE( displaced != post );
+    REQUIRE( guy.get_effective_guard_pos() == post );
+
+    for( int i = 0; i < 3; ++i ) {
+        guy.set_moves( 100 );
+        guy.move();
+    }
+
+    CHECK( guy.pos_abs() == displaced );
+}
+
+TEST_CASE( "return_to_start_pos_npc_still_uses_legacy_fallback", "[npc][schedule]" )
+{
+    clear_map_without_vision();
+    clear_avatar();
+    map &here = get_map();
+    get_player_character().setpos( here, tripoint_bub_ms( 50, 50, -2 ) );
+
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy, true );
+    // RETURN_TO_START_POS but NOT shopkeep/guard/guard_patrol,
+    // so the BT block is skipped and the legacy fallback applies.
+    guy.set_mutation( trait_RETURN_TO_START_POS );
+    guy.set_mission( NPC_MISSION_SHELTER );
+    guy.set_hunger( 0 );
+    guy.set_thirst( 0 );
+    guy.set_sleepiness( 0 );
+    guy.set_stored_kcal( guy.get_healthy_kcal() );
+    guy.set_all_parts_temp_conv( BODYTEMP_NORM );
+    guy.set_all_parts_temp_cur( BODYTEMP_NORM );
+    guy.regen_ai_cache();
+
+    const tripoint_abs_ms post = guy.pos_abs();
+    REQUIRE( guy.guard_pos == post );
+
+    // Displace the NPC.
+    guy.setpos( here, tripoint_bub_ms( 55, 50, 0 ) );
+    guy.goal = guy.pos_abs_omt();
+    guy.regen_ai_cache();
+    const int initial_dist = rl_dist( guy.pos_bub(), here.get_bub( post ) );
+
+    REQUIRE( guy.pos_abs() != post );
+
+    for( int i = 0; i < 3; ++i ) {
+        guy.set_moves( 100 );
+        guy.move();
+    }
+
+    // Legacy fallback should still fire: NPC moves closer to post.
+    CHECK( rl_dist( guy.pos_bub(), here.get_bub( post ) ) < initial_dist );
 }


### PR DESCRIPTION
#### Summary
Bugfixes "Fix NPC off-bubble sleepiness, shopkeeper/guard shift scheduling, Hub intercom"

#### Purpose of change

Fixes #86124.

Related to #28681 -- extends the BT needs system with duty/sleep arbitration.

NPCs accumulate sleepiness while off-bubble and have no way to sleep it off, so when you visit a faction everyone is exhausted and wandering to beds. Shopkeepers and guards leave their posts and don't reliably return. Luliya runs the full AI despite being in stasis. The Hub intercom is a single NPC embedded in a wall with no shift concept.

#### Describe the solution

**Shift scheduling.** `npc_class` gains a `work_hours` field ([start, end), wraps midnight). The BT gets `npc_on_shift` and `npc_hold_post` nodes. On-shift NPCs return to post and resist moderate tiredness; off-shift NPCs are free to sleep. Current assignments: RC guards day [9,21] / night [21,9], Hub intercom day [6,18] / night [18,6], Exodii shopkeepers [6,22]. Default [0,24] means always on shift -- duty urgency at post beats sleep, so the NPC stays put unless truly exhausted.

**Schedule reconciliation.** `reconcile_schedule()` runs from `npc_update_body()` (in-bubble) and `on_load()` (off-bubble). It wakes sleeping NPCs at shift start and floors sleepiness to TIRED off-shift for `!needs_food()` NPCs. On load, sleepiness is set proportional to shift progress so NPCs don't arrive fresh or exhausted.

**Persistent guard_pos.** `guard_pos` is now the authority for duty posts. `RETURN_TO_START_POS` sets it once on spawn. Cache loss (save/load, sound investigation) re-fills from persistent, so NPCs always know where home is.

**Goal commitment.** BT goals persist across turns until completed or overridden by a higher-priority category. Prevents flip-flopping between sleep and duty when urgencies are close.

**Hub intercom overhaul.** The single wall NPC is replaced by day/night shift operators in an existing office room. `find_intercom_operator()` picks whoever is on shift and awake. Trade delegates to a supply clerk NPC via `get_trade_delegate()`. This pattern could be extended later to delegate to vehicle cargo, zones, or other inventory sources. Remote dialogue mode shows "the intercom" instead of the NPC name. Old saves keep the legacy NPC via class-based fallback.

**NPC_STASIS.** Generic trait that gates `npc::move()` and `update_needs()`. Luliya uses it until the player pushes the red button.

**Pathfinder.** Skip opening shutters over impassable reinforced glass.

**IGNORE_SOUND fix.** NPCs with this trait (Rubik, intercom operators) no longer oscillate between bed and post due to ambient sound alerts.

#### Describe alternatives you've considered

Could have done time-skip sleep in `on_load()` instead of reconciliation, but that would need to simulate the full sleep cycle. Setting sleepiness proportionally is simpler and good enough.

Could have put shift logic in EOCs, but the BT already handles needs-vs-duty and adding shift awareness there keeps it in one place.

#### Testing

~900 lines of new tests covering:
- Persistent guard_pos authority (spawn, cache loss, sound anchor)
- Shopkeeper sleep/wake/return cycle
- Goal commitment (no oscillation walking to bed)
- Intercom operator shift selection (day/night/boundary/fallback)
- Schedule reconciliation (wake at shift start, sleepiness floor, proportional on_load)
- Trade delegate routing
- Off-shift displaced NPC stays put
- Legacy fallback for non-BT NPCs

Tested in-game with Exodii (Rubik stays at desk, Luliya stays in stasis), RC (guards rotate shifts), and Hub intercom (day/night operators answer).

#### Additional context

None.