### PR TITLE
[Sky Island] Add an NPC mode to control whether NPCs join raids

### DIFF
--- a/data/mods/Sky_Island/effectoncondition/obelisk_selector.json
+++ b/data/mods/Sky_Island/effectoncondition/obelisk_selector.json
@@ -6,23 +6,32 @@
       {
         "if": { "math": [ "challenge_mode_active == 1" ] },
         "then": [ { "set_string_var": "<color_red>Enabled</color>", "target_var": { "global_val": "challenge_mode_warning" } } ],
-        "else": [ { "set_string_var": "Disabled", "target_var": { "global_val": "challenge_mode_warning" } } ]
+        "else": [ { "set_string_var": "<color_dark_gray>Disabled</color>", "target_var": { "global_val": "challenge_mode_warning" } } ]
+      },
+      {
+        "if": { "math": [ "si_npcs_will_join_raid == 1" ] },
+        "then": [ { "set_string_var": "<color_green>Will</color>", "target_var": { "global_val": "si_npcs_will_join_raid_warning" } } ],
+        "else": [
+          { "set_string_var": "<color_red>Will not</color>", "target_var": { "global_val": "si_npcs_will_join_raid_warning" } }
+        ]
       },
       {
         "run_eoc_selector": [
           "EOC_raidbegin_short",
           "EOC_raidbegin_medium",
           "EOC_raidbegin_long",
+          "EOC_raid_toggle_npcs_join_raids",
           "EOC_raid_toggle_challenge_mode",
           "EOC_raidcancel"
         ],
-        "names": [ "Quick Expedition", "Large Expedition", "Extended Expedition", "Toggle Challenge Mode", "Cancel" ],
-        "keys": [ "1", "2", "3", "4", "5" ],
-        "title": "Select Expedition Length.  Challenge Mode: <global_val:challenge_mode_warning>",
+        "names": [ "Quick Expedition", "Large Expedition", "Extended Expedition", "Toggle NPC Mode", "Toggle Challenge Mode", "Cancel" ],
+        "keys": [ "1", "2", "3", "4", "5", "6" ],
+        "title": "Select Expedition Length.\nNPCs: <global_val:si_npcs_will_join_raid_warning> join expeditions.\nChallenge Mode: <global_val:challenge_mode_warning>",
         "descriptions": [
           "A simple, brief expedition at the normal time limit.  Missions and exits will be close together.  A good chance to quickly gather supplies and experience.",
           "A longer expedition that offers twice the time.  Missions and exits will be scattered over a wider area.  You will have more opportunity to dig deeper into surrounding points of interest, but also need more time to travel.  Missions offer extra warp shards as rewards.",
           "A very long expedition that triples the time limit.  Missions and exits will be very far away.  You will have time for extended activities, but a good deal of your time will be spent trying to reach objectives over potentially dangerous terrain.  Missions offer even more warp shards as rewards.",
+          "Toggles NPC Mode, changing whether NPCs will join you on a raid or not.",
           "Toggles Challenge Mode, granting more rewards at the cost of harder expeditions.  A random difficulty modifier will be applied.",
           "Stay on the island for now."
         ]
@@ -71,6 +80,24 @@
       { "math": [ "exfildistancemax = 160" ] },
       { "math": [ "exfildistancemin = 50" ] },
       { "run_eocs": [ "EOC_warp_choose_locale" ] }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_raid_toggle_npcs_join_raids",
+    "effect": [
+      {
+        "if": { "math": [ "si_npcs_will_join_raid == 1" ] },
+        "then": [
+          { "math": [ "si_npcs_will_join_raid = 0" ] },
+          { "u_message": "NPCs <color_red>will not</color> join you on expeditions.", "popup": true }
+        ],
+        "else": [
+          { "math": [ "si_npcs_will_join_raid = 1" ] },
+          { "u_message": "NPCs <color_green>will</color> join you on expeditions.", "popup": true }
+        ]
+      },
+      { "run_eocs": [ "EOC_warp_statue" ] }
     ]
   },
   {

--- a/data/mods/Sky_Island/effectoncondition/teleport.json
+++ b/data/mods/Sky_Island/effectoncondition/teleport.json
@@ -12,12 +12,22 @@
       { "run_eocs": [ "EOC_raid_challenge_mode_pre_raid" ] },
       { "u_location_variable": { "global_val": "OM_HQ_origin" } },
       { "u_location_variable": { "global_val": "OM_HQ_origin_npc" } },
-      { "u_run_npc_eocs": [ "EOC_SKY_ISLAND_DIMENSION_SHIFT_CHARACTER_EFFECTS" ], "npc_range": 10, "local": true },
+      {
+        "if": { "math": [ "si_npcs_will_join_raid == 1" ] },
+        "then": { "u_run_npc_eocs": [ "EOC_SKY_ISLAND_DIMENSION_SHIFT_CHARACTER_EFFECTS" ], "npc_range": 10, "local": true }
+      },
       { "run_eocs": [ "EOC_SKY_ISLAND_DIMENSION_SHIFT_CHARACTER_EFFECTS" ] },
       {
-        "u_travel_to_dimension": "dimension_sky_island_mission",
-        "npc_travel_radius": 10,
-        "region_type": { "global_val": "sky_island_target_region_settings" }
+        "if": { "math": [ "si_npcs_will_join_raid == 1" ] },
+        "then": {
+          "u_travel_to_dimension": "dimension_sky_island_mission",
+          "npc_travel_radius": 10,
+          "region_type": { "global_val": "sky_island_target_region_settings" }
+        },
+        "else": {
+          "u_travel_to_dimension": "dimension_sky_island_mission",
+          "region_type": { "global_val": "sky_island_target_region_settings" }
+        }
       }
     ]
   },


### PR DESCRIPTION

#### Summary
Mods "[Sky Island] Add an NPC mode to control whether NPCs join raids"

#### Purpose of change
Add a toggle to turn off NPCs joining raids so the player doesn't have to move them away or hide the statue to start raids in a remote area on their island. 

#### Describe the solution
Add a new global variable that is toggled on the obelisk selector similar to Challenge Mode
Made a cosmetic change to the Challenge mode indicator while editing the same menu so its more obviously off.
#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested starting raids with and without NPC mode enabled and NPCs nearby
<img width="771" height="511" alt="image" src="https://github.com/user-attachments/assets/25a9494e-9169-4dbd-9191-3a3b17e4e456" />
<img width="771" height="511" alt="image" src="https://github.com/user-attachments/assets/8a396f49-7077-4ded-8808-06c8f82470d9" />


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
