### PR TITLE
add `RETURN_TO_START_POS` to various robofac-associated NPCs

### DIFF
--- a/data/json/npcs/robofac/NPC_Cranberry_Foster.json
+++ b/data/json/npcs/robofac/NPC_Cranberry_Foster.json
@@ -31,7 +31,8 @@
       { "trait": "hair_medium", "variant": "blond" },
       { "trait": "natural_hair_color_blond" },
       { "trait": "eye_color", "variant": "blue" },
-      { "trait": "SKIN_PINK" }
+      { "trait": "SKIN_PINK" },
+      { "trait": "RETURN_TO_START_POS" }
     ],
     "bonus_str": 2,
     "bonus_dex": 3,

--- a/data/json/npcs/robofac/NPC_Steven_Gould.json
+++ b/data/json/npcs/robofac/NPC_Steven_Gould.json
@@ -21,7 +21,8 @@
       { "trait": "hair_medium", "variant": "black" },
       { "trait": "natural_hair_color_black" },
       { "trait": "eye_color", "variant": "brown" },
-      { "trait": "SKIN_PINK" }
+      { "trait": "SKIN_PINK" },
+      { "trait": "RETURN_TO_START_POS" }
     ],
     "bonus_str": 1,
     "bonus_dex": 1,

--- a/data/json/npcs/robofac/ROBOFAC_SURFACE_FREEMERCHANT.json
+++ b/data/json/npcs/robofac/ROBOFAC_SURFACE_FREEMERCHANT.json
@@ -15,7 +15,7 @@
     "id": "NC_ROBOFAC_FREE_MERCHANT",
     "name": { "str": "Caravaneer" },
     "job_description": "I'm the owner of a trade caravan.",
-    "traits": [ { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ],
+    "traits": [ { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" }, { "trait": "RETURN_TO_START_POS" } ],
     "//": "This is a unique NPC who doesn't get randomly selected background traits",
     "common": false,
     "bonus_int": { "one_in": 4 },

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/NC_ANCILLA_GRUNT.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/NC_ANCILLA_GRUNT.json
@@ -6,7 +6,12 @@
     "name": { "str": "Mercenary" },
     "job_description": "Fighting in the name of Hub 01 and money, mostly money.",
     "common": false,
-    "traits": [ { "group": "BG_survival_story_POLICE" }, { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ],
+    "traits": [
+      { "group": "BG_survival_story_POLICE" },
+      { "group": "NPC_starting_traits" },
+      { "group": "Appearance_demographics" },
+      { "trait": "RETURN_TO_START_POS" }
+    ],
     "bonus_str": { "rng": [ 0, 1 ] },
     "bonus_dex": { "rng": [ 0, 2 ] },
     "bonus_int": { "rng": [ -2, 0 ] },

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/NC_ROBOFAC_SCIENTIST_GARAGE.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/NC_ROBOFAC_SCIENTIST_GARAGE.json
@@ -16,7 +16,7 @@
     "name": { "str": "Hub Scientist" },
     "job_description": "A Hub 01 scientist.",
     "common": false,
-    "traits": [ { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ],
+    "traits": [ { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" }, { "trait": "RETURN_TO_START_POS" } ],
     "bonus_str": { "rng": [ 0, 1 ] },
     "bonus_dex": { "rng": [ 0, 2 ] },
     "bonus_int": { "rng": [ -2, 0 ] },

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/NPC_ANCILLA_BARKEEP.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/NPC_ANCILLA_BARKEEP.json
@@ -15,7 +15,7 @@
     "id": "NC_ANCILLA_BARTENDER",
     "name": { "str": "Bartender" },
     "job_description": "I'm looking for new drink recipes.",
-    "traits": [ { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ],
+    "traits": [ { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" }, { "trait": "RETURN_TO_START_POS" } ],
     "common": false,
     "bonus_per": { "one_in": 4 },
     "worn_override": "NC_ANCILLA_BARKEEP_worn",

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/NPC_ANCILLA_DOCTOR.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/NPC_ANCILLA_DOCTOR.json
@@ -15,7 +15,7 @@
     "id": "NC_ANCILLA_DOCTOR",
     "name": { "str": "Ancilla Doctor" },
     "job_description": "I try to keep this gang in one piece.  It's a full time job.",
-    "traits": [ { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ],
+    "traits": [ { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" }, { "trait": "RETURN_TO_START_POS" } ],
     "common": false,
     "bonus_int": { "rng": [ 3, 5 ] },
     "worn_override": "NC_ANCILLA_DOCTOR_worn",

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/PAT/NPC_Pat.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/PAT/NPC_Pat.json
@@ -16,6 +16,7 @@
     "type": "npc_class",
     "id": "NPC_ROBOFAC_MERC_PAT",
     "name": { "str": "Hub Mercenary" },
+    "traits": [ { "trait": "RETURN_TO_START_POS" } ],
     "job_description": "Fighting for the all-mighty dollar.",
     "common": false,
     "worn_override": "NPC_ROBOFAC_MERC_PAT_worn",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Hub Ancilla and adjacent return to posts after sleep/etc."

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Various NPCs need to return to their spawn location if they move to sleep.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Added `RETURN_TO_START_POS` to:
- Pat
- Cranberry
- Ancilla grunts (generic guards)
- Sebastian Smith, the exodii garage guy
- Steven Gould, the monster corpse field merc
- Bartender
- Doc Stevens
- Free Merchants Caravaneer

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

n/a

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Checked they were in the correct place after waiting.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
