### PR TITLE
NECC Fliers

### DIFF
--- a/data/json/itemgroups/Locations_MapExtras/locations.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations.json
@@ -638,6 +638,7 @@
       [ "trailmap", 25 ],
       [ "modern_tanner", 20 ],
       [ "pocket_survival", 20 ],
+      [ "godco_flier", 15 ],
       [ "flyer", 120 ],
       { "item": "paper", "prob": 500, "count": [ 10, 60 ] },
       [ "wrapper", 150 ],

--- a/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
@@ -832,6 +832,7 @@
       { "item": "trailmap", "prob": 20 },
       { "item": "touristmap", "prob": 5 },
       { "item": "restaurantmap", "prob": 5 },
+      { "item": "godco_flier", "prob": 1 },
       { "item": "magnifying_glass", "prob": 25 },
       { "item": "glasses_reading", "prob": 50 },
       { "item": "string_6", "prob": 25 },

--- a/data/json/itemgroups/SUS/trash.json
+++ b/data/json/itemgroups/SUS/trash.json
@@ -65,7 +65,8 @@
       { "group": "SUS_book_nonf_zine_news", "prob": 5 },
       { "item": "flyer", "prob": 5 },
       { "item": "flyer_evac", "prob": 10 },
-      { "item": "survnote", "prob": 1 }
+      { "item": "survnote", "prob": 1 },
+      { "item": "godco_flier", "prob": 1 }
     ]
   },
   {
@@ -205,7 +206,8 @@
       { "item": "eraser", "prob": 5 },
       { "item": "cotton_ball", "prob": 10, "count": [ 3, 7 ], "custom-flags": [ "FILTHY" ] },
       { "group": "used_toy_box", "prob": 8 },
-      { "group": "superglue_bottles", "prob": 8, "count": [ 1, 3 ] }
+      { "group": "superglue_bottles", "prob": 8, "count": [ 1, 3 ] },
+      { "item": "godco_flier", "prob": 1 }
     ]
   },
   {
@@ -255,7 +257,8 @@
       { "item": "candle", "prob": 10, "count": [ 1, 2 ], "charges": [ 0, 8 ] },
       { "item": "cotton_ball", "prob": 5, "count": [ 3, 7 ], "custom-flags": [ "FILTHY" ] },
       { "group": "used_toy_box", "prob": 8 },
-      { "group": "superglue_bottles", "prob": 8 }
+      { "group": "superglue_bottles", "prob": 8 },
+      { "item": "godco_flier", "prob": 1, "count": [ 1, 3 ] }
     ]
   },
   {

--- a/data/json/items/book/maps.json
+++ b/data/json/items/book/maps.json
@@ -685,5 +685,19 @@
     "flags": [ "PAPER_SHAPED" ],
     "weight": "5 g",
     "volume": "5 ml"
+  },
+  {
+    "id": "godco_flier",
+    "copy-from": "abstractmap",
+    "type": "ITEM",
+    "name": { "str": "religious salvation flier" },
+    "description": "A small flier describing the coming end of the world and a promises of an Ark that will save those within it from 'the Second Flood'. There's an address written on the flier, leading to something called the New England Community Church.",
+    "color": "light_blue",
+    "use_action": {
+      "type": "reveal_map",
+      "radius": 150,
+      "terrain": [ "godco_enter", "godco_1", "godco_2", "godco_3", "godco_4", "godco_5", "godco_6", "godco_7", "godco_8", "godco_9" ],
+      "message": "You add the location of the church to your map."
+    }
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Added New England Church Community fliers"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

In the lore document, it's mentioned that the NECC gave out a lot of fliers to convince people that the apocalypse is approaching. Presumably they'd add contact information (useless now) and an address to it. I've added these fliers both to pad out their lore, their attempts to save the people around them, as well as an organic way of finding them.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Added the religious salvation flier, which is a map that reveals the NECC's overmap tiles. Added it to where you'd usually find fliers, trash, recycling centers, and very rarely amongst other fliers at bookstores.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

None.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Spawned in the item group a bunch of times, used the map, confirmed that I can see the now-revealed overmap tiles.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

The limitation in the current map system is that it doesn't work so well for extremely distant single-spawn places. I think it'd be good if we integrated the PoI mission system with 'map reveals' instead.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
