### PR TITLE
Feral soldiers now have a grenade-throwing ranged attack.

### DIFF
--- a/data/json/items/ammo_types.json
+++ b/data/json/items/ammo_types.json
@@ -127,6 +127,12 @@
   },
   {
     "type": "ammunition_type",
+    "id": "feral_thrown_grenade",
+    "name": "grenade",
+    "default": "grenade_feral"
+  },   
+  {
+    "type": "ammunition_type",
     "id": "shot",
     "name": "12 gauge",
     "default": "shot_00"

--- a/data/json/items/ammo_types.json
+++ b/data/json/items/ammo_types.json
@@ -130,7 +130,7 @@
     "id": "feral_thrown_grenade",
     "name": "grenade",
     "default": "grenade_feral"
-  },   
+  },
   {
     "type": "ammunition_type",
     "id": "shot",

--- a/data/json/items/tool/explosives.json
+++ b/data/json/items/tool/explosives.json
@@ -438,7 +438,7 @@
     "to_hit": { "grip": "none", "length": "hand", "surface": "any", "balance": "uneven" },
     "material": [ "steel", "plastic" ],
     "symbol": "*",
-    "looks_like": "grenade",	
+    "looks_like": "grenade",
     "color": "green",
     "use_action": {
       "need_wielding": false,

--- a/data/json/items/tool/explosives.json
+++ b/data/json/items/tool/explosives.json
@@ -447,7 +447,7 @@
       "menu_text": "Fix, but not pull, jammed grenade pin",
       "type": "transform"
     },
-    "flags": ["BOMB", "GRENADE" ],
+    "flags": [ "BOMB", "GRENADE" ],
     "melee_damage": { "bash": 2 }
   },   
   {

--- a/data/json/items/tool/explosives.json
+++ b/data/json/items/tool/explosives.json
@@ -422,6 +422,35 @@
     "melee_damage": { "bash": 2 }
   },
   {
+    "id": "grenade_feral",
+    "//": "Used only by feral soldiers for their throw attack. Needs to be converted to a regular grenade by the player before it can be used.",
+    "type": "ITEM",
+    "subtypes": [ "TOOL", "AMMO" ],
+    "category": "weapons",
+    "name": { "str": "jammed grenade" },
+    "description": "A military-grade fragmentation hand grenade. Someone seems to have incorrectly pulled the pin and bent it out of shape, jamming it in the grenade. Use this item to unbend the pin and make the grenade ready for use.",
+    "weight": "397 g",
+    "volume": "540 ml",
+    "longest_side": "110 mm",
+    "price": "15 USD",
+    "price_postapoc": "10 USD",
+    "ammo_type": "feral_thrown_grenade",	
+    "to_hit": { "grip": "none", "length": "hand", "surface": "any", "balance": "uneven" },
+    "material": [ "steel", "plastic" ],
+    "symbol": "*",
+    "looks_like": "grenade",	
+    "color": "green",
+    "use_action": {
+      "need_wielding": false,
+      "target": "grenade",
+      "msg": "You fix the pin on the grenade.",
+      "menu_text": "Fix, but not pull, jammed grenade pin",
+      "type": "transform"
+    },
+    "flags": ["BOMB", "GRENADE" ],
+    "melee_damage": { "bash": 2 }
+  },   
+  {
     "id": "grenade_act",
     "type": "ITEM",
     "subtypes": [ "TOOL" ],

--- a/data/json/items/tool/explosives.json
+++ b/data/json/items/tool/explosives.json
@@ -449,7 +449,7 @@
     },
     "flags": [ "BOMB", "GRENADE" ],
     "melee_damage": { "bash": 2 }
-  },   
+  },
   {
     "id": "grenade_act",
     "type": "ITEM",

--- a/data/json/items/tool/explosives.json
+++ b/data/json/items/tool/explosives.json
@@ -434,7 +434,7 @@
     "longest_side": "110 mm",
     "price": "15 USD",
     "price_postapoc": "10 USD",
-    "ammo_type": "feral_thrown_grenade",	
+    "ammo_type": "feral_thrown_grenade",
     "to_hit": { "grip": "none", "length": "hand", "surface": "any", "balance": "uneven" },
     "material": [ "steel", "plastic" ],
     "symbol": "*",

--- a/data/json/monster_special_attacks/monster_gun.json
+++ b/data/json/monster_special_attacks/monster_gun.json
@@ -182,6 +182,51 @@
     "melee_damage": { "bash": 2 }
   },
   {
+    "id": "feral_soldier_thrown_grenade",
+    "type": "ITEM",
+    "subtypes": [ "GUN" ],
+    "symbol": "%",
+    "color": "red",
+    "name": { "str": "hurled grenade", "//~": "NO_I18N" },
+    "description": { "str": "Incorrectly used grenade at the ready to bonk that which isn't part of the blob.", "//~": "NO_I18N" },
+    "material": [ "steel" ],
+    "flags": [
+      "PRIMITIVE_RANGED_WEAPON",
+      "PSEUDO",
+      "NEVER_JAMS",
+      "NONCONDUCTIVE",
+      "NO_REPAIR",
+      "WATERPROOF_GUN",
+      "NO_SALVAGE",
+      "NO_UNLOAD",
+      "NO_TURRET"
+    ],
+    "skill": "throw",
+    "ammo": [ "feral_thrown_grenade" ],
+    "ammo_effects": [ "NO_PENETRATE_OBSTACLES" ],
+    "ranged_damage": { "damage_type": "bash", "amount": -1 },
+    "clip_size": 1,
+    "weight": "540 g",
+    "volume": "210 ml",
+    "longest_side": "75 mm",
+    "to_hit": { "grip": "solid", "length": "hand", "surface": "any", "balance": "neutral" },
+    "loudness": 2,
+    "range": 6,
+    "dispersion": 150,
+    "durability": 8,
+    "pocket_data": [
+      {
+        "pocket_type": "MAGAZINE",
+        "rigid": true,
+        "max_contains_volume": "200 L",
+        "max_contains_weight": "400 kg",
+        "max_item_length": "2000 m",
+        "ammo_restriction": { "feral_thrown_grenade": 5 }
+      }
+    ],
+    "melee_damage": { "bash": 2 }
+  },  
+  {
     "id": "nether_huntsman_arm",
     "type": "ITEM",
     "subtypes": [ "GUN" ],

--- a/data/json/monster_special_attacks/monster_gun.json
+++ b/data/json/monster_special_attacks/monster_gun.json
@@ -225,7 +225,7 @@
       }
     ],
     "melee_damage": { "bash": 2 }
-  },  
+  },
   {
     "id": "nether_huntsman_arm",
     "type": "ITEM",

--- a/data/json/monsters/feral_humans.json
+++ b/data/json/monsters/feral_humans.json
@@ -438,7 +438,7 @@
     "aggression": 40,
     "dodge": 4,
     "vision_night": 5,
-    "starting_ammo": { "grenade_feral": 1 },	
+    "starting_ammo": { "grenade_feral": 1 },
     "death_drops": "mon_feral_soldier_death_drops",
     "special_attacks": [
       {

--- a/data/json/monsters/feral_humans.json
+++ b/data/json/monsters/feral_humans.json
@@ -457,7 +457,7 @@
       },
       { "id": "feral_weapon_knife_combat" },
       [ "PARROT_AT_DANGER", 0 ]
-    ],	
+    ],
     "zombify_into": "mon_zombie_soldier",
     "extend": { "weakpoint_sets": [ "wps_humanoid_body_armor", "wps_humanoid_open_helmet" ], "families": [ "prof_wp_syn_armored" ] },
     "armor": { "bash": 4, "cut": 9, "bullet": 7, "electric": 3 }

--- a/data/json/monsters/feral_humans.json
+++ b/data/json/monsters/feral_humans.json
@@ -438,8 +438,26 @@
     "aggression": 40,
     "dodge": 4,
     "vision_night": 5,
+    "starting_ammo": { "grenade_feral": 1 },	
     "death_drops": "mon_feral_soldier_death_drops",
-    "special_attacks": [ { "id": "feral_weapon_knife_combat" }, [ "PARROT_AT_DANGER", 0 ] ],
+    "special_attacks": [
+      {
+        "type": "gun",
+        "cooldown": 5,
+        "move_cost": 150,
+        "gun_type": "feral_soldier_thrown_grenade",
+        "ammo_type": "grenade_feral",
+        "no_ammo_sound": "",
+        "fake_skills": [ [ "throw", 4 ] ],
+        "fake_str": 9,
+        "condition": { "not": { "u_has_effect": "maimed_arm" } },
+        "require_targeting_player": false,
+        "ranges": [ [ 4, 9, "DEFAULT" ] ],
+        "description": "The feral soldier throws a grenade!"
+      },
+      { "id": "feral_weapon_knife_combat" },
+      [ "PARROT_AT_DANGER", 0 ]
+    ],	
     "zombify_into": "mon_zombie_soldier",
     "extend": { "weakpoint_sets": [ "wps_humanoid_body_armor", "wps_humanoid_open_helmet" ], "families": [ "prof_wp_syn_armored" ] },
     "armor": { "bash": 4, "cut": 9, "bullet": 7, "electric": 3 }


### PR DESCRIPTION

#### Summary
Content "Feral Soldiers retain partial expertise with grenades"


#### Purpose of change
 Gives feral soldiers the ability to throw a grenade, in parallel with base ferals and their rocks. Not a live grenade, they don't quite manage to pull the pin before throwing it. It just bounces off and you can pick it up and throw it back.


#### Describe the solution

A moment of terror when the player sees a grenade hit their character, followed by a bit of dark humor upon realizing that the feral forgot to actually pull the pin.
This is a copypaste of the standard feral rock "gun" that fires grenades, with a corresponding ammo group to match and slightly higher stats and range. Each feral only gets one grenade so players can't try and farm free grenades, although as feral soldiers are a fairly uncommon enemy and plenty of grenades can be looted from the far more numerous soldier zombies I'm not concerned about the free grenade that this attack technically boils down to.

I initially tried to use the standard grenade by just adding the AMMO subtype to it, but that caused the stacking and wielding behavior to change, so I shifted the role of ammunition to a copy of the grenade item that once thrown and picked up can be activated by the player to turn it into a normal grenade.


#### Describe alternatives you've considered

Having feral soldiers retain that little bit more muscle memory needed to pull the pin as well. No humor, lots more terror. Justifiable from my understanding of blob  lore and consistent with feral marines being described as able to operate firearms in a limited capacity, but also highly lethal to players both from the grenade itself and the horde of armored zombies that would attracted by the explosion.
Personally I don't mind the idea of ferals being able to fire guns, but I'll respect the position of the development team on fully removing gun attacks. Beside, this is funnier.

Having feral soldiers take "pull the pin and throw it" literally and frontload the humor with the grenade pin itself harmlessly being thrown at the player, followed by the realization that the knife-clutching maniac closing the distance now has a live grenade attached to their MOLLE belt.



#### Testing

Spawned in a feral soldier, got hit by a jammed grenade, picked it up, activated it, was left with a normal grenade. Activated that, and threw it. Turned off debug invincibility and got stabbed, then blown up.

#### Additional context



<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
