### PR TITLE
[Sky Island] Fix free vision and spawn location for expeditions

### DIFF
--- a/data/mods/Sky_Island/effectoncondition/teleport.json
+++ b/data/mods/Sky_Island/effectoncondition/teleport.json
@@ -2,7 +2,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_SKY_ISLAND_DIMENSION_SHIFT_CHARACTER_EFFECTS",
-    "effect": [ { "u_add_effect": "blind", "duration": 0 }, { "u_add_effect": "effect_sky_island_momentary_flight", "duration": 1 } ]
+    "effect": [ { "u_add_effect": "effect_sky_island_momentary_flight", "duration": 1 } ]
   },
   {
     "type": "effect_on_condition",
@@ -12,11 +12,32 @@
       { "run_eocs": [ "EOC_raid_challenge_mode_pre_raid" ] },
       { "u_location_variable": { "global_val": "OM_HQ_origin" } },
       { "u_location_variable": { "global_val": "OM_HQ_origin_npc" } },
+      { "copy_var": { "global_val": "OM_HQ_origin" }, "target_var": { "global_val": "OM_temp" } },
+      { "copy_var": { "global_val": "OM_HQ_origin_npc" }, "target_var": { "global_val": "OM_npc_temp" } },
+      { "location_variable_adjust": { "global_val": "OM_temp" }, "z_adjust": -9, "z_override": true },
+      { "location_variable_adjust": { "global_val": "OM_npc_temp" }, "z_adjust": -9, "z_override": true },
       {
         "if": { "math": [ "si_npcs_will_join_raid == 1" ] },
-        "then": { "u_run_npc_eocs": [ "EOC_SKY_ISLAND_DIMENSION_SHIFT_CHARACTER_EFFECTS" ], "npc_range": 10, "local": true }
+        "then": [
+          { "u_run_npc_eocs": [ "EOC_SKY_ISLAND_DIMENSION_SHIFT_CHARACTER_EFFECTS" ], "npc_range": 10, "local": true },
+          {
+            "u_run_npc_eocs": [
+              {
+                "id": "EOC_SKY_ISLAND_MISSION_DIMENSION_SHIFT_MOVE_NPCS",
+                "condition": { "and": [ "u_following" ] },
+                "effect": [
+                  { "location_variable_adjust": { "global_val": "OM_npc_temp" }, "x_adjust": [ -2, 2 ], "y_adjust": [ -2, 2 ] },
+                  { "u_teleport": { "global_val": "OM_npc_temp" }, "force_safe": true }
+                ]
+              }
+            ],
+            "npc_range": 10,
+            "local": true
+          }
+        ]
       },
       { "run_eocs": [ "EOC_SKY_ISLAND_DIMENSION_SHIFT_CHARACTER_EFFECTS" ] },
+      { "u_teleport": { "global_val": "OM_temp" }, "force_safe": true },
       {
         "if": { "math": [ "si_npcs_will_join_raid == 1" ] },
         "then": {
@@ -38,7 +59,7 @@
     "effect": [
       { "math": [ "u_spell_level('island_hostile_eviction') = -1" ] },
       { "math": [ "u_spell_level('island_close_tear_and_portal') = -1" ] },
-      { "copy_var": { "global_val": "OM_missionspot_npc" }, "target_var": { "global_val": "OM_missionspot" } },
+      { "copy_var": { "global_val": "OM_missionspot" }, "target_var": { "global_val": "OM_missionspot_npc" } },
       {
         "u_run_npc_eocs": [
           {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Sky Island] Fix free vision and spawn location for expeditions"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #86151
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Fix the location copy for `OM_missionspot` into `OM_missionspot_npc` instead of in reverse where it was copying a null value so defaulted to 0,0,0 for both instead.
Make the player (and NPCs) teleport down to -9 before dimension shifting. Removed the blind effect as it wasn't updating vision of the player mid chain of EOCs
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested raids with and without NPCs, raids start in the proper location now and only reveal a single deep rock OMT at the same XY coordinates of the sky island deep underground. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
There is probably some deeper underlying fix to be made here for the vision but this is a simple fix for this specific bug for now. The single useless OMT being revealed on the map is trivial.


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
