### PR TITLE
Move items across dimensions with dimensional travel

### DIFF
--- a/doc/JSON/DIMENSIONS.md
+++ b/doc/JSON/DIMENSIONS.md
@@ -45,6 +45,11 @@ Travel to dimension `test`, take any item within 3 tiles of your avatar with you
 { "u_travel_to_dimension": "test", "item_travel_radius": 3 }
 ```
 
+If you pass a location variable in `target_location`, the function will use that as the center for where to get items from and where to place items after the shift. Essentially this picks up items from and places them in then same location relative to the player.  
+```jsonc
+{ "u_travel_to_dimension": "test", "item_travel_radius": 3, "region_type": "default", "target_location": { "u_val": "debug_loc" } }
+```
+
 ## Region Settings
 
 When generating a new dimension, you have the option to supply a [region_settings](REGION_SETTINGS.md) object which the dimension will use to generate it's terrain.

--- a/doc/JSON/DIMENSIONS.md
+++ b/doc/JSON/DIMENSIONS.md
@@ -45,10 +45,12 @@ Travel to dimension `test`, take any item within 3 tiles of your avatar with you
 { "u_travel_to_dimension": "test", "item_travel_radius": 3 }
 ```
 
-If you pass a location variable in `target_location`, the function will use that as the center for where to get items from and where to place items after the shift. Essentially this picks up items from and places them in then same location relative to the player.  
+If you pass a location variable in `target_location`, the function will use that as the center point for where to get items from and where to place items after the shift.
 ```jsonc
 { "u_travel_to_dimension": "test", "item_travel_radius": 3, "region_type": "default", "target_location": { "u_val": "debug_loc" } }
 ```
+
+All of the items transferred as part of the shift will be placed on the player's location, or `target_location` if set. Any items that do not fit in that tile will spill outwards from that point until all of them can be placed.
 
 ## Region Settings
 

--- a/doc/JSON/DIMENSIONS.md
+++ b/doc/JSON/DIMENSIONS.md
@@ -36,6 +36,15 @@ There are also `all` and `enemy` filters you can use.
 
 There's a quirk with NPCs right now, that causes issues when attempting to take them with you to another dimension and then attempt to teleport them to some location within the same turn, you probably have to delay the npc teleportation stage by a turn to get around this. This might get fixed in the future.
 
+## Items
+
+When using `u_travel_to_dimension` EOC, you can choose to take the nearby items with you.
+
+Travel to dimension `test`, take any item within 3 tiles of your avatar with you.
+```jsonc
+{ "u_travel_to_dimension": "test", "item_travel_radius": 3 }
+```
+
 ## Region Settings
 
 When generating a new dimension, you have the option to supply a [region_settings](REGION_SETTINGS.md) object which the dimension will use to generate it's terrain.

--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -4547,7 +4547,7 @@ Unloads the current dimension and loads the dimension with the specific ID, opti
 | "u_travel_to_dimension" | **mandatory** | string | Will teleport the player to a dimension with the ID. |
 | "npc_travel_radius" | optional | int or [variable object](#variable-object) | default 0; if a value above 0 is specified, the NPCs within that radius around the player will be transported with them when dimension hopping. |
 | "npc_travel_filter" | optional | string or [variable object](#variable-object) | default `all`; Acceps the following values: `all`, `follower`, `enemy`. Does nothing if `npc_travel_radius` is 0. |
-| "item_travel_radius" | optional | int or [variable object](#variable-object) | default 0; if a value above 0 is specified, the items within that radius around the player will be transported with them when dimension hopping. |
+| "item_travel_radius" | optional | int or [variable object](#variable-object) | default -1; if a value 0 or above is specified, the items within that radius around the player will be transported with them when dimension hopping. |
 | "target_location" | optional | [variable object](#variable-object) | default is the player's location; if present this variable will be used as the center point for items in conjunction with `item_travel_radius` |
 | "region_type" | optional | string or [variable object](#variable-object) | default `default`; The dimension is generated with the region settings of a `region_settings_new` object. |
 

--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -4547,6 +4547,7 @@ Unloads the current dimension and loads the dimension with the specific ID, opti
 | "u_travel_to_dimension" | **mandatory** | string | Will teleport the player to a dimension with the ID. |
 | "npc_travel_radius" | optional | int or [variable object](#variable-object) | default 0; if a value above 0 is specified, the NPCs within that radius around the player will be transported with them when dimension hopping. |
 | "npc_travel_filter" | optional | string or [variable object](#variable-object) | default `all`; Acceps the following values: `all`, `follower`, `enemy`. Does nothing if `npc_travel_radius` is 0. |
+| "item_travel_radius" | optional | int or [variable object](#variable-object) | default 0; if a value above 0 is specified, the items within that radius around the player will be transported with them when dimension hopping. |
 | "region_type" | optional | string or [variable object](#variable-object) | default `default`; The dimension is generated with the region settings of a `region_settings_new` object. |
 
 ##### Valid talkers:

--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -4548,6 +4548,7 @@ Unloads the current dimension and loads the dimension with the specific ID, opti
 | "npc_travel_radius" | optional | int or [variable object](#variable-object) | default 0; if a value above 0 is specified, the NPCs within that radius around the player will be transported with them when dimension hopping. |
 | "npc_travel_filter" | optional | string or [variable object](#variable-object) | default `all`; Acceps the following values: `all`, `follower`, `enemy`. Does nothing if `npc_travel_radius` is 0. |
 | "item_travel_radius" | optional | int or [variable object](#variable-object) | default 0; if a value above 0 is specified, the items within that radius around the player will be transported with them when dimension hopping. |
+| "target_location" | optional | [variable object](#variable-object) | default is the player's location; if present this variable will be used as the center point for items in conjunction with `item_travel_radius` |
 | "region_type" | optional | string or [variable object](#variable-object) | default `default`; The dimension is generated with the region settings of a `region_settings_new` object. |
 
 ##### Valid talkers:

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -9687,6 +9687,7 @@ bool game::travel_to_dimension( const std::string &new_prefix,
                                 const std::string &region_type,
                                 const std::vector<npc *> &npc_travellers,
                                 const std::vector<item_location> &item_travellers,
+                                const std::optional<tripoint_bub_ms> item_travellers_location,
                                 vehicle *veh )
 {
     map &here = get_map();
@@ -9797,8 +9798,17 @@ bool game::travel_to_dimension( const std::string &new_prefix,
         here.board_vehicle( player.pos_bub(), &player );
         player.controlling_vehicle = controlling_vehicle;
     }
-    for( item it : place_items ) {
-        here.add_item_or_charges( player.pos_bub( here ), it );
+    if( !place_items.empty() ) {
+        tripoint_bub_ms item_center;
+        if( item_travellers_location ) {
+            item_center = *item_travellers_location;
+        } else {
+            item_center = player.pos_bub( here );
+        }
+
+        for( const item &it : place_items ) {
+            here.add_item_or_charges( item_center, it );
+        }
     }
     load_npcs();
     // Handle static monsters
@@ -9808,7 +9818,8 @@ bool game::travel_to_dimension( const std::string &new_prefix,
     weather.set_nextweather( calendar::turn );
     update_overmap_seen();
     if( undo_shift ) {
-        travel_to_dimension( old_prefix, region_type, npc_travellers, item_travellers, veh );
+        travel_to_dimension( old_prefix, region_type, npc_travellers, item_travellers,
+                             item_travellers_location, veh );
     }
     game::mon_info_update();
     get_event_bus().send<event_type::dimension_travel>( player.getID(), old_prefix, dimension_prefix );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -9686,6 +9686,7 @@ void game::vertical_move( int movez, bool force, bool peeking )
 bool game::travel_to_dimension( const std::string &new_prefix,
                                 const std::string &region_type,
                                 const std::vector<npc *> &npc_travellers,
+                                const std::vector<item_location> &item_travellers,
                                 vehicle *veh )
 {
     map &here = get_map();
@@ -9719,6 +9720,17 @@ bool game::travel_to_dimension( const std::string &new_prefix,
     } else {
         unload_npcs();
     }
+
+    std::vector<item> place_items;
+    place_items.reserve( item_travellers.size() );
+    for( item_location il : item_travellers ) {
+        item *it = il.get_item();
+        if( it ) {
+            place_items.push_back( *it );
+            il.remove_item();
+        }
+    }
+
     for( monster &critter : all_monsters() ) {
         despawn_monster( critter );
     }
@@ -9785,6 +9797,9 @@ bool game::travel_to_dimension( const std::string &new_prefix,
         here.board_vehicle( player.pos_bub(), &player );
         player.controlling_vehicle = controlling_vehicle;
     }
+    for( item it : place_items ) {
+        here.add_item_or_charges( player.pos_bub( here ), it );
+    }
     load_npcs();
     // Handle static monsters
     here.spawn_monsters( true, true );
@@ -9793,7 +9808,7 @@ bool game::travel_to_dimension( const std::string &new_prefix,
     weather.set_nextweather( calendar::turn );
     update_overmap_seen();
     if( undo_shift ) {
-        travel_to_dimension( old_prefix, region_type, npc_travellers, veh );
+        travel_to_dimension( old_prefix, region_type, npc_travellers, item_travellers, veh );
     }
     game::mon_info_update();
     get_event_bus().send<event_type::dimension_travel>( player.getID(), old_prefix, dimension_prefix );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -9798,14 +9798,8 @@ bool game::travel_to_dimension( const std::string &new_prefix,
         here.board_vehicle( player.pos_bub(), &player );
         player.controlling_vehicle = controlling_vehicle;
     }
-    if( !place_items.empty() ) {
-        tripoint_bub_ms item_center;
-        if( item_travellers_location ) {
-            item_center = *item_travellers_location;
-        } else {
-            item_center = player.pos_bub( here );
-        }
-
+    if( !place_items.empty() && !undo_shift ) {
+        tripoint_bub_ms item_center = item_travellers_location.value_or( player.pos_bub( here ) );
         for( const item &it : place_items ) {
             here.add_item_or_charges( item_center, it );
         }
@@ -9818,8 +9812,13 @@ bool game::travel_to_dimension( const std::string &new_prefix,
     weather.set_nextweather( calendar::turn );
     update_overmap_seen();
     if( undo_shift ) {
-        travel_to_dimension( old_prefix, region_type, npc_travellers, item_travellers,
-                             item_travellers_location, veh );
+        travel_to_dimension( old_prefix, region_type, npc_travellers, {}, std::nullopt, veh );
+        if( !place_items.empty() ) {
+            tripoint_bub_ms item_center = item_travellers_location.value_or( player.pos_bub( here ) );
+            for( const item &it : place_items ) {
+                here.add_item_or_charges( item_center, it );
+            }
+        }
     }
     game::mon_info_update();
     get_event_bus().send<event_type::dimension_travel>( player.getID(), old_prefix, dimension_prefix );

--- a/src/game.h
+++ b/src/game.h
@@ -339,7 +339,9 @@ class game
          * @param veh pointer to a vehicle to bring along.
          */
         bool travel_to_dimension( const std::string &prefix, const std::string &region_type,
-                                  const std::vector<npc *> &npc_travellers, vehicle *veh = nullptr );
+                                  const std::vector<npc *> &npc_travellers,
+                                  const std::vector<item_location> &item_travellers,
+                                  vehicle *veh = nullptr );
         /**
          * Retrieve the identifier of the current dimension.
          * TODO: this should be a dereferencable id that gives properties of the dimension.

--- a/src/game.h
+++ b/src/game.h
@@ -341,6 +341,7 @@ class game
         bool travel_to_dimension( const std::string &prefix, const std::string &region_type,
                                   const std::vector<npc *> &npc_travellers,
                                   const std::vector<item_location> &item_travellers,
+                                  std::optional<tripoint_bub_ms> item_travellers_location,
                                   vehicle *veh = nullptr );
         /**
          * Retrieve the identifier of the current dimension.

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -7913,6 +7913,9 @@ talk_effect_fun_t::func f_travel_to_dimension( const JsonObject &jo, std::string
     dbl_or_var npc_travel_radius;
     optional( jo, false, "npc_travel_radius", npc_travel_radius, 0 );
 
+    dbl_or_var item_travel_radius;
+    optional( jo, false, "item_travel_radius", item_travel_radius, 0 );
+
     str_or_var region_type_var;
     optional( jo, false, "region_type", region_type_var, "default" );
 
@@ -7920,7 +7923,7 @@ talk_effect_fun_t::func f_travel_to_dimension( const JsonObject &jo, std::string
     optional( jo, false, "take_vehicle", take_vehicle );
 
     return [fail_message, success_message, dimension_prefix, npc_travel_filter,
-                  npc_travel_radius, region_type_var, take_vehicle]( dialogue const & d ) {
+                  npc_travel_radius, item_travel_radius, region_type_var, take_vehicle]( dialogue const & d ) {
         Creature *teleporter = d.actor( false )->get_creature();
         if( teleporter ) {
             std::string region_type = region_type_var.evaluate( d );
@@ -7948,6 +7951,18 @@ talk_effect_fun_t::func f_travel_to_dimension( const JsonObject &jo, std::string
                         }
                     } );
                 }
+
+                int item_radius = item_travel_radius.evaluate( d );
+                std::vector<item_location> items;
+                if( item_radius > 0 ) {
+                    map &here = get_map();
+                    tripoint_bub_ms center = here.get_bub( teleporter->pos_abs() );
+                    for( const tripoint_bub_ms &pos : here.points_in_radius( center, item_radius ) ) {
+                        for( item &it : here.i_at( pos ) ) {
+                            items.emplace_back( map_cursor( pos ), &it );
+                        }
+                    }
+                }
                 vehicle *veh = nullptr;
                 if( take_vehicle ) {
                     const optional_vpart_position vp_here = get_map().veh_at( teleporter->pos_bub() );
@@ -7958,7 +7973,7 @@ talk_effect_fun_t::func f_travel_to_dimension( const JsonObject &jo, std::string
                     veh = &vp_here->vehicle();
                 }
                 // returns False if fail
-                if( g->travel_to_dimension( prefix, region_type, travellers, veh ) ) {
+                if( g->travel_to_dimension( prefix, region_type, travellers, items, veh ) ) {
                     teleporter->add_msg_if_player( success_message.evaluate( d ) );
                 } else {
                     teleporter->add_msg_if_player( fail_message.evaluate( d ) );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -7919,7 +7919,7 @@ talk_effect_fun_t::func f_travel_to_dimension( const JsonObject &jo, std::string
     str_or_var region_type_var;
     optional( jo, false, "region_type", region_type_var, "default" );
 
-    bool take_vehicle = false;;
+    bool take_vehicle = false;
     optional( jo, false, "take_vehicle", take_vehicle );
 
     std::optional<var_info> target_location;
@@ -7958,7 +7958,7 @@ talk_effect_fun_t::func f_travel_to_dimension( const JsonObject &jo, std::string
 
                 int item_radius = item_travel_radius.evaluate( d );
                 std::vector<item_location> items;
-                tripoint_bub_ms center;
+                std::optional<tripoint_bub_ms> center;
                 if( item_radius > 0 ) {
                     map &here = get_map();
                     if( target_location ) {
@@ -7966,7 +7966,7 @@ talk_effect_fun_t::func f_travel_to_dimension( const JsonObject &jo, std::string
                     } else {
                         center = here.get_bub( teleporter->pos_abs() );
                     }
-                    for( const tripoint_bub_ms &pos : here.points_in_radius( center, item_radius ) ) {
+                    for( const tripoint_bub_ms &pos : here.points_in_radius( *center, item_radius ) ) {
                         for( item &it : here.i_at( pos ) ) {
                             items.emplace_back( map_cursor( pos ), &it );
                         }

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -7914,7 +7914,7 @@ talk_effect_fun_t::func f_travel_to_dimension( const JsonObject &jo, std::string
     optional( jo, false, "npc_travel_radius", npc_travel_radius, 0 );
 
     dbl_or_var item_travel_radius;
-    optional( jo, false, "item_travel_radius", item_travel_radius, 0 );
+    optional( jo, false, "item_travel_radius", item_travel_radius, -1 );
 
     str_or_var region_type_var;
     optional( jo, false, "region_type", region_type_var, "default" );
@@ -7959,7 +7959,7 @@ talk_effect_fun_t::func f_travel_to_dimension( const JsonObject &jo, std::string
                 int item_radius = item_travel_radius.evaluate( d );
                 std::vector<item_location> items;
                 std::optional<tripoint_bub_ms> center;
-                if( item_radius > 0 ) {
+                if( item_radius >= 0 ) {
                     map &here = get_map();
                     if( target_location ) {
                         center = here.get_bub( read_var_value( *target_location, d ).tripoint() );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -7922,7 +7922,11 @@ talk_effect_fun_t::func f_travel_to_dimension( const JsonObject &jo, std::string
     bool take_vehicle = false;;
     optional( jo, false, "take_vehicle", take_vehicle );
 
-    return [fail_message, success_message, dimension_prefix, npc_travel_filter,
+    std::optional<var_info> target_location;
+    optional( jo, false, "target_location", target_location );
+
+
+    return [fail_message, success_message, dimension_prefix, npc_travel_filter, target_location,
                   npc_travel_radius, item_travel_radius, region_type_var, take_vehicle]( dialogue const & d ) {
         Creature *teleporter = d.actor( false )->get_creature();
         if( teleporter ) {
@@ -7954,9 +7958,14 @@ talk_effect_fun_t::func f_travel_to_dimension( const JsonObject &jo, std::string
 
                 int item_radius = item_travel_radius.evaluate( d );
                 std::vector<item_location> items;
+                tripoint_bub_ms center;
                 if( item_radius > 0 ) {
                     map &here = get_map();
-                    tripoint_bub_ms center = here.get_bub( teleporter->pos_abs() );
+                    if( target_location ) {
+                        center = here.get_bub( read_var_value( *target_location, d ).tripoint() );
+                    } else {
+                        center = here.get_bub( teleporter->pos_abs() );
+                    }
                     for( const tripoint_bub_ms &pos : here.points_in_radius( center, item_radius ) ) {
                         for( item &it : here.i_at( pos ) ) {
                             items.emplace_back( map_cursor( pos ), &it );
@@ -7973,7 +7982,7 @@ talk_effect_fun_t::func f_travel_to_dimension( const JsonObject &jo, std::string
                     veh = &vp_here->vehicle();
                 }
                 // returns False if fail
-                if( g->travel_to_dimension( prefix, region_type, travellers, items, veh ) ) {
+                if( g->travel_to_dimension( prefix, region_type, travellers, items, center, veh ) ) {
                     teleporter->add_msg_if_player( success_message.evaluate( d ) );
                 } else {
                     teleporter->add_msg_if_player( fail_message.evaluate( d ) );


### PR DESCRIPTION
#### Summary
Infrastructure "Move items across dimensions with dimensional travel"

#### Purpose of change
Title. This will allow items on the ground to be moved across dimensions, particularly useful for mods like Sky Island.

#### Describe the solution
Add a new property to the `u_travel_to_dimension` EOC function: `item_travel_radius`.
If this value is greater than 0, the `f_travel_to_dimension` will grab all items on the map in that radius and pass them to `game::travel_to_dimension`

Add a new property `target_location`. If this variable is passed, that location will be used in conjunction with `item_travel_radius` for where to handle items instead of centered on the player's location.

`game::travel_to_dimension` is changed to accept a new vector of `item_location`s. 
When there is anything in this vector, before unloading the old map, a copy of the item is made and stored in a vector before the original item is removed and deleted. After the new map is loaded, the copied items are then placed on the map on the players location, overflowing to all available space as needed.

Docs are updated as well.

#### Describe alternatives you've considered

#### Testing

<details>

```jsonc
[
  {
    "type": "effect_on_condition",
    "id": "EOC_DEBUGGING_AWAY",
    "effect": [ { "u_travel_to_dimension": "test", "item_travel_radius": 3, "region_type": "default" } ]
  },
  {
    "type": "effect_on_condition",
    "id": "EOC_DEBUGGING_HOME",
    "effect": [ { "u_travel_to_dimension": "default", "item_travel_radius": 3, "region_type": "default" } ]
  }
]
```

[Screencast_20260329_220929.webm](https://github.com/user-attachments/assets/169eba75-ea29-46f7-be25-1ac2d7c0c40f)

</details>

#### Additional context
Created primarily for Sky Island


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
