### PR TITLE
[Bombastic Perks] Playstyle perks also require a normal perk point

### DIFF
--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -2747,7 +2747,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_PERK_MENU_SELECT_PLAYSTYLE",
-    "dynamic_line": "<context_val:trait_name>: \"<context_val:trait_description>\"\nCosts 1 playstyle perk point, <context_val:trait_requirement_description>.\n<context_val:trait_additional_details>",
+    "dynamic_line": "<context_val:trait_name>: \"<context_val:trait_description>\"\nCosts 1 playstyle perk point and 1 perk point, <context_val:trait_requirement_description>.\n<context_val:trait_additional_details>",
     "responses": [
       {
         "text": "Select Perk.",
@@ -2755,7 +2755,8 @@
         "condition": {
           "and": [
             { "or": [ { "math": [ "u_no_prerecs > 0" ] }, { "get_condition": "perk_condition" } ] },
-            { "math": [ "u_playstyle_perks_available >= 1" ] }
+            { "math": [ "u_playstyle_perks_available >= 1" ] },
+            { "math": [ "u_num_perks > 0" ] }
           ]
         },
         "failure_explanation": "Requirements Not Met",


### PR DESCRIPTION
#### Summary
Mods "[Bombastic Perks] Playstyle perks also require a normal perk point"

#### Purpose of change
Fixes #86144

#### Describe the solution
Add `u_num_perks > 0` requirement to the `TALK_PERK_MENU_SELECT_PLAYSTYLE` conditional. 
Add a remark to the same topic to note that a normal perk point is required too

#### Describe alternatives you've considered

#### Testing
<img width="1280" height="798" alt="image" src="https://github.com/user-attachments/assets/4b946b0b-9e45-4d3c-b500-3f3e81455222" />


#### Additional context
No 'fix' needed for players already in debt, the perks still cost one normal perk point, this just now gates the ability to buy playstyle perks properly


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
