### PR TITLE
Stop ref center guard EOCs from firing in alternate dimensions

### DIFF
--- a/data/json/effects_on_condition/npc_eocs/generic_npc_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/generic_npc_eocs.json
@@ -232,6 +232,8 @@
     "//": "Runs once an hour and moves refugee center npcs around based on what hour it is.",
     "global": true,
     "recurrence": "1 hours",
+    "condition": { "current_dimension": "" },
+    "deactivate_condition": { "not": { "current_dimension": "" } },
     "effect": [
       {
         "switch": { "math": [ "time_since('midnight', 'unit': 'hour')" ] },


### PR DESCRIPTION
#### Summary
Bugfixes "Stop ref center guard EOCs from firing in alternate dimensions"

#### Purpose of change
Fixes #86145

#### Describe the solution
Add a conditional and reactivation condition to `EOC_REFUGEE_CENTER_NPC_MOVEMENT`

#### Describe alternatives you've considered
Probably removing these EOCs altogether?

#### Testing
At around for hours in ref center, EOC fires. Sat around in an alternate dimension for hours, no errors.

#### Additional context



<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
