### PR TITLE
Stop spamming player log when NPCs are hot

### DIFF
--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -30,7 +30,6 @@
 #include "math_parser_diag_value.h"
 #include "map.h"
 #include "mapdata.h"
-#include "messages.h"
 #include "output.h"
 #include "overmapbuffer.h"
 #include "pimpl.h"
@@ -756,28 +755,28 @@ void Character::update_bodytemp()
         // Warn the player if condition worsens
         if( temp_before > BODYTEMP_FREEZING && temp_after < BODYTEMP_FREEZING ) {
             //~ %s is bodypart
-            add_msg( m_warning, _( "You feel your %s beginning to go numb from the cold!" ),
-                     body_part_name( bp ) );
+            add_msg_if_player( m_warning, _( "You feel your %s beginning to go numb from the cold!" ),
+                               body_part_name( bp ) );
         } else if( temp_before > BODYTEMP_VERY_COLD && temp_after < BODYTEMP_VERY_COLD ) {
             //~ %s is bodypart
-            add_msg( m_warning, _( "You feel your %s getting very cold." ),
-                     body_part_name( bp ) );
+            add_msg_if_player( m_warning, _( "You feel your %s getting very cold." ),
+                               body_part_name( bp ) );
         } else if( temp_before > BODYTEMP_COLD && temp_after < BODYTEMP_COLD ) {
             //~ %s is bodypart
-            add_msg( m_warning, _( "You feel your %s getting chilly." ),
-                     body_part_name( bp ) );
+            add_msg_if_player( m_warning, _( "You feel your %s getting chilly." ),
+                               body_part_name( bp ) );
         } else if( temp_before < BODYTEMP_SCORCHING && temp_after > BODYTEMP_SCORCHING ) {
             //~ %s is bodypart
-            add_msg( m_bad, _( "You feel your %s getting red hot from the heat!" ),
-                     body_part_name( bp ) );
+            add_msg_if_player( m_bad, _( "You feel your %s getting red hot from the heat!" ),
+                               body_part_name( bp ) );
         } else if( temp_before < BODYTEMP_VERY_HOT && temp_after > BODYTEMP_VERY_HOT ) {
             //~ %s is bodypart
-            add_msg( m_warning, _( "You feel your %s getting very hot." ),
-                     body_part_name( bp ) );
+            add_msg_if_player( m_warning, _( "You feel your %s getting very hot." ),
+                               body_part_name( bp ) );
         } else if( temp_before < BODYTEMP_HOT && temp_after > BODYTEMP_HOT ) {
             //~ %s is bodypart
-            add_msg( m_warning, _( "You feel your %s getting warm." ),
-                     body_part_name( bp ) );
+            add_msg_if_player( m_warning, _( "You feel your %s getting warm." ),
+                               body_part_name( bp ) );
         }
 
         // Note: Numbers are based off of BODYTEMP at the top of weather.h
@@ -789,15 +788,16 @@ void Character::update_bodytemp()
         // AND you have frostbite, then that also prevents you from sleeping
         if( in_sleep_state() && !has_effect( effect_narcosis ) ) {
             if( bp == body_part_torso && temp_after <= BODYTEMP_COLD && calendar::once_every( 1_hours ) ) {
-                add_msg( m_warning, _( "You feel cold and shiver." ) );
+                add_msg_if_player( m_warning, _( "You feel cold and shiver." ) );
             }
             if( temp_after <= BODYTEMP_VERY_COLD &&
                 get_sleepiness() <= sleepiness_levels::DEAD_TIRED && !has_bionic( bio_sleep_shutdown ) ) {
                 if( bp == body_part_torso ) {
-                    add_msg( m_warning, _( "Your shivering prevents you from sleeping." ) );
+                    add_msg_if_player( m_warning, _( "Your shivering prevents you from sleeping." ) );
                     wake_up();
                 } else if( has_effect( effect_frostbite ) ) {
-                    add_msg( m_warning, _( "You are too cold.  Your frostbite prevents you from sleeping." ) );
+                    add_msg_if_player( m_warning,
+                                       _( "You are too cold.  Your frostbite prevents you from sleeping." ) );
                     wake_up();
                 }
             }
@@ -808,17 +808,18 @@ void Character::update_bodytemp()
         // But only if it can be a problem, no need to spam player with "wind chills your scorching body"
         if( conv_temp <= BODYTEMP_COLD && windchill < units::from_fahrenheit_delta( -10 ) &&
             one_in( 200 ) ) {
-            add_msg( m_bad, _( "The wind is making your %s feel quite cold." ),
-                     body_part_name( bp ) );
+            add_msg_if_player( m_bad, _( "The wind is making your %s feel quite cold." ),
+                               body_part_name( bp ) );
         } else if( conv_temp <= BODYTEMP_COLD && windchill < units::from_fahrenheit_delta( -20 ) &&
                    one_in( 100 ) ) {
-            add_msg( m_bad,
-                     _( "The wind is very strong; you should find some more wind-resistant clothing for your %s." ),
-                     body_part_name( bp ) );
+            add_msg_if_player( m_bad,
+                               _( "The wind is very strong; you should find some more wind-resistant clothing for your %s." ),
+                               body_part_name( bp ) );
         } else if( conv_temp <= BODYTEMP_COLD && windchill < units::from_fahrenheit_delta( -30 ) &&
                    one_in( 50 ) ) {
-            add_msg( m_bad, _( "Your clothing is not providing enough protection from the wind for your %s!" ),
-                     body_part_name( bp ) );
+            add_msg_if_player( m_bad,
+                               _( "Your clothing is not providing enough protection from the wind for your %s!" ),
+                               body_part_name( bp ) );
         }
     }
 }
@@ -877,8 +878,8 @@ void Character::update_frostbite( const bodypart_id &bp, const int FBwindPower,
                 mod_part_frostbite_timer( bp, 3 );
             }
             if( one_in( 100 ) && !has_effect( effect_frostbite, bp.id() ) ) {
-                add_msg( m_warning, _( "Your %s will be frostnipped in the next few hours." ),
-                         body_part_name( bp ) );
+                add_msg_if_player( m_warning, _( "Your %s will be frostnipped in the next few hours." ),
+                                   body_part_name( bp ) );
             }
             // Medium risk zones
         } else if( temp_after < BODYTEMP_COLD &&
@@ -890,8 +891,8 @@ void Character::update_frostbite( const bodypart_id &bp, const int FBwindPower,
                        -4 * Ftemperature + 3 * FBwindPower - 170 >= 0 ) ) ) {
             mod_part_frostbite_timer( bp, 8 );
             if( one_in( 100 ) && intense < 2 ) {
-                add_msg( m_warning, _( "Your %s will be frostbitten within the hour!" ),
-                         body_part_name( bp ) );
+                add_msg_if_player( m_warning, _( "Your %s will be frostbitten within the hour!" ),
+                                   body_part_name( bp ) );
             }
             // High risk zones
         } else if( temp_after < BODYTEMP_COLD &&
@@ -900,8 +901,8 @@ void Character::update_frostbite( const bodypart_id &bp, const int FBwindPower,
                      ( Ftemperature < -35 && FBwindPower >= 10 ) ) ) {
             mod_part_frostbite_timer( bp, 72 );
             if( one_in( 100 ) && intense < 2 ) {
-                add_msg( m_warning, _( "Your %s will be frostbitten any minute now!" ),
-                         body_part_name( bp ) );
+                add_msg_if_player( m_warning, _( "Your %s will be frostbitten any minute now!" ),
+                                   body_part_name( bp ) );
             }
             // Risk free, so reduce frostbite timer
         } else {


### PR DESCRIPTION

#### Summary
Bugfixes "Stop spamming player log when NPCs are hot"


#### Purpose of change
Title

#### Describe the solution
Change `Character::update_bodytemp` calls from `add_msg` to `add_msg_if_player`

#### Describe alternatives you've considered
Adding an alternate NPC message but the player getting spammed for their own temperature problems is bad enough, we don't need the NPCs messages as well. 

#### Testing
Loaded ref center, no more message spam.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
