### PR TITLE
Add /retry and /rerun comment commands for failed CI jobs

### DIFF
--- a/.github/comment-commands.yml
+++ b/.github/comment-commands.yml
@@ -60,7 +60,7 @@ users:
     - SittingDucken
     - ShnitzelX2
     - BalthazarArgall
-    - dumb-kevin
+    - dobbry-vechur
     - thaelina
     - Tektolnes
 
@@ -81,3 +81,7 @@ keywords:
   - name: help-wanted
     # example: /help-wanted
     value: '\/(H|h)elp[\s-]*(W|w)anted.*'
+
+  - name: retry-jobs
+    # example: /retry, /rerun
+    value: '\/(([Rr])etry|([Rr])erun).*'

--- a/.github/workflows/comment-commands.yml
+++ b/.github/workflows/comment-commands.yml
@@ -62,6 +62,11 @@ jobs:
   pr-comment-job:
     if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+      actions: write
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -81,3 +86,32 @@ jobs:
           gh pr edit "$ISSUE_NUMBER" --remove-label "stale"
           gh pr edit "$ISSUE_NUMBER" --add-label "Help Wanted"
           gh pr reopen "$ISSUE_NUMBER"
+
+      - if: steps.comvent.outputs.retry-jobs != ''
+        name: Re-run failed CI jobs
+        run: |
+          HEAD_SHA=$(gh pr view "$ISSUE_NUMBER" --json headRefOid -q .headRefOid)
+          FAILED_RUNS=$(gh run list --commit "$HEAD_SHA" --status failure --json databaseId -q '.[].databaseId')
+          if [ -z "$FAILED_RUNS" ]; then
+            echo "No failed runs found for PR #$ISSUE_NUMBER"
+            exit 0
+          fi
+
+          # Collect failed job details
+          COMMENT="Retried failed jobs:"
+          while read -r run_id; do
+            JOBS=$(gh run view "$run_id" --json jobs \
+              -q '.jobs[] | select(.conclusion == "failure") | "- [\(.name)](\(.url))"')
+            if [ -n "$JOBS" ]; then
+              COMMENT="$COMMENT
+          $JOBS"
+            fi
+          done <<< "$FAILED_RUNS"
+
+          # Re-run failed jobs
+          while read -r run_id; do
+            echo "Re-running failed jobs in run $run_id"
+            gh run rerun "$run_id" --failed
+          done <<< "$FAILED_RUNS"
+
+          gh pr comment "$ISSUE_NUMBER" --body "$COMMENT"


### PR DESCRIPTION
#### Summary
Infrastructure "Add /retry and /rerun comment commands for failed CI jobs"

#### Purpose of change

No easy way to rerun failed CI in PR without distracting maintainers.

#### Describe the solution

New comvent keyword `retry-jobs` that finds failed workflow runs for the PR's head commit, posts a comment with links to the failed jobs, then re-runs them with `gh run rerun --failed`.

Also adds needed permissions to `pr-comment-job` and updates my username.

#### Describe alternatives you've considered

Keep pinging maintainers.

#### Testing

Dry-ran against some PRs with failed builds -- correctly found the failed jobs and produced the expected comment.

#### Additional context

Example comment:
```
Retrying failed jobs:
- [Basic Build and Test (Clang oldest supported, Ubuntu, Curses)](https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/23712572541/job/69074571397)
```