### PR TITLE
NPC needs: BT evaluates for all NPCs, add follow and goto goals

### DIFF
--- a/data/json/npcs/npc_behavior.json
+++ b/data/json/npcs/npc_behavior.json
@@ -34,7 +34,7 @@
     "type": "behavior",
     "id": "npc_priorities",
     "strategy": "utility",
-    "children": [ "npc_needs", "npc_duty" ]
+    "children": [ "npc_needs", "npc_duty", "npc_follow", "npc_player_order" ]
   },
   {
     "type": "behavior",
@@ -54,6 +54,20 @@
     "id": "npc_hold_post",
     "conditions": [ { "predicate": "npc_on_shift" } ],
     "goal": "hold_position"
+  },
+  {
+    "type": "behavior",
+    "id": "npc_follow",
+    "conditions": [ { "predicate": "npc_is_following" } ],
+    "goal": "follow_player",
+    "score": "npc_following_urgency"
+  },
+  {
+    "type": "behavior",
+    "id": "npc_player_order",
+    "conditions": [ { "predicate": "npc_has_goto_order" } ],
+    "goal": "goto_ordered_position",
+    "score": "npc_goto_order_urgency"
   },
   {
     "type": "behavior",

--- a/src/behavior_oracle.cpp
+++ b/src/behavior_oracle.cpp
@@ -54,6 +54,8 @@ predicate_map = {{
         { "npc_has_sound_alerts", make_function( &character_oracle_t::has_sound_alerts ) },
         { "npc_displaced_from_post", make_function( &character_oracle_t::displaced_from_post ) },
         { "npc_on_shift", make_function( &character_oracle_t::on_shift ) },
+        { "npc_is_following", make_function( &character_oracle_t::npc_is_following ) },
+        { "npc_has_goto_order", make_function( &character_oracle_t::npc_has_goto_order ) },
         { "monster_not_hallucination", make_function( &monster_oracle_t::not_hallucination ) },
         { "monster_items_available", make_function( &monster_oracle_t::items_available ) },
         { "monster_split_possible", make_function( &monster_oracle_t::split_possible ) },
@@ -68,7 +70,9 @@ score_predicate_map = {{
         { "npc_hunger_urgency", make_score_function( &character_oracle_t::hunger_urgency ) },
         { "npc_warmth_urgency", make_score_function( &character_oracle_t::warmth_urgency ) },
         { "npc_sleepiness_urgency", make_score_function( &character_oracle_t::sleepiness_urgency ) },
-        { "npc_duty_urgency", make_score_function( &character_oracle_t::duty_urgency ) }
+        { "npc_duty_urgency", make_score_function( &character_oracle_t::duty_urgency ) },
+        { "npc_following_urgency", make_score_function( &character_oracle_t::npc_following_urgency ) },
+        { "npc_goto_order_urgency", make_score_function( &character_oracle_t::npc_goto_order_urgency ) }
     }
 };
 

--- a/src/character_oracle.cpp
+++ b/src/character_oracle.cpp
@@ -254,7 +254,7 @@ status_t character_oracle_t::displaced_from_post( std::string_view ) const
     if( n->has_flag( json_flag_CANNOT_MOVE ) ) {
         return status_t::failure;
     }
-    std::optional<tripoint_abs_ms> gp = n->get_effective_guard_pos();
+    std::optional<tripoint_abs_ms> gp = n->get_guard_post();
     if( !gp ) {
         return status_t::failure;
     }
@@ -264,7 +264,7 @@ status_t character_oracle_t::displaced_from_post( std::string_view ) const
 status_t character_oracle_t::on_shift( std::string_view ) const
 {
     const npc *n = dynamic_cast<const npc *>( subject );
-    if( !n || !n->get_effective_guard_pos() ) {
+    if( !n || !n->get_guard_post() || !n->myclass.is_valid() ) {
         return status_t::failure;
     }
     const auto &[start, end] = n->myclass.obj().get_work_hours();
@@ -278,8 +278,8 @@ float character_oracle_t::duty_urgency( std::string_view ) const
     if( !n ) {
         return 0.0f;
     }
-    std::optional<tripoint_abs_ms> gp = n->get_effective_guard_pos();
-    if( !gp ) {
+    std::optional<tripoint_abs_ms> gp = n->get_guard_post();
+    if( !gp || !n->myclass.is_valid() ) {
         return 0.0f;
     }
     const auto &[start, end] = n->myclass.obj().get_work_hours();
@@ -300,6 +300,66 @@ float character_oracle_t::duty_urgency( std::string_view ) const
     // strongly prefers returning even when close to post.
     const int dist = rl_dist( n->pos_abs(), *gp );
     return std::max( 0.45f, std::min( 0.5f, dist * 0.05f ) );
+}
+
+status_t character_oracle_t::npc_is_following( std::string_view ) const
+{
+    const npc *n = dynamic_cast<const npc *>( subject );
+    if( !n || !n->should_follow_close() ) {
+        return status_t::failure;
+    }
+    if( n->get_guard_post() ) {
+        return status_t::failure;
+    }
+    const Character &player = get_player_character();
+    const int dist = rl_dist( n->pos_abs(), player.pos_abs() );
+    if( dist <= n->follow_distance() && n->posz() == player.posz() ) {
+        return status_t::success;
+    }
+    return status_t::running;
+}
+
+float character_oracle_t::npc_following_urgency( std::string_view ) const
+{
+    const npc *n = dynamic_cast<const npc *>( subject );
+    if( !n || !n->should_follow_close() ) {
+        return 0.0f;
+    }
+    const Character &player = get_player_character();
+    if( n->posz() != player.posz() ) {
+        return 0.6f;
+    }
+    const int dist = rl_dist( n->pos_abs(), player.pos_abs() );
+    if( dist <= n->follow_distance() ) {
+        return 0.0f;
+    }
+    return std::clamp( 0.3f + ( dist - n->follow_distance() ) * 0.015f, 0.3f, 0.6f );
+}
+
+status_t character_oracle_t::npc_has_goto_order( std::string_view ) const
+{
+    const npc *n = dynamic_cast<const npc *>( subject );
+    if( !n || !n->goto_to_this_pos || n->has_flag( json_flag_CANNOT_MOVE ) ) {
+        return status_t::failure;
+    }
+    if( n->pos_abs() == *n->goto_to_this_pos ) {
+        return status_t::success;
+    }
+    return status_t::running;
+}
+
+float character_oracle_t::npc_goto_order_urgency( std::string_view ) const
+{
+    const npc *n = dynamic_cast<const npc *>( subject );
+    if( !n || !n->goto_to_this_pos ) {
+        return 0.0f;
+    }
+    if( n->pos_abs() == *n->goto_to_this_pos ) {
+        return 0.0f;
+    }
+    // Player-directed order. Beats generic follow (capped at 0.6)
+    // but loses to life-threatening needs (thirst at 0.75+).
+    return 0.65f;
 }
 
 } // namespace behavior

--- a/src/character_oracle.h
+++ b/src/character_oracle.h
@@ -40,6 +40,8 @@ class character_oracle_t : public oracle_t
         status_t has_sound_alerts( std::string_view ) const;
         status_t displaced_from_post( std::string_view ) const;
         status_t on_shift( std::string_view ) const;
+        status_t npc_is_following( std::string_view ) const;
+        status_t npc_has_goto_order( std::string_view ) const;
         /**
          * Score predicates for utility strategy (return 0-1 urgency).
          */
@@ -48,6 +50,8 @@ class character_oracle_t : public oracle_t
         float warmth_urgency( std::string_view ) const;
         float sleepiness_urgency( std::string_view ) const;
         float duty_urgency( std::string_view ) const;
+        float npc_following_urgency( std::string_view ) const;
+        float npc_goto_order_urgency( std::string_view ) const;
     private:
         const Character *subject;
 };

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -125,6 +125,7 @@ static const item_group_id Item_spawn_data_survivor_stabbing( "survivor_stabbing
 
 static const itype_id itype_molotov( "molotov" );
 
+static const json_character_flag json_flag_CANNOT_MOVE( "CANNOT_MOVE" );
 static const json_character_flag json_flag_READ_IN_DARKNESS( "READ_IN_DARKNESS" );
 static const json_character_flag json_flag_SAPIOVORE( "SAPIOVORE" );
 
@@ -2673,6 +2674,27 @@ bool npc::guaranteed_hostile() const
 bool npc::is_walking_with() const
 {
     return attitude == NPCATT_FOLLOW || attitude == NPCATT_LEAD || attitude == NPCATT_WAIT;
+}
+
+bool npc::should_follow_close() const
+{
+    if( !is_following() ) {
+        return false;
+    }
+    if( !rules.has_flag( ally_rule::follow_close ) ) {
+        return false;
+    }
+    if( has_flag( json_flag_CANNOT_MOVE ) ) {
+        return false;
+    }
+    const Character &player = get_player_character();
+    if( player.in_vehicle && !in_vehicle ) {
+        return false;
+    }
+    if( player.in_vehicle && in_vehicle ) {
+        return false;
+    }
+    return true;
 }
 
 bool npc::is_obeying( const Character &p ) const

--- a/src/npc.h
+++ b/src/npc.h
@@ -908,6 +908,9 @@ class npc : public Character
         bool is_leader() const;
         // Leading, following, or waiting for the player
         bool is_walking_with() const;
+        // Can actively close-follow right now: walking_with + follow_close
+        // rule + can move + no vehicle mismatch with player.
+        bool should_follow_close() const;
         // In the same faction
         bool is_ally( const Character &p ) const override;
         // Is an ally of the player
@@ -1397,6 +1400,12 @@ class npc : public Character
         }
         void set_committed_goal( const std::string &goal ) {
             ai_cache.committed_goal = goal;
+        }
+        // Persistent duty post from mission/dialogue assignment.
+        // Used by BT duty predicates. Does NOT include ephemeral
+        // sound-investigation anchors from ai_cache.
+        std::optional<tripoint_abs_ms> get_guard_post() const {
+            return guard_pos;
         }
         // Effective guard position: ai_cache (ephemeral, from sound investigation)
         // falls back to persistent guard_pos (from mission/dialogue assignment).

--- a/src/npc_decision_category.h
+++ b/src/npc_decision_category.h
@@ -8,7 +8,7 @@
 // Used by the top-level npc_decision behavior tree to compare
 // BT goal selection against the legacy npc::move() cascade.
 enum class decision_category : int {
-    combat, investigate, needs, duty, idle, unmodeled
+    combat, investigate, needs, follow, order, duty, idle, unmodeled
 };
 
 const char *category_name( decision_category cat );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -256,6 +256,10 @@ const char *category_name( decision_category cat )
             return "investigate";
         case decision_category::needs:
             return "needs";
+        case decision_category::follow:
+            return "follow";
+        case decision_category::order:
+            return "order";
         case decision_category::duty:
             return "duty";
         case decision_category::idle:
@@ -277,6 +281,12 @@ decision_category bt_goal_to_category( const std::string &goal )
     if( goal == "drink_water" || goal == "eat_food" || goal == "go_to_sleep" ||
         goal == "wear_warmer_clothes" || goal == "take_shelter" || goal == "start_fire" ) {
         return decision_category::needs;
+    }
+    if( goal == "follow_player" ) {
+        return decision_category::follow;
+    }
+    if( goal == "goto_ordered_position" ) {
+        return decision_category::order;
     }
     if( goal == "return_to_guard_pos" || goal == "hold_position" ) {
         return decision_category::duty;
@@ -310,6 +320,11 @@ static decision_category cascade_action_to_category( npc_action action )
             return decision_category::investigate;
         case npc_sleep:
             return decision_category::needs;
+        case npc_follow_player:
+        case npc_follow_embarked:
+            return decision_category::follow;
+        case npc_goto_to_this_pos:
+            return decision_category::order;
         case npc_return_to_guard_pos:
             return decision_category::duty;
         case npc_undecided:
@@ -1640,14 +1655,10 @@ void npc::move()
         // No present danger
         cleanup_on_no_danger();
 
-        // Duty NPCs with a guard post: let BT arbitrate needs vs duty.
-        // The BT evaluates every turn but committed goals persist until
-        // completed or overridden by a higher-priority category
-        // (combat > investigation > needs/duty > idle).
-        bool bt_dispatched = false;
-        if( ( mission == NPC_MISSION_SHOPKEEP || mission == NPC_MISSION_GUARD ||
-              mission == NPC_MISSION_GUARD_PATROL ) && get_effective_guard_pos() ) {
-            bt_dispatched = true;
+        // BT evaluates every turn for all NPCs. Committed goals persist
+        // until completed or overridden by a higher-priority category
+        // (combat > investigation > needs > follow > duty > idle).
+        {
             behavior::character_oracle_t oracle( this );
             behavior::tree decision_tree;
             decision_tree.add( &behavior_node_t_npc_decision.obj() );
@@ -1669,12 +1680,20 @@ void npc::move()
                 } else if( committed == "go_to_sleep" ) {
                     completed_goal = has_effect( effect_sleep ) ||
                                      get_sleepiness() < static_cast<int>( sleepiness_levels::TIRED );
-                    // BT no longer wants sleep specifically: context changed
-                    // (shift started, or a more urgent need appeared).
-                    // If genuinely exhausted, BT still returns go_to_sleep
-                    // and commitment persists.
                     if( !completed_goal ) {
                         completed_goal = ( new_goal != "go_to_sleep" );
+                    }
+                } else if( committed == "follow_player" ) {
+                    const Character &pc = get_player_character();
+                    completed_goal = ( rl_dist( pos_bub(), pc.pos_bub() ) <= follow_distance()
+                                       && posz() == pc.posz() );
+                    if( !completed_goal ) {
+                        completed_goal = ( new_goal != "follow_player" );
+                    }
+                } else if( committed == "goto_ordered_position" ) {
+                    completed_goal = !goto_to_this_pos || pos_abs() == *goto_to_this_pos;
+                    if( !completed_goal ) {
+                        completed_goal = ( new_goal != "goto_ordered_position" );
                     }
                 }
                 if( completed_goal ) {
@@ -1699,34 +1718,36 @@ void npc::move()
                     ai_cache.guard_pos = get_effective_guard_pos();
                 }
                 action = npc_return_to_guard_pos;
-            } else if( new_goal == "hold_position" || new_goal == "idle" ) {
-                // At post (on shift or idle). High danger parameter
-                // prevents address_needs from sending NPC to wander.
+            } else if( new_goal == "follow_player" ) {
+                action = npc_follow_player;
+            } else if( new_goal == "goto_ordered_position" ) {
+                action = npc_goto_to_this_pos;
+            } else if( new_goal == "hold_position" ) {
                 action = address_needs( NPC_DANGER_VERY_LOW + 1 );
+            } else if( new_goal == "idle" ) {
+                if( guard_pos ) {
+                    // Persistent duty post: stay put, tend minor needs.
+                    action = address_needs( NPC_DANGER_VERY_LOW + 1 );
+                } else if( ai_cache.guard_pos ) {
+                    // Temp anchor (sound investigation): return to origin.
+                    action = npc_return_to_guard_pos;
+                } else {
+                    // No anchor. Run address_needs so the legacy sleep/eat/drink
+                    // paths still work (the BT may have returned idle because a
+                    // predicate like can_sleep failed, but address_needs has its
+                    // own fallback logic like lying_down on meth).
+                    action = address_needs();
+                }
             } else {
                 // Needs goal (sleep, eat, drink, etc.). Full address_needs.
                 action = address_needs();
             }
-        } else {
-            action = address_needs();
         }
         print_action( "address_needs %s", action );
 
         if( action == npc_undecided ) {
             action = address_player();
             print_action( "address_player %s", action );
-        }
-        if( action == npc_undecided && !bt_dispatched && ai_cache.sound_alerts.empty() &&
-            !has_flag( json_flag_CANNOT_MOVE ) ) {
-            std::optional<tripoint_abs_ms> effective = get_effective_guard_pos();
-            if( effective && pos_abs() != *effective ) {
-                if( !ai_cache.guard_pos ) {
-                    ai_cache.guard_pos = effective;
-                }
-                add_msg_debug( debugmode::DF_NPC, "NPC %s: returning to guard spot at x(%d) y(%d)",
-                               get_name(), effective->x(), effective->y() );
-                action = npc_return_to_guard_pos;
-            }
         }
     }
 
@@ -1742,10 +1763,8 @@ void npc::move()
         path.clear();
     }
 
-    if( action == npc_undecided && is_walking_with() && rules.has_flag( ally_rule::follow_close ) &&
-        rl_dist( pos_bub(), player_character.pos_bub() ) > follow_distance() &&
-        !( player_character.in_vehicle &&
-           in_vehicle ) && !has_flag( json_flag_CANNOT_MOVE ) ) {
+    if( action == npc_undecided && should_follow_close() &&
+        rl_dist( pos_bub(), player_character.pos_bub() ) > follow_distance() ) {
         action = npc_follow_player;
     }
 

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -477,6 +477,7 @@ void talk_function::stop_guard( npc &p )
     p.chatbin.first_topic = p.chatbin.talk_friend;
     p.goal = npc::no_goal_point;
     p.guard_pos = std::nullopt;
+    p.clear_ai_guard_pos();
     if( p.assigned_camp ) {
         if( std::optional<basecamp *> bcp = overmap_buffer.find_camp( ( *p.assigned_camp ).xy() ) ) {
             ( *bcp )->remove_assignee( p.getID() );

--- a/tests/behavior_test.cpp
+++ b/tests/behavior_test.cpp
@@ -37,6 +37,7 @@
 #include "monster_oracle.h"
 #include "mtype.h"
 #include "npc.h"
+#include "npc_class.h"
 #include "player_helpers.h"
 #include "pocket_type.h"
 #include "point.h"
@@ -58,6 +59,7 @@ static const itype_id itype_backpack( "backpack" );
 static const itype_id itype_corpse( "corpse" );
 static const itype_id itype_frame( "frame" );
 static const itype_id itype_lighter( "lighter" );
+static const itype_id itype_orange( "orange" );
 static const itype_id itype_pencil( "pencil" );
 static const itype_id itype_sandwich_cheese_grilled( "sandwich_cheese_grilled" );
 static const itype_id itype_sweater( "sweater" );
@@ -1253,5 +1255,370 @@ TEST_CASE( "npc_decision_predicates_registered", "[npc][behavior]" )
     CHECK( behavior::predicate_map.count( "npc_has_sound_alerts" ) == 1 );
     CHECK( behavior::predicate_map.count( "npc_displaced_from_post" ) == 1 );
     CHECK( behavior::predicate_map.count( "npc_on_shift" ) == 1 );
+    CHECK( behavior::predicate_map.count( "npc_is_following" ) == 1 );
+    CHECK( behavior::predicate_map.count( "npc_has_goto_order" ) == 1 );
     CHECK( behavior::score_predicate_map.count( "npc_duty_urgency" ) == 1 );
+    CHECK( behavior::score_predicate_map.count( "npc_following_urgency" ) == 1 );
+    CHECK( behavior::score_predicate_map.count( "npc_goto_order_urgency" ) == 1 );
+}
+
+TEST_CASE( "duty_predicates_use_persistent_guard_pos_only", "[npc][behavior]" )
+{
+    clear_map_without_vision();
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy );
+    behavior::character_oracle_t oracle( &guy );
+
+    SECTION( "displaced_from_post: failure with only temp anchor" ) {
+        guy.guard_pos = std::nullopt;
+        guy.set_ai_guard_pos( guy.pos_abs() + tripoint( 5, 0, 0 ) );
+        REQUIRE( guy.get_effective_guard_pos().has_value() );
+        REQUIRE_FALSE( guy.get_guard_post().has_value() );
+        CHECK( oracle.displaced_from_post( "" ) == behavior::status_t::failure );
+    }
+    SECTION( "on_shift: failure with only temp anchor" ) {
+        guy.guard_pos = std::nullopt;
+        guy.set_ai_guard_pos( guy.pos_abs() );
+        REQUIRE_FALSE( guy.get_guard_post().has_value() );
+        CHECK( oracle.on_shift( "" ) == behavior::status_t::failure );
+    }
+    SECTION( "duty_urgency: zero with only temp anchor" ) {
+        guy.guard_pos = std::nullopt;
+        guy.set_ai_guard_pos( guy.pos_abs() );
+        CHECK( oracle.duty_urgency( "" ) == Approx( 0.0f ) );
+    }
+    SECTION( "duty still works with persistent guard_pos" ) {
+        guy.set_guard_pos( guy.pos_abs() );
+        calendar::turn = calendar::turn_zero + 12_hours;
+        CHECK( oracle.on_shift( "" ) == behavior::status_t::running );
+        CHECK( oracle.duty_urgency( "" ) == Approx( 0.45f ) );
+    }
+}
+
+TEST_CASE( "npc_is_following_predicate", "[npc][behavior]" )
+{
+    clear_map_without_vision();
+    map &here = get_map();
+    get_player_character().setpos( here, tripoint_bub_ms( 50, 50, 0 ) );
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy );
+    guy.setpos( here, tripoint_bub_ms( 50, 50, 0 ) );
+    guy.set_fac( faction_your_followers );
+    guy.guard_pos = std::nullopt;
+    guy.clear_ai_guard_pos();
+    behavior::character_oracle_t oracle( &guy );
+
+    SECTION( "failure when not walking_with" ) {
+        guy.set_attitude( NPCATT_NULL );
+        CHECK( oracle.npc_is_following( "" ) == behavior::status_t::failure );
+    }
+    SECTION( "failure when follow_close not set" ) {
+        guy.set_attitude( NPCATT_FOLLOW );
+        guy.rules.clear_flag( ally_rule::follow_close );
+        CHECK( oracle.npc_is_following( "" ) == behavior::status_t::failure );
+    }
+    SECTION( "failure when has guard_pos" ) {
+        guy.set_attitude( NPCATT_FOLLOW );
+        guy.rules.set_flag( ally_rule::follow_close );
+        guy.set_guard_pos( guy.pos_abs() + tripoint( 10, 0, 0 ) );
+        CHECK( oracle.npc_is_following( "" ) == behavior::status_t::failure );
+    }
+    SECTION( "failure when player in vehicle and NPC not" ) {
+        guy.set_attitude( NPCATT_FOLLOW );
+        guy.rules.set_flag( ally_rule::follow_close );
+        get_player_character().in_vehicle = true;
+        guy.in_vehicle = false;
+        CHECK( oracle.npc_is_following( "" ) == behavior::status_t::failure );
+        get_player_character().in_vehicle = false;
+    }
+    SECTION( "success when within follow_distance" ) {
+        guy.set_attitude( NPCATT_FOLLOW );
+        guy.rules.set_flag( ally_rule::follow_close );
+        REQUIRE( rl_dist( guy.pos_abs(), get_player_character().pos_abs() ) == 0 );
+        CHECK( oracle.npc_is_following( "" ) == behavior::status_t::success );
+    }
+    SECTION( "running when beyond follow_distance" ) {
+        guy.set_attitude( NPCATT_FOLLOW );
+        guy.rules.set_flag( ally_rule::follow_close );
+        get_player_character().setpos( here, tripoint_bub_ms( 60, 50, 0 ) );
+        CHECK( oracle.npc_is_following( "" ) == behavior::status_t::running );
+    }
+    SECTION( "running when different z-level" ) {
+        guy.set_attitude( NPCATT_FOLLOW );
+        guy.rules.set_flag( ally_rule::follow_close );
+        get_player_character().setpos( here, tripoint_bub_ms( 50, 50, -1 ) );
+        CHECK( oracle.npc_is_following( "" ) == behavior::status_t::running );
+    }
+    SECTION( "temp anchor alone does not block follow" ) {
+        guy.set_attitude( NPCATT_FOLLOW );
+        guy.rules.set_flag( ally_rule::follow_close );
+        guy.guard_pos = std::nullopt;
+        guy.set_ai_guard_pos( guy.pos_abs() + tripoint( 3, 0, 0 ) );
+        REQUIRE( guy.get_effective_guard_pos().has_value() );
+        REQUIRE_FALSE( guy.get_guard_post().has_value() );
+        get_player_character().setpos( here, tripoint_bub_ms( 60, 50, 0 ) );
+        CHECK( oracle.npc_is_following( "" ) == behavior::status_t::running );
+    }
+}
+
+// Provisional urgency thresholds -- will change when the time_to_die
+// evaluation contract lands (#28681). Tests pin current behavior.
+TEST_CASE( "npc_following_urgency_policy", "[npc][behavior]" )
+{
+    clear_map_without_vision();
+    map &here = get_map();
+    get_player_character().setpos( here, tripoint_bub_ms( 50, 50, 0 ) );
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy );
+    guy.setpos( here, tripoint_bub_ms( 50, 50, 0 ) );
+    guy.set_fac( faction_your_followers );
+    guy.set_attitude( NPCATT_FOLLOW );
+    guy.rules.set_flag( ally_rule::follow_close );
+    guy.guard_pos = std::nullopt;
+    guy.clear_ai_guard_pos();
+    behavior::character_oracle_t oracle( &guy );
+
+    SECTION( "follow loses to severe thirst" ) {
+        get_player_character().setpos( here, tripoint_bub_ms( 70, 50, 0 ) );
+        float follow_score = oracle.npc_following_urgency( "" );
+        guy.set_thirst( 900 );
+        float thirst_score = oracle.thirst_urgency( "" );
+        CHECK( thirst_score > follow_score );
+    }
+    SECTION( "follow beats mild hunger" ) {
+        get_player_character().setpos( here, tripoint_bub_ms( 60, 50, 0 ) );
+        float follow_score = oracle.npc_following_urgency( "" );
+        guy.set_stored_kcal( static_cast<int>( guy.get_healthy_kcal() * 0.85 ) );
+        float hunger_score = oracle.hunger_urgency( "" );
+        CHECK( follow_score > hunger_score );
+    }
+    SECTION( "follow does not fire without follow_close" ) {
+        guy.rules.clear_flag( ally_rule::follow_close );
+        get_player_character().setpos( here, tripoint_bub_ms( 70, 50, 0 ) );
+        CHECK( oracle.npc_following_urgency( "" ) == Approx( 0.0f ) );
+    }
+    SECTION( "follow capped below life-threatening needs" ) {
+        get_player_character().setpos( here, tripoint_bub_ms( 100, 50, 0 ) );
+        float follow_score = oracle.npc_following_urgency( "" );
+        guy.set_stored_kcal( static_cast<int>( guy.get_healthy_kcal() * 0.2 ) );
+        float hunger_score = oracle.hunger_urgency( "" );
+        CHECK( hunger_score > follow_score );
+    }
+}
+
+TEST_CASE( "npc_decision_follow_tree", "[npc][behavior]" )
+{
+    clear_map_without_vision();
+    map &here = get_map();
+    get_player_character().setpos( here, tripoint_bub_ms( 50, 50, 0 ) );
+    behavior::tree npc_decision;
+    npc_decision.add( &behavior_node_t_npc_decision.obj() );
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy );
+    guy.setpos( here, tripoint_bub_ms( 50, 50, 0 ) );
+    guy.set_fac( faction_your_followers );
+    guy.set_attitude( NPCATT_FOLLOW );
+    guy.rules.set_flag( ally_rule::follow_close );
+    guy.guard_pos = std::nullopt;
+    guy.clear_ai_guard_pos();
+    behavior::character_oracle_t oracle( &guy );
+
+    SECTION( "follower beyond distance: follow_player" ) {
+        get_player_character().setpos( here, tripoint_bub_ms( 70, 50, 0 ) );
+        CHECK( npc_decision.tick( &oracle ) == "follow_player" );
+    }
+    SECTION( "follower at player: idle" ) {
+        REQUIRE( rl_dist( guy.pos_abs(), get_player_character().pos_abs() ) == 0 );
+        CHECK( npc_decision.tick( &oracle ) == "idle" );
+    }
+    SECTION( "extreme thirst beats following" ) {
+        get_player_character().setpos( here, tripoint_bub_ms( 70, 50, 0 ) );
+        guy.set_thirst( 900 );
+        guy.i_add( item( itype_orange ) );
+        REQUIRE( oracle.has_water( "" ) == behavior::status_t::running );
+        CHECK( npc_decision.tick( &oracle ) == "drink_water" );
+    }
+}
+
+TEST_CASE( "bt_goal_category_mapping_follow", "[npc][behavior]" )
+{
+    CHECK( bt_goal_to_category( "follow_player" ) == decision_category::follow );
+}
+
+TEST_CASE( "follow_and_duty_are_mutually_exclusive", "[npc][behavior]" )
+{
+    clear_map_without_vision();
+    map &here = get_map();
+    get_player_character().setpos( here, tripoint_bub_ms( 50, 50, 0 ) );
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy );
+    guy.set_fac( faction_your_followers );
+    behavior::character_oracle_t oracle( &guy );
+    calendar::turn = calendar::turn_zero + 12_hours;
+
+    SECTION( "guard_pos set: duty fires, follow fails" ) {
+        guy.set_attitude( NPCATT_FOLLOW );
+        guy.rules.set_flag( ally_rule::follow_close );
+        const tripoint_abs_ms post = guy.pos_abs() + tripoint( 5, 0, 0 );
+        guy.set_guard_pos( post );
+        REQUIRE( guy.myclass.is_valid() );
+        REQUIRE( guy.get_guard_post().has_value() );
+        const auto &[wh_start, wh_end] = guy.myclass.obj().get_work_hours();
+        REQUIRE( ( wh_start == 0 && wh_end == 24 ) );
+        get_player_character().setpos( here, tripoint_bub_ms( 60, 50, 0 ) );
+        CHECK( oracle.displaced_from_post( "" ) == behavior::status_t::running );
+        CHECK( oracle.npc_is_following( "" ) == behavior::status_t::failure );
+    }
+    SECTION( "no guard_pos: follow fires, duty fails" ) {
+        guy.set_attitude( NPCATT_FOLLOW );
+        guy.rules.set_flag( ally_rule::follow_close );
+        guy.guard_pos = std::nullopt;
+        guy.clear_ai_guard_pos();
+        REQUIRE_FALSE( guy.get_guard_post().has_value() );
+        get_player_character().setpos( here, tripoint_bub_ms( 60, 50, 0 ) );
+        CHECK( oracle.npc_is_following( "" ) == behavior::status_t::running );
+        CHECK( oracle.displaced_from_post( "" ) == behavior::status_t::failure );
+        CHECK( oracle.duty_urgency( "" ) == Approx( 0.0f ) );
+    }
+}
+
+static std::string bt_goal( const npc &guy )
+{
+    behavior::character_oracle_t oracle( &guy );
+    behavior::tree dt;
+    dt.add( &behavior_node_t_npc_decision.obj() );
+    return dt.tick( &oracle );
+}
+
+TEST_CASE( "npc_player_order_predicate_and_goal", "[npc][behavior]" )
+{
+    clear_map_without_vision();
+    map &here = get_map();
+    get_player_character().setpos( here, tripoint_bub_ms( 50, 50, 0 ) );
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy );
+    guy.setpos( here, tripoint_bub_ms( 50, 50, 0 ) );
+    guy.set_fac( faction_your_followers );
+    guy.set_attitude( NPCATT_FOLLOW );
+    guy.rules.set_flag( ally_rule::follow_close );
+    guy.guard_pos = std::nullopt;
+    guy.clear_ai_guard_pos();
+    behavior::character_oracle_t oracle( &guy );
+
+    SECTION( "no order: failure" ) {
+        guy.goto_to_this_pos = std::nullopt;
+        CHECK( oracle.npc_has_goto_order( "" ) == behavior::status_t::failure );
+    }
+    SECTION( "pending order: running" ) {
+        guy.goto_to_this_pos = guy.pos_abs() + tripoint( 10, 0, 0 );
+        CHECK( oracle.npc_has_goto_order( "" ) == behavior::status_t::running );
+    }
+    SECTION( "at target: success" ) {
+        guy.goto_to_this_pos = guy.pos_abs();
+        CHECK( oracle.npc_has_goto_order( "" ) == behavior::status_t::success );
+    }
+    SECTION( "order beats follow in BT" ) {
+        get_player_character().setpos( here, tripoint_bub_ms( 70, 50, 0 ) );
+        guy.goto_to_this_pos = guy.pos_abs() + tripoint( 10, 0, 0 );
+        CHECK( bt_goal( guy ) == "goto_ordered_position" );
+    }
+    SECTION( "severe thirst beats order" ) {
+        guy.goto_to_this_pos = guy.pos_abs() + tripoint( 10, 0, 0 );
+        guy.set_thirst( 900 );
+        guy.i_add( item( itype_orange ) );
+        REQUIRE( oracle.has_water( "" ) == behavior::status_t::running );
+        CHECK( bt_goal( guy ) == "drink_water" );
+    }
+}
+
+TEST_CASE( "bt_goal_category_mapping_order", "[npc][behavior]" )
+{
+    CHECK( bt_goal_to_category( "goto_ordered_position" ) == decision_category::order );
+}
+
+TEST_CASE( "bt_priority_matrix", "[npc][behavior]" )
+{
+    clear_map_without_vision();
+    map &here = get_map();
+    get_player_character().setpos( here, tripoint_bub_ms( 50, 50, 0 ) );
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy );
+    guy.setpos( here, tripoint_bub_ms( 50, 50, 0 ) );
+    guy.set_fac( faction_your_followers );
+    guy.guard_pos = std::nullopt;
+    guy.clear_ai_guard_pos();
+    calendar::turn = calendar::turn_zero + 12_hours;
+
+    SECTION( "healthy follower at player: idle" ) {
+        guy.set_attitude( NPCATT_FOLLOW );
+        guy.rules.set_flag( ally_rule::follow_close );
+        CHECK( bt_goal( guy ) == "idle" );
+    }
+    SECTION( "follower beyond distance: follow_player" ) {
+        guy.set_attitude( NPCATT_FOLLOW );
+        guy.rules.set_flag( ally_rule::follow_close );
+        get_player_character().setpos( here, tripoint_bub_ms( 70, 50, 0 ) );
+        CHECK( bt_goal( guy ) == "follow_player" );
+    }
+    SECTION( "leader: not follow_player" ) {
+        guy.set_attitude( NPCATT_LEAD );
+        guy.rules.set_flag( ally_rule::follow_close );
+        get_player_character().setpos( here, tripoint_bub_ms( 70, 50, 0 ) );
+        CHECK( bt_goal( guy ) != "follow_player" );
+    }
+    SECTION( "waiting NPC with follow_close: follows" ) {
+        // WAIT is in is_following(), same as old cascade.
+        guy.set_attitude( NPCATT_WAIT );
+        guy.rules.set_flag( ally_rule::follow_close );
+        get_player_character().setpos( here, tripoint_bub_ms( 70, 50, 0 ) );
+        CHECK( bt_goal( guy ) == "follow_player" );
+    }
+    SECTION( "guard_pos set: duty beats follow" ) {
+        guy.set_attitude( NPCATT_FOLLOW );
+        guy.rules.set_flag( ally_rule::follow_close );
+        const tripoint_abs_ms post = guy.pos_abs() + tripoint( 5, 0, 0 );
+        guy.set_guard_pos( post );
+        get_player_character().setpos( here, tripoint_bub_ms( 70, 50, 0 ) );
+        CHECK( bt_goal( guy ) == "return_to_guard_pos" );
+    }
+    SECTION( "severe thirst beats follow" ) {
+        guy.set_attitude( NPCATT_FOLLOW );
+        guy.rules.set_flag( ally_rule::follow_close );
+        get_player_character().setpos( here, tripoint_bub_ms( 70, 50, 0 ) );
+        guy.set_thirst( 900 );
+        guy.i_add( item( itype_orange ) );
+        behavior::character_oracle_t oracle( &guy );
+        REQUIRE( oracle.needs_water_badly( "" ) == behavior::status_t::running );
+        REQUIRE( oracle.has_water( "" ) == behavior::status_t::running );
+        REQUIRE( oracle.thirst_urgency( "" ) > oracle.npc_following_urgency( "" ) );
+        CHECK( bt_goal( guy ) == "drink_water" );
+    }
+    SECTION( "mild hunger loses to follow" ) {
+        guy.set_attitude( NPCATT_FOLLOW );
+        guy.rules.set_flag( ally_rule::follow_close );
+        get_player_character().setpos( here, tripoint_bub_ms( 60, 50, 0 ) );
+        guy.set_stored_kcal( static_cast<int>( guy.get_healthy_kcal() * 0.85 ) );
+        CHECK( bt_goal( guy ) == "follow_player" );
+    }
+    SECTION( "goto order beats follow" ) {
+        guy.set_attitude( NPCATT_FOLLOW );
+        guy.rules.set_flag( ally_rule::follow_close );
+        get_player_character().setpos( here, tripoint_bub_ms( 70, 50, 0 ) );
+        guy.goto_to_this_pos = guy.pos_abs() + tripoint( 10, 0, 0 );
+        CHECK( bt_goal( guy ) == "goto_ordered_position" );
+    }
+    SECTION( "no follow_close rule: idle" ) {
+        guy.set_attitude( NPCATT_FOLLOW );
+        guy.rules.clear_flag( ally_rule::follow_close );
+        get_player_character().setpos( here, tripoint_bub_ms( 70, 50, 0 ) );
+        CHECK( bt_goal( guy ) == "idle" );
+    }
+    SECTION( "player in vehicle, NPC not: no follow" ) {
+        guy.set_attitude( NPCATT_FOLLOW );
+        guy.rules.set_flag( ally_rule::follow_close );
+        get_player_character().setpos( here, tripoint_bub_ms( 70, 50, 0 ) );
+        get_player_character().in_vehicle = true;
+        CHECK( bt_goal( guy ) != "follow_player" );
+        get_player_character().in_vehicle = false;
+    }
 }

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -49,6 +49,7 @@
 #include "iexamine.h"
 #include "monster.h"
 #include "npc.h"
+#include "npc_class.h"
 #include "npctalk.h"
 #include "options_helpers.h"
 #include "output.h"
@@ -78,6 +79,7 @@ enum npc_action : int;
 static const activity_id ACT_FORAGE( "ACT_FORAGE" );
 
 static const efftype_id effect_bouldering( "bouldering" );
+static const efftype_id effect_catch_up( "catch_up" );
 static const efftype_id effect_lying_down( "lying_down" );
 static const efftype_id effect_meth( "meth" );
 static const efftype_id effect_sleep( "sleep" );
@@ -120,6 +122,8 @@ static const npc_class_id NC_ROBOFAC_INTERCOM_NIGHT( "NC_ROBOFAC_INTERCOM_NIGHT"
 static const npc_class_id NC_ROBOFAC_INTERCOM_SUPPLY( "NC_ROBOFAC_INTERCOM_SUPPLY" );
 static const npc_class_id test_shop_class( "test_shop_class" );
 
+static const string_id<behavior::node_t> behavior_node_t_npc_decision( "npc_decision" );
+
 static const ter_str_id ter_t_concrete_wall( "t_concrete_wall" );
 static const ter_str_id ter_t_door_c( "t_door_c" );
 static const ter_str_id ter_t_floor( "t_floor" );
@@ -145,6 +149,7 @@ static const vpart_id vpart_seat( "seat" );
 static const vpart_id vpart_trunk_floor( "trunk_floor" );
 
 static const vproto_id vehicle_prototype_none( "none" );
+static const vproto_id vehicle_prototype_test_rv( "test_rv" );
 static const vproto_id vehicle_prototype_test_shopping_cart( "test_shopping_cart" );
 
 static const zone_type_id zone_type_CAMP_FOOD( "CAMP_FOOD" );
@@ -3642,8 +3647,7 @@ TEST_CASE( "return_to_start_pos_npc_still_uses_legacy_fallback", "[npc][schedule
 
     npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
     clear_character( guy, true );
-    // RETURN_TO_START_POS but NOT shopkeep/guard/guard_patrol,
-    // so the BT block is skipped and the legacy fallback applies.
+    // RETURN_TO_START_POS + SHELTER. BT duty fires, same result as before.
     guy.set_mutation( trait_RETURN_TO_START_POS );
     guy.set_mission( NPC_MISSION_SHELTER );
     guy.set_hunger( 0 );
@@ -3665,11 +3669,532 @@ TEST_CASE( "return_to_start_pos_npc_still_uses_legacy_fallback", "[npc][schedule
 
     REQUIRE( guy.pos_abs() != post );
 
+    // First tick commits to return_to_guard_pos.
+    guy.set_moves( 100 );
+    guy.move();
+    CHECK( guy.get_committed_goal() == "return_to_guard_pos" );
+
+    for( int i = 0; i < 2; ++i ) {
+        guy.set_moves( 100 );
+        guy.move();
+    }
+
+    CHECK( rl_dist( guy.pos_bub(), here.get_bub( post ) ) < initial_dist );
+}
+
+TEST_CASE( "follow_player_commitment_lifecycle", "[npc][behavior]" )
+{
+    clear_map_without_vision();
+    clear_avatar();
+    map &here = get_map();
+    get_player_character().setpos( here, tripoint_bub_ms( 65, 50, 0 ) );
+
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy, true );
+    guy.set_fac( faction_your_followers );
+    guy.set_attitude( NPCATT_FOLLOW );
+    guy.rules.set_flag( ally_rule::follow_close );
+    guy.set_mission( NPC_MISSION_NULL );
+    guy.guard_pos = std::nullopt;
+    guy.clear_ai_guard_pos();
+    guy.set_hunger( 0 );
+    guy.set_thirst( 0 );
+    guy.set_sleepiness( 0 );
+    guy.set_stored_kcal( guy.get_healthy_kcal() );
+    guy.set_all_parts_temp_conv( BODYTEMP_NORM );
+    guy.set_all_parts_temp_cur( BODYTEMP_NORM );
+    guy.regen_ai_cache();
+
+    REQUIRE( rl_dist( guy.pos_abs(), get_player_character().pos_abs() ) > 4 );
+
+    SECTION( "committed_goal set to follow_player when far" ) {
+        guy.set_moves( 100 );
+        guy.move();
+        CHECK( guy.get_committed_goal() == "follow_player" );
+    }
+    SECTION( "committed_goal clears when within follow_distance" ) {
+        for( int i = 0; i < 20; ++i ) {
+            guy.set_moves( 100 );
+            guy.move();
+            if( rl_dist( guy.pos_abs(), get_player_character().pos_abs() )
+                <= guy.follow_distance() ) {
+                break;
+            }
+        }
+        REQUIRE( rl_dist( guy.pos_abs(), get_player_character().pos_abs() )
+                 <= guy.follow_distance() );
+        guy.set_moves( 100 );
+        guy.move();
+        CHECK( guy.get_committed_goal().empty() );
+    }
+}
+
+TEST_CASE( "temp_anchor_return_after_bt_idle", "[npc][behavior]" )
+{
+    clear_map_without_vision();
+    clear_avatar();
+    map &here = get_map();
+    get_player_character().setpos( here, tripoint_bub_ms( 50, 50, -2 ) );
+
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy, true );
+    guy.set_mission( NPC_MISSION_NULL );
+    guy.set_attitude( NPCATT_NULL );
+    guy.guard_pos = std::nullopt;
+
+    // NPC displaced from origin by sound investigation, temp anchor set.
+    const tripoint_abs_ms anchor = guy.pos_abs();
+    guy.setpos( here, tripoint_bub_ms( 55, 50, 0 ) );
+    guy.set_ai_guard_pos( anchor );
+    guy.set_hunger( 0 );
+    guy.set_thirst( 0 );
+    guy.set_sleepiness( 0 );
+    guy.set_stored_kcal( guy.get_healthy_kcal() );
+    guy.set_all_parts_temp_conv( BODYTEMP_NORM );
+    guy.set_all_parts_temp_cur( BODYTEMP_NORM );
+    guy.goal = guy.pos_abs_omt();
+    guy.regen_ai_cache();
+
+    REQUIRE( guy.pos_abs() != anchor );
+    REQUIRE( guy.get_effective_guard_pos() == anchor );
+    REQUIRE_FALSE( guy.get_guard_post().has_value() );
+
+    // Idle dispatch sees temp anchor, routes npc_return_to_guard_pos.
+    for( int i = 0; i < 10; ++i ) {
+        guy.set_moves( 100 );
+        guy.move();
+        if( guy.pos_abs() == anchor ) {
+            break;
+        }
+    }
+
+    CHECK( guy.pos_abs() == anchor );
+}
+
+TEST_CASE( "bt_idle_falls_through_to_cascade_goto", "[npc][behavior]" )
+{
+    clear_map_without_vision();
+    clear_avatar();
+    map &here = get_map();
+
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy, true );
+    guy.setpos( here, tripoint_bub_ms( 50, 50, 0 ) );
+    // Player within follow_distance, so BT returns idle.
+    get_player_character().setpos( here, tripoint_bub_ms( 52, 50, 0 ) );
+    guy.set_fac( faction_your_followers );
+    guy.set_attitude( NPCATT_FOLLOW );
+    guy.set_mission( NPC_MISSION_NULL );
+    guy.set_hunger( 0 );
+    guy.set_thirst( 0 );
+    guy.set_sleepiness( 0 );
+    guy.set_stored_kcal( guy.get_healthy_kcal() );
+    guy.set_all_parts_temp_conv( BODYTEMP_NORM );
+    guy.set_all_parts_temp_cur( BODYTEMP_NORM );
+    // Clear after regen so RETURN_TO_START_POS doesn't repopulate.
+    guy.regen_ai_cache();
+    guy.guard_pos = std::nullopt;
+    guy.clear_ai_guard_pos();
+    REQUIRE_FALSE( guy.get_effective_guard_pos().has_value() );
+    REQUIRE( rl_dist( guy.pos_abs(), get_player_character().pos_abs() ) <= guy.follow_distance() );
+
+    // Player-ordered goto.
+    const tripoint_abs_ms target = guy.pos_abs() + tripoint( 5, 0, 0 );
+    guy.goto_to_this_pos = target;
+
+    guy.set_moves( 100 );
+    guy.move();
+
+    CHECK( guy.get_committed_goal() == "goto_ordered_position" );
+    CHECK( rl_dist( guy.pos_abs(), target ) < 5 );
+}
+
+TEST_CASE( "anchored_follower_uses_duty_not_follow", "[npc][behavior]" )
+{
+    clear_map_without_vision();
+    clear_avatar();
+    map &here = get_map();
+
+    // Player west, guard post east. NPC at center.
+    const tripoint_bub_ms npc_pos( 50, 50, 0 );
+    const tripoint_bub_ms player_pos( 40, 50, 0 );
+    get_player_character().setpos( here, player_pos );
+
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy, true );
+    guy.setpos( here, npc_pos );
+    guy.set_fac( faction_your_followers );
+    guy.set_attitude( NPCATT_FOLLOW );
+    guy.rules.set_flag( ally_rule::follow_close );
+    guy.set_mission( NPC_MISSION_GUARD_ALLY );
+    const tripoint_abs_ms post = guy.pos_abs() + tripoint( 10, 0, 0 );
+    guy.set_guard_pos( post );
+    calendar::turn = calendar::turn_zero + 12_hours;
+    guy.set_hunger( 0 );
+    guy.set_thirst( 0 );
+    guy.set_sleepiness( 0 );
+    guy.set_stored_kcal( guy.get_healthy_kcal() );
+    guy.set_all_parts_temp_conv( BODYTEMP_NORM );
+    guy.set_all_parts_temp_cur( BODYTEMP_NORM );
+    guy.regen_ai_cache();
+
+    REQUIRE( guy.myclass.is_valid() );
+    const auto &[wh_start, wh_end] = guy.myclass.obj().get_work_hours();
+    REQUIRE( ( wh_start == 0 && wh_end == 24 ) );
+    REQUIRE( guy.get_guard_post().has_value() );
+    REQUIRE( guy.pos_abs() != post );
+    REQUIRE( rl_dist( guy.pos_abs(), get_player_character().pos_abs() ) > 4 );
+
+    SECTION( "BT returns return_to_guard_pos, not follow_player" ) {
+        behavior::character_oracle_t oracle( &guy );
+        behavior::tree decision_tree;
+        decision_tree.add( &behavior_node_t_npc_decision.obj() );
+        CHECK( decision_tree.tick( &oracle ) == "return_to_guard_pos" );
+    }
+    SECTION( "live turns: NPC moves toward post, not player" ) {
+        const int initial_dist_post = rl_dist( guy.pos_abs(), post );
+        const int initial_dist_player = rl_dist( guy.pos_abs(),
+                                        get_player_character().pos_abs() );
+        for( int i = 0; i < 3; ++i ) {
+            guy.set_moves( 100 );
+            guy.move();
+        }
+        CHECK( rl_dist( guy.pos_abs(), post ) < initial_dist_post );
+        CHECK( rl_dist( guy.pos_abs(), get_player_character().pos_abs() )
+               > initial_dist_player );
+    }
+}
+
+TEST_CASE( "guard_assignment_clears_follow_commitment", "[npc][behavior]" )
+{
+    clear_map_without_vision();
+    clear_avatar();
+    map &here = get_map();
+    get_player_character().setpos( here, tripoint_bub_ms( 65, 50, 0 ) );
+    calendar::turn = calendar::turn_zero + 12_hours;
+
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy, true );
+    guy.set_fac( faction_your_followers );
+    guy.set_attitude( NPCATT_FOLLOW );
+    guy.rules.set_flag( ally_rule::follow_close );
+    guy.set_mission( NPC_MISSION_NULL );
+    guy.guard_pos = std::nullopt;
+    guy.clear_ai_guard_pos();
+    guy.set_hunger( 0 );
+    guy.set_thirst( 0 );
+    guy.set_sleepiness( 0 );
+    guy.set_stored_kcal( guy.get_healthy_kcal() );
+    guy.set_all_parts_temp_conv( BODYTEMP_NORM );
+    guy.set_all_parts_temp_cur( BODYTEMP_NORM );
+    guy.regen_ai_cache();
+
+    REQUIRE( rl_dist( guy.pos_abs(), get_player_character().pos_abs() ) > 4 );
+
+    guy.set_moves( 100 );
+    guy.move();
+    REQUIRE( guy.get_committed_goal() == "follow_player" );
+
+    const tripoint_abs_ms pre_assign_pos = guy.pos_abs();
+
+    // Simulate assign_guard: guard current tile.
+    guy.set_attitude( NPCATT_NULL );
+    guy.set_mission( NPC_MISSION_GUARD_ALLY );
+    guy.set_omt_destination();
+    REQUIRE( guy.get_guard_post().has_value() );
+    REQUIRE( *guy.get_guard_post() == pre_assign_pos );
+    REQUIRE( guy.myclass.is_valid() );
+    const auto &[wh_start2, wh_end2] = guy.myclass.obj().get_work_hours();
+    REQUIRE( ( wh_start2 == 0 && wh_end2 == 24 ) );
+
+    // Follow commitment clears, NPC stays at post.
+    guy.set_moves( 100 );
+    guy.move();
+    CHECK( guy.get_committed_goal().empty() );
+    CHECK( guy.pos_abs() == pre_assign_pos );
+
+    // Next tick: hold_position commits.
+    guy.set_moves( 100 );
+    guy.move();
+    CHECK( guy.get_committed_goal() == "hold_position" );
+    CHECK( guy.pos_abs() == pre_assign_pos );
+}
+
+TEST_CASE( "player_embarks_clears_follow_commitment", "[npc][behavior]" )
+{
+    clear_map_without_vision();
+    clear_avatar();
+    map &here = get_map();
+    Character &pc = get_player_character();
+    pc.setpos( here, tripoint_bub_ms( 65, 50, 0 ) );
+
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy, true );
+    guy.set_fac( faction_your_followers );
+    guy.set_attitude( NPCATT_FOLLOW );
+    guy.rules.set_flag( ally_rule::follow_close );
+    guy.set_mission( NPC_MISSION_NULL );
+    guy.guard_pos = std::nullopt;
+    guy.clear_ai_guard_pos();
+    guy.set_hunger( 0 );
+    guy.set_thirst( 0 );
+    guy.set_sleepiness( 0 );
+    guy.set_stored_kcal( guy.get_healthy_kcal() );
+    guy.set_all_parts_temp_conv( BODYTEMP_NORM );
+    guy.set_all_parts_temp_cur( BODYTEMP_NORM );
+    guy.regen_ai_cache();
+
+    REQUIRE( rl_dist( guy.pos_abs(), pc.pos_abs() ) > 4 );
+
+    guy.set_moves( 100 );
+    guy.move();
+    REQUIRE( guy.get_committed_goal() == "follow_player" );
+
+    // Player boards a vehicle.
+    vehicle *veh = here.add_vehicle( vehicle_prototype_test_rv, pc.pos_bub(),
+                                     0_degrees, 100, 0 );
+    REQUIRE( veh != nullptr );
+    here.board_vehicle( pc.pos_bub(), &pc );
+    REQUIRE( pc.in_vehicle );
+    REQUIRE_FALSE( guy.in_vehicle );
+
+    // Vehicle mismatch clears follow commitment.
+    guy.set_moves( 100 );
+    guy.move();
+    CHECK( guy.get_committed_goal() != "follow_player" );
+}
+
+TEST_CASE( "goto_order_beats_generic_follow", "[npc][behavior]" )
+{
+    clear_map_without_vision();
+    clear_avatar();
+    map &here = get_map();
+
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy, true );
+    guy.setpos( here, tripoint_bub_ms( 50, 50, 0 ) );
+    guy.set_fac( faction_your_followers );
+    guy.set_attitude( NPCATT_FOLLOW );
+    guy.rules.set_flag( ally_rule::follow_close );
+    guy.set_mission( NPC_MISSION_NULL );
+    guy.guard_pos = std::nullopt;
+    guy.clear_ai_guard_pos();
+    guy.set_hunger( 0 );
+    guy.set_thirst( 0 );
+    guy.set_sleepiness( 0 );
+    guy.set_stored_kcal( guy.get_healthy_kcal() );
+    guy.set_all_parts_temp_conv( BODYTEMP_NORM );
+    guy.set_all_parts_temp_cur( BODYTEMP_NORM );
+    guy.regen_ai_cache();
+
+    // Player west, goto target east -- opposite directions.
+    get_player_character().setpos( here, tripoint_bub_ms( 40, 50, 0 ) );
+    const tripoint_abs_ms goto_target = guy.pos_abs() + tripoint( 10, 0, 0 );
+    guy.goto_to_this_pos = goto_target;
+
+    REQUIRE( rl_dist( guy.pos_abs(), get_player_character().pos_abs() )
+             > guy.follow_distance() );
+    REQUIRE( guy.goto_to_this_pos.has_value() );
+
+    const int initial_dist_goto = rl_dist( guy.pos_abs(), goto_target );
+
+    guy.set_moves( 100 );
+    guy.move();
+    CHECK( guy.get_committed_goal() == "goto_ordered_position" );
+
+    for( int i = 0; i < 2; ++i ) {
+        guy.set_moves( 100 );
+        guy.move();
+    }
+
+    // Moved east toward goto, not west toward player.
+    CHECK( guy.pos_bub().x() > 50 );
+    CHECK( rl_dist( guy.pos_abs(), goto_target ) < initial_dist_goto );
+}
+
+TEST_CASE( "follow_close_beats_fetching_item", "[npc][behavior]" )
+{
+    clear_map_without_vision();
+    clear_avatar();
+    map &here = get_map();
+
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy, true );
+    guy.setpos( here, tripoint_bub_ms( 50, 50, 0 ) );
+    guy.set_fac( faction_your_followers );
+    guy.set_attitude( NPCATT_FOLLOW );
+    guy.rules.set_flag( ally_rule::follow_close );
+    guy.set_mission( NPC_MISSION_NULL );
+    guy.guard_pos = std::nullopt;
+    guy.clear_ai_guard_pos();
+    guy.set_hunger( 0 );
+    guy.set_thirst( 0 );
+    guy.set_sleepiness( 0 );
+    guy.set_stored_kcal( guy.get_healthy_kcal() );
+    guy.set_all_parts_temp_conv( BODYTEMP_NORM );
+    guy.set_all_parts_temp_cur( BODYTEMP_NORM );
+    guy.regen_ai_cache();
+
+    // Player west, pending pickup east -- opposite directions.
+    get_player_character().setpos( here, tripoint_bub_ms( 40, 50, 0 ) );
+    REQUIRE( rl_dist( guy.pos_abs(), get_player_character().pos_abs() )
+             > guy.follow_distance() );
+
+    guy.fetching_item = true;
+    guy.wanted_item_pos = tripoint_bub_ms( 55, 50, 0 );
+
+    guy.set_moves( 100 );
+    guy.move();
+
+    // Follow wins over item pickup, matching old cascade ordering.
+    CHECK( guy.pos_bub().x() < 50 );
+}
+
+TEST_CASE( "activity_npc_without_task_reverts_to_follower", "[npc][behavior]" )
+{
+    clear_map_without_vision();
+    clear_avatar();
+    map &here = get_map();
+    get_player_character().setpos( here, tripoint_bub_ms( 50, 50, -2 ) );
+
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy, true );
+    guy.set_fac( faction_your_followers );
+    guy.set_attitude( NPCATT_ACTIVITY );
+    guy.set_mission( NPC_MISSION_NULL );
+    guy.guard_pos = std::nullopt;
+    guy.clear_ai_guard_pos();
+    guy.assigned_camp = std::nullopt;
+    guy.set_hunger( 0 );
+    guy.set_thirst( 0 );
+    guy.set_sleepiness( 0 );
+    guy.set_stored_kcal( guy.get_healthy_kcal() );
+    guy.set_all_parts_temp_conv( BODYTEMP_NORM );
+    guy.set_all_parts_temp_cur( BODYTEMP_NORM );
+    guy.regen_ai_cache();
+
+    REQUIRE( guy.get_attitude() == NPCATT_ACTIVITY );
+    REQUIRE_FALSE( guy.activity );
+
+    guy.set_moves( 100 );
+    guy.move();
+
+    // Cascade revert: ally without camp reverts to FOLLOW.
+    CHECK( guy.get_attitude() == NPCATT_FOLLOW );
+    CHECK( guy.get_committed_goal().empty() );
+}
+
+TEST_CASE( "stationary_npc_bt_idle_pauses", "[npc][behavior]" )
+{
+    clear_map_without_vision();
+    clear_avatar();
+    map &here = get_map();
+    get_player_character().setpos( here, tripoint_bub_ms( 50, 50, -2 ) );
+
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy, true );
+    guy.set_attitude( NPCATT_NULL );
+    guy.set_mission( NPC_MISSION_SHELTER );
+    guy.guard_pos = std::nullopt;
+    guy.clear_ai_guard_pos();
+    guy.goal = guy.pos_abs_omt();
+    guy.set_hunger( 0 );
+    guy.set_thirst( 0 );
+    guy.set_sleepiness( 0 );
+    guy.set_stored_kcal( guy.get_healthy_kcal() );
+    guy.set_all_parts_temp_conv( BODYTEMP_NORM );
+    guy.set_all_parts_temp_cur( BODYTEMP_NORM );
+    guy.regen_ai_cache();
+
+    REQUIRE( guy.is_stationary( true ) );
+    const tripoint_abs_ms start_pos = guy.pos_abs();
+
+    guy.set_moves( 100 );
+    guy.move();
+
+    CHECK( guy.get_committed_goal().empty() );
+    CHECK( guy.pos_abs() == start_pos );
+}
+
+TEST_CASE( "leader_npc_leads_not_follows", "[npc][behavior]" )
+{
+    clear_map();
+    clear_avatar();
+    map &here = get_map();
+
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy, true );
+    guy.setpos( here, tripoint_bub_ms( 50, 50, 0 ) );
+    guy.set_fac( faction_your_followers );
+    guy.set_attitude( NPCATT_LEAD );
+    guy.rules.set_flag( ally_rule::follow_close );
+    guy.set_mission( NPC_MISSION_NULL );
+    guy.guard_pos = std::nullopt;
+    guy.clear_ai_guard_pos();
+    guy.set_hunger( 0 );
+    guy.set_thirst( 0 );
+    guy.set_sleepiness( 0 );
+    guy.set_stored_kcal( guy.get_healthy_kcal() );
+    guy.set_all_parts_temp_conv( BODYTEMP_NORM );
+    guy.set_all_parts_temp_cur( BODYTEMP_NORM );
+
+    // Player 5 tiles west. Destination east.
+    get_player_character().setpos( here, tripoint_bub_ms( 45, 50, 0 ) );
+    guy.goal = project_to<coords::omt>( guy.pos_abs() + tripoint( 10 * SEEX, 0, 0 ) );
+    guy.regen_ai_cache();
+
+    REQUIRE( guy.is_leader() );
+    REQUIRE( guy.is_player_ally() );
+    REQUIRE( guy.has_omt_destination() );
+    REQUIRE( rl_dist( guy.pos_abs(), get_player_character().pos_abs() ) < 12 );
+
     for( int i = 0; i < 3; ++i ) {
         guy.set_moves( 100 );
         guy.move();
     }
 
-    // Legacy fallback should still fire: NPC moves closer to post.
-    CHECK( rl_dist( guy.pos_bub(), here.get_bub( post ) ) < initial_dist );
+    CHECK( guy.get_committed_goal() != "follow_player" );
+    // Did not move toward player (west). Either moved east or stayed put.
+    CHECK( guy.pos_bub().x() >= 50 );
+}
+
+TEST_CASE( "leader_npc_waits_when_player_far", "[npc][behavior]" )
+{
+    clear_map_without_vision();
+    clear_avatar();
+    map &here = get_map();
+
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy, true );
+    guy.setpos( here, tripoint_bub_ms( 50, 50, 0 ) );
+    guy.set_fac( faction_your_followers );
+    guy.set_attitude( NPCATT_LEAD );
+    guy.rules.set_flag( ally_rule::follow_close );
+    guy.set_mission( NPC_MISSION_NULL );
+    guy.guard_pos = std::nullopt;
+    guy.clear_ai_guard_pos();
+    guy.set_hunger( 0 );
+    guy.set_thirst( 0 );
+    guy.set_sleepiness( 0 );
+    guy.set_stored_kcal( guy.get_healthy_kcal() );
+    guy.set_all_parts_temp_conv( BODYTEMP_NORM );
+    guy.set_all_parts_temp_cur( BODYTEMP_NORM );
+
+    // Player 15 tiles west (>= 12, triggers "keep up").
+    get_player_character().setpos( here, tripoint_bub_ms( 35, 50, 0 ) );
+    guy.goal = project_to<coords::omt>( guy.pos_abs() + tripoint( 10 * SEEX, 0, 0 ) );
+    guy.regen_ai_cache();
+
+    REQUIRE( guy.is_leader() );
+    REQUIRE( guy.is_player_ally() );
+    REQUIRE( rl_dist( guy.pos_abs(), get_player_character().pos_abs() ) >= 12 );
+
+    const tripoint_abs_ms start_pos = guy.pos_abs();
+    guy.set_moves( 100 );
+    guy.move();
+
+    // Leader should pause and gain catch_up effect, NOT follow.
+    CHECK( guy.pos_abs() == start_pos );
+    CHECK( guy.get_committed_goal() != "follow_player" );
+    CHECK( guy.has_effect( effect_catch_up ) );
 }


### PR DESCRIPTION
#### Summary
Features "NPC behavior tree evaluates for all NPCs, not just guards"

#### Purpose of change

Related to #28681 - extends the BT needs system to all NPCs.

Previously the behavior tree only ran for guards and shopkeepers. All other NPCs used the legacy cascade in `npc::move()`. Followers, wanderers, and camp workers never got BT-driven decision-making - their needs were handled by the old `address_needs()` waterfall with `one_in(3)` random gates.

#### Describe the solution

Remove the mission gate so the BT evaluates every turn for all NPCs. Duty predicates now key off persistent `guard_pos` only, ignoring ephemeral sound-investigation anchors from `ai_cache`.

Two new BT goals under `npc_priorities` (utility scoring):
- `npc_follow`: fires for followers with `follow_close`, urgency 0.3-0.6 based on distance. `NPCATT_LEAD` excluded so leaders keep their own pause/goto/keep-up behavior via `address_player`.
- `goto_ordered_position`: player-directed goto as a first-class goal, urgency 0.65. Beats follow but loses to life-threatening needs.

Idle dispatch: persistent `guard_pos` holds post, temp anchor returns to origin, no anchor falls through to the cascade. The old `bt_dispatched` guard-return fallback is removed.

New helper `should_follow_close()` on npc, shared between the BT predicate and the cascade fallback. `get_guard_post()` accessor returns only the persistent post, not cache.

Gameplay-wise, NPC behavior should be mostly unchanged - followers still follow, guards still guard, shopkeepers still sell. The difference is that competing priorities (follow vs eat vs sleep) are now resolved by urgency scoring instead of fixed code ordering, so a starving follower will stop to eat instead of blindly chasing the player.

#### Describe alternatives you've considered

Could have kept the gate and added follow/goto as cascade-only features, but that defeats the purpose of making the BT authoritative.

Could have modeled follow as a fixed-priority branch instead of utility-scored, but that loses the ability for severe needs to override following.

#### Testing

~900 lines of new tests covering predicate registration, following urgency policy, full BT tree queries, priority matrix (FOLLOW/WAIT/LEAD/duty/thirst/hunger/goto/no-rule/vehicle), and live-turn integration (follow commitment lifecycle, temp anchor return, guard/embark/goto transitions, activity revert, leader behavior).

Tested in-game with followers, guards, and shopkeepers - no regressions.

#### Additional context

None.