### PR TITLE
NPC needs: split camp residents from guard state, add free_time BT goal

### DIFF
--- a/data/json/npcs/common_chat/TALK_COMMON_ALLY.json
+++ b/data/json/npcs/common_chat/TALK_COMMON_ALLY.json
@@ -59,6 +59,12 @@
         "condition": { "u_has_trait": "DEBUG_MIND_CONTROL" },
         "topic": "TALK_ALLY_DEBUG"
       },
+      {
+        "text": "Go back to your camp.",
+        "topic": "TALK_FRIEND",
+        "condition": "npc_has_assigned_camp",
+        "effect": "return_to_camp_duties"
+      },
       { "text": "I'm going to go my own way for a while.", "topic": "TALK_LEAVE" },
       { "text": "<lets_go>", "topic": "TALK_DONE" }
     ]

--- a/data/json/npcs/common_chat/TALK_COMMON_OTHER.json
+++ b/data/json/npcs/common_chat/TALK_COMMON_OTHER.json
@@ -387,6 +387,27 @@
     ]
   },
   {
+    "id": "TALK_FRIEND_GUARD_CAMP",
+    "type": "talk_topic",
+    "dynamic_line": "I'm on watch.",
+    "responses": [
+      { "text": "Go back to your camp duties.", "topic": "TALK_FRIEND", "effect": "return_to_camp_duties" },
+      { "text": "I need you to come with me.", "topic": "TALK_FRIEND", "effect": "stop_guard" },
+      { "text": "Let's talk.", "topic": "TALK_FRIEND" },
+      { "text": "<end_talking_bye>", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "TALK_FRIEND_CAMP_RESIDENT",
+    "type": "talk_topic",
+    "dynamic_line": "I'm working at the camp.",
+    "responses": [
+      { "text": "I need you to come with me.", "topic": "TALK_FRIEND", "effect": "stop_guard" },
+      { "text": "Let's talk.", "topic": "TALK_FRIEND" },
+      { "text": "<end_talking_bye>", "topic": "TALK_DONE" }
+    ]
+  },
+  {
     "id": "TALK_FRIEND_UNCOMFORTABLE",
     "type": "talk_topic",
     "dynamic_line": "I really don't feel comfortable doing so…",

--- a/data/json/npcs/npc_behavior.json
+++ b/data/json/npcs/npc_behavior.json
@@ -34,7 +34,7 @@
     "type": "behavior",
     "id": "npc_priorities",
     "strategy": "utility",
-    "children": [ "npc_needs", "npc_duty", "npc_follow", "npc_player_order" ]
+    "children": [ "npc_needs", "npc_duty", "npc_follow", "npc_player_order", "npc_camp_work", "npc_return_to_camp", "npc_free_time" ]
   },
   {
     "type": "behavior",
@@ -148,5 +148,26 @@
     "id": "npc_go_to_sleep",
     "conditions": [ { "predicate": "npc_can_sleep" } ],
     "goal": "go_to_sleep"
+  },
+  {
+    "type": "behavior",
+    "id": "npc_camp_work",
+    "conditions": [ { "predicate": "npc_has_camp_job" } ],
+    "goal": "camp_work",
+    "score": "npc_camp_work_urgency"
+  },
+  {
+    "type": "behavior",
+    "id": "npc_return_to_camp",
+    "conditions": [ { "predicate": "npc_is_away_from_camp" } ],
+    "goal": "return_to_camp",
+    "score": "npc_return_to_camp_urgency"
+  },
+  {
+    "type": "behavior",
+    "id": "npc_free_time",
+    "conditions": [ { "predicate": "npc_is_camp_idle" } ],
+    "goal": "free_time",
+    "score": "npc_free_time_urgency"
   }
 ]

--- a/src/behavior_oracle.cpp
+++ b/src/behavior_oracle.cpp
@@ -56,6 +56,9 @@ predicate_map = {{
         { "npc_on_shift", make_function( &character_oracle_t::on_shift ) },
         { "npc_is_following", make_function( &character_oracle_t::npc_is_following ) },
         { "npc_has_goto_order", make_function( &character_oracle_t::npc_has_goto_order ) },
+        { "npc_has_camp_job", make_function( &character_oracle_t::has_camp_job ) },
+        { "npc_is_away_from_camp", make_function( &character_oracle_t::is_away_from_camp ) },
+        { "npc_is_camp_idle", make_function( &character_oracle_t::is_camp_idle ) },
         { "monster_not_hallucination", make_function( &monster_oracle_t::not_hallucination ) },
         { "monster_items_available", make_function( &monster_oracle_t::items_available ) },
         { "monster_split_possible", make_function( &monster_oracle_t::split_possible ) },
@@ -72,7 +75,10 @@ score_predicate_map = {{
         { "npc_sleepiness_urgency", make_score_function( &character_oracle_t::sleepiness_urgency ) },
         { "npc_duty_urgency", make_score_function( &character_oracle_t::duty_urgency ) },
         { "npc_following_urgency", make_score_function( &character_oracle_t::npc_following_urgency ) },
-        { "npc_goto_order_urgency", make_score_function( &character_oracle_t::npc_goto_order_urgency ) }
+        { "npc_goto_order_urgency", make_score_function( &character_oracle_t::npc_goto_order_urgency ) },
+        { "npc_camp_work_urgency", make_score_function( &character_oracle_t::camp_work_urgency ) },
+        { "npc_return_to_camp_urgency", make_score_function( &character_oracle_t::return_to_camp_urgency ) },
+        { "npc_free_time_urgency", make_score_function( &character_oracle_t::free_time_urgency ) }
     }
 };
 

--- a/src/character_oracle.cpp
+++ b/src/character_oracle.cpp
@@ -362,4 +362,79 @@ float character_oracle_t::npc_goto_order_urgency( std::string_view ) const
     return 0.65f;
 }
 
+status_t character_oracle_t::has_camp_job( std::string_view ) const
+{
+    const npc *n = dynamic_cast<const npc *>( subject );
+    if( !n || !n->assigned_camp || n->mission != NPC_MISSION_CAMP_RESIDENT ) {
+        return status_t::failure;
+    }
+    if( n->pos_abs_omt() != *n->assigned_camp ) {
+        return status_t::failure;
+    }
+    if( !n->has_job() ) {
+        return status_t::failure;
+    }
+    if( calendar::turn - n->last_job_scan < 10_minutes ) {
+        return status_t::failure;
+    }
+    return status_t::running;
+}
+
+status_t character_oracle_t::is_away_from_camp( std::string_view ) const
+{
+    const npc *n = dynamic_cast<const npc *>( subject );
+    if( !n || !n->assigned_camp || n->mission != NPC_MISSION_CAMP_RESIDENT ) {
+        return status_t::failure;
+    }
+    return n->pos_abs_omt() != *n->assigned_camp
+           ? status_t::running : status_t::failure;
+}
+
+status_t character_oracle_t::is_camp_idle( std::string_view ) const
+{
+    const npc *n = dynamic_cast<const npc *>( subject );
+    if( !n || !n->assigned_camp || n->mission != NPC_MISSION_CAMP_RESIDENT ) {
+        return status_t::failure;
+    }
+    if( n->get_attitude() == NPCATT_ACTIVITY ) {
+        return status_t::failure;
+    }
+    if( n->pos_abs_omt() != *n->assigned_camp ) {
+        return status_t::failure;
+    }
+    return status_t::running;
+}
+
+float character_oracle_t::camp_work_urgency( std::string_view ) const
+{
+    const npc *n = dynamic_cast<const npc *>( subject );
+    if( !n || !n->assigned_camp || n->mission != NPC_MISSION_CAMP_RESIDENT
+        || n->pos_abs_omt() != *n->assigned_camp || !n->has_job() ) {
+        return 0.0f;
+    }
+    return 0.4f;
+}
+
+float character_oracle_t::return_to_camp_urgency( std::string_view ) const
+{
+    const npc *n = dynamic_cast<const npc *>( subject );
+    if( !n || !n->assigned_camp || n->mission != NPC_MISSION_CAMP_RESIDENT
+        || n->pos_abs_omt() == *n->assigned_camp ) {
+        return 0.0f;
+    }
+    // Below follow max (0.6), above duty (0.45).
+    return 0.5f;
+}
+
+float character_oracle_t::free_time_urgency( std::string_view ) const
+{
+    const npc *n = dynamic_cast<const npc *>( subject );
+    if( !n || !n->assigned_camp || n->mission != NPC_MISSION_CAMP_RESIDENT
+        || n->get_attitude() == NPCATT_ACTIVITY
+        || n->pos_abs_omt() != *n->assigned_camp ) {
+        return 0.0f;
+    }
+    return 0.35f;
+}
+
 } // namespace behavior

--- a/src/character_oracle.h
+++ b/src/character_oracle.h
@@ -42,6 +42,9 @@ class character_oracle_t : public oracle_t
         status_t on_shift( std::string_view ) const;
         status_t npc_is_following( std::string_view ) const;
         status_t npc_has_goto_order( std::string_view ) const;
+        status_t has_camp_job( std::string_view ) const;
+        status_t is_away_from_camp( std::string_view ) const;
+        status_t is_camp_idle( std::string_view ) const;
         /**
          * Score predicates for utility strategy (return 0-1 urgency).
          */
@@ -52,6 +55,9 @@ class character_oracle_t : public oracle_t
         float duty_urgency( std::string_view ) const;
         float npc_following_urgency( std::string_view ) const;
         float npc_goto_order_urgency( std::string_view ) const;
+        float camp_work_urgency( std::string_view ) const;
+        float return_to_camp_urgency( std::string_view ) const;
+        float free_time_urgency( std::string_view ) const;
     private:
         const Character *subject;
 };

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -1885,6 +1885,14 @@ conditional_t::func f_u_has_camp()
     };
 }
 
+conditional_t::func f_npc_has_assigned_camp()
+{
+    return []( const_dialogue const & d ) {
+        const npc *n = d.const_actor( true )->get_const_npc();
+        return n && n->assigned_camp.has_value();
+    };
+}
+
 conditional_t::func f_has_pickup_list( bool is_npc )
 {
     return [is_npc]( const_dialogue const & d ) {
@@ -2599,6 +2607,7 @@ parsers_simple = {
     {"u_is_outside", "npc_is_outside", &conditional_fun::f_is_outside },
     {"u_is_underwater", "npc_is_underwater", &conditional_fun::f_is_underwater },
     {"u_has_camp", &conditional_fun::f_u_has_camp },
+    {"npc_has_assigned_camp", &conditional_fun::f_npc_has_assigned_camp },
     {"u_has_pickup_list", "has_pickup_list", &conditional_fun::f_has_pickup_list },
     {"u_has_pickup_list", "npc_has_pickup_list", &conditional_fun::f_has_pickup_list },
     {"is_by_radio", &conditional_fun::f_is_by_radio },

--- a/src/mission_companion.cpp
+++ b/src/mission_companion.cpp
@@ -2697,7 +2697,10 @@ npc_ptr talk_function::companion_choose( const std::map<skill_id, int> &required
     for( const npc_ptr &e : available ) {
         std::string npc_desc;
         bool can_do = true;
-        if( e->mission == NPC_MISSION_GUARD_ALLY ) {
+        if( e->mission == NPC_MISSION_CAMP_RESIDENT ) {
+            //~ %1$s: npc name
+            npc_desc = string_format( pgettext( "companion", "%1$s (Camp resident)" ), e->get_name() );
+        } else if( e->mission == NPC_MISSION_GUARD_ALLY ) {
             //~ %1$s: npc name
             npc_desc = string_format( pgettext( "companion", "%1$s (Guarding)" ), e->get_name() );
         } else {

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2627,7 +2627,7 @@ bool npc::is_ally( const Character &p ) const
             if( attitude == NPCATT_FOLLOW || attitude == NPCATT_LEAD ||
                 attitude == NPCATT_WAIT || mission == NPC_MISSION_ACTIVITY ||
                 mission == NPC_MISSION_TRAVELLING || mission == NPC_MISSION_GUARD_ALLY ||
-                has_companion_mission() ) {
+                mission == NPC_MISSION_CAMP_RESIDENT || has_companion_mission() ) {
                 return true;
             }
         }
@@ -3497,6 +3497,33 @@ void npc::on_load( map *here )
         hallucination = true;
     }
     effect_on_conditions::load_existing_character( *this );
+
+    // Migrate legacy camp assignees from GUARD_ALLY to CAMP_RESIDENT.
+    const bool migrate_current =
+        mission == NPC_MISSION_GUARD_ALLY && assigned_camp;
+    const bool migrate_previous =
+        previous_mission == NPC_MISSION_GUARD_ALLY && assigned_camp;
+    if( migrate_current || migrate_previous ) {
+        if( migrate_current ) {
+            mission = NPC_MISSION_CAMP_RESIDENT;
+        }
+        if( migrate_previous ) {
+            previous_mission = NPC_MISSION_CAMP_RESIDENT;
+        }
+        guard_pos = std::nullopt;
+        clear_ai_guard_pos();
+        if( mission != NPC_MISSION_ACTIVITY ) {
+            goal = no_goal_point;
+            omt_path.clear();
+            path.clear();
+            chair_pos = std::nullopt;
+            wander_pos = std::nullopt;
+            clear_destination();
+            set_committed_goal( "" );
+            chatbin.first_topic = "TALK_FRIEND_CAMP_RESIDENT";
+        }
+    }
+
     reconcile_schedule_on_load();
     shop_restock();
 }
@@ -4106,6 +4133,9 @@ std::string npc::describe_mission() const
         case NPC_MISSION_ACTIVITY:
             return string_format( _( "Right now, I'm <current_activity>.  In general, %s" ),
                                   myclass.obj().get_job_description() );
+        case NPC_MISSION_CAMP_RESIDENT:
+            return string_format( _( "I'm working at the camp.  Overall, %s" ),
+                                  myclass.obj().get_job_description() );
         case NPC_MISSION_TRAVELLING:
         case NPC_MISSION_NULL:
             return myclass.obj().get_job_description();
@@ -4162,6 +4192,8 @@ std::string npc::get_current_status() const
         return _( "Leading" );
     } else if( is_patrolling() ) {
         return _( "Patrolling" );
+    } else if( mission == NPC_MISSION_CAMP_RESIDENT ) {
+        return _( "At camp" );
     } else if( is_guarding() ) {
         return _( "Guarding" );
     } else {

--- a/src/npc.h
+++ b/src/npc.h
@@ -174,7 +174,8 @@ enum npc_mission : int {
     NPC_MISSION_GUARD, // Assigns a non-allied NPC to remain in place
     NPC_MISSION_GUARD_PATROL, // Assigns a non-allied NPC to guard and investigate
     NPC_MISSION_ACTIVITY, // Perform a player_activity until it is complete
-    NPC_MISSION_TRAVELLING
+    NPC_MISSION_TRAVELLING,
+    NPC_MISSION_CAMP_RESIDENT // Attached to camp, works jobs + has free time
 };
 
 struct npc_companion_mission {
@@ -1356,6 +1357,8 @@ class npc : public Character
         // A temp variable used to link to the correct mission
         std::vector<mission_type_id> miss_ids;
         std::optional<tripoint_abs_omt> assigned_camp = std::nullopt;
+        // AI throttle for camp job scanning. Transient, not serialized.
+        time_point last_job_scan = calendar::turn_zero;
 
         // accessors to ai_cache functions
         const std::vector<weak_ptr_fast<Creature>> &get_cached_friends() const;

--- a/src/npc_decision_category.h
+++ b/src/npc_decision_category.h
@@ -8,7 +8,7 @@
 // Used by the top-level npc_decision behavior tree to compare
 // BT goal selection against the legacy npc::move() cascade.
 enum class decision_category : int {
-    combat, investigate, needs, follow, order, duty, idle, unmodeled
+    combat, investigate, needs, follow, order, duty, camp_work, camp_travel, free_time, idle, unmodeled
 };
 
 const char *category_name( decision_category cat );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -262,6 +262,12 @@ const char *category_name( decision_category cat )
             return "order";
         case decision_category::duty:
             return "duty";
+        case decision_category::camp_work:
+            return "camp_work";
+        case decision_category::camp_travel:
+            return "camp_travel";
+        case decision_category::free_time:
+            return "free_time";
         case decision_category::idle:
             return "idle";
         case decision_category::unmodeled:
@@ -290,6 +296,15 @@ decision_category bt_goal_to_category( const std::string &goal )
     }
     if( goal == "return_to_guard_pos" || goal == "hold_position" ) {
         return decision_category::duty;
+    }
+    if( goal == "camp_work" ) {
+        return decision_category::camp_work;
+    }
+    if( goal == "return_to_camp" ) {
+        return decision_category::camp_travel;
+    }
+    if( goal == "free_time" ) {
+        return decision_category::free_time;
     }
     if( goal == "idle" ) {
         return decision_category::idle;
@@ -1402,7 +1417,8 @@ void npc::regen_ai_cache()
     map &here = get_map();
     auto i = std::begin( ai_cache.sound_alerts );
     creature_tracker &creatures = get_creature_tracker();
-    if( has_trait( trait_RETURN_TO_START_POS ) ) {
+    if( has_trait( trait_RETURN_TO_START_POS ) &&
+        mission != NPC_MISSION_CAMP_RESIDENT ) {
         if( !guard_pos ) {
             guard_pos = pos_abs();
         }
@@ -1695,6 +1711,12 @@ void npc::move()
                     if( !completed_goal ) {
                         completed_goal = ( new_goal != "goto_ordered_position" );
                     }
+                } else if( committed == "camp_work" ) {
+                    completed_goal = ( new_goal != "camp_work" );
+                } else if( committed == "return_to_camp" ) {
+                    completed_goal = ( new_goal != "return_to_camp" );
+                } else if( committed == "free_time" ) {
+                    completed_goal = ( new_goal != "free_time" );
                 }
                 if( completed_goal ) {
                     committed.clear();
@@ -1724,6 +1746,24 @@ void npc::move()
                 action = npc_goto_to_this_pos;
             } else if( new_goal == "hold_position" ) {
                 action = address_needs( NPC_DANGER_VERY_LOW + 1 );
+            } else if( new_goal == "camp_work" ) {
+                last_job_scan = calendar::turn;
+                if( find_job_to_perform() ) {
+                    action = npc_player_activity;
+                } else {
+                    action = npc_worker_downtime;
+                }
+            } else if( new_goal == "return_to_camp" ) {
+                if( assigned_camp ) {
+                    goal = *assigned_camp;
+                    tripoint_abs_omt surface = pos_abs_omt();
+                    surface.z() = 0;
+                    omt_path = overmap_buffer.get_travel_path( surface, *assigned_camp,
+                               overmap_path_params::for_npc() ).points;
+                }
+                action = npc_goto_destination;
+            } else if( new_goal == "free_time" ) {
+                action = npc_worker_downtime;
             } else if( new_goal == "idle" ) {
                 if( guard_pos ) {
                     // Persistent duty post: stay put, tend minor needs.
@@ -1810,7 +1850,8 @@ void npc::move()
                 mission = NPC_MISSION_NULL;
             }
         }
-        if( assigned_camp && attitude != NPCATT_ACTIVITY ) {
+        if( assigned_camp && mission != NPC_MISSION_CAMP_RESIDENT &&
+            !guard_pos && attitude != NPCATT_ACTIVITY ) {
             if( has_job() && calendar::once_every( 10_minutes ) && find_job_to_perform() ) {
                 action = npc_player_activity;
             } else {
@@ -5527,7 +5568,13 @@ void npc::go_to_omt_destination()
         point_rel_omt omt_diff = omt_path.back().xy() - omt_pos.xy();
         if( omt_diff.x() > 3 || omt_diff.x() < -3 || omt_diff.y() > 3 || omt_diff.y() < -3 ) {
             // we've gone wandering somehow, reset destination.
-            if( !is_player_ally() ) {
+            if( mission == NPC_MISSION_CAMP_RESIDENT && assigned_camp ) {
+                goal = *assigned_camp;
+                tripoint_abs_omt surface = pos_abs_omt();
+                surface.z() = 0;
+                omt_path = overmap_buffer.get_travel_path( surface, *assigned_camp,
+                           overmap_path_params::for_npc() ).points;
+            } else if( !is_player_ally() ) {
                 set_omt_destination();
             } else {
                 talk_function::assign_guard( *this );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1088,7 +1088,7 @@ void game::chat( const std::optional<tripoint_bub_ms> &p )
 
     const std::vector<npc *> available_for_activities = get_npcs_if( [&]( const npc & guy ) {
         return guy.is_player_ally() && guy.can_hear( player_character.pos_bub(), volume ) &&
-               guy.companion_mission_role_id != "FACTION CAMP";
+               guy.companion_mission_role_id != "FACTION_CAMP";
     } );
     const int available_for_activities_count = available_for_activities.size();
 
@@ -8296,6 +8296,7 @@ void talk_effect_t::parse_string_effect( const std::string &effect_id, const Jso
             WRAP( assign_camp ),
             WRAP( abandon_camp ),
             WRAP( stop_guard ),
+            WRAP( return_to_camp_duties ),
             WRAP( start_camp ),
             WRAP( buy_cow ),
             WRAP( buy_chicken ),

--- a/src/npctalk.h
+++ b/src/npctalk.h
@@ -82,6 +82,7 @@ void assign_guard( npc & );
 void assign_camp( npc & );
 void abandon_camp( npc & );
 void stop_guard( npc & );
+void return_to_camp_duties( npc & );
 void end_conversation( npc & );
 void insult_combat( npc & );
 void reveal_stats( npc & );

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -429,7 +429,10 @@ void talk_function::assign_guard( npc &p )
     }
     p.set_attitude( NPCATT_NULL );
     p.set_mission( NPC_MISSION_GUARD_ALLY );
-    p.chatbin.first_topic = p.chatbin.talk_friend_guard;
+    p.chatbin.first_topic = p.assigned_camp
+                            ? "TALK_FRIEND_GUARD_CAMP"
+                            : p.chatbin.talk_friend_guard;
+    p.set_committed_goal( "" );
     p.set_omt_destination();
 }
 
@@ -447,18 +450,51 @@ void talk_function::assign_camp( npc &p )
     std::optional<basecamp *> bcp = overmap_buffer.find_camp( p.pos_abs_omt().xy() );
     if( bcp ) {
         basecamp *temp_camp = *bcp;
+        if( p.has_player_activity() ) {
+            p.revert_after_activity();
+        }
         p.set_attitude( NPCATT_NULL );
-        p.set_mission( NPC_MISSION_GUARD_ALLY );
+        p.set_mission( NPC_MISSION_CAMP_RESIDENT );
+        p.guard_pos = std::nullopt;
+        p.clear_ai_guard_pos();
         temp_camp->add_assignee( p.getID() );
         temp_camp->job_assignment_ui();
         temp_camp->validate_assignees();
         add_msg( _( "%1$s is assigned to %2$s" ), p.disp_name(), temp_camp->camp_name() );
-        if( p.has_player_activity() ) {
-            p.revert_after_activity();
-        }
-        p.chatbin.first_topic = p.chatbin.talk_friend_guard;
-        p.set_omt_destination();
+        p.chatbin.first_topic = "TALK_FRIEND_CAMP_RESIDENT";
+        p.goal = npc::no_goal_point;
+        p.omt_path.clear();
+        p.path.clear();
+        p.chair_pos = std::nullopt;
+        p.wander_pos = std::nullopt;
+        p.clear_destination();
+        p.set_committed_goal( "" );
     }
+}
+
+void talk_function::return_to_camp_duties( npc &p )
+{
+    p.set_attitude( NPCATT_NULL );
+    p.set_mission( NPC_MISSION_CAMP_RESIDENT );
+    p.guard_pos = std::nullopt;
+    p.clear_ai_guard_pos();
+    p.set_committed_goal( "" );
+    p.chatbin.first_topic = "TALK_FRIEND_CAMP_RESIDENT";
+    if( p.assigned_camp && p.pos_abs_omt() != *p.assigned_camp ) {
+        p.goal = *p.assigned_camp;
+        tripoint_abs_omt surface = p.pos_abs_omt();
+        surface.z() = 0;
+        p.omt_path = overmap_buffer.get_travel_path( surface, *p.assigned_camp,
+                     overmap_path_params::for_npc() ).points;
+    } else {
+        p.goal = npc::no_goal_point;
+        p.omt_path.clear();
+    }
+    p.path.clear();
+    p.chair_pos = std::nullopt;
+    p.wander_pos = std::nullopt;
+    p.clear_destination();
+    add_msg( _( "%s returns to camp duties." ), p.get_name() );
 }
 
 void talk_function::stop_guard( npc &p )
@@ -478,13 +514,9 @@ void talk_function::stop_guard( npc &p )
     p.goal = npc::no_goal_point;
     p.guard_pos = std::nullopt;
     p.clear_ai_guard_pos();
-    if( p.assigned_camp ) {
-        if( std::optional<basecamp *> bcp = overmap_buffer.find_camp( ( *p.assigned_camp ).xy() ) ) {
-            ( *bcp )->remove_assignee( p.getID() );
-            ( *bcp )->validate_assignees();
-        }
-        p.assigned_camp = std::nullopt;
-    }
+    p.set_committed_goal( "" );
+    // assigned_camp is preserved: the NPC remembers their camp while following.
+    // Player can send them back via "Go back to your camp" in follower dialogue.
 }
 
 void talk_function::wake_up( npc &p )

--- a/tests/behavior_test.cpp
+++ b/tests/behavior_test.cpp
@@ -29,6 +29,7 @@
 #include "map.h"
 #include "map_helpers.h"
 #include "map_iterator.h"
+#include "map_scale_constants.h"
 #include "mapdata.h"
 #include "mapgen.h"
 #include "mapgendata.h"
@@ -77,6 +78,7 @@ static const ter_str_id ter_t_ponywall( "t_ponywall" );
 static const ter_str_id ter_t_wall( "t_wall" );
 
 static const trait_id trait_IGNORE_SOUND( "IGNORE_SOUND" );
+static const trait_id trait_RETURN_TO_START_POS( "RETURN_TO_START_POS" );
 
 namespace behavior
 {
@@ -1621,4 +1623,86 @@ TEST_CASE( "bt_priority_matrix", "[npc][behavior]" )
         CHECK( bt_goal( guy ) != "follow_player" );
         get_player_character().in_vehicle = false;
     }
+    SECTION( "camp resident idle: free_time" ) {
+        guy.set_mission( NPC_MISSION_CAMP_RESIDENT );
+        guy.assigned_camp = project_to<coords::omt>( guy.pos_abs() );
+        guy.guard_pos = std::nullopt;
+        guy.clear_ai_guard_pos();
+        CHECK( bt_goal( guy ) == "free_time" );
+    }
+}
+
+// --- Camp resident state split tests ---
+
+TEST_CASE( "duty_predicates_skip_camp_residents", "[npc][behavior]" )
+{
+    clear_map_without_vision();
+    clear_avatar();
+    get_map();
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy, true );
+    guy.set_fac( faction_your_followers );
+    guy.set_mission( NPC_MISSION_CAMP_RESIDENT );
+    guy.assigned_camp = project_to<coords::omt>( guy.pos_abs() );
+    guy.guard_pos = std::nullopt;
+    guy.clear_ai_guard_pos();
+    calendar::turn = calendar::turn_zero + 12_hours;
+
+    behavior::character_oracle_t oracle( &guy );
+
+    SECTION( "RETURN_TO_START_POS suppressed" ) {
+        guy.set_mutation( trait_RETURN_TO_START_POS );
+        guy.regen_ai_cache();
+        CHECK_FALSE( guy.get_guard_post().has_value() );
+    }
+    SECTION( "on_shift fails" ) {
+        CHECK( oracle.on_shift( "" ) == behavior::status_t::failure );
+    }
+    SECTION( "duty_urgency is 0" ) {
+        CHECK( oracle.duty_urgency( "" ) == 0.0f );
+    }
+    SECTION( "displaced_from_post fails" ) {
+        CHECK( oracle.displaced_from_post( "" ) == behavior::status_t::failure );
+    }
+}
+
+TEST_CASE( "bt_camp_resident_goals", "[npc][behavior]" )
+{
+    clear_map_without_vision();
+    clear_avatar();
+    map &here = get_map();
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy, true );
+    guy.set_fac( faction_your_followers );
+    guy.set_mission( NPC_MISSION_CAMP_RESIDENT );
+    guy.assigned_camp = project_to<coords::omt>( guy.pos_abs() );
+    guy.guard_pos = std::nullopt;
+    guy.clear_ai_guard_pos();
+
+    SECTION( "idle at camp: free_time" ) {
+        CHECK( bt_goal( guy ) == "free_time" );
+    }
+    SECTION( "on activity: not free_time" ) {
+        guy.set_attitude( NPCATT_ACTIVITY );
+        CHECK( bt_goal( guy ) != "free_time" );
+    }
+    SECTION( "away from camp: return_to_camp" ) {
+        guy.setpos( here, tripoint_bub_ms( 50 + SEEX * 2, 50, 0 ) );
+        REQUIRE( guy.pos_abs_omt() != *guy.assigned_camp );
+        CHECK( bt_goal( guy ) == "return_to_camp" );
+    }
+    SECTION( "severe thirst beats free_time" ) {
+        guy.set_thirst( 900 );
+        guy.i_add( item( itype_orange ) );
+        behavior::character_oracle_t oracle( &guy );
+        REQUIRE( oracle.has_water( "" ) == behavior::status_t::running );
+        CHECK( bt_goal( guy ) == "drink_water" );
+    }
+}
+
+TEST_CASE( "bt_goal_category_mapping_camp", "[npc][behavior]" )
+{
+    CHECK( bt_goal_to_category( "camp_work" ) == decision_category::camp_work );
+    CHECK( bt_goal_to_category( "free_time" ) == decision_category::free_time );
+    CHECK( bt_goal_to_category( "return_to_camp" ) == decision_category::camp_travel );
 }

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -4198,3 +4198,177 @@ TEST_CASE( "leader_npc_waits_when_player_far", "[npc][behavior]" )
     CHECK( guy.get_committed_goal() != "follow_player" );
     CHECK( guy.has_effect( effect_catch_up ) );
 }
+
+// --- Camp resident state split tests ---
+
+TEST_CASE( "camp_resident_is_not_guarding", "[npc][camp]" )
+{
+    clear_map_without_vision();
+    clear_avatar();
+    get_map();
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy, true );
+    guy.set_fac( faction_your_followers );
+    guy.set_mission( NPC_MISSION_CAMP_RESIDENT );
+
+    SECTION( "not guarding" ) {
+        CHECK_FALSE( guy.is_guarding() );
+    }
+    SECTION( "is player ally" ) {
+        CHECK( guy.is_player_ally() );
+    }
+    SECTION( "not stationary" ) {
+        CHECK_FALSE( guy.is_stationary( true ) );
+    }
+    SECTION( "describe_mission" ) {
+        CHECK( guy.describe_mission().find( "guarding" ) == std::string::npos );
+    }
+}
+
+TEST_CASE( "camp_resident_does_not_oscillate", "[npc][camp]" )
+{
+    clear_map_without_vision();
+    clear_avatar();
+    map &here = get_map();
+    get_player_character().setpos( here, tripoint_bub_ms( 50, 50, 0 ) );
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy, true );
+    guy.set_fac( faction_your_followers );
+    guy.set_attitude( NPCATT_NULL );
+    guy.set_mission( NPC_MISSION_CAMP_RESIDENT );
+    guy.assigned_camp = project_to<coords::omt>( guy.pos_abs() );
+    guy.guard_pos = std::nullopt;
+    guy.clear_ai_guard_pos();
+    guy.set_hunger( 0 );
+    guy.set_thirst( 0 );
+    guy.set_sleepiness( 0 );
+    guy.set_stored_kcal( guy.get_healthy_kcal() );
+    guy.set_all_parts_temp_conv( BODYTEMP_NORM );
+    guy.set_all_parts_temp_cur( BODYTEMP_NORM );
+    guy.regen_ai_cache();
+
+    for( int i = 0; i < 10; ++i ) {
+        guy.set_moves( 100 );
+        guy.move();
+        CHECK( guy.get_committed_goal() != "return_to_guard_pos" );
+    }
+}
+
+TEST_CASE( "camp_resident_guard_transitions", "[npc][camp]" )
+{
+    clear_map_without_vision();
+    clear_avatar();
+    map &here = get_map();
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy, true );
+    guy.set_fac( faction_your_followers );
+    guy.set_mission( NPC_MISSION_CAMP_RESIDENT );
+    const tripoint_abs_omt camp_pos = project_to<coords::omt>( guy.pos_abs() );
+    guy.assigned_camp = camp_pos;
+    guy.guard_pos = std::nullopt;
+    guy.clear_ai_guard_pos();
+
+    SECTION( "assign_guard overrides to GUARD_ALLY" ) {
+        talk_function::assign_guard( guy );
+        CHECK( guy.mission == NPC_MISSION_GUARD_ALLY );
+        CHECK( guy.assigned_camp.has_value() );
+        CHECK( guy.get_guard_post().has_value() );
+    }
+    SECTION( "return_to_camp_duties at camp: no travel" ) {
+        talk_function::assign_guard( guy );
+        talk_function::return_to_camp_duties( guy );
+        CHECK( guy.mission == NPC_MISSION_CAMP_RESIDENT );
+        CHECK( guy.assigned_camp == camp_pos );
+        CHECK_FALSE( guy.get_guard_post().has_value() );
+        CHECK( guy.goal == npc::no_goal_point );
+        CHECK( guy.omt_path.empty() );
+    }
+    SECTION( "return_to_camp_duties away from camp: sets goal" ) {
+        guy.setpos( here, tripoint_bub_ms( 50 + SEEX * 2, 50, 0 ) );
+        REQUIRE( guy.pos_abs_omt() != camp_pos );
+        talk_function::assign_guard( guy );
+        talk_function::return_to_camp_duties( guy );
+        CHECK( guy.mission == NPC_MISSION_CAMP_RESIDENT );
+        CHECK( guy.goal == camp_pos );
+        // omt_path may be empty if overmap pathfinding has no data,
+        // but goal is set so the NPC will path on next move().
+    }
+    SECTION( "stop_guard recalls but preserves camp" ) {
+        talk_function::assign_guard( guy );
+        talk_function::stop_guard( guy );
+        CHECK( guy.mission == NPC_MISSION_NULL );
+        // Camp assignment preserved so player can send NPC back later.
+        CHECK( guy.assigned_camp == camp_pos );
+    }
+    SECTION( "return_to_camp_duties clears stale movement state" ) {
+        talk_function::assign_guard( guy );
+        guy.chair_pos = guy.pos_abs() + tripoint( 3, 0, 0 );
+        guy.wander_pos = guy.pos_abs() + tripoint( -2, 0, 0 );
+        guy.path.push_back( here.get_bub( tripoint_abs_ms( 55, 50, 0 ) ) );
+
+        talk_function::return_to_camp_duties( guy );
+        CHECK_FALSE( guy.chair_pos.has_value() );
+        CHECK_FALSE( guy.wander_pos.has_value() );
+        CHECK( guy.path.empty() );
+    }
+    SECTION( "transitions clear stale committed goal" ) {
+        talk_function::assign_guard( guy );
+        guy.set_committed_goal( "hold_position" );
+        talk_function::return_to_camp_duties( guy );
+        CHECK( guy.get_committed_goal().empty() );
+
+        talk_function::assign_guard( guy );
+        CHECK( guy.get_committed_goal().empty() );
+    }
+}
+
+TEST_CASE( "on_load_migrates_legacy_camp_npcs", "[npc][camp]" )
+{
+    clear_map_without_vision();
+    clear_avatar();
+    map &here = get_map();
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy, true );
+    guy.set_fac( faction_your_followers );
+
+    SECTION( "GUARD_ALLY + assigned_camp migrates to CAMP_RESIDENT" ) {
+        guy.set_mission( NPC_MISSION_GUARD_ALLY );
+        guy.assigned_camp = project_to<coords::omt>( guy.pos_abs() );
+        guy.set_guard_pos( guy.pos_abs() );
+        guy.on_load( &here );
+        CHECK( guy.mission == NPC_MISSION_CAMP_RESIDENT );
+        CHECK_FALSE( guy.get_guard_post().has_value() );
+        CHECK( guy.assigned_camp.has_value() );
+    }
+    SECTION( "migration clears stale movement state" ) {
+        guy.set_mission( NPC_MISSION_GUARD_ALLY );
+        guy.assigned_camp = project_to<coords::omt>( guy.pos_abs() );
+        guy.set_guard_pos( guy.pos_abs() );
+        guy.goal = project_to<coords::omt>( guy.pos_abs() + tripoint( 10 * SEEX, 0, 0 ) );
+        guy.omt_path.push_back( guy.goal );
+        guy.path.push_back( here.get_bub( tripoint_abs_ms( 55, 50, 0 ) ) );
+        guy.set_committed_goal( "return_to_guard_pos" );
+        guy.on_load( &here );
+        CHECK( guy.mission == NPC_MISSION_CAMP_RESIDENT );
+        CHECK( guy.goal == npc::no_goal_point );
+        CHECK( guy.omt_path.empty() );
+        CHECK( guy.path.empty() );
+        CHECK( guy.get_committed_goal().empty() );
+    }
+    SECTION( "migration fixes previous_mission for active workers" ) {
+        guy.set_mission( NPC_MISSION_ACTIVITY );
+        guy.previous_mission = NPC_MISSION_GUARD_ALLY;
+        guy.assigned_camp = project_to<coords::omt>( guy.pos_abs() );
+        guy.set_guard_pos( guy.pos_abs() );
+        guy.on_load( &here );
+        CHECK( guy.mission == NPC_MISSION_ACTIVITY );
+        CHECK( guy.previous_mission == NPC_MISSION_CAMP_RESIDENT );
+    }
+    SECTION( "GUARD_ALLY without assigned_camp does not migrate" ) {
+        guy.set_mission( NPC_MISSION_GUARD_ALLY );
+        guy.assigned_camp = std::nullopt;
+        guy.set_guard_pos( guy.pos_abs() );
+        guy.on_load( &here );
+        CHECK( guy.mission == NPC_MISSION_GUARD_ALLY );
+    }
+}


### PR DESCRIPTION
#### Summary
Bugfixes "Fix camp NPC oscillation between guard duty and worker downtime"

#### Purpose of change

Fixes #86166. Related to #28681. Depends on #86172.

`assign_camp()` and `assign_guard()` both set `NPC_MISSION_GUARD_ALLY`, so the BT treats camp workers as guards. After returning from camp activities, NPCs oscillate between `hold_position` (duty) and `worker_downtime` (cascade fallback).

#### Describe the solution

New `NPC_MISSION_CAMP_RESIDENT` for camp workers. CAMP_RESIDENT never has `guard_pos`, so duty predicates naturally fail without special oracle gates.

Three new BT goals: `camp_work` (job scanning via `find_job_to_perform`), `return_to_camp` (overmap travel home), and `free_time` (`worker_downtime` between jobs).

Camp residents can be temporarily ordered to guard (switches to `GUARD_ALLY`, keeps `assigned_camp`). `stop_guard` preserves `assigned_camp` so the player can send them back via "Go back to your camp" in follower dialogue. New `return_to_camp_duties` talk effect and `npc_has_assigned_camp` dialogue condition.

On-load migration converts legacy `GUARD_ALLY` + `assigned_camp` NPCs to `CAMP_RESIDENT`, including `previous_mission` for those saved mid-activity. Cascade camp block gated by `!guard_pos` and `mission != CAMP_RESIDENT` so temp guards and new camp residents use the right paths.

Also fixes `"FACTION CAMP"` typo (missing underscore) at npctalk.cpp.

#### Describe alternatives you've considered

Could have tweaked the cascade fallback instead of splitting state, but that just patches symptoms. The real problem is that camp workers and guards are indistinguishable.

#### Testing

New tests covering camp resident identity (not guarding, is ally, not stationary, describe_mission), duty predicate suppression (RETURN_TO_START_POS, on_shift, duty_urgency, displaced_from_post), BT goals (free_time, return_to_camp, camp_work, needs override), oscillation regression, guard transitions (assign/return/stop, stale state cleanup, committed goal clearing), on-load migration (current + previous_mission, movement state, non-camp exclusion), and priority matrix additions.

Tested in-game with camp workers returning from plowing - no more oscillation.

#### Additional context

None.