### PR TITLE
Dimensional travel checks for `DIMENSIONAL_ANCHOR` not `PORTAL_PROOF`

### DIFF
--- a/data/json/effects_on_condition/nether_eocs/labyrinth_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/labyrinth_effect_on_condition.json
@@ -2,7 +2,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_LS_Teleport_to_labyrinth",
-    "condition": { "and": [ { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_PORTAL_PROOF" }, { "not": "u_driving" } ] },
+    "condition": { "and": [ { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_DIMENSIONAL_ANCHOR" }, { "not": "u_driving" } ] },
     "effect": [
       { "u_location_variable": { "u_val": "player_location_home_before_labyrinth" } },
       { "u_add_var": "traveled_home_to_labyrinth", "value": "yes" },
@@ -31,7 +31,7 @@
     "id": "EOC_LS_SD_Teleport_to_labyrinth",
     "condition": {
       "and": [
-        { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_PORTAL_PROOF" },
+        { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_DIMENSIONAL_ANCHOR" },
         { "not": "u_driving" },
         { "current_dimension": "string_dimension" }
       ]
@@ -65,7 +65,7 @@
     "id": "EOC_LS_Exit_labyrinth",
     "condition": {
       "and": [
-        { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_PORTAL_PROOF" },
+        { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_DIMENSIONAL_ANCHOR" },
         { "not": "u_driving" },
         { "current_dimension": "netherum_labyrinth" }
       ]
@@ -89,7 +89,7 @@
     "id": "EOC_LS_SD_Exit_labyrinth",
     "condition": {
       "and": [
-        { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_PORTAL_PROOF" },
+        { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_DIMENSIONAL_ANCHOR" },
         { "not": "u_driving" },
         { "current_dimension": "netherum_labyrinth" }
       ]

--- a/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
@@ -29,6 +29,12 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_PORTAL_STORM_CONDITION_FLAG_DIMENSIONAL_ANCHOR",
+    "condition": { "not": { "u_has_worn_with_flag": "DIMENSIONAL_ANCHOR" } },
+    "effect": [  ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_PORTAL_EARLY_MESSAGES",
     "recurrence": [ "1 minutes", "30 minutes" ],
     "global": true,
@@ -627,7 +633,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_PORTAL_DIMENSION_TRAVEL",
-    "condition": { "and": [ { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_PORTAL_PROOF" }, { "not": "u_driving" } ] },
+    "condition": { "and": [ { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_DIMENSIONAL_ANCHOR" }, { "not": "u_driving" } ] },
     "effect": [
       {
         "if": {
@@ -656,7 +662,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_PORTAL_HIGHLANDS",
-    "condition": { "and": [ { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_PORTAL_PROOF" }, { "not": "u_driving" } ] },
+    "condition": { "and": [ { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_DIMENSIONAL_ANCHOR" }, { "not": "u_driving" } ] },
     "effect": [
       {
         "u_travel_to_dimension": "highlands",

--- a/data/json/effects_on_condition/nether_eocs/reverberations.json
+++ b/data/json/effects_on_condition/nether_eocs/reverberations.json
@@ -16,7 +16,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_PORTAL_RADIOSPHERE",
-    "condition": { "and": [ { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_PORTAL_PROOF" }, { "not": "u_driving" } ] },
+    "condition": { "and": [ { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_DIMENSIONAL_ANCHOR" }, { "not": "u_driving" } ] },
     "effect": [
       { "u_add_effect": "blind", "duration": 0 },
       {
@@ -47,7 +47,7 @@
     "id": "EOC_PORTAL_RADIOSPHERE_RETURN",
     "condition": {
       "and": [
-        { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_PORTAL_PROOF" },
+        { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_DIMENSIONAL_ANCHOR" },
         { "not": "u_driving" },
         { "current_dimension": "radiosphere" }
       ]
@@ -104,7 +104,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_PORTAL_CABINS",
-    "condition": { "and": [ { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_PORTAL_PROOF" }, { "not": "u_driving" } ] },
+    "condition": { "and": [ { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_DIMENSIONAL_ANCHOR" }, { "not": "u_driving" } ] },
     "effect": [
       { "u_add_effect": "blind", "duration": 0 },
       {
@@ -132,7 +132,7 @@
     "id": "EOC_PORTAL_CABINS_RETURN",
     "condition": {
       "and": [
-        { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_PORTAL_PROOF" },
+        { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_DIMENSIONAL_ANCHOR" },
         { "not": "u_driving" },
         { "current_dimension": "cabins" }
       ]
@@ -206,7 +206,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_PORTAL_INNER_CABINS",
-    "condition": { "and": [ { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_PORTAL_PROOF" }, { "not": "u_driving" } ] },
+    "condition": { "and": [ { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_DIMENSIONAL_ANCHOR" }, { "not": "u_driving" } ] },
     "effect": [
       {
         "u_travel_to_dimension": "inner_cabins",
@@ -233,7 +233,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_PORTAL_INNER_CABINS_WARPED_CABIN",
-    "condition": { "and": [ { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_PORTAL_PROOF" }, { "not": "u_driving" } ] },
+    "condition": { "and": [ { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_DIMENSIONAL_ANCHOR" }, { "not": "u_driving" } ] },
     "effect": [
       { "u_travel_to_dimension": "cabins", "npc_travel_radius": 0, "region_type": "cabins", "npc_travel_filter": "none" },
       { "u_location_variable": { "context_val": "nearest_bed" }, "furniture": "f_bed", "target_max_radius": 60 },
@@ -404,7 +404,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_INNER_CABINS_PORTAL_EXIT_TO_SMEAR",
-    "condition": { "and": [ { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_PORTAL_PROOF" }, { "not": "u_driving" } ] },
+    "condition": { "and": [ { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_DIMENSIONAL_ANCHOR" }, { "not": "u_driving" } ] },
     "effect": [
       {
         "u_location_variable": { "global_val": "inner_cabins_exit_loc" },

--- a/data/json/effects_on_condition/nether_eocs/string_dimension.json
+++ b/data/json/effects_on_condition/nether_eocs/string_dimension.json
@@ -2,7 +2,14 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_PORTAL_STRING_DIMENSION",
-    "condition": { "math": [ "u_string_dimension_ziggurat_exit <= 3" ] },
+    "condition": {
+      "and": [
+        { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_DIMENSIONAL_ANCHOR" },
+        { "not": "u_driving" },
+        { "current_dimension": "string_dimension" },
+        { "math": [ "u_string_dimension_ziggurat_exit <= 3" ] }
+      ]
+    },
     "effect": [
       {
         "u_travel_to_dimension": "string_dimension",
@@ -76,7 +83,7 @@
     "id": "EOC_PORTAL_STRING_DIMENSION_RETURN",
     "condition": {
       "and": [
-        { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_PORTAL_PROOF" },
+        { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_DIMENSIONAL_ANCHOR" },
         { "not": "u_driving" },
         { "current_dimension": "string_dimension" }
       ]
@@ -123,7 +130,7 @@
     "id": "EOC_PORTAL_STRING_DIMENSION_ZIGGURAT_RETURN",
     "effect": [
       {
-        "if": { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_PORTAL_PROOF" },
+        "if": { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_DIMENSIONAL_ANCHOR" },
         "then": {
           "u_message": "You touched the cube and there was an immense explosion of light.  The object is gone and you're back in the world you know.",
           "popup": true

--- a/data/json/effects_on_condition/nether_eocs/string_dimension.json
+++ b/data/json/effects_on_condition/nether_eocs/string_dimension.json
@@ -6,7 +6,6 @@
       "and": [
         { "test_eoc": "EOC_PORTAL_STORM_CONDITION_FLAG_DIMENSIONAL_ANCHOR" },
         { "not": "u_driving" },
-        { "current_dimension": "string_dimension" },
         { "math": [ "u_string_dimension_ziggurat_exit <= 3" ] }
       ]
     },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Dimensional travel checks for DIMENSIONAL_ANCHOR not PORTAL_PROOF"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Transporting oneself to different dimensions was checking `PORTAL_PROOF`, which meant things like the phase immersion suit blocked it.  After discussing with Candlebury on Discord, `PORTAL_PROOF` is supposed to protect from different sorts of other-dimensional assaults, whereas `DIMENSIONAL_ANCHOR` stops teleportation.  So, travel should be checking for `DIMENSIONAL_ANCHOR`.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Switch the EOC checks for `PORTAL_PROOF` to one for `DIMENSIONAL_ANCHOR`, only in instances where it results in teleportation to another dimension.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

n/a

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Teleported/tried teleporting with phase immersion suit and anchor on/off.  Only an active anchor blocks teleportation.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
