### PR TITLE
[Sky Island] Remove learning vortex token recipe on rank up

### DIFF
--- a/data/mods/Sky_Island/missions/island_upgrades/rankup.json
+++ b/data/mods/Sky_Island/missions/island_upgrades/rankup.json
@@ -25,7 +25,6 @@
         { "u_forget_recipe": "upgradekey_rankup1" },
         { "u_learn_recipe": "warp_carrier" },
         { "u_learn_recipe": "recipe_craft_random_artifact" },
-        { "u_learn_recipe": "warp_vortex_token" },
         { "u_learn_recipe": "warp_healing_salve" },
         { "u_learn_recipe": "warphaulbag" },
         { "u_learn_recipe": "sky_island_warped_pond" },


### PR DESCRIPTION
#### Summary
Mods "[Sky Island] Remove learning vortex token recipe on rank up"

#### Purpose of change
The recipe for the vortex token is controlled by difficulty EOC settings, it doesn't need to be granted on rank up. 

#### Describe the solution
One line removal from rank up EOC

#### Describe alternatives you've considered

#### Testing
Game loads 


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
