### PR TITLE
Make map::add_spawn private, replace last hardcoded call

### DIFF
--- a/data/json/monstergroups/fungi.json
+++ b/data/json/monstergroups/fungi.json
@@ -72,5 +72,10 @@
       { "monster": "mon_zombie_fungus_acidic", "weight": 50, "cost_multiplier": 0 },
       { "monster": "mon_zombie_dog_fungus", "weight": 50, "cost_multiplier": 0 }
     ]
+  },
+  {
+    "type": "monstergroup",
+    "id": "GROUP_FUNGI_QUEEN",
+    "monsters": [ { "monster": "mon_fungaloid_queen", "weight": 1000, "cost_multiplier": 0 } ]
   }
 ]

--- a/src/map.h
+++ b/src/map.h
@@ -386,6 +386,13 @@ class map
                 field_proc_data & );
         friend void field_processor_fd_incendiary( const tripoint_bub_ms &, field_entry &,
                 field_proc_data & );
+        friend void field_processor_monster_spawn( const tripoint_bub_ms &, field_entry &,
+                field_proc_data & );
+
+        // add_spawn is private; these classes need it for data-driven spawning
+        // (JSON mapgen and monster reproduction). Mapgen code should use place_spawns() instead.
+        friend class jmapgen_monster;
+        friend class monster;
 
         // for testing
         friend class map_meddler;
@@ -1734,13 +1741,6 @@ class map
         character_id place_npc( const point_bub_ms &p, const string_id<npc_template> &type );
         void apply_faction_ownership( const point_bub_ms &p1, const point_bub_ms &p2,
                                       const faction_id &id );
-        void add_spawn( const mtype_id &type, int count, const tripoint_bub_ms &p,
-                        bool friendly = false, int faction_id = -1, int mission_id = -1,
-                        const std::optional<std::string> &name = std::nullopt );
-        void add_spawn( const mtype_id &type, int count, const tripoint_bub_ms &p, bool friendly,
-                        int faction_id, int mission_id, const std::optional<std::string> &name,
-                        const spawn_data &data );
-        void add_spawn( const MonsterGroupResult &spawn_details, const tripoint_bub_ms &p );
         void do_vehicle_caching( int z );
         // Note: in 3D mode, will actually build caches on ALL z-levels
         void build_map_cache( int zlev, bool skip_lightmap = false );
@@ -1876,6 +1876,14 @@ class map
         */
         void rotten_item_spawn( const item &item, const tripoint_bub_ms &p );
     private:
+        void add_spawn( const mtype_id &type, int count, const tripoint_bub_ms &p,
+                        bool friendly = false, int faction_id = -1, int mission_id = -1,
+                        const std::optional<std::string> &name = std::nullopt );
+        void add_spawn( const mtype_id &type, int count, const tripoint_bub_ms &p, bool friendly,
+                        int faction_id, int mission_id, const std::optional<std::string> &name,
+                        const spawn_data &data );
+        void add_spawn( const MonsterGroupResult &spawn_details, const tripoint_bub_ms &p );
+
         // Helper #1 - spawns monsters on one submap
         void spawn_monsters_submap( const tripoint_rel_sm &gp, bool ignore_sight,
                                     bool spawn_nonlocal = false );
@@ -2379,12 +2387,6 @@ class tinymap : private map
                                friendly,
                                name, mission_id );
         }
-        void add_spawn( const mtype_id &type, int count, const tripoint_omt_ms &p,
-                        bool friendly = false, int faction_id = -1, int mission_id = -1,
-                        const std::optional<std::string> &name = std::nullopt ) {
-            map::add_spawn( type, count, rebase_bub( p ), friendly, faction_id, mission_id, name );
-        }
-
         using map::translate;
         ter_id ter( const tripoint_omt_ms &p ) const {
             return map::ter( rebase_bub( p ) );

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -93,13 +93,13 @@ static const map_extra_id map_extra_mx_shrubbery( "mx_shrubbery" );
 
 static const mongroup_id GROUP_FISH( "GROUP_FISH" );
 static const mongroup_id GROUP_FUNGI_FUNGALOID( "GROUP_FUNGI_FUNGALOID" );
+static const mongroup_id GROUP_FUNGI_QUEEN( "GROUP_FUNGI_QUEEN" );
 static const mongroup_id GROUP_MIL_PASSENGER( "GROUP_MIL_PASSENGER" );
 static const mongroup_id GROUP_MIL_PILOT( "GROUP_MIL_PILOT" );
 static const mongroup_id GROUP_MIL_WEAK( "GROUP_MIL_WEAK" );
 static const mongroup_id GROUP_NETHER_PORTAL( "GROUP_NETHER_PORTAL" );
 static const mongroup_id GROUP_STRAY_DOGS( "GROUP_STRAY_DOGS" );
 
-static const mtype_id mon_fungaloid_queen( "mon_fungaloid_queen" );
 
 static const oter_type_str_id oter_type_road( "road" );
 
@@ -1049,7 +1049,8 @@ static bool mx_fungal_zone( map &m, const tripoint_abs_sm &abs_sub )
     }
 
     const tripoint_bub_ms suitable_location = random_entry( suitable_locations, omt_center );
-    m.add_spawn( mon_fungaloid_queen, 1, suitable_location );
+    m.place_spawns( GROUP_FUNGI_QUEEN, 1, suitable_location.xy(), suitable_location.xy(),
+                    suitable_location.z(), 1, true );
     m.place_spawns( GROUP_FUNGI_FUNGALOID, 1,
                     suitable_location.xy() + point::north_west,
                     suitable_location.xy() + point::south_east,

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -760,8 +760,8 @@ static void field_processor_fd_electricity( const tripoint_bub_ms &p, field_entr
     }
 }
 
-static void field_processor_monster_spawn( const tripoint_bub_ms &p, field_entry &cur,
-        field_proc_data &pd )
+void field_processor_monster_spawn( const tripoint_bub_ms &p, field_entry &cur,
+                                    field_proc_data &pd )
 {
     const field_intensity_level &int_level = cur.get_intensity_level();
     int monster_spawn_chance = int_level.monster_spawn_chance;


### PR DESCRIPTION
#### Summary
Infrastructure "Make map::add_spawn private to prevent hardcoded monster spawns"

#### Purpose of change

Closes #3951.

One hardcoded `add_spawn(mon_fungaloid_queen)` call remained in `mx_fungal_zone`, and new ones kept getting re-introduced (#68752) because there was no enforcement.

#### Describe the solution

1. Replace `add_spawn(mon_fungaloid_queen)` in `mx_fungal_zone` with `place_spawns` + new `GROUP_FUNGI_QUEEN` mongroup.

2. Make all three `add_spawn` overloads private in `map` (including the `MonsterGroupResult` one -- trivially constructible from a raw `mtype_id`). Friend the legitimate external callers:
   - `jmapgen_monster` -- JSON mapgen type resolution
   - `monster` -- baby reproduction
   - `field_processor_monster_spawn` -- matches existing friended field processor pattern

3. Remove unused `tinymap::add_spawn` wrapper (zero call sites).

#### Describe alternatives you've considered

Friend-free-functions instead of `friend class monster` -- but free functions on `map` are ADL-discoverable through any `map&` argument, which is a wider escape hatch than class friendship.

Leaving `add_spawn(MonsterGroupResult)` public -- bypassed by `MonsterGroupResult{mon_zombie, 1, spawn_data()}`.

#### Testing

N/A

#### Additional context

N/A