### PR TITLE
Skip lightmap rebuild when nothing changed

### DIFF
--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -177,6 +177,9 @@ void avatar::control_npc( npc &np, const bool debug )
     np.set_fac( faction_your_followers );
     // perception and mutations may have changed, so reset light level caches
     g->reset_light_level();
+    for( int z = -OVERMAP_DEPTH; z <= OVERMAP_HEIGHT; z++ ) {
+        get_map().set_lightmap_cache_dirty( z );
+    }
     // center the map on the new avatar character
     const bool z_level_changed = g->vertical_shift( posz() );
     g->update_map( *this, z_level_changed );

--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -544,6 +544,9 @@ bool do_turn()
 
     weather.update_weather();
     g->reset_light_level();
+    for( int z = -OVERMAP_DEPTH; z <= OVERMAP_HEIGHT; z++ ) {
+        m.set_lightmap_cache_dirty( z );
+    }
 
     g->perhaps_add_random_npc( /* ignore_spawn_timers_and_rates = */ false );
     while( u.get_moves() > 0 && u.activity ) {

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -397,9 +397,8 @@ input_context game::get_player_input( std::string &action )
                 }
             }
 
-            if( pixel_minimap_option ) {
-                // TODO: more granular control to only redraw pixel minimap
-                invalidate_main_ui_adaptor();
+            if( pixel_minimap_option && g->w_pixel_minimap ) {
+                wnoutrefresh( g->w_pixel_minimap );
             }
 
             std::unique_ptr<static_popup> deathcam_msg_popup;

--- a/src/level_cache.h
+++ b/src/level_cache.h
@@ -27,6 +27,7 @@ struct level_cache {
         bool outside_cache_dirty = false;
         bool floor_cache_dirty = false;
         bool seen_cache_dirty = false;
+        bool lightmap_dirty = true;
         // True when at least one light source on this z-level has non-white color.
         // Used to skip the color blur pass when all lights are white.
         bool has_colored_lights = false;

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -448,6 +448,11 @@ void map::build_sunlight_cache( int pzlev )
 void map::generate_lightmap( const int zlev )
 {
     level_cache &map_cache = get_cache( zlev );
+    if( !map_cache.lightmap_dirty ) {
+        return;
+    }
+    map_cache.lightmap_dirty = false;
+
     auto &lm = map_cache.lm;
     auto &sm = map_cache.sm;
     auto &outside_cache = map_cache.outside_cache;

--- a/src/lightmap.h
+++ b/src/lightmap.h
@@ -69,6 +69,12 @@ struct light_color_rgb {
         b += rhs.b;
         return *this;
     }
+    bool operator==( const light_color_rgb &rhs ) const {
+        return r == rhs.r && g == rhs.g && b == rhs.b;
+    }
+    bool operator!=( const light_color_rgb &rhs ) const {
+        return !( *this == rhs );
+    }
     light_color_rgb operator*( float scale ) const {
         return { r * scale, g * scale, b * scale };
     }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -132,7 +132,9 @@ static const efftype_id effect_crushed( "crushed" );
 static const efftype_id effect_fake_common_cold( "fake_common_cold" );
 static const efftype_id effect_fake_flu( "fake_flu" );
 static const efftype_id effect_gliding( "gliding" );
+static const efftype_id effect_haslight( "haslight" );
 static const efftype_id effect_incorporeal( "incorporeal" );
+static const efftype_id effect_onfire( "onfire" );
 static const efftype_id effect_pet( "pet" );
 static const efftype_id effect_psi_stunned( "psi_stunned" );
 static const efftype_id effect_slow_descent( "slow_descent" );
@@ -342,6 +344,7 @@ void map::set_transparency_cache_dirty( const int zlev )
 {
     if( inbounds_z( zlev ) ) {
         get_cache( zlev ).transparency_cache_dirty.set();
+        set_lightmap_cache_dirty_below( zlev );
     }
 }
 
@@ -350,6 +353,7 @@ void map::set_transparency_cache_dirty( const tripoint_bub_ms &p, bool field )
     if( inbounds( p ) ) {
         const tripoint_bub_sm smp = coords::project_to<coords::sm>( p );
         get_cache( smp.z() ).transparency_cache_dirty.set( smp.x() * MAPSIZE + smp.y() );
+        set_lightmap_cache_dirty_below( smp.z() );
         if( !field ) {
             get_creature_tracker().invalidate_reachability_cache();
         }
@@ -382,6 +386,7 @@ void map::set_outside_cache_dirty( const int zlev )
 {
     if( inbounds_z( zlev ) ) {
         get_cache( zlev ).outside_cache_dirty = true;
+        set_lightmap_cache_dirty_below( zlev );
     }
 }
 
@@ -389,6 +394,23 @@ void map::set_floor_cache_dirty( const int zlev )
 {
     if( inbounds_z( zlev ) ) {
         get_cache( zlev ).floor_cache_dirty = true;
+        set_lightmap_cache_dirty_below( zlev );
+    }
+}
+
+void map::set_lightmap_cache_dirty( const int zlev )
+{
+    if( inbounds_z( zlev ) ) {
+        get_cache( zlev ).lightmap_dirty = true;
+    }
+}
+
+void map::set_lightmap_cache_dirty_below( const int zlev )
+{
+    for( int z = zlev; z >= -OVERMAP_DEPTH; z-- ) {
+        if( inbounds_z( z ) ) {
+            get_cache( z ).lightmap_dirty = true;
+        }
     }
 }
 
@@ -447,6 +469,7 @@ void map::invalidate_map_cache( const int zlev )
         ch.floor_cache_dirty = true;
         ch.seen_cache_dirty = true;
         ch.outside_cache_dirty = true;
+        ch.lightmap_dirty = true;
         set_transparency_cache_dirty( zlev );
     }
 }
@@ -2023,6 +2046,11 @@ bool map::furn_set( const tripoint_bub_ms &p, const furn_id &new_furniture, cons
         set_seen_cache_dirty( p );
     }
 
+    if( old_f.light_emitted != new_f.light_emitted ||
+        old_f.light_color != new_f.light_color ) {
+        set_lightmap_cache_dirty( p.z() );
+    }
+
     if( old_f.has_flag( ter_furn_flag::TFLAG_INDOORS ) != new_f.has_flag(
             ter_furn_flag::TFLAG_INDOORS ) ) {
         set_outside_cache_dirty( p.z() );
@@ -2509,6 +2537,11 @@ bool map::ter_set( const tripoint_bub_ms &p, const ter_id &new_terrain, bool avo
             ter_furn_flag::TFLAG_TRANSLUCENT ) ) {
         set_transparency_cache_dirty( p );
         set_seen_cache_dirty( p );
+    }
+
+    if( old_t.light_emitted != new_t.light_emitted ||
+        old_t.light_color != new_t.light_color ) {
+        set_lightmap_cache_dirty( p.z() );
     }
 
     if( old_t.has_flag( ter_furn_flag::TFLAG_INDOORS ) != new_t.has_flag(
@@ -5481,6 +5514,9 @@ map_stack::iterator map::i_rem( const tripoint_bub_ms &p, const map_stack::const
     }
 
     current_submap->update_lum_rem( l, *it );
+    if( it->is_emissive() ) {
+        set_lightmap_cache_dirty( p.z() );
+    }
 
     return current_submap->get_items( l ).erase( it );
 }
@@ -5503,6 +5539,9 @@ void map::i_clear( const tripoint_bub_ms &p )
         return;
     }
 
+    if( current_submap->get_lum( l ) > 0 ) {
+        set_lightmap_cache_dirty( p.z() );
+    }
     current_submap->set_lum( l, 0 );
     current_submap->get_items( l ).clear();
 }
@@ -5826,6 +5865,9 @@ item &map::add_item( const tripoint_bub_ms &p, item new_item, int copies )
     invalidate_max_populated_zlev( p.z() );
 
     current_submap->update_lum_add( l, new_item );
+    if( new_item.is_emissive() ) {
+        set_lightmap_cache_dirty( p.z() );
+    }
 
     const map_stack::iterator new_pos = current_submap->get_items( l ).insert( new_item );
     while( --copies > 0 ) {
@@ -5915,6 +5957,7 @@ void map::update_lum( item_location &loc, bool add )
     } else {
         current_submap->update_lum_rem( l, *target );
     }
+    set_lightmap_cache_dirty( loc.pos_bub( *this ).z() );
 }
 
 static bool process_map_items( map &here, item_stack &items, safe_reference<item> &item_ref,
@@ -7267,6 +7310,8 @@ void map::delete_field( const tripoint_bub_ms &p, const field_type_id &field_to_
         if( it->second.get_field_type() == field_to_remove ) {
             --current_submap->field_count;
             curfield.remove_field( it );
+            set_lightmap_cache_dirty( p.z() );
+            set_transparency_cache_dirty( p, true );
             break;
         }
     }
@@ -7281,11 +7326,14 @@ void map::clear_fields( const tripoint_bub_ms &p )
     point_sm_ms l;
     submap *const current_submap = unsafe_get_submap_at( p, l );
     current_submap->clear_fields( l );
+    set_lightmap_cache_dirty( p.z() );
+    set_transparency_cache_dirty( p, true );
 }
 
 void map::on_field_modified( const tripoint_bub_ms &p, const field_type &fd_type )
 {
     invalidate_max_populated_zlev( p.z() );
+    set_lightmap_cache_dirty( p.z() );
 
     get_cache( p.z() ).field_cache.set(
         static_cast<size_t>( p.x() / SEEX ) + ( ( p.y() / SEEX ) * MAPSIZE ) );
@@ -10436,6 +10484,48 @@ void map::build_map_cache( const int zlev, bool skip_lightmap )
             }
         }
     }
+    // Detect character/NPC light changes reactively.
+    // Covers equipment, effects, trade/dialogue mutations, and position changes.
+    {
+        struct char_light_state {
+            float light;
+            tripoint_bub_ms pos;
+            bool operator==( const char_light_state &o ) const {
+                return light == o.light && pos == o.pos;
+            }
+            bool operator!=( const char_light_state &o ) const {
+                return !( *this == o );
+            }
+        };
+        auto compute = []( const Character & ch ) -> char_light_state {
+            float light = ch.active_light();
+            if( ch.has_effect( effect_onfire ) )
+            {
+                light += 8.0f;
+            } else if( ch.has_effect( effect_haslight ) )
+            {
+                light += 4.0f;
+            }
+            return { light, ch.pos_bub() };
+        };
+
+        static std::vector<char_light_state> cached_char_lights;
+        std::vector<char_light_state> current_lights;
+        current_lights.push_back( compute( get_player_character() ) );
+        for( const npc &guy : g->all_npcs() ) {
+            current_lights.push_back( compute( guy ) );
+        }
+        if( current_lights != cached_char_lights ) {
+            for( const char_light_state &s : cached_char_lights ) {
+                set_lightmap_cache_dirty( s.pos.z() );
+            }
+            for( const char_light_state &s : current_lights ) {
+                set_lightmap_cache_dirty( s.pos.z() );
+            }
+            cached_char_lights = std::move( current_lights );
+        }
+    }
+
     if( !skip_lightmap ) {
         generate_lightmap( zlev );
     }

--- a/src/map.h
+++ b/src/map.h
@@ -435,6 +435,8 @@ class map
         void set_seen_cache_dirty( int zlevel );
         void set_outside_cache_dirty( int zlev );
         void set_floor_cache_dirty( int zlev );
+        void set_lightmap_cache_dirty( int zlev );
+        void set_lightmap_cache_dirty_below( int zlev );
         void set_pathfinding_cache_dirty( int zlev );
         void set_pathfinding_cache_dirty( const tripoint_bub_ms &p );
         /*@}*/

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -341,6 +341,12 @@ void monster::on_move( const tripoint_abs_ms &old_pos )
         return;
     }
     g->update_zombie_pos( *this, old_pos, pos_abs() );
+    if( has_effect( effect_onfire ) ||
+        calculate_by_enchantment( type->luminance, enchant_vals::mod::LUMINATION, true ) > 0 ) {
+        map &here = get_map();
+        here.set_lightmap_cache_dirty( old_pos.z() );
+        here.set_lightmap_cache_dirty( pos_bub().z() );
+    }
     if( has_effect( effect_ridden ) && mounted_player &&
         mounted_player->pos_abs() != pos_abs() ) {
         add_msg_debug( debugmode::DF_MONSTER, "Ridden monster %s moved independently and dumped player",
@@ -349,6 +355,15 @@ void monster::on_move( const tripoint_abs_ms &old_pos )
     }
     if( has_dest() && pos_abs() == get_dest() ) {
         unset_dest();
+    }
+}
+
+void monster::on_effect_int_change( const efftype_id &/*eid*/, int /*intensity*/,
+                                    const bodypart_id &/*bp*/ )
+{
+    map &here = get_map();
+    if( here.inbounds( pos_bub() ) ) {
+        here.set_lightmap_cache_dirty( posz() );
     }
 }
 

--- a/src/monster.h
+++ b/src/monster.h
@@ -678,6 +678,8 @@ class monster : public Creature
         void load( const JsonObject &data, const tripoint_abs_sm &submap_loc );
 
         void on_move( const tripoint_abs_ms &old_pos ) override;
+        void on_effect_int_change( const efftype_id &eid, int intensity,
+                                   const bodypart_id &bp ) override;
         /** Processes monster-specific effects of an effect. */
         void process_one_effect( effect &it, bool is_new ) override;
 };

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -6425,6 +6425,9 @@ std::optional<vehicle_stack::iterator> vehicle::add_item( map &here, vehicle_par
             if( !item_ptr->merge_charges( itm ) ) {
                 return std::nullopt;
             } else {
+                if( itm.is_emissive() ) {
+                    here.set_lightmap_cache_dirty( bub_part_pos( here, vp ).z() );
+                }
                 return std::optional<vehicle_stack::iterator>( istack.get_iterator_from_pointer( item_ptr ) );
             }
         }
@@ -6440,6 +6443,9 @@ std::optional<vehicle_stack::iterator> vehicle::add_item( map &here, vehicle_par
 
     const vehicle_stack::iterator new_pos = vp.items.insert( itm_copy );
     active_items.add( *new_pos, vp.mount );
+    if( itm_copy.is_emissive() ) {
+        here.set_lightmap_cache_dirty( bub_part_pos( here, vp ).z() );
+    }
 
     invalidate_mass();
     return std::optional<vehicle_stack::iterator>( new_pos );
@@ -6459,6 +6465,10 @@ bool vehicle::remove_item( vehicle_part &vp, item *it )
 vehicle_stack::iterator vehicle::remove_item( vehicle_part &vp,
         const vehicle_stack::const_iterator &it )
 {
+    if( it->is_emissive() ) {
+        map &here = get_map();
+        here.set_lightmap_cache_dirty( bub_part_pos( here, vp ).z() );
+    }
     invalidate_mass();
     return vp.items.erase( it );
 }

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -289,6 +289,12 @@ static void add_electronic_toggle( map &here, vehicle &veh, veh_menu &menu, cons
                 e.enabled = state;
             }
         }
+        map &here = get_map();
+        for( const vpart_reference &vp : found )
+        {
+            here.set_lightmap_cache_dirty( vp.pos_bub( here ).z() );
+            break;
+        }
     } );
 }
 

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -755,6 +755,9 @@ std::list<item> map_cursor::remove_items_with( const
         if( filter( *iter ) ) {
             // if necessary remove item from the luminosity map
             sub->update_lum_rem( offset, *iter );
+            if( iter->is_emissive() ) {
+                here.set_lightmap_cache_dirty( pos_bub().z() );
+            }
 
             // finally remove the item
             res.push_back( *iter );
@@ -808,6 +811,10 @@ std::list<item> vehicle_cursor::remove_items_with( const
     cata::colony<item> &items = veh.part( idx ).items;
     for( auto iter = items.begin(); iter != items.end(); ) {
         if( filter( *iter ) ) {
+            if( iter->is_emissive() ) {
+                map &here = get_map();
+                here.set_lightmap_cache_dirty( veh.bub_part_pos( here, veh.part( part ) ).z() );
+            }
             res.push_back( *iter );
             iter = items.erase( iter );
 


### PR DESCRIPTION
#### Summary
Performance "Skip lightmap rebuild on idle frames"

#### Purpose of change

When the game is idle (waiting for player input, nothing animated), `generate_lightmap()` still fully rebuilds every 125ms because the pixel minimap unconditionally invalidates the entire game UI, triggering `game::draw()` -> `build_map_cache()` -> `generate_lightmap()` from scratch. Profiling shows `build_sunlight_cache` at 7% and `generate_lightmap` at 2.8% of idle CPU, plus ~12% in coordinate math and ~5% in cache array zeroing -- all for a frame where absolutely nothing changed.

#### Describe the solution

Two changes:

**Lightmap dirty tracking** -- add a `lightmap_dirty` flag to `level_cache` (same pattern as the existing `floor_cache_dirty`, `seen_cache_dirty`, etc.). `generate_lightmap()` early-exits when clean. The flag is marked dirty from:
- `invalidate_map_cache()` (the generic catch-all, 30+ call sites)
- Structural cache setters (`set_transparency/outside/floor_cache_dirty`) with downward z-propagation for sunlight
- Emissive terrain/furniture swaps (`furn_set`/`ter_set` comparing `light_emitted` and `light_color`)
- Field changes (`on_field_modified`, `delete_field`, `clear_fields`)
- Map item luminance changes (`add_item_at`, `i_rem`, `i_clear`, `update_lum`, `remove_items_with`)
- Vehicle cargo add/remove and electronics toggle
- Monster movement and effect changes (for fire/luminant monsters)
- A reactive character/NPC light check in `build_map_cache` that compares active_light + effects + position against cached state
- Turn advance and avatar control swap (dirty all z-levels)

**Minimap-only redraw** -- replace `invalidate_main_ui_adaptor()` in the 125ms timeout loop with `wnoutrefresh(g->w_pixel_minimap)`, which re-enters the existing minimap draw path in sdltiles.cpp without triggering `game::draw()`. Beacon blink keeps working since it's time-based via `SDL_GetTicks()`.

#### Describe alternatives you've considered

Tried just removing the minimap invalidation entirely, but that freezes the creature beacon blink animation. The `wnoutrefresh` approach reuses the existing curses draw path so the minimap keeps updating without dragging the full scene along.

Could also try per-tile lightmap dirty tracking (like `transparency_cache_dirty`'s bitset), but light propagation is global via raycasting -- one source affects the entire z-level -- so per-z-level bool is the right granularity.

#### Testing

Perf profiled idle game before and after. Before: `build_sunlight_cache` 7%, `generate_lightmap` 2.8%, coordinate math ~12%. After: zero game rendering functions in the profile, just SDL event polling and Wayland housekeeping.

Manually verified lighting updates correctly after: walking, waiting, entering buildings, starting fires, dropping/equipping flashlights, toggling vehicle headlights, trading items with NPCs, debug-menu furniture/field edits, z-level changes, and floor destruction (sunlight propagation).

All existing vision tests pass (30 test cases, 27005 assertions). All light_color tests pass (16 test cases, 294 assertions).

#### Additional context

The pixel minimap had a TODO comment since forever: "TODO: more granular control to only redraw pixel minimap". This PR addresses that.