### PR TITLE
Debug spell to quickly fire an EOC give on quick setup

### DIFF
--- a/data/json/debug/testing.json
+++ b/data/json/debug/testing.json
@@ -1,0 +1,20 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_DEBUG_TESTING",
+    "effect": [ { "u_message": "Override EOC_DEBUG_TESTING to use this for testing.", "popup": true } ]
+  },
+  {
+    "type": "SPELL",
+    "id": "SPELL_EOC_DEBUG_TESTING",
+    "name": "Activate Debug EOC",
+    "description": "TESTING AHOY!  Fires the EOC_DEBUG_TESTING on cast.  Override this EOC for whatever testing you are doing and you can use this spell to fire it quickly and easily.",
+    "message": "",
+    "valid_targets": [ "self" ],
+    "flags": [ "NO_EXPLOSION_SFX", "NO_FAIL", "NO_LEGS", "NO_HANDS" ],
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_DEBUG_TESTING",
+    "shape": "blast",
+    "base_casting_time": 0
+  }
+]

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -162,6 +162,8 @@ static const morale_type morale_perm_debug( "morale_perm_debug" );
 
 static const mtype_id mon_generator( "mon_generator" );
 
+static const spell_id spell_SPELL_EOC_DEBUG_TESTING( "SPELL_EOC_DEBUG_TESTING" );
+
 static const trait_id trait_ASTHMA( "ASTHMA" );
 static const trait_id trait_DEBUG_BIONICS( "DEBUG_BIONICS" );
 static const trait_id trait_DEBUG_CLAIRVOYANCE( "DEBUG_CLAIRVOYANCE" );
@@ -4074,6 +4076,7 @@ void do_debug_quick_setup( bool flag_dirty )
     normalize_body( u );
     // Specifically only adds mutations instead of toggling them.
     u.set_mutations( setup_traits );
+    u.magic->set_spell_level( spell_SPELL_EOC_DEBUG_TESTING, 0, &get_avatar() );
     u.remove_weapon();
     u.clear_worn();
     item backpack( itype_debug_backpack );


### PR DESCRIPTION
#### Summary
None


#### Purpose of change
I use a setup with a spell to fire a testing EOC quickly without to having to go through the activate EOC menu every time. Upon discussing it on Discord it was suggested to integrate that directly into the game.

#### Describe the solution
`do_debug_quick_setup` now gives the player a new debug spell that cannot fail and solely triggers an EOC, `EOC_DEBUG_TESTING`. 
The dev/tester can override/modify this EOC when working to make it easy to fire whatever EOC you are using while skipping the debug menu entirely.
By default if the spell is fired it displays a popup message telling the user to override the EOC

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
<details>
<summary>Images</summary>
<img width="735" height="585" alt="image" src="https://github.com/user-attachments/assets/36f5c331-c60c-4f9b-9ebe-9deccbb7261a" />
</details>


#### Additional context
This does introduce a point where someone doing work can override/modify the EOC and can accidentally commit it in their PR.
I have a personal mod where I lifted this concept from and can use that to easily override the now built in EOC. This method helps prevent the stated issue for me but it is something to consider. 

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
