### PR TITLE
[MoM: Psychic Scream] Various updates

### DIFF
--- a/data/mods/MindOverMatterNoKnacks/eocs/eocs_crystal_awakening.json
+++ b/data/mods/MindOverMatterNoKnacks/eocs/eocs_crystal_awakening.json
@@ -20,27 +20,5 @@
       { "u_add_effect": "psionic_overload", "duration": "1 hours" },
       { "u_add_effect": "stunned", "duration": 10 }
     ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_TELEPORT_MATRIX_AWAKENING",
-    "effect": [
-      {
-        "u_message": "You gaze into the strange crystal and the light slowly grows brighter.  It starts pulsing, first slowly and more rapidly, and your head starts pounding in time with the light.  You tear your gaze away but the pounding in your head remains."
-      },
-      { "u_add_effect": "psionic_overload", "duration": "1 hours" },
-      { "u_add_effect": "stunned", "duration": 10 }
-    ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_VITAKIN_MATRIX_AWAKENING",
-    "effect": [
-      {
-        "u_message": "You gaze into the strange crystal and the light slowly grows brighter.  It starts pulsing, first slowly and more rapidly, and your head starts pounding in time with the light.  You tear your gaze away but the pounding in your head remains."
-      },
-      { "u_add_effect": "psionic_overload", "duration": "1 hours" },
-      { "u_add_effect": "stunned", "duration": 10 }
-    ]
   }
 ]

--- a/data/mods/MindOverMatterNoKnacks/items/item_blacklist.json
+++ b/data/mods/MindOverMatterNoKnacks/items/item_blacklist.json
@@ -9,6 +9,8 @@
       "matrix_crystal_electrokinesis",
       "matrix_crystal_photokinesis",
       "matrix_crystal_pyrokinesis",
+      "matrix_crystal_teleportation",
+      "matrix_crystal_vitakinesis",
       "matrix_crystal_coruscating"
     ]
   }

--- a/data/mods/MindOverMatterNoKnacks/mutation_blacklist.json
+++ b/data/mods/MindOverMatterNoKnacks/mutation_blacklist.json
@@ -95,13 +95,22 @@
     "remove": true
   },
   {
-    "type": "TRAIT_MIGRATION",
+    "//": "Migration doesn't prevent these from showing up in character gen so we need to override the starting trait field",
+    "type": "mutation",
     "id": "LIMITED_PSIONICS",
-    "remove": true
+    "copy-from": "LIMITED_PSIONICS",
+    "starting_trait": false
   },
   {
-    "type": "TRAIT_MIGRATION",
+    "type": "mutation",
     "id": "ALWAYS_GAIN_PSIONICS",
-    "remove": true
+    "copy-from": "ALWAYS_GAIN_PSIONICS",
+    "starting_trait": false
+  },
+  {
+    "type": "mutation",
+    "id": "MOM_PSYCHIC_VAMPIRE",
+    "copy-from": "MOM_PSYCHIC_VAMPIRE",
+    "starting_trait": false
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[MoM: Psychic Scream] Various updates"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Some things I noticed that needed fixing. 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

1) Blacklist awakening vitakinetic and teleportation crystals from spawning (artifact ones still spawn).
2) Remove the EoC override for those crystals.
3) Instead of migrating Latent Psion, Limited Awakening, etc., copy-from them and set them to not be starting traits so they're not visible at all. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

No more starting as a Latent Psion then having it taken away. 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
