### PR TITLE
[Sky Island] Override refugee center mission

### DIFF
--- a/data/mods/Sky_Island/effectoncondition/teleport.json
+++ b/data/mods/Sky_Island/effectoncondition/teleport.json
@@ -240,7 +240,9 @@
     "type": "effect_on_condition",
     "id": "EOC_clearmissions",
     "//": "This EOC wipes all missions you might have.  It's more or less a full list of any random missions you can be assigned.",
+    "//1": "Adding find refugee center mission here",
     "effect": [
+      { "remove_active_mission": "MISSION_REACH_REFUGEE_CENTER" },
       { "remove_active_mission": "MISSION_REACH_EXTRACT" },
       { "remove_active_mission": "MISSION_BONUS_TREASURE" },
       { "remove_active_mission": "MISSION_BONUS_KILL_LIGHT" },

--- a/data/mods/Sky_Island/missions/overrides.json
+++ b/data/mods/Sky_Island/missions/overrides.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "MISSION_REACH_REFUGEE_CENTER",
+    "type": "mission_definition",
+    "name": { "str": "Reach Refugee Center?" },
+    "goal": "MGOAL_GO_TO_TYPE",
+    "description": "Something is telling you to find this location but something else is telling you that there is nothing there.",
+    "difficulty": 1,
+    "value": 0,
+    "invisible_on_complete": true,
+    "origins": [ "ORIGIN_COMPUTER" ],
+    "start": { "assign_mission_target": { "om_terrain": "field", "reveal_radius": 0 } },
+    "destination": "field",
+    "end": { "effect": [ { "u_message": "Wait, where is this?  What happened?  Why am I here?", "popup": true } ] }
+  }
+]


### PR DESCRIPTION
#### Summary
Mods "[Sky Island] Override refugee center mission"

#### Purpose of change
The refugee center does not exist in sky island. Override the mission to something else so it gets managed properly.

#### Describe the solution
Override the mission to select the closest field omt and give the player a popup when arriving expressing their confusion. There is no rewards for this.
Adds the mission to the clear missions EOC as well so it gets removed if it was not completed.

#### Describe alternatives you've considered


#### Testing
Game loads, mission runs and completes as expected.

#### Additional context
This mission is given by the evac shelter, a fema flyer, and by some random NPCs. If it wasn't given by NPCs it would be better to override the two other givers but this method is simpler to do instead of overriding a bunch of dialog too.


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
