### PR TITLE
Add quick setup eoc and force it to execute during quick setup

### DIFF
--- a/data/json/debug/quick_setup_eoc.json
+++ b/data/json/debug/quick_setup_eoc.json
@@ -1,0 +1,11 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_DEBUG_QUICK_SETUP",
+    "effect": [
+      {
+        "u_message": "EOC_DEBUG_QUICK_SETUP is automatically executed when using quick setup.  Override it for custom functionality during quick setup."
+      }
+    ]
+  }
+]

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -145,6 +145,9 @@ static const achievement_id achievement_achievement_arcade_mode( "achievement_ar
 
 static const bodypart_str_id body_part_no_a_real_part( "no_a_real_part" );
 
+static const effect_on_condition_id
+effect_on_condition_EOC_DEBUG_QUICK_SETUP( "EOC_DEBUG_QUICK_SETUP" );
+
 static const efftype_id effect_asthma( "asthma" );
 static const efftype_id effect_bleed( "bleed" );
 
@@ -4082,6 +4085,8 @@ void do_debug_quick_setup( bool flag_dirty )
         u.set_skill_level( pair.first, 10 );
     }
     map_reveal( static_cast<int>( om_vision_level::full ) );
+    dialogue d( get_talker_for( get_avatar() ), nullptr );
+    effect_on_condition_EOC_DEBUG_QUICK_SETUP->activate( d );
     if( flag_dirty ) {
         g->save_is_dirty = true;
     }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Expand automatically ran testing functionality during quick setup

#### Describe the solution
Add an empty EOC that is automatically executed when `do_debug_quick_setup` is executed. 
This allows the dev/tester to modify/override the built in EOC to setup some sort of automatically ran debug/testing setup when using quick setup through the debug menu or via world/character naming.

#### Describe alternatives you've considered
Originally game the player a spell to trigger an EOC as seen in #86184 but after discussion there, I decided to go with automatically firing an EOC instead.

#### Testing
EOC fires and prints the default message to chat when using quick setup.

#### Additional context
Same as in the previous PR, this does introduce a point where someone doing work can override/modify the EOC and can accidentally commit it in their PR.
Personally I maintain and out of repo tweaks mod that I have a similar setup that I use to a similar effect, albeit with a bit of workaround, that makes overriding the EOC that is built in as part of this PR simple and safe.


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
