### PR TITLE
languorous spectre will only send you to the inner cabins once

### DIFF
--- a/data/json/monsters/reverberation_cabin.json
+++ b/data/json/monsters/reverberation_cabin.json
@@ -37,13 +37,32 @@
   {
     "type": "talk_topic",
     "id": "TALK_CABIN_TUNNEL_SHADOW",
-    "dynamic_line": [
-      "&The creature rolls slowly onto its back, staring up at you with stark, white eyes.  \"Lay.  Sleep in the earth.  You can leave this place.  You will be safe.\""
-    ],
+    "dynamic_line": {
+      "compare_string": [ "yes", { "u_val": "shade_sent_to_inner_cabins" } ],
+      "no": "&The creature rolls slowly onto its back, staring up at you with stark, white eyes.  \"Lay.  Sleep in the earth.  You can leave this place.  You will be safe.\"",
+      "yes": "&The creature doesn't pay you any attention."
+    },
     "responses": [
-      { "text": "Who are you?", "topic": "TALK_CABIN_TUNNEL_SHADOW_WHO" },
-      { "text": "[Lay beside the creature]", "topic": "TALK_CABIN_TUNNEL_SHADOW_SLEEP_1" },
-      { "text": "[Move away]", "topic": "TALK_DONE" }
+      {
+        "text": "Who are you?",
+        "topic": "TALK_CABIN_TUNNEL_SHADOW_WHO",
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "shade_sent_to_inner_cabins" } ] } }
+      },
+      {
+        "text": "[Lay beside the creature]",
+        "topic": "TALK_CABIN_TUNNEL_SHADOW_SLEEP_1",
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "shade_sent_to_inner_cabins" } ] } }
+      },
+      {
+        "text": "[Move away]",
+        "topic": "TALK_DONE",
+        "condition": { "not": { "compare_string": [ "yes", { "u_val": "shade_sent_to_inner_cabins" } ] } }
+      },
+      {
+        "text": "…",
+        "topic": "TALK_DONE",
+        "condition": { "compare_string": [ "yes", { "u_val": "shade_sent_to_inner_cabins" } ] }
+      }
     ]
   },
   {
@@ -64,10 +83,15 @@
       "&You lay beside the shade.  It is comfortable, but also unfamiliar.  You feel like you could stay here forever, though you might not be comfortable."
     ],
     "responses": [
-      { "text": "[Close your eyes]", "topic": "TALK_CABIN_TUNNEL_SHADOW_SLEEP_2" },
+      {
+        "text": "[Close your eyes]",
+        "effect": { "u_add_var": "shade_sent_to_inner_cabins", "value": "yes" },
+        "topic": "TALK_CABIN_TUNNEL_SHADOW_SLEEP_2"
+      },
       {
         "text": "[Stand up]",
         "condition": { "math": [ "u_limb_score('reaction', 'type': 'head') < 0.3" ] },
+        "effect": { "u_add_var": "shade_sent_to_inner_cabins", "value": "yes" },
         "topic": "TALK_CABIN_TUNNEL_SHADOW_SLEEP_NICE_TRY"
       },
       {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Languorous spectres can only send you to inner cabins dimension once"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

languorous spectre should only send you to the inner cabins dimension once

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

languorous spectres only send you to the inner cabins dimension once (new var check in dialogue)

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

languorous spectres sending you to the inner cabins dimension MORE than once.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

got a languorous spectre to send me to the inner cabins dimension once

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

languorous spectre.  inner cabins.  once.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
