### PR TITLE
Remove single-magazine assumptions in item_contents

### DIFF
--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -5683,5 +5683,28 @@
     "description": "A test powered tool with fast CUT speed when charged.",
     "qualities": [ [ "SCREW", 1 ] ],
     "charged_qualities": [ { "id": "CUT", "level": 2, "speed": 0.3 } ]
+  },
+  {
+    "id": "test_multimag_gun",
+    "type": "ITEM",
+    "subtypes": [ "GUN" ],
+    "name": { "str": "test multimag gun" },
+    "description": "Test gun with two magazine wells for multimag tests.",
+    "weight": "1000 g",
+    "volume": "1500 ml",
+    "longest_side": "400 mm",
+    "material": [ "steel" ],
+    "symbol": "(",
+    "color": "light_gray",
+    "ammo": [ "9mm", "223" ],
+    "skill": "pistol",
+    "range": 10,
+    "ranged_damage": { "damage_type": "bullet", "amount": 10 },
+    "dispersion": 480,
+    "durability": 10,
+    "pocket_data": [
+      { "magazine_well": "250 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "glockmag" ] },
+      { "magazine_well": "500 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "stanag30" ] }
+    ]
   }
 ]

--- a/src/item.h
+++ b/src/item.h
@@ -2634,10 +2634,6 @@ class item : public visitable
 
         /** Quantity of ammunition consumed per usage of tool or with each shot of gun */
         int ammo_required() const;
-        /**
-         * Return the first ammo found iterating all magazine pockets. Null if none found.
-         * Does not support multiple magazine pockets!
-         */
         item &first_ammo();
         const item &first_ammo() const;
         /**
@@ -2784,6 +2780,9 @@ class item : public visitable
          */
         item *magazine_current();
         const item *magazine_current() const;
+
+        std::vector<item *> magazines_current();
+        std::vector<const item *> magazines_current() const;
 
         /** Returns all gunmods currently attached to this item (always empty if item not a gun) */
         std::vector<item *> gunmods();

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -1295,20 +1295,24 @@ int item_contents::ammo_consume( int qty, map *here, const tripoint_bub_ms &pos,
 {
     int consumed = 0;
     for( item_pocket &pocket : contents ) {
+        if( qty <= 0 ) {
+            break;
+        }
         if( pocket.is_type( pocket_type::MAGAZINE_WELL ) ) {
-            // we are assuming only one magazine per well
             if( pocket.empty() ) {
-                return 0;
+                continue;
             }
-            // assuming only one mag
-            item &mag = pocket.front();
-            const int res = mag.ammo_consume( qty, *here, pos, nullptr );
-            if( res && mag.ammo_remaining( ) == 0 ) {
-                if( mag.has_flag( json_flag_MAG_DESTROY ) ) {
-                    pocket.remove_item( mag );
-                } else if( mag.has_flag( json_flag_MAG_EJECT ) ) {
-                    here->add_item( pos, mag );
-                    pocket.remove_item( mag );
+            item *mag = pocket.magazine_current();
+            if( mag == nullptr ) {
+                continue;
+            }
+            const int res = mag->ammo_consume( qty, *here, pos, nullptr );
+            if( res && mag->ammo_remaining() == 0 ) {
+                if( mag->has_flag( json_flag_MAG_DESTROY ) ) {
+                    pocket.remove_item( *mag );
+                } else if( mag->has_flag( json_flag_MAG_EJECT ) ) {
+                    here->add_item( pos, *mag );
+                    pocket.remove_item( *mag );
                 }
             }
             qty -= res;
@@ -1350,6 +1354,47 @@ item *item_contents::magazine_current()
     return nullptr;
 }
 
+const item *item_contents::magazine_current() const
+{
+    for( const item_pocket &pocket : contents ) {
+        if( pocket.is_type( pocket_type::MAGAZINE_WELL ) ) {
+            const item *mag = pocket.magazine_current();
+            if( mag != nullptr ) {
+                return mag;
+            }
+        }
+    }
+    return nullptr;
+}
+
+std::vector<item *> item_contents::magazines_current()
+{
+    std::vector<item *> result;
+    for( item_pocket &pocket : contents ) {
+        if( pocket.is_type( pocket_type::MAGAZINE_WELL ) ) {
+            item *mag = pocket.magazine_current();
+            if( mag != nullptr ) {
+                result.push_back( mag );
+            }
+        }
+    }
+    return result;
+}
+
+std::vector<const item *> item_contents::magazines_current() const
+{
+    std::vector<const item *> result;
+    for( const item_pocket &pocket : contents ) {
+        if( pocket.is_type( pocket_type::MAGAZINE_WELL ) ) {
+            const item *mag = pocket.magazine_current();
+            if( mag != nullptr ) {
+                result.push_back( mag );
+            }
+        }
+    }
+    return result;
+}
+
 int item_contents::ammo_capacity( const ammotype &ammo ) const
 {
     int ret = 0;
@@ -1374,13 +1419,23 @@ std::set<ammotype> item_contents::ammo_types() const
 
 item &item_contents::first_ammo()
 {
-    if( empty() ) {
+    if( contents.empty() ) {
         debugmsg( "Error: Contents has no pockets" );
         return null_item_reference();
     }
     for( item_pocket &pocket : contents ) {
         if( pocket.is_type( pocket_type::MAGAZINE_WELL ) ) {
-            return pocket.front().first_ammo();
+            if( pocket.empty() ) {
+                continue;
+            }
+            item *mag = pocket.magazine_current();
+            if( mag != nullptr ) {
+                item &ammo = mag->first_ammo();
+                if( !ammo.is_null() ) {
+                    return ammo;
+                }
+            }
+            continue;
         }
         if( !pocket.is_type( pocket_type::MAGAZINE ) || pocket.empty() ) {
             continue;
@@ -1400,13 +1455,23 @@ item &item_contents::first_ammo()
 
 const item &item_contents::first_ammo() const
 {
-    if( empty() ) {
+    if( contents.empty() ) {
         debugmsg( "Error: Contents has no pockets" );
         return null_item_reference();
     }
     for( const item_pocket &pocket : contents ) {
         if( pocket.is_type( pocket_type::MAGAZINE_WELL ) ) {
-            return pocket.front().first_ammo();
+            if( pocket.empty() ) {
+                continue;
+            }
+            const item *mag = pocket.magazine_current();
+            if( mag != nullptr ) {
+                const item &ammo = mag->first_ammo();
+                if( !ammo.is_null() ) {
+                    return ammo;
+                }
+            }
+            continue;
         }
         if( !pocket.is_type( pocket_type::MAGAZINE ) || pocket.empty() ) {
             continue;

--- a/src/item_contents.h
+++ b/src/item_contents.h
@@ -373,12 +373,11 @@ class item_contents
         int ammo_consume( int qty, const tripoint_bub_ms &pos, float fuel_efficiency = -1.0 );
         int ammo_consume( int qty, map *here, const tripoint_bub_ms &pos, float fuel_efficiency = -1.0 );
         item *magazine_current();
+        const item *magazine_current() const;
+        std::vector<item *> magazines_current();
+        std::vector<const item *> magazines_current() const;
         std::set<ammotype> ammo_types() const;
         int ammo_capacity( const ammotype &ammo ) const;
-        /**
-         * Return the first ammo found when iterating all magazine pockets. Null if none found.
-         * Does not support multiple magazine pockets!
-         */
         item &first_ammo();
         const item &first_ammo() const;
         /**

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2283,19 +2283,11 @@ void Item_factory::check_definitions() const
             msg +=  "item has unknown ascii_picture.";
         }
 
-        int mag_pocket_number = 0;
         for( const pocket_data &data : type->pockets ) {
-            if( data.type == pocket_type::MAGAZINE ||
-                data.type == pocket_type::MAGAZINE_WELL ) {
-                mag_pocket_number++;
-            }
             std::string pocket_error = data.check_definition();
             if( !pocket_error.empty() ) {
                 msg += "problem with pocket: " + pocket_error;
             }
-        }
-        if( mag_pocket_number > 1 ) {
-            msg += "cannot have more than one pocket that handles ammo (MAGAZINE or MAGAZINE_WELL)\n";
         }
 
         if( !type->category_force.is_valid() ) {

--- a/src/item_gun_tool_ammo.cpp
+++ b/src/item_gun_tool_ammo.cpp
@@ -1977,7 +1977,17 @@ item *item::magazine_current()
 
 const item *item::magazine_current() const
 {
-    return const_cast<item *>( this )->magazine_current();
+    return contents.magazine_current();
+}
+
+std::vector<item *> item::magazines_current()
+{
+    return contents.magazines_current();
+}
+
+std::vector<const item *> item::magazines_current() const
+{
+    return contents.magazines_current();
 }
 
 std::vector<item *> item::gunmods()

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -717,6 +717,14 @@ item *item_pocket::magazine_current()
     return iter != contents.end() ? &*iter : nullptr;
 }
 
+const item *item_pocket::magazine_current() const
+{
+    auto iter = std::find_if( contents.begin(), contents.end(), []( const item & it ) {
+        return !it.is_null();
+    } );
+    return iter != contents.end() ? &*iter : nullptr;
+}
+
 itype_id item_pocket::magazine_default() const
 {
     if( is_type( pocket_type::MAGAZINE_WELL ) ) {

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -248,6 +248,7 @@ class item_pocket
         std::vector<const item *> gunmods() const;
         cata::flat_set<itype_id> item_type_restrictions() const;
         item *magazine_current();
+        const item *magazine_current() const;
         // returns the default magazine if MAGAZINE_WELL, otherwise NULL_ID
         itype_id magazine_default() const;
         // returns amount of ammo consumed

--- a/tests/multimag_test.cpp
+++ b/tests/multimag_test.cpp
@@ -1,0 +1,162 @@
+#include <string>
+#include <vector>
+
+#include "calendar.h"
+#include "cata_catch.h"
+#include "coordinates.h"
+#include "item.h"
+#include "map.h"
+#include "map_helpers.h"
+#include "pocket_type.h"
+#include "point.h"
+#include "ret_val.h"
+#include "type_id.h"
+
+static const itype_id itype_38_special( "38_special" );
+static const itype_id itype_556( "556" );
+static const itype_id itype_9mm( "9mm" );
+static const itype_id itype_glock_19( "glock_19" );
+static const itype_id itype_glockmag( "glockmag" );
+static const itype_id itype_stanag30( "stanag30" );
+static const itype_id itype_sw_619( "sw_619" );
+static const itype_id itype_test_multimag_gun( "test_multimag_gun" );
+
+static item make_loaded_glock()
+{
+    item mag( itype_glockmag );
+    mag.put_in( item( itype_9mm, calendar::turn, 15 ), pocket_type::MAGAZINE );
+    item gun( itype_glock_19 );
+    gun.put_in( mag, pocket_type::MAGAZINE_WELL );
+    return gun;
+}
+
+static item make_loaded_stanag()
+{
+    item mag( itype_stanag30 );
+    mag.put_in( item( itype_556, calendar::turn, 30 ), pocket_type::MAGAZINE );
+    return mag;
+}
+
+static item make_dual_well_gun()
+{
+    item gun( itype_test_multimag_gun );
+    item glock_mag( itype_glockmag );
+    glock_mag.put_in( item( itype_9mm, calendar::turn, 15 ), pocket_type::MAGAZINE );
+    gun.put_in( glock_mag, pocket_type::MAGAZINE_WELL );
+    gun.put_in( make_loaded_stanag(), pocket_type::MAGAZINE_WELL );
+    return gun;
+}
+
+TEST_CASE( "single_well_magazine_operations", "[multimag]" )
+{
+    SECTION( "ammo_remaining and magazine_current" ) {
+        item gun = make_loaded_glock();
+
+        CHECK( gun.ammo_remaining() == 15 );
+        REQUIRE( gun.magazine_current() != nullptr );
+        CHECK( gun.magazine_current()->typeId() == itype_glockmag );
+    }
+
+    SECTION( "ammo_consume drains loaded magazine" ) {
+        clear_map();
+        map &here = get_map();
+        tripoint_bub_ms pos( tripoint_bub_ms::zero );
+        item gun = make_loaded_glock();
+
+        CHECK( gun.ammo_consume( 3, here, pos, nullptr ) == 3 );
+        CHECK( gun.ammo_remaining() == 12 );
+        CHECK( gun.ammo_consume( 12, here, pos, nullptr ) == 12 );
+        CHECK( gun.ammo_remaining() == 0 );
+    }
+
+    SECTION( "first_ammo returns loaded ammo type" ) {
+        item gun = make_loaded_glock();
+        CHECK( gun.first_ammo().typeId() == itype_9mm );
+    }
+
+    SECTION( "first_ammo on empty gun" ) {
+        item gun( itype_glock_19 );
+        CHECK( gun.first_ammo().is_null() );
+    }
+
+    SECTION( "magazines_current" ) {
+        item gun = make_loaded_glock();
+        std::vector<item *> mags = gun.magazines_current();
+        REQUIRE( mags.size() == 1 );
+        CHECK( mags[0] == gun.magazine_current() );
+
+        item empty_gun( itype_glock_19 );
+        CHECK( empty_gun.magazines_current().empty() );
+    }
+}
+
+TEST_CASE( "integral_magazine_ammo_consume", "[multimag]" )
+{
+    clear_map();
+    map &here = get_map();
+    tripoint_bub_ms pos( tripoint_bub_ms::zero );
+
+    item gun( itype_sw_619 );
+    gun.put_in( item( itype_38_special, calendar::turn, 7 ), pocket_type::MAGAZINE );
+
+    CHECK( gun.ammo_remaining() == 7 );
+    CHECK( gun.ammo_consume( 3, here, pos, nullptr ) == 3 );
+    CHECK( gun.ammo_remaining() == 4 );
+    CHECK( gun.first_ammo().typeId() == itype_38_special );
+}
+
+TEST_CASE( "dual_well_magazine_operations", "[multimag]" )
+{
+    SECTION( "magazines_current with both loaded" ) {
+        item gun = make_dual_well_gun();
+        CHECK( gun.magazines_current().size() == 2 );
+    }
+
+    SECTION( "magazines_current with only second loaded" ) {
+        item gun( itype_test_multimag_gun );
+        gun.put_in( make_loaded_stanag(), pocket_type::MAGAZINE_WELL );
+
+        std::vector<item *> mags = gun.magazines_current();
+        REQUIRE( mags.size() == 1 );
+        REQUIRE( gun.magazine_current() != nullptr );
+        CHECK( mags[0] == gun.magazine_current() );
+    }
+
+    SECTION( "ammo_consume with first well empty" ) {
+        clear_map();
+        map &here = get_map();
+        tripoint_bub_ms pos( tripoint_bub_ms::zero );
+
+        item gun( itype_test_multimag_gun );
+        gun.put_in( make_loaded_stanag(), pocket_type::MAGAZINE_WELL );
+
+        CHECK( gun.ammo_remaining() == 30 );
+        CHECK( gun.ammo_consume( 10, here, pos, nullptr ) == 10 );
+        CHECK( gun.ammo_remaining() == 20 );
+    }
+
+    SECTION( "ammo_consume drains both wells" ) {
+        clear_map();
+        map &here = get_map();
+        tripoint_bub_ms pos( tripoint_bub_ms::zero );
+
+        item gun = make_dual_well_gun();
+
+        CHECK( gun.ammo_consume( 20, here, pos, nullptr ) == 20 );
+        std::vector<item *> remaining = gun.magazines_current();
+        REQUIRE( remaining.size() == 2 );
+        CHECK( remaining[0]->ammo_remaining() == 0 );
+        CHECK( remaining[1]->ammo_remaining() == 25 );
+    }
+
+    SECTION( "first_ammo with first well empty" ) {
+        item gun( itype_test_multimag_gun );
+        gun.put_in( make_loaded_stanag(), pocket_type::MAGAZINE_WELL );
+        CHECK( gun.first_ammo().typeId() == itype_556 );
+    }
+
+    SECTION( "first_ammo with both wells empty" ) {
+        item gun( itype_test_multimag_gun );
+        CHECK( gun.first_ammo().is_null() );
+    }
+}


### PR DESCRIPTION
#### Summary
Infrastructure "Remove single-magazine assumptions in item_contents"

#### Purpose of change

Several functions in `item_contents` hardcode the assumption that an item has at most one MAGAZINE_WELL pocket. `ammo_consume()` early-returns 0 when the first well is empty (blocking any subsequent wells), and `first_ammo()` calls `pocket.front()` on a MAGAZINE_WELL without an empty check (UB if the well has no magazine loaded).

These assumptions block future work on items with multiple magazine pockets (#85928).

#### Describe the solution

- `ammo_consume()`: replace `return 0` on empty first well with `continue`, use `pocket.magazine_current()` instead of `pocket.front()`, add `qty <= 0` early break. The function now iterates all MAGAZINE_WELL pockets and accumulates consumption across them.
- `first_ammo()`: add empty/null guards, continue to next well instead of unconditional return.
- `first_ammo()` top-level guard: `empty()` returns true when pockets exist but hold no items, so calling `first_ammo()` on an unloaded gun fired a misleading "no pockets" debugmsg. Changed to `contents.empty()` which only fires when the item truly has no pocket definitions.
- Add `magazines_current()` returning all loaded magazines from all wells (vs `magazine_current()` which returns only the first).
- Add const overloads for `magazine_current()` at `item_pocket` and `item_contents` level; fix `item::magazine_current() const` to use proper const path instead of `const_cast`.
- Add `test_multimag_gun` test fixture with two MAGAZINE_WELL pockets (one for glockmag, one for stanag30).
- Tests cover single-well, dual-well (first empty / both loaded / both empty), and integral-magazine paths.

No items in the current game have multiple MAGAZINE_WELL pockets, so behavior is unchanged for all existing items.

#### Describe alternatives you've considered

N/A

#### Testing

New test file `tests/multimag_test.cpp`. Existing `[reload]` tests pass unchanged.

#### Additional context

N/A