### PR TITLE
Make factions radio-contactable

### DIFF
--- a/doc/JSON/EFFECT_ON_CONDITION.md
+++ b/doc/JSON/EFFECT_ON_CONDITION.md
@@ -1986,6 +1986,21 @@ Opens the menu to swap the avatar
 "effect": [ "take_control_menu" ]
 ```
 
+#### `u_make_radio_representative` `npc_make_radio_representative`
+Sets alpha or beta talker as faction representative, allowing avatar to contact them, if both NPC and avatar has a charged radio
+It will open `talk_radio` dialogue, so remember to change the topic of NPC you want to make a representative, otherwise the default `TALK_RADIO` will be set, used for your followers
+
+##### Valid talkers:
+
+| Avatar | NPC | Monster | Furniture | Item | Vehicle |
+| ------ | --------- | ---- | ------- | --- | ---- |
+| ❌ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+
+##### Examples
+Sets NPC to be faction representative
+```jsonc
+"effect": [ "npc_make_radio_representative" ]
+```
 
 #### `give_achievement`
 Marks the given achievement as complete

--- a/doc/JSON/NPCs.md
+++ b/doc/JSON/NPCs.md
@@ -230,7 +230,7 @@ If `npc` has the following fields, the game will display a dialogue with the ind
 Field | Default topic ID  | Uses for...
 ---|---|---
 `talk_friend` | `TALK_FRIEND` | Talk to a follower NPC
-`talk_radio` | `TALK_RADIO` | Talk to a follower NPC with two way radios
+`talk_radio` | `TALK_RADIO` | Talk to a follower NPC or faction representative with two way radios
 `talk_leader` | `TALK_LEADER` | Talk to an NPC that have 5=NPCATT_LEAD
 `talk_stole_item` | `TALK_STOLE_ITEM` | Talk to an NPC that have 18=NPCATT_RECOVER_GOODS
 `talk_wake_up` | `TALK_WAKE_UP` | Talk to a sleeping NPC

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -1768,6 +1768,16 @@ std::string avatar::total_daily_calories_string() const
     return ret;
 }
 
+std::set<character_id> avatar::get_followers() const
+{
+    return follower_ids;
+}
+
+std::set<character_id> avatar::get_known_faction_representatives() const
+{
+    return faction_representatives;
+}
+
 std::unique_ptr<talker> get_talker_for( avatar &me )
 {
     return std::make_unique<talker_avatar>( &me );

--- a/src/avatar.h
+++ b/src/avatar.h
@@ -405,6 +405,8 @@ class avatar : public Character
         void log_activity_level( float level ) override;
         std::string total_daily_calories_string() const;
         //set 0-3 random hobbies, with 1 and 2 being twice as likely as 0 and 3
+        std::set<character_id> get_followers() const;
+        std::set<character_id> get_known_faction_representatives() const;
 
         int movecounter = 0;
 
@@ -419,6 +421,7 @@ class avatar : public Character
         vproto_id starting_vehicle = vproto_id::NULL_ID();
         std::vector<mtype_id> starting_pets;
         std::set<character_id> follower_ids;
+        std::set<character_id> faction_representatives;
 
         mutable bool aim_cache_dirty = true;
 

--- a/src/faction_ui.cpp
+++ b/src/faction_ui.cpp
@@ -1,13 +1,13 @@
 #include "faction_ui.h"
 
 #include <algorithm>
+#include <cstddef>
 #include <functional>
 #include <iterator>
 #include <map>
 #include <memory>
 #include <optional>
 #include <set>
-#include <cstddef>
 #include <string>
 #include <utility>
 #include <vector>
@@ -19,8 +19,10 @@
 #include "calendar.h"
 #include "cata_imgui.h"
 #include "character.h"
+#include "character_id.h"
 #include "color.h"
 #include "coordinates.h"
+#include "dialogue_chatbin.h"
 #include "display.h"
 #include "enum_traits.h"
 #include "faction.h"
@@ -30,7 +32,6 @@
 #include "line.h"
 #include "localized_comparator.h"
 #include "map.h"
-#include "map_scale_constants.h"
 #include "mission_companion.h"
 #include "mod_manager.h"
 #include "mtype.h"
@@ -47,6 +48,7 @@
 #include "translations.h"
 #include "type_id.h"
 #include "ui_manager.h"
+#include "uilist.h"
 #include "vitamin.h"
 
 template <typename T> struct enum_traits;
@@ -65,6 +67,111 @@ void faction_manager::display() const
 {
     faction_ui ui;
     ui.execute();
+}
+
+static bool has_radio( const Character &guy )
+{
+    return guy.cache_has_item_with_flag( json_flag_TWO_WAY_RADIO, true );
+}
+
+// is physically close enough to contact the beta without much hassle
+// mainly for followers
+static bool can_contact( const Character &alpha, const Character &beta )
+{
+    const map &here = get_map();
+
+    const bool too_far_omt = rl_dist( alpha.pos_abs_omt(), beta.pos_abs_omt() ) > 3;
+    const bool see_each_other = alpha.sees( here, beta.pos_bub( here ) );
+    return !too_far_omt || see_each_other ;
+}
+
+// opposite to previouis one, far enough to check for radio contact
+static radio_contact_result can_radio_contact( const Character &alpha, const Character &beta )
+{
+    bool u_has_radio = has_radio( alpha );
+    bool guy_has_radio = has_radio( beta );
+    if( u_has_radio && guy_has_radio ) {
+        if( !( alpha.posz() >= 0 && beta.posz() >= 0 ) &&
+            !( alpha.posz() == beta.posz() ) ) {
+            //Early exit
+            return radio_contact_result::TOO_FAR;
+        } else {
+            // TODO: better range calculation than just elevation.
+            const int base_range = 200;
+            float send_elev_boost = ( 1 + ( alpha.posz() * 0.1 ) );
+            float recv_elev_boost = ( 1 + ( beta.posz() * 0.1 ) );
+            if( ( square_dist( alpha.pos_abs_sm(),
+                               beta.pos_abs_sm() ) <= base_range * send_elev_boost * recv_elev_boost ) ) {
+                //Direct radio contact, both of their elevation are in effect
+                return radio_contact_result::YES;
+            } else {
+                //contact via camp radio tower
+                int recv_range = base_range * recv_elev_boost;
+                int send_range = base_range * send_elev_boost;
+                const int radio_tower_boost = 5;
+                // find camps that are near player or npc
+                const std::vector<camp_reference> &camps_near_player = overmap_buffer.get_camps_near(
+                            alpha.pos_abs_sm(), send_range * radio_tower_boost );
+                const std::vector<camp_reference> &camps_near_npc = overmap_buffer.get_camps_near(
+                            beta.pos_abs_sm(), recv_range * radio_tower_boost );
+                bool camp_to_npc = false;
+                bool camp_to_camp = false;
+                for( const camp_reference &i : camps_near_player ) {
+                    if( !i.camp->has_provides( "radio" ) ) {
+                        continue;
+                    }
+                    if( camp_to_camp ||
+                        square_dist( i.abs_sm_pos, beta.pos_abs_sm() ) <= recv_range * radio_tower_boost ) {
+                        //one radio tower relay
+                        camp_to_npc = true;
+                        break;
+                    }
+                    for( const camp_reference &j : camps_near_npc ) {
+                        //two radio tower relays
+                        if( ( j.camp )->has_provides( "radio" ) &&
+                            ( square_dist( i.abs_sm_pos, j.abs_sm_pos ) <= base_range * radio_tower_boost *
+                              radio_tower_boost ) ) {
+                            camp_to_camp = true;
+                            break;
+                        }
+                    }
+                }
+                if( camp_to_npc || camp_to_camp ) {
+                    return radio_contact_result::YES;
+                } else {
+                    return radio_contact_result::TOO_FAR;
+                }
+            }
+        }
+    }
+
+    if( guy_has_radio && !u_has_radio ) {
+        return radio_contact_result::ALPHA_NO_RADIO;
+    }
+
+    if( !guy_has_radio && u_has_radio ) {
+        return radio_contact_result::BETA_NO_RADIO;
+    }
+
+    return radio_contact_result::BOTH_NO_RADIO;
+}
+
+static std::vector<npc *> get_known_faction_radio_representative( const faction *fac )
+{
+    const std::set<character_id> &known_fac_repres = get_avatar().faction_representatives;
+
+    std::vector<npc *> applicable_repres;
+    for( const character_id &guy : known_fac_repres ) {
+        npc *npc = g->find_npc( guy );
+        if( npc != nullptr &&
+            !npc->is_dead() &&
+            npc->faction_representative &&
+            npc->get_faction_id() == fac->id ) {
+            applicable_repres.emplace_back( npc );
+        }
+    }
+
+    return applicable_repres;
 }
 
 bool faction_ui::execute()
@@ -94,26 +201,36 @@ bool faction_ui::execute()
         }
 
         if( last_action == "CONFIRM" ) {
-            if( selected_tab == tab_mode::TAB_FOLLOWERS && picked_follower != nullptr ) {
-                hide_ui = true;
 
-                if( picked_follower->has_companion_mission() ) {
-                    talk_function::basecamp_mission( *picked_follower );
-                    return true;
-                } else if( interactable || radio_interactable ) {
-                    get_avatar().talk_to( get_talker_for( *picked_follower ), radio_interactable );
-                    return true;
+            if( selected_tab == tab_mode::TAB_FOLLOWERS && picked_follower != nullptr ) {
+                const bool interactable = can_contact( get_avatar(), *picked_follower );
+                const bool radio_interactable =
+                    can_radio_contact( get_avatar(), *picked_follower ) == radio_contact_result::YES;
+                if( interactable || radio_interactable ) {
+                    hide_ui = true;
+
+                    if( picked_follower->has_companion_mission() ) {
+                        talk_function::basecamp_mission( *picked_follower );
+                        return true;
+                    } else {
+                        get_avatar().talk_to( get_talker_for( *picked_follower ), true, false, false,
+                                              picked_follower->chatbin.talk_radio );
+                        return true;
+                    }
+                } else {
+                    popup( string_format( _( "You cannot contact %s right now." ), picked_follower->get_name() ) );
                 }
             }
             if( selected_tab == tab_mode::TAB_MYFACTION && picked_camp != nullptr ) {
                 picked_camp->query_new_name();
                 return false;
             }
-            // todo radio call faction
-            // if( selected_tab == tab_mode::TAB_OTHERFACTIONS && picked_faction != nullptr ) {
-            //     // pick new faction we can modify
-            //     faction *fac = g->faction_manager_ptr->get( picked_faction->id );
-            // }
+
+            if( selected_tab == tab_mode::TAB_OTHERFACTIONS && picked_faction != nullptr ) {
+                hide_ui = true;
+                radio_the_faction();
+                return true;
+            }
             return true;
         }
     }
@@ -125,35 +242,6 @@ void faction_ui::draw_hint_section() const
     const std::string desc = string_format(
                                  _( "[<color_yellow>%s</color>] Keybindings" ), ctxt.get_desc( "HELP_KEYBINDINGS" ) );
     cataimgui::draw_colored_text( desc, c_unset );
-    ImGui::SameLine();
-
-    if( selected_tab == tab_mode::TAB_MYFACTION ) {
-        if( cataimgui::BeginRightAlign( "##hint_faction" ) ) {
-            cataimgui::draw_colored_text( _( "Press enter to rename this camp" ), c_light_gray );
-            cataimgui::EndRightAlign();
-        }
-    }
-    if( selected_tab == tab_mode::TAB_FOLLOWERS ) {
-        if( cataimgui::BeginRightAlign( "##hint_followers" ) ) {
-            cataimgui::draw_colored_text( _( "Press enter to talk to this follower" ), c_light_gray );
-            cataimgui::EndRightAlign();
-        }
-    }
-    if( selected_tab == tab_mode::TAB_OTHERFACTIONS ) {
-        // for some reason NewLine() is smaller than the height of draw_colored_text()
-        if( cataimgui::BeginRightAlign( "##hint_other_factions" ) ) {
-            // todo: add feature to call NPCs of other factions, then use this snippet
-            cataimgui::draw_colored_text( "", c_light_gray );
-            cataimgui::EndRightAlign();
-        }
-    }
-    if( selected_tab == tab_mode::TAB_CREATURES ) {
-        // for some reason NewLine() is smaller than the height of draw_colored_text()
-        if( cataimgui::BeginRightAlign( "##hint_creatures" ) ) {
-            cataimgui::draw_colored_text( "", c_light_gray );
-            cataimgui::EndRightAlign();
-        }
-    }
     ImGui::Separator();
 }
 
@@ -258,6 +346,11 @@ void faction_ui::your_faction_display() const
     tripoint_abs_omt camp_pos = picked_camp->camp_omt_pos();
     std::string direction = direction_name( direction_from( player_abspos, camp_pos ) );
     faction *yours = player_character.get_faction();
+
+    // Hint
+    const std::string hint_desc = string_format(
+                                      _( "Press [%s] to rename this camp" ), ctxt.get_desc( "CONFIRM" ) );
+    cataimgui::draw_colored_text( hint_desc, c_light_gray, col_width );
 
     if( direction != "center" ) {
         const std::string desc_dir = string_format( _( "Direction: to the %s" ), direction );
@@ -368,7 +461,6 @@ void faction_ui::your_follower_display()
         return;
     }
 
-    const map &here = get_map();
     Character &player_character = get_player_character();
     const tripoint_abs_omt player_abspos = player_character.pos_abs_omt();
 
@@ -403,7 +495,7 @@ void faction_ui::your_follower_display()
                                                     calendar::turn );
         }
 
-        cataimgui::draw_colored_text( mission_string, col_width );
+        cataimgui::draw_colored_text( mission_eta, col_width );
     }
 
     tripoint_abs_omt guy_abspos = picked_follower->pos_abs_omt();
@@ -440,92 +532,48 @@ void faction_ui::your_follower_display()
     // Can be radio-ed
     std::string can_see;
     nc_color see_color;
-    bool u_has_radio = player_character.cache_has_item_with_flag( json_flag_TWO_WAY_RADIO, true );
-    bool guy_has_radio = picked_follower->cache_has_item_with_flag( json_flag_TWO_WAY_RADIO, true );
-    // is the NPC even in the same area as the player?
-    if( rl_dist( player_abspos, picked_follower->pos_abs_omt() ) > 3 ||
-        ( rl_dist( player_character.pos_abs(), picked_follower->pos_abs() ) > SEEX * 2 ||
-          !player_character.sees( here, picked_follower->pos_bub( here ) ) ) ) {
-        if( u_has_radio && guy_has_radio ) {
-            if( !( player_character.posz() >= 0 && picked_follower->posz() >= 0 ) &&
-                !( player_character.posz() == picked_follower->posz() ) ) {
-                //Early exit
-                can_see = _( "Not within radio range" );
-                see_color = c_light_red;
-            } else {
-                // TODO: better range calculation than just elevation.
-                const int base_range = 200;
-                float send_elev_boost = ( 1 + ( player_character.posz() * 0.1 ) );
-                float recv_elev_boost = ( 1 + ( picked_follower->posz() * 0.1 ) );
-                if( ( square_dist( player_character.pos_abs_sm(),
-                                   picked_follower->pos_abs_sm() ) <= base_range * send_elev_boost * recv_elev_boost ) ) {
-                    //Direct radio contact, both of their elevation are in effect
-                    radio_interactable = true;
-                    can_see = _( "Within radio range" );
-                    see_color = c_light_green;
-                } else {
-                    //contact via camp radio tower
-                    int recv_range = base_range * recv_elev_boost;
-                    int send_range = base_range * send_elev_boost;
-                    const int radio_tower_boost = 5;
-                    // find camps that are near player or npc
-                    const std::vector<camp_reference> &camps_near_player = overmap_buffer.get_camps_near(
-                                player_character.pos_abs_sm(), send_range * radio_tower_boost );
-                    const std::vector<camp_reference> &camps_near_npc = overmap_buffer.get_camps_near(
-                                picked_follower->pos_abs_sm(), recv_range * radio_tower_boost );
-                    bool camp_to_npc = false;
-                    bool camp_to_camp = false;
-                    for( const camp_reference &i : camps_near_player ) {
-                        if( !i.camp->has_provides( "radio" ) ) {
-                            continue;
-                        }
-                        if( camp_to_camp ||
-                            square_dist( i.abs_sm_pos, picked_follower->pos_abs_sm() ) <= recv_range * radio_tower_boost ) {
-                            //one radio tower relay
-                            camp_to_npc = true;
-                            break;
-                        }
-                        for( const camp_reference &j : camps_near_npc ) {
-                            //two radio tower relays
-                            if( ( j.camp )->has_provides( "radio" ) &&
-                                ( square_dist( i.abs_sm_pos, j.abs_sm_pos ) <= base_range * radio_tower_boost *
-                                  radio_tower_boost ) ) {
-                                camp_to_camp = true;
-                                break;
-                            }
-                        }
-                    }
-                    if( camp_to_npc || camp_to_camp ) {
-                        radio_interactable = true;
-                        can_see = _( "Within radio range" );
-                        see_color = c_light_green;
-                    } else {
-                        can_see = _( "Not within radio range" );
-                        see_color = c_light_red;
-                    }
-                }
-            }
-        } else if( guy_has_radio && !u_has_radio ) {
-            can_see = _( "You do not have a radio" );
-            see_color = c_light_red;
-        } else if( !guy_has_radio && u_has_radio ) {
-            can_see = _( "Follower does not have a radio" );
+    if( can_contact( get_avatar(), *picked_follower ) ) {
+        if( picked_follower->has_companion_mission() ) {
+            can_see = _( "Press enter to recall from their mission." );
             see_color = c_light_red;
         } else {
-            can_see = _( "Both you and follower need a radio" );
-            see_color = c_light_red;
+            can_see = _( "Within interaction range" );
+            see_color = c_light_green;
         }
     } else {
-        interactable = true;
-        can_see = _( "Within interaction range" );
-        see_color = c_light_green;
+        const radio_contact_result rad = can_radio_contact( get_avatar(), *picked_follower );
+
+        switch( rad ) {
+            case radio_contact_result::ALPHA_NO_RADIO:
+                can_see = _( "You do not have a radio" );
+                see_color = c_light_red;
+                break;
+            case radio_contact_result::BETA_NO_RADIO:
+                can_see = _( "Follower does not have a radio" );
+                see_color = c_light_red;
+                break;
+            case radio_contact_result::BOTH_NO_RADIO:
+                can_see = _( "Both you and follower need a radio" );
+                see_color = c_light_red;
+                break;
+            case radio_contact_result::TOO_FAR:
+                can_see = _( "Not within radio range" );
+                see_color = c_light_red;
+                break;
+            default:
+                can_see = _( "Within radio range" );
+                see_color = c_light_green;
+                break;
+        }
     }
-    // TODO: NPCS on mission contactable same as traveling
-    if( picked_follower->has_companion_mission() ) {
-        can_see = _( "Press enter to recall from their mission." );
-        see_color = c_light_red;
-    }
+
     cataimgui::draw_colored_text( colorize( can_see, see_color ), col_width );
+    if( see_color == c_light_green ) {
+        const std::string hint_desc = string_format(
+                                          _( "Press [%s] to talk to this follower" ), ctxt.get_desc( "CONFIRM" ) );
+        cataimgui::draw_colored_text( hint_desc, c_light_gray, col_width );
+    }
+
 
     // Status/activity
     nc_color status_col = c_white;
@@ -625,7 +673,9 @@ void faction_ui::draw_other_factions_list()
 {
     std::vector<const faction *> factions;
     for( const auto &elem : g->faction_manager_ptr->all() ) {
-        if( elem.second.known_by_u && elem.second.id != faction_your_followers ) {
+        if( elem.second.known_by_u &&
+            elem.second.id != faction_your_followers &&
+            !elem.second.lone_wolf_faction ) {
             factions.emplace_back( &elem.second );
         }
     }
@@ -686,10 +736,30 @@ void faction_ui::other_faction_display()
         return;
     }
 
+    // Attitude towards you
     const std::string attitude_text = string_format( _( "Attitude to you: %s" ),
                                       fac_ranking_text( picked_faction->likes_u ) );
-    cataimgui::draw_colored_text( attitude_text, c_light_gray, col_width );
-    cataimgui::draw_colored_text( picked_faction->desc.translated(), c_light_gray, col_width );
+    cataimgui::draw_colored_text( attitude_text, col_width );
+
+
+    // Can you contact them by radio
+    const std::vector<npc *> applicable_repres = get_known_faction_radio_representative(
+                picked_faction );
+    if( !applicable_repres.empty() ) {
+        cataimgui::draw_colored_text( _( "You know someone from this faction you can contact by radio." ),
+                                      c_green, col_width );
+        if( !has_radio( get_avatar() ) ) {
+            cataimgui::draw_colored_text( _( "Even if you do not have a radio right now." ),
+                                          c_red, col_width );
+        } else {
+            const std::string hint_desc = string_format(
+                                              _( "Press [%s] to radio the faction representative" ), ctxt.get_desc( "CONFIRM" ) );
+            cataimgui::draw_colored_text( hint_desc, c_light_gray, col_width );
+        }
+    }
+
+    // Description
+    cataimgui::draw_colored_text( picked_faction->desc.translated(), col_width );
 }
 
 void faction_ui::draw_creatures_tab()
@@ -916,4 +986,42 @@ void faction_ui::draw_controls()
         }
         ImGui::EndTabBar();
     }
+}
+
+void faction_ui::radio_the_faction()
+{
+    if( !has_radio( get_avatar() ) ) {
+        popup( _( "You do not have a radio to contact anyone." ) );
+        return;
+    }
+
+    std::vector<npc *> applicable_repres = get_known_faction_radio_representative( picked_faction );
+
+    if( applicable_repres.empty() ) {
+        popup( string_format( _( "You do not know anyone you can contact." ) ) );
+        return;
+    }
+
+    uilist call_npc_query;
+    call_npc_query.text = _( "Contact who?" );
+    for( const npc *npc : applicable_repres ) {
+        const radio_contact_result res = can_radio_contact( get_avatar(), *npc );
+        std::string desc = npc->disp_name();
+        if( res == radio_contact_result::YES ) {
+            call_npc_query.addentry( MENU_AUTOASSIGN, true, MENU_AUTOASSIGN, npc->disp_name() );
+        } else {
+            // ALPHA_NO_RADIO & BOTH_NO_RADIO are excluded by check above
+            // so this fires only for BETA_NO_RADIO and TOO_FAR
+            const std::string desc = string_format( "%s (%s)", npc->disp_name(), _( "No response" ) );
+            call_npc_query.addentry( MENU_AUTOASSIGN, false, MENU_AUTOASSIGN, desc );
+        }
+    }
+    call_npc_query.query();
+
+    if( call_npc_query.ret < 0 ) {
+        return;
+    }
+    npc *n = applicable_repres[call_npc_query.ret];
+    get_avatar().talk_to( get_talker_for( n ), true, false, false,
+                          n->chatbin.talk_radio );
 }

--- a/src/faction_ui.h
+++ b/src/faction_ui.h
@@ -25,6 +25,15 @@ enum class tab_mode : int {
     NUM_TABS
 };
 
+enum class radio_contact_result : int {
+    ALPHA_NO_RADIO,
+    BETA_NO_RADIO,
+    BOTH_NO_RADIO,
+    TOO_FAR,
+    YES,
+    last
+};
+
 class faction_ui : public cataimgui::window
 {
     public:
@@ -52,6 +61,8 @@ class faction_ui : public cataimgui::window
         void draw_creatures_tab();
         void draw_creature_list();
         void creature_display() const;
+
+        void radio_the_faction();
 
         std::string last_action;
     protected:
@@ -82,8 +93,6 @@ class faction_ui : public cataimgui::window
         npc *picked_follower = nullptr;
         const faction *picked_faction = nullptr;
         const mtype_id *picked_creature = nullptr;
-        bool interactable = false;
-        bool radio_interactable = false;
 
         float get_table_column_width() const {
             return 260.f;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -711,7 +711,6 @@ void game::setup()
     achievements_tracker_ptr->clear();
     eoc_events_ptr->clear();
     // reset follower list
-    follower_ids.clear();
     scent.reset();
     effect_on_conditions::clear( u );
     u.character_mood_face( true );
@@ -1722,13 +1721,11 @@ npc *game::find_npc_by_unique_id( const std::string &unique_id )
 
 void game::add_npc_follower( const character_id &id )
 {
-    follower_ids.insert( id );
     u.follower_ids.insert( id );
 }
 
 void game::remove_npc_follower( const character_id &id )
 {
-    follower_ids.erase( id );
     u.follower_ids.erase( id );
 }
 
@@ -1818,7 +1815,7 @@ void game::validate_camps()
 
 std::set<character_id> game::get_follower_list()
 {
-    return follower_ids;
+    return get_avatar().get_followers();
 }
 
 static hint_rating rate_action_change_side( const avatar &you, const item &it )
@@ -2892,7 +2889,6 @@ void game::death_screen()
     u.get_avatar_diary()->death_entry();
     show_scores_ui();
     disp_NPC_epilogues();
-    follower_ids.clear();
     display_faction_epilogues();
 }
 
@@ -2910,7 +2906,7 @@ std::string game::timestamp_now()
 
 void game::reset_npc_dispositions()
 {
-    for( character_id elem : follower_ids ) {
+    for( character_id elem : get_follower_list() ) {
         shared_ptr_fast<npc> npc_to_get = overmap_buffer.find_npc( elem );
         if( !npc_to_get )  {
             continue;
@@ -2987,7 +2983,7 @@ power_network_manager &game::power_networks()
 void game::disp_NPC_epilogues()
 {
     // TODO: This search needs to be expanded to all NPCs
-    for( character_id elem : follower_ids ) {
+    for( character_id elem : get_follower_list() ) {
         shared_ptr_fast<npc> guy = overmap_buffer.find_npc( elem );
         if( !guy ) {
             continue;

--- a/src/game.h
+++ b/src/game.h
@@ -1257,8 +1257,6 @@ class game
         character_id next_npc_id; // NOLINT(cata-serialize)
         int next_mission_id = 0; // NOLINT(cata-serialize)
         int64_t next_item_uid = 1; // NOLINT(cata-serialize)
-        // Keep track of follower NPC IDs
-        std::set<character_id> follower_ids; // NOLINT(cata-serialize)
 
         std::chrono::seconds time_played_at_last_load; // NOLINT(cata-serialize)
         // NOLINTNEXTLINE(cata-serialize)

--- a/src/npc.h
+++ b/src/npc.h
@@ -1476,6 +1476,8 @@ class npc : public Character
         npc_follower_rules rules;
         bool marked_for_death = false; // If true, we die as soon as we respawn!
         bool hit_by_player = false;
+        // if true, this NPC is a representative of their faction and, given radio, you can radio them
+        bool faction_representative = false;
         // times their opinion has increased from chatting, upper bounds on 'forgiveness'
         int opinion_values_raised = 0;
         bool hallucination = false; // If true, NPC is an hallucination

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -5550,6 +5550,20 @@ talk_effect_fun_t::func f_take_control_menu()
     };
 }
 
+talk_effect_fun_t::func f_make_radio_representative( const bool is_beta )
+{
+    return [is_beta]( dialogue const & d ) {
+        npc *guy = d.actor( is_beta )->get_npc();
+        if( guy != nullptr ) {
+            guy->faction_representative = true;
+            get_avatar().faction_representatives.insert( guy->as_character()->getID() );
+        } else {
+            debugmsg( "Trying to make radio representative, but %s talker is nullptr.  %s",
+                      is_beta ? "beta" : "alpha", d.get_callstack() );
+        }
+    };
+}
+
 talk_effect_fun_t::func f_sound_effect( const JsonObject &jo, std::string_view member,
                                         std::string_view )
 {
@@ -8437,6 +8451,14 @@ void talk_effect_t::parse_string_effect( const std::string &effect_id, const Jso
     }
     if( effect_id == "take_control_menu" ) {
         set_effect( talk_effect_fun_t( talk_effect_fun::f_take_control_menu() ) );
+        return;
+    }
+    if( effect_id == "u_make_radio_representative" ) {
+        set_effect( talk_effect_fun_t( talk_effect_fun::f_make_radio_representative( false ) ) );
+        return;
+    }
+    if( effect_id == "npc_make_radio_representative" ) {
+        set_effect( talk_effect_fun_t( talk_effect_fun::f_make_radio_representative( true ) ) );
         return;
     }
     if( effect_id == "u_wants_to_talk" ) {

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -1631,6 +1631,7 @@ void avatar::store( JsonOut &json ) const
     if( shadow_npc ) {
         json.member( "shadow_npc", *shadow_npc );
     }
+    json.member( "faction_representatives", faction_representatives );
     // someday, npcs may drive
     json.member( "controlling_vehicle", controlling_vehicle );
 
@@ -1722,6 +1723,7 @@ void avatar::load( const JsonObject &data )
         shadow_npc = std::make_unique<npc>();
         data.read( "shadow_npc", *shadow_npc );
     }
+    data.read( "faction_representatives", faction_representatives );
     data.read( "controlling_vehicle", controlling_vehicle );
 
     data.read( "grab_point", grab_point );
@@ -2302,6 +2304,7 @@ void npc::load( const JsonObject &data )
     }
 
     data.read( "op_of_u", op_of_u );
+    data.read( "faction_representative", faction_representative );
     data.read( "chatbin", chatbin );
     if( !data.read( "rules", rules ) ) {
         data.read( "misc_rules", rules );
@@ -2371,6 +2374,7 @@ void npc::store( JsonOut &json ) const
     json.member( "attitude", static_cast<int>( attitude ) );
     json.member( "previous_attitude", static_cast<int>( previous_attitude ) );
     json.member( "op_of_u", op_of_u );
+    json.member( "faction_representative", faction_representative );
     json.member( "chatbin", chatbin );
     json.member( "rules", rules );
 


### PR DESCRIPTION
#### Summary
Features "It is possible to make factions be radio-contactable"
#### Purpose of change
Closes #86023
#### Describe the solution
Allow NPC to be a faction representative, which allows avatar to call them from the faction screen. list of representative is stored in avatar, similar to follower list
Add dialogue effect to support it

fix a bug where mission_eta was not printed
Remove hint block of UI, moved it to actual tabs instead, similar to how it was done in previous UI

made getter for follower list, made game version of it point to avatar where it is stored, yeet the follower_ids that stored ids of followers in game, now it just point to list in avatar instead
#### Testing
For testing, added a scrap trader an ability to radio contact them
<img width="634" height="384" alt="image" src="https://github.com/user-attachments/assets/51de4585-15ca-4826-ad4b-b771fa70bdd7" />

<img width="640" height="384" alt="image" src="https://github.com/user-attachments/assets/2dee6180-b5df-4ce9-b533-f51e2180e4f3" />

<img width="165" height="85" alt="image" src="https://github.com/user-attachments/assets/c3ef77f7-3236-4aa8-ad98-7cb2e2566f7e" />

<img width="1620" height="905" alt="image" src="https://github.com/user-attachments/assets/b342143d-0b38-4a7e-b36d-c2b08e403f8a" />

Hints
<img width="637" height="374" alt="image" src="https://github.com/user-attachments/assets/6dfcd7fd-84d0-413d-a422-d4f60ae65482" />

<img width="637" height="380" alt="image" src="https://github.com/user-attachments/assets/ce106fb5-2881-407d-96b5-fb12f8bc5545" />


#### Additional context
Did you know that contacting anyone with your radio do not, in fact, consume any of the radio battery?	