### PR TITLE
Add NO_TURRET flag to test_multimag_gun

### DIFF
--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -5702,6 +5702,7 @@
     "ranged_damage": { "damage_type": "bullet", "amount": 10 },
     "dispersion": 480,
     "durability": 10,
+    "flags": [ "NO_TURRET" ],
     "pocket_data": [
       { "magazine_well": "250 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "glockmag" ] },
       { "magazine_well": "500 ml", "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "stanag30" ] }


### PR DESCRIPTION
#### Summary
Bugfixes "Add NO_TURRET flag to test_multimag_gun"

#### Purpose of change

Followup to #86190. The vehicle_turret test iterates all guns without NO_TURRET and tries to mount, load, and fire them. test_multimag_gun has two magazine wells which the turret `ammo_set` path does not handle, causing a sporadic test failure observed in https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/23860027318/job/69563890897.

#### Describe the solution

Add NO_TURRET flag to the test fixture. It's not meant to be a turret.

#### Describe alternatives you've considered

N/A

#### Testing

N/A

#### Additional context

N/A