### PR TITLE
[Sky Island] Minor fixes

### DIFF
--- a/data/mods/Sky_Island/effectoncondition/obelisk_selector.json
+++ b/data/mods/Sky_Island/effectoncondition/obelisk_selector.json
@@ -140,27 +140,6 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_Random_Loc_Warp",
-    "//": "Picks a random location of any kind and activates the actual teleport EOC.",
-    "effect": [
-      { "run_eocs": "EOC_SKY_ISLAND_MISSION_DIMENSION_SHIFT" },
-      {
-        "u_location_variable": { "global_val": "OM_missionspot" },
-        "target_params": {
-          "om_terrain": "field",
-          "om_terrain_match_type": "CONTAINS",
-          "search_range": 200,
-          "min_distance": 0,
-          "reveal_radius": { "global_val": "scoutingdistancelanding", "default": 0 },
-          "z": 0,
-          "random": true
-        }
-      },
-      { "run_eocs": [ "EOC_initiate_randomport" ] }
-    ]
-  },
-  {
-    "type": "effect_on_condition",
     "id": "EOC_Field_Loc_Warp",
     "//": "Picks a random field and activates the actual teleport EOC.",
     "effect": [

--- a/data/mods/Sky_Island/missions/island_upgrades/rankup.json
+++ b/data/mods/Sky_Island/missions/island_upgrades/rankup.json
@@ -30,7 +30,7 @@
         { "u_learn_recipe": "warphaulbag" },
         { "u_learn_recipe": "sky_island_warped_pond" },
         {
-          "u_message": "You have proved your ability to survive to the island, to the warpstream, and to yourself.\nMore unlockable upgrades will be available as you progress, and you may experience exits and targets in new locations.",
+          "u_message": "You have proved your ability to survive to the island, to the warpstream, and to yourself.\nMore unlockable upgrades will be available as you progress.",
           "type": "mixed"
         },
         {
@@ -104,7 +104,7 @@
         { "u_learn_recipe": "warphome" },
         { "u_learn_recipe": "warp_autodoc_inert" },
         {
-          "u_message": "That you are still here, fighting on, makes your determination clear.  This new existence is strange and unpredictable, but you can adapt.  It's how you made it this far, and you're not about to stop now.\nMore unlockable upgrades will be available as you progress, and you may experience exits and targets in new locations.",
+          "u_message": "That you are still here, fighting on, makes your determination clear.  This new existence is strange and unpredictable, but you can adapt.  It's how you made it this far, and you're not about to stop now.\nMore unlockable upgrades will be available as you progress.",
           "type": "mixed"
         },
         {

--- a/data/mods/Sky_Island/missions/raid_upgrades/scouting.json
+++ b/data/mods/Sky_Island/missions/raid_upgrades/scouting.json
@@ -427,7 +427,7 @@
     "type": "ITEM",
     "category": "spare_parts",
     "name": { "str_sp": "Agglomerated Oculus" },
-    "description": "This strange metaphysical artifact will empower the island and unlock a permanent upgrade for all future runs.  Will be used automatically upon crafting, and can only be used once.\n\nASSOCIATED UPGRADE: Scouting 5",
+    "description": "This strange metaphysical artifact will empower the island and unlock a permanent upgrade for all future runs.  Will be used automatically upon crafting, and can only be used once.\n\nASSOCIATED UPGRADE: Scouting 7",
     "volume": "25000 ml",
     "weight": "15000 g",
     "longest_side": "90 cm",


### PR DESCRIPTION

#### Summary
Mods "[Sky Island] Minor fixes"

#### Purpose of change
Collection of minor fixes

#### Describe the solution
Change the island rankup messages to no longer mention you may find exists and missions in more places. This is controlled by harder and hardest mission upgrades instead.

Scouting 7 upgrade item said it was for Scouting 5, typo fixed.

Removed an unused EOC `EOC_Random_Loc_Warp`

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Sky Island loads and typos are fixed.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
