### PR TITLE
[Magiclysm] Everburning candle

### DIFF
--- a/data/mods/Magiclysm/itemgroups/itemgroups.json
+++ b/data/mods/Magiclysm/itemgroups/itemgroups.json
@@ -697,6 +697,7 @@
       { "item": "heat_cube", "prob": 100 },
       { "item": "mkey_opening", "prob": 100 },
       { "item": "mtorch_everburning", "prob": 100 },
+      { "item": "mcandle_everburning", "prob": 100 },
       { "item": "mflask_hip_whiskey", "prob": 100 },
       { "item": "mtailors_kit", "prob": 100, "charges": [ 3, 24 ] },
       { "item": "mteapot", "prob": 40 },

--- a/data/mods/Magiclysm/items/enchanted_misc.json
+++ b/data/mods/Magiclysm/items/enchanted_misc.json
@@ -106,6 +106,42 @@
     "extend": { "flags": [ "FIRE", "FLAMING", "TRADER_AVOID", "WATER_EXTINGUISH", "SPAWN_ACTIVE" ] }
   },
   {
+    "id": "mcandle_everburning",
+    "type": "ITEM",
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "everburning candle", "str_pl": "everburning candles" },
+    "description": "A high quality thick wax candle.  On command, the wick ignites and provides a small amount of light.  It will burn forever.",
+    "weight": "400 g",
+    "volume": "466 ml",
+    "longest_side": "102 mm",
+    "price": "1 kUSD",
+    "price_postapoc": "1 kUSD",
+    "material": [ "paraffin_wax" ],
+    "symbol": ",",
+    "color": "white",
+    "use_action": { "target": "mcandle_everburning_lit", "msg": "You light the candle.", "menu_text": "Light", "type": "transform" }
+  },
+  {
+    "id": "mcandle_everburning_lit",
+    "type": "ITEM",
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "everburning candle", "str_pl": "everburning candles" },
+    "copy-from": "mcandle_everburning",
+    "revert_to": "mcandle_everburning",
+    "use_action": [
+      { "type": "firestarter", "moves": 500, "moves_slow": 6000 },
+      {
+        "target": "mcandle_everburning",
+        "msg": "The candle winks out.",
+        "menu_text": "Extinguish",
+        "type": "transform"
+      }
+    ],
+    "sub": "fire",
+    "light": 8,
+    "extend": { "flags": [ "FIRE", "FLAMING", "TRADER_AVOID", "WATER_EXTINGUISH", "WIND_EXTINGUISH", "SPAWN_ACTIVE" ] }
+  },
+  {
     "name": { "str": "endless flask" },
     "id": "mflask_hip_whiskey",
     "type": "ITEM",

--- a/data/mods/Magiclysm/items/enchanted_misc.json
+++ b/data/mods/Magiclysm/items/enchanted_misc.json
@@ -109,7 +109,7 @@
     "id": "mcandle_everburning",
     "type": "ITEM",
     "subtypes": [ "TOOL" ],
-    "name": { "str": "everburning candle", "str_pl": "everburning candles" },
+    "name": "everburning candle",
     "description": "A high quality thick wax candle.  On command, the wick ignites and provides a small amount of light.  It will burn forever.",
     "weight": "400 g",
     "volume": "466 ml",
@@ -125,7 +125,7 @@
     "id": "mcandle_everburning_lit",
     "type": "ITEM",
     "subtypes": [ "TOOL" ],
-    "name": { "str": "everburning candle", "str_pl": "everburning candles" },
+    "name": "everburning candle",
     "copy-from": "mcandle_everburning",
     "revert_to": "mcandle_everburning",
     "use_action": [

--- a/data/mods/TEST_DATA/overmap_terrain_coverage_test/overmap_terrain_coverage_whitelist.json
+++ b/data/mods/TEST_DATA/overmap_terrain_coverage_test/overmap_terrain_coverage_whitelist.json
@@ -95,7 +95,8 @@
       "helipad.*",
       "fort_\\d.*",
       "forge_.*",
-      "aenor_paddock.*"
+      "aenor_paddock.*",
+      "aenor_farm.*"
     ]
   }
 ]

--- a/data/mods/TEST_DATA/overmap_terrain_coverage_test/overmap_terrain_coverage_whitelist.json
+++ b/data/mods/TEST_DATA/overmap_terrain_coverage_test/overmap_terrain_coverage_whitelist.json
@@ -95,8 +95,7 @@
       "helipad.*",
       "fort_\\d.*",
       "forge_.*",
-      "aenor_paddock.*",
-      "aenor_farm.*"
+      "aenor_paddock.*"
     ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Add candle variant of everburning torch"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

Everburning candles are referenced in a couple places but did not actually exist as standalone items.

#### Describe the solution

Added the item to JSON.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Created a new world, spawned candle, lit it. Worked without errors.
Teleported to Forge of Wonders, walked to Valzain, he now sells candles for a slightly lower price than torches.
<img width="709" height="155" alt="image" src="https://github.com/user-attachments/assets/cc138092-f44c-4442-83da-d6cde6eee153" />

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Not a 1-to-1 copy of torches, changed some things so it's more in line with a candle: wind extinguish flag, paraffin wax material, size, etc.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
