### PR TITLE
Fix hit-animation overlay persisting after idle-lightmap skip

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1971,8 +1971,10 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
             draw_bullet_frame();
         }
         if( do_draw_hit ) {
-            draw_hit_frame();
             void_hit();
+            if( do_draw_hit ) {
+                draw_hit_frame();
+            }
         }
         if( do_draw_line ) {
             draw_line();
@@ -4632,6 +4634,15 @@ void cata_tiles::void_hit()
     if( hit_animations.empty() ) {
         do_draw_hit = false;
     }
+}
+bool cata_tiles::expire_hit_animations()
+{
+    if( !do_draw_hit ) {
+        return false;
+    }
+    const size_t before = hit_animations.size();
+    void_hit();
+    return hit_animations.size() != before;
 }
 void cata_tiles::void_line()
 {

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -655,6 +655,8 @@ class cata_tiles
         void init_draw_hit( const Creature &critter );
         void draw_hit_frame();
         void void_hit();
+        // Prune expired hit animations.  Returns true if any were removed.
+        bool expire_hit_animations();
 
         void draw_footsteps_frame( const tripoint_bub_ms &center );
 

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -420,6 +420,13 @@ input_context game::get_player_input( std::string &action )
 #endif
             }
 
+#if defined(TILES)
+            // Expire stale hit-animation overlays between draws
+            if( tilecontext->expire_hit_animations() ) {
+                invalidate_main_ui_adaptor();
+            }
+#endif
+
             if( g->has_blink_curses() && current_turn.blink_timeout() ) {
                 // Toggle blink phase and redraw
                 g->blink_active_phase = !g->blink_active_phase;


### PR DESCRIPTION
#### Summary
Bugfixes "Fix hit-animation overlay staying on screen after attacking"

#### Purpose of change

Follow-up to #86183. That PR stopped `cata_tiles::draw()` from running during idle input polling. Noticed a regression: hit and async-animation (bash) overlays stay on screen until the next unrelated full redraw, because their cleanup only ran inside `cata_tiles::draw()`.

#### Describe the solution

Traversed `game::draw()` -> `cata_tiles::draw()` and confirmed hit and async animations are the only overlays that leak into the idle loop. All other overlays (bullet, explosion, line, cursor, etc.) are blocking animations with their own draw loops, and weather/SCT/blink already self-invalidate independently.

- Add `expire_hit_animations()` to `cata_tiles` that prunes expired entries and reports whether any were removed; call from the idle loop, invalidate once when visible state changes
- Swap draw-path order so `void_hit()` runs before `draw_hit_frame()`, preventing a timeout-triggered redraw from painting a stale overlay one extra frame
- Make `void_async_anim()` / `void_async_anim_curses()` return bool; only invalidate on a real transition instead of every timeout tick

#### Describe alternatives you've considered

Could re-add unconditional `invalidate_main_ui_adaptor()` whenever these overlays are active, but that reintroduces periodic full redraws for the rest of the idle wait -- the same thing #86183 was trying to remove.

#### Testing

Verified in-game.

#### Additional context

None