### PR TITLE
Fix hit-animation overlay persisting after idle-lightmap skip

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1971,8 +1971,10 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
             draw_bullet_frame();
         }
         if( do_draw_hit ) {
-            draw_hit_frame();
             void_hit();
+            if( do_draw_hit ) {
+                draw_hit_frame();
+            }
         }
         if( do_draw_line ) {
             draw_line();
@@ -4633,6 +4635,15 @@ void cata_tiles::void_hit()
         do_draw_hit = false;
     }
 }
+bool cata_tiles::expire_hit_animations()
+{
+    if( !do_draw_hit ) {
+        return false;
+    }
+    const size_t before = hit_animations.size();
+    void_hit();
+    return hit_animations.size() != before;
+}
 void cata_tiles::void_line()
 {
     do_draw_line = false;
@@ -4665,10 +4676,14 @@ void cata_tiles::void_zones()
 {
     do_draw_zones = false;
 }
-void cata_tiles::void_async_anim()
+bool cata_tiles::void_async_anim()
 {
+    if( !do_draw_async_anim ) {
+        return false;
+    }
     do_draw_async_anim = false;
     async_anim_layer.clear();
+    return true;
 }
 void cata_tiles::void_radiation_override()
 {

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -655,6 +655,8 @@ class cata_tiles
         void init_draw_hit( const Creature &critter );
         void draw_hit_frame();
         void void_hit();
+        // Prune expired hit animations.  Returns true if any were removed.
+        bool expire_hit_animations();
 
         void draw_footsteps_frame( const tripoint_bub_ms &center );
 
@@ -687,7 +689,7 @@ class cata_tiles
 
         void init_draw_async_anim( const tripoint_bub_ms &p, const std::string &tile_id );
         void draw_async_anim();
-        void void_async_anim();
+        bool void_async_anim();
 
         void init_draw_radiation_override( const tripoint_bub_ms &p, int rad );
         void void_radiation_override();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3263,9 +3263,13 @@ void game::draw_async_anim_curses()
     }
 }
 
-void game::void_async_anim_curses()
+bool game::void_async_anim_curses()
 {
+    if( async_anim_layer_curses.empty() ) {
+        return false;
+    }
     async_anim_layer_curses.clear();
+    return true;
 }
 
 void game::init_draw_blink_curses( const tripoint_bub_ms &p, const std::string &ncstr,

--- a/src/game.h
+++ b/src/game.h
@@ -294,7 +294,7 @@ class game
         void init_draw_async_anim_curses( const tripoint_bub_ms &p, const std::string &ncstr,
                                           const nc_color &nccol );
         void draw_async_anim_curses();
-        void void_async_anim_curses();
+        bool void_async_anim_curses();
     protected:
         std::map<tripoint_bub_ms, std::pair <std::string, nc_color>>
                 async_anim_layer_curses; // NOLINT(cata-serialize)

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -411,14 +411,21 @@ input_context game::get_player_input( std::string &action )
 
             // Remove asynchronous animations after animation delay if no input
             if( current_turn.async_anim_timeout() ) {
-                g->void_async_anim_curses();
+                bool cleared = g->void_async_anim_curses();
 #if defined(TILES)
-                tilecontext->void_async_anim();
-#else
-                // Curses does not redraw itself so do it here
-                g->invalidate_main_ui_adaptor();
+                cleared |= tilecontext->void_async_anim();
 #endif
+                if( cleared ) {
+                    invalidate_main_ui_adaptor();
+                }
             }
+
+#if defined(TILES)
+            // Expire stale hit-animation overlays between draws
+            if( tilecontext->expire_hit_animations() ) {
+                invalidate_main_ui_adaptor();
+            }
+#endif
 
             if( g->has_blink_curses() && current_turn.blink_timeout() ) {
                 // Toggle blink phase and redraw


### PR DESCRIPTION
#### Summary
Bugfixes "Fix hit-animation overlay staying on screen after attacking"

#### Purpose of change

Follow-up to #86183. That PR stopped `cata_tiles::draw()` from running during idle input polling. Noticed a regression: hit and async-animation (bash) overlays stay on screen until the next unrelated full redraw, because their cleanup only ran inside `cata_tiles::draw()`.

#### Describe the solution

Traversed `game::draw()` -> `cata_tiles::draw()` and confirmed hit and async animations are the only overlays that leak into the idle loop. All other overlays (bullet, explosion, line, cursor, etc.) are blocking animations with their own draw loops, and weather/SCT/blink already self-invalidate independently.

- Add `expire_hit_animations()` to `cata_tiles` that prunes expired entries and reports whether any were removed; call from the idle loop, invalidate once when visible state changes
- Swap draw-path order so `void_hit()` runs before `draw_hit_frame()`, preventing a timeout-triggered redraw from painting a stale overlay one extra frame
- Make `void_async_anim()` / `void_async_anim_curses()` return bool; only invalidate on a real transition instead of every timeout tick

#### Describe alternatives you've considered

Could re-add unconditional `invalidate_main_ui_adaptor()` whenever these overlays are active, but that reintroduces periodic full redraws for the rest of the idle wait -- the same thing #86183 was trying to remove.

#### Testing

Verified in-game.

#### Additional context

None