### PR TITLE
Fix crafting GUI starting craft after Batch then Esc

### DIFF
--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -2758,6 +2758,7 @@ void crafting_ui_impl::process_action( const std::string &action_in,
             filterstring.clear();
             recalc = true;
         } else {
+            chosen = nullptr;
             done = true;
         }
     } else if( action == "HELP_KEYBINDINGS" ) {


### PR DESCRIPTION
#### Summary
Bugfixes "Fix crafting GUI starting unintended craft after using Batch then Esc"

#### Purpose of change

Closes #86212. Entering batch mode then pressing Esc twice triggers "Tried to start craft without sufficient charges".

#### Describe the solution

Entering batch mode sets `chosen` (the recipe pointer returned to the caller) to remember which recipe to display in the batch list. The QUIT path that closes the menu didn't clear it, so the caller saw a non-null recipe and called `craft_command::execute()`.

Clear `chosen` at the QUIT exit point.

#### Describe alternatives you've considered

Splitting `chosen` into separate "batch display recipe" and "confirmed recipe" variables. Correct but overkill for a one-liner.

#### Testing

Verified in-game.

#### Additional context

None.