### PR TITLE
Fix starting profession maps being unreadable

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -838,6 +838,12 @@ bool game::start_game()
     load_map( lev, /*pump_events=*/true );
 
     start_loc.place_player( u, omtstart );
+    // Set spawn location for starting items (maps need it to be readable)
+    const tripoint_abs_ms player_pos = u.pos_abs();
+    u.visit_items( [&player_pos]( item * it, item * ) {
+        it->preserve_location( player_pos );
+        return VisitResponse::NEXT;
+    } );
     map &here = reality_bubble();
     int level = here.get_abs_sub().z();
     // Rebuild map cache because we want visibility cache to avoid spawning monsters in sight


### PR DESCRIPTION
#### Summary
Bugfixes "Fix starting profession maps being unreadable"

#### Purpose of change

Fixes #86213

#86049 requires `spawn_location` for maps to work, but `add_profession_items()` never calls `preserve_location()`. Tourist and Park Ranger starting maps are permanently unreadable.

#### Describe the solution

Call `preserve_location()` on all player items after `place_player()` in `game::start_game()`. Has to be after placement since the starting position isn't known when profession items are added.

#### Describe alternatives you've considered

N/A

#### Testing

Verified in-game with Tourist and Park Ranger.

#### Additional context

None