### PR TITLE
bugfix and balance speedydex perk

### DIFF
--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -1406,7 +1406,7 @@
     "points": 0,
     "purifiable": false,
     "valid": false,
-    "description": "You've found that you can move just a little bit quicker the more dexterous you are.  Unfortunately, this applies comes at a loss to your max carry weight.  Gain 2 speed for every point of DEX away from 8 and lose 4 kg of carry weight.",
+    "description": "You've found that you can move just a little bit quicker the more dexterous you are.  Unfortunately, this applies comes at a loss to your max carry weight.  Gain 2 speed for every point of DEX away from 8.  You lose 4% of your max carry weight for each point between 8 and 20 DEX, and 2% for each point beyond 20.",
     "enchantments": [
       {
         "condition": "ALWAYS",
@@ -1414,7 +1414,11 @@
       },
       {
         "condition": "ALWAYS",
-        "values": [ { "value": "CARRY_WEIGHT", "add": { "math": [ "min( 0, 8 - u_val('dexterity') ) * 4000" ] } } ]
+        "values": [ { "value": "CARRY_WEIGHT", "multiply": { "math": [ "min( 0, 8 - u_val('dexterity') ) * 0.04" ] } } ]
+      },
+      {
+        "condition": "ALWAYS",
+        "values": [ { "value": "CARRY_WEIGHT", "multiply": { "math": [ "min( 0, 20 - u_val('dexterity') ) * -0.02" ] } } ]
       }
     ]
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Dexterous Speed perk no longer causes phantom overburdenment and scales differently"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
There was a really weird bug with the dexterous speed perk where a large boost to your dexterity could cause you to start falling over as though you were overburdened even though you weren't. For example I had a character who was carrying about 10% of their max carry weight in load, and upon activating the psychic power "physical enhancement" and receiving a +15 bonus to both strength and dexterity, and noting that my max carry weight was exactly the same, and I didn't have any speed penalties from being overburdened, I started falling on my face as though I was carrying over twice my maximum carry limit.
Thus, my primary goal was to fix this bug.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Rather than a flat -4 kg of max carry weight per point of dexterity, the perk now subtracts -4% from your max carry weight for each point above 12 up to 20, for a total of -48% carry weight if you have 20 dex (the natural limit). Further increasing beyond 20 (via mods that raise the cap) will apply -2% per level, to a total of -78% at the common modded cap of 35.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Different penalties or penalty scale. This is overall somewhat less harsh in terms of raw penalties unless you get fairly high str/dex overall, but there are times where it's definitely more severe.
Try to fix the actual underlying bug that's causing this weird issue, I have absolutely no clue how.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tried this on my character who had the problem, and saw that while their overall carry weight was lower than before, they did not have the issue of falling over due to being overburdened.
Spun up a tester character and made sure that the carryweight loss per level was appropriate. With my starter strength of 8 I had 45 kg of carryweight at 8 dex. 23.4 kg carryweight at 20 dex, and 9.9 kg of carryweight at 35 dex.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
