### PR TITLE
[BPerks/MM/Sorc] XP mods can level up more than once at a time

### DIFF
--- a/data/mods/BombasticPerks/corefiles/core_eocs.json
+++ b/data/mods/BombasticPerks/corefiles/core_eocs.json
@@ -7,22 +7,36 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_level_up",
-    "condition": { "math": [ "u_available_exp > u_exp_to_perk" ] },
     "effect": [
-      { "run_eocs": "EOC_give_perk_point" },
-      { "math": [ "u_used_exp += u_exp_to_perk" ] },
       { "math": [ "u_available_exp = u_val('exp') + u_bonus_exp - u_used_exp" ] },
-      { "math": [ "u_exp_to_perk += u_exp_per_level" ] },
-      { "math": [ "u_current_level += 1" ] },
-      { "math": [ "u_perks_toward_playstyle += 1" ] },
       {
-        "if": { "math": [ "u_perks_toward_playstyle >= u_perks_toward_playstyle_setting" ] },
-        "then": [
-          { "math": [ "u_playstyle_perks_available += 1" ] },
-          { "math": [ "u_perks_toward_playstyle -= u_perks_toward_playstyle_setting" ] }
+        "condition": { "math": [ "u_available_exp > u_exp_to_perk" ] },
+        "run_eocs": [
+          {
+            "id": "EOC_level_up_exec",
+            "effect": [
+              { "run_eocs": "EOC_give_perk_point" },
+              { "math": [ "u_bperk_leveled_up = 1" ] },
+              { "math": [ "u_used_exp += u_exp_to_perk" ] },
+              { "math": [ "u_available_exp = u_val('exp') + u_bonus_exp - u_used_exp" ] },
+              { "math": [ "u_exp_to_perk += u_exp_per_level" ] },
+              { "math": [ "u_current_level += 1" ] },
+              { "math": [ "u_perks_toward_playstyle += 1" ] },
+              {
+                "if": { "math": [ "u_perks_toward_playstyle >= u_perks_toward_playstyle_setting" ] },
+                "then": [
+                  { "math": [ "u_playstyle_perks_available += 1" ] },
+                  { "math": [ "u_perks_toward_playstyle -= u_perks_toward_playstyle_setting" ] }
+                ]
+              }
+            ]
+          }
         ]
       },
-      { "run_eocs": "EOC_level_up_notification" }
+      {
+        "if": { "math": [ "u_bperk_leveled_up == 1" ] },
+        "then": [ { "math": [ "u_bperk_leveled_up = 0" ] }, { "run_eocs": "EOC_level_up_notification" } ]
+      }
     ]
   },
   {
@@ -36,7 +50,7 @@
     "id": "EOC_on_kill_check_exp",
     "eoc_type": "EVENT",
     "required_event": "character_kills_monster",
-    "effect": [ { "math": [ "u_available_exp = u_val('exp') + u_bonus_exp - u_used_exp" ] }, { "run_eocs": "EOC_level_up" } ]
+    "effect": [ { "run_eocs": "EOC_level_up" } ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/Perk_melee/EOC/leveling.json
+++ b/data/mods/Perk_melee/EOC/leveling.json
@@ -7,31 +7,40 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_perk_ma_level_up",
-    "condition": { "math": [ "u_ma_available_exp > u_ma_exp_to_perk" ] },
     "effect": [
-      { "u_message": "Your experience with martial arts has increased!" },
-      { "run_eocs": "EOC_give_ma_perk_point" },
-      { "math": [ "u_ma_used_exp += u_ma_exp_to_perk" ] },
       { "math": [ "u_ma_available_exp = u_val('exp') + u_bonus_exp - u_ma_used_exp" ] },
-      { "math": [ "u_ma_exp_to_perk += u_ma_exp_per_level" ] },
-      { "math": [ "u_ma_current_level += 1" ] }
+      {
+        "condition": { "math": [ "u_ma_available_exp > u_ma_exp_to_perk" ] },
+        "run_eocs": [
+          {
+            "id": "EOC_perk_ma_level_up_exec",
+            "effect": [
+              { "run_eocs": "EOC_give_ma_perk_point" },
+              { "math": [ "u_melee_perk_leveled_up = 1" ] },
+              { "math": [ "u_ma_used_exp += u_ma_exp_to_perk" ] },
+              { "math": [ "u_ma_available_exp = u_val('exp') + u_bonus_exp - u_ma_used_exp" ] },
+              { "math": [ "u_ma_exp_to_perk += u_ma_exp_per_level" ] },
+              { "math": [ "u_ma_current_level += 1" ] }
+            ]
+          }
+        ]
+      },
+      {
+        "if": { "math": [ "u_melee_perk_leveled_up == 1" ] },
+        "then": [
+          { "math": [ "u_melee_perk_leveled_up = 0" ] },
+          { "u_message": "Your experience with martial arts has increased!" },
+          { "open_dialogue": { "topic": "TALK_MA_PERK_MENU_MAIN" } }
+        ]
+      }
     ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_perk_ma_level_up_notification",
-    "condition": { "math": [ "u_no_notifications != 1" ] },
-    "effect": [ { "open_dialogue": { "topic": "TALK_PERK_MENU_MAIN" } } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_perk_ma_kill_check_exp",
     "eoc_type": "EVENT",
     "required_event": "character_kills_monster",
-    "effect": [
-      { "math": [ "u_ma_available_exp = u_val('exp') + u_bonus_exp - u_ma_used_exp" ] },
-      { "run_eocs": "EOC_perk_ma_level_up" }
-    ]
+    "effect": [ { "run_eocs": "EOC_perk_ma_level_up" } ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/Sorcerer/experience_points.json
+++ b/data/mods/Sorcerer/experience_points.json
@@ -2,12 +2,22 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_check_level_up_sorcerer",
-    "condition": { "math": [ "u_available_exp_sorcerer > u_exp_to_sorcerer_level" ] },
     "effect": [
-      { "math": [ "u_used_exp_sorcerer += u_exp_to_sorcerer_level" ] },
       { "math": [ "u_available_exp_sorcerer = u_val('exp') + u_bonus_exp - u_used_exp_sorcerer" ] },
-      { "math": [ "u_exp_to_sorcerer_level += u_exp_per_sorcerer_level" ] },
-      { "run_eocs": "EOC_level_up_sorcerer" }
+      {
+        "condition": { "math": [ "u_available_exp_sorcerer > u_exp_to_sorcerer_level" ] },
+        "run_eocs": [
+          {
+            "id": "EOC_check_level_up_sorcerer_exec",
+            "effect": [
+              { "math": [ "u_used_exp_sorcerer += u_exp_to_sorcerer_level" ] },
+              { "math": [ "u_available_exp_sorcerer = u_val('exp') + u_bonus_exp - u_used_exp_sorcerer" ] },
+              { "math": [ "u_exp_to_sorcerer_level += u_exp_per_sorcerer_level" ] },
+              { "run_eocs": "EOC_level_up_sorcerer" }
+            ]
+          }
+        ]
+      }
     ]
   },
   {
@@ -16,10 +26,7 @@
     "eoc_type": "EVENT",
     "required_event": "character_kills_monster",
     "condition": { "u_has_trait": "SORCERER" },
-    "effect": [
-      { "math": [ "u_available_exp_sorcerer = u_val('exp') + u_bonus_exp - u_used_exp_sorcerer" ] },
-      { "run_eocs": "EOC_check_level_up_sorcerer" }
-    ]
+    "effect": [ { "run_eocs": "EOC_check_level_up_sorcerer" } ]
   },
   {
     "type": "effect_on_condition",


### PR DESCRIPTION


#### Summary
Mods "[BPerks/MM/Sorc] XP mods can level up more than once at a time"

#### Purpose of change
Currently the XP mods only level up one level at a time. This changes it so when the level up check is triggered it will gain all possible levels instead of just a single level

#### Describe the solution
Change the level up EOCs (`EOC_perk_ma_level_up` for Martial Mastery, `EOC_level_up` for Bombastic Perks, `EOC_check_level_up_sorcerer` for Sorcerer) to make a `run_eocs` call with a condition so it repeats the EOC until that condition fails, 100 times maximum.
This call performs all of the level up math as before. If there is not enough available xp to level up even once, it just does not run, same functionality as previously.

Bombastic Perks and Martial Mastery will only show the level up window at the end once all levels are properly gained. Sorcerer will show it's level up screen every level, I am unsure how Sorcerer actually works but I think there are things you can change at each level so this is the required method.

A related note here is that Martial mastery never showed the perk selection screen before due to not actually calling the EOC for it to display (that EOC would've displayed BPerks dialog anyways). I fixed this apparent oversight as part of this PR.


#### Describe alternatives you've considered


#### Testing
Tested by giving a massive amount of `u_bonus_exp` to the player and then triggering the level up checks. All three mods properly leveled up the right number of times and showed the level up screens as described. 

#### Additional context
This is not entirely necessary as the mods stand currently, they only really gain exp on monster kills by default. This allows a mod to grant any amount of bonus xp and trigger the level ups for whatever reason and not have to run the level up check repeatedly.


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
