### PR TITLE
You remember what was your weight when you weighted the last time

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3170,6 +3170,15 @@ units::mass Character::get_weight() const
     return enchantment_cache->modify_value( enchant_vals::mod::TOTAL_WEIGHT, ret );
 }
 
+units::mass Character::bodyweight_with_bionic() const
+{
+    units::mass ret = 0_gram;
+
+    ret += bodyweight();       // The base weight of the player's body
+    ret += bionics_weight();       // Weight of installed bionics
+    return enchantment_cache->modify_value( enchant_vals::mod::TOTAL_WEIGHT, ret );
+}
+
 int Character::avg_encumb_of_limb_type( bp_type part_type ) const
 {
     float limb_encumb = 0.0f;

--- a/src/character.h
+++ b/src/character.h
@@ -980,6 +980,8 @@ class Character : public Creature, public visitable
         /** Returns body weight plus weight of inventory and worn/wielded items */
         units::mass get_weight() const override;
 
+        units::mass bodyweight_with_bionic() const;
+
         // formats and prints encumbrance info to specified window
         void print_encumbrance( ui_adaptor &ui, const catacurses::window &win, int line = -1,
                                 const item *selected_clothing = nullptr ) const;

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -5530,6 +5530,9 @@ std::optional<int> weigh_self_actor::use( Character *p, item &, map *,
     if( weight > convert_weight( max_weight ) ) {
         popup( _( "ERROR: Max weight of %.0f %s exceeded" ), convert_weight( max_weight ), weight_units() );
     } else {
+        p->set_value( "last_weighting_weight_kg", units::to_kilogram( p->bodyweight_with_bionic() ) );
+        p->set_value( "last_weighting_time", to_turn<int>( calendar::turn ) );
+
         popup( "%.0f %s", weight, weight_units() );
     }
     return 0;

--- a/src/medical_ui.cpp
+++ b/src/medical_ui.cpp
@@ -31,6 +31,7 @@
 #include "input_context.h"
 #include "inventory.h"
 #include "item.h"
+#include "math_parser_diag_value.h"
 #include "messages.h"
 #include "output.h"
 #include "proficiency.h"
@@ -43,6 +44,7 @@
 #include "ui_manager.h"
 #include "uilist.h"
 #include "units.h"
+#include "units_utility.h"
 #include "weighted_list.h"
 #include "wound.h"
 
@@ -532,11 +534,30 @@ void medical_ui::draw_limbs_list( const std::vector<bodypart_id> &bodyparts )
 
 void medical_ui::summary_tab() const
 {
-    cataimgui::draw_colored_text( draw_speed_summary( *you ), c_unset,
-                                  ImGui::GetContentRegionAvail().x );
+    const float col_width = ImGui::GetContentRegionAvail().x;
+
+    cataimgui::draw_colored_text( draw_speed_summary( *you ), col_width );
+
     ImGui::Separator();
-    cataimgui::draw_colored_text( draw_stats_summary( *you ), c_unset,
-                                  ImGui::GetContentRegionAvail().x );
+
+    cataimgui::draw_colored_text( draw_stats_summary( *you ), col_width );
+
+    const diag_value *last_weighting_time = you->maybe_get_value( "last_weighting_time" );
+    if( last_weighting_time != nullptr ) {
+        const std::string last_weighting_weight = string_format( "%.0f %s",
+                you->get_value( "last_weighting_weight_kg" ).dbl(), weight_units() );
+        const std::string last_weighted_time = string_format( _( "last weighted %s ago" ),
+                                               to_string_approx( calendar::turn - time_point( last_weighting_time->dbl() ) ) );
+        const std::string weight_desc = string_format(
+                                            "%s: %s (%s)",
+                                            _( "Weight" ),
+                                            colorize( last_weighting_weight, c_yellow ),
+                                            colorize( last_weighted_time, c_dark_gray ) );
+        cataimgui::draw_colored_text( weight_desc, col_width );
+    } else {
+        cataimgui::draw_colored_text( _( "You do not remember when you weighted yourself the last time" ),
+                                      c_dark_gray, col_width );
+    }
 }
 
 void medical_ui::limb_tab( const std::vector<bodypart_id> &bodyparts )


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
In a bit of support toward #85796
#### Describe the solution
Store your weight and when you weighted the last time in character after activation of scales
Print this information in medical summary menu
#### Describe alternatives you've considered
Also current weight of a gear? it is accessible in inventory already, after all
#### Testing
<img width="637" height="379" alt="image" src="https://github.com/user-attachments/assets/ca084630-0bd7-40f9-9c88-8cf25434b8c1" />

<img width="637" height="383" alt="image" src="https://github.com/user-attachments/assets/c1a3d158-e246-4064-9d9b-2bc31d5bcb73" />