### PR TITLE
No more uncomfortable limbs you don't have

### DIFF
--- a/src/character.h
+++ b/src/character.h
@@ -3104,6 +3104,8 @@ class Character : public Creature, public visitable
         bool has_activity( const activity_id &type ) const;
         /** Check if player currently has any of the given activities */
         bool has_activity( const std::vector<activity_id> &types ) const;
+        /** Check if character has a given sub_bodypart */
+        bool has_sub_bodypart( const sub_bodypart_id& sbp ) const;
         void resume_backlog_activity();
         void cancel_activity();
         void cancel_stashed_activity();

--- a/src/character.h
+++ b/src/character.h
@@ -3105,7 +3105,7 @@ class Character : public Creature, public visitable
         /** Check if player currently has any of the given activities */
         bool has_activity( const std::vector<activity_id> &types ) const;
         /** Check if character has a given sub_bodypart */
-        bool has_sub_bodypart( const sub_bodypart_id& sbp ) const;
+        bool has_sub_bodypart( const sub_bodypart_id &sbp ) const;
         void resume_backlog_activity();
         void cancel_activity();
         void cancel_stashed_activity();

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -1975,7 +1975,7 @@ std::unordered_set<bodypart_id> outfit::where_discomfort( const Character &guy )
 
                 // need to go through each locations under location to check if it's covered, since secondary locations can cover multiple underlying locations
                 for( const sub_bodypart_str_id &under_sbp : sbp->locations_under ) {
-                    if( covered_sbps.count( under_sbp ) != 1 && guy.has_sub_bodypart(sbp) ) {
+                    if( covered_sbps.count( under_sbp ) != 1 && guy.has_sub_bodypart( sbp ) ) {
                         guy.add_msg_if_player(
                             string_format( _( "<color_c_red>The %s rubs uncomfortably against your unpadded %s.</color>" ),
                                            i.display_name(), under_sbp->name ) );

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -1975,7 +1975,7 @@ std::unordered_set<bodypart_id> outfit::where_discomfort( const Character &guy )
 
                 // need to go through each locations under location to check if it's covered, since secondary locations can cover multiple underlying locations
                 for( const sub_bodypart_str_id &under_sbp : sbp->locations_under ) {
-                    if( covered_sbps.count( under_sbp ) != 1 ) {
+                    if( covered_sbps.count( under_sbp ) != 1 && guy.has_sub_bodypart(sbp) ) {
                         guy.add_msg_if_player(
                             string_format( _( "<color_c_red>The %s rubs uncomfortably against your unpadded %s.</color>" ),
                                            i.display_name(), under_sbp->name ) );

--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -1580,3 +1580,17 @@ void Character::update_respiration_rate()
     constexpr float RESP_EFFECT_INT_TO_FLOAT_MULT = 0.0001f;
     respiration_rate = 1.0f + effect_mod * RESP_EFFECT_INT_TO_FLOAT_MULT;
 }
+
+bool Character::has_sub_bodypart( const sub_bodypart_id &sbp) const
+{
+    bool character_has_sub_part = false;
+    for (const bodypart_id& part : get_all_body_parts()) {
+        for (const sub_bodypart_id& sub_part : part->sub_parts) {
+            if (sub_part == sbp) {
+                character_has_sub_part = true;
+                break;
+            }
+        }
+    }
+    return character_has_sub_part;
+}

--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -1581,12 +1581,12 @@ void Character::update_respiration_rate()
     respiration_rate = 1.0f + effect_mod * RESP_EFFECT_INT_TO_FLOAT_MULT;
 }
 
-bool Character::has_sub_bodypart( const sub_bodypart_id &sbp) const
+bool Character::has_sub_bodypart( const sub_bodypart_id &sbp ) const
 {
     bool character_has_sub_part = false;
-    for (const bodypart_id& part : get_all_body_parts()) {
-        for (const sub_bodypart_id& sub_part : part->sub_parts) {
-            if (sub_part == sbp) {
+    for( const bodypart_id &part : get_all_body_parts() ) {
+        for( const sub_bodypart_id &sub_part : part->sub_parts ) {
+            if( sub_part == sbp ) {
                 character_has_sub_part = true;
                 break;
             }

--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -36,6 +36,7 @@
 #include "rng.h"
 #include "stomach.h"
 #include "string_formatter.h"
+#include "subbodypart.h"
 #include "translation.h"
 #include "translations.h"
 #include "type_id.h"

--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -1585,7 +1585,7 @@ bool Character::has_sub_bodypart( const sub_bodypart_id &sbp ) const
 {
     bool character_has_sub_part = false;
     for( const bodypart_id &part : get_all_body_parts() ) {
-        for( const sub_bodypart_id &sub_part : part->sub_parts ) {
+        for( const sub_bodypart_id sub_part : part->sub_parts ) {
             if( sub_part == sbp ) {
                 character_has_sub_part = true;
                 break;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Uncomfortable limbs must exist"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #86031 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Check if a sub bodypart exists before saying it's uncomfortable.

#### Describe alternatives you've considered
N/A - bugfix

#### Testing
Put chainmail armor onto a naked character. Only the sub parts that the character has are listed.
<img width="838" height="460" alt="image" src="https://github.com/user-attachments/assets/363ebe5a-8c53-41a9-8882-5724695c6af5" />


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
