### PR TITLE
`random` → `RANDOM`

### DIFF
--- a/data/json/effects_on_condition/mutation_eocs/mutation_effect_eocs.json
+++ b/data/json/effects_on_condition/mutation_eocs/mutation_effect_eocs.json
@@ -440,7 +440,7 @@
     "id": "rashy_skin",
     "recurrence": [ "2 hour", "24 hours" ],
     "condition": { "and": [ { "u_has_trait": "SKIN_RASHY" }, { "not": { "u_has_effect": "formication" } } ] },
-    "effect": [ { "u_add_effect": "formication", "duration": "10 minutes", "target_part": "random" } ]
+    "effect": [ { "u_add_effect": "formication", "duration": "10 minutes", "target_part": "RANDOM" } ]
   },
   {
     "type": "effect_on_condition",


### PR DESCRIPTION
#### Summary
Bugfixes "Change `target_part` value in `rashy_skin` to uppercase `RANDOM`"

#### Purpose of change
https://github.com/CleverRaven/Cataclysm-DDA/blob/192b2680f7d94e186c219f5fe3d5596c9a6d1242/src/talker_monster.cpp#L85-L94

#### Describe the solution
Use `RANDOM` instead of `random`.

#### Describe alternatives you've considered

#### Testing
No more  DEBUG : invalid body part id "random"

#### Additional context