### PR TITLE
Fix faction ui column width in curses build

### DIFF
--- a/src/faction_ui.h
+++ b/src/faction_ui.h
@@ -95,7 +95,7 @@ class faction_ui : public cataimgui::window
         const mtype_id *picked_creature = nullptr;
 
         float get_table_column_width() const {
-            return 260.f;
+            return std::min( ImGui::GetWindowSize().x / 2.5f, 256.f );
         }
 };
 


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Found that faction ui menu is broken in curses build
#### Describe the solution
Apparently it is because the width of imtui menu is not equal to width of imgui one
Make use of ImGui::GetWindowSize().x for imtui, while capping the width at 256.f for imgui interface
#### Testing
Before
<img width="657" height="407" alt="image" src="https://github.com/user-attachments/assets/0b30c553-3552-4cb2-8d20-98227d689335" />

After:
<img width="959" height="479" alt="image" src="https://github.com/user-attachments/assets/f110f529-ab9a-4bb5-bb4c-1c5824778f8d" />

Imgui:
<img width="636" height="376" alt="image" src="https://github.com/user-attachments/assets/14d0005a-5c88-49d8-8e54-7fbda396cd3a" />

(debug info was removed)