### PR TITLE
Give rural church `"existing": true` in its overmap connections

### DIFF
--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -3203,7 +3203,7 @@
       { "point": [ 2, 0, 1 ], "overmap": "rural_church_steeple_north" },
       { "point": [ 2, 0, 2 ], "overmap": "rural_church_steeple_roof_north" }
     ],
-    "connections": [ { "point": [ 0, 0, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 0, 0 ] } ],
+    "connections": [ { "point": [ 0, 0, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 0, 0 ], "existing": true } ],
     "locations": [ "forest", "field" ],
     "city_distance": [ 5, 50 ],
     "occurrences": [ 0, 3 ],


### PR DESCRIPTION


#### Summary
None


#### Purpose of change
Was annoyed at seeing rural church having their own bridges whenever it goes over a river, so i fix that, somewhat.
#### Describe the solution
Give the rural church overmap connections `"existing": true` so it can only spawn on existing road gen. Considering the rural church mapgen not being too rare, i think this is fine to use

#### Describe alternatives you've considered
Not doing it.

#### Testing
Applied the thing to my build, made a new world and reveal overmaps around me. searching up the map for rural churches gives me rural churches that is on an existing roadgen.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
