### PR TITLE
Fix animated tileset sprites freezing during idle

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1344,6 +1344,8 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
     }
 #endif
 
+    has_animated_tiles_ = false;
+
     {
         //set clipping to prevent drawing over stuff we shouldn't
         SDL_Rect clipRect = {dest.x, dest.y, width, height};
@@ -3023,6 +3025,7 @@ bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEG
 
         // idle tile animations:
         if( display_tile.animated ) {
+            has_animated_tiles_ = true;
             // idle animations run during the user's turn, and the animation speed
             // needs to be defined by the tileset to look good, so we use system clock:
             std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -897,10 +897,17 @@ class cata_tiles
          * Allows usage of night vision tilesets during sprite rendering.
          */
         bool nv_goggles_activated = false;
+        // Set during draw() when any tile with animated=true is rendered.
+        bool has_animated_tiles_ = false;
 
         pimpl<pixel_minimap> minimap;
 
     public:
+        // True if the last draw() rendered any animated tiles.
+        bool has_animated_tiles() const {
+            return has_animated_tiles_;
+        }
+
         // Draw caches persist data between draws and are only recalculated when dirty
         void set_draw_cache_dirty();
 

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -425,6 +425,11 @@ input_context game::get_player_input( std::string &action )
             if( tilecontext->expire_hit_animations() ) {
                 invalidate_main_ui_adaptor();
             }
+
+            // Animated tiles need periodic redraws to cycle frames
+            if( tilecontext->has_animated_tiles() ) {
+                invalidate_main_ui_adaptor();
+            }
 #endif
 
             if( g->has_blink_curses() && current_turn.blink_timeout() ) {


### PR DESCRIPTION
#### Summary
Bugfixes "Fix animated tileset sprites not cycling while idle"

#### Purpose of change

Fixes #86226. Regression from #86183 -- replacing the minimap's periodic `invalidate_main_ui_adaptor()` with `wnoutrefresh()` removed the only thing triggering `cata_tiles::draw()` during idle, so animated tile frames stopped advancing.

#### Describe the solution

Track whether any animated tiles were drawn, invalidate the UI in the idle loop when they are. Lightmap dirty-skip still applies so the extra redraws are cheap.

#### Describe alternatives you've considered

N/A

#### Testing

Verified in-game arrows near stairs are animated while idle.

#### Additional context

Companion fix to #86211 which addressed hit/bash overlays from the same regression.