### PR TITLE
ambient mutation in inner cabins cellar depths is slower and more obvious

### DIFF
--- a/data/json/effects_on_condition/nether_eocs/reverberations.json
+++ b/data/json/effects_on_condition/nether_eocs/reverberations.json
@@ -228,8 +228,8 @@
         "popup": true
       },
       { "run_eocs": "EOC_INNER_CABINS_UPDATE_EXIT_1", "time_in_future": [ "5 minutes", "2 hours" ] },
-      { "math": [ "interstice_counter = 100" ] },
-      { "math": [ "previous_interstice_counter = 100" ] },
+      { "math": [ "interstice_counter = 600" ] },
+      { "math": [ "previous_interstice_counter = 600" ] },
       { "u_add_trait": "INTERSTICE_SHRINKING" },
       { "run_eocs": "EOC_INNER_CABINS_INTERSTICE_COUNTER", "time_in_future": [ "1 minutes", "2 minutes" ] }
     ]
@@ -444,8 +444,8 @@
       { "math": [ "previous_interstice_counter = interstice_counter" ] },
       {
         "if": { "math": [ "u_val('pos_z') <= -8" ] },
-        "then": { "if": { "one_in_chance": 100 }, "then": { "math": [ "interstice_counter -= 10" ] } },
-        "else": { "if": { "one_in_chance": 200 }, "then": { "math": [ "interstice_counter += 1" ] } }
+        "then": { "if": { "one_in_chance": 500 }, "then": { "math": [ "interstice_counter -= 10" ] } },
+        "else": { "if": { "one_in_chance": 500 }, "then": { "math": [ "interstice_counter += 1" ] } }
       },
       { "if": { "math": [ "interstice_counter < 100" ] }, "then": { "math": [ "interstice_counter = 100" ] } },
       {
@@ -455,7 +455,10 @@
           { "u_add_trait": "INTERSTICE_GROWING" },
           {
             "if": { "one_in_chance": { "global_val": "interstice_counter" } },
-            "then": { "u_mutate_category": "INTERSTICE", "use_vitamins": false }
+            "then": [
+              { "u_message": "<inner_cabins_interstice_snippet>", "type": "info", "snippet": true },
+              { "u_mutate_category": "INTERSTICE", "use_vitamins": false }
+            ]
           }
         ],
         "else": [ { "u_lose_trait": "INTERSTICE_GROWING" }, { "u_add_trait": "INTERSTICE_SHRINKING" } ]

--- a/data/json/snippets/reverberations.json
+++ b/data/json/snippets/reverberations.json
@@ -16,5 +16,41 @@
         "text": "I'm stuck, I'm stuck here\nit wasn't a dream, I was standing relaxing enjoying the evening on the roof\nwhen the sky broke, I don't know what happened\nsoon after the sun vanished, I found myself somewhere else\nexpanse of my cabin, the exact same cabin.  Gentle wind with drizzling rain, I thought I died and this was heaven\nI must've spent hours just going through those replicas of my cabin, every single one was the same\na bench on the porch, windows\nI think there's something special about this configuration\nsomething special about the layout of my cabin\nit can't be a coincidence\nI can't tell how many hours passed when I was transported back to our world, I don't know where I am, but the sky is normal again\nI wish to go back\nThis isn't my house, looks similar though.  I don't care anymore, all I want to do is to get back there\nI know it wasn't a dream"
       }
     ]
+  },
+  {
+    "type": "snippet",
+    "category": "<inner_cabins_interstice_snippet>",
+    "text": [
+      "It's like this place is trying to teach your body how to exist within it.",
+      "The endless halls here are trying to change you.  You can feel it.",
+      "Your thoughts feel quieter, like they don't reach as far.",
+      "You feel less and less like an intruder.",
+      "Colors twinkle in the dark.",
+      "Something whisper to you from afar.",
+      "Leaving feels less important by the day.",
+      "You move without thinkin.  It works.",
+      "Your breathing slows, then fades away from your awareness for a moment.",
+      "The silence doesn't bother you as much.",
+      "An unsettling feeling fills your gut.  It passes.",
+      "It's like you can see around the edges of this place.",
+      "It's like you see between the gaps in the world.  But, you don't know what that means.",
+      "You don't feel out of place here.",
+      "Everything feels loose.  Your movements.  Your thoughts.",
+      "You don't question the way things are settling into place.",
+      "The dim light feels appropriate.",
+      "Your steps lag behind themselves.",
+      "You feel less defined, but more stable.",
+      "Discomfort is distant.",
+      "The more time you spend here, the more comfortable it is.",
+      "There are whispers in the distant darkness.",
+      "This is how it always should have been.",
+      "Something whispers \"stay\".",
+      "Something whispers \"sleep\".",
+      "Something whispers \"rest\".",
+      "Something whispers \"explore\".",
+      "The air smells different.",
+      "The air feels different.",
+      "Something is different.  Is it this place?  Is it you?"
+    ]
   }
 ]

--- a/data/json/snippets/reverberations.json
+++ b/data/json/snippets/reverberations.json
@@ -28,7 +28,7 @@
       "Colors twinkle in the dark.",
       "Something whisper to you from afar.",
       "Leaving feels less important by the day.",
-      "You move without thinkin.  It works.",
+      "You move without thinking.  It works.",
       "Your breathing slows, then fades away from your awareness for a moment.",
       "The silence doesn't bother you as much.",
       "An unsettling feeling fills your gut.  It passes.",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Balance "ambient mutation in cellar depths is slower and more obvious"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Being in the cellar depths mutates you.  I think it was a bit too quick, and there weren't any messages about what was going on.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Adds some snippets that appear when mutating.

Mutating is slowed down substantially.  Initial chances are now 1/600 each time the check is made, and the chance of increasing/decreasing the odds based on location has been changed to 1/500.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Different numbers.  Tried a few.  This feels good.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Lived in the cellar depths for a bit.  Mutated.  Watched the log.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
