### PR TITLE
Ortho tint: alpha-masked silhouette rendering with batching

### DIFF
--- a/src/cata_small_literal_vector.h
+++ b/src/cata_small_literal_vector.h
@@ -104,6 +104,14 @@ struct alignas( T * ) small_literal_vector {
         len_ -= 1;
     }
 
+    void clear() {
+        len_ = 0;
+    }
+
+    bool empty() const {
+        return len_ == 0;
+    }
+
     // Some nonstandard helpers below.
     void ensure_capacity_for( size_t count ) {
         check_capacity( count );

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -283,6 +283,7 @@ void tileset::clear()
     night_tile_values.clear();
     overexposed_tile_values.clear();
     memory_tile_values.clear();
+    silhouette_tile_values.clear();
     duplicate_ids.clear();
     tile_ids.clear();
     for( std::unordered_map<std::string, season_tile_value> &m : tile_ids_by_season ) {
@@ -456,6 +457,48 @@ static SDL_Surface_Ptr apply_color_filter( const SDL_Surface_Ptr &original,
     return surf;
 }
 
+// Compute the tightest bounding box containing non-transparent pixels within
+// a sprite rect. The surface must be 32-bit RGBA (e.g. from create_surface_32).
+// Returns coordinates relative to the sprite rect origin. A fully transparent
+// sprite returns {0, 0, 0, 0}.
+static SDL_Rect compute_opaque_rect( const SDL_Surface_Ptr &surf, const SDL_Rect &rect )
+{
+    int min_x = rect.w; // NOLINT(cata-combine-locals-into-point)
+    int min_y = rect.h;
+    int max_x = -1; // NOLINT(cata-combine-locals-into-point)
+    int max_y = -1;
+    const int pitch = surf->pitch / 4;
+    const Uint32 *pixels = static_cast<const Uint32 *>( surf->pixels );
+    for( int y = 0; y < rect.h; ++y ) {
+        for( int x = 0; x < rect.w; ++x ) {
+            const Uint32 pixel = pixels[( rect.y + y ) * pitch + ( rect.x + x )];
+            Uint8 r;
+            Uint8 g;
+            Uint8 b;
+            Uint8 a;
+            GetRGBA( pixel, surf, r, g, b, a );
+            if( a > 0 ) {
+                if( x < min_x ) {
+                    min_x = x;
+                }
+                if( y < min_y ) {
+                    min_y = y;
+                }
+                if( x > max_x ) {
+                    max_x = x;
+                }
+                if( y > max_y ) {
+                    max_y = y;
+                }
+            }
+        }
+    }
+    if( max_x < 0 ) {
+        return { 0, 0, 0, 0 };
+    }
+    return { min_x, min_y, max_x - min_x + 1, max_y - min_y + 1 };
+}
+
 static bool is_contained( const SDL_Rect &smaller, const SDL_Rect &larger )
 {
     return smaller.x >= larger.x &&
@@ -465,7 +508,8 @@ static bool is_contained( const SDL_Rect &smaller, const SDL_Rect &larger )
 }
 
 void tileset_cache::loader::copy_surface_to_texture( const SDL_Surface_Ptr &surf,
-        const point &offset, std::vector<texture> &target )
+        const point &offset, std::vector<texture> &target,
+        const std::vector<SDL_Rect> &opaque_bounds )
 {
     cata_assert( surf );
     const rect_range<SDL_Rect> input_range( sprite_width, sprite_height,
@@ -485,7 +529,10 @@ void tileset_cache::loader::copy_surface_to_texture( const SDL_Surface_Ptr &surf
                              ( tile_atlas_width / sprite_width );
         cata_assert( index < target.size() );
         cata_assert( target[index].dimension() == std::make_pair( 0, 0 ) );
-        target[index] = texture( texture_ptr, rect );
+        const SDL_Rect &opaque = index < opaque_bounds.size()
+                                 ? opaque_bounds[index]
+                                 : SDL_Rect{ 0, 0, rect.w, rect.h };
+        target[index] = texture( texture_ptr, rect, opaque );
     }
 }
 
@@ -494,14 +541,39 @@ void tileset_cache::loader::create_textures_from_tile_atlas( const SDL_Surface_P
 {
     cata_assert( tile_atlas );
 
+    // Compute per-sprite opaque bounds once from the unfiltered atlas.
+    // Color filter variants preserve the alpha channel, so rescanning is unnecessary.
+    // Blit into a 32-bit surface for format-safe pixel access.
+    SDL_Surface_Ptr scan_surf = create_surface_32( tile_atlas->w, tile_atlas->h );
+    throwErrorIf( BlitSurface( tile_atlas, nullptr, scan_surf, nullptr ) != 0,
+                  "SDL_BlitSurface failed" );
+
+    const rect_range<SDL_Rect> scan_range( sprite_width, sprite_height,
+                                           point( tile_atlas->w / sprite_width,
+                                                   tile_atlas->h / sprite_height ) );
+    // Pre-size to accommodate the maximum index this chunk can produce.
+    const int cols = tile_atlas_width / sprite_width;
+    const size_t max_index = this->offset +
+                             static_cast<size_t>( cols ) * ( tile_atlas->h / sprite_height );
+    std::vector<SDL_Rect> opaque_bounds( max_index + cols, SDL_Rect{ 0, 0, 0, 0 } );
+    for( const SDL_Rect rect : scan_range ) {
+        const point pos( offset + point( rect.x, rect.y ) );
+        const size_t index = this->offset + ( pos.x / sprite_width ) + ( pos.y / sprite_height ) *
+                             cols;
+        if( index < opaque_bounds.size() ) {
+            opaque_bounds[index] = compute_opaque_rect( scan_surf, rect );
+        }
+    }
+
     /** perform color filter conversion here */
     using tiles_pixel_color_entry = std::tuple<std::vector<texture>*, std::string>;
-    std::array<tiles_pixel_color_entry, 5> tile_values_data = {{
+    std::array<tiles_pixel_color_entry, 6> tile_values_data = {{
             { std::make_tuple( &ts.tile_values, "color_pixel_none" ) },
             { std::make_tuple( &ts.shadow_tile_values, "color_pixel_grayscale" ) },
             { std::make_tuple( &ts.night_tile_values, "color_pixel_nightvision" ) },
             { std::make_tuple( &ts.overexposed_tile_values, "color_pixel_overexposed" ) },
-            { std::make_tuple( &ts.memory_tile_values, tilecontext->memory_map_mode ) }
+            { std::make_tuple( &ts.memory_tile_values, tilecontext->memory_map_mode ) },
+            { std::make_tuple( &ts.silhouette_tile_values, "color_pixel_silhouette" ) }
         }
     };
     for( tiles_pixel_color_entry &entry : tile_values_data ) {
@@ -510,10 +582,10 @@ void tileset_cache::loader::create_textures_from_tile_atlas( const SDL_Surface_P
                 ( entry ) );
         if( !color_pixel_function ) {
             // TODO: Move it inside apply_color_filter.
-            copy_surface_to_texture( tile_atlas, offset, *tile_values );
+            copy_surface_to_texture( tile_atlas, offset, *tile_values, opaque_bounds );
         } else {
             copy_surface_to_texture( apply_color_filter( tile_atlas, color_pixel_function ), offset,
-                                     *tile_values );
+                                     *tile_values, opaque_bounds );
         }
     }
 }
@@ -598,6 +670,7 @@ void tileset_cache::loader::load_tileset( const cata_path &img_path, const bool 
     extend_vector_by( ts.night_tile_values, expected_tilecount );
     extend_vector_by( ts.overexposed_tile_values, expected_tilecount );
     extend_vector_by( ts.memory_tile_values, expected_tilecount );
+    extend_vector_by( ts.silhouette_tile_values, expected_tilecount );
 
     for( const SDL_Rect sub_rect : output_range ) {
         cata_assert( sub_rect.x % sprite_width == 0 );
@@ -1782,15 +1855,83 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
         const half_open_rectangle<point> &cur_any_tile_range = is_isometric()
                 ? z_any_tile_range[center.z() - cur_zlevel] : top_any_tile_range;
         // For each row
+        const bool iso = is_isometric();
+        const level_cache &zlev_cache = here.access_cache( cur_zlevel );
+        const bool zlev_has_color = zlev_cache.has_colored_lights;
         for( int row = cur_any_tile_range.p_min.y; row < cur_any_tile_range.p_max.y; row ++ ) {
-            // Set base height for each tile
+            // --- Per-tile prepass ---
+            // Initialize base height and decide which tiles need a colored light
+            // tint overlay. We do this before the layer loop so that:
+            //   (a) we can skip bounds/sprite tracking for tiles that won't be tinted,
+            //   (b) the overlay pass later can iterate only tinted tiles.
+            std::vector<tile_render_info *> row_tinted;
             for( tile_render_info &p : here.draw_points_cache[cur_zlevel][row] ) {
                 p.com.height_3d = ( cur_zlevel - center.z() ) * zlevel_height;
+                p.com.needs_tint = false;
+                if( !zlev_has_color ) {
+                    continue;
+                }
+                // Only visible sprite tiles can receive a tint.
+                const tile_render_info::sprite *const
+                var = std::get_if<tile_render_info::sprite>( &p.var );
+                if( !var || var->ll == lit_level::DARK || var->ll == lit_level::BLANK ||
+                    var->ll == lit_level::MEMORIZED ) {
+                    continue;
+                }
+                const light_color_rgb &lc =
+                    zlev_cache.light_color_cache[p.com.pos.x()][p.com.pos.y()];
+                if( !lc.is_colored() ) {
+                    continue;
+                }
+                // Isolate the chromatic (saturated) component by subtracting
+                // the achromatic floor (min channel). Pure white light (equal
+                // RGB) produces zero saturation and no tint.
+                const float min_ch = std::min( { lc.r, lc.g, lc.b } );
+                const float sat_r = lc.r - min_ch;
+                const float sat_g = lc.g - min_ch;
+                const float sat_b = lc.b - min_ch;
+                const float sat_mag = std::max( { sat_r, sat_g, sat_b } );
+                if( sat_mag < 0.01f ) {
+                    continue;
+                }
+                // Alpha: ratio of saturated energy to total scalar light.
+                // Effect is subtle under bright ambient, vivid in darkness.
+                const float scalar = zlev_cache.lm[p.com.pos.x()][p.com.pos.y()].max();
+                const float ratio = scalar > 0.1f ? std::min( 1.0f, sat_mag / scalar ) : 0.0f;
+                const Uint8 alpha = static_cast<Uint8>( ratio * 80.0f );
+                if( alpha == 0 ) {
+                    continue;
+                }
+                // Normalize saturated color to full brightness for the SDL tint.
+                p.com.tint_color = {
+                    static_cast<Uint8>( sat_r / sat_mag * 255.0f ),
+                    static_cast<Uint8>( sat_g / sat_mag * 255.0f ),
+                    static_cast<Uint8>( sat_b / sat_mag * 255.0f ),
+                    alpha
+                };
+                p.com.needs_tint = true;
+                row_tinted.push_back( &p );
+                // Ortho tiles need bounds tracking and sprite recording for the
+                // silhouette mask path. Reset per-frame state here.
+                if( !iso ) {
+                    p.com.bounds = {};
+                    p.com.tint_sprites.clear();
+                }
             }
-            // For each layer
+            // --- Layer loop ---
+            // Draw all layers (terrain, furniture, items, creatures, etc.).
+            // For ortho tinted tiles, we wire up m_cur_bounds and m_cur_tint_sprites
+            // so that draw_sprite_at accumulates the screen extent and records
+            // each sprite for later silhouette replay. Zone marks and revival
+            // indicators are UI overlays that shouldn't affect tint bounds.
             for( auto f : drawing_layers ) {
-                // For each tile
+                const bool track_bounds = !iso &&
+                                          f != &cata_tiles::draw_zone_mark &&
+                                          f != &cata_tiles::draw_zombie_revival_indicators;
                 for( tile_render_info &p : here.draw_points_cache[cur_zlevel][row] ) {
+                    const bool ortho_tint = track_bounds && p.com.needs_tint;
+                    m_cur_bounds = ortho_tint ? &p.com.bounds : nullptr;
+                    m_cur_tint_sprites = ortho_tint ? &p.com.tint_sprites : nullptr;
                     if( const tile_render_info::vision_effect * const
                         var = std::get_if<tile_render_info::vision_effect>( &p.var ) ) {
                         if( f == &cata_tiles::draw_terrain ) {
@@ -1826,56 +1967,198 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
                     }
                 }
             }
-            // Colored light overlay. Draws a tinted rect over tiles that have
-            // colored light energy in the cache (emergency beacons, colored fields,
-            // etc). Only the chromatic (saturated) component produces a tint --
-            // white light (equal RGB) is ignored. Alpha scales with the ratio of
-            // colored energy to total scalar light so the effect is subtle under
-            // bright ambient and vivid in darkness.
-            const level_cache &cur_cache = here.access_cache( cur_zlevel );
-            SetRenderDrawBlendMode( renderer, SDL_BLENDMODE_BLEND );
-            for( const tile_render_info &p : here.draw_points_cache[cur_zlevel][row] ) {
-                const tile_render_info::sprite *const
-                var = std::get_if<tile_render_info::sprite>( &p.var );
-                if( !var || var->ll == lit_level::DARK || var->ll == lit_level::BLANK ||
-                    var->ll == lit_level::MEMORIZED ) {
-                    continue;
+            m_cur_bounds = nullptr;
+            m_cur_tint_sprites = nullptr;
+
+            // --- Colored light tint overlay ---
+            // After all content layers are drawn, overlay a color tint on tiles
+            // that have colored light (emergency beacons, colored fields,
+            // dawn/dusk light, etc). Tint eligibility and color were precomputed
+            // in the per-tile prepass above; row_tinted holds only eligible tiles.
+            if( !row_tinted.empty() ) {
+                const int zlev_base = ( cur_zlevel - center.z() ) * zlevel_height;
+                if( iso ) {
+                    // Iso: flat tint rect over the tile footprint (unchanged
+                    // from the original tint overlay code).
+                    SetRenderDrawBlendMode( renderer, SDL_BLENDMODE_BLEND );
+                    for( const tile_render_info *tp : row_tinted ) {
+                        const point screen = player_to_screen( tp->com.pos.xy() );
+                        const SDL_Rect draw_rect = {
+                            screen.x, screen.y - zlev_base, tile_width, tile_height
+                        };
+                        const SDL_Color tc = { tp->com.tint_color.r, tp->com.tint_color.g,
+                                               tp->com.tint_color.b, tp->com.tint_color.a
+                                             };
+                        geometry->rect( renderer, draw_rect, tc );
+                    }
+                    SetRenderDrawBlendMode( renderer, SDL_BLENDMODE_NONE );
+                } else {
+                    // Ortho: hybrid tint overlay with two paths.
+                    //
+                    // "Simple" tiles whose sprites fit inside the tile footprint
+                    // get a cheap colored rect (same as iso). "Complex" tiles
+                    // with oversized sprites (tall 32x64 characters, multi-layer
+                    // gear, etc) would show a color seam at the tile boundary or
+                    // a rectangular halo around transparent padding. These use a
+                    // per-pixel silhouette mask instead:
+                    //
+                    //   1. Switch render target to a scratch texture (tint_mask_tex).
+                    //   2. Replay recorded sprites using their white silhouette
+                    //      variants (RGB=255, original alpha). This builds a
+                    //      combined alpha mask of the tile's visible pixels.
+                    //   3. Switch back to the display buffer and composite the
+                    //      mask with the tile's tint color/alpha.
+                    //
+                    // Complex tiles are batched: contiguous tiles with the same
+                    // tint color share a single target switch + composite. A union
+                    // area growth cap (2x sum of member areas) prevents degenerate
+                    // batches when tiles are far apart in screen space.
+
+                    std::vector<const tile_render_info *> batch_tiles;
+                    SDL_Color batch_color = { 0, 0, 0, 0 };
+                    SDL_Rect batch_union = { 0, 0, 0, 0 };
+                    int64_t batch_sum_area = 0;
+                    SDL_Rect saved_clip;
+                    bool clip_saved = false;
+
+                    // Flush the current complex-tile batch: render all accumulated
+                    // silhouettes into the mask texture, then composite to screen.
+                    auto flush_tint_batch = [&]() {
+                        if( batch_tiles.empty() ) {
+                            return;
+                        }
+                        ensure_tint_mask_texture( batch_union.w, batch_union.h );
+
+                        // Save and remove clip rect -- the mask texture has its own
+                        // coordinate space unrelated to the display viewport.
+                        if( !clip_saved ) {
+                            RenderGetClipRect( renderer, &saved_clip );
+                            clip_saved = true;
+                        }
+                        RenderSetClipRect( renderer, nullptr );
+
+                        // Phase 1: build the silhouette mask.
+                        SetRenderTarget( renderer, tint_mask_tex );
+                        SetRenderDrawBlendMode( renderer, SDL_BLENDMODE_NONE );
+                        SetRenderDrawColor( renderer, 0, 0, 0, 0 );
+                        const SDL_Rect clear_rect = { 0, 0, batch_union.w, batch_union.h };
+                        RenderFillRect( renderer, &clear_rect );
+
+                        for( const tile_render_info *bp : batch_tiles ) {
+                            for( const tint_sprite_record &rec : bp->com.tint_sprites ) {
+                                const texture *sil = tileset_ptr->get_silhouette_tile( rec.sprite_index );
+                                if( !sil ) {
+                                    continue;
+                                }
+                                // Translate to mask-local coordinates.
+                                SDL_Rect mask_dest = {
+                                    rec.destination.x - batch_union.x,
+                                    rec.destination.y - batch_union.y,
+                                    rec.destination.w,
+                                    rec.destination.h
+                                };
+                                sil->render_copy_ex( renderer, &mask_dest, rec.angle, nullptr,
+                                                     static_cast<SDL_RendererFlip>( rec.flip ) );
+                            }
+                        }
+
+                        // Phase 2: composite the mask to the display buffer.
+                        set_displaybuffer_rendertarget();
+                        RenderSetClipRect( renderer, &saved_clip );
+
+                        const SDL_Rect comp_src = { 0, 0, batch_union.w, batch_union.h };
+                        SetTextureColorMod( tint_mask_tex, batch_color.r,
+                                            batch_color.g, batch_color.b );
+                        SetTextureAlphaMod( tint_mask_tex, batch_color.a );
+                        RenderCopy( renderer, tint_mask_tex, &comp_src, &batch_union );
+                        SetRenderDrawBlendMode( renderer, SDL_BLENDMODE_BLEND );
+
+                        batch_tiles.clear();
+                        batch_sum_area = 0;
+                    };
+
+                    SetRenderDrawBlendMode( renderer, SDL_BLENDMODE_BLEND );
+                    for( const tile_render_info *tp : row_tinted ) {
+                        const point screen = player_to_screen( tp->com.pos.xy() );
+                        const SDL_Rect tile_rect = {
+                            screen.x, screen.y - zlev_base, tile_width, tile_height
+                        };
+
+                        // Simple: all recorded sprites fit inside the tile rect,
+                        // so a flat colored rect matches the sprite extent exactly.
+                        const bool simple = !tp->com.bounds.valid ||
+                                            tp->com.tint_sprites.empty() ||
+                                            ( tp->com.bounds.x >= tile_rect.x &&
+                                              tp->com.bounds.y >= tile_rect.y &&
+                                              tp->com.bounds.x + tp->com.bounds.w <= tile_rect.x + tile_rect.w &&
+                                              tp->com.bounds.y + tp->com.bounds.h <= tile_rect.y + tile_rect.h );
+                        if( simple ) {
+                            // Must flush any pending complex batch before drawing
+                            // a simple tile to preserve correct draw order.
+                            flush_tint_batch();
+                            const SDL_Color tc = { tp->com.tint_color.r, tp->com.tint_color.g,
+                                                   tp->com.tint_color.b, tp->com.tint_color.a
+                                                 };
+                            geometry->rect( renderer, tile_rect, tc );
+                            continue;
+                        }
+
+                        // Complex: sprites extend beyond the tile footprint.
+                        // Accumulate into the current batch or start a new one.
+
+                        // Color change forces a new batch.
+                        const SDL_Color tile_tc = { tp->com.tint_color.r, tp->com.tint_color.g,
+                                                    tp->com.tint_color.b, tp->com.tint_color.a
+                                                  };
+                        if( batch_tiles.empty() ||
+                            std::memcmp( &batch_color, &tile_tc, sizeof( SDL_Color ) ) != 0 ) {
+                            flush_tint_batch();
+                            batch_color = tile_tc;
+                        }
+                        // Area growth cap: if the union bounding box would exceed
+                        // 2x the summed area of its members, the batch has too
+                        // much empty space and the mask texture is wastefully large.
+                        if( !batch_tiles.empty() ) {
+                            // NOLINTNEXTLINE(cata-combine-locals-into-point)
+                            const int new_x = std::min( batch_union.x,
+                                                        tp->com.bounds.x );
+                            const int new_y = std::min( batch_union.y, tp->com.bounds.y );
+                            const int new_r = std::max( batch_union.x + batch_union.w,
+                                                        tp->com.bounds.x + tp->com.bounds.w );
+                            const int new_b = std::max( batch_union.y + batch_union.h,
+                                                        tp->com.bounds.y + tp->com.bounds.h );
+                            const int64_t union_area = static_cast<int64_t>( new_r - new_x ) *
+                                                       ( new_b - new_y );
+                            const int64_t sum_area = batch_sum_area +
+                                                     static_cast<int64_t>( tp->com.bounds.w ) * tp->com.bounds.h;
+                            if( union_area > sum_area * 2 ) {
+                                flush_tint_batch();
+                                batch_color = tile_tc;
+                            }
+                        }
+                        // Grow the batch union rect to include this tile.
+                        if( batch_tiles.empty() ) {
+                            batch_union = {
+                                tp->com.bounds.x, tp->com.bounds.y,
+                                tp->com.bounds.w, tp->com.bounds.h
+                            };
+                            batch_sum_area = static_cast<int64_t>( tp->com.bounds.w ) * tp->com.bounds.h;
+                        } else {
+                            const int nx = std::min( batch_union.x, tp->com.bounds.x );
+                            const int ny = std::min( batch_union.y, tp->com.bounds.y );
+                            const int nr = std::max( batch_union.x + batch_union.w,
+                                                     tp->com.bounds.x + tp->com.bounds.w );
+                            const int nb = std::max( batch_union.y + batch_union.h,
+                                                     tp->com.bounds.y + tp->com.bounds.h );
+                            batch_union = { nx, ny, nr - nx, nb - ny };
+                            batch_sum_area += static_cast<int64_t>( tp->com.bounds.w ) * tp->com.bounds.h;
+                        }
+                        batch_tiles.push_back( tp );
+                    }
+                    flush_tint_batch();
+                    SetRenderDrawBlendMode( renderer, SDL_BLENDMODE_NONE );
                 }
-                const light_color_rgb &lc =
-                    cur_cache.light_color_cache[p.com.pos.x()][p.com.pos.y()];
-                if( !lc.is_colored() ) {
-                    continue;
-                }
-                // Subtract the achromatic (white) component to isolate saturated color.
-                const float min_ch = std::min( { lc.r, lc.g, lc.b } );
-                const float sat_r = lc.r - min_ch;
-                const float sat_g = lc.g - min_ch;
-                const float sat_b = lc.b - min_ch;
-                const float sat_mag = std::max( { sat_r, sat_g, sat_b } );
-                if( sat_mag < 0.01f ) {
-                    continue; // pure white light, no tint
-                }
-                // Alpha: saturated energy relative to total scalar light at this tile
-                const float scalar = cur_cache.lm[p.com.pos.x()][p.com.pos.y()].max();
-                const float ratio = scalar > 0.1f ? std::min( 1.0f, sat_mag / scalar ) : 0.0f;
-                const Uint8 alpha = static_cast<Uint8>( ratio * 80.0f );
-                if( alpha == 0 ) {
-                    continue;
-                }
-                // Normalize saturated color to full brightness for the SDL tint.
-                const SDL_Color tint = {
-                    static_cast<Uint8>( sat_r / sat_mag * 255.0f ),
-                    static_cast<Uint8>( sat_g / sat_mag * 255.0f ),
-                    static_cast<Uint8>( sat_b / sat_mag * 255.0f ),
-                    alpha
-                };
-                const point screen = player_to_screen( p.com.pos.xy() );
-                const SDL_Rect draw_rect = {
-                    screen.x, screen.y - p.com.height_3d, tile_width, tile_height
-                };
-                geometry->rect( renderer, draw_rect, tint );
             }
-            SetRenderDrawBlendMode( renderer, SDL_BLENDMODE_NONE );
         }
         cur_zlevel += 1;
     }
@@ -2235,6 +2518,24 @@ point cata_tiles::player_to_screen( const point_bub_ms &pos ) const
     } else {
         return op + point{ colrow.x * tile_width, colrow.y * tile_height };
     }
+}
+
+void cata_tiles::ensure_tint_mask_texture( const int w, const int h )
+{
+    // Reuse the existing texture if it's large enough; only reallocate when
+    // the requested size exceeds the current allocation.
+    if( tint_mask_tex && tint_mask_w >= w && tint_mask_h >= h ) {
+        return;
+    }
+    // Grow to at least the requested size, rounding up to avoid frequent
+    // reallocation for slightly varying sprite sizes.
+    const int alloc_w = std::max( w, tint_mask_w );
+    const int alloc_h = std::max( h, tint_mask_h );
+    tint_mask_tex = CreateTexture( renderer, SDL_PIXELFORMAT_ARGB8888,
+                                   SDL_TEXTUREACCESS_TARGET, alloc_w, alloc_h );
+    SetTextureBlendMode( tint_mask_tex, SDL_BLENDMODE_BLEND );
+    tint_mask_w = alloc_w;
+    tint_mask_h = alloc_h;
 }
 
 point_bub_ms cata_tiles::screen_to_player(
@@ -3134,6 +3435,72 @@ bool cata_tiles::draw_sprite_at(
     destination.w = width * tile_width * tile.pixelscale / tileset_ptr->get_tile_width();
     destination.h = height * tile_height * tile.pixelscale / tileset_ptr->get_tile_height();
 
+    const bool iso = is_isometric();
+
+    // --- Tint bounds tracking (ortho only) ---
+    // Accumulate the screen-space extent of opaque pixels for this tile so the
+    // tint overlay knows the actual sprite footprint. We use the pre-computed
+    // opaque_rect (tightest non-transparent bounding box, computed at tileset
+    // load) rather than the full destination rect to avoid tinting transparent
+    // padding around sprites. When the sprite is flipped, mirror the opaque
+    // rect to match.
+    if( m_cur_bounds ) {
+        SDL_Rect opq = sprite_tex->get_opaque_rect();
+        if( opq.w > 0 && opq.h > 0 ) {
+            if( rotate_sprite ) {
+                // rota == -1 is horizontal flip only.
+                // rota % 4 == 2 is 180 degrees, implemented as H+V flip.
+                if( rota == -1 || ( !iso && rota % 4 == 2 ) ) {
+                    opq.x = width - opq.x - opq.w;
+                }
+                if( !iso && rota % 4 == 2 ) {
+                    opq.y = height - opq.y - opq.h;
+                }
+            }
+            // Scale from source pixel coords to destination screen coords.
+            m_cur_bounds->expand(
+                destination.x + opq.x * destination.w / width,
+                destination.y + opq.y * destination.h / height,
+                opq.w * destination.w / width,
+                opq.h * destination.h / height );
+        }
+    }
+
+    // --- Pre-compute rotation for tint recording ---
+    // We need the final angle/flip values both for the actual render call below
+    // and for recording into tint_sprites (which replays the sprite as a white
+    // silhouette during the tint overlay pass). Compute them once here.
+    double render_angle = 0;
+    SDL_RendererFlip render_flip = SDL_FLIP_NONE;
+    if( rotate_sprite ) {
+        if( rota == -1 ) {
+            render_flip = SDL_FLIP_HORIZONTAL;
+        } else if( !iso ) {
+            switch( rota % 4 ) {
+                case 1:
+                    render_angle = -90;
+                    break;
+                case 2:
+                    render_flip = static_cast<SDL_RendererFlip>( SDL_FLIP_HORIZONTAL | SDL_FLIP_VERTICAL );
+                    break;
+                case 3:
+                    render_angle = 90;
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+
+    // Record this sprite for silhouette mask replay. Must happen before the
+    // actual render because the render path may modify destination (d3d offset
+    // workaround). Only active for ortho tiles that need tinting.
+    if( m_cur_tint_sprites ) {
+        m_cur_tint_sprites->push_back( { sprite_index,
+            { destination.x, destination.y, destination.w, destination.h },
+            render_angle, static_cast<int>( render_flip ) } );
+    }
+
     if( rotate_sprite ) {
         if( rota == -1 ) {
             // flip horizontally
@@ -3157,7 +3524,7 @@ bool cata_tiles::draw_sprite_at(
                         destination.y -= 1;
                     }
 #endif
-                    if( !is_isometric() ) {
+                    if( !iso ) {
                         // never rotate isometric tiles
                         ret = sprite_tex->render_copy_ex( renderer, &destination, -90, nullptr,
                                                           SDL_FLIP_NONE );
@@ -3168,7 +3535,7 @@ bool cata_tiles::draw_sprite_at(
                     break;
                 case 2:
                     // 180 degrees, implemented with flips instead of rotation
-                    if( !is_isometric() ) {
+                    if( !iso ) {
                         // never flip isometric tiles vertically
                         ret = sprite_tex->render_copy_ex(
                                   renderer, &destination, 0, nullptr,
@@ -3187,7 +3554,7 @@ bool cata_tiles::draw_sprite_at(
                         destination.x -= 1;
                     }
 #endif
-                    if( !is_isometric() ) {
+                    if( !iso ) {
                         // never rotate isometric tiles
                         ret = sprite_tex->render_copy_ex( renderer, &destination, 90, nullptr,
                                                           SDL_FLIP_NONE );
@@ -4171,6 +4538,12 @@ bool cata_tiles::draw_critter_at( const tripoint_bub_ms &p, lit_level ll, int &h
     }
 
     if( result && !is_player && show_creature_overlay_icons ) {
+        // Attitude/sees-player icons are UI overlays, not body sprites.
+        // Exclude from tint bounds and tint replay tracking.
+        sprite_screen_bounds *saved_bounds = m_cur_bounds;
+        auto *saved_tint = m_cur_tint_sprites;
+        m_cur_bounds = nullptr;
+        m_cur_tint_sprites = nullptr;
         std::string draw_id = "overlay_" + Creature::attitude_raw_string( attitude );
         if( sees_player && !you.has_trait( trait_INATTENTIVE ) ) {
             draw_id += "_sees_player";
@@ -4179,6 +4552,8 @@ bool cata_tiles::draw_critter_at( const tripoint_bub_ms &p, lit_level ll, int &h
             draw_from_id_string( draw_id, TILE_CATEGORY::NONE, empty_string, p, 0, 0,
                                  lit_level::LIT, false, height_3d );
         }
+        m_cur_bounds = saved_bounds;
+        m_cur_tint_sprites = saved_tint;
     }
     return result;
 }
@@ -4207,6 +4582,13 @@ bool cata_tiles::draw_critter_above( const tripoint_bub_ms &p, lit_level ll, int
         return false;
     }
     const Creature &critter = *pcritter;
+
+    // Shadow and attitude icons are UI overlays, not body sprites.
+    // Exclude from tint bounds and tint replay tracking.
+    sprite_screen_bounds *saved_bounds = m_cur_bounds;
+    auto *saved_tint = m_cur_tint_sprites;
+    m_cur_bounds = nullptr;
+    m_cur_tint_sprites = nullptr;
 
     // Draw shadow
     if( draw_from_id_string( "shadow", TILE_CATEGORY::NONE, empty_string, p,
@@ -4245,8 +4627,12 @@ bool cata_tiles::draw_critter_above( const tripoint_bub_ms &p, lit_level ll, int
                                      lit_level::LIT, false, height_3d );
             }
         }
+        m_cur_bounds = saved_bounds;
+        m_cur_tint_sprites = saved_tint;
         return true;
     } else {
+        m_cur_bounds = saved_bounds;
+        m_cur_tint_sprites = saved_tint;
         return false;
     }
 }

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -22,6 +22,7 @@
 
 #include "animation.h"
 #include "calendar.h"
+#include "cata_small_literal_vector.h"
 #include "coordinates.h"
 #include "creature.h"
 #include "cuboid_rectangle.h"
@@ -43,6 +44,8 @@ class memorized_tile;
 class monster;
 class nc_color;
 class pixel_minimap;
+struct sprite_screen_bounds;
+struct tint_sprite_record;
 enum class direction : unsigned int;
 enum class lit_level : uint8_t;
 enum class visibility_type : int;
@@ -134,16 +137,30 @@ class texture
     private:
         std::shared_ptr<SDL_Texture> sdl_texture_ptr;
         SDL_Rect srcrect = { 0, 0, 0, 0 };
+        // Tightest rect containing non-transparent pixels, relative to srcrect origin.
+        // Used for tint overlay bounds so transparent padding is excluded.
+        SDL_Rect opaque_rect = { 0, 0, 0, 0 };
 
     public:
         texture( std::shared_ptr<SDL_Texture> ptr,
                  const SDL_Rect &rect ) : sdl_texture_ptr( std::move( ptr ) ),
-            srcrect( rect ) { }
+            srcrect( rect ), opaque_rect( { 0, 0, rect.w, rect.h } ) { }
+        texture( std::shared_ptr<SDL_Texture> ptr,
+                 const SDL_Rect &rect, const SDL_Rect &opaque ) : sdl_texture_ptr( std::move( ptr ) ),
+            srcrect( rect ), opaque_rect( opaque ) { }
         texture() = default;
 
         /// Returns the width (first) and height (second) of the stored texture.
         std::pair<int, int> dimension() const {
             return std::make_pair( srcrect.w, srcrect.h );
+        }
+        /// Returns the opaque pixel bounding box relative to the sprite origin.
+        const SDL_Rect &get_opaque_rect() const {
+            return opaque_rect;
+        }
+        /// Returns the underlying SDL_Texture pointer (for blend mode changes).
+        const std::shared_ptr<SDL_Texture> &get_texture_ptr() const {
+            return sdl_texture_ptr;
         }
         /// Interface to @ref SDL_RenderCopyEx, using this as the texture, and
         /// the stored source rectangle. Other parameters are simply passed through.
@@ -212,6 +229,7 @@ class tileset
         std::vector<texture> night_tile_values;
         std::vector<texture> overexposed_tile_values;
         std::vector<texture> memory_tile_values;
+        std::vector<texture> silhouette_tile_values;
 
         std::unordered_set<std::string> duplicate_ids;
 
@@ -278,6 +296,9 @@ class tileset
         const texture *get_memory_tile( const size_t index ) const {
             return get_if_available( index, memory_tile_values );
         }
+        const texture *get_silhouette_tile( const size_t index ) const {
+            return get_if_available( index, silhouette_tile_values );
+        }
 
         const std::unordered_set<std::string> &get_duplicate_ids() const {
             return duplicate_ids;
@@ -343,7 +364,8 @@ class tileset_cache::loader
         void ensure_default_item_highlight();
 
         void copy_surface_to_texture( const SDL_Surface_Ptr &surf, const point &offset,
-                                      std::vector<texture> &target );
+                                      std::vector<texture> &target,
+                                      const std::vector<SDL_Rect> &opaque_bounds );
         void create_textures_from_tile_atlas( const SDL_Surface_Ptr &tile_atlas, const point &offset );
 
         void process_variations_after_loading( weighted_int_list<std::vector<int>> &v ) const;
@@ -824,6 +846,20 @@ class cata_tiles
         int screentile_height = 0;
 
         int fog_alpha = 0;
+
+        // During the layer loop, these point to the current tile's tint tracking
+        // state. draw_sprite_at uses them to accumulate screen bounds and record
+        // sprites for later silhouette replay. Only set for ortho tiles that need
+        // tinting; null for iso tiles, UI overlays, and non-tinted tiles.
+        sprite_screen_bounds *m_cur_bounds = nullptr;
+        small_literal_vector<tint_sprite_record, 4> *m_cur_tint_sprites = nullptr;
+
+        // Scratch render target for the ortho silhouette mask tint path. Sized
+        // to fit the largest batched sprite region; reused across tiles/frames.
+        SDL_Texture_Ptr tint_mask_tex;
+        int tint_mask_w = 0;
+        int tint_mask_h = 0;
+        void ensure_tint_mask_texture( int w, int h );
 
         bool in_animation = false;
 

--- a/src/map.h
+++ b/src/map.h
@@ -23,6 +23,7 @@
 #include "active_item_cache.h"
 #include "calendar.h"
 #include "cata_assert.h"
+#include "cata_small_literal_vector.h"
 #include "cata_type_traits.h"
 #include "cata_utility.h"
 #include "colony.h"
@@ -306,11 +307,63 @@ struct drawsq_params {
         //@}
 };
 
+// Accumulated screen-pixel bounding box of all sprites drawn for a single tile
+// during the current frame. Used by the ortho tint overlay to cover the full
+// sprite extent instead of a fixed tile_width x tile_height rect.
+// NOLINTNEXTLINE(cata-xy)
+struct sprite_screen_bounds {
+    int x = 0, y = 0, w = 0, h = 0;
+    bool valid = false;
+    // NOLINTNEXTLINE(cata-large-inline-function,cata-xy)
+    void expand( int rx, int ry, int rw, int rh ) {
+        if( !valid ) {
+            x = rx;
+            y = ry;
+            w = rw;
+            h = rh;
+            valid = true;
+        } else {
+            const int nx = x < rx ? x : rx; // NOLINT(cata-combine-locals-into-point)
+            const int ny = y < ry ? y : ry;
+            const int x2 = ( x + w > rx + rw ) ? x + w : rx + rw;
+            const int y2 = ( y + h > ry + rh ) ? y + h : ry + rh;
+            x = nx;
+            y = ny;
+            w = x2 - nx;
+            h = y2 - ny;
+        }
+    }
+};
+
+// Snapshot of a single sprite draw call, recorded during the layer loop so the
+// ortho tint overlay can replay the sprite as a white silhouette into a mask
+// texture. Captures everything needed to reproduce the draw at the same screen
+// position with the silhouette color filter variant.
+struct tint_sprite_record {
+    int sprite_index;      // index into tileset tile_values / silhouette_tile_values
+    struct { // NOLINT(cata-xy)
+        int x, y, w, h;
+    } destination;         // screen-space destination rect at time of draw
+    double angle;          // rotation angle (0, -90, 90)
+    int flip;              // SDL_RendererFlip cast to int (avoids SDL include)
+};
+
 struct tile_render_info {
     struct common {
         const tripoint_bub_ms pos;
         // accumulator for 3d tallness of sprites rendered here so far;
         int height_3d = 0;
+        // Ortho tint overlay state, populated during the draw prepass and layer
+        // loop. For tiles where needs_tint is true:
+        //   bounds       - union of all content sprite screen rects (opaque only)
+        //   tint_sprites - draw records for silhouette mask replay
+        //   tint_color   - precomputed RGBA tint from the colored light cache
+        sprite_screen_bounds bounds;
+        small_literal_vector<tint_sprite_record, 4> tint_sprites;
+        bool needs_tint = false;
+        struct {
+            uint8_t r, g, b, a;
+        } tint_color = { 0, 0, 0, 0 };
 
         common( const tripoint_bub_ms &pos, const int height_3d )
             : pos( pos ), height_3d( height_3d ) {}

--- a/src/sdl_utils.cpp
+++ b/src/sdl_utils.cpp
@@ -24,6 +24,7 @@ static color_pixel_function_map builtin_color_pixel_functions = {
     { "color_pixel_grayscale", color_pixel_grayscale },
     { "color_pixel_nightvision", color_pixel_nightvision },
     { "color_pixel_overexposed", color_pixel_overexposed },
+    { "color_pixel_silhouette", color_pixel_silhouette },
 };
 
 color_pixel_function_pointer get_color_pixel_function( const std::string &name )

--- a/src/sdl_utils.h
+++ b/src/sdl_utils.h
@@ -37,6 +37,11 @@ SDL_Color color_pixel_grayscale( const SDL_Color &color );
 SDL_Color color_pixel_nightvision( const SDL_Color &color );
 SDL_Color color_pixel_overexposed( const SDL_Color &color );
 SDL_Color color_pixel_darken( const SDL_Color &color );
+// White silhouette preserving alpha. Used as tint mask texture.
+inline SDL_Color color_pixel_silhouette( const SDL_Color &color )
+{
+    return { 255, 255, 255, color.a };
+}
 SDL_Color color_pixel_mixer( const SDL_Color &color, const float &gammav,
                              const SDL_Color &color_a, const SDL_Color &color_b );
 

--- a/src/sdl_wrappers.cpp
+++ b/src/sdl_wrappers.cpp
@@ -126,7 +126,28 @@ void SetTextureBlendMode( const SDL_Texture_Ptr &texture, SDL_BlendMode blendMod
                   "SDL_SetTextureBlendMode failed" );
 }
 
+void SetTextureBlendMode( const std::shared_ptr<SDL_Texture> &texture, SDL_BlendMode blendMode )
+{
+    if( !texture ) {
+        dbg( D_ERROR ) << "Tried to use a null texture";
+        return;
+    }
+    throwErrorIf( SDL_SetTextureBlendMode( texture.get(), blendMode ) != 0,
+                  "SDL_SetTextureBlendMode failed" );
+}
+
 bool SetTextureColorMod( const SDL_Texture_Ptr &texture, Uint32 r, Uint32 g, Uint32 b )
+{
+    if( !texture ) {
+        dbg( D_ERROR ) << "Tried to use a null texture";
+        return true;
+    }
+    return printErrorIf( SDL_SetTextureColorMod( texture.get(), r, g, b ) != 0,
+                         "SDL_SetTextureColorMod failed" );
+}
+
+bool SetTextureColorMod( const std::shared_ptr<SDL_Texture> &texture, Uint32 r, Uint32 g,
+                         Uint32 b )
 {
     if( !texture ) {
         dbg( D_ERROR ) << "Tried to use a null texture";
@@ -197,6 +218,16 @@ SDL_Surface_Ptr CreateRGBSurface( const Uint32 flags, const int width, const int
 }
 
 void SetTextureAlphaMod( const SDL_Texture_Ptr &texture, const Uint8 alpha )
+{
+    if( !texture ) {
+        dbg( D_ERROR ) << "Tried to use a null texture";
+        return;
+    }
+    printErrorIf( SDL_SetTextureAlphaMod( texture.get(), alpha ) != 0,
+                  "SDL_SetTextureAlphaMod failed" );
+}
+
+void SetTextureAlphaMod( const std::shared_ptr<SDL_Texture> &texture, const Uint8 alpha )
 {
     if( !texture ) {
         dbg( D_ERROR ) << "Tried to use a null texture";
@@ -283,6 +314,17 @@ Uint32 MapRGBA( const SDL_Surface_Ptr &surface, const Uint8 r, const Uint8 g, co
         return 0;
     }
     return SDL_MapRGBA( surface->format, r, g, b, a );
+}
+
+void GetRGBA( const Uint32 pixel, const SDL_Surface_Ptr &surface, Uint8 &r, Uint8 &g, Uint8 &b,
+              Uint8 &a )
+{
+    if( !surface ) {
+        dbg( D_ERROR ) << "Tried to get RGBA from a null surface";
+        r = g = b = a = 0;
+        return;
+    }
+    SDL_GetRGBA( pixel, surface->format, &r, &g, &b, &a );
 }
 
 int SetColorKey( const SDL_Surface_Ptr &surface, const int flag, const Uint32 key )

--- a/src/sdl_wrappers.h
+++ b/src/sdl_wrappers.h
@@ -92,7 +92,10 @@ void RenderDrawPoint( const SDL_Renderer_Ptr &renderer, const point &p );
 void RenderFillRect( const SDL_Renderer_Ptr &renderer, const SDL_Rect *rect );
 int FillRect( const SDL_Surface_Ptr &surface, const SDL_Rect *rect, Uint32 color );
 void SetTextureBlendMode( const SDL_Texture_Ptr &texture, SDL_BlendMode blendMode );
+void SetTextureBlendMode( const std::shared_ptr<SDL_Texture> &texture, SDL_BlendMode blendMode );
 bool SetTextureColorMod( const SDL_Texture_Ptr &texture, Uint32 r, Uint32 g, Uint32 b );
+bool SetTextureColorMod( const std::shared_ptr<SDL_Texture> &texture, Uint32 r, Uint32 g,
+                         Uint32 b );
 void SetRenderDrawBlendMode( const SDL_Renderer_Ptr &renderer, SDL_BlendMode blendMode );
 void GetRenderDrawBlendMode( const SDL_Renderer_Ptr &renderer, SDL_BlendMode &blend_mode );
 SDL_Surface_Ptr load_image( const char *path );
@@ -101,6 +104,7 @@ void RenderClear( const SDL_Renderer_Ptr &renderer );
 SDL_Surface_Ptr CreateRGBSurface( Uint32 flags, int width, int height, int depth, Uint32 Rmask,
                                   Uint32 Gmask, Uint32 Bmask, Uint32 Amask );
 void SetTextureAlphaMod( const SDL_Texture_Ptr &texture, Uint8 alpha );
+void SetTextureAlphaMod( const std::shared_ptr<SDL_Texture> &texture, Uint8 alpha );
 void RenderCopyEx( const SDL_Renderer_Ptr &renderer, SDL_Texture *texture,
                    const SDL_Rect *srcrect, const SDL_Rect *dstrect,
                    double angle, const SDL_Point *center, SDL_RendererFlip flip );
@@ -111,6 +115,8 @@ int BlitSurface( const SDL_Surface_Ptr &src, const SDL_Rect *srcrect,
                  const SDL_Surface_Ptr &dst, SDL_Rect *dstrect );
 Uint32 MapRGB( const SDL_Surface_Ptr &surface, Uint8 r, Uint8 g, Uint8 b );
 Uint32 MapRGBA( const SDL_Surface_Ptr &surface, Uint8 r, Uint8 g, Uint8 b, Uint8 a );
+void GetRGBA( Uint32 pixel, const SDL_Surface_Ptr &surface, Uint8 &r, Uint8 &g, Uint8 &b,
+              Uint8 &a );
 int SetColorKey( const SDL_Surface_Ptr &surface, int flag, Uint32 key );
 int SetSurfaceRLE( const SDL_Surface_Ptr &surface, int flag );
 int SetSurfaceBlendMode( const SDL_Surface_Ptr &surface, SDL_BlendMode blendMode );

--- a/tests/tint_overlay_test.cpp
+++ b/tests/tint_overlay_test.cpp
@@ -1,0 +1,186 @@
+#include "cata_catch.h"
+#include "map.h"
+
+// sprite_screen_bounds is defined in map.h, no TILES dependency.
+
+TEST_CASE( "sprite_screen_bounds_first_expand_sets_valid", "[tint_overlay]" )
+{
+    sprite_screen_bounds b;
+    CHECK_FALSE( b.valid );
+    b.expand( 10, 20, 30, 40 );
+    CHECK( b.valid );
+    CHECK( b.x == 10 );
+    CHECK( b.y == 20 );
+    CHECK( b.w == 30 );
+    CHECK( b.h == 40 );
+}
+
+TEST_CASE( "sprite_screen_bounds_disjoint_union", "[tint_overlay]" )
+{
+    sprite_screen_bounds b;
+    b.expand( 0, 0, 10, 10 );
+    b.expand( 20, 20, 10, 10 );
+    // Union should span (0,0) to (30,30)
+    CHECK( b.x == 0 );
+    CHECK( b.y == 0 );
+    CHECK( b.w == 30 );
+    CHECK( b.h == 30 );
+}
+
+TEST_CASE( "sprite_screen_bounds_overlapping_union", "[tint_overlay]" )
+{
+    sprite_screen_bounds b;
+    b.expand( 0, 0, 20, 20 );
+    b.expand( 10, 10, 20, 20 );
+    CHECK( b.x == 0 );
+    CHECK( b.y == 0 );
+    CHECK( b.w == 30 );
+    CHECK( b.h == 30 );
+}
+
+TEST_CASE( "sprite_screen_bounds_nested_rect", "[tint_overlay]" )
+{
+    sprite_screen_bounds b;
+    b.expand( 0, 0, 100, 100 );
+    b.expand( 10, 10, 20, 20 );
+    // Inner rect doesn't change the outer
+    CHECK( b.x == 0 );
+    CHECK( b.y == 0 );
+    CHECK( b.w == 100 );
+    CHECK( b.h == 100 );
+}
+
+TEST_CASE( "sprite_screen_bounds_negative_coords", "[tint_overlay]" )
+{
+    sprite_screen_bounds b;
+    b.expand( -10, -20, 30, 40 );
+    CHECK( b.x == -10 );
+    CHECK( b.y == -20 );
+    b.expand( 5, 5, 10, 10 );
+    // Union: (-10,-20) to (20,20) -> w=30, h=40
+    CHECK( b.x == -10 );
+    CHECK( b.y == -20 );
+    CHECK( b.w == 30 );
+    CHECK( b.h == 40 );
+}
+
+TEST_CASE( "sprite_screen_bounds_idempotent", "[tint_overlay]" )
+{
+    sprite_screen_bounds b;
+    b.expand( 5, 10, 20, 30 );
+    b.expand( 5, 10, 20, 30 );
+    CHECK( b.x == 5 );
+    CHECK( b.y == 10 );
+    CHECK( b.w == 20 );
+    CHECK( b.h == 30 );
+}
+
+#if defined(TILES)
+
+#include "cata_tiles.h"
+
+// Helper: simulate the opaque-bounds-to-destination transform from draw_sprite_at,
+// including flip handling. Returns the bounds that would be accumulated.
+static sprite_screen_bounds simulate_opaque_bounds_transform(
+    const SDL_Rect &destination, const SDL_Rect &opq,
+    int src_w, int src_h, bool flip_h, bool flip_v )
+{
+    SDL_Rect adj = opq;
+    if( flip_h ) {
+        adj.x = src_w - opq.x - opq.w;
+    }
+    if( flip_v ) {
+        adj.y = src_h - opq.y - opq.h;
+    }
+    sprite_screen_bounds b;
+    if( adj.w > 0 && adj.h > 0 ) {
+        b.expand(
+            destination.x + adj.x * destination.w / src_w,
+            destination.y + adj.y * destination.h / src_h,
+            adj.w * destination.w / src_w,
+            adj.h * destination.h / src_h );
+    }
+    return b;
+}
+
+TEST_CASE( "texture_opaque_rect_defaults_to_full_srcrect", "[tint_overlay]" )
+{
+    // 2-arg constructor: opaque rect should default to full sprite dimensions.
+    texture tex( nullptr, SDL_Rect{ 0, 0, 32, 64 } );
+    const SDL_Rect &opq = tex.get_opaque_rect();
+    CHECK( opq.x == 0 );
+    CHECK( opq.y == 0 );
+    CHECK( opq.w == 32 );
+    CHECK( opq.h == 64 );
+}
+
+TEST_CASE( "texture_opaque_rect_stores_custom_bounds", "[tint_overlay]" )
+{
+    // 3-arg constructor: opaque rect should reflect the alpha-trimmed box.
+    texture tex( nullptr, SDL_Rect{ 0, 0, 32, 64 }, SDL_Rect{ 4, 8, 24, 48 } );
+    const SDL_Rect &opq = tex.get_opaque_rect();
+    CHECK( opq.x == 4 );
+    CHECK( opq.y == 8 );
+    CHECK( opq.w == 24 );
+    CHECK( opq.h == 48 );
+}
+
+TEST_CASE( "texture_opaque_rect_empty_for_transparent_sprite", "[tint_overlay]" )
+{
+    texture tex( nullptr, SDL_Rect{ 0, 0, 32, 32 }, SDL_Rect{ 0, 0, 0, 0 } );
+    const SDL_Rect &opq = tex.get_opaque_rect();
+    CHECK( opq.w == 0 );
+    CHECK( opq.h == 0 );
+}
+
+TEST_CASE( "opaque_bounds_transform_no_flip", "[tint_overlay]" )
+{
+    // 32x64 sprite, opaque region is the bottom 32x32 (character body, no head padding).
+    const SDL_Rect dest = { 100, 50, 64, 128 }; // 2x scaled
+    const SDL_Rect opq = { 0, 32, 32, 32 };     // bottom half in source
+    const sprite_screen_bounds b = simulate_opaque_bounds_transform( dest, opq, 32, 64, false, false );
+    CHECK( b.valid );
+    CHECK( b.x == 100 );       // no x offset (opq.x == 0)
+    CHECK( b.y == 50 + 64 );   // opq.y=32 scaled by 128/64 = 64
+    CHECK( b.w == 64 );        // opq.w=32 scaled by 64/32 = 64
+    CHECK( b.h == 64 );        // opq.h=32 scaled by 128/64 = 64
+}
+
+TEST_CASE( "opaque_bounds_transform_horizontal_flip", "[tint_overlay]" )
+{
+    // Asymmetric sprite: opaque pixels on the left side only.
+    const SDL_Rect dest = { 100, 50, 64, 64 };
+    const SDL_Rect opq = { 0, 0, 16, 32 };  // left quarter in source
+    const sprite_screen_bounds b = simulate_opaque_bounds_transform( dest, opq, 32, 32, true, false );
+    CHECK( b.valid );
+    // After H-flip: opq.x = 32 - 0 - 16 = 16, scaled: 16*64/32 = 32
+    CHECK( b.x == 100 + 32 );
+    CHECK( b.y == 50 );
+    CHECK( b.w == 32 );  // 16*64/32
+    CHECK( b.h == 64 );  // 32*64/32
+}
+
+TEST_CASE( "opaque_bounds_transform_both_flips", "[tint_overlay]" )
+{
+    // Asymmetric sprite: opaque pixels in top-left corner.
+    const SDL_Rect dest = { 0, 0, 64, 128 };
+    const SDL_Rect opq = { 0, 0, 16, 32 };  // top-left in source (32x64)
+    const sprite_screen_bounds b = simulate_opaque_bounds_transform( dest, opq, 32, 64, true, true );
+    CHECK( b.valid );
+    // After H-flip: opq.x = 32 - 0 - 16 = 16
+    // After V-flip: opq.y = 64 - 0 - 32 = 32
+    CHECK( b.x == 0 + 16 * 64 / 32 );  // 32
+    CHECK( b.y == 0 + 32 * 128 / 64 ); // 64
+    CHECK( b.w == 16 * 64 / 32 );       // 32
+    CHECK( b.h == 32 * 128 / 64 );      // 64
+}
+
+TEST_CASE( "opaque_bounds_transform_empty_opaque_rect", "[tint_overlay]" )
+{
+    const SDL_Rect dest = { 100, 50, 64, 64 };
+    const SDL_Rect opq = { 0, 0, 0, 0 };
+    const sprite_screen_bounds b = simulate_opaque_bounds_transform( dest, opq, 32, 32, false, false );
+    CHECK_FALSE( b.valid );
+}
+
+#endif // TILES


### PR DESCRIPTION
#### Summary
Interface "Pixel-accurate colored light tint overlay for ortho mode"

#### Purpose of change

The colored light tint overlay (beacons, colored fields, dawn/dusk) draws a flat rect over each tinted tile. In ortho mode with tall sprites (32x64 characters, multi-layer gear), this shows color seams at the tile boundary and rectangular halos around transparent padding.

#### Describe the solution

Hybrid tint path for ortho. Simple tiles whose sprites fit inside the tile footprint still get a cheap colored rect. Complex tiles with oversized sprites use a per-pixel silhouette mask instead: recorded sprites are replayed as white silhouettes (RGB=255, original alpha) into a scratch render target, then composited back with the tint color.

- Silhouette textures (6th color filter variant) and per-sprite opaque bounding boxes computed once at tileset load
- Tint eligibility precomputed in a per-tile prepass so the overlay iterates only eligible tiles
- Contiguous same-color complex tiles batched into one mask/composite with a union area growth cap
- `small_literal_vector<4>` for per-tile sprite records avoids heap allocation in the common case

Iso mode keeps the existing flat rect tint unchanged.

#### Describe alternatives you've considered

Proper fix would be to move to SDL3 shaders, but that's a larger effort. This works within SDL2's render target API.

#### Testing

Unit tests for the new data structures. Perf profiled near beacons, no measurable regression.

Before: 
<img width="770" height="645" alt="image" src="https://github.com/user-attachments/assets/5ceb6bb5-40de-46ba-afcd-86fe41ddd46c" />

After:
<img width="728" height="615" alt="image" src="https://github.com/user-attachments/assets/5deaf5c0-d970-42e0-af55-3cc331f7ebc1" />


#### Additional context

Only addresses ortho mode. Iso has its own set of issues (diamond footprint mismatch) that need separate treatment.