### PR TITLE
Fix null ammo_data dereferences in NPC reload and turret code

### DIFF
--- a/src/item_gun_tool_ammo.cpp
+++ b/src/item_gun_tool_ammo.cpp
@@ -1455,10 +1455,12 @@ int item::remaining_ammo_capacity() const
 
     const itype *loaded_ammo = ammo_data();
     if( loaded_ammo == nullptr ) {
-        return ammo_capacity( item::find_type( ammo_default() )->ammo->type ) - ammo_remaining( );
-    } else {
-        return ammo_capacity( loaded_ammo->ammo->type ) - ammo_remaining( );
+        loaded_ammo = item::find_type( ammo_default() );
     }
+    if( !loaded_ammo || !loaded_ammo->ammo ) {
+        return 0;
+    }
+    return ammo_capacity( loaded_ammo->ammo->type ) - ammo_remaining( );
 }
 
 int item::ammo_capacity( const ammotype &ammo, bool include_linked ) const

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -5955,8 +5955,7 @@ void npc::do_reload( const item_location &it )
     item &target = const_cast<item &>( *reload_opt.target );
     item_location &usable_ammo = reload_opt.ammo;
 
-    int qty = std::max( 1, std::min( usable_ammo->charges,
-                                     it->ammo_capacity( usable_ammo->ammo_data()->ammo->type ) - it->ammo_remaining( ) ) );
+    int qty = reload_opt.qty();
     int reload_time = item_reload_cost( *it, *usable_ammo, qty );
     // TODO: Consider printing this info to player too
     const std::string ammo_name = usable_ammo->tname();

--- a/src/turret.cpp
+++ b/src/turret.cpp
@@ -223,8 +223,7 @@ bool turret_data::can_reload() const
     if( part->base.ammo_remaining( ) == 0 ) {
         return true;
     }
-    return part->base.ammo_remaining( ) <
-           part->base.ammo_capacity( part->base.ammo_data()->ammo->type );
+    return part->base.remaining_ammo_capacity() > 0;
 }
 
 bool turret_data::can_unload() const


### PR DESCRIPTION
#### Summary
Bugfixes "Fix segfault in NPC reload when ammo has no ammo_data"

#### Purpose of change

NPC tries to reload a container with food (e.g. peanut butter), `select_ammo` returns it as valid ammo, then `do_reload` calls `usable_ammo->ammo_data()->ammo->type` which segfaults because comestibles have no `islot_ammo`. Same unguarded `ammo_data()->ammo->type` pattern exists in `turret_data::can_reload` and `item::remaining_ammo_capacity`.

#### Describe the solution

- `npc::do_reload`: use `reload_option::qty()` which already handles all reload types correctly (containers, speedloaders, liquids, regular ammo) instead of reimplementing the quantity computation with raw `ammo_data()` access.
- `turret_data::can_reload`: replace `ammo_remaining() < ammo_capacity(ammo_data()->ammo->type)` with `remaining_ammo_capacity() > 0`.
- `item::remaining_ammo_capacity`: add null guards for `ammo_data()` and `islot_ammo`, return 0 instead of crashing.

#### Describe alternatives you've considered

Could guard `select_ammo` to never return non-ammo items, but container reloads are a legitimate use of the reload system -- the problem is `do_reload` assuming gun/tool-only ammo.

#### Testing

Reproduced the crash with a save where an NPC companion attempts to reload a container with peanut butter. After the fix, the NPC reload proceeds without crashing.

#### Additional context

N/A