### PR TITLE
Enable NPC mop tool fetching for zone mopping activity

### DIFF
--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -354,6 +354,12 @@
     "components": [ [ [ "qt_wire", 1 ] ] ]
   },
   {
+    "id": "mopping_standard",
+    "type": "requirement",
+    "//": "mopping",
+    "qualities": [ { "id": "MOP", "level": 1 } ]
+  },
+  {
     "id": "mining_standard",
     "type": "requirement",
     "//": "mining",

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -180,6 +180,9 @@ class multi_mop_activity_actor : public multi_zone_activity_actor
         std::unordered_set<tripoint_abs_ms> multi_activity_locations( Character &you ) override;
         activity_reason_info multi_activity_can_do( Character &you,
                 const tripoint_bub_ms &src_loc ) override;
+        std::optional<requirement_id> multi_activity_requirements( Character &you,
+                activity_reason_info &act_info, const tripoint_bub_ms &src_loc,
+                const zone_data *zone = nullptr ) override;
         bool multi_activity_do( Character &you, const activity_reason_info &act_info,
                                 const tripoint_abs_ms &src, const tripoint_bub_ms &src_loc ) override;
         std::unique_ptr<activity_actor> clone() const override {

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -121,6 +121,7 @@ static const quality_id qual_SAW_W( "SAW_W" );
 static const quality_id qual_WELD( "WELD" );
 
 static const requirement_id requirement_data_mining_standard( "mining_standard" );
+static const requirement_id requirement_data_mopping_standard( "mopping_standard" );
 static const requirement_id requirement_data_multi_butcher( "multi_butcher" );
 static const requirement_id requirement_data_multi_butcher_big( "multi_butcher_big" );
 static const requirement_id requirement_data_multi_chopping_planks( "multi_chopping_planks" );
@@ -2484,6 +2485,7 @@ bool activity_reason_continue( do_activity_reason reason )
         reason == do_activity_reason::NEEDS_TREE_CHOPPING ||
         reason == do_activity_reason::NEEDS_FISHING ||
         reason == do_activity_reason::NEEDS_MINING ||
+        reason == do_activity_reason::NEEDS_MOP ||
         reason == do_activity_reason::NEEDS_CRAFT ||
         reason == do_activity_reason::NEEDS_DISASSEMBLE;
 }
@@ -2500,7 +2502,8 @@ bool activity_reason_picks_up_tools( do_activity_reason reason )
         reason == do_activity_reason::NEEDS_VEH_DECONST ||
         reason == do_activity_reason::NEEDS_VEH_REPAIR ||
         reason == do_activity_reason::NEEDS_TREE_CHOPPING ||
-        reason == do_activity_reason::NEEDS_MINING;
+        reason == do_activity_reason::NEEDS_MINING ||
+        reason == do_activity_reason::NEEDS_MOP;
 }
 
 bool activity_must_be_in_zone( activity_id act_id, const tripoint_bub_ms &src_loc )
@@ -3879,6 +3882,15 @@ bool multi_mine_activity_actor::multi_activity_do( Character &you,
         }
     }
     return true;
+}
+
+std::optional<requirement_id> multi_mop_activity_actor::multi_activity_requirements( Character &,
+        activity_reason_info &act_info, const tripoint_bub_ms &, const zone_data * )
+{
+    if( act_info.reason == do_activity_reason::NEEDS_MOP ) {
+        return requirement_data_mopping_standard;
+    }
+    return requirement_id::NULL_ID();
 }
 
 bool multi_mop_activity_actor::multi_activity_do( Character &you,


### PR DESCRIPTION
#### Summary
Bugfixes "Fix NPCs failing to mop when mop is not in inventory"

#### Purpose of change

NPCs assigned to mop zones always fail with "no required zone was found" when they don't have a mop in their inventory. The NPC finds moppable tiles (blood, spills) but `NEEDS_MOP` isn't in `activity_reason_continue`, so the framework silently skips every moppable tile instead of entering the fetch path. Even if `NEEDS_MOP` were in the continue list, the base `multi_activity_requirements` returns nullopt for mop, causing another silent skip.

Every other tool-needing activity (mining, chopping, butchering, etc.) has all three pieces wired up. Mopping was missing all of them.

#### Describe the solution

- Add `NEEDS_MOP` to `activity_reason_continue` so the framework enters the fetch path instead of giving up.
- Add `NEEDS_MOP` to `activity_reason_picks_up_tools` so the NPC searches loot zones for a mop.
- Add `mopping_standard` JSON requirement (MOP quality level 1).
- Add `multi_mop_activity_actor::multi_activity_requirements` override returning that requirement when `NEEDS_MOP`.

#### Describe alternatives you've considered

N/A

#### Testing

Tested in-game with NPC camp worker assigned to mop zone with blood stains, mop available in a nearby loot zone. Before the fix: "no required zone was found". After: NPC fetches the mop and mops.

#### Additional context

N/A