### PR TITLE
Add pre-rasterized scaled GUI fonts (1.5x, 2x)

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -1,5 +1,7 @@
 #include "cata_imgui.h"
 
+#include <cmath>
+
 #define IMGUI_DEFINE_MATH_OPERATORS
 #include <imgui/imgui.h>
 #include <imgui/imgui_internal.h>
@@ -380,10 +382,14 @@ static void AddGlyphRangesMisc( UNUSED ImFontGlyphRangesBuilder *b )
 // Load all fonts that exist in typefaces list
 // - typefaces is a list of paths.
 static void load_font( ImGuiIO &io, const std::vector<font_config> &typefaces,
-                       const ImWchar *ranges )
+                       const ImWchar *ranges, float font_size = 0.0f )
 {
     std::vector<font_config> io_typefaces{ typefaces };
     ensure_unifont_loaded( io_typefaces );
+
+    if( font_size <= 0.0f ) {
+        font_size = fontheight;
+    }
 
     ImFontConfig config = ImFontConfig();
 
@@ -395,7 +401,7 @@ static void load_font( ImGuiIO &io, const std::vector<font_config> &typefaces,
         } else {
             config.MergeMode = !first;
             config.FontBuilderFlags = it->imgui_config();
-            io.Fonts->AddFontFromFileTTF( it->path.c_str(), fontheight, &config, ranges );
+            io.Fonts->AddFontFromFileTTF( it->path.c_str(), font_size, &config, ranges );
             first = false;
         }
     }
@@ -445,17 +451,22 @@ void cataimgui::client::load_fonts( UNUSED const Font_Ptr &gui_font,
         ImVector<ImWchar> ranges;
         b.BuildRanges( &ranges );
 
+        // Fonts[0] = gui, Fonts[1] = mono, Fonts[2] = gui 1.5x, Fonts[3] = gui 2x
         load_font( io, gui_typefaces, ranges.begin() );
         load_font( io, mono_typefaces, ranges.begin() );
-        io.Fonts->Fonts[0]->SetFallbackStrSizeCallback( GetFallbackStrWidth );
-        io.Fonts->Fonts[0]->SetFallbackCharSizeCallback( GetFallbackCharWidth );
-        io.Fonts->Fonts[0]->SetRenderFallbackCharCallback( CanRenderFallbackChar );
-        io.Fonts->Fonts[1]->SetFallbackStrSizeCallback( GetFallbackStrWidth );
-        io.Fonts->Fonts[1]->SetFallbackCharSizeCallback( GetFallbackCharWidth );
-        io.Fonts->Fonts[1]->SetRenderFallbackCharCallback( CanRenderFallbackChar );
+        load_font( io, gui_typefaces, ranges.begin(),
+                   static_cast<float>( lroundf( fontheight * 1.5f ) ) );
+        load_font( io, gui_typefaces, ranges.begin(),
+                   static_cast<float>( fontheight * 2 ) );
+        for( int i = 0; i < io.Fonts->Fonts.Size; i++ ) {
+            io.Fonts->Fonts[i]->SetFallbackStrSizeCallback( GetFallbackStrWidth );
+            io.Fonts->Fonts[i]->SetFallbackCharSizeCallback( GetFallbackCharWidth );
+            io.Fonts->Fonts[i]->SetRenderFallbackCharCallback( CanRenderFallbackChar );
+        }
         io.Fonts->Build();
-        check_font( io.Fonts->Fonts[0] );
-        check_font( io.Fonts->Fonts[1] );
+        for( int i = 0; i < io.Fonts->Fonts.Size; i++ ) {
+            check_font( io.Fonts->Fonts[i] );
+        }
         ImGui::SetCurrentFont( ImGui::GetDefaultFont() );
         ImGui_ImplSDLRenderer2_SetFallbackGlyphDrawCallback( [&]( const ImFontGlyphToDraw & glyph ) {
             std::string uni_string = std::string( glyph.uni_str );
@@ -1084,6 +1095,20 @@ void cataimgui::PushMonoFont()
 {
 #ifdef TILES
     ImGui::PushFont( ImGui::GetIO().Fonts->Fonts[1] );
+#endif
+}
+
+void cataimgui::PushGuiFont1_5x()
+{
+#ifdef TILES
+    ImGui::PushFont( ImGui::GetIO().Fonts->Fonts[2] );
+#endif
+}
+
+void cataimgui::PushGuiFont2x()
+{
+#ifdef TILES
+    ImGui::PushFont( ImGui::GetIO().Fonts->Fonts[3] );
 #endif
 }
 

--- a/src/cata_imgui.h
+++ b/src/cata_imgui.h
@@ -162,6 +162,8 @@ bool InputFloat( const char *label, float *v, float step = 0.0f, float step_fast
 
 void PushGuiFont();
 void PushMonoFont();
+void PushGuiFont1_5x();
+void PushGuiFont2x();
 
 bool BeginRightAlign( const char *str_id );
 void EndRightAlign();

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -943,7 +943,7 @@ void crafting_ui_impl::draw_recipe_info_panel()
         // Line 1: recipe name with inline batch controls [-] name [xN] [+]
         {
             const std::string recipe_name = recp.result_name( true );
-            ImGui::SetWindowFontScale( 1.4f );
+            cataimgui::PushGuiFont1_5x();
             float region_w = ImGui::GetContentRegionAvail().x;
             float space = ImGui::CalcTextSize( " " ).x;
 
@@ -994,7 +994,7 @@ void crafting_ui_impl::draw_recipe_info_panel()
                 }
             }
 
-            ImGui::SetWindowFontScale( 1.0f );
+            ImGui::PopFont();
         }
 
         // Batch size for all subsequent calculations


### PR DESCRIPTION
#### Summary
Interface "Add pre-rasterized scaled ImGui fonts instead of bitmap scaling"

#### Purpose of change

`SetWindowFontScale()` is marked `[OBSOLETE]` in ImGui. It stretches bitmap glyphs and produces blurry text. The crafting GUI uses it at 1.4x for the recipe title.

#### Describe the solution

Load the GUI font into the atlas at 1.5x and 2x `fontheight` during `load_fonts()`. Add `PushGuiFont1_5x()` and `PushGuiFont2x()` helpers. Replace `SetWindowFontScale(1.4f)` in the crafting GUI with `PushGuiFont1_5x()`.

#### Describe alternatives you've considered

Keep using `SetWindowFontScale()`. It works but the text is blurry and the API is obsolete.

#### Testing

Opened crafting GUI, recipe title renders without blur at the larger size.
Pre:
<img width="608" height="124" alt="image" src="https://github.com/user-attachments/assets/5c936edc-f297-45c3-ae72-8cdcfffa6f0d" />

Post:
<img width="574" height="124" alt="image" src="https://github.com/user-attachments/assets/39118885-282f-4d8f-a955-37a6505b2425" />


#### Additional context

Extra atlas entries add some texture memory proportional to glyph count and size. Mostly relevant for CJK languages, negligible for Latin.