### PR TITLE
Expand craft details by default in new ImGui Crafting Menu

### DIFF
--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -440,7 +440,7 @@ class crafting_ui_impl : public cataimgui::window
         int manual_batch = 1;
         bool show_hidden = false;
         bool is_wide = false;
-        bool details_expanded = false;
+        bool details_expanded = true;
         bool steps_expanded = true;
 
         // --- Scroll state ---


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.  
-->

#### Summary
Interface "Change craft information in new ImGui Crafting Menu to match previous menu."

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

The new ImGui crafting menu has crafting details of a project collapsed by default.  This is different from the previous iteration of the menu where this information was shown by default.

Many of these details are vital when a user is deciding on a craft project and thus should be shown by default.  Example being if the user is trying to level up a specific skill and they need to know if the project  can help them improve said skill by knowing the skill level requirement.  Also if they are trying to gain specific proficiencies they can easily see if the craft will help them advance those.  Overall I would say it is good to have more information available to the user.

#### Describe the solution

Change the default behavior of crafting menu to show details, thus matching the previous implementation.

#### Describe alternatives you've considered

Expansion of this could be an option in the Settings menu where the user could select the default behavior.

#### Testing

Compiled in Windows.  Opened up the crafting menu to verify  details were expanded by default.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
