### PR TITLE
Give `trunk` vehiclepart the `FURNITURE_TIEDOWN` flag

### DIFF
--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -746,7 +746,7 @@
       },
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "5 m", "using": [ [ "repair_welding_lc_steel", 3 ] ] }
     },
-    "flags": [ "CARGO", "LOCKABLE_CARGO", "COVERED", "BOARDABLE", "SIMPLE_PART" ],
+    "flags": [ "CARGO", "LOCKABLE_CARGO", "COVERED", "BOARDABLE", "SIMPLE_PART", "FURNITURE_TIEDOWN" ],
     "breaks_into": "ig_vp_frame",
     "damage_reduction": { "all": 30 },
     "variants": [ { "symbols": "H", "symbols_broken": "#" } ]


### PR DESCRIPTION


#### Summary
None

#### Purpose of change

Give the `trunk` vehicle part the `FURNITURE_TIEDOWN` flag so it can also can have furniture on it. @RenechCDDA don't have strong objections about it so that's the best approval i can get for this.


#### Describe the solution

Put said flag into the trunk's `"flags"` field.

#### Describe alternatives you've considered

some kinda modified trunk?

#### Testing
![Screenshot_20260405_232103](https://github.com/user-attachments/assets/cd7a2624-4c47-4c9f-abe0-571d923542c4)


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
