### PR TITLE
Improve expanded component view in new ImGui Crafting Menu

### DIFF
--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1843,13 +1843,13 @@ void crafting_ui_impl::draw_components( const requirement_data &req,
         if( is_expanded ) {
             ImGui::TextColored( cataimgui::imvec4_from_color( c_white ), "%s", bullet.c_str() );
             float indent = ImGui::CalcTextSize( "    " ).x;
-            for ( size_t i = 0; i < sorted_alts.size(); ++i ) {
+            for( size_t i = 0; i < sorted_alts.size(); ++i ) {
                 const item_comp *ic = sorted_alts[i];
                 // Draw the first item on the same line as the bullet, then indent the rest
-                if ( i == 0 ) {
+                if( i == 0 ) {
                     ImGui::SameLine( 0, 0 );
                 }
-                if ( i == 1) {
+                if( i == 1 ) {
                     ImGui::Indent( indent );
                 }
                 nc_color col = ic->get_color( any_available, crafting_inv, filter, batch_size );

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1842,9 +1842,16 @@ void crafting_ui_impl::draw_components( const requirement_data &req,
 
         if( is_expanded ) {
             ImGui::TextColored( cataimgui::imvec4_from_color( c_white ), "%s", bullet.c_str() );
-            float indent = ImGui::CalcTextSize( "      " ).x;
-            ImGui::Indent( indent );
-            for( const item_comp *ic : sorted_alts ) {
+            float indent = ImGui::CalcTextSize( "    " ).x;
+            for ( size_t i = 0; i < sorted_alts.size(); ++i ) {
+                const item_comp *ic = sorted_alts[i];
+                // Draw the first item on the same line as the bullet, then indent the rest
+                if ( i == 0 ) {
+                    ImGui::SameLine( 0, 0 );
+                }
+                if ( i == 1) {
+                    ImGui::Indent( indent );
+                }
                 nc_color col = ic->get_color( any_available, crafting_inv, filter, batch_size );
                 ImGui::TextColored( cataimgui::imvec4_from_color( col ), "%s",
                                     ic->to_string( batch_size, avail_count( *ic ) ).c_str() );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Interface "Improve appearance of listed components when they are expanded in new Crafting Menu"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

In the new ImGui Crafting Menu when the list of a specific components is expanded, a bullet point is drawn followed by a newline and then the first ingredient.  Appearance wise it looks visually off and wastes a line of spacing.

#### Describe the solution

Draw the first item immediately after the bullet point and indent the rest as before.

Before:
<img width="726" height="620" alt="Screenshot 2026-04-05 191626" src="https://github.com/user-attachments/assets/0f468764-aae1-45c1-b9c0-befc5f721656" />

After:
<img width="719" height="846" alt="Screenshot 2026-04-05 190103" src="https://github.com/user-attachments/assets/c4e6ae72-6bc0-4b2b-a0d9-72ea22956c35" />

#### Describe alternatives you've considered

None.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

Compiled in Windows and opened up crafting menu to verify change.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
