### PR TITLE
Fix drystone and brick roof terrain

### DIFF
--- a/data/json/furniture_and_terrain/terrain-floors-indoor.json
+++ b/data/json/furniture_and_terrain/terrain-floors-indoor.json
@@ -171,7 +171,7 @@
     "connect_groups": [ "BRICKFLOOR", "INDOORFLOOR" ],
     "connects_to": "BRICKFLOOR",
     "move_cost": 2,
-    "roof": "t_rock_roof",
+    "roof": "t_brick_roof",
     "flags": [ "TRANSPARENT", "INDOORS", "COLLAPSES", "SUPPORTS_ROOF", "FLAT", "ROAD" ],
     "bash": { "ter_set": "t_null", "str_min": 75, "str_max": 400, "str_min_supported": 100, "bash_below": true }
   },

--- a/data/json/furniture_and_terrain/terrain-roofs.json
+++ b/data/json/furniture_and_terrain/terrain-roofs.json
@@ -206,6 +206,30 @@
   },
   {
     "type": "terrain",
+    "id": "t_drystone_roof",
+    "name": "drystone roof",
+    "description": "A section of sturdy rooftop made of tightly-fitted stone tiles without mortar.",
+    "looks_like": "t_rock_roof",
+    "symbol": ".",
+    "color": "brown",
+    "move_cost": 2,
+    "flags": [ "TRANSPARENT", "FLAT" ],
+    "bash": {
+      "str_min": 48,
+      "str_max": 80,
+      "sound": "crash!",
+      "sound_fail": "whump!",
+      "ter_set": "t_null",
+      "bash_below": false,
+      "items": [
+        { "item": "field_stone", "count": [ 500, 800 ] },
+        { "item": "rock", "count": [ 200, 400 ] },
+        { "item": "pebble", "count": [ 100, 200 ] }
+      ]
+    }
+  },
+  {
+    "type": "terrain",
     "id": "t_warped_roof",
     "name": "warped roof",
     "description": "A section of flat, stone-like rooftop.  It is patterned with grooves and lines that constantly shift.",

--- a/data/json/furniture_and_terrain/terrain-walls.json
+++ b/data/json/furniture_and_terrain/terrain-walls.json
@@ -2220,6 +2220,7 @@
     "name": "field stone wall",
     "looks_like": "t_rock_wall",
     "description": "A sturdy, dry stone wall.  Just rocks fitted together without mortar.",
+    "roof": "t_drystone_roof",
     "bash": {
       "str_min": 50,
       "str_max": 200,


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

Man-made drystone and brick walls currently have a natural rock roof by default. It's more appropriate for these artificial walls to have matching roofs.

Closes #73316.

#### Describe the solution

Man-made drystone and brick walls copy from abstract wall definitions and thus inherit a natural rock roof. I've fixed this by overriding the drystone and brick wall roofs with a more specific value. I defined a new drystone roof for this purpose, since one didn't already exist. The brick roof already exists, so I updated the brick wall definition to use a more appropriate roof.

#### Describe alternatives you've considered

I considered changing the description of the rock roof to remove the word "natural" and make it more generic, but it's pretty consistently used in other terrain definitions (such as in underground mud, dirt, and sand floors) as natural rock.

#### Testing

The changes are trivial and don't require playtesting.

#### Additional context

While the original issue (#73316) seems to use the term "rock" to describe things like naturally formed minerals and "stone" to describe man-made constructions using rock materials, the terms "rock" and "stone" are used interchangeably throughout the data.
