### PR TITLE
Snippets in loading screen + minor refactor of loading ui

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -259,6 +259,11 @@ ImVec4 cataimgui::imvec4_from_color( const nc_color &color )
              static_cast<float>( c.a / 255. ) };
 }
 
+ImU32 cataimgui::ImU32_from_color( const nc_color &color )
+{
+    return ImGui::GetColorU32( cataimgui::imvec4_from_color( color ) );
+}
+
 cataimgui::client::client( const SDL_Renderer_Ptr &sdl_renderer, const SDL_Window_Ptr &sdl_window,
                            const GeometryRenderer_Ptr &sdl_geometry ) :
     sdl_renderer( sdl_renderer ),
@@ -937,6 +942,27 @@ size_t cataimgui::window::str_height_to_pixels( size_t len )
 #else
     return len;
 #endif
+}
+
+size_t cataimgui::get_string_width( const std::string_view str )
+{
+    return str.size() * ImGui::CalcTextSize( " " ).x;
+}
+
+size_t cataimgui::get_string_height( const std::string_view str, const float wrap_width )
+{
+    const std::string new_str = remove_color_tags( str );
+    size_t chars_per_line = size_t( wrap_width );
+    if( chars_per_line == 0 ) {
+        chars_per_line = SIZE_MAX;
+    }
+#ifndef TUI
+    size_t char_width = size_t( ImGui::CalcTextSize( " " ).x );
+    chars_per_line /= char_width;
+#endif
+    const std::vector<std::string> folded_msg = foldstring( new_str, chars_per_line );
+
+    return folded_msg.size() * ImGui::GetTextLineHeightWithSpacing();
 }
 
 void cataimgui::window::mark_resized()

--- a/src/cata_imgui.h
+++ b/src/cata_imgui.h
@@ -63,6 +63,10 @@ enum class scroll : int {
     page_down
 };
 
+// smallest supported resolution, in px
+constexpr int min_screen_res_x = 640;
+constexpr int min_screen_res_y = 384;
+
 class client
 {
         std::vector<int> cata_input_trail;
@@ -102,6 +106,8 @@ void imvec2_to_point( ImVec2 *src, point *dest );
 
 ImVec4 imvec4_from_color( const nc_color &color );
 
+ImU32 ImU32_from_color( const nc_color &color );
+
 void set_scroll( scroll &s );
 
 void draw_colored_text( const std::string &original_text, const nc_color &color,
@@ -113,6 +119,11 @@ void draw_colored_text( const std::string &original_text, nc_color &color,
 void draw_colored_text( const std::string &original_text,
                         float wrap_width = 0.0F, bool *is_selected = nullptr,
                         bool *is_focused = nullptr, bool *is_hovered = nullptr );
+
+// calculates how much space the text takes horizontally, in pixels, without color tags
+size_t get_string_width( std::string_view str );
+// calculates how much space the text takes vertically, in pixels, including the wrapping
+size_t get_string_height( std::string_view str, float wrap_width );
 
 class window
 {

--- a/src/loading_ui.cpp
+++ b/src/loading_ui.cpp
@@ -1,9 +1,10 @@
 #include "loading_ui.h"
 
 #include "cached_options.h"
-#include "options.h"
 #include "input.h"
+#include "options.h"
 #include "output.h"
+#include "text_snippets.h"
 #include "ui_manager.h"
 
 #if defined(TILES)
@@ -14,6 +15,8 @@
 #include "path_info.h"
 #include "sdltiles.h"
 #include "sdl_wrappers.h"
+#include "cata_imgui.h"
+#include "text_snippets.h"
 #include "worldfactory.h"
 #else
 #include "cursesdef.h"
@@ -32,6 +35,14 @@ struct ui_state {
     std::vector<std::string> splash;
     std::string blanks;
 #endif
+    float hint_height;
+    float loading_msg_height;
+    // height of all the text that will be shown below the splash screen, tip + loading msg
+    float text_height;
+    // if screen resolution is large enough, we will increase the size of snippet text by 1.5x
+    bool large_hint_size;
+    // actual tip we generated from the tip list
+    std::string tip;
     std::string context;
     std::string step;
 };
@@ -41,23 +52,47 @@ static ui_state *gLUI = nullptr;
 static void redraw()
 {
 #ifdef TILES
-    ImVec2 pos = { 0.5f, 0.5f };
-    ImGui::SetNextWindowPos( ImGui::GetMainViewport()->Size * pos, ImGuiCond_Always, { 0.5f, 0.5f } );
-    ImGui::SetNextWindowSize( gLUI->window_size );
-    ImGui::PushStyleVar( ImGuiStyleVar_WindowBorderSize, 0.0f );
-    ImGui::PushStyleColor( ImGuiCol_WindowBg, { 0.0f, 0.0f, 0.0f, 1.0f } );
+    ImGui::SetNextWindowSize( ImGui::GetMainViewport()->Size );
+    ImGui::SetNextWindowPos( {-1, -1}, ImGuiCond_Always );
     if( ImGui::Begin( "Loading…", nullptr,
                       ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove |
                       ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoSavedSettings ) ) {
+
+        const float width = ImGui::GetContentRegionAvail().x;
+
+        // image
+        const float center_x = ImGui::GetMainViewport()->Size.x / 2;
+        const float image_start_pos_x = center_x - ( gLUI->splash_size.x / 2 );
+        ImGui::SetCursorPosX( image_start_pos_x );
         ImGui::Image( reinterpret_cast<ImTextureID>( gLUI->splash.get() ), gLUI->splash_size );
-        float w = ImGui::CalcTextSize( gLUI->context.c_str() ).x + ImGui::CalcTextSize( " " ).x +
-                  ImGui::CalcTextSize( gLUI->step.c_str() ).x;
-        ImGui::SetCursorPosX( ( ( ImGui::GetWindowWidth() - w ) * 0.5f ) );
-        ImGui::Text( "%s %s", gLUI->context.c_str(), gLUI->step.c_str() );
+
+        // hint
+        ImGui::SetCursorPosY( ImGui::GetWindowHeight() - gLUI->text_height );
+        if( gLUI->large_hint_size ) {
+            cataimgui::PushGuiFont1_5x();
+        }
+        const float tip_width = cataimgui::get_string_width( gLUI->tip );
+        // center align
+        ImGui::SetCursorPosX( std::max( ( width / 2.f ) - ( tip_width / 2.f ),
+                                        ImGui::GetStyle().WindowPadding.x ) );
+        const std::string hint = string_format( "%s", colorize( gLUI->tip, c_cyan ) );
+
+        cataimgui::draw_colored_text( hint, width );
+        if( gLUI->large_hint_size ) {
+            ImGui::PopFont();
+        }
+
+        // loading msg
+        ImGui::SetCursorPosY( ImGui::GetWindowHeight() - gLUI->loading_msg_height );
+        // somewhat arbitrary centering of loading msg
+        // hardcoded so it will not jump around depending on the step
+        const float loading_msg_pos_x = center_x - cataimgui::get_string_width( "Loading files: " );
+        ImGui::SetCursorPosX( loading_msg_pos_x );
+        const std::string loading_msg = string_format( "%s %s", gLUI->context, gLUI->step );
+        cataimgui::draw_colored_text( loading_msg, ImGui::GetContentRegionAvail().x );
     }
     ImGui::End();
-    ImGui::PopStyleColor();
-    ImGui::PopStyleVar();
+
 #else
     int x = ( TERMX - static_cast<int>( gLUI->splash_width ) ) / 2;
     int y = 0;
@@ -94,6 +129,33 @@ static void update_state( const std::string &context, const std::string &step )
         } );
 
 #ifdef TILES
+        // padding will eat some of it, but we cannot access padding without imgui window
+        // so eyeball a bit off the main viewport to compensate
+        const ImVec2 screen_size = ImGui::GetMainViewport()->Size * 0.98f;
+
+        // get snippet text and calculate it's size ahead of time
+        gLUI->tip = SNIPPET.random_from_category( "tip" ).value_or(
+                        translation() ).translated();
+
+        // if our screen space is at least twice as large as minimal, we will use 1.5x font size
+        gLUI->large_hint_size = cataimgui::min_screen_res_y * 2.f < screen_size.y;
+
+        // calculate hint_height maybe with increased font
+        // ideally it would use proper ImGui::PopFont(), but it requires imgui window, which we do not have here
+        // so we just eyeball it to be 1.6x bigger than normal-sized string
+        if( gLUI->large_hint_size ) {
+            gLUI->hint_height = cataimgui::get_string_height( gLUI->tip, screen_size.x ) * 1.6f;
+        } else {
+            gLUI->hint_height = cataimgui::get_string_height( gLUI->tip, screen_size.x );
+        }
+
+        // no matter the size, loading message always fit in 1 line,
+        // so just use dummy line to calculate it's height
+        gLUI->loading_msg_height = cataimgui::get_string_height( " ", 0 );
+
+        gLUI->text_height = gLUI->hint_height + gLUI->loading_msg_height;
+
+        // get image
         std::vector<cata_path> imgs;
         std::vector<mod_id> &active_mod_list = world_generator->active_world->active_mod_order;
         for( mod_id &some_mod : active_mod_list ) {
@@ -122,12 +184,12 @@ static void update_state( const std::string &context, const std::string &step )
             gLUI->chosen_load_img = random_entry( imgs );
         }
         SDL_Surface_Ptr surf = load_image( gLUI->chosen_load_img.get_unrelative_path().u8string().c_str() );
-        // leave some space for the loading text...
-        ImVec2 max_size = ImGui::GetMainViewport()->Size * 0.9;
-        // preserve aspect ratio by finding the longest **relative** side and scaling both sides by its ratio to max_size
+        // calculate max size of image, decreasing it by the size of text below
+        const ImVec2 max_img_size = { screen_size.x, screen_size.y - gLUI->text_height };
+        // preserve aspect ratio by finding the longest **relative** side and scaling both sides by its ratio to max_img_size
         // scales both "up" and "down"
-        float width_ratio = static_cast<float>( surf->w ) / max_size.x;
-        float height_ratio = static_cast<float>( surf->h ) / max_size.y;
+        float width_ratio = static_cast<float>( surf->w ) / max_img_size.x;
+        float height_ratio = static_cast<float>( surf->h ) / max_img_size.y;
         float longest_side_ratio = width_ratio > height_ratio ? width_ratio : height_ratio;
         gLUI->splash_size = { static_cast<float>( surf->w ) / longest_side_ratio,
                               static_cast<float>( surf->h ) / longest_side_ratio


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Always liked this idea, and i thought i got plenty of experience with imgui with a two last PRs. Boy was i wrong
Revive #80677
#### Describe the solution
Refactor a bit of loading screen UI, mainly just adding comments and rearranging logic to make more sense
Add a few cataimgui functions, one of which was not used, but should be useful in the future
Add a snippet on the loading screen
#### Testing
My main screen (2560x1440)
<img width="2560" height="1400" alt="image" src="https://github.com/user-attachments/assets/521397f2-bc6c-4113-92e7-e580ce6c5376" />

Our smallest supported resolution (at this moment, 640 x 384)
<img width="642" height="416" alt="image" src="https://github.com/user-attachments/assets/eca7e76e-f4eb-45be-9db3-b7c3e80b558c" />

#### Additional context
This works only in tiles, because apparently curses still use catacurses that i am afraid to touch still

Someone ought to revisit said snippets, lot of them are dumb and are not applicable anymore 

This PR made me think that a lot of things in computer game we take for granted are actually very difficult