### PR TITLE
Remember crafting details panel state between sessions

### DIFF
--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1193,7 +1193,8 @@ void crafting_ui_impl::draw_recipe_info_panel()
             // Practice recipes always show details
             bool show_details = uistate.crafting_expand_details || recp.is_practice();
             if( !recp.is_practice() ) {
-                const char *details_label = uistate.crafting_expand_details ? _( "- details -" ) : _( "+ details +" );
+                const char *details_label = uistate.crafting_expand_details ? _( "- details -" ) :
+                                            _( "+ details +" );
                 float btn_w = ImGui::CalcTextSize( details_label ).x;
                 float rgn_w = ImGui::GetContentRegionAvail().x;
                 ImGui::SetCursorPosX( ImGui::GetCursorPosX() + ( rgn_w - btn_w ) / 2.f );

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -440,7 +440,6 @@ class crafting_ui_impl : public cataimgui::window
         int manual_batch = 1;
         bool show_hidden = false;
         bool is_wide = false;
-        bool details_expanded = false;
         bool steps_expanded = true;
 
         // --- Scroll state ---
@@ -1191,16 +1190,15 @@ void crafting_ui_impl::draw_recipe_info_panel()
 
         // Centered "Details" button that opens the modifier table
         if( !recp.is_nested() ) {
-            // details_expanded is a member variable, reset in invalidate_info_panels()
             // Practice recipes always show details
-            bool show_details = details_expanded || recp.is_practice();
+            bool show_details = uistate.crafting_expand_details || recp.is_practice();
             if( !recp.is_practice() ) {
-                const char *details_label = details_expanded ? _( "- details -" ) : _( "+ details +" );
+                const char *details_label = uistate.crafting_expand_details ? _( "- details -" ) : _( "+ details +" );
                 float btn_w = ImGui::CalcTextSize( details_label ).x;
                 float rgn_w = ImGui::GetContentRegionAvail().x;
                 ImGui::SetCursorPosX( ImGui::GetCursorPosX() + ( rgn_w - btn_w ) / 2.f );
                 if( nav_clickable( details_label, c_cyan ) ) {
-                    details_expanded = !details_expanded;
+                    uistate.crafting_expand_details = !uistate.crafting_expand_details;
                 }
             }
             if( show_details ) {

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -393,6 +393,7 @@ void uistatedata::serialize( JsonOut &json ) const
     json.member( "expanded_recipes", expanded_recipes );
     json.member( "read_recipes", read_recipes );
     json.member( "recent_recipes", recent_recipes );
+    json.member( "crafting_expand_details", crafting_expand_details );
     json.member( "bionic_ui_sort_mode", bionic_sort_mode );
     json.member( "overmap_debug_weather", overmap_debug_weather );
     json.member( "overmap_visible_weather", overmap_visible_weather );
@@ -482,6 +483,7 @@ void uistatedata::deserialize( const JsonObject &jo )
     jo.read( "expanded_recipes", expanded_recipes );
     jo.read( "read_recipes", read_recipes );
     jo.read( "recent_recipes", recent_recipes );
+    jo.read( "crafting_expand_details", crafting_expand_details );
     jo.read( "bionic_ui_sort_mode", bionic_sort_mode );
     jo.read( "overmap_debug_weather", overmap_debug_weather );
     jo.read( "overmap_visible_weather", overmap_visible_weather );

--- a/src/uistate.h
+++ b/src/uistate.h
@@ -274,6 +274,7 @@ class uistatedata
         std::set<recipe_id> expanded_recipes;
         cata::flat_set<recipe_id> read_recipes;
         std::vector<recipe_id> recent_recipes;
+        bool crafting_expand_details = false;        
 
         bionic_ui_sort_mode bionic_sort_mode = bionic_ui_sort_mode::POWER;
 

--- a/src/uistate.h
+++ b/src/uistate.h
@@ -274,7 +274,7 @@ class uistatedata
         std::set<recipe_id> expanded_recipes;
         cata::flat_set<recipe_id> read_recipes;
         std::vector<recipe_id> recent_recipes;
-        bool crafting_expand_details = false;        
+        bool crafting_expand_details = false;
 
         bionic_ui_sort_mode bionic_sort_mode = bionic_ui_sort_mode::POWER;
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Interface "The new ImGui crafting UI will remember if recipe details are expanded/collapsed across play sessions"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

This is a compromise for the proposal in #86268.  It allows the state of the details section of the crafting UI to be maintained across play sessions, similar to the crafting favorites, hidden recipes, etc.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

The state of the crafting details for a recipe being collapsed/expanded is stored in a similar way to other persistent data in the crafting UI.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Make the details expanded by default - debatable and my personal preference but default is still collapsed.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Compiled on Windows.  Created a character, opened the crafting UI and expanded the recipe details.  Saved and closed the game.  Loaded game again and verified crafting details were still expanded.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
