### PR TITLE
Fix per-turn inventory rebuild for step recipe proficiency checks

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -5728,12 +5728,15 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
     if( rec.has_steps() && craft.get_current_step() == 0 &&
         craft.get_step_progress() == 0.0 && craft.item_counter > 0 ) {
         // Need base_total_moves for conversion; compute it fresh here.
+        const crafting_cost_context migration_ctx{ crafter.book_bonuses_nearby(),
+                compute_tool_speeds( rec, crafter ) };
         const double migration_base = std::max( 1.0,
-                                                static_cast<double>( rec.batch_time( crafter, craft.get_making_batch_size(), 1.0f, 0 ) ) );
+                                                static_cast<double>( rec.batch_time( crafter, craft.get_making_batch_size(), 1.0f, 0,
+                                                        migration_ctx ) ) );
         double accumulated = craft.item_counter * migration_base / 10000000.0;
         for( size_t i = 0; i < rec.steps().size(); ++i ) {
             double budget = rec.step_budget_moves( crafter, i,
-                                                   craft.get_making_batch_size() );
+                                                   craft.get_making_batch_size(), migration_ctx );
             if( accumulated < budget || i == rec.steps().size() - 1 ) {
                 craft.set_current_step( static_cast<int>( i ) );
                 craft.set_step_progress( accumulated );
@@ -5761,18 +5764,18 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
     if( cached_crafting_speed != crafting_speed || cached_assistants != assistants ) {
         cached_crafting_speed = crafting_speed;
         cached_assistants = assistants;
-        // Recompute per-step tool speed from current crafting inventory
-        cached_tool_speeds = compute_tool_speeds( rec, crafter );
-        const std::vector<float> *ts = cached_tool_speeds.empty() ? nullptr : &cached_tool_speeds;
+        // Recompute cost context: tool speeds + book proficiency bonuses
+        cached_cost_ctx = { crafter.book_bonuses_nearby(), compute_tool_speeds( rec, crafter ) };
 
         // Base moves for batch size with no speed modifier or assistants
         // Must ensure >= 1 so we don't divide by 0;
         cached_base_total_moves = std::max( static_cast<int64_t>( 1 ),
-                                            rec.batch_time( crafter, craft.get_making_batch_size(), 1.0f, 0, ts ) );
+                                            rec.batch_time( crafter, craft.get_making_batch_size(), 1.0f, 0,
+                                                    cached_cost_ctx ) );
         // Current expected total moves, includes crafting speed modifiers and assistants
         cached_cur_total_moves = std::max( static_cast<int64_t>( 1 ),
                                            rec.batch_time( crafter, craft.get_making_batch_size(), crafting_speed,
-                                                   assistants, ts ) );
+                                                   assistants, cached_cost_ctx ) );
     }
     const double base_total_moves = cached_base_total_moves;
     const double cur_total_moves = cached_cur_total_moves;
@@ -5800,10 +5803,10 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
     if( rec.has_steps() ) {
         craft.mod_step_progress( delta_progress );
         const int last_step_idx = static_cast<int>( rec.steps().size() ) - 1;
-        const std::vector<float> *ts = cached_tool_speeds.empty() ? nullptr : &cached_tool_speeds;
         while( craft.get_current_step() < last_step_idx ) {
             const double budget = rec.step_budget_moves( crafter,
-                                  craft.get_current_step(), craft.get_making_batch_size(), ts );
+                                  craft.get_current_step(), craft.get_making_batch_size(),
+                                  cached_cost_ctx );
             if( craft.get_step_progress() < budget ) {
                 break;
             }
@@ -5814,7 +5817,7 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
 
     // This nominal craft time is also how many practice ticks to perform
     // spread out evenly across the actual duration.
-    const double total_practice_ticks = rec.time_to_craft_moves( crafter,
+    const double total_practice_ticks = rec.time_to_craft_moves( crafter, {},
                                         recipe_time_flag::ignore_proficiencies ) / 100.0;
 
     const int ticks_per_practice = 10000000.0 / total_practice_ticks;

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -1909,7 +1909,7 @@ class craft_activity_actor : public activity_actor
         std::optional<requirement_data> cached_continuation_requirements; // NOLINT(cata-serialize)
         float cached_crafting_speed; // NOLINT(cata-serialize)
         int cached_assistants; // NOLINT(cata-serialize)
-        std::vector<float> cached_tool_speeds; // NOLINT(cata-serialize)
+        crafting_cost_context cached_cost_ctx; // NOLINT(cata-serialize)
         double cached_base_total_moves; // NOLINT(cata-serialize)
         double cached_cur_total_moves; // NOLINT(cata-serialize)
         float cached_workbench_multiplier; // NOLINT(cata-serialize)

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -65,6 +65,7 @@
 #include "player_activity.h"
 #include "pocket_type.h"
 #include "point.h"
+#include "proficiency.h"
 #include "recipe.h"
 #include "recipe_dictionary.h"
 #include "requirements.h"
@@ -3965,7 +3966,7 @@ bool multi_disassemble_activity_actor::multi_activity_do( Character &you,
                                       recipe_dictionary::get_uncraft( elem.typeId() );
                     int const qty = std::max( 1, elem.typeId() == itype_disassembly ? elem.get_making_batch_size() :
                                               elem.charges );
-                    player_activity act = player_activity( disassemble_activity_actor( r.time_to_craft_moves( you,
+                    player_activity act = player_activity( disassemble_activity_actor( r.time_to_craft_moves( you, {},
                                                            recipe_time_flag::ignore_proficiencies ) * qty ) );
                     act.targets.emplace_back( map_cursor( src_loc ), &elem );
                     act.placement = here.get_abs( src_loc );

--- a/src/basecamp.cpp
+++ b/src/basecamp.cpp
@@ -247,7 +247,8 @@ std::string basecamp::om_upgrade_description( const std::string &bldg, const map
         skills = &bld_reqs.skills;
     } else {
         reqs = &making.simple_requirements();
-        base_time = making.batch_duration( get_player_character() );
+        base_time = making.batch_duration( get_player_character(),
+                                           crafting_cost_context::for_recipe( get_player_character(), making ) );
         skills = &making.required_skills;
     }
 

--- a/src/character.h
+++ b/src/character.h
@@ -48,6 +48,7 @@
 #include "player_activity.h"
 #include "pocket_type.h"
 #include "point.h"
+#include "proficiency.h"
 #include "ranged.h"
 #include "ret_val.h"
 #include "sleep.h"
@@ -78,7 +79,6 @@ class ma_technique;
 class map;
 class player_morale;
 class profession;
-class proficiency_set;
 class recipe;
 class recipe_subset;
 class spell;
@@ -96,14 +96,12 @@ struct pick_info;
 } // namespace Pickup
 
 enum action_id : int;
-enum class proficiency_bonus_type : int;
 enum class recipe_filter_flags : int;
 enum class steed_type : int;
 enum npc_attitude : int;
 struct bionic;
 struct construction;
 struct dealt_projectile_attack;
-struct display_proficiency;
 /// @brief Item slot used to apply modifications from food and meds
 struct islot_comestible;
 struct item_comp;
@@ -3606,6 +3604,10 @@ class Character : public Creature, public visitable
                                              const tripoint_bub_ms &src_pos = tripoint_bub_ms::zero,
                                              int radius = PICKUP_RANGE, bool clear_path = true ) const;
         void invalidate_crafting_inventory();
+        // Efficiently query book proficiency bonuses from nearby items
+        // without rebuilding the full crafting inventory.
+        // Walks map tiles and vehicle cargo in range, plus character inventory.
+        book_proficiency_bonuses book_bonuses_nearby( int radius = PICKUP_RANGE ) const;
 
         /** Returns a value from 1.0 to 11.0 that acts as a multiplier
          * for the time taken to perform tasks that require detail vision,

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -11,6 +11,7 @@
 #include <map>
 #include <memory>
 #include <optional>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -485,9 +486,8 @@ int64_t Character::expected_time_to_craft( const recipe &rec, int batch_size ) c
 {
     const size_t assistants = available_assistant_count( rec );
     float modifier = crafting_speed_multiplier( rec );
-    std::vector<float> tool_speeds = compute_tool_speeds( rec, *this );
-    const std::vector<float> *ts = tool_speeds.empty() ? nullptr : &tool_speeds;
-    return rec.batch_time( *this, batch_size, modifier, assistants, ts );
+    return rec.batch_time( *this, batch_size, modifier, assistants,
+                           crafting_cost_context::for_recipe( *this, rec ) );
 }
 
 bool Character::check_eligible_containers_for_crafting( const recipe &rec, int batch_size ) const
@@ -718,6 +718,31 @@ void Character::invalidate_crafting_inventory()
 {
     crafting_cache.valid = false;
     crafting_cache.crafting_inventory->clear();
+}
+
+book_proficiency_bonuses Character::book_bonuses_nearby( int radius ) const
+{
+    book_proficiency_bonuses result;
+    // Deduplicate by item type to match inventory stacking behavior --
+    // multiple copies of the same book should not compound mitigation.
+    std::set<itype_id> seen;
+
+    auto collect = [&]( const item & it ) {
+        if( seen.insert( it.typeId() ).second ) {
+            result += it.get_book_proficiency_bonuses();
+        }
+    };
+
+    // Character inventory (wielded, worn, carried -- includes e-readers)
+    for( const item_location &it :
+         const_cast<Character *>( this )->all_items_loc() ) {
+        collect( *it );
+    }
+
+    // Map items in range (shared reachability/accessibility/vehicle logic)
+    get_map().for_each_reachable_item( pos_bub(), radius, this, collect );
+
+    return result;
 }
 
 void Character::make_craft( const recipe_id &id_to_make, int batch_size,
@@ -1580,7 +1605,8 @@ void Character::complete_craft( item &craft, const std::optional<tripoint_bub_ms
                 std::max( get_skill_level( making.skill_used ), 1.0f ) *
                 std::max( get_int(), 1 );
             const double time_to_learn = 1000 * 8 * std::pow( difficulty, 4 ) / learning_speed;
-            if( x_in_y( making.time_to_craft_moves( *this ), time_to_learn ) ) {
+            const crafting_cost_context ctx{ book_bonuses_nearby(), {} };
+            if( x_in_y( making.time_to_craft_moves( *this, ctx ), time_to_learn ) ) {
                 learn_recipe( &making );
                 if( is_avatar() ) {
                     add_msg( m_good, _( "You memorized the recipe for %s!" ),
@@ -2735,7 +2761,8 @@ bool Character::disassemble( item_location target, bool interactive, bool disass
                 num_dis = obj.charges;
             }
         }
-        const int64_t craft_moves = r.time_to_craft_moves( *this, recipe_time_flag::ignore_proficiencies );
+        const int64_t craft_moves = r.time_to_craft_moves( *this, {},
+                                    recipe_time_flag::ignore_proficiencies );
         const int num = obj.typeId() != itype_disassembly ? num_dis : obj.get_making_batch_size();
         player_activity new_act( disassemble_activity_actor( num * craft_moves ) );
         new_act.targets.emplace_back( std::move( target ) );
@@ -2751,7 +2778,7 @@ bool Character::disassemble( item_location target, bool interactive, bool disass
         activity.targets.emplace_back( std::move( target ) );
 
         if( activity.moves_left <= 0 ) {
-            activity.moves_left = r.time_to_craft_moves( *this, recipe_time_flag::ignore_proficiencies );
+            activity.moves_left = r.time_to_craft_moves( *this, {}, recipe_time_flag::ignore_proficiencies );
         }
     }
 
@@ -2848,7 +2875,8 @@ void Character::complete_disassemble( item_location target )
             num_dis = obj.charges;
         }
     }
-    int64_t moves = next_recipe.time_to_craft_moves( *this, recipe_time_flag::ignore_proficiencies );
+    int64_t moves = next_recipe.time_to_craft_moves( *this, {},
+                    recipe_time_flag::ignore_proficiencies );
     player_activity new_act( disassemble_activity_actor( moves * num_dis ) );
     new_act.targets = activity.targets;
     new_act.index = activity.index;

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1306,12 +1306,14 @@ void crafting_ui_impl::draw_recipe_info_panel()
                     int tool_group_offset = 0;
                     float step_indent = ImGui::CalcTextSize( "    " ).x;
                     float sub_indent = ImGui::CalcTextSize( "  " ).x;
-                    const std::vector<float> tspeeds = compute_tool_speeds( recp, *crafter );
-                    const std::vector<float> *ts = tspeeds.empty() ? nullptr : &tspeeds;
+                    const crafting_cost_context step_ctx{
+                        crafter->book_bonuses_nearby(),
+                        compute_tool_speeds( recp, *crafter )
+                    };
                     for( size_t si = 0; si < recp.steps().size(); ++si ) {
                         const recipe_step &step = recp.steps()[si];
                         const double step_moves = recp.step_budget_moves(
-                                                      *crafter, si, batch_size, ts );
+                                                      *crafter, si, batch_size, step_ctx );
                         const std::string time_str = to_string(
                                                          time_duration::from_moves( static_cast<int64_t>( step_moves ) ) );
                         const std::string activity = display::activity_level_str( step.exertion );
@@ -1321,7 +1323,7 @@ void crafting_ui_impl::draw_recipe_info_panel()
                         std::string batch_note;
                         if( batch_size > 1 ) {
                             const double single_moves = recp.step_budget_moves(
-                                                            *crafter, si, 1, ts );
+                                                            *crafter, si, 1, step_ctx );
                             if( step_moves < single_moves * batch_size * 0.99 ) {
                                 batch_note = string_format( _( " (x%d, saves %s)" ), batch_size,
                                                             to_string( time_duration::from_moves(
@@ -1487,7 +1489,7 @@ void crafting_ui_impl::draw_modifier_table( const recipe &recp,
         // Base row
         {
             const int64_t base_moves = recp.time_to_craft_moves(
-                                           *crafter, recipe_time_flag::ignore_proficiencies );
+                                           *crafter, {}, recipe_time_flag::ignore_proficiencies );
             const std::string base_str = to_string(
                                              time_duration::from_moves( base_moves ) );
             ImGui::TableNextRow();

--- a/src/crafting_gui_helpers.cpp
+++ b/src/crafting_gui_helpers.cpp
@@ -52,10 +52,19 @@ bool cannot_gain_skill_or_prof( const Character &crafter, const recipe &recp )
     return true;
 }
 
+const book_proficiency_bonuses &availability::get_book_bonuses() const
+{
+    if( !cached_book_bonuses ) {
+        cached_book_bonuses = crafter.book_bonuses_nearby();
+    }
+    return *cached_book_bonuses;
+}
+
 float availability::get_proficiency_time_maluses() const
 {
     if( proficiency_time_maluses < 0 ) {
-        proficiency_time_maluses = rec->proficiency_time_maluses( crafter );
+        proficiency_time_maluses = rec->proficiency_time_maluses(
+                                       crafter, get_book_bonuses() );
     }
 
     return proficiency_time_maluses;
@@ -73,7 +82,8 @@ float availability::get_max_proficiency_time_maluses() const
 float availability::get_proficiency_skill_maluses() const
 {
     if( proficiency_skill_maluses < 0 ) {
-        proficiency_skill_maluses = rec->proficiency_skill_maluses( crafter );
+        proficiency_skill_maluses = rec->proficiency_skill_maluses(
+                                        crafter, get_book_bonuses() );
     }
 
     return proficiency_skill_maluses;
@@ -202,7 +212,7 @@ craft_confirm_result can_start_craft(
 bool recipe_sort_compare(
     const recipe *a, const recipe *b,
     const availability &avail_a, const availability &avail_b,
-    const Character &crafter,
+    const Character &crafter, const crafting_cost_context &ctx,
     bool a_read, bool b_read,
     bool unread_first )
 {
@@ -222,7 +232,7 @@ bool recipe_sort_compare(
     if( a_name != b_name ) {
         return localized_compare( a_name, b_name );
     }
-    return b->time_to_craft( crafter ) < a->time_to_craft( crafter );
+    return b->time_to_craft( crafter, ctx ) < a->time_to_craft( crafter, ctx );
 }
 
 static std::string craft_success_chance_string( const recipe &recp, const Character &guy )
@@ -916,14 +926,15 @@ static void recursively_expand_recipes( std::vector<const recipe *> &current,
     }
 
     const bool want_unread = highlight_unread_recipes && unread_recipes_first;
+    const crafting_cost_context sort_ctx{ crafter.book_bonuses_nearby(), {} };
     std::stable_sort( tmp.begin(), tmp.end(), [
-                       &crafter, &availability_cache, want_unread
+                       &crafter, &availability_cache, want_unread, &sort_ctx
     ]( const recipe * const a, const recipe * const b ) {
         const bool a_read = !want_unread || uistate.read_recipes.count( a->ident() );
         const bool b_read = !want_unread || uistate.read_recipes.count( b->ident() );
         return recipe_sort_compare( a, b,
                                     availability_cache.at( a ), availability_cache.at( b ),
-                                    crafter, a_read, b_read, want_unread );
+                                    crafter, sort_ctx, a_read, b_read, want_unread );
     } );
 
     current.insert( current.begin() + i + 1, tmp.begin(), tmp.end() );
@@ -1017,14 +1028,15 @@ recipe_list_data build_recipe_list(
 
     if( !skip_sort ) {
         const bool want_unread = highlight_unread && unread_first;
+        const crafting_cost_context sort_ctx{ crafter.book_bonuses_nearby(), {} };
         std::stable_sort( result.entries.begin(), result.entries.end(), [
-                       &crafter, &availability_cache, want_unread
+                       &crafter, &availability_cache, want_unread, &sort_ctx
         ]( const recipe * const a, const recipe * const b ) {
             const bool a_read = !want_unread || uistate.read_recipes.count( a->ident() );
             const bool b_read = !want_unread || uistate.read_recipes.count( b->ident() );
             return recipe_sort_compare( a, b,
                                         availability_cache.at( a ), availability_cache.at( b ),
-                                        crafter, a_read, b_read, want_unread );
+                                        crafter, sort_ctx, a_read, b_read, want_unread );
         } );
     }
 

--- a/src/crafting_gui_helpers.h
+++ b/src/crafting_gui_helpers.h
@@ -5,18 +5,21 @@
 #include <cstddef>
 #include <functional>
 #include <map>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
 
 #include "color.h"
 #include "item.h"
+#include "proficiency.h"
 #include "translation.h"
 
 class Character;
 class inventory;
 class recipe;
 class recipe_subset;
+struct crafting_cost_context;
 struct tool_comp;
 
 // Returns true if the character cannot gain any skill or proficiency from this recipe.
@@ -49,6 +52,8 @@ struct availability {
         mutable float max_proficiency_time_maluses = -1.0f;
         mutable float proficiency_skill_maluses = -1.0f;
         mutable float max_proficiency_skill_maluses = -1.0f;
+        mutable std::optional<book_proficiency_bonuses> cached_book_bonuses;
+        const book_proficiency_bonuses &get_book_bonuses() const;
     public:
         float get_proficiency_time_maluses() const;
         float get_max_proficiency_time_maluses() const;
@@ -84,7 +89,7 @@ craft_confirm_result can_start_craft(
 bool recipe_sort_compare(
     const recipe *a, const recipe *b,
     const availability &avail_a, const availability &avail_b,
-    const Character &crafter,
+    const Character &crafter, const crafting_cost_context &ctx,
     bool a_read, bool b_read,
     bool unread_first );
 

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -2671,7 +2671,9 @@ void basecamp::start_fortifications( const mission_id &miss_id, float exertion_l
             travel_time += companion_travel_time_calc( path, 2 );
             dist += path.dist * 2;
         }
-        build_time += making.batch_duration( get_player_character() ); // TODO calculate for NPC, not player
+        build_time += making.batch_duration( get_player_character(),
+                                             crafting_cost_context::for_recipe( get_player_character(),
+                                                     making ) ); // TODO calculate for NPC, not player
     }
     // trench requires just one triangular trip
     if( miss_id.parameters != faction_wall_level_n_1_string ) {
@@ -3381,7 +3383,7 @@ void basecamp::start_crafting( const mission_id &miss_id )
     }
 
     time_duration work_days = base_camps::to_workdays( making->batch_duration( *guy_to_send,
-                              num_to_make ) );
+                              crafting_cost_context::for_recipe( *guy_to_send, *making ), num_to_make ) );
 
     int kcal_consumed = time_to_food( work_days, making->exertion_level() );
     int kcal_have = fac()->food_supply().kcal();
@@ -4629,7 +4631,9 @@ int basecamp::recipe_batch_max( const recipe &making ) const
     for( size_t batch_size = 1000; batch_size > 0; batch_size /= 10 ) {
         for( int iter = 0; iter < max_checks; iter++ ) {
             const time_duration &work_days = base_camps::to_workdays( making.batch_duration(
-                                                 get_player_character(), max_batch + batch_size ) );
+                                                 get_player_character(),
+                                                 crafting_cost_context::for_recipe( get_player_character(), making ),
+                                                 max_batch + batch_size ) );
             int food_req = time_to_food( work_days );
             bool can_make = making.deduped_requirements().can_make_with_inventory(
                                 _inv, making.get_component_filter(), max_batch + batch_size );
@@ -5283,10 +5287,14 @@ std::string basecamp::craft_description( const recipe_id &itm )
     for( auto &elem : component_print_buffer ) {
         str_append( comp, elem, "\n" );
     }
+    const crafting_cost_context camp_ctx = crafting_cost_context::for_recipe(
+            get_player_character(), making );
     comp = string_format( _( "Skill used: %s\nDifficulty: %d\n%s\nTime: %s\nCalories per craft: %s\n" ),
                           making.skill_used.obj().name(), making.difficulty, comp,
-                          to_string( base_camps::to_workdays( making.batch_duration( get_player_character() ) ) ),
-                          time_to_food( base_camps::to_workdays( making.batch_duration( get_player_character() ) ),
+                          to_string( base_camps::to_workdays( making.batch_duration(
+                                         get_player_character(), camp_ctx ) ) ),
+                          time_to_food( base_camps::to_workdays( making.batch_duration(
+                                            get_player_character(), camp_ctx ) ),
                                         itm.obj().exertion_level() ) );
     return comp;
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6698,7 +6698,7 @@ static void add_disassemblables( uilist &menu,
             }
             menu.addentry_col( menu_index++, true, hotkey, msg,
                                to_string_clipped( uncraft_recipe.time_to_craft( get_player_character(),
-                                                  recipe_time_flag::ignore_proficiencies ) ) );
+                                                  {}, recipe_time_flag::ignore_proficiencies ) ) );
             hotkey = std::nullopt;
         }
     }
@@ -6867,7 +6867,7 @@ void game::butcher( const std::optional<tripoint_bub_ms> &p )
                 }
 
                 const int time = uncraft_recipe.time_to_craft_moves(
-                                     get_player_character(), recipe_time_flag::ignore_proficiencies );
+                                     get_player_character(), {}, recipe_time_flag::ignore_proficiencies );
                 time_to_disassemble_once += time * stack.second;
                 if( stack.first->typeId() == itype_disassembly ) {
                     item test( uncraft_recipe.result(), calendar::turn, 1 );

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -57,6 +57,7 @@
 #include "player_activity.h"
 #include "pocket_type.h"
 #include "point.h"
+#include "proficiency.h"
 #include "recipe.h"
 #include "recipe_dictionary.h"
 #include "requirements.h"
@@ -643,7 +644,7 @@ class disassemble_inventory_preset : public inventory_selector_preset
 
             append_cell( [ this ]( const item_location & loc ) {
                 return to_string_clipped( get_recipe( loc ).time_to_craft( get_player_character(),
-                                          recipe_time_flag::ignore_proficiencies ) );
+                                          {}, recipe_time_flag::ignore_proficiencies ) );
             }, _( "TIME" ) );
         }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -4982,14 +4982,15 @@ const cata::value_ptr<islot_comestible> &item::get_comestible() const
 int item::get_recursive_disassemble_moves( const Character &guy ) const
 {
     int moves = recipe_dictionary::get_uncraft( type->get_id() ).time_to_craft_moves( guy,
-                recipe_time_flag::ignore_proficiencies );
+                {}, recipe_time_flag::ignore_proficiencies );
     std::vector<item_comp> to_be_disassembled = get_uncraft_components();
     while( !to_be_disassembled.empty() ) {
         item_comp current_comp = to_be_disassembled.back();
         to_be_disassembled.pop_back();
         const recipe &r = recipe_dictionary::get_uncraft( current_comp.type->get_id() );
         if( r.ident() != recipe_id::NULL_ID() ) {
-            moves += r.time_to_craft_moves( guy ) * current_comp.count;
+            moves += r.time_to_craft_moves( guy,
+                                            crafting_cost_context::for_proficiencies( guy ) ) * current_comp.count;
             std::vector<item_comp> components = item( current_comp.type->get_id() ).get_uncraft_components();
             for( item_comp &component : components ) {
                 component.count *= current_comp.count;

--- a/src/item_info.cpp
+++ b/src/item_info.cpp
@@ -3202,7 +3202,7 @@ void item::disassembly_info( std::vector<iteminfo> &info, const iteminfo_query *
     const requirement_data &req = dis.disassembly_requirements();
     if( !req.is_empty() ) {
         const std::string approx_time = to_string_approx( dis.time_to_craft( get_player_character(),
-                                        recipe_time_flag::ignore_proficiencies ) );
+                                        {}, recipe_time_flag::ignore_proficiencies ) );
 
         const requirement_data::alter_item_comp_vector &comps_list = req.get_components();
         const std::string comps_str = enumerate_as_string( comps_list,

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -102,6 +102,7 @@
 #include "pocket_type.h"
 #include "point.h"
 #include "popup.h" // For play_game
+#include "proficiency.h"
 #include "recipe.h"
 #include "recipe_dictionary.h"
 #include "requirements.h"
@@ -7648,9 +7649,9 @@ std::optional<int> iuse::multicooker( Character *p, item *it, const tripoint_bub
             const recipe *meal = dishes[choice];
             int mealtime;
             if( it->get_var( "MULTI_COOK_UPGRADE" ) == "UPGRADE" ) {
-                mealtime = meal->time_to_craft_moves( *p, recipe_time_flag::ignore_proficiencies );
+                mealtime = meal->time_to_craft_moves( *p, {}, recipe_time_flag::ignore_proficiencies );
             } else {
-                mealtime = meal->time_to_craft_moves( *p, recipe_time_flag::ignore_proficiencies ) * 2;
+                mealtime = meal->time_to_craft_moves( *p, {}, recipe_time_flag::ignore_proficiencies ) * 2;
             }
 
             const int all_charges = charges_to_start + mealtime * units::to_watt(

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -8502,6 +8502,29 @@ bool map::accessible_items( const tripoint_bub_ms &t ) const
            has_flag( ter_furn_flag::TFLAG_LIQUIDCONT, t );
 }
 
+void map::for_each_reachable_item( const tripoint_bub_ms &center, int radius,
+                                   const Character *ch,
+                                   const std::function<void( const item & )> &fn )
+{
+    for( const tripoint_bub_ms &p : reachable_flood_steps( center, radius, 1, 100 ) ) {
+        if( accessible_items( p ) ) {
+            for( const item &it : i_at( p ) ) {
+                if( ch && !it.is_owned_by( *ch, true ) ) {
+                    continue;
+                }
+                if( !it.made_of( phase_id::LIQUID ) ) {
+                    fn( it );
+                }
+            }
+        }
+        if( const std::optional<vpart_reference> vp = veh_at( p ).cargo() ) {
+            for( const item &it : vp->items() ) {
+                fn( it );
+            }
+        }
+    }
+}
+
 std::vector<tripoint_bub_ms> map::get_dir_circle( const tripoint_bub_ms &f,
         const tripoint_bub_ms &t ) const
 {

--- a/src/map.h
+++ b/src/map.h
@@ -729,6 +729,17 @@ class map
          * may prevent that (e.g. a locked safe).
          */
         bool accessible_items( const tripoint_bub_ms &t ) const;
+
+        /**
+         * Visit every non-liquid item reachable from @p center within @p radius.
+         * Handles tile accessibility, item ownership (if @p ch is non-null),
+         * and vehicle cargo.  The visitor receives each item by const reference
+         * and is never called for liquids.
+         */
+        void for_each_reachable_item( const tripoint_bub_ms &center, int radius,
+                                      const Character *ch,
+                                      const std::function<void( const item & )> &fn );
+
         /**
          * Calculate next search points surrounding the current position.
          * Points closer to the target come first.

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -88,10 +88,22 @@ int recipe::get_skill_cap() const
     }
 }
 
-time_duration recipe::batch_duration( const Character &guy, int batch, float multiplier,
+crafting_cost_context crafting_cost_context::for_recipe( const Character &guy,
+        const recipe &rec )
+{
+    return { guy.book_bonuses_nearby(), compute_tool_speeds( rec, guy ) };
+}
+
+crafting_cost_context crafting_cost_context::for_proficiencies( const Character &guy )
+{
+    return { guy.book_bonuses_nearby(), {} };
+}
+
+time_duration recipe::batch_duration( const Character &guy, const crafting_cost_context &ctx,
+                                      int batch, float multiplier,
                                       size_t assistants ) const
 {
-    return time_duration::from_turns( batch_time( guy, batch, multiplier, assistants ) / 100 );
+    return time_duration::from_turns( batch_time( guy, batch, multiplier, assistants, ctx ) / 100 );
 }
 
 static bool helpers_have_proficiencies( const Character &guy, const proficiency_id &prof )
@@ -104,28 +116,33 @@ static bool helpers_have_proficiencies( const Character &guy, const proficiency_
     return false;
 }
 
-time_duration recipe::time_to_craft( const Character &guy, recipe_time_flag flags ) const
+time_duration recipe::time_to_craft( const Character &guy, const crafting_cost_context &ctx,
+                                     recipe_time_flag flags ) const
 {
-    return time_duration::from_moves( time_to_craft_moves( guy, flags ) );
+    return time_duration::from_moves( time_to_craft_moves( guy, ctx, flags ) );
 }
 
-int64_t recipe::time_to_craft_moves( const Character &guy, recipe_time_flag flags ) const
+int64_t recipe::time_to_craft_moves( const Character &guy, const crafting_cost_context &ctx,
+                                     recipe_time_flag flags ) const
 {
+    if( flags == recipe_time_flag::ignore_proficiencies ) {
+        if( has_steps() ) {
+            double total = 0.0;
+            for( const recipe_step &s : steps_ ) {
+                total += s.time;
+            }
+            return static_cast<int64_t>( total );
+        }
+        return time;
+    }
     if( has_steps() ) {
         double total = 0.0;
         for( const recipe_step &s : steps_ ) {
-            if( flags == recipe_time_flag::ignore_proficiencies ) {
-                total += s.time;
-            } else {
-                total += s.time * proficiency_time_maluses_for_step( guy, s );
-            }
+            total += s.time * proficiency_time_maluses_for_step( guy, s, ctx.books );
         }
         return static_cast<int64_t>( total );
     }
-    if( flags == recipe_time_flag::ignore_proficiencies ) {
-        return time;
-    }
-    return time * proficiency_time_maluses( guy );
+    return time * proficiency_time_maluses( guy, ctx.books );
 }
 
 double batch_savings::apply( double time, int batch_size ) const
@@ -153,7 +170,7 @@ double batch_savings::apply( double time, int batch_size ) const
 }
 
 int64_t recipe::batch_time( const Character &guy, int batch, float multiplier,
-                            size_t assistants, const std::vector<float> *tool_speeds ) const
+                            size_t assistants, const crafting_cost_context &ctx ) const
 {
     // 1.0f is full speed
     // 0.33f is 1/3 speed
@@ -162,21 +179,22 @@ int64_t recipe::batch_time( const Character &guy, int batch, float multiplier,
         multiplier = 1.0f;
     }
 
+    const std::vector<float> &ts = ctx.tool_speeds;
     double total_time;
 
     if( has_steps() ) {
         total_time = 0.0;
         for( size_t i = 0; i < steps_.size(); ++i ) {
             const recipe_step &s = steps_[i];
-            double step_time = s.time * proficiency_time_maluses_for_step( guy, s );
-            if( tool_speeds && i < tool_speeds->size() ) {
-                step_time *= ( *tool_speeds )[i];
+            double step_time = s.time * proficiency_time_maluses_for_step( guy, s, ctx.books );
+            if( i < ts.size() ) {
+                step_time *= ts[i];
             }
             step_time /= multiplier;
             total_time += s.batch_info.apply( step_time, batch );
         }
     } else {
-        const double local_time = static_cast<double>( time_to_craft_moves( guy ) ) / multiplier;
+        const double local_time = static_cast<double>( time_to_craft_moves( guy, ctx ) ) / multiplier;
         total_time = batch_info.apply( local_time, batch );
     }
 
@@ -189,19 +207,19 @@ int64_t recipe::batch_time( const Character &guy, int batch, float multiplier,
     // Single-item floor: total can't be less than crafting one unit.
     // For step recipes with tool speed, the floor must also be speed-aware.
     double single_time;
-    if( has_steps() && tool_speeds ) {
+    if( has_steps() && !ts.empty() ) {
         single_time = 0.0;
         for( size_t i = 0; i < steps_.size(); ++i ) {
             const recipe_step &s = steps_[i];
-            double st = s.time * proficiency_time_maluses_for_step( guy, s );
-            if( i < tool_speeds->size() ) {
-                st *= ( *tool_speeds )[i];
+            double st = s.time * proficiency_time_maluses_for_step( guy, s, ctx.books );
+            if( i < ts.size() ) {
+                st *= ts[i];
             }
             st /= multiplier;
             single_time += s.batch_info.apply( st, 1 );
         }
     } else {
-        single_time = static_cast<double>( time_to_craft_moves( guy ) ) / multiplier;
+        single_time = static_cast<double>( time_to_craft_moves( guy, ctx ) ) / multiplier;
     }
     if( total_time < single_time ) {
         total_time = single_time;
@@ -1355,14 +1373,15 @@ static float get_aided_proficiency_level( const Character &crafter, const profic
     return max_prof;
 }
 
-static float proficiency_time_malus( const Character &crafter, const recipe_proficiency &prof )
+static float proficiency_time_malus( const Character &crafter, const recipe_proficiency &prof,
+                                     const book_proficiency_bonuses &books )
 {
     if( !crafter.has_proficiency( prof.id )
         && !helpers_have_proficiencies( crafter, prof.id )
         && prof.time_multiplier > 1.0f
       ) {
         double malus = prof.time_multiplier - 1.0;
-        malus *= 1.0 - crafter.crafting_inventory().get_book_proficiency_bonuses().time_factor( prof.id );
+        malus *= 1.0 - books.time_factor( prof.id );
         double pl = get_aided_proficiency_level( crafter, prof.id );
         // Sigmoid function that mitigates 100% of the time malus as pl approaches 1.0
         // but has little effect at pl < 0.5. See #49198
@@ -1372,37 +1391,41 @@ static float proficiency_time_malus( const Character &crafter, const recipe_prof
     return 1.0f;
 }
 
-float recipe::proficiency_time_maluses( const Character &crafter ) const
+float recipe::proficiency_time_maluses( const Character &crafter,
+                                        const book_proficiency_bonuses &books ) const
 {
     if( has_steps() && time > 0 ) {
         // For step recipes, compute as effective ratio from per-step aggregation
-        return static_cast<float>( time_to_craft_moves( crafter ) ) / static_cast<float>( time );
+        crafting_cost_context ctx{ books, {} };
+        return static_cast<float>( time_to_craft_moves( crafter, ctx ) ) /
+               static_cast<float>( time );
     }
     float total_malus = 1.0f;
     for( const recipe_proficiency &prof : get_proficiencies() ) {
-        total_malus *= proficiency_time_malus( crafter, prof );
+        total_malus *= proficiency_time_malus( crafter, prof, books );
     }
     return total_malus;
 }
 
 float recipe::proficiency_time_maluses_for_step(
-    const Character &crafter, const recipe_step &step )
+    const Character &crafter, const recipe_step &step,
+    const book_proficiency_bonuses &books )
 {
     float total_malus = 1.0f;
     for( const recipe_proficiency &prof : step.proficiencies ) {
-        total_malus *= proficiency_time_malus( crafter, prof );
+        total_malus *= proficiency_time_malus( crafter, prof, books );
     }
     return total_malus;
 }
 
 double recipe::step_budget_moves( const Character &guy, size_t step_idx, int batch,
-                                  const std::vector<float> *tool_speeds ) const
+                                  const crafting_cost_context &ctx ) const
 {
     cata_assert( step_idx < steps_.size() );
     const recipe_step &s = steps_[step_idx];
-    double t = s.time * proficiency_time_maluses_for_step( guy, s );
-    if( tool_speeds && step_idx < tool_speeds->size() ) {
-        t *= ( *tool_speeds )[step_idx];
+    double t = s.time * proficiency_time_maluses_for_step( guy, s, ctx.books );
+    if( step_idx < ctx.tool_speeds.size() ) {
+        t *= ctx.tool_speeds[step_idx];
     }
     return s.batch_info.apply( t, batch );
 }
@@ -1507,14 +1530,15 @@ float recipe::max_proficiency_time_maluses( const Character & ) const
     return total_malus;
 }
 
-static float proficiency_skill_malus( const Character &crafter, const recipe_proficiency &prof )
+static float proficiency_skill_malus( const Character &crafter, const recipe_proficiency &prof,
+                                      const book_proficiency_bonuses &books )
 {
     if( !crafter.has_proficiency( prof.id )
         && !helpers_have_proficiencies( crafter, prof.id )
         && prof.skill_penalty > 0.f
       ) {
         double malus =  prof.skill_penalty;
-        malus *= 1.0 - crafter.crafting_inventory().get_book_proficiency_bonuses().fail_factor( prof.id );
+        malus *= 1.0 - books.fail_factor( prof.id );
         double pl = get_aided_proficiency_level( crafter, prof.id );
         // The failure malus is not completely eliminated until the proficiency is mastered.
         // Most of the mitigation happens at higher pl. See #49198
@@ -1524,11 +1548,12 @@ static float proficiency_skill_malus( const Character &crafter, const recipe_pro
     return 0.0f;
 }
 
-float recipe::proficiency_skill_maluses( const Character &crafter ) const
+float recipe::proficiency_skill_maluses( const Character &crafter,
+        const book_proficiency_bonuses &books ) const
 {
     float total_malus = 0.f;
     for( const recipe_proficiency &prof : get_proficiencies() ) {
-        total_malus += proficiency_skill_malus( crafter, prof );
+        total_malus += proficiency_skill_malus( crafter, prof, books );
     }
     return total_malus;
 }
@@ -1549,14 +1574,13 @@ std::string recipe::missing_proficiencies_string( const Character *crafter ) con
     }
     std::vector<prof_penalty> missing_profs;
 
-    const book_proficiency_bonuses book_bonuses =
-        crafter->crafting_inventory().get_book_proficiency_bonuses();
+    const book_proficiency_bonuses book_bonuses = crafter->book_bonuses_nearby();
     for( const recipe_proficiency &prof : get_proficiencies() ) {
         if( !prof.required ) {
             if( !( crafter->has_proficiency( prof.id ) || helpers_have_proficiencies( *crafter, prof.id ) ) ) {
                 prof_penalty pen = { prof.id,
-                                     proficiency_time_malus( *crafter, prof ),
-                                     proficiency_skill_malus( *crafter, prof )
+                                     proficiency_time_malus( *crafter, prof, book_bonuses ),
+                                     proficiency_skill_malus( *crafter, prof, book_bonuses )
                                    };
                 pen.mitigated = book_bonuses.time_factor( pen.id ) != 0.0f ||
                                 book_bonuses.fail_factor( pen.id ) != 0.0f;

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -16,6 +16,7 @@
 
 #include "build_reqs.h"
 #include "calendar.h"
+#include "proficiency.h"
 #include "requirements.h"
 #include "translation.h"
 #include "type_id.h"
@@ -28,6 +29,7 @@ class cata_variant;
 class item;
 class item_components;
 class read_only_visitable;
+class recipe;
 template <typename E> struct enum_traits;
 
 enum class recipe_filter_flags : int {
@@ -123,6 +125,24 @@ struct recipe_step {
     requirement_data requirements;
 
     void load( const JsonObject &jo, const std::string &recipe_name, int step_index );
+};
+
+// Pre-computed environment data for recipe cost calculations.
+// Eliminates hidden inventory scans from recipe time/proficiency functions.
+// Construct once at the evaluation boundary (UI open, craft start, 5% tick)
+// and pass through to all recipe cost functions.
+//
+// Use for_recipe() to compute from crafter + recipe, not bare {} --
+// {} means "no book bonuses, no tool speeds" which silently drops
+// book proficiency mitigation.
+struct crafting_cost_context {
+    book_proficiency_bonuses books;     // nearby book proficiency bonuses
+    std::vector<float> tool_speeds;     // per-step tool speed modifiers (empty = none)
+
+    // Compute full context: book bonuses + tool speed modifiers for this recipe.
+    static crafting_cost_context for_recipe( const Character &guy, const recipe &rec );
+    // Book bonuses only (no tool speed modifiers). Cheaper than for_recipe().
+    static crafting_cost_context for_proficiencies( const Character &guy );
 };
 
 class recipe
@@ -271,12 +291,16 @@ class recipe
         bool character_has_required_proficiencies( const Character &c ) const;
         // Used proficiencies, will impede crafting if missing
         std::vector<proficiency_id> used_proficiencies() const;
-        // The time malus due to proficiencies lacking
-        float proficiency_time_maluses( const Character &crafter ) const;
+        // The time malus due to proficiencies lacking.
+        // book_bonuses: nearby book proficiency bonuses (avoids inventory scan).
+        float proficiency_time_maluses( const Character &crafter,
+                                        const book_proficiency_bonuses &books ) const;
         // The time malus if all the proficiencies were lacking
         float max_proficiency_time_maluses( const Character &crafter ) const;
-        // The skill malus due to proficiencies lacking
-        float proficiency_skill_maluses( const Character &crafter ) const;
+        // The skill malus due to proficiencies lacking.
+        // book_bonuses: nearby book proficiency bonuses (avoids inventory scan).
+        float proficiency_skill_maluses( const Character &crafter,
+                                         const book_proficiency_bonuses &books ) const;
         // The max skill malus due to proficiencies lacking
         float max_proficiency_skill_maluses( const Character &crafter ) const;
 
@@ -297,14 +321,15 @@ class recipe
         const std::vector<recipe_proficiency> &get_proficiencies() const {
             return has_steps() ? aggregate_proficiencies_ : proficiencies;
         }
-        // Per-step proficiency time malus (uses step's own proficiency list)
+        // Per-step proficiency time malus (uses step's own proficiency list).
+        // book_bonuses: nearby book proficiency bonuses (avoids inventory scan).
         static float proficiency_time_maluses_for_step(
-            const Character &crafter, const recipe_step &step );
+            const Character &crafter, const recipe_step &step,
+            const book_proficiency_bonuses &books );
         // Per-step time budget in base moves (with proficiency malus and batch savings).
         // Same per-step formula that batch_time() uses internally.
-        // Optional tool_speeds vector applies per-step speed modifier.
         double step_budget_moves( const Character &guy, size_t step_idx, int batch,
-                                  const std::vector<float> *tool_speeds = nullptr ) const;
+                                  const crafting_cost_context &ctx ) const;
 
         // This is used by the basecamp bulletin board.
         std::string required_all_skills_string( const std::map<skill_id, int> & ) const;
@@ -328,13 +353,14 @@ class recipe
         bool has_byproducts() const;
 
         int64_t batch_time( const Character &guy, int batch, float multiplier, size_t assistants,
-                            const std::vector<float> *tool_speeds = nullptr ) const;
-        time_duration batch_duration( const Character &guy, int batch = 1, float multiplier = 1.0,
+                            const crafting_cost_context &ctx ) const;
+        time_duration batch_duration( const Character &guy, const crafting_cost_context &ctx,
+                                      int batch = 1, float multiplier = 1.0,
                                       size_t assistants = 0 ) const;
 
-        time_duration time_to_craft( const Character &guy,
+        time_duration time_to_craft( const Character &guy, const crafting_cost_context &ctx,
                                      recipe_time_flag flags = recipe_time_flag::none ) const;
-        int64_t time_to_craft_moves( const Character &guy,
+        int64_t time_to_craft_moves( const Character &guy, const crafting_cost_context &ctx,
                                      recipe_time_flag flags = recipe_time_flag::none ) const;
 
         bool has_flag( const std::string &flag_name ) const;

--- a/tests/crafting_gui_test.cpp
+++ b/tests/crafting_gui_test.cpp
@@ -23,6 +23,7 @@
 #include "map_helpers.h"
 #include "options_helpers.h"
 #include "player_helpers.h"
+#include "proficiency.h"
 #include "recipe.h"
 #include "type_id.h"
 #include "uistate.h"
@@ -354,9 +355,9 @@ TEST_CASE( "recipe_sort_craftable_before_uncraftable", "[crafting][gui]" )
     availability avail_no( guy, &rec );
     CHECK_FALSE( avail_no.can_craft );
 
-    CHECK( recipe_sort_compare( &rec, &rec, avail_yes, avail_no, guy,
+    CHECK( recipe_sort_compare( &rec, &rec, avail_yes, avail_no, guy, {},
                                 true, true, false ) );
-    CHECK_FALSE( recipe_sort_compare( &rec, &rec, avail_no, avail_yes, guy,
+    CHECK_FALSE( recipe_sort_compare( &rec, &rec, avail_no, avail_yes, guy, {},
                                       true, true, false ) );
 }
 
@@ -375,7 +376,7 @@ TEST_CASE( "recipe_sort_by_difficulty", "[crafting][gui]" )
     availability avail_easy( guy, &rec_easy );
 
     // Higher difficulty sorts first (existing behavior: b->difficulty < a->difficulty)
-    CHECK( recipe_sort_compare( &rec_hard, &rec_easy, avail_hard, avail_easy, guy,
+    CHECK( recipe_sort_compare( &rec_hard, &rec_easy, avail_hard, avail_easy, guy, {},
                                 true, true, false ) );
 }
 
@@ -395,9 +396,9 @@ TEST_CASE( "recipe_sort_by_name", "[crafting][gui]" )
     availability avail_meat( guy, &rec_meat );
 
     // "cooked meat" < "cudgel" alphabetically
-    CHECK( recipe_sort_compare( &rec_meat, &rec_cudgel, avail_meat, avail_cudgel, guy,
+    CHECK( recipe_sort_compare( &rec_meat, &rec_cudgel, avail_meat, avail_cudgel, guy, {},
                                 true, true, false ) );
-    CHECK_FALSE( recipe_sort_compare( &rec_cudgel, &rec_meat, avail_cudgel, avail_meat, guy,
+    CHECK_FALSE( recipe_sort_compare( &rec_cudgel, &rec_meat, avail_cudgel, avail_meat, guy, {},
                                       true, true, false ) );
 }
 
@@ -415,7 +416,7 @@ TEST_CASE( "recipe_sort_by_craft_time_tiebreaker", "[crafting][gui]" )
     availability avail_slow( guy, &rec_slow );
 
     // Same name, same difficulty -> longer craft time sorts first
-    CHECK( recipe_sort_compare( &rec_slow, &rec_fast, avail_slow, avail_fast, guy,
+    CHECK( recipe_sort_compare( &rec_slow, &rec_fast, avail_slow, avail_fast, guy, {},
                                 true, true, false ) );
 }
 
@@ -431,10 +432,10 @@ TEST_CASE( "recipe_sort_unread_first", "[crafting][gui]" )
     availability avail( guy, &rec );
 
     // a_read=false (unread), b_read=true (read), unread_first=true -> a sorts before b
-    CHECK( recipe_sort_compare( &rec, &rec, avail, avail, guy,
+    CHECK( recipe_sort_compare( &rec, &rec, avail, avail, guy, {},
                                 false, true, true ) );
     // a_read=true (read), b_read=false (unread) -> b should sort first, so a < b is false
-    CHECK_FALSE( recipe_sort_compare( &rec, &rec, avail, avail, guy,
+    CHECK_FALSE( recipe_sort_compare( &rec, &rec, avail, avail, guy, {},
                                       true, false, true ) );
 }
 
@@ -456,7 +457,7 @@ TEST_CASE( "recipe_sort_unread_disabled", "[crafting][gui]" )
     availability avail_no( guy, &rec );
 
     // unread_first=false: read state ignored, craftability dominates
-    CHECK( recipe_sort_compare( &rec, &rec, avail_yes, avail_no, guy,
+    CHECK( recipe_sort_compare( &rec, &rec, avail_yes, avail_no, guy, {},
                                 true, false, false ) );
 }
 

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -632,7 +632,7 @@ TEST_CASE( "proficiency_gain_short_crafts", "[crafting][proficiency]" )
     int turns_taken = 0;
     const int max_turns = 100000;
 
-    float time_malus = rec->proficiency_time_maluses( ch );
+    float time_malus = rec->proficiency_time_maluses( ch, ch.book_bonuses_nearby() );
 
     // Proficiency progress is checked every 5% of craft progress, so up to 5% of one craft worth can be wasted depending on timing
     // Rounding effects account for another tiny bit
@@ -1150,7 +1150,7 @@ TEST_CASE( "total_crafting_time_with_or_without_interruption", "[crafting][time]
 {
     GIVEN( "a recipe and all the required tools and materials to craft it" ) {
         recipe_id test_recipe( "razor_shaving" );
-        int expected_time_taken = test_recipe->batch_time( get_player_character(), 1, 1, 0 );
+        int expected_time_taken = test_recipe->batch_time( get_player_character(), 1, 1, 0, {} );
         int expected_turns_taken = divide_round_up( expected_time_taken, 100 );
 
         std::vector<item> tools;
@@ -1437,20 +1437,24 @@ TEST_CASE( "book_proficiency_mitigation", "[crafting][proficiency]" )
         const recipe &test_recipe = *recipe_leather_belt;
 
         grant_skills_to_character( get_player_character(), test_recipe, 0 );
-        int unmitigated_time_taken = test_recipe.batch_time( get_player_character(), 1, 1, 0 );
+        const Character &ch = get_player_character();
+        crafting_cost_context ctx_no_book{ ch.book_bonuses_nearby(), {} };
+        int unmitigated_time_taken = test_recipe.batch_time( ch, 1, 1, 0, ctx_no_book );
 
         WHEN( "player has a book mitigating lack of proficiency" ) {
             std::vector<item> books;
             books.emplace_back( itype_manual_tailor );
             give_tools( books, true );
             get_player_character().invalidate_crafting_inventory();
-            int mitigated_time_taken = test_recipe.batch_time( get_player_character(), 1, 1, 0 );
+            crafting_cost_context ctx_with_book{ ch.book_bonuses_nearby(), {} };
+            int mitigated_time_taken = test_recipe.batch_time( ch, 1, 1, 0, ctx_with_book );
             THEN( "it takes less time to craft the recipe" ) {
                 CHECK( mitigated_time_taken < unmitigated_time_taken );
             }
             AND_WHEN( "player acquires missing proficiencies" ) {
                 grant_proficiencies_to_character( get_player_character(), test_recipe, true );
-                int proficient_time_taken = test_recipe.batch_time( get_player_character(), 1, 1, 0 );
+                crafting_cost_context ctx_proficient{ ch.book_bonuses_nearby(), {} };
+                int proficient_time_taken = test_recipe.batch_time( ch, 1, 1, 0, ctx_proficient );
                 THEN( "it takes even less time to craft the recipe" ) {
                     CHECK( proficient_time_taken < mitigated_time_taken );
                 }
@@ -1468,19 +1472,19 @@ TEST_CASE( "partial_proficiency_mitigation", "[crafting][proficiency]" )
         const recipe &test_recipe = *recipe_leather_belt;
 
         grant_skills_to_character( tester, test_recipe, 0 );
-        int unmitigated_time_taken = test_recipe.batch_time( tester, 1, 1, 0 );
+        int unmitigated_time_taken = test_recipe.batch_time( tester, 1, 1, 0, {} );
 
         WHEN( "player acquires partial proficiency" ) {
             for( const proficiency_id &prof : test_recipe.used_proficiencies() ) {
                 tester.set_proficiency_practice( prof, tester.proficiency_training_needed( prof ) / 2 );
             }
-            int mitigated_time_taken = test_recipe.batch_time( tester, 1, 1, 0 );
+            int mitigated_time_taken = test_recipe.batch_time( tester, 1, 1, 0, {} );
             THEN( "it takes less time to craft the recipe" ) {
                 CHECK( mitigated_time_taken < unmitigated_time_taken );
             }
             AND_WHEN( "player acquires missing proficiencies" ) {
                 grant_proficiencies_to_character( tester, test_recipe, true );
-                int proficient_time_taken = test_recipe.batch_time( tester, 1, 1, 0 );
+                int proficient_time_taken = test_recipe.batch_time( tester, 1, 1, 0, {} );
                 THEN( "it takes even less time to craft the recipe" ) {
                     CHECK( proficient_time_taken < mitigated_time_taken );
                 }

--- a/tests/recipe_steps_test.cpp
+++ b/tests/recipe_steps_test.cpp
@@ -96,7 +96,7 @@ TEST_CASE( "step_recipe_aggregate_time", "[recipe][steps]" )
     guy.set_skill_level( skill_fabrication, 10 );
 
     const int64_t expected = to_moves<int64_t>( 20_minutes );
-    CHECK( r.time_to_craft_moves( guy, recipe_time_flag::ignore_proficiencies ) == expected );
+    CHECK( r.time_to_craft_moves( guy, {}, recipe_time_flag::ignore_proficiencies ) == expected );
 }
 
 TEST_CASE( "step_recipe_root_components_preserved", "[recipe][steps]" )
@@ -207,7 +207,7 @@ TEST_CASE( "step_recipe_proficiency_malus_clean_miss", "[recipe][steps]" )
     const int64_t raw_time = to_moves<int64_t>( 20_minutes );
 
     // Shape: 10m * 2.0, Sand: 5m * 1.0, Finish: 5m * 1.5 => 32.5m total
-    const int64_t with_malus = r.time_to_craft_moves( guy );
+    const int64_t with_malus = r.time_to_craft_moves( guy, {} );
     const double expected = 10.0 * to_moves<int64_t>( 1_minutes ) * 2.0 +
                             5.0 * to_moves<int64_t>( 1_minutes ) * 1.0 +
                             5.0 * to_moves<int64_t>( 1_minutes ) * 1.5;
@@ -224,10 +224,10 @@ TEST_CASE( "step_recipe_proficiency_grant_removes_step_penalty", "[recipe][steps
 
     const recipe &r = recipe_cudgel_test_steps_basic.obj();
 
-    const int64_t full_malus_time = r.time_to_craft_moves( guy );
+    const int64_t full_malus_time = r.time_to_craft_moves( guy, {} );
 
     guy.add_proficiency( proficiency_prof_test_step_a, true );
-    const int64_t no_a_malus_time = r.time_to_craft_moves( guy );
+    const int64_t no_a_malus_time = r.time_to_craft_moves( guy, {} );
 
     CHECK( full_malus_time > no_a_malus_time );
 
@@ -244,17 +244,17 @@ TEST_CASE( "step_recipe_partial_proficiency_sigmoid_mitigation", "[recipe][steps
 
     const recipe &r = recipe_cudgel_test_steps_basic.obj();
 
-    const int64_t full_malus = r.time_to_craft_moves( guy );
+    const int64_t full_malus = r.time_to_craft_moves( guy, {} );
 
     guy.add_proficiency( proficiency_prof_test_step_a, true );
-    const int64_t no_malus = r.time_to_craft_moves( guy );
+    const int64_t no_malus = r.time_to_craft_moves( guy, {} );
 
     // Train to ~75%, well past the sigmoid midpoint
     guy.lose_proficiency( proficiency_prof_test_step_a, true );
     const time_duration three_quarter = proficiency_prof_test_step_a->time_to_learn() * 3 / 4;
     guy.practice_proficiency( proficiency_prof_test_step_a, three_quarter );
     REQUIRE( !guy.has_proficiency( proficiency_prof_test_step_a ) );
-    const int64_t partial_malus = r.time_to_craft_moves( guy );
+    const int64_t partial_malus = r.time_to_craft_moves( guy, {} );
 
     CHECK( partial_malus < full_malus );
     CHECK( partial_malus > no_malus );
@@ -280,7 +280,7 @@ TEST_CASE( "step_recipe_same_prof_in_two_steps", "[recipe][steps]" )
     Character &guy = get_player_character();
     guy.set_skill_level( skill_fabrication, 10 );
 
-    const int64_t with_malus = r.time_to_craft_moves( guy );
+    const int64_t with_malus = r.time_to_craft_moves( guy, {} );
     const double expected = 20.0 * to_moves<int64_t>( 1_minutes ) * 2.0;
     CHECK( with_malus == static_cast<int64_t>( expected ) );
 }
@@ -309,9 +309,9 @@ TEST_CASE( "step_recipe_display_malus_is_step_derived", "[recipe][steps]" )
 
     const recipe &r = recipe_cudgel_test_steps_basic.obj();
 
-    const float display_malus = r.proficiency_time_maluses( guy );
+    const float display_malus = r.proficiency_time_maluses( guy, guy.book_bonuses_nearby() );
     const int64_t raw_time = to_moves<int64_t>( 20_minutes );
-    const int64_t actual_time = r.time_to_craft_moves( guy );
+    const int64_t actual_time = r.time_to_craft_moves( guy, {} );
 
     // Display ratio should match actual_time / raw_time
     CHECK( display_malus == Approx( static_cast<float>( actual_time ) /
@@ -334,8 +334,8 @@ TEST_CASE( "step_recipe_per_step_batch_savings", "[recipe][steps]" )
     const recipe &r = recipe_cudgel_test_steps_basic.obj();
     const int batch = 4;
 
-    const int64_t batch4_time = r.batch_time( guy, batch, 1.0f, 0 );
-    const int64_t single_time = r.batch_time( guy, 1, 1.0f, 0 );
+    const int64_t batch4_time = r.batch_time( guy, batch, 1.0f, 0, {} );
+    const int64_t single_time = r.batch_time( guy, 1, 1.0f, 0, {} );
 
     CHECK( batch4_time < single_time * 4 );
     CHECK( batch4_time > single_time );
@@ -360,7 +360,7 @@ TEST_CASE( "stepless_recipe_unchanged", "[recipe][steps]" )
     Character &guy = get_player_character();
     guy.set_skill_level( skill_cooking, 10 );
 
-    CHECK( r.time_to_craft_moves( guy, recipe_time_flag::ignore_proficiencies ) ==
+    CHECK( r.time_to_craft_moves( guy, {}, recipe_time_flag::ignore_proficiencies ) ==
            to_moves<int64_t>( 15_minutes ) );
     CHECK_FALSE( r.simple_requirements().get_components().empty() );
     CHECK_FALSE( r.get_proficiencies().empty() );
@@ -605,7 +605,7 @@ TEST_CASE( "step_recipe_end_to_end_craft", "[recipe][steps][crafting]" )
     avatar &guy = get_avatar();
     const recipe &r = recipe_cudgel_test_steps_basic.obj();
 
-    const int expected_moves = r.batch_time( guy, 1, 1.0f, 0 );
+    const int expected_moves = r.batch_time( guy, 1, 1.0f, 0, {} );
     const int expected_turns = divide_round_up( expected_moves, 100 );
     REQUIRE( expected_turns > 2 );
 
@@ -632,7 +632,7 @@ TEST_CASE( "step_recipe_interrupt_and_resume", "[recipe][steps][crafting]" )
     avatar &guy = get_avatar();
     const recipe &r = recipe_cudgel_test_steps_basic.obj();
 
-    const int expected_moves = r.batch_time( guy, 1, 1.0f, 0 );
+    const int expected_moves = r.batch_time( guy, 1, 1.0f, 0, {} );
     const int expected_turns = divide_round_up( expected_moves, 100 );
     REQUIRE( expected_turns > 10 );
 
@@ -775,31 +775,31 @@ TEST_CASE( "step_budget_moves_direct", "[recipe][steps]" )
     REQUIRE( r.steps().size() == 3 );
 
     SECTION( "all profs known, batch 1" ) {
-        CHECK( r.step_budget_moves( guy, 0, 1 ) == Approx( 60000.0 ) );
-        CHECK( r.step_budget_moves( guy, 1, 1 ) == Approx( 30000.0 ) );
-        CHECK( r.step_budget_moves( guy, 2, 1 ) == Approx( 30000.0 ) );
+        CHECK( r.step_budget_moves( guy, 0, 1, {} ) == Approx( 60000.0 ) );
+        CHECK( r.step_budget_moves( guy, 1, 1, {} ) == Approx( 30000.0 ) );
+        CHECK( r.step_budget_moves( guy, 2, 1, {} ) == Approx( 30000.0 ) );
 
-        double sum = r.step_budget_moves( guy, 0, 1 ) +
-                     r.step_budget_moves( guy, 1, 1 ) +
-                     r.step_budget_moves( guy, 2, 1 );
-        CHECK( std::abs( sum - r.batch_time( guy, 1, 1.0f, 0 ) ) <= 1.0 );
+        double sum = r.step_budget_moves( guy, 0, 1, {} ) +
+                     r.step_budget_moves( guy, 1, 1, {} ) +
+                     r.step_budget_moves( guy, 2, 1, {} );
+        CHECK( std::abs( sum - r.batch_time( guy, 1, 1.0f, 0, {} ) ) <= 1.0 );
     }
 
     SECTION( "prof_A missing, batch 1" ) {
         guy.lose_proficiency( proficiency_prof_test_step_a, true );
         // Step 0 has prof_A with 2x malus -> doubled
-        CHECK( r.step_budget_moves( guy, 0, 1 ) == Approx( 120000.0 ) );
+        CHECK( r.step_budget_moves( guy, 0, 1, {} ) == Approx( 120000.0 ) );
         // Other steps unaffected
-        CHECK( r.step_budget_moves( guy, 1, 1 ) == Approx( 30000.0 ) );
-        CHECK( r.step_budget_moves( guy, 2, 1 ) == Approx( 30000.0 ) );
+        CHECK( r.step_budget_moves( guy, 1, 1, {} ) == Approx( 30000.0 ) );
+        CHECK( r.step_budget_moves( guy, 2, 1, {} ) == Approx( 30000.0 ) );
     }
 
     SECTION( "all profs known, batch 4" ) {
         double sum = 0.0;
         for( size_t i = 0; i < r.steps().size(); ++i ) {
-            sum += r.step_budget_moves( guy, i, 4 );
+            sum += r.step_budget_moves( guy, i, 4, {} );
         }
-        CHECK( std::abs( sum - r.batch_time( guy, 4, 1.0f, 0 ) ) <= 1.0 );
+        CHECK( std::abs( sum - r.batch_time( guy, 4, 1.0f, 0, {} ) ) <= 1.0 );
     }
 }
 
@@ -811,8 +811,8 @@ TEST_CASE( "step_transitions_exact_boundaries", "[recipe][steps][crafting]" )
     const recipe &r = recipe_cudgel_test_steps_basic.obj();
 
     // With all profs and batch=1, step budgets are 600, 300, 300 turns
-    const int step_0_turns = static_cast<int>( r.step_budget_moves( guy, 0, 1 ) / 100 );
-    const int step_1_turns = static_cast<int>( r.step_budget_moves( guy, 1, 1 ) / 100 );
+    const int step_0_turns = static_cast<int>( r.step_budget_moves( guy, 0, 1, {} ) / 100 );
+    const int step_1_turns = static_cast<int>( r.step_budget_moves( guy, 1, 1, {} ) / 100 );
     REQUIRE( step_0_turns == 600 );
     REQUIRE( step_1_turns == 300 );
 
@@ -1067,7 +1067,7 @@ TEST_CASE( "step_interrupt_resume_completes", "[recipe][steps][crafting]" )
     avatar &guy = get_avatar();
     const recipe &r = recipe_cudgel_test_steps_basic.obj();
 
-    const int expected_moves = r.batch_time( guy, 1, 1.0f, 0 );
+    const int expected_moves = r.batch_time( guy, 1, 1.0f, 0, {} );
     const int expected_turns = divide_round_up( expected_moves, 100 );
 
     // Advance into step 1
@@ -1128,7 +1128,7 @@ TEST_CASE( "step_legacy_migration", "[recipe][steps][crafting]" )
 
     // Advance to ~60% progress
     const int total_turns = divide_round_up(
-                                static_cast<int>( r.batch_time( guy, 1, 1.0f, 0 ) ), 100 );
+                                static_cast<int>( r.batch_time( guy, 1, 1.0f, 0, {} ) ), 100 );
     advance_turns( guy, total_turns * 6 / 10 );
     REQUIRE( guy.activity.id() == ACT_CRAFT );
 
@@ -1564,13 +1564,13 @@ TEST_CASE( "step_budget_with_tool_speed", "[recipe][steps][tool_speed]" )
     REQUIRE( r.steps().size() == 3 );
 
     // Without tool speed: Finish step (idx 2) budget = 30000
-    CHECK( r.step_budget_moves( guy, 2, 1 ) == Approx( 30000.0 ) );
+    CHECK( r.step_budget_moves( guy, 2, 1, {} ) == Approx( 30000.0 ) );
 
     // With tool speed vector: [1.0, 1.0, 0.5] -- only Finish affected
     std::vector<float> speeds = { 1.0f, 1.0f, 0.5f };
-    CHECK( r.step_budget_moves( guy, 0, 1, &speeds ) == Approx( 60000.0 ) );
-    CHECK( r.step_budget_moves( guy, 1, 1, &speeds ) == Approx( 30000.0 ) );
-    CHECK( r.step_budget_moves( guy, 2, 1, &speeds ) == Approx( 15000.0 ) );
+    CHECK( r.step_budget_moves( guy, 0, 1, crafting_cost_context{ {}, speeds } ) == Approx( 60000.0 ) );
+    CHECK( r.step_budget_moves( guy, 1, 1, crafting_cost_context{ {}, speeds } ) == Approx( 30000.0 ) );
+    CHECK( r.step_budget_moves( guy, 2, 1, crafting_cost_context{ {}, speeds } ) == Approx( 15000.0 ) );
 }
 
 TEST_CASE( "tool_speed_composes_with_proficiency", "[recipe][steps][tool_speed]" )
@@ -1584,7 +1584,7 @@ TEST_CASE( "tool_speed_composes_with_proficiency", "[recipe][steps][tool_speed]"
 
     const recipe &r = recipe_cudgel_test_steps_basic.obj();
     std::vector<float> speeds = { 1.0f, 1.0f, 0.5f };
-    CHECK( r.step_budget_moves( guy, 2, 1, &speeds ) == Approx( 22500.0 ) );
+    CHECK( r.step_budget_moves( guy, 2, 1, crafting_cost_context{ {}, speeds } ) == Approx( 22500.0 ) );
 }
 
 TEST_CASE( "batch_time_with_tool_speed", "[recipe][steps][tool_speed]" )
@@ -1597,9 +1597,9 @@ TEST_CASE( "batch_time_with_tool_speed", "[recipe][steps][tool_speed]" )
     guy.add_proficiency( proficiency_prof_test_step_b, true );
 
     const recipe &r = recipe_cudgel_test_steps_basic.obj();
-    int64_t time_no_speed = r.batch_time( guy, 1, 1.0f, 0 );
+    int64_t time_no_speed = r.batch_time( guy, 1, 1.0f, 0, {} );
     std::vector<float> speeds = { 1.0f, 1.0f, 0.5f };
-    int64_t time_with_speed = r.batch_time( guy, 1, 1.0f, 0, &speeds );
+    int64_t time_with_speed = r.batch_time( guy, 1, 1.0f, 0, crafting_cost_context{ {}, speeds } );
 
     // Finish step is 30000 -> 15000 with tool speed, so total drops by 15000
     CHECK( time_with_speed < time_no_speed );
@@ -1624,8 +1624,8 @@ TEST_CASE( "step_without_qualities_unaffected", "[recipe][steps][tool_speed]" )
     // This test verifies that the CALLER (compute_tool_speeds) produces 1.0
     // for steps without quality requirements. For now, test the vector path.
     std::vector<float> speeds = { 1.0f, 1.0f, 0.5f };
-    CHECK( r.step_budget_moves( guy, 0, 1, &speeds ) == Approx( 60000.0 ) );
-    CHECK( r.step_budget_moves( guy, 1, 1, &speeds ) == Approx( 30000.0 ) );
+    CHECK( r.step_budget_moves( guy, 0, 1, crafting_cost_context{ {}, speeds } ) == Approx( 60000.0 ) );
+    CHECK( r.step_budget_moves( guy, 1, 1, crafting_cost_context{ {}, speeds } ) == Approx( 30000.0 ) );
 }
 
 TEST_CASE( "slow_tool_increases_step_time", "[recipe][steps][tool_speed]" )
@@ -1639,7 +1639,7 @@ TEST_CASE( "slow_tool_increases_step_time", "[recipe][steps][tool_speed]" )
 
     const recipe &r = recipe_cudgel_test_steps_basic.obj();
     std::vector<float> speeds = { 1.0f, 1.0f, 1.5f };
-    CHECK( r.step_budget_moves( guy, 2, 1, &speeds ) == Approx( 45000.0 ) );
+    CHECK( r.step_budget_moves( guy, 2, 1, crafting_cost_context{ {}, speeds } ) == Approx( 45000.0 ) );
 }
 
 TEST_CASE( "mixed_speed_multi_step_invariant", "[recipe][steps][tool_speed]" )
@@ -1656,9 +1656,9 @@ TEST_CASE( "mixed_speed_multi_step_invariant", "[recipe][steps][tool_speed]" )
 
     double sum = 0.0;
     for( size_t i = 0; i < r.steps().size(); ++i ) {
-        sum += r.step_budget_moves( guy, i, 1, &speeds );
+        sum += r.step_budget_moves( guy, i, 1, crafting_cost_context{ {}, speeds } );
     }
-    int64_t bt = r.batch_time( guy, 1, 1.0f, 0, &speeds );
+    int64_t bt = r.batch_time( guy, 1, 1.0f, 0, crafting_cost_context{ {}, speeds } );
     // batch_time truncates to int64_t; sum is double. Within 1 move.
     CHECK( std::abs( sum - static_cast<double>( bt ) ) <= 1.0 );
 }
@@ -1674,9 +1674,9 @@ TEST_CASE( "single_item_floor_with_tool_speed", "[recipe][steps][tool_speed]" )
     guy.add_proficiency( proficiency_prof_test_step_b, true );
 
     const recipe &r = recipe_cudgel_test_steps_basic.obj();
-    int64_t no_speed = r.batch_time( guy, 1, 1.0f, 0 );
+    int64_t no_speed = r.batch_time( guy, 1, 1.0f, 0, {} );
     std::vector<float> speeds = { 1.0f, 1.0f, 0.5f };
-    int64_t with_speed = r.batch_time( guy, 1, 1.0f, 0, &speeds );
+    int64_t with_speed = r.batch_time( guy, 1, 1.0f, 0, crafting_cost_context{ {}, speeds } );
 
     // batch=1 hits the single-item floor. If the floor is NOT speed-aware,
     // with_speed would equal no_speed (clamped back up). It must be less.
@@ -1764,9 +1764,9 @@ TEST_CASE( "stepless_recipe_unaffected_by_tool_speed", "[recipe][steps][tool_spe
     }
 
     // batch_time with and without tool speeds should be identical for stepless
-    int64_t no_speed = r.batch_time( guy, 1, 1.0f, 0 );
+    int64_t no_speed = r.batch_time( guy, 1, 1.0f, 0, {} );
     std::vector<float> speeds;  // empty for stepless
-    int64_t with_speed = r.batch_time( guy, 1, 1.0f, 0, &speeds );
+    int64_t with_speed = r.batch_time( guy, 1, 1.0f, 0, crafting_cost_context{ {}, speeds } );
     CHECK( no_speed == with_speed );
 }
 


### PR DESCRIPTION
#### Summary
Performance "Fix per-turn inventory rebuild for step recipe proficiency checks"

#### Purpose of change

Fixes #86267. Step recipes (currently just bread) trigger a full crafting inventory rebuild every game turn. `step_budget_moves()` calls `proficiency_time_malus()` which pulls book bonuses from `crafting_inventory()`, but the inventory cache is always stale at that point because `set_moves(0)` invalidates it earlier in the same `do_turn()` call. With many nearby items this is an O(N^2) rebuild per turn (copy every item + stacking search). Same bug pattern that #48650 fixed for `batch_time()`.

#### Describe the solution

`crafting_cost_context` struct bundles `book_proficiency_bonuses` and per-step `tool_speeds` -- the two things that previously had nullable pointer params with implicit fallback scans. It's a required parameter on `batch_time()`, `time_to_craft_moves()`, and `step_budget_moves()`, so there's no way to accidentally trigger an inventory scan from inside a recipe cost function. Factory methods `for_recipe()` and `for_proficiencies()` make the right construction easy; bare `{}` only works for `ignore_proficiencies` paths where books are never consulted.

The leaf proficiency functions (`proficiency_time_malus`, `proficiency_skill_malus`) take `book_proficiency_bonuses` as a required reference -- they physically cannot reach into the environment.

`Character::book_bonuses_nearby()` is the lightweight replacement for the old "rebuild crafting inventory, then scan it for books" path. It walks map tiles and vehicle cargo in-place using `map::for_each_reachable_item()` -- a shared primitive that captures the reachability/accessibility/ownership/vehicle-cargo logic so it doesn't drift from `form_from_map()`.

The craft activity actor caches one `crafting_cost_context`, recomputed only when crafting speed or assistants change (same invalidation as the existing `batch_time()` cache). Crafting GUI paths (`availability`, step display, recipe sort) also precompute once and share.

#### Describe alternatives you've considered

Caching `get_book_proficiency_bonuses()` lazily on the inventory object. Still tied to the `crafting_inventory()` rebuild lifecycle, so doesn't eliminate the O(N^2) stacking cost, and doesn't prevent new callers from accidentally going through the slow path.

Removing `moves` from the `crafting_inventory()` cache key to avoid the false invalidation. Fixes the symptom but `moves` is there as a "something changed" proxy for other callers, and doesn't address the architectural issue of proficiency functions pulling from the environment.

#### Testing

Existing [steps], [crafting], and [recipe] test suites pass. The `book_proficiency_mitigation` test was updated to construct a proper context. Verified in-game with the save from #86267.

#### Additional context

`form_from_map()` itself is not refactored to use `for_each_reachable_item()` yet -- it handles liquid containers, pseudo-items, fire, water, and keg kludges that the shared primitive intentionally doesn't cover. The primitive captures the common subset; `form_from_map()` can adopt it later.