### PR TITLE
[Sky Island] Blacklist evacuation flyer

### DIFF
--- a/data/mods/Sky_Island/item_blacklist.json
+++ b/data/mods/Sky_Island/item_blacklist.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "ITEM_BLACKLIST",
+    "whitelist": false,
+    "items": [ "flyer_evac" ]
+  }
+]


### PR DESCRIPTION


#### Summary
None

#### Purpose of change
Considering refugee center don't exists in sky island and the evacuation flyer being quite common, this blacklists the evacuation flyer from spawning.

#### Describe the solution
Make the item blacklist JSON for it.

#### Describe alternatives you've considered

Not doing it.

#### Testing
Put the thing on my build of the mod and go around in sky island world. while the preexisting fliers on the sky island is still there, i haven't seen one in the raid dimension.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
