### PR TITLE
[Sky Island] Require the player to examine the statue to receive warp shards

### DIFF
--- a/data/mods/Sky_Island/effectoncondition/raid_missions.json
+++ b/data/mods/Sky_Island/effectoncondition/raid_missions.json
@@ -310,5 +310,27 @@
       },
       { "math": [ "total_difficulty_bonus = lengthofthisraid + 1" ] }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_SKY_ISLAND_WARP_SHARD_STATUE_REWARD",
+    "effect": [
+      { "math": [ "u_missionswon++" ] },
+      { "math": [ "totalbonus = rand(5) + 1" ] },
+      {
+        "if": { "math": [ "challenge_mode_active == 1" ] },
+        "then": [ { "math": [ "totalbonus = totalbonus * challenge_mode_reward_multiplier" ] } ]
+      },
+      { "u_message": "You retrieved the warp shards from the statue.", "type": "mixed" },
+      { "run_eocs": "EOC_bonuspulse" },
+      { "u_spawn_item": "warptoken", "count": { "global_val": "totalbonus", "default": 1 } },
+      { "run_eocs": "EOC_innawood_bonus_exp_warpshards" },
+      { "u_transform_radius": 3, "ter_furn_transform": "sky_island_shard_statue" }
+    ]
+  },
+  {
+    "type": "ter_furn_transform",
+    "id": "sky_island_shard_statue",
+    "furniture": [ { "result": [ "f_warpshardrewardstatue_empty" ], "valid_furniture": [ "f_warpshardrewardstatue" ] } ]
   }
 ]

--- a/data/mods/Sky_Island/furniture_and_terrain.json
+++ b/data/mods/Sky_Island/furniture_and_terrain.json
@@ -50,14 +50,22 @@
     "type": "furniture",
     "id": "f_warpshardrewardstatue",
     "name": "Warp Shard Obelisk",
-    "description": "A strange statue that is holding some warp shards.",
+    "description": "A strange statue with an arm raised, holding some warp shards in it's palm.",
     "symbol": "S",
     "color": "dark_gray",
     "looks_like": "f_statue",
     "move_cost_mod": -1,
     "coverage": 0,
     "required_str": -1,
-    "flags": [ "NOCOLLIDE", "NO_PICKUP_ON_EXAMINE", "TRANSPARENT" ]
+    "flags": [ "NOCOLLIDE", "NO_PICKUP_ON_EXAMINE", "TRANSPARENT" ],
+    "examine_action": { "type": "effect_on_condition", "effect_on_conditions": [ "EOC_SKY_ISLAND_WARP_SHARD_STATUE_REWARD" ] }
+  },
+  {
+    "type": "furniture",
+    "id": "f_warpshardrewardstatue_empty",
+    "copy-from": "f_warpshardrewardstatue",
+    "description": "A strange statue with an arm raised, it's palm empty.",
+    "examine_action": "none"
   },
   {
     "type": "terrain",

--- a/data/mods/Sky_Island/missions/raid_missions.json
+++ b/data/mods/Sky_Island/missions/raid_missions.json
@@ -18,7 +18,7 @@
     "type": "mission_definition",
     "name": { "str": "Find the warp shards!" },
     "goal": "MGOAL_GO_TO",
-    "description": "A very small cluster of warp energy has left shards behind at this location.  All you need to do is find and retrieve them.  There may be threats nearby, but unlike most tasks, no special guards are on-site.  A minimal reward, but little risk.",
+    "description": "A very small cluster of warp energy has left shards behind at this location.  All you need to do is find and retrieve them from the statue.  There may be threats nearby, but unlike most tasks, no special guards are on-site.  A minimal reward, but little risk.",
     "difficulty": 0,
     "value": 0,
     "invisible_on_complete": true,
@@ -28,19 +28,7 @@
     },
     "end": {
       "effect": [
-        { "math": [ "u_missionswon++" ] },
-        { "math": [ "totalbonus = rand(5) + 1" ] },
-        {
-          "if": { "math": [ "challenge_mode_active == 1" ] },
-          "then": [ { "math": [ "totalbonus = totalbonus * challenge_mode_reward_multiplier" ] } ]
-        },
-        {
-          "u_message": "It's done.  You found the statue.  Warp shards filter in from seams in reality.  Your reward rains down on you.",
-          "type": "mixed"
-        },
-        { "run_eocs": "EOC_bonuspulse" },
-        { "u_spawn_item": "warptoken", "count": { "global_val": "totalbonus", "default": 1 } },
-        { "run_eocs": "EOC_innawood_bonus_exp_warpshards" }
+        { "u_message": "You found the statue.  Now you need to find a way to get the warp shards from it.", "type": "mixed" }
       ]
     }
   },


### PR DESCRIPTION

#### Summary
Mods "[Sky Island] Require the player to examine the statue to receive warp shards"


#### Purpose of change
Previously, warp shards were lying on the ground for the Find Warp Shards mission. This required the player to walk over to them and pick them up. When implementing challenge mode, I changed the mission to complete when the player got close enough since the previous method wasn't able to be adjusted on the fly for Challenge mode.
Since these missions can spawn inside of houses that have zeds, this reintroduces the danger associated with those locations.

#### Describe the solution
Change the `MISSION_BONUS_TREASURE` `end` effect to just a simple message telling the player they have to find a way to get the shards from the statue. This should naturally lead them to examine the statue. The statue description clearly states there are warp shards in the palm of its hand.
Using the examine actions on the `f_warpshardrewardstatue` warp shard statue will fire an EOC that performed the same actions as the mission completion used to and execute a `ter_furn_transform` to change the statue into a new one with a description change to indicate it no longer has the shards.

#### Describe alternatives you've considered


#### Testing
Game loads, mission is generated as normal, statue grants shards and transforms as expected.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
