### PR TITLE
Create parse_shopkeeper_whitelist for string extractor

### DIFF
--- a/lang/string_extractor/parser.py
+++ b/lang/string_extractor/parser.py
@@ -69,6 +69,7 @@ from .parsers.practice import parse_practice
 from .parsers.requirement import parse_requirement
 from .parsers.scenario import parse_scenario
 from .parsers.shop_blacklist import parse_shopkeeper_blacklist
+from .parsers.shop_whitelist import parse_shopkeeper_whitelist
 from .parsers.skill import parse_skill
 from .parsers.skill_display_type import parse_skill_display_type
 from .parsers.speech import parse_speech

--- a/lang/string_extractor/parser.py
+++ b/lang/string_extractor/parser.py
@@ -241,6 +241,7 @@ parsers = {
     "scent_type": dummy_parser,
     "score": dummy_parser,
     "shopkeeper_blacklist": parse_shopkeeper_blacklist,
+    "shopkeeper_whitelist": parse_shopkeeper_whitelist,
     "shopkeeper_consumption_rates": dummy_parser,
     "skill": parse_skill,
     "skill_boost": dummy_parser,

--- a/lang/string_extractor/parsers/shop_blacklist.py
+++ b/lang/string_extractor/parsers/shop_blacklist.py
@@ -7,3 +7,10 @@ def parse_shopkeeper_blacklist(json, origin):
         write_text(
             entry.get("message"), origin,
             comment=["Reason for a shopkeeper blacklist entry", comment])
+
+def parse_shopkeeper_whitelist(json, origin):
+    for entry in json["entries"]:
+        comment = entry.get("//")
+        write_text(
+            entry.get("message"), origin,
+            comment=["Reason for a shopkeeper whitelist entry", comment])

--- a/lang/string_extractor/parsers/shop_blacklist.py
+++ b/lang/string_extractor/parsers/shop_blacklist.py
@@ -7,4 +7,3 @@ def parse_shopkeeper_blacklist(json, origin):
         write_text(
             entry.get("message"), origin,
             comment=["Reason for a shopkeeper blacklist entry", comment])
-            

--- a/lang/string_extractor/parsers/shop_blacklist.py
+++ b/lang/string_extractor/parsers/shop_blacklist.py
@@ -7,3 +7,4 @@ def parse_shopkeeper_blacklist(json, origin):
         write_text(
             entry.get("message"), origin,
             comment=["Reason for a shopkeeper blacklist entry", comment])
+            

--- a/lang/string_extractor/parsers/shop_whitelist.py
+++ b/lang/string_extractor/parsers/shop_whitelist.py
@@ -1,9 +1,9 @@
 from ..write_text import write_text
 
 
-def parse_shopkeeper_blacklist(json, origin):
+def parse_shopkeeper_whitelist(json, origin):
     for entry in json["entries"]:
         comment = entry.get("//")
         write_text(
             entry.get("message"), origin,
-            comment=["Reason for a shopkeeper blacklist entry", comment])
+            comment=["Reason for a shopkeeper whitelist entry", comment])

--- a/lang/string_extractor/parsers/shop_whitelist.py
+++ b/lang/string_extractor/parsers/shop_whitelist.py
@@ -7,3 +7,4 @@ def parse_shopkeeper_whitelist(json, origin):
         write_text(
             entry.get("message"), origin,
             comment=["Reason for a shopkeeper whitelist entry", comment])
+            

--- a/lang/string_extractor/parsers/shop_whitelist.py
+++ b/lang/string_extractor/parsers/shop_whitelist.py
@@ -7,4 +7,3 @@ def parse_shopkeeper_whitelist(json, origin):
         write_text(
             entry.get("message"), origin,
             comment=["Reason for a shopkeeper whitelist entry", comment])
-            


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Reading #85035, found there is a bespoke code for translation string extractor that is missing from shopkeeper_whitelist
#### Describe the solution
add one by copypasting and adjusting parse_shopkeeper_blacklist