### PR TITLE
Crafting UI: List missing required proficiencies

### DIFF
--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1144,9 +1144,17 @@ void crafting_ui_impl::draw_recipe_info_panel()
         if( avail.can_craft && avail.would_use_favorite ) {
             cataimgui::TextColoredParagraphNewline( c_red, _( "Will use favorited ingredients" ) );
         }
-        if( !avail.can_craft && !avail.has_proficiencies ) {
-            cataimgui::TextColoredParagraphNewline( c_red,
-                                                    _( "Cannot craft: crafter lacks required proficiencies." ) );
+        if( !avail.can_craft && !avail.has_proficiencies ) { 
+            cataimgui::TextColoredParagraph( c_red,
+                                                    _( "Missing required proficiencies: " ) );                                       
+            auto profs = recp.required_proficiencies();
+            for ( const auto &prof: profs ) {
+                cataimgui::TextColoredParagraph( c_red, prof->name() );
+                if ( (profs.size() > 1) && (&prof != &profs.back() ) ) {
+                    cataimgui::TextColoredParagraph( c_red, _( ", " ) );
+                }
+            }
+            cataimgui::TextColoredParagraphNewline( c_red, "" );
         }
         if( !avail.crafter_has_primary_skill ) {
             cataimgui::TextColoredParagraphNewline( c_red,

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1144,13 +1144,13 @@ void crafting_ui_impl::draw_recipe_info_panel()
         if( avail.can_craft && avail.would_use_favorite ) {
             cataimgui::TextColoredParagraphNewline( c_red, _( "Will use favorited ingredients" ) );
         }
-        if( !avail.can_craft && !avail.has_proficiencies ) { 
+        if( !avail.can_craft && !avail.has_proficiencies ) {
             cataimgui::TextColoredParagraph( c_red,
-                                                    _( "Missing required proficiencies: " ) );                                       
+                                             _( "Missing required proficiencies: " ) );
             auto profs = recp.required_proficiencies();
-            for ( const auto &prof: profs ) {
+            for( const auto &prof : profs ) {
                 cataimgui::TextColoredParagraph( c_red, prof->name() );
-                if ( (profs.size() > 1) && (&prof != &profs.back() ) ) {
+                if( ( profs.size() > 1 ) && ( &prof != &profs.back() ) ) {
                     cataimgui::TextColoredParagraph( c_red, _( ", " ) );
                 }
             }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Interface "Show missing required proficiencies for crafting a project"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The current implementation just says you are missing required proficiencies but doesn't show them.  Adds the missing proficiencies.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Show the missing required proficiencies.

Before:
<img width="717" height="460" alt="Screenshot 2026-04-06 132900" src="https://github.com/user-attachments/assets/49d5a022-06ee-4609-8e0d-0294fc52e063" />

After:
<img width="717" height="452" alt="Screenshot 2026-04-06 133413" src="https://github.com/user-attachments/assets/486eb439-392e-4b30-89a9-004163a4c329" />

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Change the text to red in the details for the proficiency that is required, but then users who like the details collapsed by default would need to open it.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Compiled in Windows.  Loaded a game, checked that recipes with missing proficiencies looked correct.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
