### PR TITLE
[MoM] Set Loci Technique volume limit

### DIFF
--- a/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
+++ b/data/mods/MindOverMatter/PowerDescriptionSpoilers.md
@@ -1552,7 +1552,7 @@ Powers causing telepathic damage have a 5% chance to down the target, a 33% chan
 *Duration*: Instant<br />
 *Stamina Cost*: 6000, minus 200 per level to a minimum of 3000<br />
 *Channeling Time*: 200 moves, minus 5.5 moves per level to a minimum of 75<br />
-*Effects*: Allows the psion to teleport to a locus that they are maintaining with Loci Establishment, does nothing if not maintaining a locus. Loci Technique and Loci Establishment are learned from contemplating Loci Establishment but have separate practice meditations.<br />
+*Effects*: Allows the psion to teleport to a locus that they are maintaining with Loci Establishment, does nothing if not maintaining a locus. Loci Technique and Loci Establishment are learned from contemplating Loci Establishment but have separate practice meditations.  The psion may always teleport themselves, and can carry 8L of gear, plus 5L per power level.<br />
 *Prerequisites*: Extended Stride 6, Farstep 6 (Learned with Loci Establishment)<br />
 </details>
 <details>

--- a/data/mods/MindOverMatter/powers/teleportation_eoc.json
+++ b/data/mods/MindOverMatter/powers/teleportation_eoc.json
@@ -1778,9 +1778,37 @@
     "condition": { "u_has_effect": "effect_teleport_loci_establishment" },
     "effect": [
       {
-        "u_teleport": { "u_val": "teleporter_loci_establishment_loc" },
-        "success_message": "You feel a moment of darkness and terrible cold, but you are quickly back at your established locus.",
-        "fail_message": "Something goes wrong with the Loci Technique!"
+        "if": {
+          "and": [
+            { "not": { "u_has_worn_with_flag": "DIMENSIONAL_ANCHOR" } },
+            { "not": { "u_has_flag": "DIMENSIONAL_ANCHOR" } },
+            { "not": { "u_has_flag": "TELEPORT_LOCK" } }
+          ]
+        },
+        "then": [
+          { "run_eocs": "EOC_TELEPORT_SELF_CARRIED_VOLUME_CHECKER" },
+          {
+            "math": [
+              "_teleport_loci_technique_limit = ( ( ( u_spell_level('teleport_loci_technique') * 5000 ) + 8000 ) * scaling_factor( u_val('intelligence') ) * u_nether_attunement_power_scaling )"
+            ]
+          },
+          {
+            "u_message": "Your Loci Technique volume limit is <context_val:teleport_loci_technique_limit>.",
+            "type": "debug"
+          },
+          {
+            "if": { "math": [ "u_teleport_total_carried_volume <= _teleport_loci_technique_limit" ] },
+            "then": [
+              {
+                "u_teleport": { "u_val": "teleporter_loci_establishment_loc" },
+                "success_message": "You feel a moment of darkness and terrible cold, but you are quickly back at your established locus.",
+                "fail_message": "Something goes wrong with the Loci Technique!"
+              }
+            ],
+            "else": [ { "run_eocs": [ "EOC_TELEPORTER_GATEWAY_MESSAGE_CARRYING_TOO_MUCH" ] } ]
+          }
+        ],
+        "else": { "u_message": "You feel a strange, inward force.", "type": "bad" }
       }
     ],
     "false_effect": [ { "u_message": "You are currently not concentrating on [Ψ]Loci Establishment!" } ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[MoM] Set Loci Technique volume limit"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

It didn't have one. 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Give it the same limit as Farstep. (8L + 5L per level)

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Established a locus, teleported to it.

Picked up a large cardboard box, could not teleport to it. 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
