### PR TITLE
Fix starting TCL mutants not being able to unmute themselves

### DIFF
--- a/data/json/effects_on_condition/scenario_specific_eocs.json
+++ b/data/json/effects_on_condition/scenario_specific_eocs.json
@@ -350,31 +350,19 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_MUTE_BIRD_START",
-    "condition": {
-      "and": [
-        { "u_has_profession": "mutant_patient_bird" }
-      ]
-    },
+    "condition": { "and": [ { "u_has_profession": "mutant_patient_bird" } ] },
     "effect": [ { "u_learn_recipe": "prac_unmute_bird" } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_MUTE_CEPHALOPOD_START",
-    "condition": {
-      "and": [
-        { "u_has_profession": "mutant_patient_cephalopod" }
-      ]
-    },
+    "condition": { "and": [ { "u_has_profession": "mutant_patient_cephalopod" } ] },
     "effect": [ { "u_learn_recipe": "prac_unmute_ceph" } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_MUTE_INSECT_START",
-    "condition": {
-      "and": [
-        { "u_has_profession": "mutant_patient_insect" }
-      ]
-    },
+    "condition": { "and": [ { "u_has_profession": "mutant_patient_insect" } ] },
     "effect": [ { "u_learn_recipe": "prac_unmute_insect" } ]
   },
   {

--- a/data/json/effects_on_condition/scenario_specific_eocs.json
+++ b/data/json/effects_on_condition/scenario_specific_eocs.json
@@ -349,6 +349,36 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_MUTE_BIRD_START",
+    "condition": {
+      "and": [
+        { "u_has_profession": "mutant_patient_bird" }
+      ]
+    },
+    "effect": [ { "u_learn_recipe": "prac_unmute_bird" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_MUTE_CEPHALOPOD_START",
+    "condition": {
+      "and": [
+        { "u_has_profession": "mutant_patient_cephalopod" }
+      ]
+    },
+    "effect": [ { "u_learn_recipe": "prac_unmute_ceph" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_MUTE_INSECT_START",
+    "condition": {
+      "and": [
+        { "u_has_profession": "mutant_patient_insect" }
+      ]
+    },
+    "effect": [ { "u_learn_recipe": "prac_unmute_insect" } ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_scenario_eldritch_ire",
     "recurrence": [ "6 hours", "12 hours" ],
     "condition": { "u_has_trait": "ELDRITCH_IRE" },

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -8216,7 +8216,7 @@
       "FORGETFUL",
       "CHITIN",
       "CHITIN2",
-	  "MUTE_INSECT"
+      "MUTE_INSECT"
     ]
   },
   {

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -8215,7 +8215,8 @@
       "TERRIFYING",
       "FORGETFUL",
       "CHITIN",
-      "CHITIN2"
+      "CHITIN2",
+	  "MUTE_INSECT"
     ]
   },
   {

--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -538,7 +538,13 @@
     "map_extra": "mx_lab_concourse_area",
     "requirement": "achievement_reach_trans_coast_lab",
     "flags": [ "CHALLENGE", "LONE_START" ],
-    "eoc": [ "EOC_LAB_MUTANT_FRIENDS", "EOC_LAB_MUTANT_NO_MUTAGENS", "EOC_MUTE_BIRD_START", "EOC_MUTE_CEPHALOPOD_START", "EOC_MUTE_INSECT_START" ]
+    "eoc": [
+      "EOC_LAB_MUTANT_FRIENDS",
+      "EOC_LAB_MUTANT_NO_MUTAGENS",
+      "EOC_MUTE_BIRD_START",
+      "EOC_MUTE_CEPHALOPOD_START",
+      "EOC_MUTE_INSECT_START"
+    ]
   },
   {
     "type": "scenario",

--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -538,7 +538,7 @@
     "map_extra": "mx_lab_concourse_area",
     "requirement": "achievement_reach_trans_coast_lab",
     "flags": [ "CHALLENGE", "LONE_START" ],
-    "eoc": [ "EOC_LAB_MUTANT_FRIENDS", "EOC_LAB_MUTANT_NO_MUTAGENS" ]
+    "eoc": [ "EOC_LAB_MUTANT_FRIENDS", "EOC_LAB_MUTANT_NO_MUTAGENS", "EOC_MUTE_BIRD_START", "EOC_MUTE_CEPHALOPOD_START", "EOC_MUTE_INSECT_START" ]
   },
   {
     "type": "scenario",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "TCL mutants are now able to unmute themselves over time"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #86279 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Create new EOCs that run on scenario start for TCL Mutants that give them the relevant practice recipes to unmute themselves. Also gave insects the mute trait, as other mutants had it when relevant.

#### Describe alternatives you've considered
Removing the mute trait from all mutants that start in TCL under the assumption that the scientists need to talk with their subjects, but odds are good they just need the subjects to understand instructions, not be able to talk back. Not being able to talk back is probably a boon, in fact.

#### Testing
Spawned as the relevant mutant types. They had the relevant practice recipes.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
