### PR TITLE
Smart watch link_up CTD fix

### DIFF
--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -544,7 +544,12 @@
       "CALORIES_INTAKE_TRACKER",
       "FITNESS_CHECK",
       "PORTABLE_GAME",
-      { "type": "mp3", "transform": "smart_watch_music", "message": "You put in the earbuds and start listening to music.", "activate": true }
+      {
+        "type": "mp3",
+        "transform": "smart_watch_music",
+        "message": "You put in the earbuds and start listening to music.",
+        "activate": true
+      }
     ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 20 } } ],
     "armor": [ { "coverage": 100, "covers": [ "hand_l", "hand_r" ], "specifically_covers": [ "hand_wrist_l", "hand_wrist_r" ] } ],

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -541,15 +541,10 @@
     "symbol": "[",
     "charges_per_use": 1,
     "use_action": [
-      {
-        "type": "mp3",
-        "transform": "smart_watch_music",
-        "message": "You put in the earbuds and start listening to music.",
-        "activate": true
-      },
       "CALORIES_INTAKE_TRACKER",
       "FITNESS_CHECK",
-      "PORTABLE_GAME"
+      "PORTABLE_GAME",
+      { "type": "mp3", "transform": "smart_watch_music", "message": "You put in the earbuds and start listening to music.", "activate": true }
     ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 20 } } ],
     "armor": [ { "coverage": 100, "covers": [ "hand_l", "hand_r" ], "specifically_covers": [ "hand_wrist_l", "hand_wrist_r" ] } ],
@@ -559,15 +554,16 @@
     "id": "smart_watch_music",
     "copy-from": "smart_watch",
     "type": "ITEM",
-    "subtypes": [ "TOOL" ],
+    "subtypes": [ "TOOL", "ARMOR" ],
     "name": { "str": "smart watch - music", "str_pl": "smart watches - music" },
     "description": "This smart watch is playing music, steadily raising your morale.  You can't hear anything else while you're listening.",
+    "power_draw": "200 mW",
     "revert_to": "smart_watch",
     "use_action": [
-      { "type": "mp3", "transform": "smart_watch", "message": "The smart watch turns off.", "activate": false },
       "CALORIES_INTAKE_TRACKER",
       "FITNESS_CHECK",
-      "PORTABLE_GAME"
+      "PORTABLE_GAME",
+      { "type": "mp3", "transform": "smart_watch", "message": "The smart watch turns off.", "activate": false }
     ],
     "tick_action": [ "MP3_ON" ],
     "extend": { "flags": [ "TRADER_AVOID" ] }
@@ -590,16 +586,11 @@
       "E_FILE_DEVICE",
       "EBOOKSAVE",
       "CAMERA",
-      {
-        "type": "mp3",
-        "transform": "smart_watch_adv_music",
-        "message": "You put in the earbuds and start listening to music.",
-        "activate": true
-      },
       "CALORIES_INTAKE_TRACKER",
       "FITNESS_CHECK",
       "WEATHER_TOOL",
       "PORTABLE_GAME",
+      { "type": "mp3", "transform": "smart_watch_adv_music", "message": "You put in the earbuds and start listening to music.", "activate": true },
       { "type": "link_up", "cable_length": 3, "charge_rate": "20 W" }
     ],
     "pocket_data": [
@@ -618,15 +609,20 @@
     "id": "smart_watch_adv_music",
     "copy-from": "smart_watch_adv",
     "type": "ITEM",
-    "subtypes": [ "TOOL" ],
+    "subtypes": [ "TOOL", "ARMOR" ],
     "name": { "str": "advanced smart watch - music", "str_pl": "advanced smart watches - music" },
     "description": "This advanced smart watch is playing music, steadily raising your morale.  You can't hear anything else while you're listening.",
-    "revert_to": "smart_watch",
+    "power_draw": "200 mW",
+    "revert_to": "smart_watch_adv",
     "use_action": [
-      { "type": "mp3", "transform": "smart_watch_adv", "message": "The smart watch turns off.", "activate": false },
+      "E_FILE_DEVICE",
+      "EBOOKSAVE",
+      "CAMERA",
       "CALORIES_INTAKE_TRACKER",
       "FITNESS_CHECK",
-      "PORTABLE_GAME"
+      "PORTABLE_GAME",
+      { "type": "mp3", "transform": "smart_watch_adv", "message": "The smart watch turns off.", "activate": false },
+      { "type": "link_up", "cable_length": 3, "charge_rate": "20 W" }
     ],
     "tick_action": [ "MP3_ON" ],
     "extend": { "flags": [ "TRADER_AVOID" ] }

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -595,7 +595,12 @@
       "FITNESS_CHECK",
       "WEATHER_TOOL",
       "PORTABLE_GAME",
-      { "type": "mp3", "transform": "smart_watch_adv_music", "message": "You put in the earbuds and start listening to music.", "activate": true },
+      {
+        "type": "mp3",
+        "transform": "smart_watch_adv_music",
+        "message": "You put in the earbuds and start listening to music.",
+        "activate": true
+      },
       { "type": "link_up", "cable_length": 3, "charge_rate": "20 W" }
     ],
     "pocket_data": [

--- a/src/item_gun_tool_ammo.cpp
+++ b/src/item_gun_tool_ammo.cpp
@@ -2482,8 +2482,9 @@ bool item::has_link_data() const
 bool item::can_link_up() const
 {
     const bool can_link = has_link_data() || type->can_use( "link_up" );
-    if(can_link && !get_use( "link_up" ) ) {
-        debugmsg( "can_link_up() found no link_up use function for %s. Most likely missing link_up in item transform", type_name() );
+    if( can_link && !get_use( "link_up" ) ) {
+        debugmsg( "can_link_up() found no link_up use function for %s. Most likely missing link_up in item transform",
+                  type_name() );
         return false;
     }
     return can_link;

--- a/src/item_gun_tool_ammo.cpp
+++ b/src/item_gun_tool_ammo.cpp
@@ -2481,7 +2481,12 @@ bool item::has_link_data() const
 
 bool item::can_link_up() const
 {
-    return has_link_data() || type->can_use( "link_up" );
+    const bool can_link = has_link_data() || type->can_use( "link_up" );
+    if(can_link && !get_use( "link_up" ) ) {
+        debugmsg( "can_link_up() found no link_up use function for %s. Most likely missing link_up in item transform", type_name() );
+        return false;
+    }
+    return can_link;
 }
 
 bool item::link_has_state( link_state state ) const

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -611,7 +611,7 @@ std::optional<int> mp3_iuse::use( Character *p, item &it, map *, const tripoint_
         if( !it.ammo_sufficient( p ) ) {
             p->add_msg_if_player( m_info, _( "The %s's batteries are dead." ), it.tname() );
         } else if( p->cache_has_item_with( "active_MP3_ON", &item::is_active, []( const item & q ) {
-        return q.type->has_tick( "MP3_ON" );
+            return q.type->has_tick( "MP3_ON" );
         } ) ) {
             p->add_msg_if_player( m_info, _( "You are already listening to music!" ) );
         } else {

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -611,7 +611,7 @@ std::optional<int> mp3_iuse::use( Character *p, item &it, map *, const tripoint_
         if( !it.ammo_sufficient( p ) ) {
             p->add_msg_if_player( m_info, _( "The %s's batteries are dead." ), it.tname() );
         } else if( p->cache_has_item_with( "active_MP3_ON", &item::is_active, []( const item & q ) {
-            return q.type->has_tick( "MP3_ON" );
+        return q.type->has_tick( "MP3_ON" );
         } ) ) {
             p->add_msg_if_player( m_info, _( "You are already listening to music!" ) );
         } else {


### PR DESCRIPTION
#### Summary
Bugfixes "Smart/Advanced smart watch CTD fix + safeguard"

#### Purpose of change

1) Music/mp3 functionality was broken on smart watches/advanced smart watches, causing a CTD. Fixes #83730 
2) If you somehow got them to work, they would not drain any battery once activated
3) Advanced smart watches were reverting to smart watches when turned off

#### Describe the solution

1) Added link_up values to smart_watch_music and smart_watch_adv_music in tool_armor.json. This fixes the CTD issue.
1.1) Safeguard was added in item_gun_tool_ammo.cpp that checks get_use("link_up"). Will prevent future CTDs if someone misses a entry, and print a debugmsg to inform user.
2) Added 200mW to both smart watch json entries so that they now properly drain batteries
3) Changed revert entry for smart_watch_adv_music to smart_watch_adv(was smart_watch)

#### Describe alternatives you've considered

#### Testing

Tested in-game with smart and advanced smart watches specifically, though I do believe this issue can only pop up with a mangled link_up transform entry.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
