### PR TITLE
Fix NPC infinite loop with NO_NPC_FOOD mod

### DIFF
--- a/src/character_oracle.cpp
+++ b/src/character_oracle.cpp
@@ -49,6 +49,10 @@ status_t character_oracle_t::needs_warmth_badly( std::string_view ) const
 
 status_t character_oracle_t::needs_water_badly( std::string_view ) const
 {
+    // NO_NPC_FOOD disables thirst for NPCs.
+    if( !subject->needs_food() ) {
+        return status_t::success;
+    }
     // Check thirst threshold.
     if( subject->get_thirst() > 520 ) {
         return status_t::running;
@@ -58,6 +62,10 @@ status_t character_oracle_t::needs_water_badly( std::string_view ) const
 
 status_t character_oracle_t::needs_food_badly( std::string_view ) const
 {
+    // NO_NPC_FOOD disables hunger for NPCs.
+    if( !subject->needs_food() ) {
+        return status_t::success;
+    }
     // Short-term: stomach empty and actively starving.
     if( subject->get_hunger() >= 300 && subject->get_starvation() > base_metabolic_rate ) {
         return status_t::running;
@@ -191,6 +199,9 @@ status_t character_oracle_t::needs_sleep_badly( std::string_view ) const
 
 float character_oracle_t::thirst_urgency( std::string_view ) const
 {
+    if( !subject->needs_food() ) {
+        return 0.0f;
+    }
     // 0 = hydrated, 1 = dehydration death (threshold 1200, character_health.cpp).
     static constexpr float death_threshold = 1200.0f;
     return std::clamp( subject->get_thirst() / death_threshold, 0.0f, 1.0f );
@@ -198,6 +209,9 @@ float character_oracle_t::thirst_urgency( std::string_view ) const
 
 float character_oracle_t::hunger_urgency( std::string_view ) const
 {
+    if( !subject->needs_food() ) {
+        return 0.0f;
+    }
     // 0 = healthy weight, 1 = starvation death (stored_kcal <= 0, character_health.cpp).
     const int healthy = subject->get_healthy_kcal();
     if( healthy <= 0 ) {

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2503,7 +2503,10 @@ void npc::execute_action( npc_action action )
 
         case npc_noop:
             add_msg_debug( debugmode::DF_NPC, "%s skips turn (noop)", disp_name() );
-            return;
+            if( oldmoves == moves ) {
+                move_pause();
+            }
+            break;
 
         default:
             debugmsg( "Unknown NPC action (%d)", action );
@@ -3107,8 +3110,8 @@ npc_action npc::address_needs( float danger )
     }
 
     // Extreme thirst or hunger, bypass safety check.
-    if( get_thirst() > 80 ||
-        get_stored_kcal() + stomach.get_calories() < get_healthy_kcal() * 0.75 ) {
+    if( needs_food() && ( get_thirst() > 80 ||
+                          get_stored_kcal() + stomach.get_calories() < get_healthy_kcal() * 0.75 ) ) {
         if( consume_food_from_camp() ) {
             return npc_noop;
         }
@@ -3157,8 +3160,8 @@ npc_action npc::address_needs( float danger )
     // Extreme food/water pathing: the pre-gate block only consumed adjacent
     // resources. If extreme need persists and we passed the danger gate,
     // path to distant ground food or water deterministically.
-    if( get_thirst() > 80 ||
-        get_stored_kcal() + stomach.get_calories() < get_healthy_kcal() * 0.75 ) {
+    if( needs_food() && ( get_thirst() > 80 ||
+                          get_stored_kcal() + stomach.get_calories() < get_healthy_kcal() * 0.75 ) ) {
         for( scored_item &c : find_nearby_food() ) {
             if( square_dist( pos_bub(), c.loc.pos_bub( here ) ) <= 1 ) {
                 if( consume_food_at( c.loc ) ) {
@@ -3194,8 +3197,8 @@ npc_action npc::address_needs( float danger )
 
     // Normal food/drink: camp -> inventory -> ground food -> terrain water.
     // All under the same random gate so ground never outranks camp/inventory.
-    if( one_in( 3 ) && ( get_thirst() > NPC_THIRST_CONSUME ||
-                         get_hunger() > NPC_HUNGER_CONSUME ) ) {
+    if( needs_food() && one_in( 3 ) && ( get_thirst() > NPC_THIRST_CONSUME ||
+                                         get_hunger() > NPC_HUNGER_CONSUME ) ) {
         if( consume_food_from_camp() ) {
             return npc_noop;
         }

--- a/tests/behavior_test.cpp
+++ b/tests/behavior_test.cpp
@@ -39,6 +39,7 @@
 #include "mtype.h"
 #include "npc.h"
 #include "npc_class.h"
+#include "options_helpers.h"
 #include "player_helpers.h"
 #include "pocket_type.h"
 #include "point.h"
@@ -246,6 +247,26 @@ TEST_CASE( "check_npc_behavior_tree", "[npc][behavior]" )
         REQUIRE( oracle.has_food( "" ) == behavior::status_t::running );
         CHECK( npc_needs.tick( &oracle ) == "eat_food" );
         food.remove_item();
+        CHECK( npc_needs.tick( &oracle ) == "idle" );
+    }
+    SECTION( "NO_NPC_FOOD suppresses hunger and thirst" ) {
+        override_option no_food( "NO_NPC_FOOD", "true" );
+        REQUIRE_FALSE( test_npc.needs_food() );
+
+        // Extreme values that would normally trigger needs.
+        test_npc.set_hunger( 500 );
+        test_npc.set_stored_kcal( 1000 );
+        test_npc.set_thirst( 700 );
+        CHECK( oracle.needs_food_badly( "" ) == behavior::status_t::success );
+        CHECK( oracle.needs_water_badly( "" ) == behavior::status_t::success );
+        CHECK( oracle.hunger_urgency( "" ) == 0.0f );
+        CHECK( oracle.thirst_urgency( "" ) == 0.0f );
+
+        // Even with food and water in inventory, BT returns idle.
+        test_npc.i_add( item( itype_sandwich_cheese_grilled ) );
+        const item_group::ItemList water_items = item_group::items_from(
+                    Item_spawn_data_test_bottle_water );
+        test_npc.i_add( water_items.front() );
         CHECK( npc_needs.tick( &oracle ) == "idle" );
     }
     SECTION( "Thirsty" ) {

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -4465,6 +4465,23 @@ TEST_CASE( "npc_no_infinite_loop_foraging", "[npc][needs][forage]" )
         CHECK_FALSE( guy.has_effect( effect_npc_suspend ) );
     }
 
+    SECTION( "NO_NPC_FOOD NPC with stale hunger does not loop" ) {
+        override_option no_food( "NO_NPC_FOOD", "true" );
+        REQUIRE_FALSE( guy.needs_food() );
+
+        // Stale hunger/thirst values that would trigger food-seeking
+        // if the needs_food() guards were missing.
+        guy.set_hunger( 300 );
+        guy.set_thirst( 100 );
+        guy.set_stored_kcal( 1000 );
+        guy.i_add( item( itype_sandwich_cheese_grilled ) );
+
+        set_time_to_day();
+        here.build_map_cache( 0 );
+
+        CHECK_FALSE( npc_loops() );
+    }
+
     SECTION( "forage activity completes without backlog flooding" ) {
         set_time_to_day();
         here.ter_set( adj, ter_t_underbrush );


### PR DESCRIPTION
#### Summary
Bugfixes "Fix NPC infinite loop and fainting with Disable NPC Needs mod"

#### Purpose of change

Fixes #86299. Refugee center guards (and likely other stationary NPCs) may enter an infinite decision loop and "faint" every turn when the NO_NPC_FOOD mod is active. The BT oracle predicates and the legacy `address_needs()` food/water handling don't check `needs_food()`, so NPCs with disabled needs can still get routed into food-seeking behavior that goes nowhere.

#### Describe the solution

Two layers:

The BT oracle predicates `needs_food_badly`, `needs_water_badly`, `hunger_urgency`, and `thirst_urgency` now early-return when `needs_food()` is false. This prevents the behavior tree from ever selecting eat_food or drink_water goals for NO_NPC_FOOD NPCs.

The legacy `address_needs()` had three food/water handling blocks (extreme pre-gate, extreme post-gate, normal) that ran unconditionally. All three are now gated on `needs_food()`. Without this, NPCs carrying food could still eat/seek food through the hold_position and idle dispatch paths even when the BT was properly suppressed.

As a safety net, `npc_noop` in `execute_action()` now calls `move_pause()` when no moves were consumed by the caller. Previously it returned without spending moves, which triggered the do_turn.cpp infinite loop detector (the "faints!" message). The generic loop detector itself is left untouched so it still catches genuinely broken action handlers.

#### Describe alternatives you've considered

N/A

#### Testing

Existing `[behavior]` and `[npc][needs]` / `[npc][forage]` suites pass. Three new test sections added:
- behavior_test: NO_NPC_FOOD suppresses hunger/thirst predicates and keeps npc_needs at idle
- npc_test (complaints): NO_NPC_FOOD NPC with food in inventory doesn't consume it
- npc_test (forage loop): NO_NPC_FOOD NPC with stale hunger values doesn't enter infinite loop

Verified in-game with the reporter's save.

#### Additional context

None