### PR TITLE
[Bombastic Perks] Ascetic Empowerment fix

### DIFF
--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -1191,15 +1191,9 @@
         "condition": "ALWAYS",
         "values": [
           { "value": "STRENGTH", "add": { "math": [ "clamp(((u_val('thirst')/120) + (u_val('sleepiness')/150)), 0, 50))" ] } },
-          {
-            "value": "DEXTERITY", "add": { "math": [ "clamp(((u_val('thirst')/120) + (u_val('sleepiness')/150)), 0, 50)" ] }
-          },
-          {
-            "value": "INTELLIGENCE", "add": { "math": [ "clamp(((u_val('thirst')/120) + (u_val('sleepiness')/150)), 0, 50)" ] }
-          },
-          {
-            "value": "PERCEPTION","add": { "math": [ "clamp(((u_val('thirst')/120) + (u_val('sleepiness')/150)), 0, 50)" ] }
-          },
+          { "value": "DEXTERITY", "add": { "math": [ "clamp(((u_val('thirst')/120) + (u_val('sleepiness')/150)), 0, 50)" ] } },
+          {  "value": "INTELLIGENCE", "add": { "math": [ "clamp(((u_val('thirst')/120) + (u_val('sleepiness')/150)), 0, 50)" ] } },
+          { "value": "PERCEPTION","add": { "math": [ "clamp(((u_val('thirst')/120) + (u_val('sleepiness')/150)), 0, 50)" ] } },
           { "value": "SPEED", "add": { "math": [ "clamp(( (u_val('thirst') - 80 ) / 10 ) , 0, 50)" ] } }
         ]
       },

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -1191,9 +1191,18 @@
         "condition": "ALWAYS",
         "values": [
           { "value": "STRENGTH", "add": { "math": [ "clamp(((u_val('thirst')/120) + (u_val('sleepiness')/150)), 0, 50))" ] } },
-          { "value": "DEXTERITY", "add": { "math": [ "clamp(((u_val('thirst')/120) + (u_val('sleepiness')/150)), 0, 50)" ] } },
-          {  "value": "INTELLIGENCE", "add": { "math": [ "clamp(((u_val('thirst')/120) + (u_val('sleepiness')/150)), 0, 50)" ] } },
-          { "value": "PERCEPTION","add": { "math": [ "clamp(((u_val('thirst')/120) + (u_val('sleepiness')/150)), 0, 50)" ] } },
+          {
+            "value": "DEXTERITY",
+            "add": { "math": [ "clamp(((u_val('thirst')/120) + (u_val('sleepiness')/150)), 0, 50)" ] }
+          },
+          {
+            "value": "INTELLIGENCE",
+            "add": { "math": [ "clamp(((u_val('thirst')/120) + (u_val('sleepiness')/150)), 0, 50)" ] }
+          },
+          {
+            "value": "PERCEPTION",
+            "add": { "math": [ "clamp(((u_val('thirst')/120) + (u_val('sleepiness')/150)), 0, 50)" ] }
+          },
           { "value": "SPEED", "add": { "math": [ "clamp(( (u_val('thirst') - 80 ) / 10 ) , 0, 50)" ] } }
         ]
       },

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -1190,7 +1190,7 @@
       {
         "condition": "ALWAYS",
         "values": [
-          { "value": "STRENGTH", "add": { "math": [ "clamp(((u_val('thirst')/120) + (u_val('sleepiness')/150)), 0, 50))" ] } },
+          { "value": "STRENGTH", "add": { "math": [ "clamp(((u_val('thirst')/120) + (u_val('sleepiness')/150)), 0, 50)" ] } },
           {
             "value": "DEXTERITY",
             "add": { "math": [ "clamp(((u_val('thirst')/120) + (u_val('sleepiness')/150)), 0, 50)" ] }

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -1190,10 +1190,16 @@
       {
         "condition": "ALWAYS",
         "values": [
-          { "value": "STRENGTH", "add": { "math": [ "(u_val('thirst')/120) + (u_val('sleepiness')/150)" ] } },
-          { "value": "DEXTERITY", "add": { "math": [ "(u_val('thirst')/120) + (u_val('sleepiness')/150)" ] } },
-          { "value": "INTELLIGENCE", "add": { "math": [ "(u_val('thirst')/120) + (u_val('sleepiness')/150)" ] } },
-          { "value": "PERCEPTION", "add": { "math": [ "(u_val('thirst')/120) + (u_val('sleepiness')/150)" ] } },
+          { "value": "STRENGTH", "add": { "math": [ "clamp(((u_val('thirst')/120) + (u_val('sleepiness')/150)), 0, 50))" ] } },
+          {
+            "value": "DEXTERITY", "add": { "math": [ "clamp(((u_val('thirst')/120) + (u_val('sleepiness')/150)), 0, 50)" ] }
+          },
+          {
+            "value": "INTELLIGENCE", "add": { "math": [ "clamp(((u_val('thirst')/120) + (u_val('sleepiness')/150)), 0, 50)" ] }
+          },
+          {
+            "value": "PERCEPTION","add": { "math": [ "clamp(((u_val('thirst')/120) + (u_val('sleepiness')/150)), 0, 50)" ] }
+          },
           { "value": "SPEED", "add": { "math": [ "clamp(( (u_val('thirst') - 80 ) / 10 ) , 0, 50)" ] } }
         ]
       },


### PR DESCRIPTION
sometimes, Ascetic Empowerment will negate stat bonuses, for example from perk "smarter"

#### Summary
Bugfixes "Ascetic Empowerment"

#### Purpose of change

sometimes ascetic empowermet will negate stat bonuses, when you well enought hydrated and rest

#### Describe the solution

add clamp((body), 0, 50) like in speed section.

#### Describe alternatives you've considered

none

#### Testing

Load the game and see that the stat bonuses are not lost.

#### Additional context
 none
