### PR TITLE
Fix faction-hostile NPCs sleeping instead of fighting

### DIFF
--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -994,8 +994,8 @@ void npc::assess_danger()
     }
     if( is_friendly( player_character ) && sees_player ) {
         ai_cache.friends.emplace_back( g->shared_from( player_character ) );
-    } else if( sees_player && is_enemy() && sees( here, player_character ) ) {
-        // Unlike allies, hostile npcs should not see invisible players
+    } else if( sees_player && guaranteed_hostile() && sees( here, player_character ) ) {
+        // Includes faction hostility, not just the attitude enum.
         ai_cache.hostile_guys.emplace_back( g->shared_from( player_character ) );
     }
 
@@ -1209,10 +1209,12 @@ void npc::assess_danger()
         // NPC will try hard not to break and run while in formation.
         // This code should eventually remove the 'player' special case and be applied to
         // whoever the NPC perceives as their closest leader.
-        float player_diff = std::max( evaluate_character( player_character, npc_ranged, is_enemy() ),
+        const bool hostile_to_player = guaranteed_hostile();
+        float player_diff = std::max( evaluate_character( player_character, npc_ranged,
+                                      hostile_to_player ),
                                       NPC_DANGER_VERY_LOW );
         int dist = rl_dist( pos_bub(), player_character.pos_bub() );
-        if( is_enemy() ) {
+        if( hostile_to_player ) {
             add_msg_debug( debugmode::DF_NPC_COMBATAI,
                            "<color_light_gray>%s identified player as an</color> <color_red>enemy</color> <color_light_gray>of threat level %1.2f</color>",
                            name, player_diff );
@@ -1587,6 +1589,8 @@ void npc::move()
         } else {
             set_attitude( NPCATT_KILL );    // Yeah, we think we could take you!
         }
+        // Rebuild cache so danger/target reflect the new attitude.
+        regen_ai_cache();
     }
 
     // Top-level decision BT: evaluate before side-effecting cascade for convergence

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -1386,6 +1386,67 @@ TEST_CASE( "npc_nonally_sleeps_when_tired", "[npc][needs]" )
     }
 }
 
+// Thugs are guaranteed_hostile() by faction but start NPCATT_NULL.
+// assess_danger() must detect faction hostility so combat beats sleep.
+
+TEST_CASE( "faction_hostile_npc_detects_player_threat", "[npc][npc_ai]" )
+{
+    g->faction_manager_ptr->create_if_needed();
+    clear_map_without_vision();
+    clear_avatar();
+    set_time_to_day();
+
+    Character &player_character = get_player_character();
+    npc &bandit = spawn_npc( player_character.pos_bub().xy() + point::south, "thug" );
+    REQUIRE( rl_dist( player_character.pos_bub(), bandit.pos_bub() ) <= 1 );
+
+    // Thug is guaranteed_hostile by faction, but attitude has not flipped yet.
+    REQUIRE( bandit.guaranteed_hostile() );
+    REQUIRE_FALSE( bandit.is_enemy() );
+
+    bandit.regen_ai_cache();
+
+    // assess_danger() must count the player as a threat even before the
+    // attitude enum flips to NPCATT_KILL.
+    CHECK( bandit.get_ai_danger() > 0 );
+    CHECK( bandit.current_target() == static_cast<Creature *>( &player_character ) );
+}
+
+TEST_CASE( "faction_hostile_tired_npc_fights_not_sleeps", "[npc][npc_ai][needs]" )
+{
+    g->faction_manager_ptr->create_if_needed();
+    clear_map_without_vision();
+    clear_avatar();
+    // 30+ minutes past turn_zero so can_sleep() cooldown does not interfere.
+    calendar::turn = calendar::turn_zero + 1_hours;
+
+    Character &player_character = get_player_character();
+    npc &bandit = spawn_npc( player_character.pos_bub().xy() + point( 0, 3 ), "thug" );
+    clear_character( bandit, true );
+    bandit.set_hunger( 0 );
+    bandit.set_thirst( 0 );
+    bandit.set_stored_kcal( bandit.get_healthy_kcal() );
+    bandit.set_all_parts_temp_conv( BODYTEMP_NORM );
+    bandit.set_all_parts_temp_cur( BODYTEMP_NORM );
+    // Exhausted -- would sleep if no danger present.
+    bandit.set_sleepiness( 800 );
+    bandit.set_moves( 100 );
+
+    // Thug is guaranteed_hostile by faction, but attitude starts neutral.
+    // The move() pipeline must detect the player as a threat and choose
+    // combat over sleep.
+    REQUIRE( bandit.guaranteed_hostile() );
+    REQUIRE_FALSE( bandit.is_enemy() );
+
+    bandit.move();
+
+    // Must NOT have fallen asleep.
+    CHECK_FALSE( bandit.has_effect( effect_sleep ) );
+    CHECK_FALSE( bandit.has_effect( effect_lying_down ) );
+    // The attitude must have flipped to hostile.
+    CHECK( bandit.is_enemy() );
+}
+
 // ---------------------------------------------------------------------------
 // Helper-level tests for local resource acquisition
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
#### Summary
Bugfixes "Faction-hostile NPCs (bandits, raiders) no longer fall asleep on the turn they spot you"

#### Purpose of change

Fixes #86307. Bandits from the caravan raider mission (and other faction-hostile NPCs) would aggro on the player and then immediately fall asleep. Trivially exploitable, you could just punch them in their sleep.

#### Describe the solution

Two changes in `assess_danger()` and one in `move()`, all in npcmove.cpp.

`assess_danger()` used `is_enemy()` to decide whether the player counts as a threat. `is_enemy()` checks the `attitude` enum (NPCATT_KILL, etc.), but for faction-hostile NPCs the attitude starts as NPCATT_NULL and only gets flipped to NPCATT_KILL later in `move()`. So on the first turn the NPC sees the player, `assess_danger()` runs with `is_enemy() == false`, danger stays at zero, and the BT happily picks sleep over combat.

Changed both sites in `assess_danger()` to use `guaranteed_hostile()` instead, which includes faction hostility. Also added a `regen_ai_cache()` call right after the attitude flip in `move()` so the danger/target cache is fresh for the rest of the turn.

#### Describe alternatives you've considered

Could have added an enemy check to `needs_sleep_badly()` or `can_sleep()` in the BT predicates. That would work as defense-in-depth but doesn't fix the root cause of assess_danger ignoring faction hostility.

#### Testing

Two new test cases: one verifies `assess_danger()` detects the player as a threat for a `guaranteed_hostile()` NPC that hasn't had its attitude flipped yet, the other is end-to-end where an exhausted thug near the player calls `move()` and must fight, not sleep. Existing [npc_ai] and [npc][needs] suites pass.

#### Additional context

N/A