### PR TITLE
Bionics UI: Don't assign hotkeys that are menu navigation keys

### DIFF
--- a/src/bionics_ui.cpp
+++ b/src/bionics_ui.cpp
@@ -208,12 +208,11 @@ char get_free_invlet( Character &p )
         return ' ';
     }
 
-    input_context ctxt( "BIONICS_MENU", keyboard_mode::keychar );
+    input_context ctxt( "BIONICS", keyboard_mode::keychar );
     // Register standard uilist actions that might be bound to keys
-    ctxt.register_action( "UILIST.UP" );
-    ctxt.register_action( "UILIST.DOWN" );
-    ctxt.register_action( "UILIST.LEFT" );
-    ctxt.register_action( "UILIST.RIGHT" );
+    ctxt.register_updown();
+    ctxt.register_action( "NEXT_TAB" );
+    ctxt.register_action( "PREV_TAB" );
     for( const char &inv_char : bionic_chars ) {
         if( action_bound_to_key( ctxt, inv_char ) != "ERROR" ) {
             continue;

--- a/src/bionics_ui.cpp
+++ b/src/bionics_ui.cpp
@@ -217,7 +217,7 @@ char get_free_invlet( Character &p )
         if( action_bound_to_key( ctxt, inv_char ) != "ERROR" ) {
             continue;
         }
-        if( p.as_avatar()->bionic_by_invlet( inv_char ) == nullptr ) {        
+        if( p.as_avatar()->bionic_by_invlet( inv_char ) == nullptr ) {
             return inv_char;
         }
     }

--- a/src/bionics_ui.cpp
+++ b/src/bionics_ui.cpp
@@ -196,14 +196,29 @@ bionic *avatar::bionic_by_invlet( const int ch )
     return nullptr;
 }
 
+static std::string action_bound_to_key( const input_context &ctxt, char key )
+{
+    return ctxt.input_to_action( input_event( key, input_event_t::keyboard_char ) );
+}
+
 char get_free_invlet( Character &p )
 {
     if( p.is_npc() ) {
         // npcs don't need an invlet
         return ' ';
     }
+
+    input_context ctxt( "BIONICS_MENU", keyboard_mode::keychar );
+    // Register standard uilist actions that might be bound to keys
+    ctxt.register_action( "UILIST.UP" );
+    ctxt.register_action( "UILIST.DOWN" );
+    ctxt.register_action( "UILIST.LEFT" );
+    ctxt.register_action( "UILIST.RIGHT" );
     for( const char &inv_char : bionic_chars ) {
-        if( p.as_avatar()->bionic_by_invlet( inv_char ) == nullptr ) {
+        if( action_bound_to_key( ctxt, inv_char ) != "ERROR" ) {
+            continue;
+        }
+        if( p.as_avatar()->bionic_by_invlet( inv_char ) == nullptr ) {        
             return inv_char;
         }
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Interface "Don't assign hotkey letters that are already bound to menu navigation in the Bionics UI"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
This is a continuation of #86288 that addresses an inconsistent menu experience for VI key users.  This PR is on the Bionics UI.  

See original PR (#86288) for more details.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Check if the hotkey being assigned has already been mapped for UI navigation and if it has, skip it for the next available letter. Changes the behavior to the same as the inventory.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Hardcode to not accept the standard VI keys 'hjkl' as hotkeys. My implementation is a more elegant solution though as users who are not using VI keys will not notice any changes.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Assigned VI key navigation to the bionics menu. Created a new character with all bionics, checked that the assigned hotkeys where not part of the navigation keys that were mapped.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
