### PR TITLE
Fix: Prevent NPCs from approaching player in moving vehicles

### DIFF
--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2341,6 +2341,14 @@ void npc::execute_action( npc_action action )
             break;
         }
         case npc_follow_player:
+            // Fix: Prevent NPCs from approaching player in moving vehicles 
+            if( player_character.in_vehicle() ) {
+                const vehicle *veh = player_character.in_vehicle();
+                if( veh && std::abs( veh->velocity ) > 0 ) {
+                    move_pause();
+                    break;
+                }
+            }
             update_path( player_character.pos_bub() );
             if( path.empty() ||
                 ( static_cast<int>( path.size() ) <= follow_distance() &&


### PR DESCRIPTION
## Summary

This PR fixes an issue where NPC followers attempt to approach the player while they are inside a moving vehicle, which can lead to unrealistic behavior and unintended collisions.

Fixes #86313

---

## Problem

Currently, NPCs in "follow" mode continuously path toward the player's position without considering whether the player is inside a moving vehicle.

In `npcmove.cpp`, the `npc_follow_player` logic executes:

```cpp
update_path( player_character.pos_bub() );
move_to_next();
```
This causes NPCs to treat the player as a stationary target, even when the player is moving, leading to situations where NPCs walk directly into the vehicle’s path.

## Solution

A guard condition is added to prevent NPCs from approaching the player when they are inside a moving vehicle.
```
if( player_character.in_vehicle() ) {
    const vehicle *veh = player_character.in_vehicle();
    if( veh && std::abs( veh->velocity ) > 0 ) {
        move_pause();
        break;
    }
}
```

With this change:

NPCs will wait instead of moving toward a moving vehicle
Normal follow behavior resumes once the player stops

## Rationale

Prevents NPCs from walking into moving vehicles
Aligns NPC behavior with realistic expectations
Minimal and localized change with no impact on other AI behaviors

## Testing

To validate this fix, the following test scenario should be used:
- Load a save where NPCs are following the player
- Drive a vehicle toward NPCs
- Verify that NPCs do not approach while the vehicle is moving
- Confirm that NPCs resume following once the vehicle stops

Given that the change only introduces a conditional check before movement, the risk of unintended side effects is minimal.

## Notes

As a potential improvement, a velocity threshold (instead of > 0) could be used to allow NPCs to approach slow-moving vehicles while still avoiding dangerous situations.