### PR TITLE
Remove ESP knowledge of map extras

### DIFF
--- a/doc/JSON/MAPGEN.md
+++ b/doc/JSON/MAPGEN.md
@@ -1656,6 +1656,7 @@ Map extras can be used to place environmental objects and structures that can he
   "sym": "M",
   "color": "red",
   "autonote": true,
+  "see_from_afar": true,
   "flags": [ "MAN_MADE" ]
 }
 ```
@@ -1667,6 +1668,7 @@ Map extras can be used to place environmental objects and structures that can he
 | sym            | (_optional_) The symbol to use when marking this extra on the overmap. Defaults to no symbol.
 | color          | (_optional_) The color of the symbol identifying this extra on the overmap. Defaults to white.
 | autonote       | (_optional_) Whether to automatically mark this extra on the overmap. Defaults to false.
+| see_from_afar  | (_optional_) Whether autonotes will be placed when the map extra is generated. Without this boolean autonotes will only be placed when the OMT is specifically visited. Defaults to false.
 | flags          | (_optional_) List of flags that identify this extra. These flags can be listed in `overmap_feature_flag_settings` to blacklist or whitelist map extras.
 
 The `generator` can use one of 3 methods:

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -11383,6 +11383,22 @@ bool game::can_pulp_acid_corpse( const Character &you, const mtype &corpse_mtype
     return true;
 }
 
+static void do_delayed_autonote( const tripoint_abs_omt &target )
+{
+    auto iter = g->unvisited_map_extras.find( target );
+    if( iter == g->unvisited_map_extras.end() ) {
+        return; // No unvisited map extras here!
+    }
+
+    overmap *om_target = overmap_buffer.get_existing( project_to<coords::om>( target.xy() ) );
+
+    if( om_target ) {
+        om_target->add_deferred_extra_note( target );
+    }
+
+    g->unvisited_map_extras.erase( iter );
+}
+
 namespace cata_event_dispatch
 {
 void avatar_moves( const tripoint_abs_ms &old_abs_pos, const avatar &u, const map &m )
@@ -11404,6 +11420,7 @@ void avatar_moves( const tripoint_abs_ms &old_abs_pos, const avatar &u, const ma
         const oter_id &cur_ter = overmap_buffer.ter( new_abs_omt );
         const oter_id &past_ter = overmap_buffer.ter( old_abs_omt );
         get_event_bus().send<event_type::avatar_enters_omt>( new_abs_omt.raw(), cur_ter );
+        do_delayed_autonote( new_abs_omt );
         // if the player has moved omt then might trigger an EOC for that OMT
         if( !past_ter->get_exit_EOC().is_null() ) {
             dialogue d( get_talker_for( get_avatar() ), nullptr );

--- a/src/game.h
+++ b/src/game.h
@@ -1169,6 +1169,8 @@ class game
         global_variables global_variables_instance;
         std::unordered_map<std::string, point_abs_om> unique_npcs;
     public:
+        // Map extras that have been generated, but not yet traveled to. Will trigger autonotes once visited.
+        std::unordered_set<tripoint_abs_omt> unvisited_map_extras;
         void update_unique_npc_location( const std::string &id, point_abs_om loc );
         point_abs_om get_unique_npc_location( const std::string &id );
         bool unique_npc_exists( const std::string &id );

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -1308,6 +1308,7 @@ void map_extra::load( const JsonObject &jo, std::string_view )
     color = jo.has_member( "color" ) ? color_from_string( jo.get_string( "color" ) ) : was_loaded ?
             color : c_white;
     optional( jo, was_loaded, "autonote", autonote, false );
+    optional( jo, was_loaded, "see_from_afar", see_from_afar, false );
     optional( jo, was_loaded, "min_max_zlevel", min_max_zlevel_ );
     optional( jo, was_loaded, "flags", flags_, string_reader{} );
     if( was_loaded && jo.has_member( "extend" ) ) {

--- a/src/map_extras.h
+++ b/src/map_extras.h
@@ -47,6 +47,7 @@ class map_extra
         std::string generator_id;
         map_extra_method generator_method = map_extra_method::null;
         bool autonote = false;
+        bool see_from_afar = false;
         uint32_t symbol = UTF8_getch( "X" );
         nc_color color = c_red;
 

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -686,12 +686,26 @@ void overmap::add_extra( const tripoint_om_omt &p, const map_extra_id &id )
     }
 }
 
-void overmap::add_extra_note( const tripoint_om_omt &p )
+static void defer_auto_note( const tripoint_abs_omt &target )
+{
+    g->unvisited_map_extras.insert( target );
+}
+
+void overmap::add_deferred_extra_note( const tripoint_abs_omt &p )
+{
+    point_abs_om overmap_coord;
+    tripoint_om_omt omt_coord;
+    std::tie( overmap_coord, omt_coord ) = project_remain<coords::om>( p );
+    add_extra_note( omt_coord, true );
+}
+
+void overmap::add_extra_note( const tripoint_om_omt &p, bool force_add )
 {
     if( seen( p ) < om_vision_level::details ) {
         return;
     }
 
+    // WTF is this doing? We just figured out the map extra's ID in overmap::add_extra(), what's with this bizarre lookup?
     const std::vector<om_map_extra> &layer_extras = layer[p.z() + OVERMAP_DEPTH].extras;
     auto extrait = std::find_if( layer_extras.begin(),
     layer_extras.end(), [&p]( const om_map_extra & extra ) {
@@ -701,6 +715,13 @@ void overmap::add_extra_note( const tripoint_om_omt &p )
         return;
     }
     const map_extra_id &extra = extrait->id;
+
+    if( !force_add && !extra->see_from_afar ) {
+        tripoint_abs_omt target = project_combine( this->pos(), p );
+        defer_auto_note( target );
+        return;
+    }
+
 
     auto_notes::auto_note_settings &auto_note_settings = get_auto_notes_settings();
 

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -512,7 +512,8 @@ class overmap
         bool has_extra( const tripoint_om_omt &p ) const;
         const map_extra_id &extra( const tripoint_om_omt &p ) const;
         void add_extra( const tripoint_om_omt &p, const map_extra_id &id );
-        void add_extra_note( const tripoint_om_omt &p );
+        void add_deferred_extra_note( const tripoint_abs_omt &p );
+        void add_extra_note( const tripoint_om_omt &p, bool force_add = false );
         void delete_extra( const tripoint_om_omt &p );
 
         /**

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -159,6 +159,7 @@ void game::serialize_json( std::ostream &fout )
     global_variables_instance.serialize( json );
     Messages::serialize( json );
     json.member( "unique_npcs", unique_npcs );
+    json.member( "unvisited_map_extras", unvisited_map_extras );
     json.end_object();
 }
 
@@ -318,6 +319,7 @@ void game::unserialize_impl( const JsonObject &data )
     }
     global_variables_instance.unserialize( data );
     data.read( "unique_npcs", unique_npcs );
+    data.read( "unvisited_map_extras", unvisited_map_extras );
     inp_mngr.pump_events();
     data.read( "stats_tracker", *stats_tracker_ptr );
     data.read( "achievements_tracker", *achievements_tracker_ptr );


### PR DESCRIPTION
#### Summary
Bugfixes "Remove ESP knowledge of map extras"

#### Purpose of change
#86330 brought up the current (poor) behavior of extra map noting, where map extras can be (unfairly!) autonoted without the player character ever seeing them.

Adding autonotes to berry bushes as-is would make searching for them about 10x more effective, thus undoing the intentional scarcity (but only for people abusing autonote).

#### Describe the solution
Fix this, and keep the intentional scarcity.

Map extras are now only marked if their specific OMT is visited, or they can be "seen from afar" (new boolean, default false).

#### Describe alternatives you've considered


#### Testing
Made `mx_drugdeal` exceedingly common, ran around in fields and saw some at the edge of my vision. Confirmed they were not noted. Walked into the middle of them, checked map again. Confirmed autonote had triggered.

#### Additional context
Known issues:
`unvisited_map_extras` might grow unbounded, performance concerns(?)

I have not audited map extras to ensure that all that want this new boolean have it.