### PR TITLE
Tile fallback fixes

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1185,58 +1185,58 @@ void tileset_cache::loader::load_ascii_set( const JsonObject &entry )
         switch( ascii_char ) {
             // box bottom/top side (horizontal line)
             case LINE_OXOX_C:
-                sprites[0] = 205 + base_offset;
+                sprites[0] = 196 + base_offset;
                 break;
             // box left/right side (vertical line)
             case LINE_XOXO_C:
-                sprites[0] = 186 + base_offset;
+                sprites[0] = 179 + base_offset;
                 break;
             // box top left
             case LINE_OXXO_C:
-                sprites[0] = 201 + base_offset;
+                sprites[0] = 218 + base_offset;
                 break;
             // box top right
             case LINE_OOXX_C:
-                sprites[0] = 187 + base_offset;
+                sprites[0] = 191 + base_offset;
                 break;
             // box bottom right
             case LINE_XOOX_C:
-                sprites[0] = 188 + base_offset;
+                sprites[0] = 217 + base_offset;
                 break;
             // box bottom left
             case LINE_XXOO_C:
-                sprites[0] = 200 + base_offset;
+                sprites[0] = 192 + base_offset;
                 break;
             // box bottom north T (left, right, up)
             case LINE_XXOX_C:
-                sprites[0] = 202 + base_offset;
+                sprites[0] = 193 + base_offset;
                 break;
             // box bottom east T (up, right, down)
             case LINE_XXXO_C:
-                sprites[0] = 208 + base_offset;
+                sprites[0] = 195 + base_offset;
                 break;
             // box bottom south T (left, right, down)
             case LINE_OXXX_C:
-                sprites[0] = 203 + base_offset;
+                sprites[0] = 194 + base_offset;
                 break;
             // box X (left down up right)
             case LINE_XXXX_C:
-                sprites[0] = 206 + base_offset;
+                sprites[0] = 197 + base_offset;
                 break;
             // box bottom east T (left, down, up)
             case LINE_XOXX_C:
-                sprites[0] = 184 + base_offset;
+                sprites[0] = 180 + base_offset;
                 break;
         }
         if( ascii_char == LINE_XOXO_C || ascii_char == LINE_OXOX_C ) {
             curr_tile.rotates = false;
             curr_tile.multitile = true;
-            add_ascii_subtile( curr_tile, id, 206 + base_offset, "center" );
-            add_ascii_subtile( curr_tile, id, 201 + base_offset, "corner" );
-            add_ascii_subtile( curr_tile, id, 186 + base_offset, "edge" );
-            add_ascii_subtile( curr_tile, id, 203 + base_offset, "t_connection" );
-            add_ascii_subtile( curr_tile, id, 210 + base_offset, "end_piece" );
-            add_ascii_subtile( curr_tile, id, 219 + base_offset, "unconnected" );
+            add_ascii_subtile( curr_tile, id, 197 + base_offset, "center" );
+            add_ascii_subtile( curr_tile, id, 218 + base_offset, "corner" );
+            add_ascii_subtile( curr_tile, id, 179 + base_offset, "edge" );
+            add_ascii_subtile( curr_tile, id, 194 + base_offset, "t_connection" );
+            add_ascii_subtile( curr_tile, id, 179 + base_offset, "end_piece" );
+            add_ascii_subtile( curr_tile, id, 197 + base_offset, "unconnected" );
         }
         ts.create_tile_type( id, std::move( curr_tile ) );
     }

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2981,6 +2981,7 @@ bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEG
             }
         }
 
+        bool is_linear = false;
         uint32_t sym = UNKNOWN_UNICODE;
         nc_color col = c_white;
         if( category == TILE_CATEGORY::FURNITURE ) {
@@ -3068,7 +3069,8 @@ bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEG
         } else if( category == TILE_CATEGORY::OVERMAP_TERRAIN ) {
             const oter_type_str_id tmp( id );
             if( tmp.is_valid() ) {
-                if( !tmp->is_linear() ) {
+                is_linear = tmp->is_linear();
+                if( !is_linear ) {
                     // if rota is for a omt with connections, it can be outside the bounds of
                     // om_direction::type. We can't do anything about that now, so just stay inbounds
                     rota %= om_direction::size;
@@ -3142,8 +3144,8 @@ bool cata_tiles::draw_from_id_string_internal( const std::string &id, TILE_CATEG
             const int FG = colorpair.FG + ( isBold ? 8 : 0 );
             std::string generic_id = get_ascii_tile_id( sym, FG, -1 );
 
-            // do not rotate fallback tiles!
-            if( sym != LINE_XOXO_C && sym != LINE_OXOX_C ) {
+            // do not rotate fallback tiles for non line drawings (roads and such)
+            if( !is_linear ) {
                 rota = 0;
             }
             if( tileset_ptr->find_tile_type( generic_id ) ) {

--- a/src/overmap_terrain.cpp
+++ b/src/overmap_terrain.cpp
@@ -819,7 +819,7 @@ void oter_t::get_rotation_and_subtile( int &rotation, int &subtile ) const
         rotation = t.rotation;
         subtile = t.subtile;
     } else if( is_rotatable() ) {
-        rotation = ( 4 - static_cast<int>( get_dir() ) ) % 4;
+        rotation = static_cast<int>( get_dir() );
         subtile = -1;
     } else {
         rotation = 0;


### PR DESCRIPTION
#### Summary
Bugfixes "Tile fallback fixes"

#### Purpose of change
Fixes tile fallback rotation and selection.
Fixes #80976

#### Describe the solution
Revert #62443
This change was causing tiles in some rotations (specifically 1 and 3) of specials to be flipped to the opposite of what they needed to be as seen in #80976

Reverting that change fixed only part of the problem since it left specials using the `|` and `-` glyph in a state of still being messed up in half of the rotations of the special.
<details>
<summary>Example Speedway</summary>
<img width="637" height="641" alt="image" src="https://github.com/user-attachments/assets/fba98507-a016-43b2-94c0-ab737c757fbc" />
</details>

---

When `cata_tiles::draw_from_id_string_internal` reaches the fallback section to grab something from the fallback sheet, it removes rotation from the fallback tile, except when the main tile is used for "LINEAR" flagged tiles, such as roads and trails. To do this it checked the symbol being requested if it was one of the two symbols hardcoded to be used for that instead of if the tile being requested was actually used for line drawings or not. 

This adds a boolean flag that is set based on if the request is for a tile that's flagged with "LINEAR" and uses that to remove or allow rotations of the fallback tile. 

---

When ascii fallback sheets are loaded in `tileset_cache::loader::load_ascii_set`, the tile ids for the single line drawing glyphs, (`┘`, `└`, `┌`, `┐` and friends), were pointed to the double line glyphs (`╝`, `╚`, `╔`, `╗` and friends). 
This changes it so the tile matches the symbol.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Lots of ingame testing, loading every single tileset and loading a ton of the map to check what was broken and if fallbacks worked properly.
All the fallback tile selection and rotation properly matches the symbols of the omt on the overmap now.

<details>
<summary>Working Images Of Fallbacks</summary>
<img width="1001" height="849" alt="image" src="https://github.com/user-attachments/assets/f92d9894-9215-45f6-85fd-2961fd5691f7" />
<img width="1101" height="849" alt="image" src="https://github.com/user-attachments/assets/4a1b4b31-c412-449d-84da-5ca912d2ae33" />
</details>

Some tilesets are now "broken" however, such and Larwick and MSX+ when it comes to places like Speedway where their `tile_config.json` is setup to fix the previously bugged state of reversed rotations for tiles

<details>
<summary>Bugged Image</summary>
Note the incorrectly aligned roads based on the config and the correctly aligned fallback tiles for the speedway track.

<img width="1101" height="849" alt="image" src="https://github.com/user-attachments/assets/d4ffc25b-8a4c-4f78-80bc-255375c82ddd" />
</details>

Larwick has a related but different issue.
Larwick's fallback tilesheet is not the correct current set of tiles. @esotericist mentioned on discord that she is most likely going to fix this one herself.

#### Additional context

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
