### PR TITLE
Remove unused 2x scaled ImGui font to reduce atlas size

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -456,13 +456,11 @@ void cataimgui::client::load_fonts( UNUSED const Font_Ptr &gui_font,
         ImVector<ImWchar> ranges;
         b.BuildRanges( &ranges );
 
-        // Fonts[0] = gui, Fonts[1] = mono, Fonts[2] = gui 1.5x, Fonts[3] = gui 2x
+        // Fonts[0] = gui, Fonts[1] = mono, Fonts[2] = gui 1.5x
         load_font( io, gui_typefaces, ranges.begin() );
         load_font( io, mono_typefaces, ranges.begin() );
         load_font( io, gui_typefaces, ranges.begin(),
                    static_cast<float>( lroundf( fontheight * 1.5f ) ) );
-        load_font( io, gui_typefaces, ranges.begin(),
-                   static_cast<float>( fontheight * 2 ) );
         for( int i = 0; i < io.Fonts->Fonts.Size; i++ ) {
             io.Fonts->Fonts[i]->SetFallbackStrSizeCallback( GetFallbackStrWidth );
             io.Fonts->Fonts[i]->SetFallbackCharSizeCallback( GetFallbackCharWidth );
@@ -1131,12 +1129,6 @@ void cataimgui::PushGuiFont1_5x()
 #endif
 }
 
-void cataimgui::PushGuiFont2x()
-{
-#ifdef TILES
-    ImGui::PushFont( ImGui::GetIO().Fonts->Fonts[3] );
-#endif
-}
 
 bool cataimgui::BeginRightAlign( const char *str_id )
 {

--- a/src/cata_imgui.h
+++ b/src/cata_imgui.h
@@ -174,7 +174,6 @@ bool InputFloat( const char *label, float *v, float step = 0.0f, float step_fast
 void PushGuiFont();
 void PushMonoFont();
 void PushGuiFont1_5x();
-void PushGuiFont2x();
 
 bool BeginRightAlign( const char *str_id );
 void EndRightAlign();


### PR DESCRIPTION
#### Summary
Bugfixes "Remove unused 2x scaled ImGui font to reduce CJK atlas overflow"

#### Purpose of change

Attempt to address #86283 (and duplicate #86318). My earlier #86265 added 1.5x and 2x pre-rasterized GUI fonts, doubling the number of font atlas entries from 2 to 4. With `IMGUI_LOAD_CHINESE` enabled (full CJK range - ~21k glyphs), the atlas texture overflows GPU memory and glyphs render as solid color blocks or mosaic.

#### Describe the solution

Remove the 2x font -- it was never called anywhere. This brings the atlas back down from 4 fonts to 3. If 3 is still too many for CJK users, the next step would be falling back to `SetWindowFontScale()` when CJK is enabled, but hopefully just dropping the dead weight is enough.

#### Describe alternatives you've considered

Could skip loading scaled fonts entirely when `IMGUI_LOAD_CHINESE` is on and fall back to `SetWindowFontScale()`. That guarantees it fits but reintroduces blurry scaled text. Trying the minimal removal first.

#### Testing

Need confirmation from CJK users -- I can't reproduce the atlas overflow on my hardware. Crafting GUI recipe title and loading screen snippets still use `PushGuiFont1_5x()` and render correctly with Latin glyphs.

#### Additional context

N/A