### PR TITLE
Overmap zoom level persistence

### DIFF
--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -23,7 +23,6 @@
 #include "calendar.h"
 #include "cata_assert.h"
 #include "cata_imgui.h"
-#include "cata_scope_helpers.h"
 #include "cata_utility.h"
 #include "cata_variant.h"
 #include "catacharset.h"
@@ -1985,8 +1984,6 @@ static std::vector<tripoint_abs_omt> get_overmap_path_to( const tripoint_abs_omt
     }
 }
 
-static int overmap_zoom_level = DEFAULT_TILESET_ZOOM;
-
 static bool try_travel_to_destination( avatar &player_character, const tripoint_abs_omt curs,
                                        const tripoint_abs_omt dest, const bool driving )
 {
@@ -2069,14 +2066,6 @@ static tripoint_abs_omt display()
     std::vector<tripoint_abs_omt> &display_path = data.display_path;
     tripoint_abs_omt &select = data.select;
     input_context ictxt( "OVERMAP" );
-
-    const int previous_zoom = g->get_zoom();
-    g->set_zoom( overmap_zoom_level );
-    on_out_of_scope reset_zoom( [&]() {
-        overmap_zoom_level = g->get_zoom();
-        g->set_zoom( previous_zoom );
-        g->mark_main_ui_adaptor_resize();
-    } );
 
     background_pane bg_pane;
 


### PR DESCRIPTION
#### Summary
Bugfixes "Overmap zoom level persistence"

#### Purpose of change
Fixes incorrect overmap zoom level when opening the map

#### Describe the solution
#84475 added zoom level persistence. The overmap zoom is controlled by `game::zoom_in_overmap()` and `game::zoom_out_overmap()`. 
However in `overmap_ui::display()` there is a random `overmap_zoom_level` and management of overmap zoom level using that instead upon drawing the overmap.

This just deletes `overmap_zoom_level` and all uses of it. 

#### Describe alternatives you've considered


#### Testing
Loaded a game, set a zoom level on the overmap, opened and closed the overmap to see the same zoom level. Saved and closed the game, launched and reopened the save, zoom level on the overmap is preserved.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
