### PR TITLE
Further tweak post-threshold interstitial mutations

### DIFF
--- a/data/json/mutations/baseline.json
+++ b/data/json/mutations/baseline.json
@@ -135,6 +135,7 @@
       "INFRARED",
       "INTERSTICEEYES",
       "INTERSTICE_VISION",
+      "INTERSTICE_VISION2",
       "MEMBRANE",
       "MYOPIC",
       "HYPEROPIC",

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -959,7 +959,17 @@
     "threshreq": [ "THRESH_INTERSTICE" ],
     "points": 5,
     "vitamin_cost": 210,
-    "enchantments": [ { "condition": "ALWAYS", "special_vision": [ { "distance": 10, "descriptions": [ { "id": "interstice_creature_sense", "symbol": "?", "color": "c_pink", "text": "You sense something here." } ] } ] } ]
+    "enchantments": [
+      {
+        "condition": "ALWAYS",
+        "special_vision": [
+          {
+            "distance": 10,
+            "descriptions": [ { "id": "interstice_creature_sense", "symbol": "?", "color": "c_pink", "text": "You sense something here." } ]
+          }
+        ]
+      }
+    ]
   },
   {
     "type": "mutation",
@@ -3421,7 +3431,9 @@
     "purifiable": false,
     "points": 6,
     "vitamin_cost": 400,
-    "enchantments": [ { "values": [ { "value": "MOVE_COST", "multiply": -0.10 }, { "value": "MOVECOST_OBSTACLE_MOD", "multiply": -0.75 } ] } ]
+    "enchantments": [
+      { "values": [ { "value": "MOVE_COST", "multiply": -0.1 }, { "value": "MOVECOST_OBSTACLE_MOD", "multiply": -0.75 } ] }
+    ]
   },
   {
     "type": "mutation",

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -183,26 +183,41 @@
     "category": [ "INTERSTICE" ],
     "prereqs": [ "INTERSTICE_AURA" ],
     "threshreq": [ "THRESH_INTERSTICE" ],
-    "changes_to": [ "INTERSTICE_RESONANCE_2" ],
+    "leads_to": [ "INTERSTICE_RESONANCE_2" ],
     "strict_threshreq": true,
     "points": -3,
     "purifiable": false,
     "vitamin_cost": 120,
-    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "ARTIFACT_RESONANCE", "add": 2000 } ] } ]
+    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "ARTIFACT_RESONANCE", "add": 750 } ] } ]
   },
   {
     "type": "mutation",
     "id": "INTERSTICE_RESONANCE_2",
     "name": { "str": "Outsider" },
-    "description": "Your physiology plays by different rules, and it has caught the attention of something.",
+    "description": "Your physiology plays by different rules.  The universe will notice you in your former homeworld.",
     "category": [ "INTERSTICE" ],
     "prereqs": [ "INTERSTICE_RESONANCE" ],
+    "changes_to": [ "INTERSTICE_RESONANCE_3" ],
     "threshreq": [ "THRESH_INTERSTICE" ],
     "strict_threshreq": true,
-    "points": -6,
+    "points": -4,
     "purifiable": true,
+    "vitamin_cost": 240,
+    "enchantments": [ { "condition": { "current_dimension": "" }, "values": [ { "value": "ARTIFACT_RESONANCE", "add": 1250 } ] } ]
+  },
+  {
+    "type": "mutation",
+    "id": "INTERSTICE_RESONANCE_3",
+    "name": { "str": "Deeply Incongruent" },
+    "description": "Your physiology plays by different rules, and it has caught the attention of something.",
+    "category": [ "INTERSTICE" ],
+    "prereqs": [ "INTERSTICE_RESONANCE_2" ],
+    "threshreq": [ "THRESH_INTERSTICE" ],
+    "strict_threshreq": true,
+    "points": -5,
+    "purifiable": false,
     "vitamin_cost": 300,
-    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "ARTIFACT_RESONANCE", "add": 4500 } ] } ]
+    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "ARTIFACT_RESONANCE", "add": 1250 } ] } ]
   },
   {
     "type": "mutation",
@@ -931,9 +946,20 @@
     "prereqs": [ "INTERSTICEEYES" ],
     "threshreq": [ "THRESH_INTERSTICE" ],
     "points": 1,
-    "starting_trait": true,
     "vitamin_cost": 60,
     "enchantments": [ { "condition": { "not": "is_day" }, "values": [ { "value": "OVERMAP_SIGHT", "add": 15 } ] } ]
+  },
+  {
+    "type": "mutation",
+    "id": "INTERSTICE_VISION2",
+    "name": { "str": "Ontological Sight" },
+    "description": "You've become attuned to the folds and gaps in the world and you now detect nearby creatures through them.",
+    "category": [ "INTERSTICE" ],
+    "prereqs": [ "INTERSTICE_VISION" ],
+    "threshreq": [ "THRESH_INTERSTICE" ],
+    "points": 5,
+    "vitamin_cost": 210,
+    "enchantments": [ { "condition": "ALWAYS", "special_vision": [ { "distance": 10, "descriptions": [ { "id": "interstice_creature_sense", "symbol": "?", "color": "c_pink", "text": "You sense something here." } ] } ] } ]
   },
   {
     "type": "mutation",
@@ -3343,6 +3369,7 @@
     "types": [ "DEX" ],
     "prereqs": [ "DEX_UP_2" ],
     "changes_to": [ "DEX_UP_4" ],
+    "leads_to": [ "DEX_INTERSTICE" ],
     "threshreq": [
       "THRESH_BIRD",
       "THRESH_ELFA",
@@ -3382,6 +3409,19 @@
     "points": 6,
     "vitamin_cost": 400,
     "enchantments": [ { "values": [ { "value": "DEXTERITY", "add": { "math": [ "alpha_stat_bonus(u_val('dexterity_base'))" ] } } ] } ]
+  },
+  {
+    "type": "mutation",
+    "id": "DEX_INTERSTICE",
+    "name": { "str": "Liminal Stride" },
+    "description": "You are just passing through these places.  They present no distractions or resistance.  You move much easier, particularly over obstacles and through tight spaces.",
+    "category": [ "INTERSTICE" ],
+    "prereqs": [ "DEX_UP_3" ],
+    "threshreq": [ "THRESH_INTERSTICE" ],
+    "purifiable": false,
+    "points": 6,
+    "vitamin_cost": 400,
+    "enchantments": [ { "values": [ { "value": "MOVE_COST", "multiply": -0.10 }, { "value": "MOVECOST_OBSTACLE_MOD", "multiply": -0.75 } ] } ]
   },
   {
     "type": "mutation",
@@ -3540,7 +3580,7 @@
     "type": "mutation",
     "id": "PER_INTERSTICE",
     "name": { "str": "Perceptual Overreach" },
-    "description": "You see all the colors of space.  It is maddening and confusing.  +9 Perception, -3 intelligence.",
+    "description": "You see all the colors of space.  It is maddening and confusing.  +12 Perception, -3 intelligence.",
     "category": [ "INTERSTICE" ],
     "types": [ "PER" ],
     "prereqs": [ "PER_UP_4" ],
@@ -3549,7 +3589,7 @@
     "mixed_effect": true,
     "points": 4,
     "vitamin_cost": 300,
-    "enchantments": [ { "values": [ { "value": "PERCEPTION", "add": 9 }, { "value": "INTELLIGENCE", "add": -3 } ] } ]
+    "enchantments": [ { "values": [ { "value": "PERCEPTION", "add": 12 }, { "value": "INTELLIGENCE", "add": -3 } ] } ]
   },
   {
     "type": "mutation",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Balance "Tweak interstitial mutations further"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Balance post-threshold positives/negatives + finish giving this the flavor intended

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Several tweaks:

- INTERSTICE_RESONANCE = 750 baseline resonance. Not purifiable.
- INTERSTICE_RESONANCE_2 = now stacks with instead of replaces INTERSTICE_RESONANCE. +1250 on home dimension.  This is an "in between" step that is purifiable.
- INTERSTICE_RESONANCE_3 = replaces INTERSTICE_RESONANCE_2.  +1250 resonance on all dimensions.  Not purifiable - locks you in if you go this deep.

- INTERSTICE_VISION = (bugfix) no longer starting trait
- INTERSTICE_VISION2 = post-threshold that allows you to detect nearby life (10 tiles)

- PER_INTERSTICE = now +12 per (thus matching bird eyes, and not useful for high-per characters), but still with -3 intelligence (making it vastly inferior to bird eyes)
- DEX_INTERSTICE = (new) requires DEX_3.  -10% move cost.  +75% obstacle clearance

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

n/a

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

mutated them

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
