### PR TITLE
Fix speedway copy-from

### DIFF
--- a/data/json/overmap/overmap_terrain/overmap_terrain_speedway.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_speedway.json
@@ -41,7 +41,7 @@
   {
     "type": "overmap_terrain",
     "abstract": "speedway_track_abstract",
-    "copy-from": "generic_city_building_no_sidewalk",
+    "copy-from": "road_abstract",
     "vision_levels": "blends_till_outlines",
     "name": "speedway",
     "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }


### PR DESCRIPTION


#### Summary
Bugfixes "Fix speedway copy-from"

#### Purpose of change
While working on tile fallback fixes in #86335 we discovered that tiles will grab from `copy-from` parents for tiles before going all the way back to the ascii fallback sheets. This changes the race track part of the speedway to `copy-from` something more reasonable.

#### Describe the solution
Change the `speedway_track_abstract` to copy from `road_abstract` instead of `generic_city_building_no_sidewalk`

#### Describe alternatives you've considered


#### Testing
Speedways still display as normal for all tilesets and no tiles overmaps. Larwick overmap no longer displays buildings for the speedway track.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
