### PR TITLE
Aftershock: Add a reactor outlet to the spaceship

### DIFF
--- a/data/mods/aftershock_exoplanet/maps/mapgen/ship.json
+++ b/data/mods/aftershock_exoplanet/maps/mapgen/ship.json
@@ -34,7 +34,7 @@
         " U..|l.|5|5||5|||..T..U ",
         " U8.|l.|d|.A|.h|L.....U ",
         "|||>||5|||.ä|??||5|??|||",
-        "  ||||.|R|.¿||||ë.||||  ",
+        "  ||||.|Ë|.¿||||ë.||||  ",
         "     |5|5|5||__||5|     ",
         "     |____________|     ",
         " |0| |é___________| |0  ",
@@ -76,6 +76,7 @@
         "S": "t_ship_bay_heated",
         "é": "t_ship_bay_heated",
         "á": "t_ship_floor_heated",
+        "Ë": "t_ship_floor_heated",
         "l": "t_ship_floor_heated",
         "L": "t_ship_floor_heated",
         "ä": "t_ship_floor_heated",
@@ -110,7 +111,10 @@
         "?": "f_sleep_pod",
         "¿": "f_cryo_pod"
       },
-      "vehicles": { "é": { "vehicle": "handjack", "chance": 75, "rotation": 0 } },
+      "vehicles": {
+        "é": { "vehicle": "handjack", "chance": 75, "rotation": 0 },
+        "Ë": { "vehicle": "ship_reactor", "status": 0, "rotation": 0 }
+      },
       "items": {
         "á": { "item": "afs_your_ship_display_case" },
         "?": { "item": "bed" },

--- a/data/mods/aftershock_exoplanet/vehicles/part_items.json
+++ b/data/mods/aftershock_exoplanet/vehicles/part_items.json
@@ -52,6 +52,15 @@
   },
   {
     "type": "ITEM",
+    "id": "ship_reactor_pdu",
+    "copy-from": "veh_tools_abstract",
+    "name": { "str": "Ship's PDU" },
+    "weight": "10000 kg",
+    "description": "A distribution cabinet linking to the ship's main reactor, can be used to build an external electric grid powered by the ship's surplus power.",
+    "looks_like": "minireactor"
+  },
+  {
+    "type": "ITEM",
     "subtypes": [ "TOOL" ],
     "id": "minireactor",
     "name": { "str": "minireactor" },

--- a/data/mods/aftershock_exoplanet/vehicles/vehicle_parts.json
+++ b/data/mods/aftershock_exoplanet/vehicles/vehicle_parts.json
@@ -279,5 +279,28 @@
     "item": "veh_tools_kitchen",
     "looks_like": "kitchen_unit",
     "extend": { "allowed_tools": [ "afs_atompot" ] }
+  },
+  {
+    "id": "ship_reactor_pdu",
+    "type": "vehicle_part",
+    "categories": [ "movement" ],
+    "color": "light_blue",
+    "flags": [ "NO_INSTALL_HIDDEN", "NO_UNINSTALL", "NO_REPAIR", "OBSTACLE", "PERPETUAL", "REACTOR" ],
+    "looks_like": "minireactor",
+    "location": "center",
+    "epower": "200 kW",
+    "requirements": {
+      "install": { "skills": [ [ "mechanics", 3 ] ], "time": "60 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
+      "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": [ [ "vehicle_wrench_2", 1 ] ] },
+      "repair": { "skills": [ [ "mechanics", 4 ] ], "time": "60 m", "using": [ [ "welding_standard", 5 ] ] }
+    },
+    "item": "ship_reactor_pdu",
+    "description": "A distribution cabinet linking to the ship's main reactor, can be used to build an external electric grid powered by the ship's surplus power.",
+    "variants": [ { "symbols": "X", "symbols_broken": "O" } ],
+    "breaks_into": [
+      { "item": "mc_steel_lump", "count": [ 3, 6 ] },
+      { "item": "mc_steel_chunk", "count": [ 3, 6 ] },
+      { "item": "scrap", "count": [ 3, 6 ] }
+    ]
   }
 ]

--- a/data/mods/aftershock_exoplanet/vehicles/vehicle_parts.json
+++ b/data/mods/aftershock_exoplanet/vehicles/vehicle_parts.json
@@ -285,6 +285,7 @@
     "type": "vehicle_part",
     "categories": [ "movement" ],
     "color": "light_blue",
+    "durability": 800,
     "flags": [ "NO_INSTALL_HIDDEN", "NO_UNINSTALL", "NO_REPAIR", "OBSTACLE", "PERPETUAL", "REACTOR" ],
     "looks_like": "minireactor",
     "location": "center",

--- a/data/mods/aftershock_exoplanet/vehicles/vehicles.json
+++ b/data/mods/aftershock_exoplanet/vehicles/vehicles.json
@@ -492,5 +492,12 @@
       { "x": -3, "y": 2, "parts": [ "hdframe#horizontal", "hdboard#se" ] },
       { "x": -3, "y": 2, "parts": [ "wheel_mount_heavy", "wheel_armor", "plating_military" ] }
     ]
+  },
+  {
+    "id": "ship_reactor",
+    "type": "vehicle",
+    "name": "ship PDU",
+    "blueprint": [ "#" ],
+    "parts": [ { "x": 0, "y": 0, "parts": [ "hdframe#horizontal", "dashboard", "ship_reactor_pdu", "storage_battery" ] } ]
   }
 ]


### PR DESCRIPTION
#### Summary
Mods "Aftershock: Add a reactor outlet to the spaceship"

#### Describe the solution
A new one tile vehicle that produces power and can be used to start an electric grid.

#### Describe alternatives you've considered
No need to have a grid at all, everything magically has power within the spaceship.

#### Testing
Loaded and connected stuff to the grid.
