### PR TITLE
Learn Parkour by Doing Parkour

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7841,7 +7841,7 @@ int Character::impact( const int force, const tripoint_bub_ms &p )
     }
 
     if( !has_proficiency( proficiency_prof_parkour ) ) {
-        practice_proficiency( proficiency_prof_parkour, 1_seconds );
+        practice_proficiency( proficiency_prof_parkour, 10_seconds );
     }
 
     if( !slam && mod < 1.0f && mod * force < 5 ) {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -6086,8 +6086,9 @@ std::vector<run_cost_effect> Character::run_cost_effects( float &movecost ) cons
                               1 );
         run_cost_effect_mul( obstacle_mult, _( "Obstacle Muts." ) );
 
-        if( has_proficiency( proficiency_prof_parkour ) && !is_prone() ) {
-            run_cost_effect_mul( 0.5, _( "Parkour" ) );
+        float parkour_mult = get_proficiency_practice( proficiency_prof_parkour );
+        if( parkour_mult > 0.0 && !is_prone() ) {
+            run_cost_effect_mul( 1 - ( 0.5 * parkour_mult ), _( "Parkour" ) );
         }
 
 
@@ -7724,9 +7725,7 @@ float Character::fall_damage_mod() const
     // 100% damage at 0, 75% at 10, 50% at 20 and so on
     ret *= ( 100.0f - ( dex_dodge * 4.0f ) ) / 100.0f;
 
-    if( has_proficiency( proficiency_prof_parkour ) ) {
-        ret *= 2.0f / 3.0f;
-    }
+    ret *= 1 - ( ( 1.0f / 3.0f ) * get_proficiency_practice( proficiency_prof_parkour ) );
 
     // TODO: Bonus for Judo, mutations. Penalty for heavy weight (including mutations)
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7841,6 +7841,10 @@ int Character::impact( const int force, const tripoint_bub_ms &p )
         }
     }
 
+    if( !has_proficiency(proficiency_prof_parkour) ) {
+        practice_proficiency( proficiency_prof_parkour, 1_seconds );
+    }
+
     if( !slam && mod < 1.0f && mod * force < 5 ) {
         // Perfect landing, no damage (regardless of armor)
         add_msg_if_player( m_warning, _( "You land on %s." ), target_name );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7840,7 +7840,7 @@ int Character::impact( const int force, const tripoint_bub_ms &p )
         }
     }
 
-    if( !has_proficiency(proficiency_prof_parkour) ) {
+    if( !has_proficiency( proficiency_prof_parkour ) ) {
         practice_proficiency( proficiency_prof_parkour, 1_seconds );
     }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -7782,7 +7782,7 @@ bool game::walk_move( const tripoint_bub_ms &dest_loc, const bool via_ramp,
     if( !u.has_proficiency( proficiency_prof_parkour ) && ( mcost_to > 2 || mcost_from > 2 ) &&
         !( mcost_to > 4 || mcost_from > 4 ) ) {
         is_slowed_by_parkour_inexperience = true;
-        u.practice_proficiency( proficiency_prof_parkour, time_duration::from_moves( mcost ) );
+        u.practice_proficiency( proficiency_prof_parkour, time_duration::from_moves( 10 * mcost ) );
     }
     const bool slowed = ( is_slowed_by_parkour_inexperience ||
                           mcost_to > 4 || mcost_from > 4 ) ||
@@ -8132,7 +8132,7 @@ point_rel_sm game::place_player( const tripoint_bub_ms &dest_loc, bool quick )
             }
         } else {
             if( !u.has_proficiency( proficiency_prof_parkour ) ) {
-                u.practice_proficiency( proficiency_prof_parkour, 1_seconds );
+                u.practice_proficiency( proficiency_prof_parkour, 10_seconds );
             }
             if( u.get_hp() > sharp_damage ) {
                 const bodypart_id bp = u.get_random_body_part();
@@ -10903,7 +10903,7 @@ bool game::slip_down( climb_maneuver maneuver, climbing_aid_id aid_id,
             add_msg( m_bad, _( "Climbing is impossible in your current state." ) );
         }
         if( !u.has_proficiency( proficiency_prof_parkour ) ) {
-            u.practice_proficiency( proficiency_prof_parkour, 1_seconds );
+            u.practice_proficiency( proficiency_prof_parkour, 10_seconds );
         }
         // Check for traps and gravity if climbing up or down.
         if( maneuver != climb_maneuver::over_obstacle ) {
@@ -11207,7 +11207,7 @@ void game::climb_down_using( const tripoint_bub_ms &examp, climbing_aid_id aid_i
         } else {
             if( !you.has_proficiency( proficiency_prof_parkour ) ) {
                 // slip_down practices proficiency as well
-                you.practice_proficiency( proficiency_prof_parkour, time_duration::from_moves( moves_used ) );
+                you.practice_proficiency( proficiency_prof_parkour, time_duration::from_moves( 10 * moves_used ) );
             }
             descent_pos.z()--;
             if( aid.down.deploys_furniture() ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -7778,8 +7778,12 @@ bool game::walk_move( const tripoint_bub_ms &dest_loc, const bool via_ramp,
     const bool fungus = here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_FUNGUS, pos ) ||
                         here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_FUNGUS,
                                 dest_loc ); //fungal furniture has no slowing effect on Mycus characters
-    const bool slowed = ( ( !u.has_proficiency( proficiency_prof_parkour ) && ( mcost_to > 2 ||
-                            mcost_from > 2 ) ) ||
+    bool is_slowed_by_parkour_inexperience = false;
+    if ( !u.has_proficiency( proficiency_prof_parkour ) && ( mcost_to > 2 || mcost_from > 2 ) ) {
+        is_slowed_by_parkour_inexperience = true;
+        u.practice_proficiency( proficiency_prof_parkour, time_duration::from_moves(mcost) );
+    }
+    const bool slowed = ( is_slowed_by_parkour_inexperience ||
                           mcost_to > 4 || mcost_from > 4 ) ||
                         ( !u.has_trait( trait_M_IMMUNE ) && fungus );
     if( slowed && !u.is_mounted() ) {
@@ -8126,6 +8130,9 @@ point_rel_sm game::place_player( const tripoint_bub_ms &dest_loc, bool quick )
                 u.mounted_creature->apply_damage( nullptr, bodypart_id( "torso" ), sharp_damage );
             }
         } else {
+            if( !u.has_proficiency( proficiency_prof_parkour ) ) {
+                u.practice_proficiency( proficiency_prof_parkour, 1_seconds );
+            }
             if( u.get_hp() > sharp_damage ) {
                 const bodypart_id bp = u.get_random_body_part();
                 if( u.deal_damage( nullptr, bp,
@@ -10740,7 +10747,7 @@ void game::shift_destination_preview( const point_rel_ms &delta )
 }
 
 float game::slip_down_chance( climb_maneuver, climbing_aid_id aid_id,
-                              bool show_chance_messages )
+                              bool show_chance_messages ) const
 {
     if( aid_id.is_null() ) {
         // The NULL climbing aid ID may be passed as a default argument.
@@ -10764,12 +10771,12 @@ float game::slip_down_chance( climb_maneuver, climbing_aid_id aid_id,
         if( show_chance_messages ) {
             add_msg( m_info, _( "Your skill in parkour makes up for your bad knees while climbing." ) );
         }
-    } else if( u.has_proficiency( proficiency_prof_parkour ) ) {
+    } else if( parkour ) {
         slip /= 2;
         if( show_chance_messages ) {
             add_msg( m_info, _( "Your skill in parkour makes it easier to climb." ) );
         }
-    } else if( u.has_trait( trait_BADKNEES ) ) {
+    } else if( badknees ) {
         slip *= 2;
         if( show_chance_messages ) {
             add_msg( m_info, _( "Your bad knees make it difficult to climb." ) );
@@ -10893,6 +10900,9 @@ bool game::slip_down( climb_maneuver maneuver, climbing_aid_id aid_id,
         add_msg( m_bad, _( "You slip while climbing and fall down." ) );
         if( slip >= 100 ) {
             add_msg( m_bad, _( "Climbing is impossible in your current state." ) );
+        }
+        if( !u.has_proficiency( proficiency_prof_parkour ) ) {
+            u.practice_proficiency( proficiency_prof_parkour, 1_seconds );
         }
         // Check for traps and gravity if climbing up or down.
         if( maneuver != climb_maneuver::over_obstacle ) {
@@ -11178,7 +11188,8 @@ void game::climb_down_using( const tripoint_bub_ms &examp, climbing_aid_id aid_i
     you.set_activity_level( ACTIVE_EXERCISE );
     float weary_mult = 1.0f / you.exertion_adjusted_move_multiplier( ACTIVE_EXERCISE );
 
-    you.mod_moves( -to_moves<int>( 1_seconds + 1_seconds * fall_mod ) * weary_mult );
+    const int moves_used = -to_moves<int>( 1_seconds + 1_seconds * fall_mod ) * weary_mult;
+    you.mod_moves( -moves_used );
     you.setpos( here, examp, false );
 
     // Pre-descent message.
@@ -11193,6 +11204,10 @@ void game::climb_down_using( const tripoint_bub_ms &examp, climbing_aid_id aid_i
             // The player has slipped and probably fallen.
             return;
         } else {
+            if( !you.has_proficiency(proficiency_prof_parkour) ) {
+                // slip_down practices proficiency as well
+                you.practice_proficiency( proficiency_prof_parkour, time_duration::from_moves(moves_used) );
+            }
             descent_pos.z()--;
             if( aid.down.deploys_furniture() ) {
                 here.furn_set( descent_pos, aid.down.deploy_furn );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -7779,7 +7779,7 @@ bool game::walk_move( const tripoint_bub_ms &dest_loc, const bool via_ramp,
                         here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_FUNGUS,
                                 dest_loc ); //fungal furniture has no slowing effect on Mycus characters
     bool is_slowed_by_parkour_inexperience = false;
-    if ( !u.has_proficiency( proficiency_prof_parkour ) && ( mcost_to > 2 || mcost_from > 2 ) ) {
+    if ( !u.has_proficiency( proficiency_prof_parkour ) && ( mcost_to > 2 || mcost_from > 2 ) && !( mcost_to > 4 || mcost_from > 4 ) ) {
         is_slowed_by_parkour_inexperience = true;
         u.practice_proficiency( proficiency_prof_parkour, time_duration::from_moves(mcost) );
     }
@@ -10767,17 +10767,17 @@ float game::slip_down_chance( climb_maneuver, climbing_aid_id aid_id,
         slip = 0;
     }
 
+    slip = slip * ( badknees ? 2 : 1 ) / ( 1 + u.get_proficiency_practice( proficiency_prof_parkour ) );
+
     if( parkour && badknees ) {
         if( show_chance_messages ) {
             add_msg( m_info, _( "Your skill in parkour makes up for your bad knees while climbing." ) );
         }
     } else if( parkour ) {
-        slip /= 2;
         if( show_chance_messages ) {
             add_msg( m_info, _( "Your skill in parkour makes it easier to climb." ) );
         }
     } else if( badknees ) {
-        slip *= 2;
         if( show_chance_messages ) {
             add_msg( m_info, _( "Your bad knees make it difficult to climb." ) );
         }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -7779,9 +7779,10 @@ bool game::walk_move( const tripoint_bub_ms &dest_loc, const bool via_ramp,
                         here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_FUNGUS,
                                 dest_loc ); //fungal furniture has no slowing effect on Mycus characters
     bool is_slowed_by_parkour_inexperience = false;
-    if ( !u.has_proficiency( proficiency_prof_parkour ) && ( mcost_to > 2 || mcost_from > 2 ) && !( mcost_to > 4 || mcost_from > 4 ) ) {
+    if( !u.has_proficiency( proficiency_prof_parkour ) && ( mcost_to > 2 || mcost_from > 2 ) &&
+        !( mcost_to > 4 || mcost_from > 4 ) ) {
         is_slowed_by_parkour_inexperience = true;
-        u.practice_proficiency( proficiency_prof_parkour, time_duration::from_moves(mcost) );
+        u.practice_proficiency( proficiency_prof_parkour, time_duration::from_moves( mcost ) );
     }
     const bool slowed = ( is_slowed_by_parkour_inexperience ||
                           mcost_to > 4 || mcost_from > 4 ) ||
@@ -11204,9 +11205,9 @@ void game::climb_down_using( const tripoint_bub_ms &examp, climbing_aid_id aid_i
             // The player has slipped and probably fallen.
             return;
         } else {
-            if( !you.has_proficiency(proficiency_prof_parkour) ) {
+            if( !you.has_proficiency( proficiency_prof_parkour ) ) {
                 // slip_down practices proficiency as well
-                you.practice_proficiency( proficiency_prof_parkour, time_duration::from_moves(moves_used) );
+                you.practice_proficiency( proficiency_prof_parkour, time_duration::from_moves( moves_used ) );
             }
             descent_pos.z()--;
             if( aid.down.deploys_furniture() ) {

--- a/src/game.h
+++ b/src/game.h
@@ -1352,7 +1352,7 @@ class game
         float slip_down_chance(
             climb_maneuver maneuver,
             climbing_aid_id aid = climbing_aid_id::NULL_ID(),
-            bool show_chance_messages = true );
+            bool show_chance_messages = true ) const;
 
         /**
         * Climb down from a ledge.

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1559,6 +1559,8 @@ void iexamine::chainfence( Character &you, const tripoint_bub_ms &examp )
 
     map &here = get_map();
     int move_cost = 400;
+    const float parkour_modifier = you.get_proficiency_practice( proficiency_prof_parkour );
+
     // TODO: Remove hardcoded trait checks when new arthropod bits happen
     if( here.has_flag( ter_furn_flag::TFLAG_CLIMB_SIMPLE, examp ) ) {
 
@@ -1567,7 +1569,9 @@ void iexamine::chainfence( Character &you, const tripoint_bub_ms &examp )
             move_cost = 100; // Not tall enough to warrant spider-climbing, so only relevant trait.
         } else {
             add_msg( _( "You vault over the obstacle." ) );
-            move_cost = 300; // Most common move cost for barricades pre-change.
+             // Most common move cost for barricades pre-change.
+            move_cost = 300 - (200 * you.get_proficiency_practice( proficiency_prof_parkour ) );
+            you.practice_proficiency( proficiency_prof_parkour, time_duration::from_moves( move_cost / 100) );
         }
     } else if( you.has_trait( trait_ARACHNID_ARMS_OK ) &&
                !you.wearing_fitting_on( bodypart_id( "torso" ) ) ) {
@@ -1581,7 +1585,11 @@ void iexamine::chainfence( Character &you, const tripoint_bub_ms &examp )
         add_msg( _( "This obstacle is no match for your freerunning abilities." ) );
         move_cost = 100;
     } else {
-        move_cost = you.has_trait( trait_BADKNEES ) ? 800 : 400;
+        move_cost = 400 - (300 * you.get_proficiency_practice( proficiency_prof_parkour ) );
+        if (you.has_trait( trait_BADKNEES )) {
+            move_cost *= 2;
+        }
+        you.practice_proficiency( proficiency_prof_parkour, time_duration::from_moves( move_cost / 100) );
         if( g->slip_down( game::climb_maneuver::over_obstacle, climbing_aid_furn_CLIMBABLE ) ) {
             you.mod_moves( -move_cost );
             return;

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1571,7 +1571,7 @@ void iexamine::chainfence( Character &you, const tripoint_bub_ms &examp )
             add_msg( _( "You vault over the obstacle." ) );
             // Most common move cost for barricades pre-change.
             move_cost = 300 - ( 200 * you.get_proficiency_practice( proficiency_prof_parkour ) );
-            you.practice_proficiency( proficiency_prof_parkour, time_duration::from_moves( move_cost / 100 ) );
+            you.practice_proficiency( proficiency_prof_parkour, time_duration::from_moves( move_cost / 10 ) );
         }
     } else if( you.has_trait( trait_ARACHNID_ARMS_OK ) &&
                !you.wearing_fitting_on( bodypart_id( "torso" ) ) ) {
@@ -1589,7 +1589,7 @@ void iexamine::chainfence( Character &you, const tripoint_bub_ms &examp )
         if( you.has_trait( trait_BADKNEES ) ) {
             move_cost *= 2;
         }
-        you.practice_proficiency( proficiency_prof_parkour, time_duration::from_moves( move_cost / 100 ) );
+        you.practice_proficiency( proficiency_prof_parkour, time_duration::from_moves( move_cost / 10 ) );
         if( g->slip_down( game::climb_maneuver::over_obstacle, climbing_aid_furn_CLIMBABLE ) ) {
             you.mod_moves( -move_cost );
             return;

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1570,7 +1570,7 @@ void iexamine::chainfence( Character &you, const tripoint_bub_ms &examp )
         } else {
             add_msg( _( "You vault over the obstacle." ) );
             // Most common move cost for barricades pre-change.
-            move_cost = 300 - ( 200 * you.get_proficiency_practice( proficiency_prof_parkour ) );
+            move_cost = 300 - ( 200 * parkour_modifier );
             you.practice_proficiency( proficiency_prof_parkour, time_duration::from_moves( move_cost / 10 ) );
         }
     } else if( you.has_trait( trait_ARACHNID_ARMS_OK ) &&
@@ -1585,7 +1585,7 @@ void iexamine::chainfence( Character &you, const tripoint_bub_ms &examp )
         add_msg( _( "This obstacle is no match for your freerunning abilities." ) );
         move_cost = 100;
     } else {
-        move_cost = 400 - ( 300 * you.get_proficiency_practice( proficiency_prof_parkour ) );
+        move_cost = 400 - ( 300 * parkour_modifier );
         if( you.has_trait( trait_BADKNEES ) ) {
             move_cost *= 2;
         }

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1569,9 +1569,9 @@ void iexamine::chainfence( Character &you, const tripoint_bub_ms &examp )
             move_cost = 100; // Not tall enough to warrant spider-climbing, so only relevant trait.
         } else {
             add_msg( _( "You vault over the obstacle." ) );
-             // Most common move cost for barricades pre-change.
-            move_cost = 300 - (200 * you.get_proficiency_practice( proficiency_prof_parkour ) );
-            you.practice_proficiency( proficiency_prof_parkour, time_duration::from_moves( move_cost / 100) );
+            // Most common move cost for barricades pre-change.
+            move_cost = 300 - ( 200 * you.get_proficiency_practice( proficiency_prof_parkour ) );
+            you.practice_proficiency( proficiency_prof_parkour, time_duration::from_moves( move_cost / 100 ) );
         }
     } else if( you.has_trait( trait_ARACHNID_ARMS_OK ) &&
                !you.wearing_fitting_on( bodypart_id( "torso" ) ) ) {
@@ -1585,11 +1585,11 @@ void iexamine::chainfence( Character &you, const tripoint_bub_ms &examp )
         add_msg( _( "This obstacle is no match for your freerunning abilities." ) );
         move_cost = 100;
     } else {
-        move_cost = 400 - (300 * you.get_proficiency_practice( proficiency_prof_parkour ) );
-        if (you.has_trait( trait_BADKNEES )) {
+        move_cost = 400 - ( 300 * you.get_proficiency_practice( proficiency_prof_parkour ) );
+        if( you.has_trait( trait_BADKNEES ) ) {
             move_cost *= 2;
         }
-        you.practice_proficiency( proficiency_prof_parkour, time_duration::from_moves( move_cost / 100) );
+        you.practice_proficiency( proficiency_prof_parkour, time_duration::from_moves( move_cost / 100 ) );
         if( g->slip_down( game::climb_maneuver::over_obstacle, climbing_aid_furn_CLIMBABLE ) ) {
             you.mod_moves( -move_cost );
             return;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Learn Parkour by Doing Parkour"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
1: Allow learning the parkour proficiency by doing things that are affected by the parkour proficiency
2: Allow partial parkour proficiency levels to affect things proportional to skill in parkour

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add parkour training where the parkour proficiency is used to influence an outcome and the character does not already have full parkour training.
In places where the parkour proficiency is used, alter math to proportionally use the proficiency instead of just having it be all or nothing.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Recipe only.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
<img width="2555" height="1360" alt="parkour training" src="https://github.com/user-attachments/assets/6a2e358b-ad77-4eeb-8efb-f03c55d75241" />
Used some prints to confirm that parkour move cost is proportional

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
