### PR TITLE
Wrap remaining SDL2 calls behind abstraction layer for SDL3 dual support

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -611,57 +611,58 @@ void tileset_cache::loader::load_tileset( const cata_path &img_path, const bool 
         throwErrorIf( SetSurfaceRLE( tile_atlas, 1 ), "SDL_SetSurfaceRLE failed" );
     }
 
-    SDL_RendererInfo info;
-    throwErrorIf( SDL_GetRendererInfo( renderer.get(), &info ) != 0, "SDL_GetRendererInfo failed" );
+    int max_tex_w = 0;
+    int max_tex_h = 0;
+    throwErrorIf( !GetRendererMaxTextureSize( renderer, &max_tex_w, &max_tex_h ),
+                  "GetRendererMaxTextureSize failed" );
     // Software rendering stores textures as surfaces with run-length encoding, which makes
     // extracting a part in the middle of the texture slow. Therefore this "simulates" that the
-    // renderer only supports one tile
-    // per texture. Each tile will go on its own texture object.
-    if( info.flags & SDL_RENDERER_SOFTWARE ) {
-        info.max_texture_width = sprite_width;
-        info.max_texture_height = sprite_height;
+    // renderer only supports one tile per texture.
+    if( IsRendererSoftware( renderer ) ) {
+        max_tex_w = sprite_width;
+        max_tex_h = sprite_height;
     }
     // for debugging only: force a very small maximal texture size, as to trigger
     // splitting the tile atlas.
 #if 0
     // +1 to check correct rounding
-    info.max_texture_width = sprite_width * 10 + 1;
-    info.max_texture_height = sprite_height * 20 + 1;
+    max_tex_w = sprite_width * 10 + 1;
+    max_tex_h = sprite_height * 20 + 1;
 #endif
 
     const int min_tile_xcount = 128;
     const int min_tile_ycount = min_tile_xcount * 2;
 
-    if( info.max_texture_width == 0 ) {
-        info.max_texture_width = sprite_width * min_tile_xcount;
-        DebugLog( D_INFO, DC_ALL ) << "SDL_RendererInfo max_texture_width was set to 0. " <<
-                                   " Changing it to " << info.max_texture_width;
+    if( max_tex_w == 0 ) {
+        max_tex_w = sprite_width * min_tile_xcount;
+        DebugLog( D_INFO, DC_ALL ) << "Renderer max_texture_width was 0. "
+                                   << "Changed to " << max_tex_w;
     } else {
-        throwErrorIf( info.max_texture_width < sprite_width,
+        throwErrorIf( max_tex_w < sprite_width,
                       "Maximal texture width is smaller than tile width" );
     }
 
-    if( info.max_texture_height == 0 ) {
-        info.max_texture_height = sprite_height * min_tile_ycount;
-        DebugLog( D_INFO, DC_ALL ) << "SDL_RendererInfo max_texture_height was set to 0. " <<
-                                   " Changing it to " << info.max_texture_height;
+    if( max_tex_h == 0 ) {
+        max_tex_h = sprite_height * min_tile_ycount;
+        DebugLog( D_INFO, DC_ALL ) << "Renderer max_texture_height was 0. "
+                                   << "Changed to " << max_tex_h;
     } else {
-        throwErrorIf( info.max_texture_height < sprite_height,
+        throwErrorIf( max_tex_h < sprite_height,
                       "Maximal texture height is smaller than tile height" );
     }
 
     // Number of tiles in each dimension that fits into a (maximal) SDL texture.
     // If the tile atlas contains more than that, we have to split it.
-    const int max_tile_xcount = info.max_texture_width / sprite_width;
-    const int max_tile_ycount = info.max_texture_height / sprite_height;
+    const int max_tile_xcount = max_tex_w / sprite_width;
+    const int max_tile_ycount = max_tex_h / sprite_height;
     // Range over the tile atlas, wherein each rectangle fits into the maximal
     // SDL texture size. In other words: a range over the parts into which the
     // tile atlas needs to be split.
     const rect_range<SDL_Rect> output_range(
         max_tile_xcount * sprite_width,
         max_tile_ycount * sprite_height,
-        point( divide_round_up( tile_atlas->w, info.max_texture_width ),
-               divide_round_up( tile_atlas->h, info.max_texture_height ) ) );
+        point( divide_round_up( tile_atlas->w, max_tex_w ),
+               divide_round_up( tile_atlas->h, max_tex_h ) ) );
 
     const int expected_tilecount = ( tile_atlas->w / sprite_width ) *
                                    ( tile_atlas->h / sprite_height );
@@ -5972,16 +5973,15 @@ std::vector<options_manager::id_and_option> cata_tiles::build_renderer_list()
         { "opengl", to_translation( "opengl" ) },
         { "opengles2", to_translation( "opengles2" ) },
     };
-    int numRenderDrivers = SDL_GetNumRenderDrivers();
+    const int numRenderDrivers = GetNumRenderDrivers();
     for( int ii = 0; ii < numRenderDrivers; ii++ ) {
-        SDL_RendererInfo ri;
-        SDL_GetRenderDriverInfo( ii, &ri );
+        const char *name = GetRenderDriverName( ii );
         // First default renderer name we will put first on the list. We can use it later as
         // default value.
-        if( ri.name == default_renderer_names.front().first ) {
+        if( name == default_renderer_names.front().first ) {
             renderer_names.emplace( renderer_names.begin(), default_renderer_names.front() );
         } else {
-            renderer_names.emplace_back( ri.name, no_translation( ri.name ) );
+            renderer_names.emplace_back( name, no_translation( name ) );
         }
     }
     DebugLog( D_INFO, DC_ALL ) << "SDL render devices: " << enumerate_as_string( renderer_names,
@@ -5999,11 +5999,11 @@ std::vector<options_manager::id_and_option> cata_tiles::build_display_list()
         { "0", to_translation( "Display 0" ) }
     };
 
-    int numdisplays = SDL_GetNumVideoDisplays();
+    const int numdisplays = GetNumVideoDisplays();
     display_names.reserve( numdisplays );
     for( int i = 0 ; i < numdisplays ; i++ ) {
         display_names.emplace_back( std::to_string( i ),
-                                    no_translation( SDL_GetDisplayName( i ) ) );
+                                    no_translation( GetDisplayName( i ) ) );
     }
 
     return display_names.empty() ? default_display_names : display_names;

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -399,7 +399,7 @@ static void debug_error_prompt(
 #if defined(TILES)
             case 'c':
             case 'C':
-                SDL_SetClipboardText( formatted_report.c_str() );
+                SetClipboardText( formatted_report );
                 break;
 #endif // TILES
             case 'i':

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -3513,9 +3513,9 @@ static void game_report()
             _( "Copy game report to clipboard?" ) +
             std::string( "\n\n" ) +
             _( "If not copied to clipboard it will be displayed on screen as a message.  You will have to copy it down or record it manually." ) ) ) {
-        int clipboard_result = SDL_SetClipboardText( report.c_str() );
-        printErrorIf( clipboard_result != 0, "Error while copying the game report to the clipboard." );
-        if( clipboard_result == 0 ) {
+        const bool clipboard_ok = SetClipboardText( report );
+        printErrorIf( !clipboard_ok, "Error while copying the game report to the clipboard." );
+        if( clipboard_ok ) {
             popup_msg += _( " and to the clipboard." );
         }
     } else {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,11 +78,7 @@
 class ui_adaptor;
 
 #if defined(TILES) || defined(SDL_SOUND)
-#   if defined(_MSC_VER) && defined(USE_VCPKG)
-#      include <SDL2/SDL_version.h>
-#   else
-#      include <SDL_version.h>
-#   endif
+#   include "sdl_version_wrappers.h"
 #endif
 
 #if defined(__ANDROID__)
@@ -744,19 +740,19 @@ int main( int argc, const char *argv[] )
     DebugLog( D_INFO, DC_ALL ) << "[main] C++ locale set to " << std::locale().name();
 
 #if defined(TILES) || defined(SDL_SOUND)
-    SDL_version compiled;
-    SDL_VERSION( &compiled );
-    DebugLog( D_INFO, DC_ALL ) << "SDL version used during compile is "
-                               << static_cast<int>( compiled.major ) << "."
-                               << static_cast<int>( compiled.minor ) << "."
-                               << static_cast<int>( compiled.patch );
+    {
+        const SDLVersionInfo compiled = GetCompiledSDLVersion();
+        DebugLog( D_INFO, DC_ALL ) << "SDL version used during compile is "
+                                   << compiled.major << "."
+                                   << compiled.minor << "."
+                                   << compiled.patch;
 
-    SDL_version linked;
-    SDL_GetVersion( &linked );
-    DebugLog( D_INFO, DC_ALL ) << "SDL version used during linking and in runtime is "
-                               << static_cast<int>( linked.major ) << "."
-                               << static_cast<int>( linked.minor ) << "."
-                               << static_cast<int>( linked.patch );
+        const SDLVersionInfo linked = GetLinkedSDLVersion();
+        DebugLog( D_INFO, DC_ALL ) << "SDL version used during linking and in runtime is "
+                                   << linked.major << "."
+                                   << linked.minor << "."
+                                   << linked.patch;
+    }
 #endif
 
 #if !defined(TILES)

--- a/src/pixel_minimap.cpp
+++ b/src/pixel_minimap.cpp
@@ -68,7 +68,7 @@ float get_animation_phase( int phase_length_ms )
         return 0.0f;
     }
 
-    return std::fmod<float>( SDL_GetTicks(), phase_length_ms ) / phase_length_ms;
+    return std::fmod<float>( GetTicks(), phase_length_ms ) / phase_length_ms;
 }
 
 //creates the texture that individual minimap updates are drawn to
@@ -393,9 +393,9 @@ void pixel_minimap::set_screen_rect( const SDL_Rect &screen_rect )
         main_tex_clip_rect = SDL_Rect{ 0, 0, size_on_screen.x, size_on_screen.y };
         screen_clip_rect = fit_rect_inside( main_tex_clip_rect, screen_rect );
 
-        SDL_SetHint( SDL_HINT_RENDER_SCALE_QUALITY, "1" );
         main_tex = create_cache_texture( renderer, size_on_screen.x, size_on_screen.y );
-        SDL_SetHint( SDL_HINT_RENDER_SCALE_QUALITY, "0" );
+        // This texture is scaled to fit the screen; use linear filtering for smooth presentation.
+        SetTextureScaleQuality( main_tex, "linear" );
 
     } else {
         const point d( ( size_on_screen.x - screen_rect.w ) / 2, ( size_on_screen.y - screen_rect.h ) / 2 );

--- a/src/sdl_gamepad.cpp
+++ b/src/sdl_gamepad.cpp
@@ -19,17 +19,72 @@
 namespace gamepad
 {
 
+// SDL3 compat: normalized event and API constants
+#if SDL_MAJOR_VERSION >= 3
+static constexpr Uint32 CATA_CONTROLLERBUTTONDOWN    = SDL_EVENT_GAMEPAD_BUTTON_DOWN;
+static constexpr Uint32 CATA_CONTROLLERBUTTONUP      = SDL_EVENT_GAMEPAD_BUTTON_UP;
+static constexpr Uint32 CATA_CONTROLLERAXISMOTION    = SDL_EVENT_GAMEPAD_AXIS_MOTION;
+static constexpr Uint32 CATA_CONTROLLERDEVICEADDED   = SDL_EVENT_GAMEPAD_ADDED;
+static constexpr Uint32 CATA_CONTROLLERDEVICEREMOVED = SDL_EVENT_GAMEPAD_REMOVED;
+static constexpr int CATA_AXIS_TRIGGERLEFT  = SDL_GAMEPAD_AXIS_LEFT_TRIGGER;
+static constexpr int CATA_AXIS_TRIGGERRIGHT = SDL_GAMEPAD_AXIS_RIGHT_TRIGGER;
+static constexpr int CATA_AXIS_LEFTX       = SDL_GAMEPAD_AXIS_LEFTX;
+static constexpr int CATA_AXIS_LEFTY       = SDL_GAMEPAD_AXIS_LEFTY;
+static constexpr int CATA_AXIS_RIGHTX      = SDL_GAMEPAD_AXIS_RIGHTX;
+static constexpr int CATA_AXIS_RIGHTY      = SDL_GAMEPAD_AXIS_RIGHTY;
+static constexpr int CATA_BUTTON_A              = SDL_GAMEPAD_BUTTON_SOUTH;
+static constexpr int CATA_BUTTON_B              = SDL_GAMEPAD_BUTTON_EAST;
+static constexpr int CATA_BUTTON_X              = SDL_GAMEPAD_BUTTON_WEST;
+static constexpr int CATA_BUTTON_Y              = SDL_GAMEPAD_BUTTON_NORTH;
+static constexpr int CATA_BUTTON_LEFTSHOULDER   = SDL_GAMEPAD_BUTTON_LEFT_SHOULDER;
+static constexpr int CATA_BUTTON_RIGHTSHOULDER  = SDL_GAMEPAD_BUTTON_RIGHT_SHOULDER;
+static constexpr int CATA_BUTTON_LEFTSTICK      = SDL_GAMEPAD_BUTTON_LEFT_STICK;
+static constexpr int CATA_BUTTON_RIGHTSTICK     = SDL_GAMEPAD_BUTTON_RIGHT_STICK;
+static constexpr int CATA_BUTTON_START          = SDL_GAMEPAD_BUTTON_START;
+static constexpr int CATA_BUTTON_BACK           = SDL_GAMEPAD_BUTTON_BACK;
+static constexpr int CATA_BUTTON_DPAD_UP        = SDL_GAMEPAD_BUTTON_DPAD_UP;
+static constexpr int CATA_BUTTON_DPAD_DOWN      = SDL_GAMEPAD_BUTTON_DPAD_DOWN;
+static constexpr int CATA_BUTTON_DPAD_LEFT      = SDL_GAMEPAD_BUTTON_DPAD_LEFT;
+static constexpr int CATA_BUTTON_DPAD_RIGHT     = SDL_GAMEPAD_BUTTON_DPAD_RIGHT;
+#else
+static constexpr Uint32 CATA_CONTROLLERBUTTONDOWN    = SDL_CONTROLLERBUTTONDOWN;
+static constexpr Uint32 CATA_CONTROLLERBUTTONUP      = SDL_CONTROLLERBUTTONUP;
+static constexpr Uint32 CATA_CONTROLLERAXISMOTION    = SDL_CONTROLLERAXISMOTION;
+static constexpr Uint32 CATA_CONTROLLERDEVICEADDED   = SDL_CONTROLLERDEVICEADDED;
+static constexpr Uint32 CATA_CONTROLLERDEVICEREMOVED = SDL_CONTROLLERDEVICEREMOVED;
+static constexpr int CATA_AXIS_TRIGGERLEFT  = SDL_CONTROLLER_AXIS_TRIGGERLEFT;
+static constexpr int CATA_AXIS_TRIGGERRIGHT = SDL_CONTROLLER_AXIS_TRIGGERRIGHT;
+static constexpr int CATA_AXIS_LEFTX       = SDL_CONTROLLER_AXIS_LEFTX;
+static constexpr int CATA_AXIS_LEFTY       = SDL_CONTROLLER_AXIS_LEFTY;
+static constexpr int CATA_AXIS_RIGHTX      = SDL_CONTROLLER_AXIS_RIGHTX;
+static constexpr int CATA_AXIS_RIGHTY      = SDL_CONTROLLER_AXIS_RIGHTY;
+static constexpr int CATA_BUTTON_A              = SDL_CONTROLLER_BUTTON_A;
+static constexpr int CATA_BUTTON_B              = SDL_CONTROLLER_BUTTON_B;
+static constexpr int CATA_BUTTON_X              = SDL_CONTROLLER_BUTTON_X;
+static constexpr int CATA_BUTTON_Y              = SDL_CONTROLLER_BUTTON_Y;
+static constexpr int CATA_BUTTON_LEFTSHOULDER   = SDL_CONTROLLER_BUTTON_LEFTSHOULDER;
+static constexpr int CATA_BUTTON_RIGHTSHOULDER  = SDL_CONTROLLER_BUTTON_RIGHTSHOULDER;
+static constexpr int CATA_BUTTON_LEFTSTICK      = SDL_CONTROLLER_BUTTON_LEFTSTICK;
+static constexpr int CATA_BUTTON_RIGHTSTICK     = SDL_CONTROLLER_BUTTON_RIGHTSTICK;
+static constexpr int CATA_BUTTON_START          = SDL_CONTROLLER_BUTTON_START;
+static constexpr int CATA_BUTTON_BACK           = SDL_CONTROLLER_BUTTON_BACK;
+static constexpr int CATA_BUTTON_DPAD_UP        = SDL_CONTROLLER_BUTTON_DPAD_UP;
+static constexpr int CATA_BUTTON_DPAD_DOWN      = SDL_CONTROLLER_BUTTON_DPAD_DOWN;
+static constexpr int CATA_BUTTON_DPAD_LEFT      = SDL_CONTROLLER_BUTTON_DPAD_LEFT;
+static constexpr int CATA_BUTTON_DPAD_RIGHT     = SDL_CONTROLLER_BUTTON_DPAD_RIGHT;
+#endif
+
 static constexpr int max_triggers = 2;
 static constexpr int max_sticks = 2;
 static constexpr int max_buttons = 30;
 
 static std::array<int, max_triggers> triggers_axis = {
-    SDL_CONTROLLER_AXIS_TRIGGERLEFT,
-    SDL_CONTROLLER_AXIS_TRIGGERRIGHT
+    CATA_AXIS_TRIGGERLEFT,
+    CATA_AXIS_TRIGGERRIGHT
 };
 static std::array<std::array<int, 2>, max_sticks> sticks_axis = { {
-        { {SDL_CONTROLLER_AXIS_LEFTX,  SDL_CONTROLLER_AXIS_LEFTY}  },
-        { {SDL_CONTROLLER_AXIS_RIGHTX, SDL_CONTROLLER_AXIS_RIGHTY} }
+        { {CATA_AXIS_LEFTX,  CATA_AXIS_LEFTY}  },
+        { {CATA_AXIS_RIGHTX, CATA_AXIS_RIGHTY} }
     }
 };
 
@@ -40,7 +95,10 @@ static int sticks_threshold = 16000;
 static int error_margin = 2000;
 
 struct task_t {
-    Uint32 when;
+    // Millisecond timestamp from GetTicks(), not raw event timestamps.
+    // SDL3 event timestamps are nanoseconds (Uint64); using GetTicks() keeps
+    // everything in a consistent millisecond timebase across both versions.
+    uint32_t when;
     int button;
     int counter;
     int state;
@@ -58,8 +116,13 @@ static int repeat_interval = 50;
 
 // SDL related stuff
 static SDL_TimerID timer_id;
+#if SDL_MAJOR_VERSION >= 3
+static SDL_Gamepad *controller = nullptr;
+static SDL_JoystickID controller_id = 0; // SDL3 uses 0 as invalid
+#else
 static SDL_GameController *controller = nullptr;
 static SDL_JoystickID controller_id = -1;
+#endif
 
 static direction left_stick_dir = direction::NONE;
 static direction right_stick_dir = direction::NONE;
@@ -69,7 +132,12 @@ static bool radial_left_open = false;
 static bool radial_right_open = false;
 static bool alt_modifier_held = false;
 
+// SDL3: callback signature changes to (void *userdata, SDL_TimerID timerID, Uint32 interval)
+#if SDL_MAJOR_VERSION >= 3
+static Uint32 timer_func( void *, SDL_TimerID, Uint32 interval )
+#else
 static Uint32 timer_func( Uint32 interval, void * )
+#endif
 {
     SDL_Event event;
     SDL_UserEvent userevent;
@@ -92,14 +160,30 @@ void init()
         task.counter = 0;
     }
 
+#if SDL_MAJOR_VERSION >= 3
+    // SDL3: SDL_INIT_GAMECONTROLLER removed; use SDL_INIT_GAMEPAD.
+    int ret = SDL_Init( SDL_INIT_TIMER | SDL_INIT_GAMEPAD );
+    if( !ret ) {
+        printErrorIf( true, "Init gamepad+timer failed" );
+        return;
+    }
+
+    int num_joysticks = 0;
+    SDL_JoystickID *joysticks = SDL_GetJoysticks( &num_joysticks );
+    if( joysticks && num_joysticks > 0 ) {
+        controller = SDL_OpenGamepad( joysticks[0] );
+        if( controller ) {
+            controller_id = SDL_GetGamepadID( controller );
+        }
+    }
+    SDL_free( joysticks );
+#else
     int ret = SDL_Init( SDL_INIT_TIMER | SDL_INIT_GAMECONTROLLER );
     if( ret < 0 ) {
         printErrorIf( ret != 0, "Init gamecontroller+timer failed" );
         return;
     }
 
-    // SDL3: SDL_NumJoysticks is replaced by SDL_GetJoysticks (returns array).
-    // SDL3: SDL_GameControllerOpen becomes SDL_OpenGamepad and takes instance ID, not device index.
     if( SDL_NumJoysticks() > 0 ) {
         controller = SDL_GameControllerOpen( 0 );
         if( controller ) {
@@ -107,6 +191,7 @@ void init()
             SDL_GameControllerEventState( SDL_ENABLE );
         }
     }
+#endif
 
     timer_id = SDL_AddTimer( 50, timer_func, nullptr );
     printErrorIf( timer_id == 0, "SDL_AddTimer failed" );
@@ -119,15 +204,22 @@ void quit()
         timer_id = 0;
     }
     if( controller ) {
+#if SDL_MAJOR_VERSION >= 3
+        SDL_CloseGamepad( controller );
+#else
         SDL_GameControllerClose( controller );
+#endif
         controller = nullptr;
     }
 }
 
-// SDL3: SDL_GameControllerGetAxis becomes SDL_GetGamepadAxis.
-static Sint16 get_controller_axis( SDL_GameControllerAxis axis )
+static Sint16 get_controller_axis( int axis )
 {
-    return SDL_GameControllerGetAxis( controller, axis );
+#if SDL_MAJOR_VERSION >= 3
+    return SDL_GetGamepadAxis( controller, static_cast<SDL_GamepadAxis>( axis ) );
+#else
+    return SDL_GameControllerGetAxis( controller, static_cast<SDL_GameControllerAxis>( axis ) );
+#endif
 }
 
 static int one_of_two( const std::array<int, 2> &arr, int val )
@@ -141,7 +233,7 @@ static int one_of_two( const std::array<int, 2> &arr, int val )
     return -1;
 }
 
-static void schedule_task( task_t &task, Uint32 when, int button, int state,
+static void schedule_task( task_t &task, uint32_t when, int button, int state,
                            input_event_t type = input_event_t::gamepad )
 {
     task.when = when;
@@ -329,13 +421,21 @@ static void send_direction_movement()
 
 static bool handle_axis_event( SDL_Event &event )
 {
-    if( event.type != SDL_CONTROLLERAXISMOTION ) {
+    if( event.type != CATA_CONTROLLERAXISMOTION ) {
         return false;
     }
 
+    // SDL3: event.caxis becomes event.gaxis
+#if SDL_MAJOR_VERSION >= 3
+    int axis = event.gaxis.axis;
+    int value = event.gaxis.value;
+#else
     int axis = event.caxis.axis;
     int value = event.caxis.value;
-    Uint32 now = event.caxis.timestamp;
+#endif
+    // Use GetTicks() instead of event timestamps for consistent millisecond
+    // timebase. SDL3 event timestamps are nanoseconds, not milliseconds.
+    uint32_t now = GetTicks();
     bool direction_changed = false;
 
     // check triggers
@@ -409,8 +509,8 @@ static bool handle_axis_event( SDL_Event &event )
         if( axis_idx >= 0 ) {
             // Get current values for both axes of this stick
             const point val(
-                get_controller_axis( static_cast<SDL_GameControllerAxis>( sticks_axis[i][0] ) ),
-                get_controller_axis( static_cast<SDL_GameControllerAxis>( sticks_axis[i][1] ) ) );
+                get_controller_axis( sticks_axis[i][0] ),
+                get_controller_axis( sticks_axis[i][1] ) );
 
             // Calculate magnitude (distance from center)
             double magnitude = std::sqrt( static_cast<double>( val.x ) * val.x +
@@ -518,10 +618,15 @@ static bool handle_axis_event( SDL_Event &event )
 
 static void handle_button_event( SDL_Event &event )
 {
+    // SDL3: event.cbutton becomes event.gbutton
+#if SDL_MAJOR_VERSION >= 3
+    int button = event.gbutton.button;
+#else
     int button = event.cbutton.button;
-    Uint32 now = event.cbutton.timestamp;
+#endif
+    uint32_t now = GetTicks();
 
-    if( event.type == SDL_CONTROLLERBUTTONUP ) {
+    if( event.type == CATA_CONTROLLERBUTTONUP ) {
         // Button released - only handle cleanup/task cancellation
         if( button < max_buttons ) {
             cancel_task( all_tasks[button] );
@@ -529,13 +634,12 @@ static void handle_button_event( SDL_Event &event )
         return;
     }
 
-    // SDL_CONTROLLERBUTTONDOWN:
     // Button pressed - determine which input to send
     int joy_code = -1;
     input_event_t input_type = input_event_t::gamepad;
 
     switch( button ) {
-        case SDL_CONTROLLER_BUTTON_A:
+        case CATA_BUTTON_A:
             if( is_in_menu() ) {
                 joy_code = '\n';
                 input_type = input_event_t::keyboard_char;
@@ -543,7 +647,7 @@ static void handle_button_event( SDL_Event &event )
                 joy_code = JOY_A;
             }
             break;
-        case SDL_CONTROLLER_BUTTON_B:
+        case CATA_BUTTON_B:
             if( is_in_menu() ) {
                 joy_code = KEY_ESCAPE;
                 input_type = input_event_t::keyboard_code;
@@ -551,13 +655,13 @@ static void handle_button_event( SDL_Event &event )
                 joy_code = JOY_B;
             }
             break;
-        case SDL_CONTROLLER_BUTTON_X:
+        case CATA_BUTTON_X:
             joy_code = JOY_X;
             break;
-        case SDL_CONTROLLER_BUTTON_Y:
+        case CATA_BUTTON_Y:
             joy_code = JOY_Y;
             break;
-        case SDL_CONTROLLER_BUTTON_RIGHTSHOULDER:
+        case CATA_BUTTON_RIGHTSHOULDER:
             if( is_in_menu() ) {
                 joy_code = '\t';
                 input_type = input_event_t::keyboard_char;
@@ -565,7 +669,7 @@ static void handle_button_event( SDL_Event &event )
                 joy_code = JOY_RB;
             }
             break;
-        case SDL_CONTROLLER_BUTTON_LEFTSHOULDER:
+        case CATA_BUTTON_LEFTSHOULDER:
             if( is_in_menu() ) {
                 joy_code = KEY_BTAB;
                 input_type = input_event_t::keyboard_char;
@@ -573,13 +677,13 @@ static void handle_button_event( SDL_Event &event )
                 joy_code = JOY_LB;
             }
             break;
-        case SDL_CONTROLLER_BUTTON_LEFTSTICK:
+        case CATA_BUTTON_LEFTSTICK:
             joy_code = JOY_LS;
             break;
-        case SDL_CONTROLLER_BUTTON_RIGHTSTICK:
+        case CATA_BUTTON_RIGHTSTICK:
             joy_code = JOY_RS;
             break;
-        case SDL_CONTROLLER_BUTTON_START:
+        case CATA_BUTTON_START:
             if( is_in_menu() ) {
                 joy_code = KEY_ESCAPE;
                 input_type = input_event_t::keyboard_code;
@@ -587,7 +691,7 @@ static void handle_button_event( SDL_Event &event )
                 joy_code = JOY_START;
             }
             break;
-        case SDL_CONTROLLER_BUTTON_BACK:
+        case CATA_BUTTON_BACK:
             if( is_in_menu() ) {
                 joy_code = KEY_ESCAPE;
                 input_type = input_event_t::keyboard_code;
@@ -599,7 +703,7 @@ static void handle_button_event( SDL_Event &event )
         // D-pad handling
         // If in a menu, send keyboard arrow keys for navigation
         // If in gameplay, send JOY_* codes for mapped actions
-        case SDL_CONTROLLER_BUTTON_DPAD_UP:
+        case CATA_BUTTON_DPAD_UP:
             if( is_in_menu() && !alt_modifier_held ) {
                 joy_code = KEY_UP;
                 input_type = input_event_t::keyboard_char;
@@ -607,7 +711,7 @@ static void handle_button_event( SDL_Event &event )
                 joy_code = JOY_UP;
             }
             break;
-        case SDL_CONTROLLER_BUTTON_DPAD_DOWN:
+        case CATA_BUTTON_DPAD_DOWN:
             if( is_in_menu() && !alt_modifier_held ) {
                 joy_code = KEY_DOWN;
                 input_type = input_event_t::keyboard_char;
@@ -615,7 +719,7 @@ static void handle_button_event( SDL_Event &event )
                 joy_code = JOY_DOWN;
             }
             break;
-        case SDL_CONTROLLER_BUTTON_DPAD_LEFT:
+        case CATA_BUTTON_DPAD_LEFT:
             if( is_in_menu() && !alt_modifier_held ) {
                 joy_code = KEY_LEFT;
                 input_type = input_event_t::keyboard_char;
@@ -623,7 +727,7 @@ static void handle_button_event( SDL_Event &event )
                 joy_code = JOY_LEFT;
             }
             break;
-        case SDL_CONTROLLER_BUTTON_DPAD_RIGHT:
+        case CATA_BUTTON_DPAD_RIGHT:
             if( is_in_menu() && !alt_modifier_held ) {
                 joy_code = KEY_RIGHT;
                 input_type = input_event_t::keyboard_char;
@@ -644,36 +748,49 @@ static void handle_button_event( SDL_Event &event )
     if( joy_code != -1 ) {
         send_input( joy_code, input_type );
         // Only D-pad buttons repeat
-        if( button >= SDL_CONTROLLER_BUTTON_DPAD_UP && button <= SDL_CONTROLLER_BUTTON_DPAD_RIGHT ) {
+        if( button >= CATA_BUTTON_DPAD_UP && button <= CATA_BUTTON_DPAD_RIGHT ) {
             schedule_task( all_tasks[button], now + repeat_delay, joy_code, 1, input_type );
         }
     }
 }
 
-// SDL3: SDL_CONTROLLERDEVICEADDED/REMOVED become SDL_EVENT_GAMEPAD_ADDED/REMOVED.
-// SDL3: event.cdevice.which for ADDED is an instance ID (not device index).
-// SDL3: SDL_GameControllerOpen becomes SDL_OpenGamepad.
 static void handle_device_event( SDL_Event &event )
 {
-    if( event.type == SDL_CONTROLLERDEVICEADDED ) {
+    if( event.type == CATA_CONTROLLERDEVICEADDED ) {
         if( controller == nullptr ) {
+#if SDL_MAJOR_VERSION >= 3
+            // SDL3: event provides instance ID directly; SDL_OpenGamepad takes it.
+            controller = SDL_OpenGamepad( event.gdevice.which );
+            if( controller ) {
+                controller_id = SDL_GetGamepadID( controller );
+            }
+#else
             controller = SDL_GameControllerOpen( event.cdevice.which );
             if( controller ) {
                 controller_id = SDL_JoystickInstanceID( SDL_GameControllerGetJoystick( controller ) );
             }
+#endif
         }
-    } else if( event.type == SDL_CONTROLLERDEVICEREMOVED ) {
+    } else if( event.type == CATA_CONTROLLERDEVICEREMOVED ) {
+#if SDL_MAJOR_VERSION >= 3
+        if( controller != nullptr && event.gdevice.which == controller_id ) {
+            SDL_CloseGamepad( controller );
+            controller = nullptr;
+            controller_id = 0;
+        }
+#else
         if( controller != nullptr && event.cdevice.which == controller_id ) {
             SDL_GameControllerClose( controller );
             controller = nullptr;
             controller_id = -1;
         }
+#endif
     }
 }
 
-static void handle_scheduler_event( SDL_Event &event )
+static void handle_scheduler_event( SDL_Event &/*event*/ )
 {
-    Uint32 now = event.user.timestamp;
+    uint32_t now = GetTicks();
     for( size_t i = 0; i < all_tasks.size(); ++i ) {
         gamepad::task_t &task = all_tasks[i];
         if( task.counter && task.when <= now ) {
@@ -768,18 +885,17 @@ tripoint direction_to_offset( direction dir )
     }
 }
 
-// SDL3: SDL_CONTROLLERBUTTONDOWN/UP become SDL_EVENT_GAMEPAD_BUTTON_DOWN/UP.
-// SDL3: SDL_CONTROLLERAXISMOTION becomes SDL_EVENT_GAMEPAD_AXIS_MOTION.
-// SDL3: SDL_CONTROLLERDEVICEADDED/REMOVED become SDL_EVENT_GAMEPAD_ADDED/REMOVED.
+// SDL3: event constants and struct members are remapped via the CATA_CONTROLLER*
+// constants and #if blocks defined at the top of this file.
 // SDL3: event.caxis/cbutton/cdevice become event.gaxis/gbutton/gdevice.
 bool is_gamepad_event( const SDL_Event &event )
 {
     switch( event.type ) {
-        case SDL_CONTROLLERBUTTONDOWN:
-        case SDL_CONTROLLERBUTTONUP:
-        case SDL_CONTROLLERAXISMOTION:
-        case SDL_CONTROLLERDEVICEADDED:
-        case SDL_CONTROLLERDEVICEREMOVED:
+        case CATA_CONTROLLERBUTTONDOWN:
+        case CATA_CONTROLLERBUTTONUP:
+        case CATA_CONTROLLERAXISMOTION:
+        case CATA_CONTROLLERDEVICEADDED:
+        case CATA_CONTROLLERDEVICEREMOVED:
         case SDL_GAMEPAD_SCHEDULER:
             return true;
         default:
@@ -790,14 +906,14 @@ bool is_gamepad_event( const SDL_Event &event )
 bool handle_event( SDL_Event &event )
 {
     switch( event.type ) {
-        case SDL_CONTROLLERBUTTONDOWN:
-        case SDL_CONTROLLERBUTTONUP:
+        case CATA_CONTROLLERBUTTONDOWN:
+        case CATA_CONTROLLERBUTTONUP:
             handle_button_event( event );
             return false;
-        case SDL_CONTROLLERAXISMOTION:
+        case CATA_CONTROLLERAXISMOTION:
             return handle_axis_event( event );
-        case SDL_CONTROLLERDEVICEADDED:
-        case SDL_CONTROLLERDEVICEREMOVED:
+        case CATA_CONTROLLERDEVICEADDED:
+        case CATA_CONTROLLERDEVICEREMOVED:
             handle_device_event( event );
             return false;
         case SDL_GAMEPAD_SCHEDULER:

--- a/src/sdl_version_wrappers.h
+++ b/src/sdl_version_wrappers.h
@@ -1,0 +1,51 @@
+#pragma once
+#ifndef CATA_SRC_SDL_VERSION_WRAPPERS_H
+#define CATA_SRC_SDL_VERSION_WRAPPERS_H
+
+// Minimal header for SDL version queries. Intentionally does NOT include
+// sdl_wrappers.h, which defines SDL_MAIN_HANDLED and would break entry-point
+// handling in main.cpp (WinMain / SDL_main plumbing).
+
+#if defined(_MSC_VER) && defined(USE_VCPKG)
+#   include <SDL2/SDL_version.h>
+#else
+#   include <SDL_version.h>
+#endif
+
+struct SDLVersionInfo {
+    int major;
+    int minor;
+    int patch;
+};
+
+// Returns the SDL version the program was compiled against.
+// SDL2: SDL_VERSION() macro fills SDL_version struct.
+// SDL3: SDL_VERSION is a compile-time int constant; decompose with SDL_VERSIONNUM_MAJOR/MINOR/MICRO.
+inline SDLVersionInfo GetCompiledSDLVersion()
+{
+#if SDL_MAJOR_VERSION >= 3
+    const int v = SDL_VERSION;
+    return { SDL_VERSIONNUM_MAJOR( v ), SDL_VERSIONNUM_MINOR( v ), SDL_VERSIONNUM_MICRO( v ) };
+#else
+    SDL_version v;
+    SDL_VERSION( &v );
+    return { v.major, v.minor, v.patch };
+#endif
+}
+
+// Returns the SDL version linked at runtime.
+// SDL2: SDL_GetVersion() fills an SDL_version struct.
+// SDL3: SDL_GetVersion() returns a single int; decompose with SDL_VERSIONNUM_MAJOR/MINOR/MICRO.
+inline SDLVersionInfo GetLinkedSDLVersion()
+{
+#if SDL_MAJOR_VERSION >= 3
+    const int v = SDL_GetVersion();
+    return { SDL_VERSIONNUM_MAJOR( v ), SDL_VERSIONNUM_MINOR( v ), SDL_VERSIONNUM_MICRO( v ) };
+#else
+    SDL_version v;
+    SDL_GetVersion( &v );
+    return { v.major, v.minor, v.patch };
+#endif
+}
+
+#endif // CATA_SRC_SDL_VERSION_WRAPPERS_H

--- a/src/sdl_wrappers.cpp
+++ b/src/sdl_wrappers.cpp
@@ -37,6 +37,21 @@ void throwErrorIf( const bool condition, const char *const message )
 
 #if defined(TILES)
 
+// Default texture scale quality applied by CreateTexture/CreateTextureFromSurface.
+// Replaces the global SDL_HINT_RENDER_SCALE_QUALITY approach with per-texture mode.
+// Initialized to "nearest" to match SDL2's documented default for the hint.
+static std::string g_default_texture_scale_quality = "nearest";
+
+static SDL_ScaleMode scale_quality_to_mode( const std::string &quality )
+{
+    if( quality == "0" || quality == "nearest" || quality == "none" ) {
+        return SDL_ScaleModeNearest;
+    }
+    // "1", "linear", or anything else defaults to linear.
+    // SDL3: SDL_SCALEMODE_NEAREST / SDL_SCALEMODE_LINEAR (renamed enums).
+    return SDL_ScaleModeLinear;
+}
+
 void RenderCopy( const SDL_Renderer_Ptr &renderer, const SDL_Texture_Ptr &texture,
                  const SDL_Rect *srcrect, const SDL_Rect *dstrect )
 {
@@ -61,6 +76,10 @@ SDL_Texture_Ptr CreateTexture( const SDL_Renderer_Ptr &renderer, Uint32 format, 
     }
     SDL_Texture_Ptr result( SDL_CreateTexture( renderer.get(), format, access, w, h ) );
     printErrorIf( !result, "SDL_CreateTexture failed" );
+    if( result ) {
+        SDL_SetTextureScaleMode( result.get(),
+                                 scale_quality_to_mode( g_default_texture_scale_quality ) );
+    }
     return result;
 }
 
@@ -77,6 +96,10 @@ SDL_Texture_Ptr CreateTextureFromSurface( const SDL_Renderer_Ptr &renderer,
     }
     SDL_Texture_Ptr result( SDL_CreateTextureFromSurface( renderer.get(), surface.get() ) );
     printErrorIf( !result, "SDL_CreateTextureFromSurface failed" );
+    if( result ) {
+        SDL_SetTextureScaleMode( result.get(),
+                                 scale_quality_to_mode( g_default_texture_scale_quality ) );
+    }
     return result;
 }
 
@@ -188,15 +211,16 @@ SDL_Surface_Ptr load_image( const char *const path )
     return result;
 }
 
-void SetRenderTarget( const SDL_Renderer_Ptr &renderer, const SDL_Texture_Ptr &texture )
+bool SetRenderTarget( const SDL_Renderer_Ptr &renderer, const SDL_Texture_Ptr &texture )
 {
     if( !renderer ) {
         dbg( D_ERROR ) << "Tried to use a null renderer";
-        return;
+        return false;
     }
-    // a null texture is fine for SDL
-    printErrorIf( SDL_SetRenderTarget( renderer.get(), texture.get() ) != 0,
-                  "SDL_SetRenderTarget failed" );
+    // a null texture is fine for SDL (resets to default target)
+    const bool failed = printErrorIf( SDL_SetRenderTarget( renderer.get(), texture.get() ) != 0,
+                                      "SDL_SetRenderTarget failed" );
+    return !failed;
 }
 
 void RenderClear( const SDL_Renderer_Ptr &renderer )
@@ -469,5 +493,442 @@ bool CanRenderGlyph( const TTF_Font_Ptr &font, const Uint32 ch )
     }
     return TTF_GlyphIsProvided( font.get(), static_cast<Uint16>( ch ) ) != 0;
 }
+
+int GetNumVideoDisplays()
+{
+    // SDL3: SDL_GetDisplays(&count) returns SDL_DisplayID* array; return count.
+    return SDL_GetNumVideoDisplays();
+}
+
+const char *GetDisplayName( const int displayIndex )
+{
+    // SDL3: SDL_GetDisplays() + SDL_GetDisplayName(displayID). Map index to ID.
+    return SDL_GetDisplayName( displayIndex );
+}
+
+bool GetDesktopDisplayMode( const int displayIndex, SDL_DisplayMode *mode )
+{
+    if( !mode ) {
+        return false;
+    }
+    // SDL3: SDL_GetDesktopDisplayMode(displayID) returns const SDL_DisplayMode*.
+    // Copy into caller's struct.
+    return SDL_GetDesktopDisplayMode( displayIndex, mode ) == 0;
+}
+
+
+int GetNumRenderDrivers()
+{
+    // SDL3: same name, no change needed.
+    return SDL_GetNumRenderDrivers();
+}
+
+const char *GetRenderDriverName( const int index )
+{
+    // SDL3: SDL_GetRenderDriver(index) returns const char* directly.
+    // SDL2: need to go through SDL_RendererInfo.
+    static SDL_RendererInfo info;
+    if( SDL_GetRenderDriverInfo( index, &info ) != 0 ) {
+        return "";
+    }
+    return info.name;
+}
+
+
+const char *GetRendererName( const SDL_Renderer_Ptr &renderer )
+{
+    if( !renderer ) {
+        return "";
+    }
+    // SDL3: SDL_GetRendererName(renderer) returns const char* directly.
+    // SDL2: go through SDL_RendererInfo.
+    static SDL_RendererInfo info;
+    if( SDL_GetRendererInfo( renderer.get(), &info ) != 0 ) {
+        return "";
+    }
+    return info.name;
+}
+
+bool IsRendererSoftware( const SDL_Renderer_Ptr &renderer )
+{
+    if( !renderer ) {
+        return false;
+    }
+    // SDL3: check renderer name == "software" or property query.
+    SDL_RendererInfo info;
+    if( SDL_GetRendererInfo( renderer.get(), &info ) != 0 ) {
+        return false;
+    }
+    return ( info.flags & SDL_RENDERER_SOFTWARE ) != 0;
+}
+
+bool GetRendererMaxTextureSize( const SDL_Renderer_Ptr &renderer, int *max_w, int *max_h )
+{
+    if( !renderer ) {
+        return false;
+    }
+    // SDL3: SDL_GetNumberProperty(SDL_GetRendererProperties(r),
+    //       SDL_PROP_RENDERER_MAX_TEXTURE_SIZE_NUMBER, 0).
+    SDL_RendererInfo info;
+    if( SDL_GetRendererInfo( renderer.get(), &info ) != 0 ) {
+        return false;
+    }
+    if( max_w ) {
+        *max_w = info.max_texture_width;
+    }
+    if( max_h ) {
+        *max_h = info.max_texture_height;
+    }
+    return true;
+}
+
+
+void RenderPresent( const SDL_Renderer_Ptr &renderer )
+{
+    if( !renderer ) {
+        return;
+    }
+    // SDL3: returns bool (SDL2: void).
+    SDL_RenderPresent( renderer.get() );
+}
+
+void RenderDrawRect( const SDL_Renderer_Ptr &renderer, const SDL_Rect *rect )
+{
+    if( !renderer ) {
+        return;
+    }
+    // SDL3: SDL_RenderRect (renamed, uses SDL_FRect internally).
+    printErrorIf( SDL_RenderDrawRect( renderer.get(), rect ) != 0,
+                  "SDL_RenderDrawRect failed" );
+}
+
+void RenderGetViewport( const SDL_Renderer_Ptr &renderer, SDL_Rect *rect )
+{
+    if( !renderer ) {
+        return;
+    }
+    // SDL3: SDL_GetRenderViewport (renamed).
+    SDL_RenderGetViewport( renderer.get(), rect );
+}
+
+void RenderSetLogicalSize( const SDL_Renderer_Ptr &renderer, const int w, const int h )
+{
+    if( !renderer ) {
+        return;
+    }
+    // SDL3: SDL_SetRenderLogicalPresentation(r, w, h, SDL_LOGICAL_PRESENTATION_LETTERBOX).
+    // Note: SDL3 does NOT auto-scale mouse/touch events for logical size.
+    // Callers must use ConvertEventCoordinates after SDL_PollEvent.
+    printErrorIf( SDL_RenderSetLogicalSize( renderer.get(), w, h ) != 0,
+                  "SDL_RenderSetLogicalSize failed" );
+}
+
+void RenderSetScale( const SDL_Renderer_Ptr &renderer, const float scaleX, const float scaleY )
+{
+    if( !renderer ) {
+        return;
+    }
+    // SDL3: SDL_SetRenderScale (renamed).
+    printErrorIf( SDL_RenderSetScale( renderer.get(), scaleX, scaleY ) != 0,
+                  "SDL_RenderSetScale failed" );
+}
+
+bool RenderReadPixels( const SDL_Renderer_Ptr &renderer, const SDL_Rect *rect,
+                       const Uint32 format, void *pixels, const int pitch )
+{
+    if( !renderer ) {
+        return false;
+    }
+    // SDL3: returns SDL_Surface* instead of writing into a buffer.
+    // Wrapper would allocate surface, copy data out, free surface.
+    return SDL_RenderReadPixels( renderer.get(), rect, format, pixels, pitch ) == 0;
+}
+
+void GetRendererOutputSize( const SDL_Renderer_Ptr &renderer, int *w, int *h )
+{
+    if( !renderer ) {
+        return;
+    }
+    // SDL3: SDL_GetCurrentRenderOutputSize (renamed).
+    printErrorIf( SDL_GetRendererOutputSize( renderer.get(), w, h ) != 0,
+                  "SDL_GetRendererOutputSize failed" );
+}
+
+
+uint32_t GetTicks()
+{
+    // SDL3: returns Uint64. Static cast is safe for ~49 days of uptime.
+    return static_cast<uint32_t>( SDL_GetTicks() );
+}
+
+
+bool IsCursorVisible()
+{
+    // SDL3: SDL_CursorVisible() returns bool.
+    return SDL_ShowCursor( SDL_QUERY ) == SDL_ENABLE;
+}
+
+void ShowCursor()
+{
+    // SDL3: SDL_ShowCursor() (no param).
+    SDL_ShowCursor( SDL_ENABLE );
+}
+
+void HideCursor()
+{
+    // SDL3: SDL_HideCursor().
+    SDL_ShowCursor( SDL_DISABLE );
+}
+
+
+std::string GetClipboardText()
+{
+    char *clip = SDL_GetClipboardText();
+    if( !clip ) {
+        return {};
+    }
+    std::string result( clip );
+    SDL_free( clip );
+    return result;
+}
+
+bool SetClipboardText( const std::string &text )
+{
+    return SDL_SetClipboardText( text.c_str() ) == 0;
+}
+
+
+Uint32 GetMouseState( int *x, int *y )
+{
+    // SDL3: returns float coordinates. Wrapper truncates to int.
+    // Stays in window-space; downstream pipeline handles logical scaling.
+    return SDL_GetMouseState( x, y );
+}
+
+
+bool IsScancodePressed( const SDL_Scancode scancode )
+{
+    const Uint8 *state = SDL_GetKeyboardState( nullptr );
+    if( !state ) {
+        return false;
+    }
+    // SDL3: returns const bool*, but the index semantics are the same.
+    return state[scancode] != 0;
+}
+
+
+void GetWindowSize( SDL_Window *window, int *w, int *h )
+{
+    if( !window ) {
+        return;
+    }
+    SDL_GetWindowSize( window, w, h );
+}
+
+void GetWindowSizeInPixels( SDL_Window *window, int *w, int *h )
+{
+    if( !window ) {
+        return;
+    }
+    // SDL3: always available.
+#if SDL_VERSION_ATLEAST(2,26,0)
+    SDL_GetWindowSizeInPixels( window, w, h );
+#else
+    // Fallback for old SDL2: logical and pixel size are the same.
+    SDL_GetWindowSize( window, w, h );
+#endif
+}
+
+
+void SetTextureScaleQuality( const SDL_Texture_Ptr &texture, const std::string &quality )
+{
+    if( !texture ) {
+        return;
+    }
+    SDL_SetTextureScaleMode( texture.get(), scale_quality_to_mode( quality ) );
+}
+
+void SetDefaultTextureScaleQuality( const std::string &quality )
+{
+    g_default_texture_scale_quality = quality;
+}
+
+
+void StartTextInput( SDL_Window */*window*/ )
+{
+    // SDL3: SDL_StartTextInput(window). SDL2: no window param.
+    SDL_StartTextInput();
+}
+
+void StopTextInput( SDL_Window */*window*/ )
+{
+    // SDL3: SDL_StopTextInput(window). SDL2: no window param.
+    SDL_StopTextInput();
+}
+
+bool IsTextInputActive( SDL_Window */*window*/ )
+{
+    // SDL3: SDL_TextInputActive(window). SDL2: no window param.
+    return SDL_IsTextInputActive() == SDL_TRUE;
+}
+
+
+bool IsWindowEvent( const SDL_Event &ev )
+{
+#if SDL_MAJOR_VERSION >= 3
+    return ev.type >= SDL_EVENT_WINDOW_FIRST && ev.type <= SDL_EVENT_WINDOW_LAST;
+#else
+    return ev.type == SDL_WINDOWEVENT;
+#endif
+}
+
+Uint32 GetWindowEventID( const SDL_Event &ev )
+{
+#if SDL_MAJOR_VERSION >= 3
+    // SDL3: window event type IS the top-level event type.
+    return ev.type;
+#else
+    return ev.window.event;
+#endif
+}
+
+CataKeysym GetKeysym( const SDL_Event &ev )
+{
+#if SDL_MAJOR_VERSION >= 3
+    return { ev.key.key, ev.key.mod, ev.key.scancode };
+#else
+    return { ev.key.keysym.sym, ev.key.keysym.mod, ev.key.keysym.scancode };
+#endif
+}
+
+
+SDL_Window_Ptr CreateGameWindow( const char *title, const int display, const int w, const int h,
+                                 const Uint32 flags )
+{
+    // SDL3: SDL_CreateWindowWithProperties to handle display placement for maximized
+    // windows (SDL_SetWindowPosition has no effect on maximized windows in SDL3).
+    SDL_Window_Ptr result( SDL_CreateWindow( title,
+                           SDL_WINDOWPOS_CENTERED_DISPLAY( display ),
+                           SDL_WINDOWPOS_CENTERED_DISPLAY( display ),
+                           w, h, flags ) );
+    printErrorIf( !result, "SDL_CreateWindow failed" );
+    return result;
+}
+
+
+bool SetWindowFullscreen( SDL_Window *window, const FullscreenMode mode )
+{
+    if( !window ) {
+        return false;
+    }
+    // SDL3: SDL_SetWindowFullscreen(window, true/false). For exclusive vs desktop,
+    // call SDL_SetWindowFullscreenMode() first. All paths call SDL_SyncWindow.
+    Uint32 flags = 0;
+    switch( mode ) {
+        case FullscreenMode::windowed:
+            flags = 0;
+            break;
+        case FullscreenMode::fullscreen_desktop:
+            flags = SDL_WINDOW_FULLSCREEN_DESKTOP;
+            break;
+        case FullscreenMode::fullscreen_exclusive:
+            flags = SDL_WINDOW_FULLSCREEN;
+            break;
+    }
+    return SDL_SetWindowFullscreen( window, flags ) == 0;
+}
+
+
+void RestoreWindow( SDL_Window *window )
+{
+    if( window ) {
+        SDL_RestoreWindow( window );
+        // SDL3: would call SDL_SyncWindow here.
+    }
+}
+
+void SetWindowSize( SDL_Window *window, const int w, const int h )
+{
+    if( window ) {
+        SDL_SetWindowSize( window, w, h );
+        // SDL3: would call SDL_SyncWindow here.
+    }
+}
+
+void SetWindowMinimumSize( SDL_Window *window, const int w, const int h )
+{
+    if( window ) {
+        SDL_SetWindowMinimumSize( window, w, h );
+    }
+}
+
+void SetWindowTitle( SDL_Window *window, const char *title )
+{
+    if( window ) {
+        SDL_SetWindowTitle( window, title );
+    }
+}
+
+
+SDL_Renderer_Ptr CreateRenderer( const SDL_Window_Ptr &window, const char *driver_name,
+                                 const bool software, const bool vsync )
+{
+    if( !window ) {
+        dbg( D_ERROR ) << "Tried to create renderer with a null window";
+        return SDL_Renderer_Ptr();
+    }
+
+    int driver_index = -1;
+    Uint32 flags = SDL_RENDERER_TARGETTEXTURE;
+
+    if( software ) {
+        flags |= SDL_RENDERER_SOFTWARE;
+        // SDL3: pass "software" as driver name.
+    } else {
+        flags |= SDL_RENDERER_ACCELERATED;
+        if( vsync ) {
+            flags |= SDL_RENDERER_PRESENTVSYNC;
+        }
+        // Find driver index by name if specified
+        if( driver_name && driver_name[0] != '\0' ) {
+            const int num = SDL_GetNumRenderDrivers();
+            for( int i = 0; i < num; i++ ) {
+                SDL_RendererInfo ri;
+                if( SDL_GetRenderDriverInfo( i, &ri ) == 0 && ri.name == std::string( driver_name ) ) {
+                    driver_index = i;
+                    break;
+                }
+            }
+        }
+    }
+
+    // SDL3: SDL_CreateRenderer(window, name). Flags removed; vsync via SDL_SetRenderVSync.
+    SDL_Renderer_Ptr result( SDL_CreateRenderer( window.get(), driver_index, flags ) );
+    printErrorIf( !result, "SDL_CreateRenderer failed" );
+    return result;
+}
+
+
+void ConvertEventCoordinates( const SDL_Renderer_Ptr &/*renderer*/, SDL_Event */*event*/ )
+{
+    // SDL2: no-op. SDL_RenderSetLogicalSize auto-scales mouse/touch events.
+    // SDL3: SDL_ConvertEventToRenderCoordinates(renderer, event) on all event types.
+}
+
+
+float GetFingerX( const SDL_Event &ev, const int windowWidth )
+{
+    // SDL2: finger coords are normalized [0,1]; multiply by window width.
+    // SDL3 (after ConvertEventCoordinates): already absolute render-logical.
+    return ev.tfinger.x * windowWidth;
+}
+
+float GetFingerY( const SDL_Event &ev, const int windowHeight )
+{
+    // SDL2: finger coords are normalized [0,1]; multiply by window height.
+    // SDL3 (after ConvertEventCoordinates): already absolute render-logical.
+    return ev.tfinger.y * windowHeight;
+}
+
 #endif // defined(TILES)
 #endif // defined(TILES) || defined(SDL_SOUND)

--- a/src/sdl_wrappers.h
+++ b/src/sdl_wrappers.h
@@ -23,6 +23,7 @@
 // IWYU pragma: end_exports
 
 #include <memory>
+#include <string>
 
 struct point;
 
@@ -99,7 +100,7 @@ bool SetTextureColorMod( const std::shared_ptr<SDL_Texture> &texture, Uint32 r, 
 void SetRenderDrawBlendMode( const SDL_Renderer_Ptr &renderer, SDL_BlendMode blendMode );
 void GetRenderDrawBlendMode( const SDL_Renderer_Ptr &renderer, SDL_BlendMode &blend_mode );
 SDL_Surface_Ptr load_image( const char *path );
-void SetRenderTarget( const SDL_Renderer_Ptr &renderer, const SDL_Texture_Ptr &texture );
+bool SetRenderTarget( const SDL_Renderer_Ptr &renderer, const SDL_Texture_Ptr &texture );
 void RenderClear( const SDL_Renderer_Ptr &renderer );
 SDL_Surface_Ptr CreateRGBSurface( Uint32 flags, int width, int height, int depth, Uint32 Rmask,
                                   Uint32 Gmask, Uint32 Bmask, Uint32 Amask );
@@ -137,10 +138,188 @@ SDL_Surface_Ptr RenderUTF8_Blended( const TTF_Font_Ptr &font, const char *text, 
 // In SDL3_ttf there is no direct TTF_GlyphIsProvided equivalent; this will be
 // emulated via glyph metrics or a render attempt.
 bool CanRenderGlyph( const TTF_Font_Ptr &font, Uint32 ch );
+
+// SDL3: index-based API replaced by SDL_DisplayID arrays. Wrappers
+// present the SDL2-style index interface, mapping internally on SDL3.
+int GetNumVideoDisplays();
+const char *GetDisplayName( int displayIndex );
+bool GetDesktopDisplayMode( int displayIndex, SDL_DisplayMode *mode );
+
+// SDL3: SDL_GetRenderDriverInfo removed; SDL_GetRenderDriver returns name directly.
+int GetNumRenderDrivers();
+const char *GetRenderDriverName( int index );
+
+// SDL3: SDL_RendererInfo struct removed. Name via SDL_GetRendererName,
+// capabilities via SDL_GetRendererProperties.
+const char *GetRendererName( const SDL_Renderer_Ptr &renderer );
+bool IsRendererSoftware( const SDL_Renderer_Ptr &renderer );
+bool GetRendererMaxTextureSize( const SDL_Renderer_Ptr &renderer, int *max_w, int *max_h );
+
+// SDL3: various renames, signature changes, behavioral changes.
+void RenderPresent( const SDL_Renderer_Ptr &renderer );
+void RenderDrawRect( const SDL_Renderer_Ptr &renderer, const SDL_Rect *rect );
+void RenderGetViewport( const SDL_Renderer_Ptr &renderer, SDL_Rect *rect );
+// SDL3: replaced by SDL_SetRenderLogicalPresentation(r, w, h, mode).
+// Callers must also use ConvertEventCoordinates (SDL3 does not auto-scale events).
+void RenderSetLogicalSize( const SDL_Renderer_Ptr &renderer, int w, int h );
+void RenderSetScale( const SDL_Renderer_Ptr &renderer, float scaleX, float scaleY );
+// SDL3: returns SDL_Surface* instead of filling a buffer. Wrapper copies data out.
+bool RenderReadPixels( const SDL_Renderer_Ptr &renderer, const SDL_Rect *rect,
+                       Uint32 format, void *pixels, int pitch );
+// SDL3: renamed to SDL_GetCurrentRenderOutputSize.
+void GetRendererOutputSize( const SDL_Renderer_Ptr &renderer, int *w, int *h );
+
+// SDL3: SDL_GetTicks returns Uint64. Wrapper keeps uint32_t for source compat.
+uint32_t GetTicks();
+
+// SDL3: SDL_ShowCursor split into SDL_ShowCursor/SDL_HideCursor/SDL_CursorVisible.
+bool IsCursorVisible();
+void ShowCursor();
+void HideCursor();
+
+// Returns clipboard text as std::string. Handles SDL_free internally on both versions.
+std::string GetClipboardText();
+bool SetClipboardText( const std::string &text );
+
+// SDL3: returns float coordinates. Wrapper truncates to int.
+// Returns window-space coordinates (NOT render-logical); downstream pipeline
+// handles scaling separately.
+Uint32 GetMouseState( int *x, int *y );
+
+// SDL3: SDL_GetKeyboardState returns const bool*. Rather than exposing the raw
+// array (bool* to Uint8* cast is unsafe), provide a per-scancode query.
+bool IsScancodePressed( SDL_Scancode scancode );
+
+// Takes raw SDL_Window* for use with both smart-pointer and raw windows.
+void GetWindowSize( SDL_Window *window, int *w, int *h );
+// Falls back to GetWindowSize on SDL2 < 2.26.
+void GetWindowSizeInPixels( SDL_Window *window, int *w, int *h );
+
+// Replaces SDL_HINT_RENDER_SCALE_QUALITY with per-texture SDL_SetTextureScaleMode
+// (available in SDL2 2.0.12+ and SDL3). Accepts game option strings
+// ("none"/"nearest"/"linear") and SDL2 hint values ("0"/"1").
+void SetTextureScaleQuality( const SDL_Texture_Ptr &texture, const std::string &quality );
+// Store a default scale quality applied by CreateTexture/CreateTextureFromSurface.
+void SetDefaultTextureScaleQuality( const std::string &quality );
+
+// SDL3: all three take SDL_Window*. SDL2 versions ignore the parameter.
+void StartTextInput( SDL_Window *window );
+void StopTextInput( SDL_Window *window );
+bool IsTextInputActive( SDL_Window *window );
+
+// Use these instead of raw SDL flags at call sites. Raw macros like
+// SDL_WINDOW_ALLOW_HIGHDPI / SDL_WINDOW_FULLSCREEN_DESKTOP may not exist
+// in SDL3 headers.
+// SDL3: SDL_WINDOW_ALLOW_HIGHDPI -> SDL_WINDOW_HIGH_PIXEL_DENSITY
+// SDL3: SDL_WINDOW_FULLSCREEN_DESKTOP removed; SDL_WINDOW_FULLSCREEN is borderless
+#if SDL_MAJOR_VERSION >= 3
+inline constexpr Uint32 CATA_WINDOW_HIDDEN    = SDL_WINDOW_HIDDEN;
+inline constexpr Uint32 CATA_WINDOW_RESIZABLE = SDL_WINDOW_RESIZABLE;
+inline constexpr Uint32 CATA_WINDOW_MAXIMIZED = SDL_WINDOW_MAXIMIZED;
+inline constexpr Uint32 CATA_WINDOW_HIGH_DPI  = SDL_WINDOW_HIGH_PIXEL_DENSITY;
+#else
+inline constexpr Uint32 CATA_WINDOW_HIDDEN    = SDL_WINDOW_HIDDEN;
+inline constexpr Uint32 CATA_WINDOW_RESIZABLE = SDL_WINDOW_RESIZABLE;
+inline constexpr Uint32 CATA_WINDOW_MAXIMIZED = SDL_WINDOW_MAXIMIZED;
+inline constexpr Uint32 CATA_WINDOW_HIGH_DPI  = SDL_WINDOW_ALLOW_HIGHDPI;
+#endif
+
+// Creates a window centered on the given display. Uses CATA_WINDOW_* flags.
+// No fullscreen flags -- call SetWindowFullscreen after creation for that.
+// SDL3: uses SDL_CreateWindowWithProperties to handle maximized+display placement.
+SDL_Window_Ptr CreateGameWindow( const char *title, int display, int w, int h, Uint32 flags );
+
+enum class FullscreenMode { windowed, fullscreen_desktop, fullscreen_exclusive };
+// SDL3: maps to SDL_SetWindowFullscreen(bool) + SDL_SetWindowFullscreenMode.
+// Calls SDL_SyncWindow on SDL3 to ensure state is settled before returning.
+bool SetWindowFullscreen( SDL_Window *window, FullscreenMode mode );
+
+// All call SDL_SyncWindow on SDL3 for async-safe behavior.
+void RestoreWindow( SDL_Window *window );
+void SetWindowSize( SDL_Window *window, int w, int h );
+void SetWindowMinimumSize( SDL_Window *window, int w, int h );
+void SetWindowTitle( SDL_Window *window, const char *title );
+
+// SDL3: takes name string instead of index, flags removed. Vsync via SDL_SetRenderVSync.
+// When software == true, SDL3 path passes "software" as driver name.
+SDL_Renderer_Ptr CreateRenderer( const SDL_Window_Ptr &window, const char *driver_name,
+                                 bool software, bool vsync );
+
+// SDL2: no-op (logical size auto-scales events).
+// SDL3: calls SDL_ConvertEventToRenderCoordinates on all event types.
+void ConvertEventCoordinates( const SDL_Renderer_Ptr &renderer, SDL_Event *event );
+
+// SDL2: finger coords are normalized [0,1]; multiply by window dimension.
+// SDL3: after ConvertEventCoordinates, coords are already absolute render-logical.
+float GetFingerX( const SDL_Event &ev, int windowWidth );
+float GetFingerY( const SDL_Event &ev, int windowHeight );
+
 /**@}*/
 
-void StartTextInput();
-void StopTextInput();
+// SDL2 nests window events under SDL_WINDOWEVENT with subtypes in ev.window.event.
+// SDL3 flattens them to top-level SDL_EVENT_WINDOW_* constants.
+
+// Returns true if the event is a window event.
+bool IsWindowEvent( const SDL_Event &ev );
+// Returns the window event subtype for use in switch statements.
+Uint32 GetWindowEventID( const SDL_Event &ev );
+
+// Normalized window event constants. Use with switch(GetWindowEventID(ev)).
+#if SDL_MAJOR_VERSION >= 3
+inline constexpr Uint32 CATA_WINDOWEVENT_SHOWN        = SDL_EVENT_WINDOW_SHOWN;
+inline constexpr Uint32 CATA_WINDOWEVENT_EXPOSED      = SDL_EVENT_WINDOW_EXPOSED;
+inline constexpr Uint32 CATA_WINDOWEVENT_MINIMIZED    = SDL_EVENT_WINDOW_MINIMIZED;
+inline constexpr Uint32 CATA_WINDOWEVENT_RESTORED     = SDL_EVENT_WINDOW_RESTORED;
+inline constexpr Uint32 CATA_WINDOWEVENT_RESIZED      = SDL_EVENT_WINDOW_RESIZED;
+// SIZE_CHANGED removed in SDL3; use RESIZED instead.
+inline constexpr Uint32 CATA_WINDOWEVENT_FOCUS_LOST   = SDL_EVENT_WINDOW_FOCUS_LOST;
+inline constexpr Uint32 CATA_WINDOWEVENT_FOCUS_GAINED = SDL_EVENT_WINDOW_FOCUS_GAINED;
+#else
+inline constexpr Uint32 CATA_WINDOWEVENT_SHOWN        = SDL_WINDOWEVENT_SHOWN;
+inline constexpr Uint32 CATA_WINDOWEVENT_EXPOSED      = SDL_WINDOWEVENT_EXPOSED;
+inline constexpr Uint32 CATA_WINDOWEVENT_MINIMIZED    = SDL_WINDOWEVENT_MINIMIZED;
+inline constexpr Uint32 CATA_WINDOWEVENT_RESTORED     = SDL_WINDOWEVENT_RESTORED;
+inline constexpr Uint32 CATA_WINDOWEVENT_RESIZED      = SDL_WINDOWEVENT_RESIZED;
+inline constexpr Uint32 CATA_WINDOWEVENT_FOCUS_LOST   = SDL_WINDOWEVENT_FOCUS_LOST;
+inline constexpr Uint32 CATA_WINDOWEVENT_FOCUS_GAINED = SDL_WINDOWEVENT_FOCUS_GAINED;
+#endif
+
+#if SDL_MAJOR_VERSION >= 3
+inline constexpr Uint32 CATA_RENDER_TARGETS_RESET = SDL_EVENT_RENDER_TARGETS_RESET;
+#else
+inline constexpr Uint32 CATA_RENDER_TARGETS_RESET = SDL_RENDER_TARGETS_RESET;
+#endif
+
+// Touch finger ID accessor. SDL3 renames fingerId -> fingerID.
+inline SDL_FingerID GetFingerID( const SDL_Event &ev )
+{
+#if SDL_MAJOR_VERSION >= 3
+    return ev.tfinger.fingerID;
+#else
+    return ev.tfinger.fingerId;
+#endif
+}
+
+// Touch event renames. SDL3: SDL_FINGER* -> SDL_EVENT_FINGER_*.
+#if SDL_MAJOR_VERSION >= 3
+inline constexpr Uint32 CATA_FINGERMOTION = SDL_EVENT_FINGER_MOTION;
+inline constexpr Uint32 CATA_FINGERDOWN   = SDL_EVENT_FINGER_DOWN;
+inline constexpr Uint32 CATA_FINGERUP     = SDL_EVENT_FINGER_UP;
+#else
+inline constexpr Uint32 CATA_FINGERMOTION = SDL_FINGERMOTION;
+inline constexpr Uint32 CATA_FINGERDOWN   = SDL_FINGERDOWN;
+inline constexpr Uint32 CATA_FINGERUP     = SDL_FINGERUP;
+#endif
+
+// SDL3 removes SDL_Keysym from key events: ev.key.keysym.sym -> ev.key.key,
+// ev.key.keysym.mod -> ev.key.mod, ev.key.keysym.scancode -> ev.key.scancode.
+// CataKeysym provides a version-independent accessor.
+struct CataKeysym {
+    SDL_Keycode sym;
+    Uint16 mod;
+    SDL_Scancode scancode;
+};
+CataKeysym GetKeysym( const SDL_Event &ev );
 
 /**
  * Comparison operators which SDL lacks being a C-ish lib.

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -237,13 +237,13 @@ static void InitSDL()
 static bool SetupRenderTarget()
 {
     SetRenderDrawBlendMode( renderer, SDL_BLENDMODE_NONE );
-    display_buffer.reset( SDL_CreateTexture( renderer.get(), SDL_PIXELFORMAT_ARGB8888,
-                          SDL_TEXTUREACCESS_TARGET, WindowWidth / scaling_factor, WindowHeight / scaling_factor ) );
+    display_buffer = CreateTexture( renderer, SDL_PIXELFORMAT_ARGB8888,
+                                    SDL_TEXTUREACCESS_TARGET, WindowWidth / scaling_factor,
+                                    WindowHeight / scaling_factor );
     if( printErrorIf( !display_buffer, "Failed to create window buffer" ) ) {
         return false;
     }
-    if( printErrorIf( SDL_SetRenderTarget( renderer.get(), display_buffer.get() ) != 0,
-                      "SDL_SetRenderTarget failed" ) ) {
+    if( !SetRenderTarget( renderer, display_buffer ) ) {
         return false;
     }
     ClearScreen();
@@ -254,43 +254,45 @@ static bool SetupRenderTarget()
 //Registers, creates, and shows the Window!!
 static void WinCreate()
 {
-    // Common flags used for fulscreen and for windowed
-    int window_flags = 0;
+    // Common flags used for windowed mode (fullscreen applied after creation)
+    Uint32 window_flags = CATA_WINDOW_RESIZABLE | CATA_WINDOW_HIGH_DPI;
     WindowWidth = TERMINAL_WIDTH * fontwidth * scaling_factor;
     WindowHeight = TERMINAL_HEIGHT * fontheight * scaling_factor;
-    window_flags |= SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI;
 
     if( get_option<std::string>( "SCALING_MODE" ) != "none" ) {
-        SDL_SetHint( SDL_HINT_RENDER_SCALE_QUALITY, get_option<std::string>( "SCALING_MODE" ).c_str() );
+        SetDefaultTextureScaleQuality( get_option<std::string>( "SCALING_MODE" ) );
     }
+
+    // Track desired fullscreen mode separately; applied after window creation
+    FullscreenMode desired_fullscreen = FullscreenMode::windowed;
 
 #if !defined(__ANDROID__) && !defined(EMSCRIPTEN)
     if( get_option<std::string>( "FULLSCREEN" ) == "fullscreen" ) {
-        window_flags |= SDL_WINDOW_FULLSCREEN;
+        desired_fullscreen = FullscreenMode::fullscreen_exclusive;
         fullscreen = true;
         // It still minimizes, but the screen size is not set to 0 to cause
         // division by zero
         SDL_SetHint( SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, "0" );
     } else if( get_option<std::string>( "FULLSCREEN" ) == "windowedbl" ) {
-        window_flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
+        desired_fullscreen = FullscreenMode::fullscreen_desktop;
         fullscreen = true;
         // So you can switch to desktop without the game window obscuring it.
         SDL_SetHint( SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, "1" );
     } else if( get_option<std::string>( "FULLSCREEN" ) == "maximized" ) {
-        window_flags |= SDL_WINDOW_MAXIMIZED;
+        window_flags |= CATA_WINDOW_MAXIMIZED;
     }
 #endif
 #if defined(EMSCRIPTEN)
     // Without this, the game only displays in the top-left 1/4 of the window.
-    window_flags &= ~SDL_WINDOW_ALLOW_HIGHDPI;
+    window_flags &= ~CATA_WINDOW_HIGH_DPI;
 #endif
 #if defined(__ANDROID__)
     // Without this, the game only displays in the top-left 1/4 of the window.
-    window_flags = SDL_WINDOW_ALLOW_HIGHDPI | SDL_WINDOW_MAXIMIZED;
+    window_flags = CATA_WINDOW_HIGH_DPI | CATA_WINDOW_MAXIMIZED;
 #endif
 
     int display = std::stoi( get_option<std::string>( "DISPLAY" ) );
-    if( display < 0 || display >= SDL_GetNumVideoDisplays() ) {
+    if( display < 0 || display >= GetNumVideoDisplays() ) {
         display = 0;
     }
 
@@ -316,22 +318,21 @@ static void WinCreate()
 #endif
 #endif
 
-    ::window.reset( SDL_CreateWindow( "",
-                                      SDL_WINDOWPOS_CENTERED_DISPLAY( display ),
-                                      SDL_WINDOWPOS_CENTERED_DISPLAY( display ),
-                                      WindowWidth,
-                                      WindowHeight,
-                                      window_flags
-                                    ) );
-    throwErrorIf( !::window, "SDL_CreateWindow failed" );
+    ::window = CreateGameWindow( "", display, WindowWidth, WindowHeight, window_flags );
+    throwErrorIf( !::window, "CreateWindow failed" );
+
+    // Apply fullscreen after creation to preserve exclusive vs desktop distinction
+    if( desired_fullscreen != FullscreenMode::windowed ) {
+        SetWindowFullscreen( ::window.get(), desired_fullscreen );
+    }
 
 #if !defined(__ANDROID__) && !defined(EMSCRIPTEN)
     // On Android SDL seems janky in windowed mode so we're fullscreen all the time.
     // Fullscreen mode is now modified so it obeys terminal width/height, rather than
     // overwriting it with this calculation.
-    if( window_flags & SDL_WINDOW_FULLSCREEN || window_flags & SDL_WINDOW_FULLSCREEN_DESKTOP
-        || window_flags & SDL_WINDOW_MAXIMIZED ) {
-        SDL_GetWindowSize( ::window.get(), &WindowWidth, &WindowHeight );
+    if( desired_fullscreen != FullscreenMode::windowed
+        || ( window_flags & CATA_WINDOW_MAXIMIZED ) ) {
+        GetWindowSize( ::window.get(), &WindowWidth, &WindowHeight );
         // Ignore previous values, use the whole window, but nothing more.
         TERMINAL_WIDTH = WindowWidth / fontwidth / scaling_factor;
         TERMINAL_HEIGHT = WindowHeight / fontheight / scaling_factor;
@@ -340,7 +341,6 @@ static void WinCreate()
     pixel_format = SDL_GetWindowPixelFormat( ::window.get() );
     throwErrorIf( pixel_format == SDL_PIXELFORMAT_UNKNOWN, "SDL_GetWindowPixelFormat failed" );
 
-    int renderer_id = -1;
 #if !defined(__ANDROID__)
     bool software_renderer = get_option<std::string>( "RENDERER" ).empty();
     std::string renderer_name;
@@ -353,29 +353,19 @@ static void WinCreate()
     if( renderer_name == "direct3d" ) {
         direct3d_mode = true;
     }
-
-    const int numRenderDrivers = SDL_GetNumRenderDrivers();
-    for( int i = 0; i < numRenderDrivers; i++ ) {
-        SDL_RendererInfo ri;
-        SDL_GetRenderDriverInfo( i, &ri );
-        if( renderer_name == ri.name ) {
-            renderer_id = i;
-            DebugLog( D_INFO, DC_ALL ) << "Active renderer: " << renderer_id << "/" << ri.name;
-            break;
-        }
-    }
 #else
     bool software_renderer = get_option<bool>( "SOFTWARE_RENDERING" );
+    std::string renderer_name = software_renderer ? "software" : "";
 #endif
 
-#if defined(SDL_HINT_RENDER_BATCHING)
+#if SDL_MAJOR_VERSION < 3
+    // SDL3: batching is always on.
     SDL_SetHint( SDL_HINT_RENDER_BATCHING, get_option<bool>( "RENDER_BATCHING" ) ? "1" : "0" );
 #endif
     if( !software_renderer ) {
         dbg( D_INFO ) << "Attempting to initialize accelerated SDL renderer.";
 
-        renderer.reset( SDL_CreateRenderer( ::window.get(), renderer_id, SDL_RENDERER_ACCELERATED |
-                                            SDL_RENDERER_PRESENTVSYNC | SDL_RENDERER_TARGETTEXTURE ) );
+        renderer = CreateRenderer( ::window, renderer_name.c_str(), false, true );
         if( printErrorIf( !renderer,
                           "Failed to initialize accelerated renderer, falling back to software rendering" ) ) {
             software_renderer = true;
@@ -392,21 +382,20 @@ static void WinCreate()
         if( get_option<bool>( "FRAMEBUFFER_ACCEL" ) ) {
             SDL_SetHint( SDL_HINT_FRAMEBUFFER_ACCELERATION, "1" );
         }
-        renderer.reset( SDL_CreateRenderer( ::window.get(), -1,
-                                            SDL_RENDERER_SOFTWARE | SDL_RENDERER_TARGETTEXTURE ) );
+        renderer = CreateRenderer( ::window, nullptr, true, false );
         throwErrorIf( !renderer, "Failed to initialize software renderer" );
         throwErrorIf( !SetupRenderTarget(),
                       "Failed to initialize display buffer under software rendering, unable to continue." );
     }
 
-    SDL_SetWindowMinimumSize( ::window.get(), fontwidth * EVEN_MINIMUM_TERM_WIDTH * scaling_factor,
-                              fontheight * EVEN_MINIMUM_TERM_HEIGHT * scaling_factor );
+    SetWindowMinimumSize( ::window.get(), fontwidth * EVEN_MINIMUM_TERM_WIDTH * scaling_factor,
+                          fontheight * EVEN_MINIMUM_TERM_HEIGHT * scaling_factor );
 
 #if defined(__ANDROID__)
     // TODO: Not too sure why this works to make fullscreen on Android behave. :/
-    if( window_flags & SDL_WINDOW_FULLSCREEN || window_flags & SDL_WINDOW_FULLSCREEN_DESKTOP
-        || window_flags & SDL_WINDOW_MAXIMIZED ) {
-        SDL_GetWindowSize( ::window.get(), &WindowWidth, &WindowHeight );
+    if( desired_fullscreen != FullscreenMode::windowed
+        || ( window_flags & CATA_WINDOW_MAXIMIZED ) ) {
+        GetWindowSize( ::window.get(), &WindowWidth, &WindowHeight );
     }
 
     // Load virtual joystick texture
@@ -417,10 +406,10 @@ static void WinCreate()
 
     // Errors here are ignored, worst case: the option does not work as expected,
     // but that won't crash
-    if( get_option<std::string>( "HIDE_CURSOR" ) != "show" && SDL_ShowCursor( -1 ) ) {
-        SDL_ShowCursor( SDL_DISABLE );
+    if( get_option<std::string>( "HIDE_CURSOR" ) != "show" && IsCursorVisible() ) {
+        HideCursor();
     } else {
-        SDL_ShowCursor( SDL_ENABLE );
+        ShowCursor();
     }
 
     if( get_option<bool>( "ENABLE_JOYSTICK" ) ) {
@@ -541,7 +530,7 @@ static void draw_gamepad_radial_menu();
 void refresh_display()
 {
     needupdate = false;
-    lastupdate = SDL_GetTicks();
+    lastupdate = GetTicks();
 
     if( test_mode ) {
         return;
@@ -567,14 +556,14 @@ void refresh_display()
     draw_virtual_joystick();
 #endif
     draw_gamepad_radial_menu();
-    SDL_RenderPresent( renderer.get() );
+    RenderPresent( renderer );
     SetRenderTarget( renderer, display_buffer );
 }
 
 // only update if the set interval has elapsed
 static void try_sdl_update()
 {
-    uint32_t now = SDL_GetTicks();
+    uint32_t now = GetTicks();
     if( now - lastupdate >= interval ) {
         refresh_display();
     } else {
@@ -1261,8 +1250,8 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
 static bool draw_window( Font_Ptr &font, const catacurses::window &w, const point &offset )
 {
     if( scaling_factor > 1 ) {
-        SDL_RenderSetLogicalSize( renderer.get(), WindowWidth / scaling_factor,
-                                  WindowHeight / scaling_factor );
+        RenderSetLogicalSize( renderer, WindowWidth / scaling_factor,
+                              WindowHeight / scaling_factor );
     }
 
     cata_cursesport::WINDOW *const win = w.get<cata_cursesport::WINDOW>();
@@ -1386,8 +1375,8 @@ static bool draw_window( Font_Ptr &font, const catacurses::window &w )
 void cata_cursesport::curses_drawwindow( const catacurses::window &w )
 {
     if( scaling_factor > 1 ) {
-        SDL_RenderSetLogicalSize( renderer.get(), WindowWidth / scaling_factor,
-                                  WindowHeight / scaling_factor );
+        RenderSetLogicalSize( renderer, WindowWidth / scaling_factor,
+                              WindowHeight / scaling_factor );
     }
     WINDOW *const win = w.get<WINDOW>();
     bool update = false;
@@ -1629,7 +1618,7 @@ static void end_arrow_combo()
  * -1 when a ALT+number sequence has been started,
  * or something that a call to ncurses getch would return.
  */
-static int sdl_keysym_to_curses( const SDL_Keysym &keysym )
+static int sdl_keysym_to_curses( const CataKeysym &keysym )
 {
 
     const std::string diag_mode = get_option<std::string>( "DIAG_MOVE_WITH_MODIFIERS_MODE" );
@@ -1694,40 +1683,41 @@ static int sdl_keysym_to_curses( const SDL_Keysym &keysym )
 
     if( diag_mode == "mode4" ) {
         if( ( keysym.mod & KMOD_SHIFT ) || ( keysym.mod & KMOD_CTRL ) ) {
-            const Uint8 *s = SDL_GetKeyboardState( nullptr );
-            const int count = s[SDL_SCANCODE_LEFT] + s[SDL_SCANCODE_RIGHT] + s[SDL_SCANCODE_UP] +
-                              s[SDL_SCANCODE_DOWN];
+            const int count = IsScancodePressed( SDL_SCANCODE_LEFT )
+                              + IsScancodePressed( SDL_SCANCODE_RIGHT )
+                              + IsScancodePressed( SDL_SCANCODE_UP )
+                              + IsScancodePressed( SDL_SCANCODE_DOWN );
             if( count == 2 ) {
                 switch( keysym.sym ) {
                     case SDLK_LEFT:
-                        if( s[SDL_SCANCODE_UP] ) {
+                        if( IsScancodePressed( SDL_SCANCODE_UP ) ) {
                             return inp_mngr.get_first_char_for_action( "LEFTUP" );
                         }
-                        if( s[SDL_SCANCODE_DOWN] ) {
+                        if( IsScancodePressed( SDL_SCANCODE_DOWN ) ) {
                             return inp_mngr.get_first_char_for_action( "LEFTDOWN" );
                         }
                         return 0;
                     case SDLK_RIGHT:
-                        if( s[SDL_SCANCODE_UP] ) {
+                        if( IsScancodePressed( SDL_SCANCODE_UP ) ) {
                             return inp_mngr.get_first_char_for_action( "RIGHTUP" );
                         }
-                        if( s[SDL_SCANCODE_DOWN] ) {
+                        if( IsScancodePressed( SDL_SCANCODE_DOWN ) ) {
                             return inp_mngr.get_first_char_for_action( "RIGHTDOWN" );
                         }
                         return 0;
                     case SDLK_UP:
-                        if( s[SDL_SCANCODE_LEFT] ) {
+                        if( IsScancodePressed( SDL_SCANCODE_LEFT ) ) {
                             return inp_mngr.get_first_char_for_action( "LEFTUP" );
                         }
-                        if( s[SDL_SCANCODE_RIGHT] ) {
+                        if( IsScancodePressed( SDL_SCANCODE_RIGHT ) ) {
                             return inp_mngr.get_first_char_for_action( "RIGHTUP" );
                         }
                         return 0;
                     case SDLK_DOWN:
-                        if( s[SDL_SCANCODE_LEFT] ) {
+                        if( IsScancodePressed( SDL_SCANCODE_LEFT ) ) {
                             return inp_mngr.get_first_char_for_action( "LEFTDOWN" );
                         }
-                        if( s[SDL_SCANCODE_RIGHT] ) {
+                        if( IsScancodePressed( SDL_SCANCODE_RIGHT ) ) {
                             return inp_mngr.get_first_char_for_action( "RIGHTDOWN" );
                         }
                         return 0;
@@ -1819,7 +1809,7 @@ static int sdl_keysym_to_curses( const SDL_Keysym &keysym )
     }
 }
 
-static input_event sdl_keysym_to_keycode_evt( const SDL_Keysym &keysym )
+static input_event sdl_keysym_to_keycode_evt( const CataKeysym &keysym )
 {
     switch( keysym.sym ) {
         case SDLK_LCTRL:
@@ -1868,8 +1858,8 @@ void resize_term( const int cell_w, const int cell_h )
 {
     int w = cell_w * fontwidth * scaling_factor;
     int h = cell_h * fontheight * scaling_factor;
-    SDL_SetWindowSize( window.get(), w, h );
-    SDL_GetWindowSize( window.get(), &w, &h );
+    SetWindowSize( window.get(), w, h );
+    GetWindowSize( window.get(), &w, &h );
     handle_resize( w, h );
 }
 
@@ -1884,25 +1874,25 @@ void toggle_fullscreen_window()
     static int restore_win_h = get_option<int>( "TERMINAL_Y" ) * fontheight * scaling_factor;
 
     if( fullscreen ) {
-        if( printErrorIf( SDL_SetWindowFullscreen( window.get(), 0 ) != 0,
-                          "SDL_SetWindowFullscreen failed" ) ) {
+        if( !SetWindowFullscreen( window.get(), FullscreenMode::windowed ) ) {
+            printErrorIf( true, "SetWindowFullscreen(windowed) failed" );
             return;
         }
-        SDL_RestoreWindow( window.get() );
-        SDL_SetWindowSize( window.get(), restore_win_w, restore_win_h );
-        SDL_SetWindowMinimumSize( window.get(), fontwidth * EVEN_MINIMUM_TERM_WIDTH * scaling_factor,
-                                  fontheight * EVEN_MINIMUM_TERM_HEIGHT * scaling_factor );
+        RestoreWindow( window.get() );
+        SetWindowSize( window.get(), restore_win_w, restore_win_h );
+        SetWindowMinimumSize( window.get(), fontwidth * EVEN_MINIMUM_TERM_WIDTH * scaling_factor,
+                              fontheight * EVEN_MINIMUM_TERM_HEIGHT * scaling_factor );
     } else {
         restore_win_w = WindowWidth;
         restore_win_h = WindowHeight;
-        if( printErrorIf( SDL_SetWindowFullscreen( window.get(), SDL_WINDOW_FULLSCREEN_DESKTOP ) != 0,
-                          "SDL_SetWindowFullscreen failed" ) ) {
+        if( !SetWindowFullscreen( window.get(), FullscreenMode::fullscreen_desktop ) ) {
+            printErrorIf( true, "SetWindowFullscreen(fullscreen_desktop) failed" );
             return;
         }
     }
     int nw = 0;
     int nh = 0;
-    SDL_GetWindowSize( window.get(), &nw, &nh );
+    GetWindowSize( window.get(), &nw, &nh );
     handle_resize( nw, nh );
     fullscreen = !fullscreen;
 }
@@ -2243,15 +2233,15 @@ void draw_terminal_size_preview()
                                   ||
                                   preview_terminal_height != get_option<int>( "TERMINAL_Y" ) * fontheight;
     if( preview_terminal_dirty ||
-        ( preview_terminal_change_time > 0 && SDL_GetTicks() - preview_terminal_change_time < 1000 ) ) {
+        ( preview_terminal_change_time > 0 && GetTicks() - preview_terminal_change_time < 1000 ) ) {
         if( preview_terminal_dirty ) {
             preview_terminal_width = get_option<int>( "TERMINAL_X" ) * fontwidth;
             preview_terminal_height = get_option<int>( "TERMINAL_Y" ) * fontheight;
-            preview_terminal_change_time = SDL_GetTicks();
+            preview_terminal_change_time = GetTicks();
         }
         SetRenderDrawColor( renderer, 255, 255, 255, 255 );
         SDL_Rect previewrect = get_android_render_rect( preview_terminal_width, preview_terminal_height );
-        SDL_RenderDrawRect( renderer.get(), &previewrect );
+        RenderDrawRect( renderer, &previewrect );
         SetRenderDrawColor( renderer, 0, 0, 0, 255 );
     }
 }
@@ -2261,9 +2251,9 @@ void draw_quick_shortcuts()
 {
 
     if( !quick_shortcuts_enabled ||
-        SDL_IsTextInputActive() ||
+        IsTextInputActive( ::window.get() ) ||
         ( get_option<bool>( "ANDROID_HIDE_HOLDS" ) && !is_quick_shortcut_touch && finger_down_time > 0 &&
-          SDL_GetTicks() - finger_down_time >= static_cast<uint32_t>(
+          GetTicks() - finger_down_time >= static_cast<uint32_t>(
               get_option<int>( "ANDROID_INITIAL_DELAY" ) ) ) ) { // player is swipe + holding in a direction
         return;
     }
@@ -2337,7 +2327,7 @@ void draw_quick_shortcuts()
         }
         hovered = is_quick_shortcut_touch && hovered_quick_shortcut == &event;
         show_hint = hovered &&
-                    SDL_GetTicks() - finger_down_time > static_cast<uint32_t>
+                    GetTicks() - finger_down_time > static_cast<uint32_t>
                     ( get_option<int>( "ANDROID_INITIAL_DELAY" ) );
         std::string hint_text;
         if( show_hint ) {
@@ -2401,7 +2391,7 @@ void draw_quick_shortcuts()
             }
         }
         SetRenderDrawBlendMode( renderer, SDL_BLENDMODE_NONE );
-        SDL_RenderSetScale( renderer.get(), text_scale, text_scale );
+        RenderSetScale( renderer, text_scale, text_scale );
         int text_x, text_y;
         if( shortcut_right ) {
             text_x = ( WindowWidth - ( i + 0.5f ) * width - ( font->width * utf8_width(
@@ -2433,7 +2423,7 @@ void draw_quick_shortcuts()
                     text_scale *= ( WindowWidth * safe_margin ) / ( font->width * text_scale *
                                   hint_length );    // scale to fit comfortably
                 }
-                SDL_RenderSetScale( renderer.get(), text_scale, text_scale );
+                RenderSetScale( renderer, text_scale, text_scale );
                 text_x = ( WindowWidth - ( ( font->width  * hint_length ) * text_scale ) ) * 0.5f / text_scale;
                 text_y = ( WindowHeight - font->height * text_scale ) * 0.5f / text_scale;
                 font->OutputChar( renderer, geometry, hint_text, point( text_x + 1, text_y + 1 ), 0,
@@ -2443,7 +2433,7 @@ void draw_quick_shortcuts()
                                   get_option<int>( "ANDROID_SHORTCUT_OPACITY_FG" ) * 0.01f );
             }
         }
-        SDL_RenderSetScale( renderer.get(), 1.0f, 1.0f );
+        RenderSetScale( renderer, 1.0f, 1.0f );
         i++;
         if( ( i + 1 ) * width > WindowWidth ) {
             break;
@@ -2457,7 +2447,7 @@ void draw_virtual_joystick()
     // Bail out if we don't need to draw the joystick
     if( !get_option<bool>( "ANDROID_SHOW_VIRTUAL_JOYSTICK" ) ||
         finger_down_time <= 0 ||
-        SDL_GetTicks() - finger_down_time <= static_cast<uint32_t>
+        GetTicks() - finger_down_time <= static_cast<uint32_t>
         ( get_option<int>( "ANDROID_INITIAL_DELAY" ) ) ||
         is_quick_shortcut_touch ||
         is_two_finger_touch ||
@@ -2525,7 +2515,7 @@ static void draw_gamepad_radial_menu()
 
     int w;
     int h;
-    SDL_GetRendererOutputSize( renderer.get(), &w, &h );
+    GetRendererOutputSize( renderer, &w, &h );
 
     // Draw a semi-transparent black background over the whole screen
     SetRenderDrawBlendMode( renderer, SDL_BLENDMODE_BLEND );
@@ -2538,7 +2528,7 @@ static void draw_gamepad_radial_menu()
     // Scale font relative to window height.
     // Base scale 1.0 at 720p, for labels to be legible.
     float text_scale = static_cast<float>( h ) / 720.0f * 1.0f;
-    SDL_RenderSetScale( renderer.get(), text_scale, text_scale );
+    RenderSetScale( renderer, text_scale, text_scale );
 
     static const std::vector<gamepad::direction> directions = {
         gamepad::direction::N, gamepad::direction::NE, gamepad::direction::E,
@@ -2585,7 +2575,7 @@ static void draw_gamepad_radial_menu()
     }
 
     // Restore scale
-    SDL_RenderSetScale( renderer.get(), 1.0f, 1.0f );
+    RenderSetScale( renderer, 1.0f, 1.0f );
 }
 
 #if defined(__ANDROID__)
@@ -2749,30 +2739,34 @@ static bool window_focus = false;
 static bool text_input_active_when_regaining_focus = false;
 #endif
 
-void StartTextInput()
+// Focus-aware text input helpers. These manage state around focus
+// loss/gain to avoid sending text input to wrong targets. The pure
+// SDL wrappers (StartTextInput/StopTextInput/IsTextInputActive) live
+// in sdl_wrappers.cpp and take SDL_Window*.
+static void focus_aware_start_text_input()
 {
     // prevent sending spurious empty SDL_TEXTEDITING events
-    if( SDL_IsTextInputActive() == SDL_TRUE ) {
+    if( IsTextInputActive( ::window.get() ) ) {
         return;
     }
 #if defined(__ANDROID__)
-    SDL_StartTextInput();
+    StartTextInput( ::window.get() );
 #else
     if( window_focus ) {
-        SDL_StartTextInput();
+        StartTextInput( ::window.get() );
     } else {
         text_input_active_when_regaining_focus = true;
     }
 #endif
 }
 
-void StopTextInput()
+static void focus_aware_stop_text_input()
 {
 #if defined(__ANDROID__)
-    SDL_StopTextInput();
+    StopTextInput( ::window.get() );
 #else
     if( window_focus ) {
-        SDL_StopTextInput();
+        StopTextInput( ::window.get() );
     } else {
         text_input_active_when_regaining_focus = false;
     }
@@ -2794,11 +2788,11 @@ static void CheckMessages()
         visible_display_frame_dirty = false;
     }
 
-    uint32_t ticks = SDL_GetTicks();
+    uint32_t ticks = GetTicks();
 
     // Force text input mode if hardware keyboard is available.
-    if( android_is_hardware_keyboard_available() && !SDL_IsTextInputActive() ) {
-        StartTextInput();
+    if( android_is_hardware_keyboard_available() && !IsTextInputActive( ::window.get() ) ) {
+        focus_aware_start_text_input();
     }
 
     // Make sure the SDL surface view is visible, otherwise the "Z" loading screen is visible.
@@ -2823,9 +2817,9 @@ static void CheckMessages()
         if( touch_input_context.allow_text_entry &&
             !new_input_context->allow_text_entry &&
             !is_string_input( *new_input_context ) &&
-            SDL_IsTextInputActive() &&
+            IsTextInputActive( ::window.get() ) &&
             get_option<bool>( "ANDROID_AUTO_KEYBOARD" ) ) {
-            StopTextInput();
+            focus_aware_stop_text_input();
         }
 
         touch_input_context = *new_input_context;
@@ -3053,7 +3047,7 @@ static void CheckMessages()
                 finger_repeat_time = ticks;
                 // Prevent repeating inputs on the next call to this function if there is a fingerup event
                 while( SDL_PollEvent( &ev ) ) {
-                    if( ev.type == SDL_FINGERUP ) {
+                    if( ev.type == CATA_FINGERUP ) {
                         third_finger_down_x = third_finger_curr_x = second_finger_down_x = second_finger_curr_x =
                                                   finger_down_x = finger_curr_x = -1.0f;
                         third_finger_down_y = third_finger_curr_y = second_finger_down_y = second_finger_curr_y =
@@ -3099,407 +3093,477 @@ static void CheckMessages()
     using cata::options::mouse;
 
     while( SDL_PollEvent( &ev ) ) {
+        // SDL3: converts event coordinates from window space to render-logical space.
+        // SDL2: no-op (logical size auto-scales events).
+        ConvertEventCoordinates( renderer, &ev );
         imclient->process_input( &ev );
-        switch( ev.type ) {
-            case SDL_WINDOWEVENT:
-                switch( ev.window.event ) {
-#if defined(__ANDROID__)
-                    // SDL will send a focus lost event whenever the app loses focus (eg. lock screen, switch app focus etc.)
-                    // If we detect it and the game seems in a saveable state, try and do a quicksave. This is a bit dodgy
-                    // as the player could be ANYWHERE doing ANYTHING (a sub-menu, interacting with an NPC/computer etc.)
-                    // but it seems to work so far, and the alternative is the player losing their progress as the app is likely
-                    // to be destroyed pretty quickly when it goes out of focus due to memory usage.
-                    case SDL_WINDOWEVENT_FOCUS_LOST:
-                        if( world_generator &&
-                            world_generator->active_world &&
-                            g && g->uquit == QUIT_NO &&
-                            get_option<bool>( "ANDROID_QUICKSAVE" ) &&
-                            !std::uncaught_exception() ) {
-                            g->quicksave();
-                        }
-                        break;
-                    // SDL sends a window size changed event whenever the screen rotates orientation
-                    case SDL_WINDOWEVENT_SIZE_CHANGED:
-                        WindowWidth = ev.window.data1;
-                        WindowHeight = ev.window.data2;
-                        SDL_Delay( 500 );
-                        SDL_GetWindowSurface( window.get() );
-                        ui_manager::redraw_invalidated();
-                        refresh_display();
-                        needupdate = true;
-                        break;
-#else
-                    case SDL_WINDOWEVENT_FOCUS_LOST:
-                        window_focus = false;
-                        if( SDL_IsTextInputActive() ) {
-                            text_input_active_when_regaining_focus = true;
-                            // Stop text input to not intefere with other programs
-                            SDL_StopTextInput();
-                            // Clear uncommited IME text. TODO: commit IME text instead.
-                            last_input = input_event();
-                            last_input.type = input_event_t::keyboard_char;
-                            last_input.edit.clear();
-                            last_input.edit_refresh = true;
-                            text_refresh = true;
-                        } else {
-                            text_input_active_when_regaining_focus = false;
-                        }
-                        break;
-                    case SDL_WINDOWEVENT_FOCUS_GAINED:
-                        window_focus = true;
-                        // Restore text input status
-                        if( text_input_active_when_regaining_focus ) {
-                            SDL_StartTextInput();
-                        }
-                        break;
-#endif
-                    case SDL_WINDOWEVENT_SHOWN:
-                    case SDL_WINDOWEVENT_MINIMIZED:
-                        break;
-                    case SDL_WINDOWEVENT_EXPOSED:
-                        needupdate = true;
-                        break;
-                    case SDL_WINDOWEVENT_RESTORED:
-#if defined(__ANDROID__)
-                        needs_sdl_surface_visibility_refresh = true;
-                        if( android_is_hardware_keyboard_available() ) {
-                            StopTextInput();
-                            StartTextInput();
-                        }
-#endif
-                        break;
-                    case SDL_WINDOWEVENT_RESIZED:
-                        resize_dims = point( ev.window.data1, ev.window.data2 );
-                        break;
-                    default:
-                        break;
-                }
-                break;
-            case SDL_RENDER_TARGETS_RESET:
-                render_target_reset = true;
-                break;
-            case SDL_KEYDOWN: {
-#if defined(__ANDROID__)
-                // Toggle virtual keyboard with Android back button. For some reason I get double inputs, so ignore everything once it's already down.
-                if( ev.key.keysym.sym == SDLK_AC_BACK && ac_back_down_time == 0 ) {
-                    ac_back_down_time = ticks;
-                    quick_shortcuts_toggle_handled = false;
-                }
-#endif
-                is_repeat = ev.key.repeat;
-                //hide mouse cursor on keyboard input
-                if( get_option<std::string>( "HIDE_CURSOR" ) != "show" && SDL_ShowCursor( -1 ) ) {
-                    SDL_ShowCursor( SDL_DISABLE );
-                }
-                keyboard_mode mode = keyboard_mode::keychar;
-#if !defined(__ANDROID__) && !(defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE == 1)
-                if( !SDL_IsTextInputActive() ) {
-                    mode = keyboard_mode::keycode;
-                }
-#endif
-                if( mode == keyboard_mode::keychar ) {
-                    const int lc = sdl_keysym_to_curses( ev.key.keysym );
-                    if( lc <= 0 ) {
-                        // a key we don't know in curses and won't handle.
-                        break;
-                    } else if( add_alt_code( lc ) ) {
-                        // key was handled
-                    } else {
-                        last_input = input_event( lc, input_event_t::keyboard_char );
-#if defined(__ANDROID__)
-                        if( !android_is_hardware_keyboard_available() ) {
-                            if( !is_string_input( touch_input_context ) && !touch_input_context.allow_text_entry ) {
-                                if( get_option<bool>( "ANDROID_AUTO_KEYBOARD" ) ) {
-                                    StopTextInput();
-                                }
 
-                                // add a quick shortcut
-                                if( !last_input.text.empty() ||
-                                    !inp_mngr.get_keyname( lc, input_event_t::keyboard_char ).empty() ) {
+        // Window events: SDL3 flattens the SDL_WINDOWEVENT+subtype to top-level events.
+        // IsWindowEvent/GetWindowEventID normalize across versions.
+        if( IsWindowEvent( ev ) ) {
+            switch( GetWindowEventID( ev ) ) {
+#if defined(__ANDROID__)
+                // SDL will send a focus lost event whenever the app loses focus (eg. lock screen, switch app focus etc.)
+                // If we detect it and the game seems in a saveable state, try and do a quicksave. This is a bit dodgy
+                // as the player could be ANYWHERE doing ANYTHING (a sub-menu, interacting with an NPC/computer etc.)
+                // but it seems to work so far, and the alternative is the player losing their progress as the app is likely
+                // to be destroyed pretty quickly when it goes out of focus due to memory usage.
+                case CATA_WINDOWEVENT_FOCUS_LOST:
+                    if( world_generator &&
+                        world_generator->active_world &&
+                        g && g->uquit == QUIT_NO &&
+                        get_option<bool>( "ANDROID_QUICKSAVE" ) &&
+                        !std::uncaught_exception() ) {
+                        g->quicksave();
+                    }
+                    break;
+                // SDL sends a window resize event whenever the screen rotates orientation.
+                // SDL3: SIZE_CHANGED removed; RESIZED covers the same case.
+                case CATA_WINDOWEVENT_RESIZED:
+                    WindowWidth = ev.window.data1;
+                    WindowHeight = ev.window.data2;
+                    SDL_Delay( 500 );
+                    SDL_GetWindowSurface( window.get() );
+                    ui_manager::redraw_invalidated();
+                    refresh_display();
+                    needupdate = true;
+                    break;
+#else
+                case CATA_WINDOWEVENT_FOCUS_LOST:
+                    window_focus = false;
+                    if( IsTextInputActive( ::window.get() ) ) {
+                        text_input_active_when_regaining_focus = true;
+                        // Stop text input to not interfere with other programs
+                        StopTextInput( ::window.get() );
+                        // Clear uncommitted IME text. TODO: commit IME text instead.
+                        last_input = input_event();
+                        last_input.type = input_event_t::keyboard_char;
+                        last_input.edit.clear();
+                        last_input.edit_refresh = true;
+                        text_refresh = true;
+                    } else {
+                        text_input_active_when_regaining_focus = false;
+                    }
+                    break;
+                case CATA_WINDOWEVENT_FOCUS_GAINED:
+                    window_focus = true;
+                    // Restore text input status
+                    if( text_input_active_when_regaining_focus ) {
+                        StartTextInput( ::window.get() );
+                    }
+                    break;
+#endif
+                case CATA_WINDOWEVENT_SHOWN:
+                case CATA_WINDOWEVENT_MINIMIZED:
+                    break;
+                case CATA_WINDOWEVENT_EXPOSED:
+                    needupdate = true;
+                    break;
+                case CATA_WINDOWEVENT_RESTORED:
+#if defined(__ANDROID__)
+                    needs_sdl_surface_visibility_refresh = true;
+                    if( android_is_hardware_keyboard_available() ) {
+                        focus_aware_stop_text_input();
+                        focus_aware_start_text_input();
+                    }
+#endif
+                    break;
+#if !defined(__ANDROID__)
+                // Non-Android resize: store dimensions for deferred handling
+                case CATA_WINDOWEVENT_RESIZED:
+                    resize_dims = point( ev.window.data1, ev.window.data2 );
+                    break;
+#endif
+                default:
+                    break;
+            }
+        } else {
+            switch( ev.type ) {
+                case CATA_RENDER_TARGETS_RESET:
+                    render_target_reset = true;
+                    break;
+                case SDL_KEYDOWN: {
+#if defined(__ANDROID__)
+                    // Toggle virtual keyboard with Android back button. For some reason I get double inputs, so ignore everything once it's already down.
+                    if( GetKeysym( ev ).sym == SDLK_AC_BACK && ac_back_down_time == 0 ) {
+                        ac_back_down_time = ticks;
+                        quick_shortcuts_toggle_handled = false;
+                    }
+#endif
+                    is_repeat = ev.key.repeat;
+                    //hide mouse cursor on keyboard input
+                    if( get_option<std::string>( "HIDE_CURSOR" ) != "show" && IsCursorVisible() ) {
+                        HideCursor();
+                    }
+                    keyboard_mode mode = keyboard_mode::keychar;
+#if !defined(__ANDROID__) && !(defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE == 1)
+                    if( !IsTextInputActive( ::window.get() ) ) {
+                        mode = keyboard_mode::keycode;
+                    }
+#endif
+                    if( mode == keyboard_mode::keychar ) {
+                        const int lc = sdl_keysym_to_curses( GetKeysym( ev ) );
+                        if( lc <= 0 ) {
+                            // a key we don't know in curses and won't handle.
+                            break;
+                        } else if( add_alt_code( lc ) ) {
+                            // key was handled
+                        } else {
+                            last_input = input_event( lc, input_event_t::keyboard_char );
+#if defined(__ANDROID__)
+                            if( !android_is_hardware_keyboard_available() ) {
+                                if( !is_string_input( touch_input_context ) && !touch_input_context.allow_text_entry ) {
+                                    if( get_option<bool>( "ANDROID_AUTO_KEYBOARD" ) ) {
+                                        focus_aware_stop_text_input();
+                                    }
+
+                                    // add a quick shortcut
+                                    if( !last_input.text.empty() ||
+                                        !inp_mngr.get_keyname( lc, input_event_t::keyboard_char ).empty() ) {
+                                        qsl.remove( last_input );
+                                        add_quick_shortcut( qsl, last_input, false, true );
+                                        ui_manager::redraw_invalidated();
+                                        refresh_display();
+                                    }
+                                } else if( lc == '\n' || lc == KEY_ESCAPE ) {
+                                    if( get_option<bool>( "ANDROID_AUTO_KEYBOARD" ) ) {
+                                        focus_aware_stop_text_input();
+                                    }
+                                }
+                            }
+#endif
+                        }
+                    } else {
+                        last_input = sdl_keysym_to_keycode_evt( GetKeysym( ev ) );
+                    }
+                }
+                break;
+                case SDL_KEYUP: {
+#if defined(__ANDROID__)
+                    // Toggle virtual keyboard with Android back button
+                    if( GetKeysym( ev ).sym == SDLK_AC_BACK ) {
+                        if( ticks - ac_back_down_time <= static_cast<uint32_t>
+                            ( get_option<int>( "ANDROID_INITIAL_DELAY" ) ) ) {
+                            if( IsTextInputActive( ::window.get() ) ) {
+                                focus_aware_stop_text_input();
+                            } else {
+                                focus_aware_start_text_input();
+                            }
+                        }
+                        ac_back_down_time = 0;
+                    }
+#endif
+                    keyboard_mode mode = keyboard_mode::keychar;
+#if !defined(__ANDROID__) && !(defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE == 1)
+                    if( !IsTextInputActive( ::window.get() ) ) {
+                        mode = keyboard_mode::keycode;
+                    }
+#endif
+                    is_repeat = ev.key.repeat;
+                    if( mode == keyboard_mode::keychar ) {
+                        if( GetKeysym( ev ).sym == SDLK_LALT || GetKeysym( ev ).sym == SDLK_RALT ) {
+                            int code = end_alt_code();
+                            if( code ) {
+                                last_input = input_event( code, input_event_t::keyboard_char );
+                                last_input.text = utf32_to_utf8( code );
+                            }
+                        }
+                    } else if( is_repeat ) {
+                        last_input = sdl_keysym_to_keycode_evt( GetKeysym( ev ) );
+                    }
+                }
+                break;
+                case SDL_TEXTINPUT:
+                    if( !add_alt_code( *ev.text.text ) ) {
+                        if( strlen( ev.text.text ) > 0 ) {
+                            const unsigned lc = UTF8_getch( ev.text.text );
+                            last_input = input_event( lc, input_event_t::keyboard_char );
+#if defined(__ANDROID__)
+                            if( !android_is_hardware_keyboard_available() ) {
+                                if( !is_string_input( touch_input_context ) && !touch_input_context.allow_text_entry ) {
+                                    if( get_option<bool>( "ANDROID_AUTO_KEYBOARD" ) ) {
+                                        focus_aware_stop_text_input();
+                                    }
+
+                                    quick_shortcuts_t &qsl = quick_shortcuts_map[get_quick_shortcut_name(
+                                                                 touch_input_context.get_category() )];
                                     qsl.remove( last_input );
                                     add_quick_shortcut( qsl, last_input, false, true );
                                     ui_manager::redraw_invalidated();
                                     refresh_display();
-                                }
-                            } else if( lc == '\n' || lc == KEY_ESCAPE ) {
-                                if( get_option<bool>( "ANDROID_AUTO_KEYBOARD" ) ) {
-                                    StopTextInput();
+                                } else if( lc == '\n' || lc == KEY_ESCAPE ) {
+                                    if( get_option<bool>( "ANDROID_AUTO_KEYBOARD" ) ) {
+                                        focus_aware_stop_text_input();
+                                    }
                                 }
                             }
-                        }
 #endif
-                    }
-                } else {
-                    last_input = sdl_keysym_to_keycode_evt( ev.key.keysym );
-                }
-            }
-            break;
-            case SDL_KEYUP: {
-#if defined(__ANDROID__)
-                // Toggle virtual keyboard with Android back button
-                if( ev.key.keysym.sym == SDLK_AC_BACK ) {
-                    if( ticks - ac_back_down_time <= static_cast<uint32_t>
-                        ( get_option<int>( "ANDROID_INITIAL_DELAY" ) ) ) {
-                        if( SDL_IsTextInputActive() ) {
-                            StopTextInput();
                         } else {
-                            StartTextInput();
+                            // no key pressed in this event
+                            last_input = input_event();
+                            last_input.type = input_event_t::keyboard_char;
                         }
+                        last_input.text = ev.text.text;
+                        text_refresh = true;
                     }
-                    ac_back_down_time = 0;
-                }
-#endif
-                keyboard_mode mode = keyboard_mode::keychar;
-#if !defined(__ANDROID__) && !(defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE == 1)
-                if( !SDL_IsTextInputActive() ) {
-                    mode = keyboard_mode::keycode;
-                }
-#endif
-                is_repeat = ev.key.repeat;
-                if( mode == keyboard_mode::keychar ) {
-                    if( ev.key.keysym.sym == SDLK_LALT || ev.key.keysym.sym == SDLK_RALT ) {
-                        int code = end_alt_code();
-                        if( code ) {
-                            last_input = input_event( code, input_event_t::keyboard_char );
-                            last_input.text = utf32_to_utf8( code );
-                        }
-                    }
-                } else if( is_repeat ) {
-                    last_input = sdl_keysym_to_keycode_evt( ev.key.keysym );
-                }
-            }
-            break;
-            case SDL_TEXTINPUT:
-                if( !add_alt_code( *ev.text.text ) ) {
-                    if( strlen( ev.text.text ) > 0 ) {
-                        const unsigned lc = UTF8_getch( ev.text.text );
+                    break;
+                case SDL_TEXTEDITING: {
+                    if( strlen( ev.edit.text ) > 0 ) {
+                        const unsigned lc = UTF8_getch( ev.edit.text );
                         last_input = input_event( lc, input_event_t::keyboard_char );
-#if defined(__ANDROID__)
-                        if( !android_is_hardware_keyboard_available() ) {
-                            if( !is_string_input( touch_input_context ) && !touch_input_context.allow_text_entry ) {
-                                if( get_option<bool>( "ANDROID_AUTO_KEYBOARD" ) ) {
-                                    StopTextInput();
-                                }
-
-                                quick_shortcuts_t &qsl = quick_shortcuts_map[get_quick_shortcut_name(
-                                                             touch_input_context.get_category() )];
-                                qsl.remove( last_input );
-                                add_quick_shortcut( qsl, last_input, false, true );
-                                ui_manager::redraw_invalidated();
-                                refresh_display();
-                            } else if( lc == '\n' || lc == KEY_ESCAPE ) {
-                                if( get_option<bool>( "ANDROID_AUTO_KEYBOARD" ) ) {
-                                    StopTextInput();
-                                }
-                            }
-                        }
-#endif
                     } else {
                         // no key pressed in this event
                         last_input = input_event();
                         last_input.type = input_event_t::keyboard_char;
                     }
-                    last_input.text = ev.text.text;
+                    // Convert to string explicitly to avoid accidentally using
+                    // the array out of scope.
+                    last_input.edit = std::string( ev.edit.text );
+                    last_input.edit_refresh = true;
                     text_refresh = true;
+                    break;
                 }
-                break;
-            case SDL_TEXTEDITING: {
-                if( strlen( ev.edit.text ) > 0 ) {
-                    const unsigned lc = UTF8_getch( ev.edit.text );
-                    last_input = input_event( lc, input_event_t::keyboard_char );
-                } else {
-                    // no key pressed in this event
-                    last_input = input_event();
-                    last_input.type = input_event_t::keyboard_char;
-                }
-                // Convert to string explicitly to avoid accidentally using
-                // the array out of scope.
-                last_input.edit = std::string( ev.edit.text );
-                last_input.edit_refresh = true;
-                text_refresh = true;
-                break;
-            }
 #if defined(SDL_HINT_IME_SUPPORT_EXTENDED_TEXT)
-            case SDL_TEXTEDITING_EXT: {
-                if( !ev.editExt.text ) {
-                    break;
-                }
-                if( strlen( ev.editExt.text ) > 0 ) {
-                    const unsigned lc = UTF8_getch( ev.editExt.text );
-                    last_input = input_event( lc, input_event_t::keyboard_char );
-                } else {
-                    // no key pressed in this event
-                    last_input = input_event();
-                    last_input.type = input_event_t::keyboard_char;
-                }
-                // Convert to string explicitly to avoid accidentally using
-                // a pointer that will be freed
-                last_input.edit = std::string( ev.editExt.text );
-                last_input.edit_refresh = true;
-                text_refresh = true;
-                SDL_free( ev.editExt.text );
-                break;
-            }
-#endif
-            case SDL_MOUSEMOTION:
-                if( ! mouse.enabled ) {
-                    break;
-                }
-                if( get_option<std::string>( "HIDE_CURSOR" ) == "show" ||
-                    get_option<std::string>( "HIDE_CURSOR" ) == "hidekb" ) {
-                    if( !SDL_ShowCursor( -1 ) ) {
-                        SDL_ShowCursor( SDL_ENABLE );
+                case SDL_TEXTEDITING_EXT: {
+                    if( !ev.editExt.text ) {
+                        break;
                     }
-
-                    // Only monitor motion when cursor is visible
-                    last_input = input_event( MouseInput::Move, input_event_t::mouse );
-                }
-                break;
-
-            case SDL_MOUSEBUTTONDOWN:
-                if( ! mouse.enabled ) {
+                    if( strlen( ev.editExt.text ) > 0 ) {
+                        const unsigned lc = UTF8_getch( ev.editExt.text );
+                        last_input = input_event( lc, input_event_t::keyboard_char );
+                    } else {
+                        // no key pressed in this event
+                        last_input = input_event();
+                        last_input.type = input_event_t::keyboard_char;
+                    }
+                    // Convert to string explicitly to avoid accidentally using
+                    // a pointer that will be freed
+                    last_input.edit = std::string( ev.editExt.text );
+                    last_input.edit_refresh = true;
+                    text_refresh = true;
+                    SDL_free( ev.editExt.text );
                     break;
                 }
-                switch( ev.button.button ) {
-                    case SDL_BUTTON_LEFT:
-                        last_input = input_event( MouseInput::LeftButtonPressed, input_event_t::mouse );
+#endif
+                case SDL_MOUSEMOTION:
+                    if( ! mouse.enabled ) {
                         break;
-                    case SDL_BUTTON_RIGHT:
-                        last_input = input_event( MouseInput::RightButtonPressed, input_event_t::mouse );
-                        break;
-                    case SDL_BUTTON_X1:
-                        last_input = input_event( MouseInput::X1ButtonPressed, input_event_t::mouse );
-                        break;
-                    case SDL_BUTTON_X2:
-                        last_input = input_event( MouseInput::X2ButtonPressed, input_event_t::mouse );
-                        break;
-                }
-                break;
+                    }
+                    if( get_option<std::string>( "HIDE_CURSOR" ) == "show" ||
+                        get_option<std::string>( "HIDE_CURSOR" ) == "hidekb" ) {
+                        if( !IsCursorVisible() ) {
+                            ShowCursor();
+                        }
 
-            case SDL_MOUSEBUTTONUP:
-                if( ! mouse.enabled ) {
+                        // Only monitor motion when cursor is visible
+                        last_input = input_event( MouseInput::Move, input_event_t::mouse );
+                    }
                     break;
-                }
-                switch( ev.button.button ) {
-                    case SDL_BUTTON_LEFT:
-                        last_input = input_event( MouseInput::LeftButtonReleased, input_event_t::mouse );
-                        break;
-                    case SDL_BUTTON_RIGHT:
-                        last_input = input_event( MouseInput::RightButtonReleased, input_event_t::mouse );
-                        break;
-                    case SDL_BUTTON_X1:
-                        last_input = input_event( MouseInput::X1ButtonReleased, input_event_t::mouse );
-                        break;
-                    case SDL_BUTTON_X2:
-                        last_input = input_event( MouseInput::X2ButtonReleased, input_event_t::mouse );
-                        break;
-                }
-                break;
 
-            case SDL_MOUSEWHEEL:
-                if( ! mouse.enabled ) {
+                case SDL_MOUSEBUTTONDOWN:
+                    if( ! mouse.enabled ) {
+                        break;
+                    }
+                    switch( ev.button.button ) {
+                        case SDL_BUTTON_LEFT:
+                            last_input = input_event( MouseInput::LeftButtonPressed, input_event_t::mouse );
+                            break;
+                        case SDL_BUTTON_RIGHT:
+                            last_input = input_event( MouseInput::RightButtonPressed, input_event_t::mouse );
+                            break;
+                        case SDL_BUTTON_X1:
+                            last_input = input_event( MouseInput::X1ButtonPressed, input_event_t::mouse );
+                            break;
+                        case SDL_BUTTON_X2:
+                            last_input = input_event( MouseInput::X2ButtonPressed, input_event_t::mouse );
+                            break;
+                    }
                     break;
-                }
-                if( ev.wheel.y > 0 ) {
-                    last_input = input_event( MouseInput::ScrollWheelUp, input_event_t::mouse );
-                } else if( ev.wheel.y < 0 ) {
-                    last_input = input_event( MouseInput::ScrollWheelDown, input_event_t::mouse );
-                }
-                break;
+
+                case SDL_MOUSEBUTTONUP:
+                    if( ! mouse.enabled ) {
+                        break;
+                    }
+                    switch( ev.button.button ) {
+                        case SDL_BUTTON_LEFT:
+                            last_input = input_event( MouseInput::LeftButtonReleased, input_event_t::mouse );
+                            break;
+                        case SDL_BUTTON_RIGHT:
+                            last_input = input_event( MouseInput::RightButtonReleased, input_event_t::mouse );
+                            break;
+                        case SDL_BUTTON_X1:
+                            last_input = input_event( MouseInput::X1ButtonReleased, input_event_t::mouse );
+                            break;
+                        case SDL_BUTTON_X2:
+                            last_input = input_event( MouseInput::X2ButtonReleased, input_event_t::mouse );
+                            break;
+                    }
+                    break;
+
+                case SDL_MOUSEWHEEL:
+                    if( ! mouse.enabled ) {
+                        break;
+                    }
+                    if( ev.wheel.y > 0 ) {
+                        last_input = input_event( MouseInput::ScrollWheelUp, input_event_t::mouse );
+                    } else if( ev.wheel.y < 0 ) {
+                        last_input = input_event( MouseInput::ScrollWheelDown, input_event_t::mouse );
+                    }
+                    break;
 
 #if defined(__ANDROID__)
-            case SDL_FINGERMOTION:
-                if( ev.tfinger.fingerId == 0 ) {
-                    if( !is_quick_shortcut_touch ) {
-                        update_finger_repeat_delay();
-                    }
-                    needupdate = true; // ensure virtual joystick and quick shortcuts redraw as we interact
-                    ui_manager::redraw_invalidated();
-                    finger_curr_x = ev.tfinger.x * WindowWidth;
-                    finger_curr_y = ev.tfinger.y * WindowHeight;
+                case CATA_FINGERMOTION:
+                    if( GetFingerID( ev ) == 0 ) {
+                        if( !is_quick_shortcut_touch ) {
+                            update_finger_repeat_delay();
+                        }
+                        needupdate = true; // ensure virtual joystick and quick shortcuts redraw as we interact
+                        ui_manager::redraw_invalidated();
+                        finger_curr_x = GetFingerX( ev, WindowWidth );
+                        finger_curr_y = GetFingerY( ev, WindowHeight );
 
-                    if( get_option<bool>( "ANDROID_VIRTUAL_JOYSTICK_FOLLOW" ) && !is_two_finger_touch &&
-                        !is_three_finger_touch ) {
-                        // If we've moved too far from joystick center, offset joystick center automatically
-                        float delta_x = finger_curr_x - finger_down_x;
-                        float delta_y = finger_curr_y - finger_down_y;
-                        float dist = std::sqrt( delta_x * delta_x + delta_y * delta_y );
-                        float max_dist = ( get_option<float>( "ANDROID_DEADZONE_RANGE" ) +
-                                           get_option<float>( "ANDROID_REPEAT_DELAY_RANGE" ) ) * std::max( WindowWidth, WindowHeight );
-                        if( dist > max_dist ) {
-                            float delta_ratio = ( dist / max_dist ) - 1.0f;
-                            finger_down_x += delta_x * delta_ratio;
-                            finger_down_y += delta_y * delta_ratio;
+                        if( get_option<bool>( "ANDROID_VIRTUAL_JOYSTICK_FOLLOW" ) && !is_two_finger_touch &&
+                            !is_three_finger_touch ) {
+                            // If we've moved too far from joystick center, offset joystick center automatically
+                            float delta_x = finger_curr_x - finger_down_x;
+                            float delta_y = finger_curr_y - finger_down_y;
+                            float dist = std::sqrt( delta_x * delta_x + delta_y * delta_y );
+                            float max_dist = ( get_option<float>( "ANDROID_DEADZONE_RANGE" ) +
+                                               get_option<float>( "ANDROID_REPEAT_DELAY_RANGE" ) ) * std::max( WindowWidth, WindowHeight );
+                            if( dist > max_dist ) {
+                                float delta_ratio = ( dist / max_dist ) - 1.0f;
+                                finger_down_x += delta_x * delta_ratio;
+                                finger_down_y += delta_y * delta_ratio;
+                            }
+                        }
+
+                    } else if( GetFingerID( ev ) == 1 ) {
+                        second_finger_curr_x = GetFingerX( ev, WindowWidth );
+                        second_finger_curr_y = GetFingerY( ev, WindowHeight );
+                    } else if( GetFingerID( ev ) == 2 ) {
+                        third_finger_curr_x = GetFingerX( ev, WindowWidth );
+                        third_finger_curr_y = GetFingerY( ev, WindowHeight );
+                    }
+                    break;
+                case CATA_FINGERDOWN:
+                    if( GetFingerID( ev ) == 0 ) {
+                        finger_down_x = finger_curr_x = GetFingerX( ev, WindowWidth );
+                        finger_down_y = finger_curr_y = GetFingerY( ev, WindowHeight );
+                        finger_down_time = ticks;
+                        finger_repeat_time = 0;
+                        is_quick_shortcut_touch = get_quick_shortcut_under_finger() != NULL;
+                        if( !is_quick_shortcut_touch ) {
+                            update_finger_repeat_delay();
+                        }
+                        ui_manager::redraw_invalidated();
+                        needupdate = true; // ensure virtual joystick and quick shortcuts redraw as we interact
+                    } else if( GetFingerID( ev ) == 1 ) {
+                        if( !is_quick_shortcut_touch ) {
+                            second_finger_down_x = second_finger_curr_x = GetFingerX( ev, WindowWidth );
+                            second_finger_down_y = second_finger_curr_y = GetFingerY( ev, WindowHeight );
+                            is_two_finger_touch = true;
+                        }
+                    } else if( GetFingerID( ev ) == 2 ) {
+                        if( !is_quick_shortcut_touch ) {
+                            third_finger_down_x = third_finger_curr_x = GetFingerX( ev, WindowWidth );
+                            third_finger_down_y = third_finger_curr_y = GetFingerY( ev, WindowHeight );
+                            is_three_finger_touch = true;
+                            is_two_finger_touch = false;
                         }
                     }
-
-                } else if( ev.tfinger.fingerId == 1 ) {
-                    second_finger_curr_x = ev.tfinger.x * WindowWidth;
-                    second_finger_curr_y = ev.tfinger.y * WindowHeight;
-                } else if( ev.tfinger.fingerId == 2 ) {
-                    third_finger_curr_x = ev.tfinger.x * WindowWidth;
-                    third_finger_curr_y = ev.tfinger.y * WindowHeight;
-                }
-                break;
-            case SDL_FINGERDOWN:
-                if( ev.tfinger.fingerId == 0 ) {
-                    finger_down_x = finger_curr_x = ev.tfinger.x * WindowWidth;
-                    finger_down_y = finger_curr_y = ev.tfinger.y * WindowHeight;
-                    finger_down_time = ticks;
-                    finger_repeat_time = 0;
-                    is_quick_shortcut_touch = get_quick_shortcut_under_finger() != NULL;
-                    if( !is_quick_shortcut_touch ) {
-                        update_finger_repeat_delay();
-                    }
-                    ui_manager::redraw_invalidated();
-                    needupdate = true; // ensure virtual joystick and quick shortcuts redraw as we interact
-                } else if( ev.tfinger.fingerId == 1 ) {
-                    if( !is_quick_shortcut_touch ) {
-                        second_finger_down_x = second_finger_curr_x = ev.tfinger.x * WindowWidth;
-                        second_finger_down_y = second_finger_curr_y = ev.tfinger.y * WindowHeight;
-                        is_two_finger_touch = true;
-                    }
-                } else if( ev.tfinger.fingerId == 2 ) {
-                    if( !is_quick_shortcut_touch ) {
-                        third_finger_down_x = third_finger_curr_x = ev.tfinger.x * WindowWidth;
-                        third_finger_down_y = third_finger_curr_y = ev.tfinger.y * WindowHeight;
-                        is_three_finger_touch = true;
-                        is_two_finger_touch = false;
-                    }
-                }
-                break;
-            case SDL_FINGERUP:
-                if( ev.tfinger.fingerId == 0 ) {
-                    finger_curr_x = ev.tfinger.x * WindowWidth;
-                    finger_curr_y = ev.tfinger.y * WindowHeight;
-                    if( is_quick_shortcut_touch ) {
-                        input_event *quick_shortcut = get_quick_shortcut_under_finger();
-                        if( quick_shortcut ) {
-                            last_input = *quick_shortcut;
-                            if( get_option<bool>( "ANDROID_SHORTCUT_MOVE_FRONT" ) ) {
-                                quick_shortcuts_t &qsl = quick_shortcuts_map[get_quick_shortcut_name(
-                                                             touch_input_context.get_category() )];
-                                reorder_quick_shortcut( qsl, quick_shortcut->get_first_input(), false );
+                    break;
+                case CATA_FINGERUP:
+                    if( GetFingerID( ev ) == 0 ) {
+                        finger_curr_x = GetFingerX( ev, WindowWidth );
+                        finger_curr_y = GetFingerY( ev, WindowHeight );
+                        if( is_quick_shortcut_touch ) {
+                            input_event *quick_shortcut = get_quick_shortcut_under_finger();
+                            if( quick_shortcut ) {
+                                last_input = *quick_shortcut;
+                                if( get_option<bool>( "ANDROID_SHORTCUT_MOVE_FRONT" ) ) {
+                                    quick_shortcuts_t &qsl = quick_shortcuts_map[get_quick_shortcut_name(
+                                                                 touch_input_context.get_category() )];
+                                    reorder_quick_shortcut( qsl, quick_shortcut->get_first_input(), false );
+                                }
+                                quick_shortcut->shortcut_last_used_action_counter = g->get_user_action_counter();
+                            } else {
+                                // Get the quick shortcut that was originally touched
+                                quick_shortcut = get_quick_shortcut_under_finger( true );
+                                if( quick_shortcut &&
+                                    ticks - finger_down_time <= static_cast<uint32_t>( get_option<int>( "ANDROID_INITIAL_DELAY" ) )
+                                    &&
+                                    finger_curr_y < finger_down_y &&
+                                    finger_down_y - finger_curr_y > std::abs( finger_down_x - finger_curr_x ) ) {
+                                    // a flick up was detected, remove the quick shortcut!
+                                    quick_shortcuts_t &qsl = quick_shortcuts_map[get_quick_shortcut_name(
+                                                                 touch_input_context.get_category() )];
+                                    qsl.remove( *quick_shortcut );
+                                }
                             }
-                            quick_shortcut->shortcut_last_used_action_counter = g->get_user_action_counter();
                         } else {
-                            // Get the quick shortcut that was originally touched
-                            quick_shortcut = get_quick_shortcut_under_finger( true );
-                            if( quick_shortcut &&
-                                ticks - finger_down_time <= static_cast<uint32_t>( get_option<int>( "ANDROID_INITIAL_DELAY" ) )
-                                &&
-                                finger_curr_y < finger_down_y &&
-                                finger_down_y - finger_curr_y > std::abs( finger_down_x - finger_curr_x ) ) {
-                                // a flick up was detected, remove the quick shortcut!
-                                quick_shortcuts_t &qsl = quick_shortcuts_map[get_quick_shortcut_name(
-                                                             touch_input_context.get_category() )];
-                                qsl.remove( *quick_shortcut );
-                            }
-                        }
-                    } else {
-                        if( is_two_finger_touch ) {
-                            // handle zoom in/out
-                            if( is_default_mode ) {
+                            if( is_two_finger_touch ) {
+                                // handle zoom in/out
+                                if( is_default_mode ) {
+                                    float x1 = ( finger_curr_x - finger_down_x );
+                                    float y1 = ( finger_curr_y - finger_down_y );
+                                    float d1 = std::sqrt( x1 * x1 + y1 * y1 );
+
+                                    float x2 = ( second_finger_curr_x - second_finger_down_x );
+                                    float y2 = ( second_finger_curr_y - second_finger_down_y );
+                                    float d2 = std::sqrt( x2 * x2 + y2 * y2 );
+
+                                    float longest_window_edge = std::max( WindowWidth, WindowHeight );
+
+                                    if( std::max( d1, d2 ) < get_option<float>( "ANDROID_DEADZONE_RANGE" ) * longest_window_edge ) {
+                                        last_input = input_event( get_key_event_from_string(
+                                                                      get_option<std::string>( "ANDROID_2_TAP_KEY" ) ), input_event_t::keyboard_char );
+                                    } else {
+                                        float dot = ( x1 * x2 + y1 * y2 ) / ( d1 * d2 ); // dot product of two finger vectors, -1 to +1
+                                        if( dot > 0.0f ) { // both fingers mostly heading in same direction, check for double-finger swipe gesture
+                                            float dratio = d1 / d2;
+                                            const float dist_ratio = 0.3f;
+                                            if( dratio > dist_ratio &&
+                                                dratio < ( 1.0f /
+                                                           dist_ratio ) ) { // both fingers moved roughly the same distance, so it's a double-finger swipe!
+                                                float xavg = 0.5f * ( x1 + x2 );
+                                                float yavg = 0.5f * ( y1 + y2 );
+                                                if( xavg > 0 && xavg > std::abs( yavg ) ) {
+                                                    last_input = input_event( get_key_event_from_string(
+                                                                                  get_option<std::string>( "ANDROID_2_SWIPE_LEFT_KEY" ) ), input_event_t::keyboard_char );
+                                                } else if( xavg < 0 && -xavg > std::abs( yavg ) ) {
+                                                    last_input = input_event( get_key_event_from_string(
+                                                                                  get_option<std::string>( "ANDROID_2_SWIPE_RIGHT_KEY" ) ), input_event_t::keyboard_char );
+                                                } else if( yavg > 0 && yavg > std::abs( xavg ) ) {
+                                                    last_input = input_event( get_key_event_from_string(
+                                                                                  get_option<std::string>( "ANDROID_2_SWIPE_DOWN_KEY" ) ), input_event_t::keyboard_char );
+                                                } else {
+                                                    last_input = input_event( get_key_event_from_string(
+                                                                                  get_option<std::string>( "ANDROID_2_SWIPE_UP_KEY" ) ), input_event_t::keyboard_char );
+                                                }
+                                            }
+                                        } else {
+                                            // both fingers heading in opposite direction, check for zoom gesture
+                                            float down_x = finger_down_x - second_finger_down_x;
+                                            float down_y = finger_down_y - second_finger_down_y;
+                                            float down_dist = std::sqrt( down_x * down_x + down_y * down_y );
+
+                                            float curr_x = finger_curr_x - second_finger_curr_x;
+                                            float curr_y = finger_curr_y - second_finger_curr_y;
+                                            float curr_dist = std::sqrt( curr_x * curr_x + curr_y * curr_y );
+
+                                            const float zoom_ratio = 0.9f;
+                                            if( curr_dist < down_dist * zoom_ratio ) {
+                                                last_input = input_event( get_key_event_from_string(
+                                                                              get_option<std::string>( "ANDROID_PINCH_IN_KEY" ) ), input_event_t::keyboard_char );
+                                            } else if( curr_dist > down_dist / zoom_ratio ) {
+                                                last_input = input_event( get_key_event_from_string(
+                                                                              get_option<std::string>( "ANDROID_PINCH_OUT_KEY" ) ), input_event_t::keyboard_char );
+                                            }
+                                        }
+                                    }
+                                }
+                            } else if( is_three_finger_touch ) {
+                                // handle zoom in/out
                                 float x1 = ( finger_curr_x - finger_down_x );
                                 float y1 = ( finger_curr_y - finger_down_y );
                                 float d1 = std::sqrt( x1 * x1 + y1 * y1 );
@@ -3508,14 +3572,40 @@ static void CheckMessages()
                                 float y2 = ( second_finger_curr_y - second_finger_down_y );
                                 float d2 = std::sqrt( x2 * x2 + y2 * y2 );
 
+                                float x3 = ( third_finger_curr_x - third_finger_down_x );
+                                float y3 = ( third_finger_curr_y - third_finger_down_y );
+                                float d3 = std::sqrt( x3 * x3 + y3 * y3 );
+
                                 float longest_window_edge = std::max( WindowWidth, WindowHeight );
 
-                                if( std::max( d1, d2 ) < get_option<float>( "ANDROID_DEADZONE_RANGE" ) * longest_window_edge ) {
-                                    last_input = input_event( get_key_event_from_string(
-                                                                  get_option<std::string>( "ANDROID_2_TAP_KEY" ) ), input_event_t::keyboard_char );
+                                if( std::max( d1, std::max( d2,
+                                                            d3 ) ) < get_option<float>( "ANDROID_DEADZONE_RANGE" ) * longest_window_edge ) {
+                                    int three_tap_key = 0; //get_option<int>( "ANDROID_3_TAP_KEY" );
+                                    if( three_tap_key == 0 ) { // not set
+                                        quick_shortcuts_enabled = !quick_shortcuts_enabled;
+
+                                        quick_shortcuts_toggle_handled = true;
+
+                                        // Display an Android toast message
+                                        {
+                                            JNIEnv *env = ( JNIEnv * )SDL_AndroidGetJNIEnv();
+                                            jobject activity = ( jobject )SDL_AndroidGetActivity();
+                                            jclass clazz( env->GetObjectClass( activity ) );
+                                            jstring toast_message = env->NewStringUTF( quick_shortcuts_enabled ? "Shortcuts visible" :
+                                                                    "Shortcuts hidden" );
+                                            jmethodID method_id = env->GetMethodID( clazz, "toast", "(Ljava/lang/String;)V" );
+                                            env->CallVoidMethod( activity, method_id, toast_message );
+                                            env->DeleteLocalRef( activity );
+                                            env->DeleteLocalRef( clazz );
+                                        }
+                                    } else {
+                                        last_input = input_event( three_tap_key, input_event_t::keyboard_char );
+                                    }
                                 } else {
                                     float dot = ( x1 * x2 + y1 * y2 ) / ( d1 * d2 ); // dot product of two finger vectors, -1 to +1
-                                    if( dot > 0.0f ) { // both fingers mostly heading in same direction, check for double-finger swipe gesture
+                                    float dot2 = ( x1 * x3 + y1 * y3 ) / ( d1 * d3 ); // dot product of three finger vectors, -1 to +1
+                                    if( dot > 0.0f &&
+                                        dot2 > 0.0f ) { // all fingers mostly heading in same direction, check for triple-finger swipe gesture
                                         float dratio = d1 / d2;
                                         const float dist_ratio = 0.3f;
                                         if( dratio > dist_ratio &&
@@ -3524,150 +3614,65 @@ static void CheckMessages()
                                             float xavg = 0.5f * ( x1 + x2 );
                                             float yavg = 0.5f * ( y1 + y2 );
                                             if( xavg > 0 && xavg > std::abs( yavg ) ) {
-                                                last_input = input_event( get_key_event_from_string(
-                                                                              get_option<std::string>( "ANDROID_2_SWIPE_LEFT_KEY" ) ), input_event_t::keyboard_char );
+                                                last_input = input_event( '\t', input_event_t::keyboard_char );
                                             } else if( xavg < 0 && -xavg > std::abs( yavg ) ) {
-                                                last_input = input_event( get_key_event_from_string(
-                                                                              get_option<std::string>( "ANDROID_2_SWIPE_RIGHT_KEY" ) ), input_event_t::keyboard_char );
+                                                last_input = input_event( KEY_BTAB, input_event_t::keyboard_char );
                                             } else if( yavg > 0 && yavg > std::abs( xavg ) ) {
-                                                last_input = input_event( get_key_event_from_string(
-                                                                              get_option<std::string>( "ANDROID_2_SWIPE_DOWN_KEY" ) ), input_event_t::keyboard_char );
+                                                last_input = input_event( KEY_NPAGE, input_event_t::keyboard_char );
                                             } else {
-                                                last_input = input_event( get_key_event_from_string(
-                                                                              get_option<std::string>( "ANDROID_2_SWIPE_UP_KEY" ) ), input_event_t::keyboard_char );
+                                                last_input = input_event( KEY_PPAGE, input_event_t::keyboard_char );
                                             }
                                         }
-                                    } else {
-                                        // both fingers heading in opposite direction, check for zoom gesture
-                                        float down_x = finger_down_x - second_finger_down_x;
-                                        float down_y = finger_down_y - second_finger_down_y;
-                                        float down_dist = std::sqrt( down_x * down_x + down_y * down_y );
-
-                                        float curr_x = finger_curr_x - second_finger_curr_x;
-                                        float curr_y = finger_curr_y - second_finger_curr_y;
-                                        float curr_dist = std::sqrt( curr_x * curr_x + curr_y * curr_y );
-
-                                        const float zoom_ratio = 0.9f;
-                                        if( curr_dist < down_dist * zoom_ratio ) {
-                                            last_input = input_event( get_key_event_from_string(
-                                                                          get_option<std::string>( "ANDROID_PINCH_IN_KEY" ) ), input_event_t::keyboard_char );
-                                        } else if( curr_dist > down_dist / zoom_ratio ) {
-                                            last_input = input_event( get_key_event_from_string(
-                                                                          get_option<std::string>( "ANDROID_PINCH_OUT_KEY" ) ), input_event_t::keyboard_char );
-                                        }
                                     }
                                 }
+
+                            } else if( ticks - finger_down_time <= static_cast<uint32_t>(
+                                           get_option<int>( "ANDROID_INITIAL_DELAY" ) ) ) {
+                                handle_finger_input( ticks );
                             }
-                        } else if( is_three_finger_touch ) {
-                            // handle zoom in/out
-                            float x1 = ( finger_curr_x - finger_down_x );
-                            float y1 = ( finger_curr_y - finger_down_y );
-                            float d1 = std::sqrt( x1 * x1 + y1 * y1 );
-
-                            float x2 = ( second_finger_curr_x - second_finger_down_x );
-                            float y2 = ( second_finger_curr_y - second_finger_down_y );
-                            float d2 = std::sqrt( x2 * x2 + y2 * y2 );
-
-                            float x3 = ( third_finger_curr_x - third_finger_down_x );
-                            float y3 = ( third_finger_curr_y - third_finger_down_y );
-                            float d3 = std::sqrt( x3 * x3 + y3 * y3 );
-
-                            float longest_window_edge = std::max( WindowWidth, WindowHeight );
-
-                            if( std::max( d1, std::max( d2,
-                                                        d3 ) ) < get_option<float>( "ANDROID_DEADZONE_RANGE" ) * longest_window_edge ) {
-                                int three_tap_key = 0; //get_option<int>( "ANDROID_3_TAP_KEY" );
-                                if( three_tap_key == 0 ) { // not set
-                                    quick_shortcuts_enabled = !quick_shortcuts_enabled;
-
-                                    quick_shortcuts_toggle_handled = true;
-
-                                    // Display an Android toast message
-                                    {
-                                        JNIEnv *env = ( JNIEnv * )SDL_AndroidGetJNIEnv();
-                                        jobject activity = ( jobject )SDL_AndroidGetActivity();
-                                        jclass clazz( env->GetObjectClass( activity ) );
-                                        jstring toast_message = env->NewStringUTF( quick_shortcuts_enabled ? "Shortcuts visible" :
-                                                                "Shortcuts hidden" );
-                                        jmethodID method_id = env->GetMethodID( clazz, "toast", "(Ljava/lang/String;)V" );
-                                        env->CallVoidMethod( activity, method_id, toast_message );
-                                        env->DeleteLocalRef( activity );
-                                        env->DeleteLocalRef( clazz );
-                                    }
-                                } else {
-                                    last_input = input_event( three_tap_key, input_event_t::keyboard_char );
-                                }
-                            } else {
-                                float dot = ( x1 * x2 + y1 * y2 ) / ( d1 * d2 ); // dot product of two finger vectors, -1 to +1
-                                float dot2 = ( x1 * x3 + y1 * y3 ) / ( d1 * d3 ); // dot product of three finger vectors, -1 to +1
-                                if( dot > 0.0f &&
-                                    dot2 > 0.0f ) { // all fingers mostly heading in same direction, check for triple-finger swipe gesture
-                                    float dratio = d1 / d2;
-                                    const float dist_ratio = 0.3f;
-                                    if( dratio > dist_ratio &&
-                                        dratio < ( 1.0f /
-                                                   dist_ratio ) ) { // both fingers moved roughly the same distance, so it's a double-finger swipe!
-                                        float xavg = 0.5f * ( x1 + x2 );
-                                        float yavg = 0.5f * ( y1 + y2 );
-                                        if( xavg > 0 && xavg > std::abs( yavg ) ) {
-                                            last_input = input_event( '\t', input_event_t::keyboard_char );
-                                        } else if( xavg < 0 && -xavg > std::abs( yavg ) ) {
-                                            last_input = input_event( KEY_BTAB, input_event_t::keyboard_char );
-                                        } else if( yavg > 0 && yavg > std::abs( xavg ) ) {
-                                            last_input = input_event( KEY_NPAGE, input_event_t::keyboard_char );
-                                        } else {
-                                            last_input = input_event( KEY_PPAGE, input_event_t::keyboard_char );
-                                        }
-                                    }
-                                }
-                            }
-
-                        } else if( ticks - finger_down_time <= static_cast<uint32_t>(
-                                       get_option<int>( "ANDROID_INITIAL_DELAY" ) ) ) {
-                            handle_finger_input( ticks );
+                        }
+                        third_finger_down_x = third_finger_curr_x = second_finger_down_x = second_finger_curr_x =
+                                                  finger_down_x = finger_curr_x = -1.0f;
+                        third_finger_down_y = third_finger_curr_y = second_finger_down_y = second_finger_curr_y =
+                                                  finger_down_y = finger_curr_y = -1.0f;
+                        is_two_finger_touch = false;
+                        is_three_finger_touch = false;
+                        finger_down_time = 0;
+                        finger_repeat_time = 0;
+                        needupdate = true; // ensure virtual joystick and quick shortcuts are updated properly
+                        ui_manager::redraw_invalidated();
+                        refresh_display(); // as above, but actually redraw it now as well
+                    } else if( GetFingerID( ev ) == 1 ) {
+                        if( is_two_finger_touch ) {
+                            // on second finger release, just remember the x/y position so we can calculate delta once first finger is done
+                            // is_two_finger_touch will be reset when first finger lifts (see above)
+                            second_finger_curr_x = GetFingerX( ev, WindowWidth );
+                            second_finger_curr_y = GetFingerY( ev, WindowHeight );
+                        }
+                    } else if( GetFingerID( ev ) == 2 ) {
+                        if( is_three_finger_touch ) {
+                            // on third finger release, just remember the x/y position so we can calculate delta once first finger is done
+                            // is_three_finger_touch will be reset when first finger lifts (see above)
+                            third_finger_curr_x = GetFingerX( ev, WindowWidth );
+                            third_finger_curr_y = GetFingerY( ev, WindowHeight );
                         }
                     }
-                    third_finger_down_x = third_finger_curr_x = second_finger_down_x = second_finger_curr_x =
-                                              finger_down_x = finger_curr_x = -1.0f;
-                    third_finger_down_y = third_finger_curr_y = second_finger_down_y = second_finger_curr_y =
-                                              finger_down_y = finger_curr_y = -1.0f;
-                    is_two_finger_touch = false;
-                    is_three_finger_touch = false;
-                    finger_down_time = 0;
-                    finger_repeat_time = 0;
-                    needupdate = true; // ensure virtual joystick and quick shortcuts are updated properly
-                    ui_manager::redraw_invalidated();
-                    refresh_display(); // as above, but actually redraw it now as well
-                } else if( ev.tfinger.fingerId == 1 ) {
-                    if( is_two_finger_touch ) {
-                        // on second finger release, just remember the x/y position so we can calculate delta once first finger is done
-                        // is_two_finger_touch will be reset when first finger lifts (see above)
-                        second_finger_curr_x = ev.tfinger.x * WindowWidth;
-                        second_finger_curr_y = ev.tfinger.y * WindowHeight;
-                    }
-                } else if( ev.tfinger.fingerId == 2 ) {
-                    if( is_three_finger_touch ) {
-                        // on third finger release, just remember the x/y position so we can calculate delta once first finger is done
-                        // is_three_finger_touch will be reset when first finger lifts (see above)
-                        third_finger_curr_x = ev.tfinger.x * WindowWidth;
-                        third_finger_curr_y = ev.tfinger.y * WindowHeight;
-                    }
-                }
 
-                break;
+                    break;
 #endif
 
-            case SDL_QUIT:
-                quit = true;
-                break;
-            default:
-                if( gamepad::is_gamepad_event( ev ) ) {
-                    if( gamepad::handle_event( ev ) ) {
-                        needupdate = true;
-                        ui_manager::redraw_invalidated();
+                case SDL_QUIT:
+                    quit = true;
+                    break;
+                default:
+                    if( gamepad::is_gamepad_event( ev ) ) {
+                        if( gamepad::handle_event( ev ) ) {
+                            needupdate = true;
+                            ui_manager::redraw_invalidated();
+                        }
                     }
-                }
-                break;
+                    break;
+            }
         }
         if( text_refresh && !is_repeat ) {
             break;
@@ -3721,28 +3726,19 @@ int projected_window_height()
 static std::pair<float, float> get_display_scale( int display_index )
 {
 #if SDL_VERSION_ATLEAST(2,26,0)
-    // NOLINTNEXTLINE(cata-combine-locals-into-point)
-    int x = SDL_WINDOWPOS_CENTERED_DISPLAY( display_index );
-    // NOLINTNEXTLINE(cata-combine-locals-into-point)
-    int y = SDL_WINDOWPOS_CENTERED_DISPLAY( display_index );
-
-    SDL_Window *w = SDL_CreateWindow(
-                        "probe",
-                        x, y,
-                        16, 16,
-                        SDL_WINDOW_HIDDEN | SDL_WINDOW_ALLOW_HIGHDPI
-                    );
-    if( !w ) {
+    SDL_Window_Ptr probe = CreateGameWindow( "probe", display_index, 16, 16,
+                           CATA_WINDOW_HIDDEN | CATA_WINDOW_HIGH_DPI );
+    if( !probe ) {
         return std::make_pair( 1.0f, 1.0f );
     }
 
     int lw = 0;
     int lh = 0;
-    SDL_GetWindowSize( w, &lw, &lh );
-    int pw;
-    int ph;
-    SDL_GetWindowSizeInPixels( w, &pw, &ph );
-    SDL_DestroyWindow( w );
+    GetWindowSize( probe.get(), &lw, &lh );
+    int pw = 0;
+    int ph = 0;
+    GetWindowSizeInPixels( probe.get(), &pw, &ph );
+    probe.reset();
 
     float scale_w = lw ? static_cast<float>( pw ) / static_cast<float>( lw ) : 1.0f;
     float scale_h = lh ? static_cast<float>( ph ) / static_cast<float>( lh ) : 1.0f;
@@ -3774,24 +3770,17 @@ static void init_term_size_and_scaling_factor()
         int current_display_id = std::stoi( get_option<std::string>( "DISPLAY" ) );
         SDL_DisplayMode current_display;
 
-        if( SDL_GetDesktopDisplayMode( current_display_id, &current_display ) == 0 ) {
+        if( GetDesktopDisplayMode( current_display_id, &current_display ) ) {
             if( get_option<std::string>( "FULLSCREEN" ) == "no" ) {
 
                 // Make a maximized test window to determine maximum windowed size
-                SDL_Window_Ptr test_window;
-                test_window.reset( SDL_CreateWindow( "test_window",
-                                                     SDL_WINDOWPOS_CENTERED_DISPLAY( current_display_id ),
-                                                     SDL_WINDOWPOS_CENTERED_DISPLAY( current_display_id ),
-                                                     EVEN_MINIMUM_TERM_WIDTH * fontwidth,
-                                                     EVEN_MINIMUM_TERM_HEIGHT * fontheight,
-                                                     SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI | SDL_WINDOW_MAXIMIZED
-                                                   ) );
+                SDL_Window_Ptr test_window = CreateGameWindow(
+                                                 "test_window", current_display_id,
+                                                 EVEN_MINIMUM_TERM_WIDTH * fontwidth,
+                                                 EVEN_MINIMUM_TERM_HEIGHT * fontheight,
+                                                 CATA_WINDOW_RESIZABLE | CATA_WINDOW_HIGH_DPI | CATA_WINDOW_MAXIMIZED );
 
-#if SDL_VERSION_ATLEAST(2,26,0)
-                SDL_GetWindowSizeInPixels( test_window.get(), &max_width, &max_height );
-#else
-                SDL_GetWindowSize( test_window.get(), &max_width, &max_height );
-#endif
+                GetWindowSizeInPixels( test_window.get(), &max_width, &max_height );
 
                 // If the video subsystem isn't reset the test window messes things up later
                 test_window.reset();
@@ -4050,9 +4039,9 @@ input_event input_manager::get_input_event( const keyboard_mode preferred_keyboa
 
 #if !defined(__ANDROID__) && !(defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE == 1)
     if( actual_keyboard_mode( preferred_keyboard_mode ) == keyboard_mode::keychar ) {
-        StartTextInput();
+        focus_aware_start_text_input();
     } else {
-        StopTextInput();
+        focus_aware_stop_text_input();
     }
 #else
     // TODO: support keycode mode if hardware keyboard is connected?
@@ -4084,12 +4073,12 @@ input_event input_manager::get_input_event( const keyboard_mode preferred_keyboa
             SDL_Delay( 1 );
         } while( last_input.type == input_event_t::error );
     } else if( inputdelay > 0 ) {
-        uint32_t starttime = SDL_GetTicks();
+        uint32_t starttime = GetTicks();
         uint32_t endtime = 0;
         bool timedout = false;
         do {
             CheckMessages();
-            endtime = SDL_GetTicks();
+            endtime = GetTicks();
             if( last_input.type != input_event_t::error ) {
                 break;
             }
@@ -4103,7 +4092,7 @@ input_event input_manager::get_input_event( const keyboard_mode preferred_keyboa
         CheckMessages();
     }
 
-    SDL_GetMouseState( &last_input.mouse_pos.x, &last_input.mouse_pos.y );
+    GetMouseState( &last_input.mouse_pos.x, &last_input.mouse_pos.y );
     if( last_input.type == input_event_t::keyboard_char ) {
         previously_pressed_key = last_input.get_first_input();
 #if defined(__ANDROID__)
@@ -4387,14 +4376,14 @@ bool save_screenshot( const std::string &file_path )
     SDL_Rect viewport;
 
     // Get the viewport size (width and height of the screen)
-    SDL_RenderGetViewport( renderer.get(), &viewport );
+    RenderGetViewport( renderer, &viewport );
 
     // Create SDL_Surface with depth of 32 bits (note: using zeros for the RGB masks sets a default value, based on the depth; Alpha mask will be 0).
     SDL_Surface_Ptr surface = CreateRGBSurface( 0, viewport.w, viewport.h, 32, 0, 0, 0, 0 );
 
     // Get data from SDL_Renderer and save them into surface
-    if( printErrorIf( SDL_RenderReadPixels( renderer.get(), nullptr, GetSurfacePixelFormat( surface ),
-                                            surface->pixels, surface->pitch ) != 0,
+    if( printErrorIf( !RenderReadPixels( renderer, nullptr, GetSurfacePixelFormat( surface ),
+                                         surface->pixels, surface->pitch ),
                       "save_screenshot: cannot read data from SDL_Renderer." ) ) {
         return false;
     }
@@ -4421,13 +4410,18 @@ HWND getWindowHandle()
 void set_title( const std::string &title )
 {
     if( ::window ) {
-        SDL_SetWindowTitle( ::window.get(), title.c_str() );
+        SetWindowTitle( ::window.get(), title.c_str() );
     }
 }
 
 const SDL_Renderer_Ptr &get_sdl_renderer()
 {
     return renderer;
+}
+
+SDL_Window *get_sdl_window()
+{
+    return ::window.get();
 }
 
 #endif // TILES

--- a/src/sdltiles.h
+++ b/src/sdltiles.h
@@ -64,6 +64,9 @@ window_dimensions get_window_dimensions( const catacurses::window &win );
 window_dimensions get_window_dimensions( const point &pos, const point &size );
 
 const SDL_Renderer_Ptr &get_sdl_renderer();
+// Returns the main game window. Needed by text input wrappers and other
+// SDL3 APIs that require an explicit window parameter.
+SDL_Window *get_sdl_window();
 
 #endif // TILES
 

--- a/src/string_editor_window.cpp
+++ b/src/string_editor_window.cpp
@@ -8,6 +8,7 @@
 
 #if defined(TILES)
 #include "sdl_wrappers.h"
+#include "sdltiles.h"
 #endif
 
 #if defined(__ANDROID__)
@@ -416,7 +417,7 @@ std::pair<bool, std::string> string_editor_window::query_string()
 #if defined(__ANDROID__)
     on_out_of_scope stop_text_input( []() {
         if( get_option<bool>( "ANDROID_AUTO_KEYBOARD" ) ) {
-            StopTextInput();
+            StopTextInput( get_sdl_window() );
         }
     } );
 #endif
@@ -509,11 +510,7 @@ std::pair<bool, std::string> string_editor_window::query_string()
             if( action == "TEXT.PASTE" ) {
 #if defined(TILES)
                 if( edit.empty() ) {
-                    char *const clip = SDL_GetClipboardText();
-                    if( clip ) {
-                        entered = clip;
-                        SDL_free( clip );
-                    }
+                    entered = GetClipboardText();
                 }
 #endif
             } else if( action == "TEXT.INPUT_FROM_FILE" ) {

--- a/src/string_input_popup.cpp
+++ b/src/string_input_popup.cpp
@@ -22,6 +22,7 @@
 
 #if defined(TILES)
 #include "sdl_wrappers.h"
+#include "sdltiles.h"
 #endif
 
 #if defined(__ANDROID__)
@@ -488,7 +489,7 @@ const std::string &string_input_popup::query_string( const bool loop, const bool
         } else if( action == "TEXT.QUIT" ) {
 #if defined(__ANDROID__)
             if( get_option<bool>( "ANDROID_AUTO_KEYBOARD" ) ) {
-                StopTextInput();
+                StopTextInput( get_sdl_window() );
             }
 #endif
             _text.clear();
@@ -561,11 +562,7 @@ const std::string &string_input_popup::query_string( const bool loop, const bool
                 if( action == "TEXT.PASTE" ) {
 #if defined(TILES)
                     if( edit.empty() ) {
-                        char *const clip = SDL_GetClipboardText();
-                        if( clip ) {
-                            entered = clip;
-                            SDL_free( clip );
-                        }
+                        entered = GetClipboardText();
                     }
 #endif
                 } else if( action == "TEXT.INPUT_FROM_FILE" ) {

--- a/src/uilist.cpp
+++ b/src/uilist.cpp
@@ -66,7 +66,7 @@ void uilist_impl::draw_controls()
 {
 #if defined(TILES)
     using cata::options::mouse;
-    bool cursor_shown = SDL_ShowCursor( SDL_QUERY ) == SDL_ENABLE;
+    bool cursor_shown = IsCursorVisible();
     if( mouse.hidekb && !cursor_shown ) {
         ImGui::GetIO().ConfigFlags |= ImGuiConfigFlags_NoMouse;
     } else {


### PR DESCRIPTION
#### Summary
Infrastructure "Wrap remaining SDL2 calls behind abstraction layer for SDL3 dual support"

#### Purpose of change

Continuation of the SDL abstraction series (#86055, #86103, #86105, #86106). Those PRs wrapped rendering, surfaces, TTF, and gamepad dispatch. This one wraps everything else so the codebase can eventually build against both SDL2 and SDL3 from the same source. All SDL version differences concentrate inside `sdl_wrappers.cpp` (and `sdl_gamepad.cpp` internals), with callers using only version-independent APIs.

#### Describe the solution

New wrappers in `sdl_wrappers.h/cpp` for display enumeration, renderer info/enumeration, render ops (`RenderPresent`, `RenderSetLogicalSize`, `RenderSetScale`, `RenderReadPixels`, etc.), timers, cursor show/hide/query, clipboard, mouse state, keyboard scancode query, window size, and text input. Text input wrappers now take `SDL_Window *` (SDL3 requirement) with a `get_sdl_window()` accessor added to `sdltiles.h`. Focus-aware text input helpers in sdltiles.cpp renamed to `focus_aware_start/stop_text_input()` to avoid collision with the pure wrappers.

Higher-level abstractions for window creation (`CreateWindow` with `CATA_WINDOW_*` normalized flag constants), renderer creation (`CreateRenderer` taking a driver name + boolean flags instead of raw index + SDL flags), and fullscreen toggling (`SetWindowFullscreen` with a `FullscreenMode` enum preserving exclusive vs borderless semantics). Startup fullscreen is applied after window creation rather than baked into window flags, so both modes work through the same code path.

Event loop restructured: `SDL_WINDOWEVENT` + subtypes replaced with `IsWindowEvent()`/`GetWindowEventID()` + `CATA_WINDOWEVENT_*` constants. `SDL_TEXTEDITING_EXT` guarded for SDL3 removal. `ConvertEventCoordinates()` inserted after `SDL_PollEvent` for SDL3's explicit coordinate conversion (SDL2 path is a no-op). Touch events use `CATA_FINGERMOTION/DOWN/UP` constants, `GetFingerX/Y()` helpers for the normalized-vs-absolute coordinate split, and `GetFingerID()` for the `fingerId`->`fingerID` rename. Keyboard events use `CataKeysym` struct + `GetKeysym()` accessor replacing direct `ev.key.keysym` access (SDL3 removes `SDL_Keysym` from key events).

`SDL_HINT_RENDER_SCALE_QUALITY` replaced entirely with per-texture `SetTextureScaleQuality()` / `SetDefaultTextureScaleQuality()` using `SDL_SetTextureScaleMode` (available in SDL2 2.0.12+ and SDL3). Default initialized to "nearest" matching SDL2's documented hint default. `CreateTexture`/`CreateTextureFromSurface` wrappers auto-apply the stored default.

Gamepad module (`sdl_gamepad.cpp`) gets full dual-support: normalized event/button/axis constants, `#if SDL_MAJOR_VERSION >= 3` branches for init (`SDL_INIT_GAMEPAD`), open/close (`SDL_OpenGamepad`/`SDL_CloseGamepad`), axis query (`SDL_GetGamepadAxis`), timer callback signature, device event struct members (`gdevice`/`gbutton`/`gaxis` vs `cdevice`/`cbutton`/`caxis`), and joystick ID semantics. Event timestamps replaced with `GetTicks()` for consistent millisecond timebase (SDL3 event timestamps are nanoseconds).

Separate `sdl_version_wrappers.h` (header-only) for version queries, avoiding the `SDL_MAIN_HANDLED` define in `sdl_wrappers.h` that would break `main.cpp` entry-point plumbing.

`SetRenderTarget` return type changed from `void` to `bool` so `SetupRenderTarget()` can still propagate bind failures.

#### Describe alternatives you've considered

N/A

#### Testing

Verified in-game: loaded a world, toggled fullscreen, checked cursor hide/show, pasted from clipboard in string editor, took a screenshot, tested 2x scaling factor. No visual or behavioral regressions.

#### Additional context

Deliberately does not touch ImGui (`imgui_impl_sdl2` / `imgui_impl_sdlrenderer2`), `sdlsound.cpp` (Mix_* calls), or the build system. Those belong in the follow-up PR that actually enables SDL3 compilation.