### PR TITLE
Fix camp NPC oscillation on expansion tiles

### DIFF
--- a/src/character_oracle.cpp
+++ b/src/character_oracle.cpp
@@ -6,6 +6,7 @@
 #include <optional>
 #include <vector>
 
+#include "basecamp.h"
 #include "behavior.h"
 #include "bodypart.h"
 #include "calendar.h"
@@ -17,6 +18,7 @@
 #include "mapdata.h"
 #include "npc.h"
 #include "npc_class.h"
+#include "overmapbuffer.h"
 #include "point.h"
 #include "ret_val.h"
 #include "stomach.h"
@@ -29,6 +31,22 @@ static const efftype_id effect_meth( "meth" );
 static const efftype_id effect_npc_run_away( "npc_run_away" );
 static const json_character_flag json_flag_CANNOT_MOVE( "CANNOT_MOVE" );
 static const trait_id trait_IGNORE_SOUND( "IGNORE_SOUND" );
+
+// Whether the NPC is on any tile belonging to their assigned camp,
+// including expansions.  Falls back to base-OMT match when the camp
+// object is gone (abandoned) but assigned_camp is still set.
+static bool npc_within_camp( const npc &n )
+{
+    if( !n.assigned_camp ) {
+        return false;
+    }
+    std::optional<basecamp *> bcp = overmap_buffer.find_camp( n.assigned_camp->xy() );
+    if( !bcp || !*bcp ) {
+        // Camp object gone -- fall back to base-OMT check.
+        return n.pos_abs_omt() == *n.assigned_camp;
+    }
+    return ( *bcp )->point_within_camp( n.pos_abs_omt() );
+}
 
 namespace behavior
 {
@@ -436,7 +454,7 @@ status_t character_oracle_t::has_camp_job( std::string_view ) const
     if( !n || !n->assigned_camp || n->mission != NPC_MISSION_CAMP_RESIDENT ) {
         return status_t::failure;
     }
-    if( n->pos_abs_omt() != *n->assigned_camp ) {
+    if( !npc_within_camp( *n ) ) {
         return status_t::failure;
     }
     if( !n->has_job() ) {
@@ -454,8 +472,7 @@ status_t character_oracle_t::is_away_from_camp( std::string_view ) const
     if( !n || !n->assigned_camp || n->mission != NPC_MISSION_CAMP_RESIDENT ) {
         return status_t::failure;
     }
-    return n->pos_abs_omt() != *n->assigned_camp
-           ? status_t::running : status_t::failure;
+    return npc_within_camp( *n ) ? status_t::failure : status_t::running;
 }
 
 status_t character_oracle_t::is_camp_idle( std::string_view ) const
@@ -467,7 +484,7 @@ status_t character_oracle_t::is_camp_idle( std::string_view ) const
     if( n->get_attitude() == NPCATT_ACTIVITY ) {
         return status_t::failure;
     }
-    if( n->pos_abs_omt() != *n->assigned_camp ) {
+    if( !npc_within_camp( *n ) ) {
         return status_t::failure;
     }
     return status_t::running;
@@ -477,7 +494,7 @@ float character_oracle_t::camp_work_urgency( std::string_view ) const
 {
     const npc *n = dynamic_cast<const npc *>( subject );
     if( !n || !n->assigned_camp || n->mission != NPC_MISSION_CAMP_RESIDENT
-        || n->pos_abs_omt() != *n->assigned_camp || !n->has_job() ) {
+        || !npc_within_camp( *n ) || !n->has_job() ) {
         return 0.0f;
     }
     return 0.4f;
@@ -487,7 +504,7 @@ float character_oracle_t::return_to_camp_urgency( std::string_view ) const
 {
     const npc *n = dynamic_cast<const npc *>( subject );
     if( !n || !n->assigned_camp || n->mission != NPC_MISSION_CAMP_RESIDENT
-        || n->pos_abs_omt() == *n->assigned_camp ) {
+        || npc_within_camp( *n ) ) {
         return 0.0f;
     }
     // Below follow max (0.6), above duty (0.45).
@@ -499,7 +516,7 @@ float character_oracle_t::free_time_urgency( std::string_view ) const
     const npc *n = dynamic_cast<const npc *>( subject );
     if( !n || !n->assigned_camp || n->mission != NPC_MISSION_CAMP_RESIDENT
         || n->get_attitude() == NPCATT_ACTIVITY
-        || n->pos_abs_omt() != *n->assigned_camp ) {
+        || !npc_within_camp( *n ) ) {
         return 0.0f;
     }
     return 0.35f;

--- a/src/npctalk_funcs.cpp
+++ b/src/npctalk_funcs.cpp
@@ -480,7 +480,16 @@ void talk_function::return_to_camp_duties( npc &p )
     p.clear_ai_guard_pos();
     p.clear_committed_goal();
     p.chatbin.first_topic = "TALK_FRIEND_CAMP_RESIDENT";
-    if( p.assigned_camp && p.pos_abs_omt() != *p.assigned_camp ) {
+    // Check whether the NPC is already within the camp footprint
+    // (including expansion tiles), not just the base OMT.
+    bool at_camp = false;
+    if( p.assigned_camp ) {
+        std::optional<basecamp *> bcp = overmap_buffer.find_camp( p.assigned_camp->xy() );
+        at_camp = ( bcp && *bcp )
+                  ? ( *bcp )->point_within_camp( p.pos_abs_omt() )
+                  : p.pos_abs_omt() == *p.assigned_camp;
+    }
+    if( p.assigned_camp && !at_camp ) {
         p.goal = *p.assigned_camp;
         tripoint_abs_omt surface = p.pos_abs_omt();
         surface.z() = 0;

--- a/tests/behavior_test.cpp
+++ b/tests/behavior_test.cpp
@@ -8,6 +8,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "basecamp.h"
 #include "behavior.h"
 #include "behavior_oracle.h"
 #include "behavior_strategy.h"
@@ -40,6 +41,7 @@
 #include "npc.h"
 #include "npc_class.h"
 #include "options_helpers.h"
+#include "overmapbuffer.h"
 #include "player_helpers.h"
 #include "pocket_type.h"
 #include "point.h"
@@ -1701,7 +1703,12 @@ TEST_CASE( "bt_priority_matrix", "[npc][behavior]" )
     }
     SECTION( "camp resident idle: free_time" ) {
         guy.set_mission( NPC_MISSION_CAMP_RESIDENT );
-        guy.assigned_camp = project_to<coords::omt>( guy.pos_abs() );
+        const tripoint_abs_omt comt = project_to<coords::omt>( guy.pos_abs() );
+        here.add_camp( comt, "faction_camp" );
+        std::optional<basecamp *> cbcp = overmap_buffer.find_camp( comt.xy() );
+        REQUIRE( cbcp );
+        ( *cbcp )->define_camp( comt, "faction_base_bare_bones_NPC_camp_0", false );
+        guy.assigned_camp = comt;
         guy.guard_pos = std::nullopt;
         guy.clear_ai_guard_pos();
         CHECK( bt_goal( guy ) == "free_time" );
@@ -1751,7 +1758,15 @@ TEST_CASE( "bt_camp_resident_goals", "[npc][behavior]" )
     clear_character( guy, true );
     guy.set_fac( faction_your_followers );
     guy.set_mission( NPC_MISSION_CAMP_RESIDENT );
-    guy.assigned_camp = project_to<coords::omt>( guy.pos_abs() );
+
+    // Create a real camp so the BT predicates can resolve it.
+    const tripoint_abs_omt camp_omt = project_to<coords::omt>( guy.pos_abs() );
+    here.add_camp( camp_omt, "faction_camp" );
+    std::optional<basecamp *> bcp = overmap_buffer.find_camp( camp_omt.xy() );
+    REQUIRE( bcp );
+    ( *bcp )->define_camp( camp_omt, "faction_base_bare_bones_NPC_camp_0", false );
+
+    guy.assigned_camp = camp_omt;
     guy.guard_pos = std::nullopt;
     guy.clear_ai_guard_pos();
 
@@ -1773,6 +1788,63 @@ TEST_CASE( "bt_camp_resident_goals", "[npc][behavior]" )
         behavior::character_oracle_t oracle( &guy );
         REQUIRE( oracle.has_water( "" ) == behavior::status_t::running );
         CHECK( bt_goal( guy ) == "drink_water" );
+    }
+}
+
+TEST_CASE( "bt_camp_resident_expansion_tile", "[npc][behavior]" )
+{
+    clear_map_without_vision();
+    clear_avatar();
+    map &here = get_map();
+
+    // Place camp at mid-map so we control OMT alignment.
+    const tripoint_bub_ms mid{ MAPSIZE_X / 2, MAPSIZE_Y / 2, 0 };
+    const tripoint_abs_omt camp_omt = project_to<coords::omt>( here.get_abs( mid ) );
+
+    here.add_camp( camp_omt, "faction_camp" );
+    std::optional<basecamp *> bcp = overmap_buffer.find_camp( camp_omt.xy() );
+    REQUIRE( bcp );
+    basecamp *test_camp = *bcp;
+    test_camp->define_camp( camp_omt, "faction_base_bare_bones_NPC_camp_0", false );
+
+    // Add an expansion one OMT to the east.
+    const tripoint_abs_omt expansion_omt = camp_omt + tripoint::east;
+    test_camp->add_expansion( "faction_base_farm_0", expansion_omt,
+                              point_rel_omt{ 1, 0 } );
+    REQUIRE( test_camp->point_within_camp( expansion_omt ) );
+
+    // Spawn NPC anywhere, then teleport to the expansion tile.
+    npc &guy = spawn_npc( mid.xy(), "test_talker" );
+    clear_character( guy, true );
+    const tripoint_abs_ms expansion_center =
+        project_to<coords::ms>( expansion_omt ) + tripoint{ SEEX, SEEY, 0 };
+    const tripoint_bub_ms expansion_local = here.get_bub( expansion_center );
+    REQUIRE( here.inbounds( expansion_local ) );
+    guy.setpos( here, expansion_local );
+    guy.set_fac( faction_your_followers );
+    guy.set_mission( NPC_MISSION_CAMP_RESIDENT );
+    guy.assigned_camp = camp_omt;
+    guy.guard_pos = std::nullopt;
+    guy.clear_ai_guard_pos();
+
+    REQUIRE( guy.pos_abs_omt() == expansion_omt );
+    REQUIRE( guy.pos_abs_omt() != camp_omt );
+
+    SECTION( "on expansion tile: free_time, not return_to_camp" ) {
+        CHECK( bt_goal( guy ) == "free_time" );
+    }
+    SECTION( "on expansion tile: camp predicates treat as at-camp" ) {
+        behavior::character_oracle_t oracle( &guy );
+        CHECK( oracle.is_camp_idle( "" ) == behavior::status_t::running );
+        CHECK( oracle.is_away_from_camp( "" ) == behavior::status_t::failure );
+    }
+    SECTION( "on expansion tile with job: camp_work fires" ) {
+        guy.job.set_all_priorities( 1 );
+        REQUIRE( guy.has_job() );
+        guy.last_job_scan = calendar::turn - 11_minutes;
+        behavior::character_oracle_t oracle( &guy );
+        CHECK( oracle.has_camp_job( "" ) == behavior::status_t::running );
+        CHECK( oracle.camp_work_urgency( "" ) > 0.0f );
     }
 }
 


### PR DESCRIPTION
#### Summary
Bugfixes "Fix camp NPC oscillation on expansion tiles"

#### Purpose of change

Fixes #86361. NPCs assigned to an expanded faction camp oscillate between `return_to_camp` and `free_time` every turn. The BT camp predicates in `character_oracle.cpp` all gate on `pos_abs_omt() == *assigned_camp`, which only matches the base camp OMT. When `worker_downtime()` sends an NPC to a chair in an expansion tile (it correctly uses `basecamp::point_within_camp()`), the BT sees them as "away from camp" and fires `return_to_camp`. They walk back, `free_time` fires, they find the expansion chair again, repeat forever.

#### Describe the solution

New `npc_within_camp()` helper in `character_oracle.cpp` that resolves `assigned_camp` to the actual `basecamp` object via `overmap_buffer::find_camp()` and checks `point_within_camp()`, covering all expansion tiles. All six camp BT predicates/scores (`has_camp_job`, `is_away_from_camp`, `is_camp_idle`, `camp_work_urgency`, `return_to_camp_urgency`, `free_time_urgency`) use it instead of the old direct OMT comparison.

When the camp object is gone (player abandoned it) but `assigned_camp` is still set (preserved by `stop_guard()` for the "go back to camp" dialogue path), the helper falls back to the old exact-OMT match so NPCs can still idle at the remembered location.

Same expansion-aware check applied to `return_to_camp_duties()` in `npctalk_funcs.cpp` so the dialogue path doesn't needlessly route an NPC already standing on an expansion tile back to the base OMT.

#### Describe alternatives you've considered

N/A

#### Testing

Three new test sections in `bt_camp_resident_expansion_tile`: NPC on expansion tile gets `free_time` (not `return_to_camp`), `is_camp_idle`/`is_away_from_camp` predicates treat expansion as at-camp, and `has_camp_job`/`camp_work_urgency` fire correctly on expansion tiles with a job set. Existing `[npc][behavior]` suite passes. Verified in-game.

#### Additional context

None.