### PR TITLE
Fix restock time display for Hub 01 intercom

### DIFF
--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2324,6 +2324,21 @@ npc &npc::get_trade_delegate()
     return *this;
 }
 
+const npc &npc::get_trade_delegate() const
+{
+    if( !has_trait( trait_INTERCOM_OPERATOR ) ) {
+        return *this;
+    }
+    const faction_id fac = get_fac_id();
+    for( const npc *guy : g->get_npcs_if( [&fac]( const npc & n ) {
+    return n.has_trait( trait_TRADE_BACKEND ) &&
+               n.get_fac_id() == fac;
+    } ) ) {
+        return *guy;
+    }
+    return *this;
+}
+
 void npc::reconcile_schedule()
 {
     if( myclass.is_null() ) {

--- a/src/npc.h
+++ b/src/npc.h
@@ -1014,6 +1014,7 @@ class npc : public Character
         // Return the NPC who should actually handle trade for this NPC.
         // Default: self. Intercom operators delegate to the supply clerk.
         npc &get_trade_delegate();
+        const npc &get_trade_delegate() const;
         // Reconcile shift-based schedule state. Wakes sleeping NPCs at
         // shift start, floors sleepiness off-shift for !needs_food() NPCs.
         // Called from npc_update_body() (in-bubble) and on_load() (off-bubble).

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -2504,24 +2504,26 @@ void parse_tags( std::string &phrase, const_talker const &u, const_talker const 
             phrase.replace( fa, l, format_money( price ) );
         } else if( tag == "<interval>" ) {
             const npc *guy = dynamic_cast<const npc *>( me_chr );
-            std::string restock_interval = guy ? guy->get_restock_interval() : _( "a few days" );
+            const npc *trader = guy ? &guy->get_trade_delegate() : nullptr;
+            std::string restock_interval = trader ? trader->get_restock_interval() : _( "a few days" );
             phrase.replace( fa, l, restock_interval );
         } else if( tag == "<restock_time_point>" ) {
             const npc *guy = dynamic_cast<const npc *>( me_chr );
-            if( guy == nullptr ) {
+            const npc *trader = guy ? &guy->get_trade_delegate() : nullptr;
+            if( trader == nullptr ) {
                 phrase.replace( fa, l, _( "the future" ) );
             } else if( get_option<bool>( "SHOW_MONTHS" ) && calendar::year_length() ==  364_days ) {
-                std::pair<month, int> month_day = month_and_day( guy->restock_time() );
+                std::pair<month, int> month_day = month_and_day( trader->restock_time() );
                 //~ 1 is month, 2 is day
                 phrase.replace( fa, l, string_format( pgettext( "month, day and time", "%1$s %2$d, %3$s" ),
                                                       to_string( month_day.first ), month_day.second,
-                                                      to_string_time_of_day( guy->restock_time() ) ) );
+                                                      to_string_time_of_day( trader->restock_time() ) ) );
             } else {
                 //~ 1 is season, 2 is day
                 phrase.replace( fa, l, string_format( pgettext( "season, day, and time", "%1$s %2$d, %3$s" ),
-                                                      calendar::name_season( season_of_year( guy->restock_time() ) ),
-                                                      day_of_season<int>( guy->restock_time() ) + 1,
-                                                      to_string_time_of_day( guy->restock_time() ) ) );
+                                                      calendar::name_season( season_of_year( trader->restock_time() ) ),
+                                                      day_of_season<int>( trader->restock_time() ) + 1,
+                                                      to_string_time_of_day( trader->restock_time() ) ) );
             }
         } else if( tag.find( "<u_val:" ) == 0 ) {
             //adding a user variable to the string


### PR DESCRIPTION
#### Summary
Bugfixes "Fix restock time display for Hub 01 intercom"

#### Purpose of change

Fixes #86351.

The intercom shift rotation in #86140 split trade into a delegate pattern -- the intercom operator handles dialogue, but a supply clerk NPC holds the shop inventory and gets restocked. The `<restock_time_point>` and `<interval>` dialogue tags still read from the operator, whose `restock` field is never set, so the displayed date is always relative to `calendar::turn_zero`.

#### Describe the solution

Added a const overload of `npc::get_trade_delegate()` and wired both dialogue tags through it. For regular shopkeepers the delegate is self, so nothing changes. For intercom operators it resolves to the supply clerk and reads the correct restock time.

#### Describe alternatives you've considered

Could have made `restock_time()` / `get_restock_interval()` themselves delegate-aware, but that's a broader semantic change to methods used elsewhere. Fixing it at the call site in `parse_tags` is more explicit and keeps the delegation visible.

#### Testing

Existing [npc] test suite passes. Verified in-game.

#### Additional context

None.