### PR TITLE
Add VI key navigation to menus that are missing them

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -4,8 +4,9 @@
     "id": "UILIST.UP",
     "name": "Pan up",
     "bindings": [
+      { "input_method": "keyboard_any", "key": "k" },
       { "input_method": "keyboard_any", "key": "UP" },
-      { "input_method": "keyboard_any", "key": "8" },
+      { "input_method": "keyboard_any", "key": "8" },  
       { "input_method": "keyboard_code", "key": "KEYPAD_8" },
       { "input_method": "gamepad", "key": "RS_UP" }
     ]
@@ -15,6 +16,7 @@
     "id": "UILIST.DOWN",
     "name": "Pan down",
     "bindings": [
+      { "input_method": "keyboard_any", "key": "j" },
       { "input_method": "keyboard_any", "key": "DOWN" },
       { "input_method": "keyboard_any", "key": "2" },
       { "input_method": "keyboard_code", "key": "KEYPAD_2" },
@@ -26,6 +28,7 @@
     "id": "UILIST.LEFT",
     "name": "Pan left",
     "bindings": [
+      { "input_method": "keyboard_any", "key": "h" },
       { "input_method": "keyboard_any", "key": "LEFT" },
       { "input_method": "keyboard_any", "key": "4" },
       { "input_method": "keyboard_code", "key": "KEYPAD_4" },
@@ -37,6 +40,7 @@
     "id": "UILIST.RIGHT",
     "name": "Pan right",
     "bindings": [
+      { "input_method": "keyboard_any", "key": "l" },
       { "input_method": "keyboard_any", "key": "RIGHT" },
       { "input_method": "keyboard_any", "key": "6" },
       { "input_method": "keyboard_code", "key": "KEYPAD_6" },
@@ -3868,6 +3872,7 @@
     "category": "BIONICS",
     "name": "Move cursor up",
     "bindings": [
+      { "input_method": "keyboard_any", "key": "k" },
       { "input_method": "keyboard_any", "key": "8" },
       { "input_method": "keyboard_code", "key": "KEYPAD_8" },
       { "input_method": "keyboard_any", "key": "UP" },
@@ -3880,6 +3885,7 @@
     "category": "BIONICS",
     "name": "Move cursor down",
     "bindings": [
+      { "input_method": "keyboard_any", "key": "j" },
       { "input_method": "keyboard_any", "key": "DOWN" },
       { "input_method": "keyboard_any", "key": "2" },
       { "input_method": "keyboard_code", "key": "KEYPAD_2" },

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -6,7 +6,7 @@
     "bindings": [
       { "input_method": "keyboard_any", "key": "k" },
       { "input_method": "keyboard_any", "key": "UP" },
-      { "input_method": "keyboard_any", "key": "8" },  
+      { "input_method": "keyboard_any", "key": "8" },
       { "input_method": "keyboard_code", "key": "KEYPAD_8" },
       { "input_method": "gamepad", "key": "RS_UP" }
     ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Interface "Standardize menu navigation by adding VI keys to menus they are missing from"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
This is a continuation of my crusade to create a more consistent menu experience for VI key users that was started in #86288.  See that PR for more details on rationale behind this.

This PR focuses on making the standard menu navigation keybinds consistent across all menus.  It adds VI key navigation for Spellcasting, Bionics, Escape Menu, Debug and others.  Potential conflicts have been addressed so far in #86288 and #86317.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add VI keys for menu navigation to the locations that do not currently contain them, thus creating a consistent menu experience for VI key users.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
None.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Compiled on Windows
Open and checked that there was no issues/conflicts on the following menus:
- Spellcasting
- Bionics
- Escape Menu
- Debug

**IF THERE ARE MENUS I HAVE MISSED, OR CONFLICTS YOU HAVE FOUND PLEASE LET ME KNOW**

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Spellcasting UI: Don't assign hotkeys that are menu navigation keys
#86288
Bionics UI: Don't assign hotkeys that are menu navigation keys
#86317

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
