### PR TITLE
Skip pre-rasterized 1.5x font when CJK glyphs are enabled

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -456,11 +456,14 @@ void cataimgui::client::load_fonts( UNUSED const Font_Ptr &gui_font,
         ImVector<ImWchar> ranges;
         b.BuildRanges( &ranges );
 
-        // Fonts[0] = gui, Fonts[1] = mono, Fonts[2] = gui 1.5x
+        const bool cjk = get_option<bool>( "IMGUI_LOAD_CHINESE" );
+        // Fonts[0] = gui, Fonts[1] = mono, Fonts[2] = gui 1.5x (non-CJK only)
         load_font( io, gui_typefaces, ranges.begin() );
         load_font( io, mono_typefaces, ranges.begin() );
-        load_font( io, gui_typefaces, ranges.begin(),
-                   static_cast<float>( lroundf( fontheight * 1.5f ) ) );
+        if( !cjk ) {
+            load_font( io, gui_typefaces, ranges.begin(),
+                       static_cast<float>( lroundf( fontheight * 1.5f ) ) );
+        }
         for( int i = 0; i < io.Fonts->Fonts.Size; i++ ) {
             io.Fonts->Fonts[i]->SetFallbackStrSizeCallback( GetFallbackStrWidth );
             io.Fonts->Fonts[i]->SetFallbackCharSizeCallback( GetFallbackCharWidth );
@@ -1125,7 +1128,26 @@ void cataimgui::PushMonoFont()
 void cataimgui::PushGuiFont1_5x()
 {
 #ifdef TILES
-    ImGui::PushFont( ImGui::GetIO().Fonts->Fonts[2] );
+    if( ImGui::GetIO().Fonts->Fonts.Size > 2 ) {
+        ImGui::PushFont( ImGui::GetIO().Fonts->Fonts[2] );
+    } else {
+        // CJK mode: no pre-rasterized 1.5x font, fall back to bitmap scaling.
+        // TODO: find a better solution - SetWindowFontScale is obsolete in ImGui
+        // and produces blurry text. Possible ideas: split the atlas into multiple
+        // textures, or use a smaller glyph subset for the scaled font.
+        ImGui::SetWindowFontScale( 1.5f );
+    }
+#endif
+}
+
+void cataimgui::PopGuiFont1_5x()
+{
+#ifdef TILES
+    if( ImGui::GetIO().Fonts->Fonts.Size > 2 ) {
+        ImGui::PopFont();
+    } else {
+        ImGui::SetWindowFontScale( 1.0f );
+    }
 #endif
 }
 

--- a/src/cata_imgui.h
+++ b/src/cata_imgui.h
@@ -174,6 +174,7 @@ bool InputFloat( const char *label, float *v, float step = 0.0f, float step_fast
 void PushGuiFont();
 void PushMonoFont();
 void PushGuiFont1_5x();
+void PopGuiFont1_5x();
 
 bool BeginRightAlign( const char *str_id );
 void EndRightAlign();

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -993,7 +993,7 @@ void crafting_ui_impl::draw_recipe_info_panel()
                 }
             }
 
-            ImGui::PopFont();
+            cataimgui::PopGuiFont1_5x();
         }
 
         // Batch size for all subsequent calculations

--- a/src/loading_ui.cpp
+++ b/src/loading_ui.cpp
@@ -79,7 +79,7 @@ static void redraw()
 
         cataimgui::draw_colored_text( hint, width );
         if( gLUI->large_hint_size ) {
-            ImGui::PopFont();
+            cataimgui::PopGuiFont1_5x();
         }
 
         // loading msg


### PR DESCRIPTION
#### Summary
Bugfixes "Fix ImGui mosaic rendering when CJK glyph ranges are enabled"

#### Purpose of change

#86265 added pre-rasterized scaled GUI fonts to the atlas. With `IMGUI_LOAD_CHINESE` enabled (~21k glyphs), the atlas overflows and glyphs render as color blocks (#86283, #86318). Removing the 2x font in #86337 wasn't enough.

#### Describe the solution

Skip loading the 1.5x font when `IMGUI_LOAD_CHINESE` is on. `PushGuiFont1_5x` falls back to `SetWindowFontScale(1.5f)` when the pre-rasterized font isn't available. Added `PopGuiFont1_5x` to handle cleanup for both paths. Non-CJK users are unaffected.

#### Describe alternatives you've considered

Could load a reduced glyph subset for the scaled font, but that's fragile and still adds atlas pressure. Slightly blurry text beats no text.

#### Testing

Need confirmation from CJK users -- can't reproduce the overflow locally. Both paths render correctly with Latin glyphs.

#### Additional context

N/A