### PR TITLE
[Magiclysm] Add Druid spell caster_conditions

### DIFF
--- a/data/mods/Magiclysm/Spells/druid.json
+++ b/data/mods/Magiclysm/Spells/druid.json
@@ -571,6 +571,20 @@
     "flags": [ "CHANNELING_SPELL", "CONCENTRATE", "SOMATIC", "VERBAL", "NO_LEGS", "NO_HANDS" ],
     "magic_type": "magiclysm_channeling_magic",
     "spell_class": "DRUID",
+    "caster_condition": {
+      "and": [
+        "u_is_outside",
+        {
+          "or": [
+            { "u_is_on_terrain_with_flag": "SHRUB" },
+            { "u_is_on_terrain_with_flag": "DIGGABLE" },
+            { "u_is_on_terrain_with_flag": "YOUNG" }
+          ]
+        },
+        { "not": { "u_near_om_location": "road", "range": 1 } }
+      ]
+    },
+    "caster_condition_fail_message": "You must be surrounded by nature to commune with nature.",
     "difficulty": 4,
     "base_casting_time": 12000,
     "base_energy_cost": 250,
@@ -585,19 +599,6 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_NATURE_COMMUNE",
-    "condition": {
-      "and": [
-        "u_is_outside",
-        {
-          "or": [
-            { "u_is_on_terrain_with_flag": "SHRUB" },
-            { "u_is_on_terrain_with_flag": "DIGGABLE" },
-            { "u_is_on_terrain_with_flag": "YOUNG" }
-          ]
-        },
-        { "not": { "u_near_om_location": "road", "range": 1 } }
-      ]
-    },
     "effect": [
       {
         "u_add_effect": "natures_commune",
@@ -613,8 +614,7 @@
           "math": [ "(( 300 + (u_spell_level('druid_natures_commune') * 165) ) / 2)  * ( channeling_proficiency_modifier() )" ]
         }
       }
-    ],
-    "false_effect": [ { "u_message": "You must be surrounded by nature to commune with nature.", "type": "bad" } ]
+    ]
   },
   {
     "id": "druid_growth",
@@ -1061,6 +1061,8 @@
     "valid_targets": [ "self" ],
     "max_level": 25,
     "spell_class": "DRUID",
+    "caster_condition": "u_is_outside",
+    "caster_condition_fail_message": "You must be outside to cast Renewing the Forest.",
     "shape": "blast",
     "difficulty": 10,
     "effect": "effect_on_condition",
@@ -1073,7 +1075,6 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_DRUID_RENEW_FOREST_SPELL",
-    "condition": "u_is_outside",
     "effect": {
       "run_eocs": [
         {
@@ -1115,8 +1116,7 @@
           }
         }
       ]
-    },
-    "false_effect": [ { "u_message": "You must be outside to cast Renewing the Forest!", "type": "bad" } ]
+    }
   },
   {
     "id": "druid_wood_living_tree_spell",
@@ -1271,23 +1271,7 @@
     "valid_targets": [ "self" ],
     "spell_class": "DRUID",
     "flags": [ "ENHANCEMENT_SPELL", "CONCENTRATE", "VERBAL", "SOMATIC" ],
-    "effect": "effect_on_condition",
-    "effect_str": "EOC_DRUID_TRAVERSE_THE_WILDS",
-    "shape": "blast",
-    "difficulty": 3,
-    "max_level": 15,
-    "min_duration": 90000,
-    "max_duration": 1440000,
-    "duration_increment": 90000,
-    "magic_type": "magiclysm_enhancement_magic",
-    "base_energy_cost": 150,
-    "base_casting_time": 250,
-    "extra_effects": [ { "id": "eoc_enhancement_setup", "hit_self": true } ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_DRUID_TRAVERSE_THE_WILDS",
-    "condition": {
+    "caster_condition": {
       "and": [
         "u_is_outside",
         {
@@ -1300,13 +1284,19 @@
         { "not": { "u_near_om_location": "road", "range": 1 } }
       ]
     },
-    "effect": [
-      {
-        "u_add_effect": "effect_druid_traverse_the_wilds",
-        "duration": { "math": [ "( 900 + (u_spell_level('druid_traverse_the_wilds') * 900)) * enhancement_proficiency_modifier()" ] }
-      }
-    ],
-    "false_effect": [ { "u_message": "You must be surrounded by the wilds to traverse them.", "type": "bad" } ]
+    "caster_condition_fail_message": "You must be surrounded by the wilds to traverse them.",
+    "effect": "attack",
+    "effect_str": "effect_druid_traverse_the_wilds",
+    "shape": "blast",
+    "difficulty": 3,
+    "max_level": 15,
+    "min_duration": 90000,
+    "max_duration": 1440000,
+    "duration_increment": 90000,
+    "magic_type": "magiclysm_enhancement_magic",
+    "base_energy_cost": 150,
+    "base_casting_time": 250,
+    "extra_effects": [ { "id": "eoc_enhancement_setup", "hit_self": true } ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/Magiclysm/Spells/druid.json
+++ b/data/mods/Magiclysm/Spells/druid.json
@@ -698,12 +698,26 @@
     "name": "Restoration",
     "description": "Slowly heal your wounds by drawing on the power of nature.\n\nYou must be <color_yellow>outdoors and in a natural area</color> away from civilization to cast Restoration.",
     "valid_targets": [ "self" ],
-    "effect": "effect_on_condition",
-    "effect_str": "EOC_DRUID_RESTORATION",
+    "effect": "attack",
+    "effect_str": "flask_regeneration",
     "shape": "blast",
     "flags": [ "RESTORATION_SPELL", "CONCENTRATE", "SOMATIC", "VERBAL", "NO_LEGS" ],
     "magic_type": "magiclysm_restoration_magic",
     "spell_class": "DRUID",
+    "caster_condition": {
+      "and": [
+        "u_is_outside",
+        {
+          "or": [
+            { "u_is_on_terrain_with_flag": "SHRUB" },
+            { "u_is_on_terrain_with_flag": "DIGGABLE" },
+            { "u_is_on_terrain_with_flag": "YOUNG" }
+          ]
+        },
+        { "not": { "u_near_om_location": "road", "range": 1 } }
+      ]
+    },
+    "caster_condition_fail_message": "You must be surrounded by nature to use its power to heal.",
     "difficulty": 8,
     "base_casting_time": 12000,
     "final_casting_time": 3000,
@@ -717,30 +731,6 @@
     "min_duration": 15000,
     "max_duration": 90000,
     "duration_increment": 3000
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_DRUID_RESTORATION",
-    "condition": {
-      "and": [
-        "u_is_outside",
-        {
-          "or": [
-            { "u_is_on_terrain_with_flag": "SHRUB" },
-            { "u_is_on_terrain_with_flag": "DIGGABLE" },
-            { "u_is_on_terrain_with_flag": "YOUNG" }
-          ]
-        },
-        { "not": { "u_near_om_location": "road", "range": 1 } }
-      ]
-    },
-    "effect": [
-      {
-        "u_add_effect": "flask_regeneration",
-        "duration": { "math": [ "( 150 + (u_spell_level('druid_healing') * 30)) * ( restoration_proficiency_modifier() )" ] }
-      }
-    ],
-    "false_effect": [ { "u_message": "You must be surrounded by nature to use its power to heal.", "type": "bad" } ]
   },
   {
     "id": "druid_healing_herb",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Magiclysm] Add Druid spell caster_conditions"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

New use of `caster_condition` feature.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Go through druid spells and, where appropriate, add a `caster_condition`. This doesn't add anything new, just converts from existing conditions checked with EoCs

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

It works.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
