### PR TITLE
Scaling cold/flu sleepiness to character using enchants

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -3393,14 +3393,8 @@
     "rating": "bad",
     "resist_effects": [ "took_flumed" ],
     "immune_flags": [ "NO_DISEASE" ],
-    "base_mods": {
-      "thirst_tick": [ 3600 ],
-      "thirst_min": [ 1 ],
-      "sleepiness_tick": [ 600 ],
-      "sleepiness_min": [ 1 ],
-      "str_mod": [ -1, 0 ],
-      "cough_chance": [ 600, 0 ]
-    }
+    "base_mods": { "thirst_tick": [ 3600 ], "thirst_min": [ 1 ], "str_mod": [ -1, 0 ], "cough_chance": [ 600, 0 ] },
+    "enchantments": [ { "values": [ { "value": "SLEEPINESS", "multiply": 0.025 }, { "value": "SLEEPINESS_REGEN", "multiply": -0.025 } ] } ]
   },
   {
     "//": "For player, indistinguishable from pre_cold, but separate here to allow for separate resistances from flu shot/antibodies.",
@@ -3415,14 +3409,8 @@
     "rating": "bad",
     "resist_effects": [ "took_flumed" ],
     "immune_flags": [ "NO_DISEASE" ],
-    "base_mods": {
-      "thirst_tick": [ 3600 ],
-      "thirst_min": [ 1 ],
-      "sleepiness_tick": [ 600 ],
-      "sleepiness_min": [ 1 ],
-      "str_mod": [ -1, 0 ],
-      "cough_chance": [ 600, 0 ]
-    }
+    "base_mods": { "thirst_tick": [ 3600 ], "thirst_min": [ 1 ], "str_mod": [ -1, 0 ], "cough_chance": [ 600, 0 ] },
+    "enchantments": [ { "values": [ { "value": "SLEEPINESS", "multiply": 0.05 }, { "value": "SLEEPINESS_REGEN", "multiply": -0.05 } ] } ]
   },
   {
     "type": "effect_type",
@@ -3439,14 +3427,21 @@
     "base_mods": {
       "thirst_tick": [ 1800 ],
       "thirst_min": [ 1 ],
-      "sleepiness_tick": [ 300 ],
-      "sleepiness_min": [ 1 ],
       "str_mod": [ -3, -1 ],
       "dex_mod": [ -1, 0 ],
       "per_mod": [ -1, 0 ],
       "int_mod": [ -2, -1 ],
       "cough_chance": [ 300, 0 ]
     },
+    "enchantments": [
+      {
+        "values": [
+          { "value": "SLEEPINESS", "multiply": 0.05 },
+          { "value": "SLEEPINESS_REGEN", "multiply": -0.05 },
+          { "value": "SLEEPY", "add": -5 }
+        ]
+      }
+    ],
     "blood_analysis_description": "Viral Infection"
   },
   {
@@ -3466,8 +3461,6 @@
     "base_mods": {
       "thirst_tick": [ 1800 ],
       "thirst_min": [ 1 ],
-      "sleepiness_tick": [ 300 ],
-      "sleepiness_min": [ 1 ],
       "str_mod": [ -4, -2 ],
       "dex_mod": [ -2, 0 ],
       "per_mod": [ -1, 0 ],
@@ -3477,6 +3470,15 @@
       "cough_chance": [ 300, 0 ],
       "vomit_chance": [ 3600, 7200 ]
     },
+    "enchantments": [
+      {
+        "values": [
+          { "value": "SLEEPINESS", "multiply": 0.15 },
+          { "value": "SLEEPINESS_REGEN", "multiply": -0.15 },
+          { "value": "SLEEPY", "add": -10 }
+        ]
+      }
+    ],
     "blood_analysis_description": "Viral Infection"
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Balance "Scaling cold/flu sleepiness to character using enchants"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

The additional sleepiness caused by the cold and flu were flat amounts (1 point per 5 minutes) and didn't take into account various mutations that might affect how naturally sleepy your character is. 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Remove the `sleepiness_min` and change to `SLEEPINESS` and `SLEEPINESS_REGEN` enchants. A full cold is 5% (you get sleepy 5% faster and sleep is 5% less restorative), and a flu is 15%. Both a cold and flu also make it slightly harder to fall asleep, flu more than cold. 

Pre-cold and pre-flu have reduced versions of these penalties. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
