### PR TITLE
Fix use-after-free in NPC zone sort viewport restore

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -12926,12 +12926,23 @@ void zone_sort_activity_actor::update_other_activity_items()
 void zone_sort_activity_actor::do_turn( player_activity &act, Character &you )
 {
     update_other_activity_items();
+    // Save viewport state before base call. For NPCs, revert_after_activity()
+    // replaces the activity and destroys this actor before returning.
+    const bool had_viewport = viewport_was_active;
+    const int saved_zoom = viewport_saved_zoom;
     zone_activity_actor::do_turn( act, you );
 
     // True completion: activity nulled AND no auto-move destination pending.
     // route_to_destination sets destination before nulling; true end does not.
-    if( act.is_null() && !you.has_destination() && viewport_was_active ) {
-        restore_viewport( you );
+    // Use saved locals since this may be destroyed.
+    if( act.is_null() && !you.has_destination() && had_viewport ) {
+        if( !test_mode ) {
+            g->set_zoom( saved_zoom );
+            g->mark_main_ui_adaptor_resize();
+        }
+        if( you.is_avatar() ) {
+            you.as_avatar()->zone_sort_viewport = {};
+        }
     }
 }
 


### PR DESCRIPTION
#### Summary
Bugfixes "Fix use-after-free in NPC zone sort viewport restore"

#### Purpose of change

When an NPC finishes zone sorting, `revert_after_activity` replaces the activity and destroys the actor. `zone_sort_activity_actor::do_turn` then reads `viewport_was_active` on freed memory. Shows up in all recent ASAN builds.

No impact on release builds -- the viewport is only active for the avatar, so the freed read is always `false`.

#### Describe the solution

Save viewport state to locals before the base `do_turn` call. Use the locals for the post-call viewport restore instead of member access.

#### Describe alternatives you've considered

N/A

#### Testing

N/A

#### Additional context

Mentioned in Discord, fires on every ASAN CI run.