### PR TITLE
Change Stat Caps

### DIFF
--- a/data/core/external_options.json
+++ b/data/core/external_options.json
@@ -25,28 +25,28 @@
     "name": "PLAYER_MAX_STR_VALUE",
     "//": "Sets a cap on maximum effective strength for characters.",
     "stype": "int",
-    "value": 20
+    "value": 25
   },
   {
     "type": "EXTERNAL_OPTION",
     "name": "PLAYER_MAX_DEX_VALUE",
     "//": "Sets a cap on maximum effective dexterity for characters.",
     "stype": "int",
-    "value": 20
+    "value": 25
   },
   {
     "type": "EXTERNAL_OPTION",
     "name": "PLAYER_MAX_PER_VALUE",
     "//": "Sets a cap on maximum effective perception for characters.",
     "stype": "int",
-    "value": 20
+    "value": 25
   },
   {
     "type": "EXTERNAL_OPTION",
     "name": "PLAYER_MAX_INT_VALUE",
     "//": "Sets a cap on maximum effective intelligence for characters.",
     "stype": "int",
-    "value": 20
+    "value": 25
   },
   {
     "type": "EXTERNAL_OPTION",


### PR DESCRIPTION

#### Summary
Balance "Stat Caps"

#### Purpose of change

I think stats cap too little.
Acording to GAME_BALANCE.md attaining 20 in stat is within of pre-Cataclysm human possibilities. But with mutations, cbms, artefacts it's clearly should be possible to surpass them.

#### Describe the solution

there couple cap point mentioned by Cactoideae in original PR(#83001). 
> Mutation attacks that scale off dexterity generally max out at 25 DEX.
> Reading speed maxes out at around 28 INT

So cap around 25 seems(because reading speed not instantenoius) and "feels"(because it is a multiple of 5) right.

#### Describe alternatives you've considered

Make 35 cap to reduce the number of exceptions. But i don't thing it's way to do. Making caps too high goes aginst original PR purpose and supernatural mods have higher cap because they have way more ways to surpass biological limit and overal that mods have highter power level.

#### Testing
Try debug stat above cap and see 25 instead.
