### PR TITLE
[Sky Island] Remove warp obelisk from bunker entrance upgrade

### DIFF
--- a/data/mods/Sky_Island/mapgen/island_upgrades.json
+++ b/data/mods/Sky_Island/mapgen/island_upgrades.json
@@ -65,7 +65,7 @@
         "          #####         ",
         "          #...#         ",
         "          #.<.#         ",
-        "          #.X.#         ",
+        "          #...#         ",
         "          #####         "
       ],
       "flags": [ "NO_UNDERLYING_ROTATE", "ALLOW_TERRAIN_UNDER_OTHER_DATA" ],


### PR DESCRIPTION
#### Summary
Mods "[Sky Island] Remove warp obelisk from bunker entrance upgrade"

#### Purpose of change
Furniture, like the warp obelisk, can be moved across Z-levels. There is no need for an extra warp obelisk being placed in the bunker entrance. If the player moved the first one that spawns in the entrance then uses the fix my bunker entrance option, it will spawn more and there is no way to get rid of them. 

#### Describe the solution
Change the `update_mapgen` for the bunker entrance to no longer have a warp obelisk in the 3x3 room
#### Describe alternatives you've considered

#### Testing
Game no longer spawns free the obelisks
#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
