### PR TITLE
Fix drinking water from vehicle faucet

### DIFF
--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -5,6 +5,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <list>
+#include <initializer_list>
 #include <memory>
 #include <string>
 #include <tuple>

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -2440,7 +2440,9 @@ void vehicle::build_interact_menu( veh_menu &menu, map *here, const tripoint_bub
         int vp_tank_idx = -1;
         item *water_item = nullptr;
         // Prefer clean water over standard
-        for( const itype_id &preferred : { itype_water_clean, itype_water } ) {
+        for( const itype_id &preferred : {
+                 itype_water_clean, itype_water
+             } ) {
             for( const int i : fuel_containers ) {
                 vehicle_part &part = parts[i];
                 if( part.ammo_current() == preferred &&

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -4,8 +4,8 @@
 #include <array>
 #include <cmath>
 #include <cstdlib>
-#include <list>
 #include <initializer_list>
+#include <list>
 #include <memory>
 #include <string>
 #include <tuple>

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -2439,12 +2439,18 @@ void vehicle::build_interact_menu( veh_menu &menu, map *here, const tripoint_bub
     if( vp.part_with_tool( *here, itype_water_faucet ) ) {
         int vp_tank_idx = -1;
         item *water_item = nullptr;
-        for( const int i : fuel_containers ) {
-            vehicle_part &part = parts[i];
-            if( part.ammo_current() == itype_water_clean &&
-                part.base.only_item().made_of( phase_id::LIQUID ) ) {
-                vp_tank_idx = i;
-                water_item = &part.base.only_item();
+        // Prefer clean water over standard
+        for( const itype_id &preferred : { itype_water_clean, itype_water } ) {
+            for( const int i : fuel_containers ) {
+                vehicle_part &part = parts[i];
+                if( part.ammo_current() == preferred &&
+                    part.base.only_item().made_of( phase_id::LIQUID ) ) {
+                    vp_tank_idx = i;
+                    water_item = &part.base.only_item();
+                    break;
+                }
+            }
+            if( vp_tank_idx != -1 ) {
                 break;
             }
         }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Fix drinking water from vehicle faucet"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Currently if you have a tank of 'water' in your vehicle, and you also have a faucet installed it will not give you the option to take a drink or pour water into a container.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

Fixes #80984

#### Describe the solution
Treat 'water' the same as 'clean water' for the purpose of faucet interactions.  If the user has both clean water and water containers it will give priority to the clean water.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
None.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Compile in Windows
Create a new world and spawn a vehicle
Attach container with water and faucet to said vehicle
Interact with faucet to verify water is registered.
Do above but with both water and clean water; verify clean water is given priority.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
