### PR TITLE
Fix monster attacking through terrain with TFLAG_SWIM_UNDER

### DIFF
--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -386,6 +386,14 @@ bool mon_spellcasting_actor::call( monster &mon ) const
     spell spell_instance = spell_data.get_spell( mon );
     spell_instance.set_message( spell_data.trigger_message );
 
+    if( !spell_data.self && !allow_no_target ) {
+        Creature *tgt_creature = get_creature_tracker().creature_at( target );
+        if( tgt_creature && mon.is_underwater() && !tgt_creature->is_underwater() &&
+            get_map().has_flag_ter_or_furn( ter_furn_flag::TFLAG_SWIM_UNDER, mon.pos_bub() ) ) {
+            return false;
+        }
+    }
+
     // Bail out if the target is out of range.
     if( !spell_data.self && rl_dist( mon.pos_bub(), target ) > spell_instance.range( mon ) ) {
         return false;
@@ -806,6 +814,11 @@ bool melee_actor::call( monster &z ) const
 
     Creature *target = find_target( z );
     if( target == nullptr ) {
+        return false;
+    }
+
+    if( z.is_underwater() && !target->is_underwater() &&
+        here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_SWIM_UNDER, z.pos_bub() ) ) {
         return false;
     }
 
@@ -1338,6 +1351,11 @@ bool gun_actor::call( monster &z ) const
             }
             aim_at = random_entry( moving_veh_parts, tripoint_bub_ms() );
         }
+    }
+
+    if( target && z.is_underwater() && !target->is_underwater() &&
+        here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_SWIM_UNDER, z.pos_bub() ) ) {
+        return false;
     }
 
     const int dist = rl_dist( z.pos_bub(), aim_at );

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -174,6 +174,13 @@ bool monster::will_move_to( map *here, const tripoint_bub_ms &p ) const
         }
     }
 
+    // Aquatic monsters can't climb onto walkways over water
+    if( has_flag( mon_flag_AQUATIC ) && !flies() &&
+        here->has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, p ) &&
+        !here->has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, pos_bub() ) ) {
+        return false;
+    }
+
     // digging monster can ONLY move underground?
     if( digs() && !here->has_flag( ter_furn_flag::TFLAG_DIGGABLE, p ) &&
         !here->has_flag( ter_furn_flag::TFLAG_BURROWABLE, p ) ) {
@@ -2069,6 +2076,11 @@ bool monster::move_to( const tripoint_bub_ms &p, bool force, bool step_on_critte
                // AQUATIC creatures stay submerged in any swimmable terrain (including shallow water)
                ( has_flag( mon_flag_AQUATIC ) &&
                  here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, destination ) ) );
+
+    // Prevents monsters from surfacing when under a SWIM_UNDER terrain tile.
+    if( is_underwater() && here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, destination ) ) {
+        will_be_water = true;
+    }
 
     if( get_option<bool>( "LOG_MONSTER_MOVEMENT" ) ) {
         //Birds and other flying creatures flying over the deep water terrain

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -174,13 +174,6 @@ bool monster::will_move_to( map *here, const tripoint_bub_ms &p ) const
         }
     }
 
-    // Aquatic monsters can't climb onto walkways over water
-    if( has_flag( mon_flag_AQUATIC ) && !flies() &&
-        here->has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, p ) &&
-        !here->has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, pos_bub() ) ) {
-        return false;
-    }
-
     // digging monster can ONLY move underground?
     if( digs() && !here->has_flag( ter_furn_flag::TFLAG_DIGGABLE, p ) &&
         !here->has_flag( ter_furn_flag::TFLAG_BURROWABLE, p ) ) {
@@ -2076,11 +2069,6 @@ bool monster::move_to( const tripoint_bub_ms &p, bool force, bool step_on_critte
                // AQUATIC creatures stay submerged in any swimmable terrain (including shallow water)
                ( has_flag( mon_flag_AQUATIC ) &&
                  here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, destination ) ) );
-
-    // Prevents monsters from surfacing when under a SWIM_UNDER terrain tile.
-    if( is_underwater() && here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, destination ) ) {
-        will_be_water = true;
-    }
 
     if( get_option<bool>( "LOG_MONSTER_MOVEMENT" ) ) {
         //Birds and other flying creatures flying over the deep water terrain

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2149,11 +2149,11 @@ bool monster::melee_attack( Creature &target, float accuracy )
         debugmsg( "Z-Level view violation: %s tried to attack %s.", disp_name(), target.disp_name() );
         return false;
     }
-    // Prevent monsters from attacking THROUGH terrain if they are submerged under it.
-    if( is_underwater() && here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, pos_bub() ) ) {
-        if( !target.is_underwater() ) {
-            return false;
-        }
+    // Prevent monsters from attacking THROUGH terrain if they are submerged under it & target isn't.
+    if( is_underwater() && !target.is_underwater() &&
+        ( here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, pos_bub() ) ||
+          here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, target.pos_bub() ) ) ) {
+        return false;
     }
 
     const int monster_hit_roll = melee::melee_hit_range( accuracy );

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2149,6 +2149,12 @@ bool monster::melee_attack( Creature &target, float accuracy )
         debugmsg( "Z-Level view violation: %s tried to attack %s.", disp_name(), target.disp_name() );
         return false;
     }
+    // Prevent monsters from attacking THROUGH terrain if they are submerged under it.
+    if( is_underwater() && here.has_flag( ter_furn_flag::TFLAG_SWIM_UNDER, pos_bub() ) ) {
+        if( !target.is_underwater() ) {
+            return false;
+        }
+    }
 
     const int monster_hit_roll = melee::melee_hit_range( accuracy );
     int hitspread = target.deal_melee_attack( this, monster_hit_roll );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Fix monster attack logic around TFLAG_SWIM_UNDER terrain, such as walkways"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
This PR is intended to fix logic errors when handling monster movement around terrain that has water below it, such as sewer walkways. Currently, monsters are able to attack and grab through the terrain despite being submerged under it. Fixes #86386

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Monster attacks now check if a submerged creature is on a tile with the TFLAG_SWIM_UNDER flag, and if it's targeting a creature that is not also submerged. If both of these are true, the attack misses. This checks both `monster::melee_attack` and a couple special attacks (Ie `mon_spellcasting_actor::call melee_actor::do_grab` and `gun_actor::call`)
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
There may be more attacks that could be thrown in with this check in mattack_actors.cpp, but I think that this should cover 99% of use cases and should be sufficient.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Spawned a zombie in a sewer, and kited until it moved underneath a walkway. Then moved adjacent to the zombie and made sure that it didn't make any attacks on the Player.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
