### PR TITLE
add "low power" mod

### DIFF
--- a/data/mods/low_power/item_blacklist.json
+++ b/data/mods/low_power/item_blacklist.json
@@ -1,0 +1,10 @@
+{
+  "type": "ITEM_BLACKLIST",
+  "whitelist": false,
+  "items": [
+    "diesel",
+    "gasoline",
+    "avgas",
+    "jp8"
+  ]
+}

--- a/data/mods/low_power/modinfo.json
+++ b/data/mods/low_power/modinfo.json
@@ -1,0 +1,26 @@
+[
+  {
+    "type": "MOD_INFO",
+    "id": "low_power",
+    "name": "No Pre-Cataclysm Power Sources",
+    "authors": [ "Blueflowers" ],
+    "maintainers": [ "Blueflowers" ],
+    "description": "Makes solar panels useless, gets rid of gasoline/diesel/other fuels. Forcing the survivor to rely on post-cataclysm solutions.",
+    "category": "rebalance",
+    "dependencies": [ "dda" ]
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "OVERRIDE_VEHICLE_INIT_STATE",
+    "//": "If true, initial status and amount of fuel for all spawned vehicles will be overridden by values of VEHICLE_STATUS_AT_SPAWN and VEHICLE_FUEL_AT_SPAWN options.",
+    "stype": "bool",
+    "value": true
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "VEHICLE_FUEL_AT_SPAWN",
+    "//": "All vehicles spawn with this percentage of fuel.  0 is empty, 100 is fully loaded, -1 is random amount from 7% to 35% (default).  Values are read only if OVERRIDE_VEHICLE_INIT_STATE is set to true.",
+    "stype": "int",
+    "value": 0
+  }
+]

--- a/data/mods/low_power/solar.json
+++ b/data/mods/low_power/solar.json
@@ -1,0 +1,86 @@
+[
+  {
+    "type": "vehicle_part",
+    "id": "ap_ground_solar_panel",
+    "categories": [ "energy" ],
+    "copy-from": "ap_ground_solar_panel",
+    "epower": "0 W"
+  },
+  {
+    "type": "vehicle_part",
+    "id": "ap_solar_panel",
+    "categories": [ "energy" ],
+    "copy-from": "ap_solar_panel",
+    "epower": "0 W"
+  },
+  {
+    "type": "vehicle_part",
+    "id": "solar_panel",
+    "categories": [ "energy" ],
+    "copy-from": "solar_panel",
+    "epower": "0 W"
+  },
+  {
+    "type": "vehicle_part",
+    "id": "ap_ground_solar_panel_v2",
+    "categories": [ "energy" ],
+    "copy-from": "ap_ground_solar_panel_v2",
+    "epower": "0 W"
+  },
+  {
+    "type": "vehicle_part",
+    "id": "ap_solar_panel_v2",
+    "categories": [ "energy" ],
+    "copy-from": "ap_solar_panel_v2",
+    "epower": "0 W"
+  },
+  {
+    "type": "vehicle_part",
+    "id": "solar_panel_v2",
+    "categories": [ "energy" ],
+    "copy-from": "solar_panel_v2",
+    "epower": "0 W"
+  },
+  {
+    "type": "vehicle_part",
+    "id": "ap_folding_solar_panel",
+    "categories": [ "energy" ],
+    "copy-from": "ap_folding_solar_panel",
+    "epower": "0 W"
+  },
+  {
+    "type": "vehicle_part",
+    "id": "reinforced_solar_panel",
+    "categories": [ "energy" ],
+    "copy-from": "reinforced_solar_panel",
+    "epower": "0 W"
+  },
+  {
+    "type": "vehicle_part",
+    "id": "ap_reinforced_solar_panel",
+    "categories": [ "energy" ],
+    "copy-from": "ap_reinforced_solar_panel",
+    "epower": "0 W"
+  },
+  {
+    "type": "vehicle_part",
+    "id": "reinforced_solar_panel_v2",
+    "categories": [ "energy" ],
+    "copy-from": "reinforced_solar_panel_v2",
+    "epower": "0 W"
+  },
+  {
+    "type": "vehicle_part",
+    "id": "ap_reinforced_solar_panel_v2",
+    "categories": [ "energy" ],
+    "copy-from": "ap_reinforced_solar_panel_v2",
+    "epower": "0 W"
+  },
+  {
+    "type": "vehicle_part",
+    "id": "ap_folding_solar_panel_v2",
+    "categories": [ "energy" ],
+    "copy-from": "ap_folding_solar_panel_v2",
+    "epower": "0 W"
+  }
+]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "Low Power mod"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Thought it'd be interesting if the survivor didn't have access to pre-cataclysm sources of power.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Sets solar panel power generation to 0W. External option sets all vehicles to not have fuel nor battery charge. Blacklists all fuels so they don't spawn. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Solar panels don't generate power, couldn't find any fuelled up vehicles. Gas stations were empty.
Though i did find a somewhat loaded up storage battery at the gas station, but since you can't recharge it i think it's fine
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
If someone wants a lore justification, Blob ate the sun and now it emits light that specifically ONLY solar panels can't get. And also blob teleported out literally all liquid fuel off-world.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
