### PR TITLE
Remove fire fields from library mapgen

### DIFF
--- a/data/json/mapgen/library.json
+++ b/data/json/mapgen/library.json
@@ -31,8 +31,7 @@
         ".....4..................",
         "........................"
       ],
-      "palettes": [ "standard_building_shared_palette", "library_palette" ],
-      "place_nested": [ { "chunks": [ [ "null", 199 ], [ "fire_field", 1 ] ], "x": [ 10, 20 ], "y": [ 9, 19 ] } ]
+      "palettes": [ "standard_building_shared_palette", "library_palette" ]
     }
   },
   {
@@ -69,8 +68,7 @@
         "........................"
       ],
       "palettes": [ "standard_building_shared_palette", "standard_building_vandalized_palette", "vandalized_library_palette" ],
-      "place_rubble": [ { "x": [ 4, 21 ], "y": [ 5, 21 ], "repeat": [ 30, 100 ] } ],
-      "place_nested": [ { "chunks": [ [ "null", 80 ], [ "fire_field", 20 ] ], "x": [ 10, 20 ], "y": [ 9, 19 ] } ]
+      "place_rubble": [ { "x": [ 4, 21 ], "y": [ 5, 21 ], "repeat": [ 30, 100 ] } ]
     }
   },
   {
@@ -160,7 +158,6 @@
         "..........######o####..."
       ],
       "palettes": [ "standard_building_shared_palette", "library_palette" ],
-      "place_nested": [ { "chunks": [ [ "null", 199 ], [ "fire_field", 1 ] ], "x": [ 3, 22 ], "y": [ 10, 14 ] } ],
       "place_monsters": [ { "monster": "GROUP_MAYBE_ZOMBIE", "x": [ 16, 21 ], "y": [ 5, 7 ], "density": 1 } ]
     }
   },
@@ -199,7 +196,6 @@
       ],
       "palettes": [ "standard_building_shared_palette", "standard_building_vandalized_palette", "vandalized_library_palette" ],
       "place_rubble": [ { "x": [ 4, 21 ], "y": [ 5, 21 ], "repeat": [ 30, 100 ] } ],
-      "place_nested": [ { "chunks": [ [ "null", 80 ], [ "fire_field", 20 ] ], "x": [ 3, 22 ], "y": [ 10, 14 ] } ],
       "place_monsters": [ { "monster": "GROUP_MAYBE_ZOMBIE", "x": [ 16, 21 ], "y": [ 5, 7 ], "density": 1 } ]
     }
   },
@@ -294,7 +290,6 @@
       ],
       "palettes": [ "standard_building_shared_palette", "library_palette" ],
       "nested": { "G": { "chunks": [ "roof_6x6_garden_1" ] } },
-      "place_nested": [ { "chunks": [ [ "null", 199 ], [ "fire_field", 1 ] ], "x": [ 5, 9 ], "y": [ 4, 16 ] } ],
       "terrain": { "G": "t_grass" },
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 0, 0 ], "y": [ 23, 23 ], "chance": 2, "repeat": [ 2, 3 ] } ]
     }
@@ -335,7 +330,6 @@
       "palettes": [ "standard_building_shared_palette", "standard_building_vandalized_palette", "vandalized_library_palette" ],
       "place_rubble": [ { "x": [ 4, 21 ], "y": [ 5, 21 ], "repeat": [ 30, 100 ] } ],
       "nested": { "G": { "chunks": [ "roof_6x6_garden_1" ] } },
-      "place_nested": [ { "chunks": [ [ "null", 199 ], [ "fire_field", 1 ] ], "x": [ 5, 9 ], "y": [ 4, 16 ] } ],
       "terrain": { "G": "t_grass" },
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 0, 0 ], "y": [ 23, 23 ], "chance": 2, "repeat": [ 2, 3 ] } ]
     }
@@ -429,8 +423,7 @@
         "........................",
         "........................"
       ],
-      "palettes": [ "standard_building_shared_palette", "library_palette" ],
-      "place_nested": [ { "chunks": [ [ "null", 199 ], [ "fire_field", 1 ] ], "x": [ 10, 20 ], "y": [ 9, 19 ] } ]
+      "palettes": [ "standard_building_shared_palette", "library_palette" ]
     }
   },
   {
@@ -466,8 +459,7 @@
         "........................",
         "........................"
       ],
-      "palettes": [ "standard_building_shared_palette", "standard_building_vandalized_palette", "vandalized_library_palette" ],
-      "place_nested": [ { "chunks": [ [ "null", 80 ], [ "fire_field", 20 ] ], "x": [ 10, 20 ], "y": [ 9, 19 ] } ]
+      "palettes": [ "standard_building_shared_palette", "standard_building_vandalized_palette", "vandalized_library_palette" ]
     }
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Remove fire fields from library mapgen"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
With the riot damage generators, buildings being on fire is now handled automatically for all maps. No need to have libraries, specifically, of all places, to be even more on fire.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Remove fire
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
