### PR TITLE
Mirror monster fire nerfs on the player side

### DIFF
--- a/data/json/damage_types.json
+++ b/data/json/damage_types.json
@@ -150,7 +150,7 @@
     "magic_color": "red",
     "name": { "ctxt": "damage_type", "str": "fire" },
     "material_required": true,
-    "immune_flags": { "character": [ "HEAT_IMMUNE" ] }
+    "immune_flags": { "character": [ "HEAT_IMMUNE" ], "monster": [ "FIREPROOF" ] }
   },
   {
     "id": "heat",

--- a/doc/JSON/JSON_FLAGS.md
+++ b/doc/JSON/JSON_FLAGS.md
@@ -391,7 +391,7 @@ Character flags can be `trait_id`, `json_flag_id` or `flag_id`.  Some of these a
 - ```GLIDING``` You are in the process of gliding.
 - ```HARDTOHIT``` Whenever something attacks you, RNG gets rolled twice, and you get the better result.
 - ```HEATSINK``` You are resistant to extreme heat.
-- ```HEAT_IMMUNE``` Immune to very hot temperatures.
+- ```HEAT_IMMUNE``` Immune to very hot temperatures and fire damage.
 - ```HERITAGE``` Turns a mutation with this flag light cyan on the list.  Currently used in mods for mutations that indicate non-human ancestry.
 - ```HUGE``` Changes your size to `creature_size::huge`.  Checked last of the size category flags, if no size flags are found your size defaults to `creature_size::medium`.
 - ```BLOCK_HUGE_ATTACKS``` Size limitations on blocking are ignored

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -91,6 +91,7 @@ static const itype_id itype_ash( "ash" );
 static const itype_id itype_rm13_armor_on( "rm13_armor_on" );
 static const itype_id itype_rock( "rock" );
 
+static const json_character_flag json_flag_HEAT_IMMUNE( "HEAT_IMMUNE" );
 static const json_character_flag json_flag_HEATSINK( "HEATSINK" );
 
 static const material_id material_iflesh( "iflesh" );
@@ -1528,7 +1529,7 @@ void map::player_in_field( Character &you )
         }
         if( ft == fd_fire ) {
             // Heatsink or suit prevents ALL fire damage.
-            if( !you.has_flag( json_flag_HEATSINK ) && !you.is_wearing( itype_rm13_armor_on ) ) {
+            if( !you.has_flag( json_flag_HEATSINK ) && !you.has_flag( json_flag_HEAT_IMMUNE ) && !you.is_wearing( itype_rm13_armor_on ) ) {
 
                 // To modify power of a field based on... whatever is relevant for the effect.
                 int adjusted_intensity = cur.get_field_intensity();
@@ -1539,6 +1540,14 @@ void map::player_in_field( Character &you )
                     } else {
                         adjusted_intensity -= 1;
                     }
+                }
+
+                // After adjusting intensity, check if the fire is powerful enough to actually hurt us
+                if( cur.get_field_intensity() == 1 ) {
+                    continue; // Small piddly fire cannot hurt anything
+                }
+                if( cur.get_field_intensity() == 2 && !one_in( 10 ) ) {
+                    continue; // Active fire can barely hurt anything walking through, 10% chance
                 }
 
                 if( adjusted_intensity >= 1 ) {

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -91,8 +91,8 @@ static const itype_id itype_ash( "ash" );
 static const itype_id itype_rm13_armor_on( "rm13_armor_on" );
 static const itype_id itype_rock( "rock" );
 
-static const json_character_flag json_flag_HEAT_IMMUNE( "HEAT_IMMUNE" );
 static const json_character_flag json_flag_HEATSINK( "HEATSINK" );
+static const json_character_flag json_flag_HEAT_IMMUNE( "HEAT_IMMUNE" );
 
 static const material_id material_iflesh( "iflesh" );
 static const material_id material_veggy( "veggy" );

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -1529,7 +1529,8 @@ void map::player_in_field( Character &you )
         }
         if( ft == fd_fire ) {
             // Heatsink or suit prevents ALL fire damage.
-            if( !you.has_flag( json_flag_HEATSINK ) && !you.has_flag( json_flag_HEAT_IMMUNE ) && !you.is_wearing( itype_rm13_armor_on ) ) {
+            if( !you.has_flag( json_flag_HEATSINK ) && !you.has_flag( json_flag_HEAT_IMMUNE ) &&
+                !you.is_wearing( itype_rm13_armor_on ) ) {
 
                 // To modify power of a field based on... whatever is relevant for the effect.
                 int adjusted_intensity = cur.get_field_intensity();


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Balance "Mirror monster fire nerfs on the player side"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

It does not make much sense that zombies can walk straight through small fires but when the player steps into them, their legs catch fire and burn into uselessness in under ten seconds, as happened to me an hour ago when I was testing something else.

The difference between being alive and not is already handled in only the player suffering from hot temperatures caused by fire--even if a small flame doesn't hurt you, you're not going to want to walk through a bunch of flame due to the heat and smoke

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Just use the same checks for the player as monster--if the fire is intensity 1, you can walk through with no risk. If it's intensity 2, it only hurts you 10% of the time. If it's intensity 3 (raging), then don't do it.

Also set it so that the `HEAT_IMMUNE` flag makes you immune to fire, clarify that `HEAT_IMMUNE` is the flag to not take fire damage (since the damage type is `heat`), and add the pre-existing `FIREPROOF` flag to the damage type for monster immunity.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Walked into an isolated small fire, suffered no damage.

Let the fire spread, walked into a fire (not raging fire), took no damage from the fire. _Did_ take damage from all the heat being thrown off by the giant fire. 

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
