### PR TITLE
Fix newline rendering in extended description window

### DIFF
--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -523,6 +523,10 @@ std::string map_common_deconstruct_info::potential_deconstruct_items( const map_
                    _( "\nYou feel you might also learn something about <color_cyan>%s</color>." ),
                    skill->id.obj().name() );
     }
+    // Remove extra whitespace
+    if( !ret.empty() && ret.back() == '\n' ) {
+        ret.pop_back();
+    }
     return ret;
 }
 

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -523,7 +523,7 @@ std::string map_common_deconstruct_info::potential_deconstruct_items( const map_
                    _( "\nYou feel you might also learn something about <color_cyan>%s</color>." ),
                    skill->id.obj().name() );
     }
-    // Remove extra whitespace
+    // Remove extra newline
     if( !ret.empty() && ret.back() == '\n' ) {
         ret.pop_back();
     }

--- a/src/ui_extended_description.cpp
+++ b/src/ui_extended_description.cpp
@@ -79,7 +79,7 @@ void draw_extended_description( const std::vector<std::string> &description, cat
         if( s == "--" ) {
             ImGui::Separator();
         } else {
-            cataimgui::TextColoredParagraph( c_light_gray, s );
+            cataimgui::draw_colored_text( s, c_light_gray );
             ImGui::NewLine();
         }
     }

--- a/src/ui_extended_description.cpp
+++ b/src/ui_extended_description.cpp
@@ -79,7 +79,6 @@ void draw_extended_description( const std::vector<std::string> &description, cat
             ImGui::Separator();
         } else {
             cataimgui::draw_colored_text( s, c_light_gray );
-            ImGui::NewLine();
         }
     }
 }

--- a/src/ui_extended_description.cpp
+++ b/src/ui_extended_description.cpp
@@ -78,7 +78,7 @@ void draw_extended_description( const std::vector<std::string> &description, cat
         if( s == "--" ) {
             ImGui::Separator();
         } else {
-            cataimgui::draw_colored_text( s, c_light_gray );
+            cataimgui::draw_colored_text( s, c_light_gray, ImGui::GetContentRegionAvail().x );
         }
     }
 }

--- a/src/ui_extended_description.cpp
+++ b/src/ui_extended_description.cpp
@@ -10,7 +10,6 @@
 #include "mapdata.h"
 #include "point.h"
 #include "string_formatter.h"
-#include "text.h"
 #include "translations.h"
 #include "type_id.h"
 #include "ui_manager.h"

--- a/src/ui_extended_description.cpp
+++ b/src/ui_extended_description.cpp
@@ -9,7 +9,9 @@
 #include "map.h"
 #include "mapdata.h"
 #include "point.h"
+#include "cata_utility.h"
 #include "string_formatter.h"
+#include "text.h"
 #include "translations.h"
 #include "type_id.h"
 #include "ui_manager.h"
@@ -78,7 +80,10 @@ void draw_extended_description( const std::vector<std::string> &description, cat
         if( s == "--" ) {
             ImGui::Separator();
         } else {
-            cataimgui::draw_colored_text( s, c_light_gray, ImGui::GetContentRegionAvail().x );
+            for( const std::string &line : string_split( s, '\n' ) ) {
+                cataimgui::TextColoredParagraph( c_light_gray, line );
+                ImGui::NewLine();
+            }
         }
     }
 }

--- a/src/ui_extended_description.cpp
+++ b/src/ui_extended_description.cpp
@@ -2,6 +2,7 @@
 
 #include <imgui/imgui.h>
 
+#include "cata_utility.h"
 #include "character.h"
 #include "color.h"
 #include "creature.h"
@@ -9,7 +10,6 @@
 #include "map.h"
 #include "mapdata.h"
 #include "point.h"
-#include "cata_utility.h"
 #include "string_formatter.h"
 #include "text.h"
 #include "translations.h"


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Fix newline not being registered in extended description window"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The extended description window is currently using an ImGui draw function that does not correctly register newlines in strings.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Switch to a function that correctly registers newlines in strings.

Before:
<img width="829" height="228" alt="Screenshot 2026-04-11 062109" src="https://github.com/user-attachments/assets/2e2b6cc6-1302-4c89-a8c3-cca935ba80cf" />

After:
<img width="725" height="359" alt="image" src="https://github.com/user-attachments/assets/4f17d855-b12f-4341-83d3-7590f9b5881b" />

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
None
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Compiled in Windows, Created a character and examined a tile, Verified newlines were appearing in extended description window.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
