### PR TITLE
Fix bug in gun mag/ammo inventory color

### DIFF
--- a/src/character.h
+++ b/src/character.h
@@ -2215,8 +2215,12 @@ class Character : public Creature, public visitable
          * @param obj item to be reloaded. By design any currently loaded ammunition or magazine is ignored
          * @param empty whether empty magazines should be considered as possible ammo
          * @param radius adjacent map/vehicle tiles to search. 0 for only player tile, -1 for only inventory
+         * @param now if true, only match candidates that can actually be loaded into obj right now
+         *        (i.e. obj has capacity for them); if false, match any type-compatible candidate
+         *        regardless of current capacity.
          */
-        std::vector<item_location> find_ammo( const item &obj, bool empty = true, int radius = 1 ) const;
+        std::vector<item_location> find_ammo( const item &obj, bool empty = true, int radius = 1,
+                                              bool now = true ) const;
 
         /**
          * Searches for weapons and magazines that can be reloaded.

--- a/src/character_guns.cpp
+++ b/src/character_guns.cpp
@@ -38,9 +38,10 @@ static const itype_id itype_small_repairkit( "small_repairkit" );
 static const trait_id trait_DEBUG_HS( "DEBUG_HS" );
 
 template <typename T, typename Output>
-void find_ammo_helper( T &src, const item &obj, bool empty, Output out, bool nested )
+void find_ammo_helper( T &src, const item &obj, bool empty, Output out, bool nested,
+                       bool now = true )
 {
-    src.visit_items( [&src, &nested, &out, &obj, empty]( item * node, item * parent ) {
+    src.visit_items( [&src, &nested, &out, &obj, empty, now]( item * node, item * parent ) {
 
         // This stops containers and magazines counting *themselves* as ammo sources
         if( node == &obj ) {
@@ -80,7 +81,7 @@ void find_ammo_helper( T &src, const item &obj, bool empty, Output out, bool nes
             // All speedloaders are accepted.
             // Ammo check is done somewhere else
             // Ammo check should probably happen here...
-            if( obj.can_reload_with( *node, true ) ) {
+            if( obj.can_reload_with( *node, now ) ) {
                 if( parent != nullptr ) {
                     out = item_location( item_location( src, parent ), node );
                 } else {
@@ -90,7 +91,7 @@ void find_ammo_helper( T &src, const item &obj, bool empty, Output out, bool nes
             return VisitResponse::SKIP;
         }
 
-        if( obj.can_reload_with( *node, true ) ) {
+        if( obj.can_reload_with( *node, now ) ) {
             if( parent != nullptr ) {
                 out = item_location( item_location( src, parent ), node );
             } else {
@@ -111,17 +112,18 @@ std::vector<item_location> Character::get_ammo( const ammotype &at ) const
     } );
 }
 
-std::vector<item_location> Character::find_ammo( const item &obj, bool empty, int radius ) const
+std::vector<item_location> Character::find_ammo( const item &obj, bool empty, int radius,
+        bool now ) const
 {
     map &here = get_map();
 
     std::vector<item_location> res = cache_get_items_with( "is_ammo",
-    &item::is_ammo, [&obj]( const item_location & it ) {
-        return obj.can_reload_with( *it, true );
+    &item::is_ammo, [&obj, now]( const item_location & it ) {
+        return obj.can_reload_with( *it, now );
     } );
 
     std::vector<item_location> mag_locs = cache_get_items_with( "is_magazine",
-    &item::is_magazine, [&obj, &empty]( const item_location & it ) {
+    &item::is_magazine, [&obj, &empty, now]( const item_location & it ) {
         if( &obj == &*it ) {
             return false;
         }
@@ -134,17 +136,17 @@ std::vector<item_location> Character::find_ammo( const item &obj, bool empty, in
         if( it->has_flag( flag_SPEEDLOADER ) && ( !it->ammo_remaining() || !obj.magazine_integral() ) ) {
             return false;
         }
-        return obj.can_reload_with( *it, true );
+        return obj.can_reload_with( *it, now );
     } );
 
     res.insert( res.end(), mag_locs.begin(), mag_locs.end() );
 
     if( radius >= 0 ) {
         for( map_cursor &cursor : map_selector( pos_bub(), radius ) ) {
-            find_ammo_helper( cursor, obj, empty, std::back_inserter( res ), false );
+            find_ammo_helper( cursor, obj, empty, std::back_inserter( res ), false, now );
         }
         for( vehicle_cursor &cursor : vehicle_selector( here, pos_bub( here ), radius ) ) {
-            find_ammo_helper( cursor, obj, empty, std::back_inserter( res ), false );
+            find_ammo_helper( cursor, obj, empty, std::back_inserter( res ), false, now );
         }
     }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1248,10 +1248,13 @@ nc_color item::color_in_inventory( const Character *const ch ) const
         // ltred if you have ammo but no mags
         // Gun with integrated mag counts as both
         for( const ammotype &at : ammo_types() ) {
-            // get_ammo finds uncontained ammo, find_ammo finds ammo in magazines
+            // get_ammo finds uncontained ammo, find_ammo finds ammo in magazines.
+            // Pass now=false: we want "does the player possess compatible ammo/mags?",
+            // not "can this be reloaded right this second?".
             bool has_ammo = !player_character.get_ammo( at ).empty() ||
-                            !player_character.find_ammo( *this, false, -1 ).empty();
-            bool has_mag = magazine_integral() || !player_character.find_ammo( *this, true, -1 ).empty();
+                            !player_character.find_ammo( *this, false, -1, false ).empty();
+            bool has_mag = magazine_integral() ||
+                           !player_character.find_ammo( *this, true, -1, false ).empty();
             if( has_ammo && has_mag ) {
                 ret = c_green;
                 break;
@@ -1290,7 +1293,9 @@ nc_color item::color_in_inventory( const Character *const ch ) const
         [this]( const item & it ) {
             return it.magazine_compatible().count( typeId() ) > 0;
         } );
-        bool has_ammo = !player_character.find_ammo( *this, false, -1 ).empty();
+        // Pass now=false so a full magazine still counts as "you have ammo for it"
+        // when the player is still carrying spare loose rounds of the same type.
+        bool has_ammo = !player_character.find_ammo( *this, false, -1, false ).empty();
         if( has_gun && has_ammo ) {
             ret = c_green;
         } else if( has_gun || has_ammo ) {

--- a/tests/item_gun_mag_ammo_inventory_color_test.cpp
+++ b/tests/item_gun_mag_ammo_inventory_color_test.cpp
@@ -1,0 +1,114 @@
+#include "cata_catch.h"
+
+#include "avatar.h"
+#include "calendar.h"
+#include "character.h"
+#include "color.h"
+#include "item.h"
+#include "item_location.h"
+#include "player_helpers.h"
+#include "type_id.h"
+
+static const ammotype ammo_38( "38" );
+static const ammotype ammo_9mm( "9mm" );
+
+static const itype_id itype_38_special( "38_special" );
+static const itype_id itype_9mm( "9mm" );
+static const itype_id itype_backpack( "backpack" );
+static const itype_id itype_glock_19( "glock_19" );
+static const itype_id itype_glockmag( "glockmag" );
+static const itype_id itype_sw_619( "sw_619" );
+
+static void prepare_avatar( avatar &u )
+{
+    clear_avatar();
+    u.clear_worn();
+    u.inv->clear();
+    u.remove_weapon();
+    u.wear_item( item( itype_backpack ) );
+}
+
+TEST_CASE( "full_gun_with_spare_mag_is_green", "[item][color][gun][inventory][reload]" )
+{
+    avatar &u = get_avatar();
+    prepare_avatar( u );
+
+    // Put a fully-loaded gun in the inventory.
+    item_location gun = u.i_add( item( itype_glock_19 ) );
+    item_location mag_for_gun = u.i_add( item( itype_glockmag ) );
+    const int mag_cap = mag_for_gun->ammo_capacity( ammo_9mm );
+    item_location ammo_for_gun = u.i_add( item( itype_9mm, calendar::turn, mag_cap ) );
+    REQUIRE( mag_for_gun->reload( u, ammo_for_gun, mag_cap ) );
+    REQUIRE( gun->reload( u, mag_for_gun, mag_cap ) );
+    REQUIRE( gun->remaining_ammo_capacity() == 0 );
+
+    // Player also carries a second loaded magazine.
+    item_location spare_mag = u.i_add( item( itype_glockmag ) );
+    item_location ammo_for_spare = u.i_add( item( itype_9mm, calendar::turn, mag_cap ) );
+    REQUIRE( spare_mag->reload( u, ammo_for_spare, mag_cap ) );
+
+    // Gun is full, but the player still possesses a loaded magazine for it,
+    // so the display color should signal "equipped" (green), not "missing
+    // something" (light red).
+    CHECK( gun->color_in_inventory( &u ) == c_green );
+}
+
+TEST_CASE( "full_revolver_with_spare_ammo_is_green", "[item][color][gun][inventory][reload]" )
+{
+    avatar &u = get_avatar();
+    prepare_avatar( u );
+
+    item_location gun = u.i_add( item( itype_sw_619 ) );
+    const int cylinder_cap = gun->ammo_capacity( ammo_38 );
+    REQUIRE( cylinder_cap > 0 );
+
+    // Two cylinders' worth of rounds: one to load the revolver, one to keep.
+    item_location ammo =
+        u.i_add( item( itype_38_special, calendar::turn, cylinder_cap * 2 ) );
+    REQUIRE( gun->reload( u, ammo, cylinder_cap ) );
+    REQUIRE( gun->remaining_ammo_capacity() == 0 );
+
+    // Integral-magazine gun is full but the player still has loose rounds.
+    CHECK( gun->color_in_inventory( &u ) == c_green );
+}
+
+TEST_CASE( "full_magazine_with_gun_and_spare_ammo_is_green",
+           "[item][color][magazine][inventory][reload]" )
+{
+    avatar &u = get_avatar();
+    prepare_avatar( u );
+
+    u.i_add( item( itype_glock_19 ) );
+    item_location mag = u.i_add( item( itype_glockmag ) );
+    const int mag_cap = mag->ammo_capacity( ammo_9mm );
+    item_location ammo = u.i_add( item( itype_9mm, calendar::turn, mag_cap * 2 ) );
+    REQUIRE( mag->reload( u, ammo, mag_cap ) );
+    REQUIRE( mag->remaining_ammo_capacity() == 0 );
+
+    // Magazine is full, but the player still has a compatible gun and spare
+    // loose rounds, so it should color green.
+    CHECK( mag->color_in_inventory( &u ) == c_green );
+}
+
+TEST_CASE( "empty_gun_alone_is_uncolored", "[item][color][gun][inventory]" )
+{
+    avatar &u = get_avatar();
+    prepare_avatar( u );
+
+    item_location gun = u.i_add( item( itype_glock_19 ) );
+    // No ammo, no magazine in inventory: neither green nor light red (will be default).
+    const nc_color c = gun->color_in_inventory( &u );
+    CHECK( c != c_green );
+    CHECK( c != c_light_red );
+}
+
+TEST_CASE( "gun_with_ammo_but_no_mag_is_light_red", "[item][color][gun][inventory]" )
+{
+    avatar &u = get_avatar();
+    prepare_avatar( u );
+
+    item_location gun = u.i_add( item( itype_glock_19 ) );
+    u.i_add( item( itype_9mm, calendar::turn, 10 ) );
+    // Compatible loose ammo but no magazine -> light red.
+    CHECK( gun->color_in_inventory( &u ) == c_light_red );
+}


### PR DESCRIPTION


<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Fix bug in gun mag/ammo inventory color"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Guns, magazines, and ammo in inventory are meant to be colored green when the player has a full set of compatible ammo, magazine, and gun. Fully loaded guns and magazines were displaying light red (partial readiness) even when the player had spare magazines or ammo because the find_ammo method was actually checking to see if the gun/magazine could be loaded right now (which it can't be, because there is no space, because it was already fully loaded).

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

This commit just plumbs a new "now" parameter through the find_ammo method. Defaults to "true" to preserve existing behavior everywhere except for the inventory color method.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

None

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

Added a set of tests. Manually verified the combination of states in game.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

N/A


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
