### PR TITLE
Move some in-item `passive_effects` to defined enchantments

### DIFF
--- a/data/json/enchantments.json
+++ b/data/json/enchantments.json
@@ -386,5 +386,66 @@
       { "value": "CARRY_WEIGHT", "multiply": 0.4 },
       { "value": "CLIMATE_CONTROL_CHILL", "add": 50 }
     ]
+  },
+  {
+    "id": "resonance_suit_active",
+    "type": "enchantment",
+    "name": { "str": "Anomaly protection" },
+    "description": "The electronics in your suit are protecting you from some types of extra-dimensional interference.",
+    "has": "WORN",
+    "condition": "ACTIVE",
+    "values": [ { "value": "ARTIFACT_RESONANCE", "add": -750 } ]
+  },
+  {
+    "id": "AR_targeting_system",
+    "type": "enchantment",
+    "name": { "str": "Adaptive targeting system" },
+    "description": "Your AR HUD includes an adaptive targeting system, making firearm target acquistion easier.",
+    "has": "WORN",
+    "condition": "ACTIVE",
+    "values": [ { "value": "WEAPON_DISPERSION", "add": -0.25 } ]
+  },
+  {
+    "id": "robofac_XM_LEG_on",
+    "type": "enchantment",
+    "name": { "str": "Active XM-LEG" },
+    "description": "Your active leg cybernetics are helping you move quicker and easier over flat ground and obstacles, and are increasing your carry weight.",
+    "has": "WORN",
+    "condition": "ACTIVE",
+    "values": [
+      { "value": "MOVEMENT_EXERTION_MODIFIER", "multiply": -0.2 },
+      { "value": "MOVE_COST", "multiply": -0.15 },
+      { "value": "MOVECOST_OBSTACLE_MOD", "multiply": -0.5 },
+      { "value": "CARRY_WEIGHT", "add": 20000 }
+    ]
+  },
+  {
+    "id": "robofac_XM_ARM_on",
+    "type": "enchantment",
+    "name": { "str": "Active XM-ARM" },
+    "description": "Your active arm cybernetics are improving your weapon handling and throwing ability.",
+    "has": "WORN",
+    "condition": "ACTIVE",
+    "values": [
+      { "value": "RECOIL_MODIFIER", "multiply": -0.3 },
+      { "value": "WEAPON_DISPERSION", "multiply": -0.1 },
+      { "value": "THROW_STR", "multiply": 0.5 },
+      { "value": "THROW_DAMAGE", "multiply": 0.25 }
+    ]
+  },
+  {
+    "id": "robofac_XM_BACK_on",
+    "type": "enchantment",
+    "name": { "str": "Active XM-BACK" },
+    "description": "Your active torso cybernetics are <color_white>slightly</color> increasing your carry weight and improving your ability to throw and absorb recoil.",
+    "has": "WORN",
+    "condition": "ACTIVE",
+    "values": [
+      { "value": "CARRY_WEIGHT", "multiply": 0.35 },
+      { "value": "RECOIL_MODIFIER", "multiply": -0.05 },
+      { "value": "WEAPON_DISPERSION", "multiply": -0.05 },
+      { "value": "THROW_STR", "multiply": 0.05 },
+      { "value": "THROW_DAMAGE", "multiply": 0.05 }
+    ]
   }
 ]

--- a/data/json/enchantments.json
+++ b/data/json/enchantments.json
@@ -400,7 +400,7 @@
     "id": "AR_targeting_system",
     "type": "enchantment",
     "name": { "str": "Adaptive targeting system" },
-    "description": "Your AR HUD includes an adaptive targeting system, making firearm target acquistion easier.",
+    "description": "Your AR HUD includes an adaptive targeting system, making firearm target acquisition easier.",
     "has": "WORN",
     "condition": "ACTIVE",
     "values": [ { "value": "WEAPON_DISPERSION", "add": -0.25 } ]

--- a/data/json/items/armor/integrated.json
+++ b/data/json/items/armor/integrated.json
@@ -2390,17 +2390,7 @@
     "use_action": [
       { "type": "transform", "msg": "You activate your Hub 01 XM-LEG system.", "target": "integrated_bio_robofac_xmleg_on" }
     ],
-    "passive_effects": [
-      {
-        "has": "WORN",
-        "condition": "ACTIVE",
-        "values": [
-          { "value": "MOVE_COST", "multiply": -0.15 },
-          { "value": "MOVECOST_OBSTACLE_MOD", "multiply": -0.5 },
-          { "value": "CARRY_WEIGHT", "add": 20000 }
-        ]
-      }
-    ],
+    "passive_effects": [ { "id": "robofac_XM_LEG_on" } ],
     "tool_ammo": [ "battery" ]
   },
   {
@@ -2476,18 +2466,7 @@
     "use_action": [
       { "type": "transform", "msg": "You activate your Hub 01 XM-ARM system.", "target": "integrated_bio_robofac_xmarm_on" }
     ],
-    "passive_effects": [
-      {
-        "has": "WORN",
-        "condition": "ACTIVE",
-        "values": [
-          { "value": "RECOIL_MODIFIER", "multiply": -0.3 },
-          { "value": "WEAPON_DISPERSION", "multiply": -0.1 },
-          { "value": "THROW_STR", "multiply": 0.5 },
-          { "value": "THROW_DAMAGE", "multiply": 0.25 }
-        ]
-      }
-    ],
+    "passive_effects": [ { "id": "robofac_XM_ARM_on" } ],
     "tool_ammo": [ "battery" ]
   },
   {
@@ -2547,19 +2526,7 @@
     "use_action": [
       { "type": "transform", "msg": "You activate your Hub 01 XM-BACK system.", "target": "integrated_bio_robofac_xmback_on" }
     ],
-    "passive_effects": [
-      {
-        "has": "WORN",
-        "condition": "ACTIVE",
-        "values": [
-          { "value": "CARRY_WEIGHT", "multiply": 0.35 },
-          { "value": "RECOIL_MODIFIER", "multiply": -0.05 },
-          { "value": "WEAPON_DISPERSION", "multiply": -0.05 },
-          { "value": "THROW_STR", "multiply": 0.05 },
-          { "value": "THROW_DAMAGE", "multiply": 0.05 }
-        ]
-      }
-    ],
+    "passive_effects": [ { "id": "robofac_XM_BACK_on" } ],
     "tool_ammo": [ "battery" ]
   },
   {

--- a/data/json/items/armor/robofac_armor.json
+++ b/data/json/items/armor/robofac_armor.json
@@ -520,11 +520,7 @@
         "volume_encumber_modifier": 0
       }
     ],
-    "passive_effects": [
-      { "id": "nvg_great" },
-      { "id": "THERMAL_VISION_GOOD" },
-      { "has": "WORN", "condition": "ACTIVE", "values": [ { "value": "WEAPON_DISPERSION", "add": -0.25 } ] }
-    ]
+    "passive_effects": [ { "id": "nvg_great" }, { "id": "THERMAL_VISION_GOOD" }, { "id": "AR_targeting_system" } ]
   },
   {
     "id": "robofac_robotrig",
@@ -1431,11 +1427,7 @@
       { "covers": [ "head" ], "coverage": 100, "encumbrance_modifiers": [ "RESTRICTS_NECK", "WELL_SUPPORTED" ] },
       { "covers": [ "eyes" ], "rigid_layer_only": true, "coverage": 100, "encumbrance": 0 }
     ],
-    "passive_effects": [
-      { "id": "nvg_great" },
-      { "id": "THERMAL_VISION_GOOD" },
-      { "has": "WORN", "condition": "ACTIVE", "values": [ { "value": "WEAPON_DISPERSION", "add": -0.25 } ] }
-    ]
+    "passive_effects": [ { "id": "nvg_great" }, { "id": "THERMAL_VISION_GOOD" }, { "id": "AR_targeting_system" } ]
   },
   {
     "id": "robofac_lens_mask_bal",

--- a/data/json/items/armor/suits_protection.json
+++ b/data/json/items/armor/suits_protection.json
@@ -2850,7 +2850,7 @@
     },
     "charges_per_use": 1,
     "tool_ammo": "battery",
-    "passive_effects": [ { "has": "WORN", "condition": "ACTIVE", "values": [ { "value": "ARTIFACT_RESONANCE", "add": -750 } ] } ]
+    "passive_effects": [ { "id": "resonance_suit_active" } ]
   },
   {
     "id": "xedra_artifact_cleansuit_on",
@@ -3470,7 +3470,7 @@
     },
     "tool_ammo": "battery",
     "flags": [ "WATERPROOF", "RAINPROOF", "GAS_PROOF", "RAD_PROOF", "ELECTRIC_IMMUNE", "STURDY", "NO_REPAIR", "NANOFAB_REPAIR" ],
-    "passive_effects": [ { "has": "WORN", "condition": "ACTIVE", "values": [ { "value": "ARTIFACT_RESONANCE", "add": -750 } ] } ]
+    "passive_effects": [ { "id": "resonance_suit_active" } ]
   },
   {
     "id": "robofac_resonance_suit_on",

--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -5096,10 +5096,6 @@
       { "covers": [ "head" ], "encumbrance": 20, "coverage": 80, "specifically_covers": [ "head_forehead" ] },
       { "covers": [ "head" ], "encumbrance": 5, "coverage": 40, "specifically_covers": [ "head_crown" ] }
     ],
-    "passive_effects": [
-      { "id": "nvg_great" },
-      { "id": "THERMAL_VISION_GOOD" },
-      { "has": "WORN", "condition": "ACTIVE", "values": [ { "value": "WEAPON_DISPERSION", "add": -0.25 } ] }
-    ]
+    "passive_effects": [ { "id": "nvg_great" }, { "id": "THERMAL_VISION_GOOD" }, { "id": "AR_targeting_system" } ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I've implemented several items over many months with `passive_effects`.  Usually, items with `passive_effects` use defined enchantments.  I didn't do that for these items - they were all defined in the item definition themselves, so didn't have effect descriptions, which I want them to have. (honestly, I just didn't know at the time it worked this way!)

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Switched the `passive_effects` definitions from the following items to enchantments, then replaced the definitions with the enchantment ID.  Now they all have effect names and descriptions when active, like other similar items.

- S02a cleansuit
- Hub 01 hazardous materials suit
- Hub 01 XM-ARM
- Hub 01 XM-LEG
- Hub 01 XM-BACK
- military visual augmentation system
- Hub 01 visual augmentation headgear
- Hub 01 LENS helmet

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

n/a

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Made sure they all worked in game

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
