### PR TITLE
Make certain map extras visible from afar by default

### DIFF
--- a/data/json/overmap/map_extras.json
+++ b/data/json/overmap/map_extras.json
@@ -104,6 +104,7 @@
     "sym": "X",
     "color": "blue",
     "autonote": true,
+	"see_from_afar": true,
     "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
@@ -263,7 +264,6 @@
     "sym": "S",
     "color": "yellow",
     "autonote": true,
-	"see_from_afar": true,
     "flags": [ "SPIDER" ]
   },
   {
@@ -276,7 +276,6 @@
     "sym": "W",
     "color": "yellow",
     "autonote": true,
-	"see_from_afar": true,
     "flags": [ "WASP" ]
   },
   {

--- a/data/json/overmap/map_extras.json
+++ b/data/json/overmap/map_extras.json
@@ -116,6 +116,7 @@
     "sym": "X",
     "color": "red",
     "autonote": true,
+	"see_from_afar": true,
     "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
@@ -141,6 +142,7 @@
     "sym": "C",
     "color": "yellow",
     "autonote": true,
+	"see_from_afar": true,
     "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
@@ -261,6 +263,7 @@
     "sym": "S",
     "color": "yellow",
     "autonote": true,
+	"see_from_afar": true,
     "flags": [ "SPIDER" ]
   },
   {
@@ -273,6 +276,7 @@
     "sym": "W",
     "color": "yellow",
     "autonote": true,
+	"see_from_afar": true,
     "flags": [ "WASP" ]
   },
   {
@@ -351,6 +355,7 @@
     "sym": ".",
     "color": "brown",
     "autonote": true,
+	"see_from_afar": true,
     "flags": [ "CLASSIC" ]
   },
   {
@@ -508,6 +513,7 @@
     "sym": "^",
     "color": "dark_gray",
     "autonote": true,
+	"see_from_afar": true,
     "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
@@ -645,6 +651,7 @@
     "sym": "W",
     "color": "yellow",
     "autonote": true,
+	"see_from_afar": true,
     "flags": [ "WASP" ]
   },
   {
@@ -657,6 +664,7 @@
     "sym": "D",
     "color": "brown",
     "autonote": true,
+	"see_from_afar": true,
     "flags": [ "WASP" ]
   },
   {
@@ -678,6 +686,7 @@
     "sym": "X",
     "color": "yellow",
     "autonote": true,
+	"see_from_afar": true,
     "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {

--- a/data/json/overmap/map_extras.json
+++ b/data/json/overmap/map_extras.json
@@ -104,7 +104,7 @@
     "sym": "X",
     "color": "blue",
     "autonote": true,
-	"see_from_afar": true,
+    "see_from_afar": true,
     "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
@@ -117,7 +117,7 @@
     "sym": "X",
     "color": "red",
     "autonote": true,
-	"see_from_afar": true,
+    "see_from_afar": true,
     "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
@@ -143,7 +143,7 @@
     "sym": "C",
     "color": "yellow",
     "autonote": true,
-	"see_from_afar": true,
+    "see_from_afar": true,
     "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
@@ -354,7 +354,7 @@
     "sym": ".",
     "color": "brown",
     "autonote": true,
-	"see_from_afar": true,
+    "see_from_afar": true,
     "flags": [ "CLASSIC" ]
   },
   {
@@ -649,7 +649,7 @@
     "sym": "W",
     "color": "yellow",
     "autonote": true,
-	"see_from_afar": true,
+    "see_from_afar": true,
     "flags": [ "WASP" ]
   },
   {
@@ -662,7 +662,7 @@
     "sym": "D",
     "color": "brown",
     "autonote": true,
-	"see_from_afar": true,
+    "see_from_afar": true,
     "flags": [ "WASP" ]
   },
   {
@@ -684,7 +684,7 @@
     "sym": "X",
     "color": "yellow",
     "autonote": true,
-	"see_from_afar": true,
+    "see_from_afar": true,
     "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {

--- a/data/json/overmap/map_extras.json
+++ b/data/json/overmap/map_extras.json
@@ -512,7 +512,6 @@
     "sym": "^",
     "color": "dark_gray",
     "autonote": true,
-	"see_from_afar": true,
     "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Balance "Add see_from_afar to map extras where it makes sense"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Certain map extras make sense to be able to see from afar - this PR adds what I consider the bare minimum.

#### Describe the solution
Add `see_from_afar` flag to map extras where it makes sense

#### Describe alternatives you've considered
Making a personal mod. Alternatively, I suppose we could split these into field and forest extras, making ones that are visible in fields, but not visible in forests.

#### Testing
None - If the auto tests say it's good, we're good. Fight me.

#### Additional context
Rationale for each map extra explained below:

`mx_roadblock` and `mx_roadblock_mil`
These extras have searchlights and sandbags, which I would imagine are relatively tall, especially compared to a road, which is the only place these things appear. Even allowing for minor elevation changes, I think we would be able to see these.

`mx_supplydrop`
These extras only appear in fields, and are large crates. I think we would be able to see these.

`mx_clearcut`
A lack of trees in a section of forest would probably stand out, even through the treeline.

`mx_mass_grave`
These are quite large holes in the ground. I think we would be able to see these. However, since these can technically appear inside of forests (which probably should be removed in its own PR - Why would the military choose an area covered in trees for a mass gravesite?), I would be open to arguments against this one.

`mx_nest_wasp` and `mx_nest_dermatik`
I'm open to arguments against this one too, but if they exist in the middle of a field, I would think they're visible. Since these can spawn in forests, I would be open to arguments against this. Alternatively, we can split the versions that appear in forests into their own IDs and only make the ones that spawn in fields visible.



