### PR TITLE
Highlight yield amount in crafting UI

### DIFF
--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1105,19 +1105,19 @@ void crafting_ui_impl::draw_recipe_info_panel()
                 const std::string chance_str = string_format( "~%.0f%%", success );
                 const std::string time_str = approx_craft_time( expected_turns );
                 const std::string activity_str = string_format( _( "%s activity" ), activity_lc );
-                const std::string total_yield = string_format( "%d", recp.makes_amount() * batch_size );
+                const int total_yield = recp.makes_amount() * batch_size;
 
                 // Single format string so translators can reorder parts.
                 // Plain version for width measurement, colored for rendering.
                 std::string plain;
                 std::string colored;
                 if( total_yield > 1 ) {
-                    //~ %1$s: success chance, %2$d: yield count, %3$s: time, %4$s: activity level
-                    const std::string fmt = _( "%1$s chance to yield %2$d in %3$s of %4$s" );
+                    //~ %1$s: success chance, %2$s: yield count, %3$s: time, %4$s: activity level
+                    const std::string fmt = _( "%1$s chance to yield %2$s in %3$s of %4$s" );
                     plain = string_format( fmt, chance_str, total_yield, time_str, activity_str );
                     colored = string_format( fmt,
                                              colorize( chance_str, success_col ),
-                                             colorize( total_yield, c_cyan ),
+                                             colorize( std::to_string( total_yield ), c_cyan ),
                                              colorize( time_str, c_cyan ),
                                              colorize( activity_str, activity_col ) );
                 } else {

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1105,7 +1105,7 @@ void crafting_ui_impl::draw_recipe_info_panel()
                 const std::string chance_str = string_format( "~%.0f%%", success );
                 const std::string time_str = approx_craft_time( expected_turns );
                 const std::string activity_str = string_format( _( "%s activity" ), activity_lc );
-                const int total_yield = recp.makes_amount() * batch_size;
+                const std::string total_yield = string_format( "%d", recp.makes_amount() * batch_size );
 
                 // Single format string so translators can reorder parts.
                 // Plain version for width measurement, colored for rendering.
@@ -1116,7 +1116,8 @@ void crafting_ui_impl::draw_recipe_info_panel()
                     const std::string fmt = _( "%1$s chance to yield %2$d in %3$s of %4$s" );
                     plain = string_format( fmt, chance_str, total_yield, time_str, activity_str );
                     colored = string_format( fmt,
-                                             colorize( chance_str, success_col ), total_yield,
+                                             colorize( chance_str, success_col ),
+                                             colorize( total_yield, c_cyan ),
                                              colorize( time_str, c_cyan ),
                                              colorize( activity_str, activity_col ) );
                 } else {

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1117,7 +1117,7 @@ void crafting_ui_impl::draw_recipe_info_panel()
                     plain = string_format( fmt, chance_str, std::to_string( total_yield ), time_str, activity_str );
                     colored = string_format( fmt,
                                              colorize( chance_str, success_col ),
-                                             colorize( std::to_string( total_yield ), c_cyan ),
+                                             colorize( std::to_string( total_yield ), c_light_blue ),
                                              colorize( time_str, c_cyan ),
                                              colorize( activity_str, activity_col ) );
                 } else {

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1114,7 +1114,7 @@ void crafting_ui_impl::draw_recipe_info_panel()
                 if( total_yield > 1 ) {
                     //~ %1$s: success chance, %2$s: yield count, %3$s: time, %4$s: activity level
                     const std::string fmt = _( "%1$s chance to yield %2$s in %3$s of %4$s" );
-                    plain = string_format( fmt, chance_str, total_yield, time_str, activity_str );
+                    plain = string_format( fmt, chance_str, std::to_string( total_yield ), time_str, activity_str );
                     colored = string_format( fmt,
                                              colorize( chance_str, success_col ),
                                              colorize( std::to_string( total_yield ), c_cyan ),


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Interface "Highlight the amount produced by a recipe in the crafting UI"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The crafting UI has the amount you get from a recipe as gray text.  This is hard to see and blends in with the rest of the flavor text, especially if you are skimming through multiple entries quickly trying to determine what you want.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Highlight the amount produced from a recipe (light blue chosen) for higher visibility. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

Before:
<img width="714" height="282" alt="image" src="https://github.com/user-attachments/assets/b8fed266-3db8-45a3-8136-1d82107ebf2a" />

After:
<img width="715" height="272" alt="Screenshot 2026-04-12 031329" src="https://github.com/user-attachments/assets/8a3492d9-5c66-4c9b-ba0d-dc5f30088513" />

#### Describe alternatives you've considered
None.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Compiled in Windows, started new game and verified recipe amount was highlighted.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
