### PR TITLE
Npcs dont freeze to death with NPC needs disabled

### DIFF
--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -3404,7 +3404,7 @@ void npc::on_unload()
 
 void npc::update_bodytemp_and_wetness()
 {
-    if(  needs_food() ) {
+    if( needs_food() ) {
         update_bodytemp();
         update_body_wetness( *get_weather().weather_precise );
     }

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -3404,8 +3404,10 @@ void npc::on_unload()
 
 void npc::update_bodytemp_and_wetness()
 {
-    update_bodytemp();
-    update_body_wetness( *get_weather().weather_precise );
+    if(  needs_food() ) {
+        update_bodytemp();
+        update_body_wetness( *get_weather().weather_precise );
+    }
 }
 
 // A throtled version of player::update_body since npc's don't need to-the-turn updates.


### PR DESCRIPTION

#### Summary
Bugfixes "Npcs dont freeze to death with NPC needs disabled"

#### Purpose of change
Fix #86414

#### Describe the solution
No npc needs also makes NPCs not update their temperature, they are always comfortable.

#### Describe alternatives you've considered
Traits given to npcs, but this is more robust. Plus every single npc in aftershock would need this trait (and a way to remove it if you swap to a follower)

#### Testing
My home laptop cant compile this game. No testing till monday.

#### Additional context
