### PR TITLE
Fixing refugee center merc conversations

### DIFF
--- a/data/json/npcs/Backgrounds/scavenger_merc_1.json
+++ b/data/json/npcs/Backgrounds/scavenger_merc_1.json
@@ -29,7 +29,7 @@
       },
       {
         "text": "Is this enough whisky for you?",
-        "condition": { "and": [ { "u_has_item": "whiskey" }, { "npc_has_effect": "player_BGSS_SAIDYES" } ] },
+        "condition": { "and": [ { "u_has_item": "single_malt_whiskey" }, { "npc_has_effect": "player_BGSS_SAIDYES" } ] },
         "topic": "BGSS_SCAVENGER_MERC_1_STORY2"
       },
       { "text": "Fine.  Let's talk business, then.", "topic": "TALK_NONE" },


### PR DESCRIPTION
They say they want 'Single Malt' in order to tell you their background, but they really want plain whiskey.

Fixing to make them actually want single malt as per the conversation.


#### Summary
Bugfixes "Refugee Center Merc conversation fix"

#### Purpose of change

If you hire the Refugee Center Mercenary NPC, there is a conversation option to ask about their background.  If you succeed, they'll tell you that they'll only share their story if you bring them "a bottle of single malt".

However, the conversation can only proceed to the full story if you pass the conditional { "u_has_item": "whiskey" }.  That's the plain whiskey.  Single malt whiskey is "single_malt_whiskey".

#### Describe the solution

I merely fixed the conditional to test for single_malt_whiskey.

#### Describe alternatives you've considered

The other option is to change the conversation to talk instead about plain whiskey.  However, there are other whiskey variants, such as cheap whiskey, Canadian whiskey, etc, so changing the conversation to merely reflect plain whiskey would be hard.  Allowing any whiskey would make the conversation change relatively basic but would require a much more complicated conditional.  I went with what seemed the simplest solution.

#### Testing

I hired the NPC and talked to them.  Now the conversation can continue if you possess single malt whiskey.

#### Additional context

