### PR TITLE
Add "see_from_afar" to some specials that make most sense

### DIFF
--- a/data/json/overmap/map_extras.json
+++ b/data/json/overmap/map_extras.json
@@ -68,6 +68,7 @@
     "sym": "X",
     "color": "yellow",
     "autonote": true,
+    "see_from_afar":true,
     "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
@@ -80,6 +81,7 @@
     "sym": "M",
     "color": "light_red",
     "autonote": true,
+    "see_from_afar":true,
     "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
@@ -92,6 +94,7 @@
     "sym": "M",
     "color": "light_red",
     "autonote": true,
+    "see_from_afar":true,
     "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
@@ -104,6 +107,7 @@
     "sym": "X",
     "color": "blue",
     "autonote": true,
+    "see_from_afar":true,
     "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
@@ -116,6 +120,7 @@
     "sym": "X",
     "color": "red",
     "autonote": true,
+    "see_from_afar":true,
     "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
@@ -141,6 +146,7 @@
     "sym": "C",
     "color": "yellow",
     "autonote": true,
+    "see_from_afar":true,
     "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
@@ -165,6 +171,7 @@
     "sym": "X",
     "color": "light_blue",
     "autonote": true,
+    "see_from_afar":true,
     "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
@@ -189,6 +196,7 @@
     "sym": "P",
     "color": "magenta",
     "autonote": true,
+    "see_from_afar":true,
     "flags": [ "PORTAL" ]
   },
   {
@@ -201,6 +209,7 @@
     "sym": "P",
     "color": "magenta",
     "autonote": true,
+    "see_from_afar":true,
     "flags": [ "PORTAL" ]
   },
   {
@@ -213,6 +222,7 @@
     "sym": "x",
     "color": "light_gray",
     "autonote": true,
+    "see_from_afar":true,
     "flags": [ "EXODII" ]
   },
   {
@@ -225,6 +235,7 @@
     "sym": "x",
     "color": "light_gray",
     "autonote": true,
+    "see_from_afar":true,
     "flags": [ "EXODII" ]
   },
   {
@@ -237,6 +248,7 @@
     "sym": "x",
     "color": "yellow",
     "autonote": true,
+    "see_from_afar":true,
     "flags": [ "YRAX" ]
   },
   {
@@ -261,6 +273,7 @@
     "sym": "S",
     "color": "yellow",
     "autonote": true,
+    "see_from_afar":true,
     "flags": [ "SPIDER" ]
   },
   {
@@ -273,6 +286,7 @@
     "sym": "W",
     "color": "yellow",
     "autonote": true,
+    "see_from_afar":true,
     "flags": [ "WASP" ]
   },
   {
@@ -296,6 +310,7 @@
     "min_max_zlevel": [ -2, 0 ],
     "sym": "S",
     "color": "yellow",
+    "see_from_afar":true,
     "autonote": true
   },
   {
@@ -327,6 +342,7 @@
     "sym": "F",
     "color": "light_green",
     "autonote": true,
+    "see_from_afar":true,
     "flags": [ "CLASSIC" ]
   },
   {
@@ -351,6 +367,7 @@
     "sym": ".",
     "color": "brown",
     "autonote": true,
+    "see_from_afar":true,
     "flags": [ "CLASSIC" ]
   },
   {
@@ -363,6 +380,7 @@
     "sym": "p",
     "color": "blue",
     "autonote": true,
+    "see_from_afar":true,
     "flags": [ "CLASSIC", "WATER" ]
   },
   {
@@ -508,6 +526,7 @@
     "sym": "^",
     "color": "dark_gray",
     "autonote": true,
+    "see_from_afar":true,
     "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
@@ -543,7 +562,7 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": ".",
     "color": "brown",
-    "autonote": true,
+    "see_from_afar":true,
     "flags": [ "CLASSIC" ]
   },
   {
@@ -645,6 +664,7 @@
     "sym": "W",
     "color": "yellow",
     "autonote": true,
+    "see_from_afar":true,
     "flags": [ "WASP" ]
   },
   {
@@ -657,6 +677,7 @@
     "sym": "D",
     "color": "brown",
     "autonote": true,
+    "see_from_afar":true,
     "flags": [ "WASP" ]
   },
   {
@@ -678,6 +699,7 @@
     "sym": "X",
     "color": "yellow",
     "autonote": true,
+    "see_from_afar":true,
     "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
@@ -690,6 +712,7 @@
     "sym": "X",
     "color": "yellow",
     "autonote": true,
+    "see_from_afar":true,
     "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
@@ -761,6 +784,7 @@
     "sym": "D",
     "color": "magenta",
     "autonote": true,
+    "see_from_afar":true,
     "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Category "Brief description"
 Added the new flag to some specials that made most sense
 

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Balance


<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Added the new flag some of the specials that made the most sense to me. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Wait for the person who did the nerfs to also use the new flag they added
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Added the flag to a special, checked in game, the note comes up properly even though I haven't gone onto the tile of the special
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Maybe more specials would make sense to have it
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
