### PR TITLE
reduce performance load of noncombatant perk

### DIFF
--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -626,46 +626,10 @@
     "points": 0,
     "purifiable": false,
     "valid": false,
-    "description": "Hey, that's against the Geneva Convention!  When not wielding a weapon, or object that could be used as an improvised weapon, you take -25% reduced damage.",
-    "//": "u_has_weapon checks if you're wielding ANYTHNG, not a weapon specifically, hence the long condition below.",
+    "description": "Hey, that's against the Geneva Convention!  When completely unarmed, you take -25% reduced damage.",
     "enchantments": [
       {
-        "condition": {
-          "and": [
-            { "not": { "u_has_wielded_with_weapon_category": "AUTOMATIC_PISTOLS" } },
-            { "not": { "u_has_wielded_with_weapon_category": "SHIVS" } },
-            { "not": { "u_has_wielded_with_weapon_category": "QUARTERSTAVES" } },
-            { "not": { "u_has_wielded_with_weapon_category": "HOOKING_WEAPONRY" } },
-            { "not": { "u_has_wielded_with_weapon_category": "AUTOMATIC_RIFLES" } },
-            { "not": { "u_has_wielded_with_weapon_category": "KNIVES" } },
-            { "not": { "u_has_wielded_with_weapon_category": "MEDIUM_SWORDS" } },
-            { "not": { "u_has_wielded_with_weapon_category": "GREAT_HAMMERS" } },
-            { "not": { "u_has_wielded_with_weapon_category": "GREAT_AXES" } },
-            { "not": { "u_has_wielded_with_weapon_category": "MACES" } },
-            { "not": { "u_has_wielded_with_weapon_category": "SPEARS" } },
-            { "not": { "u_has_wielded_with_weapon_category": "FENCING_WEAPONRY" } },
-            { "not": { "u_has_wielded_with_weapon_category": "LONG_SWORDS" } },
-            { "not": { "u_has_wielded_with_weapon_category": "GREAT_SWORDS" } },
-            { "not": { "u_has_wielded_with_weapon_category": "BIONIC_WEAPONRY" } },
-            { "not": { "u_has_wielded_with_weapon_category": "SHORT_SWORDS" } },
-            { "not": { "u_has_wielded_with_weapon_category": "HAND_AXES" } },
-            { "not": { "u_has_wielded_with_weapon_category": "BATONS" } },
-            { "not": { "u_has_wielded_with_weapon_category": "FLAILS" } },
-            { "not": { "u_has_wielded_with_weapon_category": "POLEARMS" } },
-            { "not": { "u_has_wielded_with_weapon_category": "LONG_THRUSTING_SWORDS" } },
-            { "not": { "u_has_wielded_with_weapon_category": "BIONIC_SWORDS" } },
-            { "not": { "u_has_wielded_with_flag": "OLD_GUN" } },
-            { "not": { "u_has_wielded_with_flag": "NEVER_JAMS" } },
-            { "not": { "u_has_wielded_with_flag": "NON_FOULING" } },
-            { "not": { "u_has_wielded_with_flag": "RELOAD_AND_SHOOT" } },
-            { "not": { "u_has_wielded_with_flag": "RELOAD_EJECT" } },
-            { "not": { "u_has_wielded_with_flag": "RELOAD_ONE" } },
-            { "not": { "u_has_wielded_with_flag": "STR_DRAW" } },
-            { "not": { "u_has_wielded_with_flag": "DURABLE_MELEE" } },
-            { "not": { "u_has_wielded_with_flag": "BIONIC_WEAPON" } },
-            { "not": { "u_has_wielded_with_flag": "POLEARM" } }
-          ]
-        },
+        "condition": { "and": [ { "not": "u_has_weapon" } ] },
         "values": [ { "value": "ARMOR_ALL", "multiply": -0.25 } ]
       }
     ]

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -627,12 +627,7 @@
     "purifiable": false,
     "valid": false,
     "description": "Hey, that's against the Geneva Convention!  When completely unarmed, you take -25% reduced damage.",
-    "enchantments": [
-      {
-        "condition": { "and": [ { "not": "u_has_weapon" } ] },
-        "values": [ { "value": "ARMOR_ALL", "multiply": -0.25 } ]
-      }
-    ]
+    "enchantments": [ { "condition": { "not": "u_has_weapon" }, "values": [ { "value": "ARMOR_ALL", "multiply": -0.25 } ] } ]
   },
   {
     "type": "mutation",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
none

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Noncombatant perk had quite a high performance load because it needed to check a held item against dozens of categories each turn for relatively minimal benefit (like wielding a body bag or something)
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Simply check against being bare handed.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I do not know if short circuit evaluation works for our JSON conditionals; if it did, that could be a different way to do this (if you have no weapon OR the weapon you have is not any of the following...)
There is a sort-of exploit where you can take the perk while you have the pacifist trait, and then later lose the pacifist trait, and retain the benefit. I think that's kind of funny so I don't care to patch it.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
