### PR TITLE
Modify ring of sustenance to target BMI category

### DIFF
--- a/data/mods/Magiclysm/items/enchanted_rings.json
+++ b/data/mods/Magiclysm/items/enchanted_rings.json
@@ -590,10 +590,7 @@
           "id": "EOC_MAGICLYSM_WEARING_RING_OF_SUSTENANCE_FOLLOW_UP_TRUE",
           "condition": { "math": [ "u_effect_intensity('effect_mring_sustenance') >= 25" ] },
           "effect": [
-            {
-              "if": { "math": [ "u_calories('format':'percent') <= 60" ] },
-              "then": { "math": [ "u_calories() += 5" ] }
-            },
+            { "if": { "math": [ "u_calories('format':'percent') <= 60" ] }, "then": { "math": [ "u_calories() += 5" ] } },
             {
               "if": { "math": [ "u_calories('format':'percent') <= 94.4" ] },
               "then": { "math": [ "u_calories() += 7" ] }

--- a/data/mods/Magiclysm/items/enchanted_rings.json
+++ b/data/mods/Magiclysm/items/enchanted_rings.json
@@ -580,14 +580,6 @@
     ]
   },
   {
-    "type": "jmath_function",
-    "id": "get_target_bmi_kcal_From_height",
-    "num_args": 2,
-    "//arg1": "Target BMI category. <1=skeletal,1-2=emaciated,2-3=underweight,3-5=normal,5-10=overweight,10-15=obese,15-20=v. obese,20+=m. obese",
-    "//arg2": "Character current height",
-    "return": "floor(7716.17 * _0 * ((_1/100) ^ 2))"
-  },
-  {
     "type": "effect_on_condition",
     "id": "EOC_MAGICLYSM_WEARING_RING_OF_SUSTENANCE_FOLLOW_UP",
     "effect": {
@@ -599,11 +591,11 @@
           "condition": { "math": [ "u_effect_intensity('effect_mring_sustenance') >= 25" ] },
           "effect": [
             {
-              "if": { "math": [ "u_calories() <= (get_target_bmi_kcal_From_height(3, u_val('height')) - 2)" ] },
+              "if": { "math": [ "u_calories('format':'percent') <= 60" ] },
               "then": { "math": [ "u_calories() += 5" ] }
             },
             {
-              "if": { "math": [ "u_calories() <= (get_target_bmi_kcal_From_height(4.72, u_val('height')) - 1)" ] },
+              "if": { "math": [ "u_calories('format':'percent') <= 94.4" ] },
               "then": { "math": [ "u_calories() += 7" ] }
             },
             { "run_eocs": "EOC_MAGICLYSM_WEARING_RING_OF_SUSTENANCE_FOLLOW_UP", "time_in_future": 60 }

--- a/data/mods/Magiclysm/items/enchanted_rings.json
+++ b/data/mods/Magiclysm/items/enchanted_rings.json
@@ -598,8 +598,14 @@
           "id": "EOC_MAGICLYSM_WEARING_RING_OF_SUSTENANCE_FOLLOW_UP_TRUE",
           "condition": { "math": [ "u_effect_intensity('effect_mring_sustenance') >= 25" ] },
           "effect": [
-            { "if": { "math": [ "u_calories() <= (get_target_bmi_kcal_From_height(3, u_val('height')) - 2)" ] }, "then": { "math": [ "u_calories() += 5" ] } },
-            { "if": { "math": [ "u_calories() <= (get_target_bmi_kcal_From_height(4.72, u_val('height')) - 1)" ] }, "then": { "math": [ "u_calories() += 7" ] } },
+            {
+              "if": { "math": [ "u_calories() <= (get_target_bmi_kcal_From_height(3, u_val('height')) - 2)" ] },
+              "then": { "math": [ "u_calories() += 5" ] }
+            },
+            {
+              "if": { "math": [ "u_calories() <= (get_target_bmi_kcal_From_height(4.72, u_val('height')) - 1)" ] },
+              "then": { "math": [ "u_calories() += 7" ] }
+            },
             { "run_eocs": "EOC_MAGICLYSM_WEARING_RING_OF_SUSTENANCE_FOLLOW_UP", "time_in_future": 60 }
           ],
           "false_effect": [ { "run_eocs": "EOC_MAGICLYSM_WEARING_RING_OF_SUSTENANCE_FOLLOW_UP", "time_in_future": 60 } ]

--- a/data/mods/Magiclysm/items/enchanted_rings.json
+++ b/data/mods/Magiclysm/items/enchanted_rings.json
@@ -585,7 +585,7 @@
     "num_args": 2,
     "//arg1": "Target BMI category. <1=skeletal,1-2=emaciated,2-3=underweight,3-5=normal,5-10=overweight,10-15=obese,15-20=v. obese,20+=m. obese",
     "//arg2": "Character current height",
-    "return": "7716.17 * _0 * ((_1/100) ^ 2)"
+    "return": "floor(7716.17 * _0 * ((_1/100) ^ 2))"
   },
   {
     "type": "effect_on_condition",
@@ -599,7 +599,7 @@
           "condition": { "math": [ "u_effect_intensity('effect_mring_sustenance') >= 25" ] },
           "effect": [
             { "if": { "math": [ "u_calories() <= (get_target_bmi_kcal_From_height(3, u_val('height')) - 2)" ] }, "then": { "math": [ "u_calories() += 5" ] } },
-            { "if": { "math": [ "u_calories() <= (get_target_bmi_kcal_From_height(4.72, u_val('height')) - 2)" ] }, "then": { "math": [ "u_calories() += 7" ] } },
+            { "if": { "math": [ "u_calories() <= (get_target_bmi_kcal_From_height(4.72, u_val('height')) - 1)" ] }, "then": { "math": [ "u_calories() += 7" ] } },
             { "run_eocs": "EOC_MAGICLYSM_WEARING_RING_OF_SUSTENANCE_FOLLOW_UP", "time_in_future": 60 }
           ],
           "false_effect": [ { "run_eocs": "EOC_MAGICLYSM_WEARING_RING_OF_SUSTENANCE_FOLLOW_UP", "time_in_future": 60 } ]

--- a/data/mods/Magiclysm/items/enchanted_rings.json
+++ b/data/mods/Magiclysm/items/enchanted_rings.json
@@ -580,6 +580,14 @@
     ]
   },
   {
+    "type": "jmath_function",
+    "id": "get_target_bmi_kcal_From_height",
+    "num_args": 2,
+    "//arg1": "Target BMI category. <1=skeletal,1-2=emaciated,2-3=underweight,3-5=normal,5-10=overweight,10-15=obese,15-20=v. obese,20+=m. obese",
+    "//arg2": "Character current height",
+    "return": "7716.17 * _0 * ((_1/100) ^ 2)"
+  },
+  {
     "type": "effect_on_condition",
     "id": "EOC_MAGICLYSM_WEARING_RING_OF_SUSTENANCE_FOLLOW_UP",
     "effect": {
@@ -590,8 +598,8 @@
           "id": "EOC_MAGICLYSM_WEARING_RING_OF_SUSTENANCE_FOLLOW_UP_TRUE",
           "condition": { "math": [ "u_effect_intensity('effect_mring_sustenance') >= 25" ] },
           "effect": [
-            { "if": { "math": [ "u_calories() <= 74999" ] }, "then": { "math": [ "u_calories() += 5" ] } },
-            { "if": { "math": [ "u_calories() <= 118000" ] }, "then": { "math": [ "u_calories() += 7" ] } },
+            { "if": { "math": [ "u_calories() <= (get_target_bmi_kcal_From_height(3, u_val('height')) - 2)" ] }, "then": { "math": [ "u_calories() += 5" ] } },
+            { "if": { "math": [ "u_calories() <= (get_target_bmi_kcal_From_height(4.72, u_val('height')) - 2)" ] }, "then": { "math": [ "u_calories() += 7" ] } },
             { "run_eocs": "EOC_MAGICLYSM_WEARING_RING_OF_SUSTENANCE_FOLLOW_UP", "time_in_future": 60 }
           ],
           "false_effect": [ { "run_eocs": "EOC_MAGICLYSM_WEARING_RING_OF_SUSTENANCE_FOLLOW_UP", "time_in_future": 60 } ]


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
This modifies the ring of sustenance item to dynamically target a weight category based on the character's height, replacing the assumption that the character is 180cm tall.

With this change, characters will have their weight supported in the Normal range, no matter the character's height.

#### Describe the solution
<del>This recreates the game's internal BMI category calculation using the KCAL_PER_KG constant.
<del>Assumptions:
<del>* the example character was 180cm tall
<del>* the ring is meant to keep the character in the normal weight category

<del>Inputs and outputs:
<del>* 3 (the start of the normal weight category) and 180cm gives 75001 kcal.
<del>* 4.72 and 180cm gives 118001 kcal.

<ins>The check has been modified to compare `u_calories('format':'percent')` against 60% and  94.4% to closely match the previous functionality.</ins>

#### Describe alternatives you've considered

Not applicable

#### Testing

Tested on an experimental build from Feb.

#### Additional context

The JSON style bot demanded the two lines be formatted differently.