### PR TITLE
[Mind over Matter] Coagulation fix

### DIFF
--- a/data/mods/MindOverMatter/powers/vitakinesis.json
+++ b/data/mods/MindOverMatter/powers/vitakinesis.json
@@ -66,12 +66,12 @@
     },
     "base_energy_cost": {
       "math": [
-        "u_effect_intensity('effect_vitakin_slow_bleeding') > -1 ? 0 : max((2500 - (u_spell_level('vita_health_power') * 95)), 1250)"
+        "u_effect_intensity('effect_vitakin_slow_bleeding') > -1 ? 0 : max((2500 - (u_spell_level('vita_slow_bleeding') * 95)), 1250)"
       ]
     },
     "base_casting_time": {
       "math": [
-        "u_effect_intensity('effect_vitakin_slow_bleeding') > -1 ? 10 : max((200 -(u_spell_level('vita_health_power') * 6.5)), 50)"
+        "u_effect_intensity('effect_vitakin_slow_bleeding') > -1 ? 10 : max((200 -(u_spell_level('vita_slow_bleeding') * 6.5)), 50)"
       ]
     }
   },


### PR DESCRIPTION

#### Summary
Bugfixes "Coagulation cost and time now scales from coagulation and not Healthy Glow"


#### Purpose of change

While diving in code i noticed that Coagulation cost and time scales from Health glow

#### Describe the solution

change u_spell_level('vita_health_power') into u_spell_level('vita_slow_bleeding')

#### Describe alternatives you've considered
I doubt that it's intended behaviour. 

#### Testing

none

