### PR TITLE
Fix under-alignment of small_literal_vector

### DIFF
--- a/src/cata_small_literal_vector.h
+++ b/src/cata_small_literal_vector.h
@@ -18,7 +18,7 @@
  * default to uint8_t for minimal overhead over the inline storage.
  */
 template<typename T, size_t kInlineCount = 4, typename SizeT = uint8_t>
-struct alignas( T * ) small_literal_vector {
+struct alignas( T * ) alignas( T ) small_literal_vector {
     // To avoid having to invoke constructors and destructors when copying Elements
     // around or inserting new ones, we enforce it is a literal type.
     static_assert( std::is_trivially_destructible_v<T>, "T must be trivially destructible." );
@@ -216,9 +216,9 @@ private:
         return capacity_ > kInlineCount;
     }
 
-    // The whole small_literal_vector has alignas(T*) so that the alignment requirements of heap_
+    // The whole small_literal_vector has at least alignas(T*) so that the alignment requirements of heap_
     // are never violated, even if you allocate several of these in a row. However we use pragma pack
-    // So there are no padding bytes inserted into the union to bring it to a multiple of sizeof(T*)
+    // so there are no padding bytes inserted into the union to bring it to a multiple of sizeof(T*)
     // so that capacity_ and len_ can be tightly packed adjacent to it. Their alignments will still
     // be legal because the compiler will insert padding before capacity_ if necessary.
     // We put T *heap_ as the first entry in the union to avoid default initializing the whole inline storage.


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes the build error
```
  /home/runner/work/Cataclysm-DDA/Cataclysm-DDA/android/app/jni/src/../../../../src/cata_small_literal_vector.h:21:8: error: requested alignment is less than minimum alignment of 8 for type 'small_literal_vector<tint_sprite_record, 4>'
  struct alignas( T * ) small_literal_vector {
         ^
  /home/runner/work/Cataclysm-DDA/Cataclysm-DDA/android/app/jni/src/../../../../src/map.h:362:53: note: in instantiation of template class 'small_literal_vector<tint_sprite_record, 4>' requested here
          small_literal_vector<tint_sprite_record, 4> tint_sprites;
                                                      ^
```
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
`small_literal_vector` must be aligned *at least* to `T*` and not strictly as `T*`. So stack the alignas statements to mae it so.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Built 32 bit android locally w/o error.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
