### PR TITLE
[Magiclysm] Add steps to crystallized mana recipe

### DIFF
--- a/data/mods/Magiclysm/items/alchemy_items.json
+++ b/data/mods/Magiclysm/items/alchemy_items.json
@@ -80,7 +80,7 @@
     "warmth": 0,
     "material_thickness": 1,
     "flags": [ "BELTED" ],
-    "qualities": [ [ "MANA_FOCUS", 1 ] ],
+    "qualities": [ { "id": "MANA_FOCUS", "level": 1 } ],
     "armor": [ { "encumbrance": 1, "coverage": 5, "covers": [ "head" ] } ]
   },
   {
@@ -100,7 +100,7 @@
     "warmth": 0,
     "material_thickness": 1,
     "flags": [ "BELTED" ],
-    "qualities": [ [ "MANA_FOCUS", 2 ] ],
+    "qualities": [ { "id": "MANA_FOCUS", "level": 2, "speed": 0.66 } ],
     "armor": [ { "encumbrance": 1, "coverage": 5, "covers": [ "head" ] } ]
   },
   {

--- a/data/mods/Magiclysm/recipes/alchemy.json
+++ b/data/mods/Magiclysm/recipes/alchemy.json
@@ -160,33 +160,47 @@
   },
   {
     "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
     "result": "crystallized_mana",
     "id_suffix": "using_alchemy",
     "charges": 8,
-    "batch_time_factors": [ 40, 3 ],
-    "qualities": [
-      { "id": "CONCENTRATE", "level": 1 },
-      { "id": "FINE_DISTILL", "level": 1 },
-      { "id": "SEPARATE", "level": 1 },
-      { "id": "CONTAIN", "level": 1 },
-      { "id": "MANA_FOCUS", "level": 1 }
-    ],
-    "tools": [ [ [ "surface_heat", 20, "LIST" ] ] ],
     "components": [
       [ [ "crystallized_mana_raw", 1 ] ],
       [ [ "mana_energy_weak", 1, "LIST" ] ],
       [ [ "mercury", 5 ] ],
       [ [ "chem_sulphur", 20 ], [ "chunk_sulfur", 1 ] ]
     ],
-    "proficiencies": [ { "proficiency": "prof_alchemy", "required": false } ],
-    "time": "4 h",
     "skill_used": "chemistry",
     "difficulty": 5,
     "skills_required": [ "spellcraft", 6 ],
     "book_learn": [ [ "alchemy_master", 6 ], [ "alchemy_mana_processing", 4 ] ],
     "category": "CC_ENCHANTED",
-    "subcategory": "CSC_ENCHANTED_OTHER"
+    "subcategory": "CSC_ENCHANTED_OTHER",
+    "steps": [
+      {
+        "name": "Calcinate the mana",
+        "time": "20 m",
+        "activity_level": "LIGHT_EXERCISE",
+        "tools": [ [ [ "surface_heat", 10, "LIST" ] ] ],
+        "qualities": [ { "id": "SEPARATE", "level": 1 }, { "id": "CONTAIN", "level": 1 }, { "id": "CONCENTRATE", "level": 1 } ],
+        "batch_time_factors": [ 40, 3 ],
+        "proficiencies": [ { "proficiency": "prof_alchemy", "required": false } ]
+      },
+      {
+        "name": "Alchemical purification",
+        "time": "40 m",
+        "activity_level": "LIGHT_EXERCISE",
+        "tools": [ [ [ "surface_heat", 10, "LIST" ] ] ],
+        "qualities": [ { "id": "FINE_DISTILL", "level": 1 }, { "id": "CONTAIN", "level": 1 }, { "id": "CONCENTRATE", "level": 1 } ],
+        "batch_time_factors": [ 40, 3 ],
+        "proficiencies": [ { "proficiency": "prof_alchemy", "required": false } ]
+      },
+      {
+        "name": "Focus the mana",
+        "time": "3 h",
+        "activity_level": "NO_EXERCISE",
+        "qualities": [ { "id": "MANA_FOCUS", "level": 1 } ]
+      }
+    ]
   },
   {
     "type": "recipe",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Mods "[Magiclysm] Add steps to crystallized mana recipe"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Recipe steps!

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add steps to the alchemical crystallized mana. The main point of this is making it so that higher levels of the Mana Focusing quality speed the process up (since it's easier to crystallize the mana if you're more efficient at focusing it. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Recipe has steps, Mana Focusing 2 makes it faster.

<img width="810" height="580" alt="Untitled" src="https://github.com/user-attachments/assets/aeb1dd2a-0fa0-4c40-a365-deaacc37c115" />


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
