### PR TITLE
[Magiclysm] Enhanced Magic Circle have effect on recipe steps

### DIFF
--- a/data/mods/Magiclysm/items/tools.json
+++ b/data/mods/Magiclysm/items/tools.json
@@ -250,7 +250,7 @@
     "color": "red",
     "weight": "0 g",
     "volume": "0 ml",
-    "qualities": [ [ "MANA_INFUSE", 2 ], [ "MANA_FOCUS", 2 ] ],
+    "qualities": [ [ "MANA_INFUSE", 2 ], [ { "id": "MANA_FOCUS", "level": 2, "speed": 0.66 } ] ],
     "flags": [ "ZERO_WEIGHT" ]
   }
 ]

--- a/data/mods/Magiclysm/items/tools.json
+++ b/data/mods/Magiclysm/items/tools.json
@@ -250,7 +250,7 @@
     "color": "red",
     "weight": "0 g",
     "volume": "0 ml",
-    "qualities": [ [ "MANA_INFUSE", 2 ], [ { "id": "MANA_FOCUS", "level": 2, "speed": 0.66 } ] ],
+    "qualities": [ [ "MANA_INFUSE", 2 ], { "id": "MANA_FOCUS", "level": 2, "speed": 0.66 } ],
     "flags": [ "ZERO_WEIGHT" ]
   }
 ]


### PR DESCRIPTION
#### Summary
Mods "[Magiclysm] Enhanced Magic Circle have effect on recipe steps"

#### Purpose of change

#86459 added recipe speed increase for silver circlet, but does not for second level of magic circle, so i fix oversight. 

#### Describe the solution
copy-paste part of silver circlet into magic_circle_2

#### Describe alternatives you've considered

none

#### Testing

Game loads without errors

#### Additional context

none
