### PR TITLE
[Magiclysm] Alchemic Circlets actually calmy to wear.

### DIFF
--- a/data/mods/Magiclysm/items/alchemy_items.json
+++ b/data/mods/Magiclysm/items/alchemy_items.json
@@ -79,7 +79,7 @@
     "color": "brown",
     "warmth": 0,
     "material_thickness": 1,
-    "flags": [ "BELTED" ],
+    "flags": [ "BELTED", "PADDED" ],
     "qualities": [ { "id": "MANA_FOCUS", "level": 1 } ],
     "armor": [ { "encumbrance": 1, "coverage": 5, "covers": [ "head" ] } ]
   },
@@ -99,7 +99,7 @@
     "color": "light_gray",
     "warmth": 0,
     "material_thickness": 1,
-    "flags": [ "BELTED" ],
+    "flags": [ "BELTED", "PADDED" ],
     "qualities": [ { "id": "MANA_FOCUS", "level": 2, "speed": 0.66 } ],
     "armor": [ { "encumbrance": 1, "coverage": 5, "covers": [ "head" ] } ]
   },


### PR DESCRIPTION
fixing contradiction between "calming to wear" in descriprition and uncomfortably rubbing all over head.

#### Summary
Mods "[Magiclysm] Alchemic Circlets actually calmy to wear"

#### Purpose of change

both cicrclet have in description 

> Touching your temples with it on makes you feel very calm.

but if you try to wear it then this happens

<img width="444" height="130" alt="logscreenshot" src="https://github.com/user-attachments/assets/a1649fd6-4e18-4b3a-913c-05eed4dcf739" />


#### Describe the solution

Add "PADDED" flag to them

#### Describe alternatives you've considered

Also adding some very minor magical effect to them, either increase in mana, focus or mana regen

#### Testing

Game loads, no rubbing against throat.