### PR TITLE
Negative healing traits purifiable now

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -627,7 +627,7 @@
     "type": "mutation",
     "id": "NOHEAL",
     "name": { "str": "Irreparable" },
-    "description": "Whatever caused the end of the world affected you in a horrible irrepairable way.  Your wounds will never heal on their own and your broken limbs will never mend.",
+    "description": "Whatever caused the end of the world affected you in a horrible irreparable way.  Your wounds will never heal on their own and your broken limbs will never mend.",
     "types": [ "HEALING" ],
     "points": -12,
     "starting_trait": true,

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -609,7 +609,6 @@
     "types": [ "HEALING" ],
     "points": -4,
     "starting_trait": true,
-    "purifiable": false,
     "valid": false,
     "enchantments": [ { "values": [ { "value": "MENDING_MODIFIER", "multiply": -0.67 }, { "value": "REGEN_HP", "multiply": -0.67 } ] } ]
   },
@@ -621,7 +620,6 @@
     "types": [ "HEALING" ],
     "points": -8,
     "starting_trait": true,
-    "purifiable": false,
     "valid": false,
     "enchantments": [ { "values": [ { "value": "MENDING_MODIFIER", "multiply": -0.9 }, { "value": "REGEN_HP", "multiply": -0.9 } ] } ]
   },
@@ -633,7 +631,6 @@
     "types": [ "HEALING" ],
     "points": -12,
     "starting_trait": true,
-    "purifiable": false,
     "valid": false,
     "enchantments": [ { "values": [ { "value": "MENDING_MODIFIER", "multiply": -1 }, { "value": "REGEN_HP", "multiply": -1 } ] } ]
   },

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -627,10 +627,11 @@
     "type": "mutation",
     "id": "NOHEAL",
     "name": { "str": "Irreparable" },
-    "description": "Whatever caused the end of the world affected you in a horrible way.  Your wounds will never heal on their own and your broken limbs will never mend.",
+    "description": "Whatever caused the end of the world affected you in a horrible irrepairable way.  Your wounds will never heal on their own and your broken limbs will never mend.",
     "types": [ "HEALING" ],
     "points": -12,
     "starting_trait": true,
+    "purifiable": false,
     "valid": false,
     "enchantments": [ { "values": [ { "value": "MENDING_MODIFIER", "multiply": -1 }, { "value": "REGEN_HP", "multiply": -1 } ] } ]
   },


### PR DESCRIPTION
#### Summary
Balance "Negative healing traits purifiable now"

#### Purpose of change

Many mutations cancels these traits, but due to their non-purifiable nature, it is impossible to mutate into these mutations.  These traits seem like an roleplay traits, earlygame obstacle that eventially can be fixed by mutations, not like "Genetic Downward Spiral" thath both challenge trait and one of capstone mutations of Chimera tree.

#### Describe the solution

remove lines

#### Describe alternatives you've considered

Leave some or all mutations as is, but change their descriptions to make it clear that they are permanent challenge traits like GDS.

#### Testing

game loads without erroes

#### Additional context