### PR TITLE
Add extra attack confirmation for the Exodii

### DIFF
--- a/data/json/monsters/cyborgs.json
+++ b/data/json/monsters/cyborgs.json
@@ -133,7 +133,8 @@
       "PATH_AVOID_DANGER",
       "PRIORITIZE_TARGETS",
       "PULP_PRYING",
-      "HIT_AND_RUN"
+      "HIT_AND_RUN",
+      "ATTACK_CONFIRM"
     ],
     "armor": { "bash": 12, "cut": 28, "acid": 12, "heat": 8, "bullet": 12 }
   },
@@ -201,7 +202,8 @@
       "PATH_AVOID_DANGER",
       "PRIORITIZE_TARGETS",
       "PULP_PRYING",
-      "HIT_AND_RUN"
+      "HIT_AND_RUN",
+      "ATTACK_CONFIRM"
     ],
     "armor": { "bash": 42, "cut": 48, "acid": 12, "heat": 8, "bullet": 35 }
   },

--- a/data/json/monsters/monster_flags.json
+++ b/data/json/monsters/monster_flags.json
@@ -620,6 +620,11 @@
     "//COMMENT": "This monster appears neutral but AI behaves as if not. (The effect is hardcoded)"
   },
   {
+    "id": "ATTACK_CONFIRM",
+    "type": "monster_flag",
+    "//": "This monster requires confirmation to attack regardless of safe mode settings"
+  },
+  {
     "id": "ALWAYS_SEES_YOU",
     "type": "monster_flag",
     "//": "This monster always knows where the avatar is"

--- a/doc/JSON/JSON_FLAGS.md
+++ b/doc/JSON/JSON_FLAGS.md
@@ -210,7 +210,7 @@ Some armor flags, such as `WATCH` and `ALARMCLOCK` are compatible with other ite
 - ```HELMET_NAPE_PROTECTOR``` Item can be worn with different hard helmets, as attachment; specifically can be put in pocket for armor with this flag restriction.
 - ```HOOD``` Allow this clothing to conditionally cover the head, for additional warmth or water protection, if the player's head isn't encumbered.
 - ```HYGROMETER``` This gear is equipped with an accurate hygrometer (which is used to measure humidity).
-- ```INTANGIBLE_ARMOR``` The armor provides no protection on any covered body part, as thought it had a coverage of 0%. 
+- ```INTANGIBLE_ARMOR``` The armor provides no protection on any covered body part, as thought it had a coverage of 0%.
 - ```INTEGRATED``` This item represents a part of you granted by mutations or bionics.  It will always fit, will not conflict with armor-blocking mutations, cannot be unequipped (aside from losing the source), and won't drop on death, but otherwise behaves like normal armor with regards to function, encumbrance, layer conflicts and so on.
 - ```MUTATED_ANATOMY_ONLY``` For gear designed only for players with non-standard bodyparts.  Prevents normal humans from wearing the item
 - ```MUTE``` Makes the player mute.
@@ -316,7 +316,7 @@ Some armor flags, such as `WATCH` and `ALARMCLOCK` are compatible with other ite
 
 - ```ALWAYS_BLOCK``` This nonstandard bodypart is always eligible to block in unarmed combat even if your martial arts don't allow such blocks.
 - ```ALWAYS_HEAL``` This bodypart regenerates every regen tick (5 minutes, currently) regardless if the part would have healed normally.
-- ```BIONIC_LIMB``` This bodypart is mechanical and thus cannot bleed or cause pain when hit. 
+- ```BIONIC_LIMB``` This bodypart is mechanical and thus cannot bleed or cause pain when hit.
 - ```HEAL_OVERRIDE``` This bodypart will always regenerate its `heal_bonus` HP instead of it modifying the base healing step.  Without `ALWAYS_HEAL` this still only happens when the part would have healed non-zero amount of damage.
 - ```IGNORE_TEMP``` This bodypart is ignored for temperature calculations.
 - ```LIMB_LOWER``` This bodypart is close to the ground, and as such has a higher chance to be attacked by small monsters - hitsize is tripled for creatures that can't attack upper limbs.
@@ -465,7 +465,7 @@ Character flags can be `trait_id`, `json_flag_id` or `flag_id`.  Some of these a
 - ```SUPPRESS_INVISIBILITY``` Any invisibility effects on the creature, including the `PERMANENT_INVISIBILITY` flag, are ignored for the duration of the effect with this flag
 - ```TELEPORT_LOCK``` You cannot teleport.  This has none of the protective effects of `DIMENSIONAL_ANCHOR`.
 - ```TEMPORARY_SHAPESHIFT``` You are in another shape due to some supernatural effect.
-- ```TEMPORARY_SHAPESHIFT_NO_HANDS``` You do not have hands in your new shapeshifted form, and so cannot pick up or manipulate objects. 
+- ```TEMPORARY_SHAPESHIFT_NO_HANDS``` You do not have hands in your new shapeshifted form, and so cannot pick up or manipulate objects.
 - ```THERMOMETER``` You always know what temperature it is.
 - ```TINY``` Changes your size to `creature_size::tiny`.  Checked first of the size category flags.
 - ```TREE_COMMUNION_PLUS``` Gain greatly enhanced effects from the Mycorrhizal Communion mutation.
@@ -1135,6 +1135,7 @@ Used to describe monster characteristics and set their properties and abilities.
 - ```AQUATIC``` Confined to water.
 - ```ARTHROPOD_BLOOD``` Forces monster to bleed hemolymph.
 - ```ATTACKMON``` Attacks other monsters regardless of faction relations when pathing through their space.
+- ```ATTACK_CONFIRM``` This monster requires confirmation to attack regardless of safe mode settings.
 - ```ATTACK_LOWER``` Even though this monster is large in size it can't attack upper limbs.
 - ```ATTACK_UPPER``` Even though this monster is small in size it can attack upper limbs.
 - ```BADVENOM``` Attack may **severely** poison the player.

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -89,6 +89,8 @@ static const json_character_flag json_flag_CANNOT_MOVE( "CANNOT_MOVE" );
 static const json_character_flag json_flag_ITEM_WATERPROOFING( "ITEM_WATERPROOFING" );
 static const json_character_flag json_flag_WATERWALKING( "WATERWALKING" );
 
+static const mon_flag_str_id mon_flag_ATTACK_CONFIRM( "ATTACK_CONFIRM" );
+
 static const move_mode_id move_mode_prone( "prone" );
 
 static const skill_id skill_swimming( "swimming" );
@@ -395,21 +397,24 @@ bool avatar_action::move( avatar &you, map &m, const tripoint_rel_ms &d )
                                           _( "You're too pacified to strike anything…" ) ) ) {
                 return false;
             }
+            const bool is_neutral = critter.attitude_to( you ) == Creature::Attitude::NEUTRAL;
             bool safe_mode = ( get_option<bool>( "SAFEMODE" ) ? SAFE_MODE_ON : SAFE_MODE_OFF );
             if( safe_mode ) {
                 // If safe mode is enabled, only allow attacking neutral creatures when it is inactive
-                if( critter.attitude_to( you ) == Creature::Attitude::NEUTRAL &&
-                    g->safe_mode != SAFE_MODE_OFF ) {
+                if( is_neutral && g->safe_mode != SAFE_MODE_OFF ) {
                     const std::string msg_safe_mode = press_x( ACTION_TOGGLE_SAFEMODE );
                     add_msg( m_warning,
                              _( "Not attacking the %1$s -- safe mode is on!  (%2$s to turn it off)" ), critter.name(),
                              msg_safe_mode );
                     return false;
+                } else if( critter.has_flag( mon_flag_ATTACK_CONFIRM ) && is_neutral ) {
+                    if( !query_yn( _( "This really feels like a bad idea. Proceed to attack?" ) ) ) {
+                        return false;
+                    }
                 }
             } else {
                 // If safe mode is disabled, ask for confirmation before attacking a neutral creature
-                if( critter.attitude_to( you ) == Creature::Attitude::NEUTRAL &&
-                    !query_yn( _( "You may be attacked!  Proceed?" ) ) ) {
+                if( is_neutral && !query_yn( _( "You may be attacked!  Proceed?" ) ) ) {
                     return false;
                 }
             }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Feature "Add `ATTACK_CONFIRM` monster flag to prevent accidental attacks on neutral Exodii units"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
A player navigating through an Exodii base with safe mode toggled off can accidentally attack an Exodii worker or quadruped by bumping into them; the game assumes any move into a neutral creature is an intentional attack. The result is instant player death from the retaliation. Given that the Exodii are heavily armed and surrounded by allies, this is almost never what the player intended.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Add a new monster flag `ATTACK_CONFIRM`. When a monster with this flag is neutral and the player has safe mode enabled but currently toggled off, a confirmation prompt - "This really feels like a bad idea. Proceed to attack?" is shown before the attack proceeds.
- Apply the flag to `mon_exodii_worker` and `mon_exodii_quad`, as both are neutral Exodii faction members commonly encountered in in the Exodii base.
- The flag has no effect when safe mode is fully disabled (the existing "You may be attacked! Proceed?" prompt already covers that case) or when the monster is already hostile.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Continued tragic, unintended deaths at the hands of Exodii.
Converting Exodii from mosters to NPCs so attack isn't automatically triggered on interaction.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Compiled on Windows.
Loaded a game and went to the Exodii castle.
Verified extra confirmation was shown when Safe Mode was disabled.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
