### PR TITLE
Overmap vision based map extra visibility

### DIFF
--- a/data/json/overmap/map_extras.json
+++ b/data/json/overmap/map_extras.json
@@ -8,7 +8,7 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "o",
     "color": "red",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -20,7 +20,7 @@
     "min_max_zlevel": [ -1, 0 ],
     "sym": "c",
     "color": "light_red",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
@@ -32,7 +32,7 @@
     "min_max_zlevel": [ -1, 0 ],
     "sym": "f",
     "color": "light_red",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
@@ -55,7 +55,7 @@
     "min_max_zlevel": [ -2, 0 ],
     "sym": "d",
     "color": "light_red",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
@@ -67,7 +67,7 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "X",
     "color": "yellow",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
@@ -79,7 +79,7 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "M",
     "color": "light_red",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
@@ -91,7 +91,7 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "M",
     "color": "light_red",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
@@ -103,8 +103,7 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "X",
     "color": "blue",
-    "autonote": true,
-    "see_from_afar": true,
+    "autonote_visibility": "details",
     "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
@@ -116,8 +115,7 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "X",
     "color": "red",
-    "autonote": true,
-    "see_from_afar": true,
+    "autonote_visibility": "details",
     "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
@@ -130,7 +128,7 @@
     "sym": "X",
     "color": "red",
     "//": "Can't be true because it doesn't always place anything",
-    "autonote": false,
+    "autonote_visibility": "none",
     "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
@@ -142,8 +140,7 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "C",
     "color": "yellow",
-    "autonote": true,
-    "see_from_afar": true,
+    "autonote_visibility": "details",
     "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
@@ -155,7 +152,7 @@
     "min_max_zlevel": [ -4, 5 ],
     "sym": "m",
     "color": "light_red",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
@@ -167,7 +164,7 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "X",
     "color": "light_blue",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
@@ -179,7 +176,7 @@
     "min_max_zlevel": [ -5, 0 ],
     "sym": "s",
     "color": "light_red",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "MAN_MADE" ]
   },
   {
@@ -191,7 +188,7 @@
     "min_max_zlevel": [ -5, 5 ],
     "sym": "P",
     "color": "magenta",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "PORTAL" ]
   },
   {
@@ -203,7 +200,7 @@
     "min_max_zlevel": [ -5, 5 ],
     "sym": "P",
     "color": "magenta",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "PORTAL" ]
   },
   {
@@ -215,8 +212,7 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "x",
     "color": "light_gray",
-    "autonote": true,
-    "see_from_afar": true,
+    "autonote_visibility": "details",
     "flags": [ "EXODII" ]
   },
   {
@@ -228,8 +224,7 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "x",
     "color": "light_gray",
-    "autonote": true,
-    "see_from_afar": true,
+    "autonote_visibility": "details",
     "flags": [ "EXODII" ]
   },
   {
@@ -241,7 +236,7 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "x",
     "color": "yellow",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "YRAX" ]
   },
   {
@@ -253,7 +248,7 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "F",
     "color": "light_gray",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "MAN_MADE" ]
   },
   {
@@ -265,7 +260,7 @@
     "min_max_zlevel": [ -1, -1 ],
     "sym": "S",
     "color": "yellow",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "SPIDER" ]
   },
   {
@@ -277,7 +272,7 @@
     "min_max_zlevel": [ 0, 10 ],
     "sym": "W",
     "color": "yellow",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "WASP" ]
   },
   {
@@ -289,7 +284,7 @@
     "min_max_zlevel": [ -1, 1 ],
     "sym": "c",
     "color": "light_red",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
@@ -301,7 +296,7 @@
     "min_max_zlevel": [ -2, 0 ],
     "sym": "S",
     "color": "yellow",
-    "autonote": true
+    "autonote_visibility": "same_tile"
   },
   {
     "id": "mx_Trapdoor_spider_den",
@@ -320,7 +315,7 @@
     "min_max_zlevel": [ -2, 5 ],
     "sym": "J",
     "color": "red",
-    "autonote": true
+    "autonote_visibility": "same_tile"
   },
   {
     "id": "mx_grove",
@@ -331,7 +326,7 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "F",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -343,7 +338,7 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "s",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -355,8 +350,7 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": ".",
     "color": "brown",
-    "autonote": true,
-    "see_from_afar": true,
+    "autonote_visibility": "details",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -368,8 +362,7 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "p",
     "color": "blue",
-    "autonote": true,
-    "see_from_afar": true,
+    "autonote_visibility": "details",
     "flags": [ "CLASSIC", "WATER" ]
   },
   {
@@ -414,7 +407,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_blackberry_patch" },
     "sym": "o",
     "color": "light_green",
-    "autonote": true
+    "autonote_visibility": "same_tile"
   },
   {
     "id": "mx_strawberry_patch",
@@ -424,7 +417,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_strawberry_patch" },
     "sym": "o",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -435,7 +428,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_blueberry_patch" },
     "sym": "o",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -446,7 +439,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_raspberry_patch" },
     "sym": "o",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -457,7 +450,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_huckleberry_patch" },
     "sym": "o",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -468,7 +461,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_hobblebush_patch" },
     "sym": "o",
     "color": "brown",
-    "autonote": true
+    "autonote_visibility": "same_tile"
   },
   {
     "id": "mx_autumn_olive_patch",
@@ -478,7 +471,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_autumn_olive_patch" },
     "sym": "o",
     "color": "brown",
-    "autonote": true
+    "autonote_visibility": "same_tile"
   },
   {
     "id": "mx_knotweed_patch",
@@ -514,7 +507,7 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "^",
     "color": "dark_gray",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
@@ -526,7 +519,7 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "c",
     "color": "brown",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -538,7 +531,7 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": ".",
     "color": "yellow",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -550,7 +543,7 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": ".",
     "color": "brown",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -562,7 +555,7 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": ".",
     "color": "brown",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -574,7 +567,7 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": ".",
     "color": "light_gray",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -586,7 +579,7 @@
     "min_max_zlevel": [ 0, 5 ],
     "sym": ".",
     "color": "light_gray",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -598,7 +591,7 @@
     "min_max_zlevel": [ -9, -9 ],
     "sym": "~",
     "color": "green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -610,7 +603,7 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "F",
     "color": "dark_gray",
-    "autonote": true
+    "autonote_visibility": "same_tile"
   },
   {
     "id": "mx_casings",
@@ -621,7 +614,7 @@
     "min_max_zlevel": [ -5, 5 ],
     "sym": "c",
     "color": "dark_gray",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
@@ -651,8 +644,7 @@
     "min_max_zlevel": [ 0, 9 ],
     "sym": "W",
     "color": "yellow",
-    "autonote": true,
-    "see_from_afar": true,
+    "autonote_visibility": "details",
     "flags": [ "WASP" ]
   },
   {
@@ -664,8 +656,7 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "D",
     "color": "brown",
-    "autonote": true,
-    "see_from_afar": true,
+    "autonote_visibility": "details",
     "flags": [ "WASP" ]
   },
   {
@@ -686,8 +677,7 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "X",
     "color": "yellow",
-    "autonote": true,
-    "see_from_afar": true,
+    "autonote_visibility": "details",
     "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
@@ -699,7 +689,7 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "X",
     "color": "yellow",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
@@ -719,7 +709,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_laststand" },
     "sym": "X",
     "color": "green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "min_max_zlevel": [ 0, 0 ],
     "flags": [ "MAN_MADE", "CLASSIC" ]
   },
@@ -731,7 +721,7 @@
     "generator": { "generator_method": "map_extra_function", "generator_id": "mx_fungal_zone" },
     "sym": "F",
     "color": "yellow",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "min_max_zlevel": [ 0, 0 ],
     "flags": [ "FUNGAL" ]
   },
@@ -770,7 +760,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_toxic_waste" },
     "sym": "D",
     "color": "magenta",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "MAN_MADE", "CLASSIC" ]
   },
   {
@@ -800,7 +790,7 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "o",
     "color": "red",
-    "autonote": true
+    "autonote_visibility": "same_tile"
   },
   {
     "id": "mx_sandy_beach",

--- a/data/mods/Backrooms/map_extras.json
+++ b/data/mods/Backrooms/map_extras.json
@@ -7,7 +7,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_teleporter_node" },
     "sym": "X",
     "color": "red",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "BACKROOMS" ]
   },
   {
@@ -18,7 +18,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_autodoc_room" },
     "sym": "A",
     "color": "pink",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "BACKROOMS" ]
   },
   {
@@ -58,7 +58,7 @@
     "min_max_zlevel": [ -3, 3 ],
     "sym": "W",
     "color": "yellow",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "WASP", "BACKROOMS" ]
   },
   {
@@ -70,7 +70,7 @@
     "min_max_zlevel": [ -3, 3 ],
     "sym": "D",
     "color": "brown",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "WASP", "BACKROOMS" ]
   },
   {

--- a/data/mods/CrazyCataclysm/crazy_mapgen.json
+++ b/data/mods/CrazyCataclysm/crazy_mapgen.json
@@ -18,7 +18,7 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "s",
     "color": "red",
-    "autonote": true
+    "autonote_visibility": "same_tile"
   },
   {
     "id": "mx_jackson",
@@ -29,7 +29,7 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "j",
     "color": "red",
-    "autonote": true
+    "autonote_visibility": "same_tile"
   },
   {
     "type": "map_extra_collection",

--- a/data/mods/DinoMod/overmap/map_extras.json
+++ b/data/mods/DinoMod/overmap/map_extras.json
@@ -8,7 +8,7 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "X",
     "color": "yellow",
-    "autonote": true,
+    "autonote_visibility": "details",
     "flags": [ "MAN_MADE" ]
   },
   {
@@ -19,7 +19,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_pred_abandoned" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -30,7 +30,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_achelousaurus" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -41,7 +41,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_acrocanthosaurus" },
     "sym": "D",
     "color": "yellow",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -52,7 +52,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_albertosaurus" },
     "sym": "D",
     "color": "yellow",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -63,7 +63,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_allosaurus" },
     "sym": "D",
     "color": "yellow",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -74,7 +74,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_anchisaurus" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -85,7 +85,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_ankylosaurus" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -96,7 +96,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_appalachiosaurus" },
     "sym": "D",
     "color": "yellow",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -107,7 +107,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_aquilops" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -118,7 +118,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_camptosaurus" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -129,7 +129,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_centrosaurus" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -140,7 +140,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_ceratosaurus" },
     "sym": "D",
     "color": "yellow",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -151,7 +151,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_chasmosaurus" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -162,7 +162,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_coelophysis" },
     "sym": "D",
     "color": "yellow",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -173,7 +173,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_corythosaurus" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -184,7 +184,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_daspletosaurus" },
     "sym": "D",
     "color": "yellow",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -195,7 +195,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_deinonychus" },
     "sym": "D",
     "color": "yellow",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -206,7 +206,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_dilophosaurus" },
     "sym": "D",
     "color": "yellow",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -217,7 +217,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_dromaeosaurus" },
     "sym": "D",
     "color": "yellow",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -228,7 +228,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_dryosaurus" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -239,7 +239,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_dryptosaurus" },
     "sym": "D",
     "color": "yellow",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -250,7 +250,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_dyoplosaurus" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -261,7 +261,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_edmontonia" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -272,7 +272,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_edmontosaurus" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -283,7 +283,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_einiosaurus" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -294,7 +294,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_eolambia" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -305,7 +305,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_euoplocephalus" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -316,7 +316,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_falcarius" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -327,7 +327,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_gallimimus" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -338,7 +338,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_gargoyleosaurus" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -349,7 +349,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_gastonia" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -360,7 +360,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_gorgosaurus" },
     "sym": "D",
     "color": "yellow",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -371,7 +371,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_gryposaurus" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -382,7 +382,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_hadrosaurus" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -393,7 +393,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_hesperosaurus" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -404,7 +404,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_hypacrosaurus" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -415,7 +415,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_issi" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -426,7 +426,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_kosmoceratops" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -437,7 +437,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_lambeosaurus" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -448,7 +448,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_lokiceratops" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -459,7 +459,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_maiasaura" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -470,7 +470,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_nanosaurus" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -481,7 +481,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_nanotyrannus" },
     "sym": "D",
     "color": "yellow",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -492,7 +492,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_nanuqsaurus" },
     "sym": "D",
     "color": "yellow",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -503,7 +503,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_nedcolbertia" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -514,7 +514,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_nodosaurus" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -525,7 +525,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_nothronychus" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -536,7 +536,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_ornithomimus" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -547,7 +547,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_pachycephalosaurus" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -558,7 +558,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_pachyrhinosaurus" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -569,7 +569,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_panoplosaurus" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -580,7 +580,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_parasaurolophus" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -591,7 +591,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_pentaceratops" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -602,7 +602,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_prosaurolophus" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -613,7 +613,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_sarahsaurus" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -624,7 +624,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_saurolophus" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -635,7 +635,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_sauropelta" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -646,7 +646,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_saurornitholestes" },
     "sym": "D",
     "color": "yellow",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -657,7 +657,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_scolosaurus" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -668,7 +668,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_scutellosaurus" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -679,7 +679,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_siats" },
     "sym": "D",
     "color": "yellow",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -690,7 +690,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_stegoceras" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -701,7 +701,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_stegosaurus" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -712,7 +712,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_stenonychosaurus" },
     "sym": "D",
     "color": "yellow",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -723,7 +723,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_struthiomimus" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -734,7 +734,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_styracosaurus" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -745,7 +745,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_tawa" },
     "sym": "D",
     "color": "yellow",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -756,7 +756,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_tenontosaurus" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -767,7 +767,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_thescelosaurus" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -778,7 +778,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_torosaurus" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -789,7 +789,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_torvosaurus" },
     "sym": "D",
     "color": "yellow",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -800,7 +800,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_triceratops" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -811,7 +811,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_tyrannosaurus" },
     "sym": "D",
     "color": "yellow",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -822,7 +822,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_utahraptor" },
     "sym": "D",
     "color": "yellow",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -833,7 +833,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_velociraptor" },
     "sym": "D",
     "color": "yellow",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -844,7 +844,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_zuniceratops" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -855,7 +855,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nest_zuul" },
     "sym": "D",
     "color": "light_green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -867,7 +867,7 @@
     "min_max_zlevel": [ -5, 5 ],
     "sym": "P",
     "color": "magenta",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -879,7 +879,7 @@
     "min_max_zlevel": [ -5, 5 ],
     "sym": "P",
     "color": "magenta",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -891,7 +891,7 @@
     "min_max_zlevel": [ -5, 5 ],
     "sym": "P",
     "color": "magenta",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   }
 ]

--- a/data/mods/Magiclysm/worldgen/map_extras.json
+++ b/data/mods/Magiclysm/worldgen/map_extras.json
@@ -8,6 +8,6 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "C",
     "color": "brown",
-    "autonote": false
+    "autonote_visibility": "none"
   }
 ]

--- a/data/mods/MindOverMatter/overmap/map_extras.json
+++ b/data/mods/MindOverMatter/overmap/map_extras.json
@@ -7,7 +7,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_alien_grass" },
     "sym": "A",
     "color": "red",
-    "autonote": true
+    "autonote_visibility": "same_tile"
   },
   {
     "id": "mx_alien_grass_2",
@@ -17,7 +17,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_alien_grass_2" },
     "sym": "A",
     "color": "magenta",
-    "autonote": true
+    "autonote_visibility": "same_tile"
   },
   {
     "id": "mx_alien_grass_3",
@@ -27,7 +27,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_alien_grass_3" },
     "sym": "A",
     "color": "cyan",
-    "autonote": true
+    "autonote_visibility": "same_tile"
   },
   {
     "id": "mx_alien_grass_4",
@@ -37,7 +37,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_alien_grass_4" },
     "sym": "A",
     "color": "yellow",
-    "autonote": true
+    "autonote_visibility": "same_tile"
   },
   {
     "id": "mx_alien_grass_5",
@@ -47,7 +47,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_alien_grass_5" },
     "sym": "A",
     "color": "light_red",
-    "autonote": true
+    "autonote_visibility": "same_tile"
   },
   {
     "id": "mx_alien_grove",
@@ -57,7 +57,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_alien_grove" },
     "sym": "F",
     "color": "magenta",
-    "autonote": true
+    "autonote_visibility": "same_tile"
   },
   {
     "id": "mx_nether_pond",
@@ -67,7 +67,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nether_pond" },
     "sym": "O",
     "color": "dark_gray",
-    "autonote": true
+    "autonote_visibility": "same_tile"
   },
   {
     "id": "mx_fear_hawk_copse",
@@ -76,7 +76,7 @@
     "description": "A suspicious copse of trees.",
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_fear_hawk_copse" },
     "min_max_zlevel": [ 0, 0 ],
-    "autonote": true
+    "autonote_visibility": "same_tile"
   },
   {
     "id": "mx_glass_and_crystal",
@@ -86,7 +86,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_glass_and_crystal" },
     "sym": "C",
     "color": "dark_gray",
-    "autonote": true
+    "autonote_visibility": "same_tile"
   },
   {
     "id": "mx_phavian_science",
@@ -97,7 +97,7 @@
     "min_max_zlevel": [ -5, 0 ],
     "sym": "s",
     "color": "light_blue",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "MAN_MADE" ]
   }
 ]

--- a/data/mods/MindOverMatter/overmap/map_extras.json
+++ b/data/mods/MindOverMatter/overmap/map_extras.json
@@ -7,7 +7,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_alien_grass" },
     "sym": "A",
     "color": "red",
-    "autonote_visibility": "same_tile"
+    "autonote_visibility": "details"
   },
   {
     "id": "mx_alien_grass_2",
@@ -17,7 +17,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_alien_grass_2" },
     "sym": "A",
     "color": "magenta",
-    "autonote_visibility": "same_tile"
+    "autonote_visibility": "outlines"
   },
   {
     "id": "mx_alien_grass_3",
@@ -27,7 +27,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_alien_grass_3" },
     "sym": "A",
     "color": "cyan",
-    "autonote_visibility": "same_tile"
+    "autonote_visibility": "details"
   },
   {
     "id": "mx_alien_grass_4",
@@ -37,7 +37,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_alien_grass_4" },
     "sym": "A",
     "color": "yellow",
-    "autonote_visibility": "same_tile"
+    "autonote_visibility": "outlines"
   },
   {
     "id": "mx_alien_grass_5",
@@ -47,7 +47,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_alien_grass_5" },
     "sym": "A",
     "color": "light_red",
-    "autonote_visibility": "same_tile"
+    "autonote_visibility": "outlines"
   },
   {
     "id": "mx_alien_grove",
@@ -57,7 +57,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_alien_grove" },
     "sym": "F",
     "color": "magenta",
-    "autonote_visibility": "same_tile"
+    "autonote_visibility": "vague"
   },
   {
     "id": "mx_nether_pond",
@@ -67,7 +67,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_nether_pond" },
     "sym": "O",
     "color": "dark_gray",
-    "autonote_visibility": "same_tile"
+    "autonote_visibility": "vague"
   },
   {
     "id": "mx_fear_hawk_copse",
@@ -76,7 +76,7 @@
     "description": "A suspicious copse of trees.",
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_fear_hawk_copse" },
     "min_max_zlevel": [ 0, 0 ],
-    "autonote_visibility": "same_tile"
+    "autonote_visibility": "outlines"
   },
   {
     "id": "mx_glass_and_crystal",
@@ -86,7 +86,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_glass_and_crystal" },
     "sym": "C",
     "color": "dark_gray",
-    "autonote_visibility": "same_tile"
+    "autonote_visibility": "vague"
   },
   {
     "id": "mx_phavian_science",

--- a/data/mods/Xedra_Evolved/mapgen/cave_wendi.json
+++ b/data/mods/Xedra_Evolved/mapgen/cave_wendi.json
@@ -8,7 +8,7 @@
     "sym": "l",
     "min_max_zlevel": [ 0, 0 ],
     "color": "magenta_yellow",
-    "autonote": true
+    "autonote_visibility": "same_tile"
   },
   {
     "type": "mapgen",

--- a/data/mods/Xedra_Evolved/mapgen/cryptids.json
+++ b/data/mods/Xedra_Evolved/mapgen/cryptids.json
@@ -8,7 +8,7 @@
     "sym": "l",
     "min_max_zlevel": [ 0, 0 ],
     "color": "magenta_yellow",
-    "autonote": true
+    "autonote_visibility": "same_tile"
   },
   {
     "type": "mapgen",
@@ -154,7 +154,7 @@
     "sym": "l",
     "min_max_zlevel": [ 0, 0 ],
     "color": "magenta_yellow",
-    "autonote": true
+    "autonote_visibility": "same_tile"
   },
   {
     "type": "mapgen",

--- a/data/mods/Xedra_Evolved/mapgen/map_extras.json
+++ b/data/mods/Xedra_Evolved/mapgen/map_extras.json
@@ -598,7 +598,7 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "G",
     "color": "magenta",
-    "autonote_visibility": "same_tile",
+    "autonote_visibility": "details",
     "flags": [ "CLASSIC" ]
   },
   {

--- a/data/mods/Xedra_Evolved/mapgen/map_extras.json
+++ b/data/mods/Xedra_Evolved/mapgen/map_extras.json
@@ -8,7 +8,7 @@
     "sym": "I",
     "min_max_zlevel": [ 0, 0 ],
     "color": "magenta_yellow",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -81,7 +81,7 @@
     "min_max_zlevel": [ -2, 0 ],
     "sym": "S",
     "color": "yellow",
-    "autonote": true
+    "autonote_visibility": "same_tile"
   },
   {
     "id": "mx_goblin_spider",
@@ -92,7 +92,7 @@
     "min_max_zlevel": [ -2, 0 ],
     "sym": "S",
     "color": "yellow",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -104,7 +104,7 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "E",
     "color": "green",
-    "autonote": true
+    "autonote_visibility": "same_tile"
   },
   {
     "type": "mapgen",
@@ -150,7 +150,7 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "E",
     "color": "green",
-    "autonote": true
+    "autonote_visibility": "same_tile"
   },
   {
     "type": "mapgen",
@@ -196,7 +196,7 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "E",
     "color": "green",
-    "autonote": true
+    "autonote_visibility": "same_tile"
   },
   {
     "type": "mapgen",
@@ -242,7 +242,7 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "E",
     "color": "green",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "MAN_MADE" ]
   },
   {
@@ -310,7 +310,7 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "E",
     "color": "light_green",
-    "autonote": true
+    "autonote_visibility": "same_tile"
   },
   {
     "type": "mapgen",
@@ -381,7 +381,7 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "E",
     "color": "light_green",
-    "autonote": true
+    "autonote_visibility": "same_tile"
   },
   {
     "type": "mapgen",
@@ -453,7 +453,7 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "E",
     "color": "blue",
-    "autonote": true
+    "autonote_visibility": "same_tile"
   },
   {
     "type": "mapgen",
@@ -525,7 +525,7 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "E",
     "color": "blue",
-    "autonote": true
+    "autonote_visibility": "same_tile"
   },
   {
     "type": "mapgen",
@@ -598,7 +598,7 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "G",
     "color": "magenta",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -673,7 +673,7 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "m",
     "color": "light_gray",
-    "autonote": false,
+    "autonote_visibility": "none",
     "flags": [ "CLASSIC" ]
   },
   {
@@ -894,7 +894,7 @@
     "sym": "w",
     "min_max_zlevel": [ 0, 0 ],
     "color": "dark_gray_red",
-    "autonote": true,
+    "autonote_visibility": "same_tile",
     "flags": [ "CLASSIC" ]
   }
 ]

--- a/data/mods/aftershock_exoplanet/maps/overmap_map_extras.json
+++ b/data/mods/aftershock_exoplanet/maps/overmap_map_extras.json
@@ -7,7 +7,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_wraitheon_droneswarm" },
     "sym": "w",
     "color": "pink",
-    "autonote": true
+    "autonote_visibility": "same_tile"
   },
   {
     "id": "mx_reaver_bandits",
@@ -17,7 +17,7 @@
     "generator": { "generator_method": "update_mapgen", "generator_id": "mx_reaver_bandits" },
     "sym": "b",
     "color": "pink",
-    "autonote": true
+    "autonote_visibility": "same_tile"
   },
   {
     "id": "mx_gunship",
@@ -28,6 +28,6 @@
     "min_max_zlevel": [ 0, 0 ],
     "sym": "X",
     "color": "light_blue",
-    "autonote": true
+    "autonote_visibility": "same_tile"
   }
 ]

--- a/doc/JSON/MAPGEN.md
+++ b/doc/JSON/MAPGEN.md
@@ -1655,21 +1655,19 @@ Map extras can be used to place environmental objects and structures that can he
   "min_max_zlevel": [ 0, 0 ],
   "sym": "M",
   "color": "red",
-  "autonote": true,
-  "see_from_afar": true,
+  "autonote_visibility": "details",
   "flags": [ "MAN_MADE" ]
 }
 ```
 
-| Field          | Description
-| ---            | ---
-| generator      | (_optional_) An object defining how and what this extra should spawn.
-| min_max_zlevel | (_optional_) A pair of integers defining the minimum and maximum zlevel in which this extra can spawn. Defaults to none (can spawn at any zlevel).
-| sym            | (_optional_) The symbol to use when marking this extra on the overmap. Defaults to no symbol.
-| color          | (_optional_) The color of the symbol identifying this extra on the overmap. Defaults to white.
-| autonote       | (_optional_) Whether to automatically mark this extra on the overmap. Defaults to false.
-| see_from_afar  | (_optional_) Whether autonotes will be placed when the map extra is generated. Without this boolean autonotes will only be placed when the OMT is specifically visited. Defaults to false.
-| flags          | (_optional_) List of flags that identify this extra. These flags can be listed in `overmap_feature_flag_settings` to blacklist or whitelist map extras.
+| Field               | Description
+| ---                 | ---
+| generator           | (_optional_) An object defining how and what this extra should spawn.
+| min_max_zlevel      | (_optional_) A pair of integers defining the minimum and maximum zlevel in which this extra can spawn. Defaults to none (can spawn at any zlevel).
+| sym                 | (_optional_) The symbol to use when marking this extra on the overmap. Defaults to no symbol.
+| color               | (_optional_) The color of the symbol identifying this extra on the overmap. Defaults to white.
+| autonote_visibility | (_optional_) When to automatically mark this extra on the overmap. Defaults to "none", never marking it on the overmap. Other options listed below.
+| flags               | (_optional_) List of flags that identify this extra. These flags can be listed in `overmap_feature_flag_settings` to blacklist or whitelist map extras.
 
 The `generator` can use one of 3 methods:
 
@@ -1678,6 +1676,18 @@ The `generator` can use one of 3 methods:
 | `map_extra_function` | The `generator_id` points to a builtin function to generate the extra. See the `builtin_functions` function map in map_extras.cpp for the current list.
 | `mapgen`             | The `generator_id` points to a `om_terrain` string within a `mapgen` definition.
 | `update_mapgen`      | The `generator_id` points to a `update_mapgen_id` string within a `mapgen` definition.
+
+The `autonote_visibility` has 7 options:
+
+| Name          | Description
+| ------------- | ---
+| `"none"`      | Never shown.
+| `"always"`    | Shown as soon as it is generated.
+| `"vague"`     | Shown once the player's vision of the tile meets the corresponding vision level.
+| `"outlines"`  | Shown once the player's vision of the tile meets the corresponding vision level.
+| `"details"`   | Shown once the player's vision of the tile meets the corresponding vision level.
+| `"full"`      | Shown once the player's vision of the tile meets the corresponding vision level.
+| `"same_tile"` | Shown once the player enters the same overmap.
 
 ### Example: mx_science
 

--- a/src/auto_note.cpp
+++ b/src/auto_note.cpp
@@ -165,7 +165,7 @@ void auto_note_settings::default_initialize()
     load( false );
 
     for( const map_extra &extra : MapExtras::mapExtraFactory().get_all() ) {
-        if( has_auto_note_enabled( extra.id, false ) && extra.autonote ) {
+        if( has_auto_note_enabled( extra.id, false ) && extra.visibility != map_extra_visibility::none ) {
             character_autoNoteEnabled.insert( extra.id );
         }
     }
@@ -247,7 +247,7 @@ auto_note_manager_gui::auto_note_manager_gui()
     for( const map_extra &extra : MapExtras::mapExtraFactory().get_all() ) {
         // Ignore all extras that have autonote disabled in the JSON.
         // This filters out lots of extras users shouldn't see (like "normal")
-        if( !extra.autonote ) {
+        if( extra.visibility == map_extra_visibility::none ) {
             continue;
         }
 

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -5882,7 +5882,7 @@ void cata_tiles::do_tile_loading_report()
     map_extra_ids.erase(
         std::remove_if( map_extra_ids.begin(), map_extra_ids.end(),
     []( const map_extra_id & id ) {
-        return !id->autonote;
+        return id->visibility == map_extra_visibility::none;
     } ), map_extra_ids.end() );
     tile_loading_report_seq_ids( map_extra_ids, TILE_CATEGORY::MAP_EXTRA );
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -11435,22 +11435,6 @@ bool game::can_pulp_acid_corpse( const Character &you, const mtype &corpse_mtype
     return true;
 }
 
-static void do_delayed_autonote( const tripoint_abs_omt &target )
-{
-    auto iter = g->unvisited_map_extras.find( target );
-    if( iter == g->unvisited_map_extras.end() ) {
-        return; // No unvisited map extras here!
-    }
-
-    overmap *om_target = overmap_buffer.get_existing( project_to<coords::om>( target.xy() ) );
-
-    if( om_target ) {
-        om_target->add_deferred_extra_note( target );
-    }
-
-    g->unvisited_map_extras.erase( iter );
-}
-
 namespace cata_event_dispatch
 {
 void avatar_moves( const tripoint_abs_ms &old_abs_pos, const avatar &u, const map &m )
@@ -11472,7 +11456,7 @@ void avatar_moves( const tripoint_abs_ms &old_abs_pos, const avatar &u, const ma
         const oter_id &cur_ter = overmap_buffer.ter( new_abs_omt );
         const oter_id &past_ter = overmap_buffer.ter( old_abs_omt );
         get_event_bus().send<event_type::avatar_enters_omt>( new_abs_omt.raw(), cur_ter );
-        do_delayed_autonote( new_abs_omt );
+        overmap_buffer.add_extra_note( new_abs_omt );
         // if the player has moved omt then might trigger an EOC for that OMT
         if( !past_ter->get_exit_EOC().is_null() ) {
             dialogue d( get_talker_for( get_avatar() ), nullptr );

--- a/src/game.h
+++ b/src/game.h
@@ -1172,8 +1172,6 @@ class game
         global_variables global_variables_instance;
         std::unordered_map<std::string, point_abs_om> unique_npcs;
     public:
-        // Map extras that have been generated, but not yet traveled to. Will trigger autonotes once visited.
-        std::unordered_set<tripoint_abs_omt> unvisited_map_extras;
         void update_unique_npc_location( const std::string &id, point_abs_om loc );
         point_abs_om get_unique_npc_location( const std::string &id );
         bool unique_npc_exists( const std::string &id );

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -32,6 +32,7 @@
 #include "mapgen_functions.h"
 #include "mapgendata.h"
 #include "omdata.h"
+#include "overmap.h"
 #include "overmapbuffer.h"
 #include "point.h"
 #include "regional_settings.h"
@@ -164,6 +165,30 @@ std::string enum_to_string<map_extra_method>( map_extra_method data )
         // *INDENT-ON*
     }
     cata_fatal( "Invalid map_extra_method" );
+}
+
+template<>
+std::string enum_to_string<map_extra_visibility>( map_extra_visibility data )
+{
+    switch( data ) {
+        case map_extra_visibility::none:
+            return "none";
+        case map_extra_visibility::always:
+            return "always";
+        case map_extra_visibility::vague:
+            return "vague";
+        case map_extra_visibility::outlines:
+            return "outlines";
+        case map_extra_visibility::details:
+            return "details";
+        case map_extra_visibility::full:
+            return "full";
+        case map_extra_visibility::same_tile:
+            return "same_tile";
+        case map_extra_visibility::LAST:
+            break;
+    }
+    cata_fatal( "Invalid map extra visibility" );
 }
 
 } // namespace io
@@ -1295,6 +1320,28 @@ bool map_extra::is_valid_for( const mapgendata &md ) const
     return true;
 }
 
+bool map_extra::potentially_visible_at( om_vision_level vis ) const
+{
+    switch( visibility ) {
+        case map_extra_visibility::none:
+            return false;
+        case map_extra_visibility::always:
+            return true;
+        case map_extra_visibility::vague:
+            return vis >= om_vision_level::vague;
+        case map_extra_visibility::outlines:
+            return vis >= om_vision_level::outlines;
+        case map_extra_visibility::details:
+            return vis >= om_vision_level::details;
+        case map_extra_visibility::full:
+            return vis >= om_vision_level::full;
+        case map_extra_visibility::same_tile: // this is a weird case and has it's own checks
+            return true;
+        case map_extra_visibility::LAST:
+            return false;
+    }
+}
+
 void map_extra::load( const JsonObject &jo, std::string_view )
 {
     mandatory( jo, was_loaded, "name", name_ );
@@ -1308,8 +1355,7 @@ void map_extra::load( const JsonObject &jo, std::string_view )
     optional( jo, was_loaded, "sym", symbol, unicode_codepoint_from_symbol_reader, NULL_UNICODE );
     color = jo.has_member( "color" ) ? color_from_string( jo.get_string( "color" ) ) : was_loaded ?
             color : c_white;
-    optional( jo, was_loaded, "autonote", autonote, false );
-    optional( jo, was_loaded, "see_from_afar", see_from_afar, false );
+    optional( jo, was_loaded, "autonote_visibility", visibility, map_extra_visibility::none );
     optional( jo, was_loaded, "min_max_zlevel", min_max_zlevel_ );
     optional( jo, was_loaded, "flags", flags_, string_reader{} );
     if( was_loaded && jo.has_member( "extend" ) ) {

--- a/src/map_extras.h
+++ b/src/map_extras.h
@@ -24,6 +24,8 @@ class tinymap;
 template<typename T> class generic_factory;
 template<typename T> struct enum_traits;
 
+enum class om_vision_level : int8_t;
+
 enum class map_extra_method : int {
     null = 0,
     map_extra_function,
@@ -37,6 +39,22 @@ struct enum_traits<map_extra_method> {
     static constexpr map_extra_method last = map_extra_method::num_map_extra_methods;
 };
 
+enum class map_extra_visibility {
+    none,
+    always,
+    vague,
+    outlines,
+    details,
+    full,
+    same_tile,
+    LAST
+};
+
+template<>
+struct enum_traits<map_extra_visibility> {
+    static constexpr map_extra_visibility last = map_extra_visibility::LAST;
+};
+
 using map_extra_pointer = bool( * )( map &, const tripoint_abs_sm & );
 
 class map_extra
@@ -46,8 +64,7 @@ class map_extra
         std::vector<std::pair<map_extra_id, mod_id>> src;
         std::string generator_id;
         map_extra_method generator_method = map_extra_method::null;
-        bool autonote = false;
-        bool see_from_afar = false;
+        map_extra_visibility visibility;
         uint32_t symbol = UTF8_getch( "X" );
         nc_color color = c_red;
 
@@ -68,6 +85,8 @@ class map_extra
         const cata::flat_set<std::string> &get_flags() const {
             return flags_;
         }
+
+        bool potentially_visible_at( om_vision_level vis ) const;
 
         // Used by generic_factory
         bool was_loaded = false;

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -427,9 +427,7 @@ void overmap::set_seen( const tripoint_om_omt &p, om_vision_level val, bool forc
 
     layer[p.z() + OVERMAP_DEPTH].visible[p.xy()] = val;
 
-    if( val > om_vision_level::details ) {
-        add_extra_note( p );
-    }
+    add_extra_note( p );
 }
 
 om_vision_level overmap::seen( const tripoint_om_omt &p ) const
@@ -686,26 +684,10 @@ void overmap::add_extra( const tripoint_om_omt &p, const map_extra_id &id )
     }
 }
 
-static void defer_auto_note( const tripoint_abs_omt &target )
-{
-    g->unvisited_map_extras.insert( target );
-}
-
-void overmap::add_deferred_extra_note( const tripoint_abs_omt &p )
-{
-    point_abs_om overmap_coord;
-    tripoint_om_omt omt_coord;
-    std::tie( overmap_coord, omt_coord ) = project_remain<coords::om>( p );
-    add_extra_note( omt_coord, true );
-}
-
 void overmap::add_extra_note( const tripoint_om_omt &p, bool force_add )
 {
-    if( seen( p ) < om_vision_level::details ) {
-        return;
-    }
-
-    // WTF is this doing? We just figured out the map extra's ID in overmap::add_extra(), what's with this bizarre lookup?
+    // overmap::add_extra_note is called from overmap::set_seen - to add notes for already generated,
+    // but as yet unseen, tiles.
     const std::vector<om_map_extra> &layer_extras = layer[p.z() + OVERMAP_DEPTH].extras;
     auto extrait = std::find_if( layer_extras.begin(),
     layer_extras.end(), [&p]( const om_map_extra & extra ) {
@@ -716,10 +698,15 @@ void overmap::add_extra_note( const tripoint_om_omt &p, bool force_add )
     }
     const map_extra_id &extra = extrait->id;
 
-    if( !force_add && !extra->see_from_afar ) {
-        tripoint_abs_omt target = project_combine( this->pos(), p );
-        defer_auto_note( target );
+    if( !force_add && !extra->potentially_visible_at( seen( p ) ) ) {
         return;
+    }
+
+    if( !force_add && extra->visibility == map_extra_visibility::same_tile ) {
+        tripoint_abs_omt target = project_combine( this->pos(), p );
+        if( target != get_avatar().pos_abs_omt() ) {
+            return;
+        }
     }
 
 

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -512,7 +512,6 @@ class overmap
         bool has_extra( const tripoint_om_omt &p ) const;
         const map_extra_id &extra( const tripoint_om_omt &p ) const;
         void add_extra( const tripoint_om_omt &p, const map_extra_id &id );
-        void add_deferred_extra_note( const tripoint_abs_omt &p );
         void add_extra_note( const tripoint_om_omt &p, bool force_add = false );
         void delete_extra( const tripoint_om_omt &p );
 

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -322,6 +322,12 @@ void overmapbuffer::add_extra( const tripoint_abs_omt &p, const map_extra_id &id
     om_loc.om->add_extra( om_loc.local, id );
 }
 
+void overmapbuffer::add_extra_note( const tripoint_abs_omt &p, const bool force_add )
+{
+    overmap_with_local_coords om_loc = get_om_global( p );
+    om_loc.om->add_extra_note( om_loc.local, force_add );
+}
+
 void overmapbuffer::delete_extra( const tripoint_abs_omt &p )
 {
     if( has_extra( p ) ) {

--- a/src/overmapbuffer.h
+++ b/src/overmapbuffer.h
@@ -247,6 +247,7 @@ class overmapbuffer
         bool has_extra( const tripoint_abs_omt &p );
         const map_extra_id &extra( const tripoint_abs_omt &p );
         void add_extra( const tripoint_abs_omt &p, const map_extra_id &id );
+        void add_extra_note( const tripoint_abs_omt &p, bool force_add = false );
         void delete_extra( const tripoint_abs_omt &p );
         bool is_explored( const tripoint_abs_omt &p );
         void toggle_explored( const tripoint_abs_omt &p );

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -159,7 +159,6 @@ void game::serialize_json( std::ostream &fout )
     global_variables_instance.serialize( json );
     Messages::serialize( json );
     json.member( "unique_npcs", unique_npcs );
-    json.member( "unvisited_map_extras", unvisited_map_extras );
     json.end_object();
 }
 
@@ -319,7 +318,6 @@ void game::unserialize_impl( const JsonObject &data )
     }
     global_variables_instance.unserialize( data );
     data.read( "unique_npcs", unique_npcs );
-    data.read( "unvisited_map_extras", unvisited_map_extras );
     inp_mngr.pump_events();
     data.read( "stats_tracker", *stats_tracker_ptr );
     data.read( "achievements_tracker", *achievements_tracker_ptr );

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -859,7 +859,7 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
             draw_from_id_string( id, category,
                                  category == TILE_CATEGORY::OVERMAP_TERRAIN ? "overmap_terrain" : "",
                                  omp, subtile, rotation, ll, false, height_3d );
-            if( !mx.is_empty() && mx->autonote ) {
+            if( !mx.is_empty() && mx->visibility != map_extra_visibility::none ) {
                 draw_from_id_string( mx.str(), TILE_CATEGORY::MAP_EXTRA, "map_extra", omp,
                                      0, 0, ll, false );
             }


### PR DESCRIPTION


#### Summary
Features "Allow map extras to specify the level of overmap vision at which they become visible."

#### Purpose of change
Expansion on https://github.com/CleverRaven/Cataclysm-DDA/pull/86334

#### Describe the solution
Replace the autonote/see_from_afar boolean values with a single autonote_visibility enum value covering all possible vision levels and an extra "same_tile" level that matches the see_from_afar: false behavior.

Remove the deferred map extra visibility infrastructure in game and use the existing capability for that by calling add_extra_note for the entered overmap tile (with the new visibility checks).

#### Testing
Walk around, find map extras. Some (casings) only reveal on entering the tile, while others reveal from afar (pond).