### PR TITLE
Use weighed not weighted in medical menu

### DIFF
--- a/src/medical_ui.cpp
+++ b/src/medical_ui.cpp
@@ -546,7 +546,7 @@ void medical_ui::summary_tab() const
     if( last_weighting_time != nullptr ) {
         const std::string last_weighting_weight = string_format( "%.0f %s",
                 you->get_value( "last_weighting_weight_kg" ).dbl(), weight_units() );
-        const std::string last_weighted_time = string_format( _( "last weighted %s ago" ),
+        const std::string last_weighted_time = string_format( _( "last weighed %s ago." ),
                                                to_string_approx( calendar::turn - time_point( last_weighting_time->dbl() ) ) );
         const std::string weight_desc = string_format(
                                             "%s: %s (%s)",
@@ -555,7 +555,7 @@ void medical_ui::summary_tab() const
                                             colorize( last_weighted_time, c_dark_gray ) );
         cataimgui::draw_colored_text( weight_desc, col_width );
     } else {
-        cataimgui::draw_colored_text( _( "You do not remember when you weighted yourself the last time" ),
+        cataimgui::draw_colored_text( _( "You do not remember the last time you weighed yourself." ),
                                       c_dark_gray, col_width );
     }
 }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Weighed is the past tense of weigh, the action of measuring weight. Weighted is to apply weights.

#### Testing
<img width="460" height="32" alt="Weight: 60 lbs (last weighed about 0 seconds ago.)" src="https://github.com/user-attachments/assets/0154ea7f-2587-44bb-bcb8-46d5f4a9304d" />
<img width="505" height="36" alt="You do not remember the last time you weighed yourself." src="https://github.com/user-attachments/assets/44221a65-cd20-4024-a6e4-90a20326113e" />

