### PR TITLE
Update robot.json (Wraitheon Fulgent Dissassembly-fix) [Aftershock]

### DIFF
--- a/data/mods/aftershock_exoplanet/recipes/deconstruction/robot.json
+++ b/data/mods/aftershock_exoplanet/recipes/deconstruction/robot.json
@@ -181,7 +181,7 @@
       [ [ "power_supply", 4 ] ],
       [ [ "solar_cell", 2 ] ],
       [ [ "targeting_module", 1 ] ],
-      [ [ "xray_laser_barrel", 1 ] ],
+      [ [ "afs_av22", 1 ] ],
       [ [ "spidery_legs_big", 1 ] ]
     ]
   }

--- a/data/mods/aftershock_exoplanet/recipes/deconstruction/robot.json
+++ b/data/mods/aftershock_exoplanet/recipes/deconstruction/robot.json
@@ -162,5 +162,28 @@
       [ [ "afs_energy_storage_3", 1 ] ],
       [ [ "canister_empty", 1 ] ]
     ]
+  },
+  {
+    "result": "broken_advbot_laser",
+    "type": "uncraft",
+    "activity_level": "MODERATE_EXERCISE",
+    "skill_used": "electronics",
+    "difficulty": 6,
+    "time":"2 h",
+    "using": [ [ "soldering_standard", 20 ], [ "welding_standard", 5 ] ],
+    "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
+    "components": [
+      [ [ "ai_module", 1 ] ],
+      [ [ "sensor_module", 1 ] ],
+      [ [ "memory_module", 1 ] ],
+      [ [ "pathfinding_module", 1 ] ],
+      [ [ "identification_module", 1 ] ],
+      [ [ "power_supply", 4 ] ],
+      [ [ "solar_cell", 2 ] ],
+      [ [ "targeting_module", 1 ] ],
+      [ [ "xray_laser_barrel", 1] ],
+      [ [ "laser_cannon_xray", 1 ] ],
+      [ [ "spidery_legs_big", 1 ] ]
+    ]
   }
 ]

--- a/data/mods/aftershock_exoplanet/recipes/deconstruction/robot.json
+++ b/data/mods/aftershock_exoplanet/recipes/deconstruction/robot.json
@@ -169,7 +169,7 @@
     "activity_level": "MODERATE_EXERCISE",
     "skill_used": "electronics",
     "difficulty": 6,
-    "time":"2 h",
+    "time": "2 h",
     "using": [ [ "soldering_standard", 20 ], [ "welding_standard", 5 ] ],
     "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
     "components": [

--- a/data/mods/aftershock_exoplanet/recipes/deconstruction/robot.json
+++ b/data/mods/aftershock_exoplanet/recipes/deconstruction/robot.json
@@ -182,7 +182,6 @@
       [ [ "solar_cell", 2 ] ],
       [ [ "targeting_module", 1 ] ],
       [ [ "xray_laser_barrel", 1 ] ],
-      [ [ "laser_cannon_xray", 1 ] ],
       [ [ "spidery_legs_big", 1 ] ]
     ]
   }

--- a/data/mods/aftershock_exoplanet/recipes/deconstruction/robot.json
+++ b/data/mods/aftershock_exoplanet/recipes/deconstruction/robot.json
@@ -181,7 +181,7 @@
       [ [ "power_supply", 4 ] ],
       [ [ "solar_cell", 2 ] ],
       [ [ "targeting_module", 1 ] ],
-      [ [ "xray_laser_barrel", 1] ],
+      [ [ "xray_laser_barrel", 1 ] ],
       [ [ "laser_cannon_xray", 1 ] ],
       [ [ "spidery_legs_big", 1 ] ]
     ]


### PR DESCRIPTION


#### Summary
Bugfixes "Fixed the issue of the broken advanced robot dropped by the Wraitheon Fulgeon not being dissassembleable [Aftershock]"



#### Purpose of change

I wanted to fix the problem adressed in Wraitheon Fulgent can not be dissassembled [Aftershock] #86252 ( fixes #86252 ).


#### Describe the solution

I added a new deconstruction/uncraft recipe to aftershock_exoplanet\recipes\deconstruction\robot.json in order to make it possible for the item broken_advbot_laser to be dissassembled. I copied the dissassembling requirements and time from the other robot uncraft to keep it consistent. I also tried to select components based on the uther robots' uncrafts and the item's and Wraitheon Fulgeon's description.

#### Describe alternatives you've considered

I could have probably used some other components as alternatives.
An alternative to making a dissassembly recipe could have been to make the Wraitheon Fulgeon butcherable?

#### Testing

I spawned in a Wraitheon Fulgeon in debug mode, killed it and attempted to deconstruct the broken advanced robot it dropped. It worked and yielded the components I gave it in the json. Pictures are attached in the additional context section.


#### Additional context

<img width="1915" height="374" alt="Screenshot 2026-04-15 004655" src="https://github.com/user-attachments/assets/7d9ead18-3874-4cf7-b738-e7b2b33a9de0" />

<img width="338" height="188" alt="image" src="https://github.com/user-attachments/assets/444a83fc-3e61-4ba9-bf15-0c94afc0f92c" />




