### PR TITLE
Character creator UI: first-pass improvements

### DIFF
--- a/src/character.h
+++ b/src/character.h
@@ -126,6 +126,8 @@ const int CHARACTER_STAT_MAX = 20;
 const int CHARACTER_AGE_MIN = 16;
 const int CHARACTER_AGE_MAX = 55;
 
+const int NAME_CHARACTER_LIMIT = 50;
+
 extern int character_max_str;
 extern int character_max_dex;
 extern int character_max_per;

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -3382,6 +3382,7 @@ bool character_creator_ui::handle_action( const std::string &action )
     } else if( action == "CHANGE_NAME" ) {
         string_input_popup_imgui popup( 60, you.name );
         popup.set_description( _( "Enter name.  Cancel to delete all." ) );
+        popup.set_max_input_length( NAME_CHARACTER_LIMIT );
         you.name = popup.query();
     } else if( action == "CHANGE_AGE" ) {
         const int age_current = you.base_age();

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1178,7 +1178,9 @@ void draw_character_proficiencies( const Character &who )
 void draw_character_traits( const Character &who )
 {
     cataimgui::draw_colored_text( _( "Traits:" ), COL_HEADER );
-    for( const trait_and_var &character_trait : who.get_mutations_variants( false ) ) {
+    trait_group::Trait_list traits_list = who.get_mutations_variants( false );
+    std::sort( traits_list.begin(), traits_list.end(), trait_var_display_sort );
+    for( const trait_and_var &character_trait : traits_list ) {
         const nc_color trait_color = character_trait.trait->get_display_color();
         cataimgui::draw_colored_text( character_trait.name(), trait_color );
     }

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1985,8 +1985,8 @@ void draw_time_game_start()
 
 void draw_profession( const avatar &you )
 {
-    cataimgui::draw_colored_text( string_format( _( "Profession: %s" ),
-                                  colorize( you.prof->gender_appropriate_name( you.male ), c_light_gray ) ), c_white );
+    draw_colored_text_wrap( string_format( _( "Profession: %s" ),
+                                           colorize( you.prof->gender_appropriate_name( you.male ), c_light_gray ) ), c_white );
 }
 
 
@@ -2715,33 +2715,47 @@ void character_creator_ui_impl::draw_top_bar( const avatar &u ) const
         draw_colored_text_wrap( " | ", c_white );
         ImGui::SameLine();
     };
-    const avatar &you = get_avatar();
-    char_creation::draw_name( you, cc_uistate.no_name_entered );
-    draw_separator();
-    char_creation::draw_scenario( you );
-    draw_separator();
-    char_creation::draw_profession( you );
 
-    char_creation::draw_gender( you );
-    draw_separator();
-    char_creation::draw_outfit();
-    draw_separator();
-    cataimgui::draw_colored_text( "Randomize:", c_white );
-    ImGui::SameLine();
-    char_creation::draw_action_button( _( "Name" ), "RANDOMIZE_CHAR_NAME" );
-    ImGui::SameLine();
-    char_creation::draw_action_button( _( "Description" ), "RANDOMIZE_CHAR_DESCRIPTION" );
-    if( cc_uistate.generation_type == character_type::RANDOM ) {
+    if( ImGui::BeginTable( "TOPBAR", 2, ImGuiTableFlags_BordersInnerV ) ) {
+        ImGui::TableSetupColumn( "", ImGuiTableColumnFlags_WidthFixed );
+        ImGui::TableSetupColumn( "", ImGuiTableColumnFlags_WidthFixed );
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex( 0 );
+        const avatar &you = get_avatar();
+        char_creation::draw_name( you, cc_uistate.no_name_entered );
+
+        ImGui::TableSetColumnIndex( 1 );
+        char_creation::draw_scenario( you );
+        draw_separator();
+        char_creation::draw_profession( you );
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex( 0 );
+        char_creation::draw_gender( you );
+        draw_separator();
+        char_creation::draw_outfit();
+
+        ImGui::TableSetColumnIndex( 1 );
+        cataimgui::draw_colored_text( "Randomize:", c_white );
         ImGui::SameLine();
-        char_creation::draw_action_button( _( "All" ), "REROLL_CHARACTER" );
+        char_creation::draw_action_button( _( "Name" ), "RANDOMIZE_CHAR_NAME" );
         ImGui::SameLine();
-        char_creation::draw_action_button( _( "Keep Scenario" ), "REROLL_CHARACTER_WITH_SCENARIO" );
+        char_creation::draw_action_button( _( "Description" ), "RANDOMIZE_CHAR_DESCRIPTION" );
+        if( cc_uistate.generation_type == character_type::RANDOM ) {
+            ImGui::SameLine();
+            char_creation::draw_action_button( _( "All" ), "REROLL_CHARACTER" );
+            ImGui::SameLine();
+            char_creation::draw_action_button( _( "Keep Scenario" ), "REROLL_CHARACTER_WITH_SCENARIO" );
+        }
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex( 0 );
+        char_creation::draw_time_cataclysm_start();
+        ImGui::TableSetColumnIndex( 1 );
+        char_creation::draw_time_game_start();
+        ImGui::EndTable();
     }
-
-    char_creation::draw_time_cataclysm_start();
-    draw_separator();
-    char_creation::draw_time_game_start();
-
     if( cc_uistate.recalc_rating ) {
         cc_uistate.recalc_rating = false;
         cc_uistate.rating_string = player_difficulty::getInstance().difficulty_to_string( u );

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -1146,6 +1146,7 @@ static void on_customize_character( Character &you )
         popup
         .title( _( "New name ( leave empty to reset ):" ) )
         .width( 85 )
+        .max_length( NAME_CHARACTER_LIMIT )
         .edit( filterstring );
         if( popup.confirmed() ) {
             if( filterstring.empty() ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Interface "Character creator UI: first-pass improvements"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Address various comments concerning the new character creator UI.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

- Sort traits in summary menu like they're sorted in the '@' menu
- Align top bar elements for better readability
- Limit name input to 50 characters to avoid overflow on top bar, '@' menu

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

50 characters for name was arbitrary, could be smaller or larger

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Inputted >50 character names to character creator and '@' menu, no overflow

Sorted traits:
<img width="501" height="421" alt="image" src="https://github.com/user-attachments/assets/badb86a7-67e8-4a90-8d3e-893d547cd213" />

Aligned Top Bar:
<img width="894" height="138" alt="image" src="https://github.com/user-attachments/assets/7fb1ea90-0330-45c3-bd28-7407748807b1" />

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
