### PR TITLE
Fix #86479

### DIFF
--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -2421,6 +2421,7 @@ void character_creator_ui::setup_new_uilist()
             new_uilist->desc_enabled = true;
             new_uilist->allow_disabled = true;
             new_uilist->hilight_disabled = true;
+            new_uilist->size_to_all_categories = true;
             new_uilist->callback = &cc_callback;
             //snap to left edge of screen, position and height updated later
             new_uilist->desired_bounds = { 0, -1.0f, -1.0f, -1.0f };

--- a/src/uilist.cpp
+++ b/src/uilist.cpp
@@ -725,7 +725,7 @@ void uilist::calc_data()
     calculated_menu_size.x += calculated_label_width + padding;
     calculated_menu_size.x += calculated_secondary_width + padding;
 
-    if( !categories.empty() ) {
+    if( !categories.empty() && size_to_all_categories ) {
         float category_total_width = s.ItemInnerSpacing.x * ( categories.size() - 1 );
         for( const std::pair<std::string, std::string> &category_text : categories ) {
             category_total_width += ImGui::TabItemCalcSize( category_text.second.c_str(), false ).x;

--- a/src/uilist.h
+++ b/src/uilist.h
@@ -479,6 +479,8 @@ class uilist // NOLINT(cata-xy)
         // and unhandled by callback, default false.
         bool allow_additional = false;
         bool hilight_disabled = false;
+        // if true, calculates size to include all categories
+        bool size_to_all_categories = false;
 
     private:
         report_color_error _color_error = report_color_error::yes;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "option to size uilist to all categories"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fix #86479

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add an option to size `uilist` to the size of all categories (tabs) rather than assuming it always should.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Spell menu description displays correctly with many categories, character creator also looks normal
<img width="644" height="578" alt="image" src="https://github.com/user-attachments/assets/a072630d-6da6-43b6-a764-036cc893a59e" />
<img width="386" height="80" alt="image" src="https://github.com/user-attachments/assets/1ef17441-fa75-451d-b312-bd387f71e7aa" />

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

May conflict with #86477, merge that PR first

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
