### PR TITLE
Fix control reaches end of non-void function for old gcc versions

### DIFF
--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -1340,6 +1340,7 @@ bool map_extra::potentially_visible_at( om_vision_level vis ) const
         case map_extra_visibility::LAST:
             return false;
     }
+    return false;
 }
 
 void map_extra::load( const JsonObject &jo, std::string_view )


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Older gcc versions don't detect that the switch handles the return.

#### Describe the solution
Add return statement.

#### Additional context
Introduced in https://github.com/CleverRaven/Cataclysm-DDA/pull/86474