### PR TITLE
Removes direct cooked acorn recipe

### DIFF
--- a/data/json/recipes/food/nuts.json
+++ b/data/json/recipes/food/nuts.json
@@ -2,33 +2,6 @@
   {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
-    "result": "acorns_cooked",
-    "category": "CC_FOOD",
-    "subcategory": "CSC_FOOD_VEGGI",
-    "skill_used": "cooking",
-    "difficulty": 3,
-    "skills_required": [ "survival", 2 ],
-    "time": "19 m",
-    "autolearn": true,
-    "charges": 1,
-    "batch_time_factors": [ 40, 1 ],
-    "qualities": [
-      { "id": "HAMMER", "level": 1 },
-      { "id": "CUT", "level": 2 },
-      { "id": "BOIL", "level": 1 },
-      { "id": "COOK", "level": 2 }
-    ],
-    "tools": [ [ [ "water_boiling_heat", 5, "LIST" ] ] ],
-    "proficiencies": [
-      { "proficiency": "prof_food_prep" },
-      { "proficiency": "prof_knife_skills" },
-      { "proficiency": "prof_forage_cooking" }
-    ],
-    "components": [ [ [ "acorns", 1 ] ], [ [ "water", 2 ], [ "water_clean", 2 ] ] ]
-  },
-  {
-    "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
     "result": "walnut_roasted",
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_VEGGI",


### PR DESCRIPTION
Acorns need to be blanched first. Removes the direct recipe to turn acorns into cooked acorns.

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Balance "Acorns can no longer be cooked without blanching first"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
While acorns can technically be consumed without blanching them, this results in an extremely unpleasant food that is high in tannins. Quoting a foraging resource "Raw acorns are high in tannins—bitter compounds that can cause digestive upset and interfere with nutrient absorption." And building on this, acorns must be leached of their tannins. I believe the blanching acorns recipe tree is sufficient to represent this.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
I deleted the recipe to cook raw acorns into cooked acorns. There are already recipes to blanch the acorns, and from there you can either dehydrate them, or cook them. I see no issues with this removal.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not removing it? I mean it's possible there is some incredibly fast process to leach the tannins in the like 20 minute crafting time, but I don't think the tools and qualities associated with it could do that. The resource i'm relying on suggests this process takes several days, so I think this recipe is just legacy or something.
I also think that blanching acorns should require grinding them up first, but I believe that was outside the scope of what this PR was wanting to achieve, maybe in a follow-up PR I or someone else can address that. To quote that resource again "If you read about processing whole acorns to remove tannins, don’t believe it!  Acorns must be ground in order to effectively remove their tannins. To do this, use a flour or grain mill, or, in the absence of such a specialized tool, a blender or food processor can work."
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
I downloaded a recent binary from 4-14, added it to my repo folder, made a new world, made a new character, debug learned all recipes. I searched the string "acorn" and did not see two entries for cooked acorns.
#### Additional context
https://www.wildabundance.net/blog/how-to-eat-acorns/

Unless I am making an error, I don't believe this should impede using acorns. One can blanch acorns, then once they're blanched you can smoke/dehydrate them to get cooked acorns, or roast the acorns. And from there you can grind those acorns. As I stated before I think grinding the acorns before blanching makes more sense but I didn't want to tackle that in this pr as that would be more involved.
The website I used to make sure the in game notes about acorn tannins weren't inaccurate.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
