### PR TITLE
Expand wheel faults, no invincible cart wheels

### DIFF
--- a/data/json/faults/faults_vehicles.json
+++ b/data/json/faults/faults_vehicles.json
@@ -97,5 +97,29 @@
     "vehicle_move_penalty_mod": 5,
     "item_suffix": "rim",
     "flags": [ "FLAT_TIRE" ]
+  },
+  {
+    "id": "fault_axle_broken",
+    "type": "fault",
+    "name": { "str": "Broken axle" },
+    "//COMMENT": "INTENTIONALLY CANNOT BE REPAIRED. It must be replaced. You aren't fixing this!",
+    "description": "This primitive wheel's axle has completely snapped.  The wheel will have to be replaced entirely.",
+    "//COMMENT2": "These values are meant to instantly render the vehicle part 'destroyed'.",
+    "instant_damage": 4000,
+    "degradation_mod": 4000,
+    "price_modifier": 0.0,
+    "item_suffix": "broken axle"
+  },
+  {
+    "id": "fault_cracked_rim",
+    "type": "fault",
+    "name": { "str": "Cracked" },
+    "description": "This primitive wheel has been damaged by riding rough.",
+    "//COMMENT": "This damage causes the wheel to have worse steering until 'repaired'. The fault itself cannot be mended and will continue to impair its ability as a wheel.",
+    "instant_damage": 1000,
+    "price_modifier": 0.1,
+    "contact_area_mod": 0.7,
+    "rolling_resistance_mod": 1.5,
+    "item_suffix": "cracked"
   }
 ]

--- a/data/json/items/vehicle/wheel.json
+++ b/data/json/items/vehicle/wheel.json
@@ -783,6 +783,7 @@
     "color": "brown",
     "diameter": 20,
     "width": 3,
+    "faults": [ { "fault": "fault_axle_broken" }, { "fault": "fault_cracked_rim" } ],
     "melee_damage": { "bash": 8 }
   },
   {

--- a/doc/JSON/JSON_INFO.md
+++ b/doc/JSON/JSON_INFO.md
@@ -1672,6 +1672,7 @@ Faults can be defined for more specialized damage of an item.
   "message": "%s has it's handle broken!", // Message, that would be shown when such fault is applied, unless supressed
   "fault_type": "gun_mechanical_simple", // type of a fault, code may call for a random fault in a group instead of specific fault
   "affected_by_degradation": false, // default false. If true, the item degradation value would be added to fault weight on roll
+  "instant_damage": 500,  // default 0. Instantly applies this much damage to the item when the fault is applied. (A "full health" item has 4000 "HP" currently)
   "degradation_mod": 50,  // default 0. Having this fault would add this amount of temporary degradation on the item, resulting in higher chance to trigger faults with "affected_by_degradation": true. Such degradation will be removed when fault is fixed
   "price_modifier": 0.4, // (Optional, double) Defaults to 1 if not specified. A multiplier on the price of an item when this fault is present. Values above 1.0 will increase the item's value.
   "melee_damage_mod": [ { "damage_id": "cut", "add": -5, "multiply": 0.8 } ], // (Optional) alters the melee damage of this type for item, if fault of this type is presented. `damage_id` is mandatory, `add` is 0 by default, `multiply` is 1 by default

--- a/src/fault.cpp
+++ b/src/fault.cpp
@@ -173,6 +173,11 @@ int fault::degradation_mod() const
     return degradation_mod_;
 }
 
+int fault::instant_damage() const
+{
+    return instant_damage_;
+}
+
 std::vector<std::tuple<int, float, damage_type_id>> fault::melee_damage_mod() const
 {
     return melee_damage_mod_;
@@ -246,6 +251,7 @@ void fault::load( const JsonObject &jo, std::string_view )
     optional( jo, was_loaded, "block_faults", block_faults );
     optional( jo, was_loaded, "price_modifier", price_modifier, 1.0 );
     optional( jo, was_loaded, "degradation_mod", degradation_mod_, 0 );
+    optional( jo, was_loaded, "instant_damage", instant_damage_, 0 );
     optional( jo, was_loaded, "affected_by_degradation", affected_by_degradation_, false );
     optional( jo, was_loaded, "encumbrance_add", encumbrance_mod_flat_, 0 );
     optional( jo, was_loaded, "encumbrance_mult", encumbrance_mod_mult_, 1.f );

--- a/src/fault.h
+++ b/src/fault.h
@@ -83,6 +83,8 @@ class fault
         double price_mod() const;
         // having this faults adds this much of temporary (will be removed when fault is fixed) degradation
         int degradation_mod() const;
+        // Damage applied when fault is applied.
+        int instant_damage() const;
         // int is additive (default 0), float is multiplier (default 1)
         std::vector<std::tuple<int, float, damage_type_id>> melee_damage_mod() const;
         // int is additive (default 0), float is multiplier (default 1)
@@ -115,6 +117,7 @@ class fault
         std::set<fault_id> block_faults;
         double price_modifier = 1.0;
         int degradation_mod_ = 0;
+        int instant_damage_ = 0;
         float contact_area_mod_ = 1.f;
         float rolling_resistance_mod_ = 1.f;
         int vehicle_move_penalty_mod_ = 1.f;

--- a/src/item_degrade.cpp
+++ b/src/item_degrade.cpp
@@ -376,6 +376,7 @@ bool item::set_fault( const fault_id &f_id, bool force, bool message )
     }
 
     faults.insert( f_id );
+    mod_damage( f_id->instant_damage() );
     return true;
 }
 

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -1328,6 +1328,41 @@ double vehicle::wheel_damage_chance_vs_item( const item &it, const vehicle_part 
     return chance_to_damage;
 }
 
+static void apply_tire_punctures( vehicle_part *vp_wheel, std::vector<std::string> *messages )
+{
+    if( vp_wheel->has_fault( fault_flat_tire_riding_on_rims ) ) { // Already in worst possible state.
+        return;
+    }
+
+    if( !vp_wheel->has_fault( fault_punctured_tires ) ) {
+        if( vp_wheel->fault_set( fault_punctured_tires ) ) {
+            messages->emplace_back( string_format(
+                                        _( "You hear a loud pop from below, and your vehicle suddenly start to wobble like crazy!" ) ) );
+            return;
+        }
+    } else {
+        // Already punctured, but get hit *again* --> chance to instantly set 100% flat
+        if( vp_wheel->fault_set( fault_flat_tire_riding_on_rims ) ) {
+            messages->emplace_back( string_format(
+                                        _( "With a jolt, hitting something has blown out your tire!" ) ) );
+            return;
+        }
+    }
+}
+
+static void apply_generic_wheel_fault( vehicle_part *vp_wheel, std::vector<std::string> *messages )
+{
+}
+
+static void apply_wheel_faults( vehicle_part *vp_wheel, std::vector<std::string> *messages )
+{
+    if( vp_wheel->faults_potential().count( fault_punctured_tires ) ) {
+        apply_tire_punctures( vp_wheel, messages );
+    } else {
+        apply_generic_wheel_fault( vp_wheel, messages );
+    }
+}
+
 void vehicle::damage_wheel_on_item( vehicle_part *vp_wheel, const item &it,
                                     std::vector<std::string> *messages ) const
 {
@@ -1335,29 +1370,12 @@ void vehicle::damage_wheel_on_item( vehicle_part *vp_wheel, const item &it,
         return;
     }
 
-    if( vp_wheel->has_fault( fault_flat_tire_riding_on_rims ) ) { // Already in worst possible state.
-        return;
-    }
-
     const double chance_to_damage = wheel_damage_chance_vs_item( it, *vp_wheel );
 
     if( chance_to_damage > 0.0 && chance_to_damage >= rng_float( 0.0, 1.0 ) ) {
-        if( !vp_wheel->has_fault( fault_punctured_tires ) ) {
-            if( vp_wheel->fault_set( fault_punctured_tires ) ) {
-                messages->emplace_back( string_format(
-                                            _( "You hear a loud pop from below, and your vehicle suddenly start to wobble like crazy!" ) ) );
-                refresh_pivot( get_map() );
-                return;
-            }
-        } else {
-            // Already punctured, but get hit *again* --> chance to instantly set 100% flat
-            if( vp_wheel->fault_set( fault_flat_tire_riding_on_rims ) ) {
-                messages->emplace_back( string_format(
-                                            _( "With a jolt, hitting something has blown out your tire!" ) ) );
-                refresh_pivot( get_map() );
-                return;
-            }
-        }
+        apply_wheel_faults( vp_wheel, messages );
+        refresh_pivot( get_map() );
+        return;
     }
 }
 

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -54,6 +54,8 @@ static const efftype_id effect_harnessed( "harnessed" );
 static const efftype_id effect_pet( "pet" );
 static const efftype_id effect_stunned( "stunned" );
 
+static const fault_id fault_axle_broken( "fault_axle_broken" );
+static const fault_id fault_cracked_rim( "fault_cracked_rim" );
 static const fault_id fault_flat_tire_riding_on_rims( "fault_flat_tire_riding_on_rims" );
 static const fault_id fault_punctured_tires( "fault_punctured_tires" );
 
@@ -1352,13 +1354,33 @@ static void apply_tire_punctures( vehicle_part *vp_wheel, std::vector<std::strin
 
 static void apply_generic_wheel_fault( vehicle_part *vp_wheel, std::vector<std::string> *messages )
 {
+    if( vp_wheel->has_fault( fault_axle_broken ) ) { // Already in worst possible state.
+        return;
+    }
+
+    // 90% chance to just crack rim on 'first' failure
+    // 10% chance to go straight to broken axle on any 'first' failure
+    // Wagon wheels are notorious for this kind of critical failure.
+    if( !vp_wheel->has_fault( fault_cracked_rim ) && x_in_y( 90, 100 ) ) {
+        if( vp_wheel->fault_set( fault_cracked_rim ) ) {
+            messages->emplace_back( string_format(
+                                        _( "You hear a crunch as you run something over!" ) ) );
+            return;
+        }
+    } else {
+        if( vp_wheel->fault_set( fault_axle_broken ) ) {
+            messages->emplace_back( string_format(
+                                        _( "Your vehicle lurches as one of the wheels gives out!" ) ) );
+            return;
+        }
+    }
 }
 
 static void apply_wheel_faults( vehicle_part *vp_wheel, std::vector<std::string> *messages )
 {
-    if( vp_wheel->faults_potential().count( fault_punctured_tires ) ) {
+    if( vp_wheel->faults_potential().count( fault_punctured_tires ) ) { // Most wheels
         apply_tire_punctures( vp_wheel, messages );
-    } else {
+    } else if( vp_wheel->faults_potential().count( fault_cracked_rim ) ) { // Wooden cart wheels
         apply_generic_wheel_fault( vp_wheel, messages );
     }
 }


### PR DESCRIPTION
#### Summary
Bugfixes "Wooden cart wheels are damaged by running stuff over"

#### Purpose of change
Wooden cart wheels were immune to wheel damage despite being notorious for breaking even in very good road conditions.

#### Describe the solution
Add some new faults, just for them.

#### Describe alternatives you've considered
Instead of faults, just apply damage directly to the wheel.

#### Testing
<img width="1225" height="495" alt="image" src="https://github.com/user-attachments/assets/6b215e14-575f-4b9b-a344-bdbd4df21b9c" />

Ran over some stuff, the cart did not like that.

#### Additional context

Known issues:
This reuses the PUNCTURE_VEHICLE_WHEELS flag because wooden wheels are incredibly fragile and anything that can puncture a tire can also break them.

They SHOULD be vulnerable to even more stuff, but that would require duplicating the flag (and repeating this process for every distinct type of wheel...). So I've currently done the bare minimum, and let them remain immune to running over rocks, boulders, and the like. This can be expanded on later.