### PR TITLE
Disable __COUNTER__ in Catch2 when building with clang

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -35,6 +35,12 @@ ifndef CLANG
   CLANG = 0
 endif
 
+# clang 22 bug results in non-trivially supressable error about counter with -Wc2y-extensions
+# see https://github.com/llvm/llvm-project/issues/189645
+ifeq ($(CLANG), 1)
+  DEFINES += -DCATCH_CONFIG_NO_COUNTER
+endif
+
 ifeq ($(PCH), 1)
 PCHFLAGS += -DCATA_CATCH_PCH
 PCH_H = pch/tests-pch.hpp


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
See https://github.com/catchorg/Catch2/issues/3076

#### Describe the solution
The lowest impact workaround seems to be to disable the use of `__COUNTER__` for internal name generation, using `__LINE__` instead. Because astyle forbids any constructs like `INFO(...); INFO(...);`, this should not result in any issues.

This only fixes the Makefile build. It would be more robust to put this config in somewhere else, but I couldn't find a good place to do that.

#### Describe alternatives you've considered
"backport" https://github.com/catchorg/Catch2/commit/51b0532d1fba061d0802ccfd906cc87fc2dd49c2 to our catch.hpp
Disable `__COUNTER__` for all test builds, by defining this config at the top of catch.hpp (it cannot be done in cata_catch.hpp because of PCH).
Stick a more complicated compiler-specific section at the top of catch.hpp to implement a workaround for the specific compiler version.

#### Testing
A build with CLANG=1 TESTS=1 works, with clang version 22+
