### PR TITLE
Segfault fix: sort companion armor

### DIFF
--- a/src/armor_layers.cpp
+++ b/src/armor_layers.cpp
@@ -690,9 +690,9 @@ void outfit::sort_armor( Character &guy )
     ctxt.register_action( "SCROLL_ITEM_INFO_DOWN" );
 
     Character &player_character = get_player_character();
-    auto do_return_entry = [this, &player_character]() {
-        uistate.open_menu = [this, &player_character]() {
-            sort_armor( player_character );
+    auto do_return_entry = [this, guy_ptr = &guy]() {
+        uistate.open_menu = [this, guy_ptr]() {
+            sort_armor( *guy_ptr );
         };
     };
 


### PR DESCRIPTION
#### Summary
Bugfixes "Segfault CTD fix for sort armor (npc)"

#### Purpose of change

Fixes #84879

#### Describe the solution

do_return_entry() for armor sort on line 693 was improperly _always_ referencing player_character, which was resulting in a CTD (trying to remove the item that you were unequipping on NPC from the player character)

guy_ptr accounts for both player character and npc, so player_character was replaced with guy_ptr

#### Describe alternatives you've considered

None. Pretty straightforward fix

#### Testing

I'm not actually sure how the existing code ever worked, maybe something was changed recently?

1) Equip item on npc via sort_armor
2) Try to unequip item
3) CTD

With fix:
1) Equip item on npc via sort_armor
2) Try to unequip item
3) Item unequips as expected, returns to sort_armor menu as expected

#### Additional context
