### PR TITLE
Fix minimap beacon colors not cycling during idle

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2331,6 +2331,11 @@ void cata_tiles::draw_minimap( const point &dest, const tripoint_bub_ms &center,
     minimap->draw( SDL_Rect{ dest.x, dest.y, width, height }, center );
 }
 
+bool cata_tiles::has_blinking_minimap() const
+{
+    return minimap->has_blinking_beacons();
+}
+
 point cata_tiles::get_window_base_tile_counts(
     const point &size, const point &tile_size, const bool iso )
 {

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -944,6 +944,9 @@ class cata_tiles
             return has_animated_tiles_;
         }
 
+        // True if the minimap rendered critters with blinking beacons.
+        bool has_blinking_minimap() const;
+
         // Draw caches persist data between draws and are only recalculated when dirty
         void set_draw_cache_dirty();
 

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -399,6 +399,12 @@ input_context game::get_player_input( std::string &action )
             }
 
             if( pixel_minimap_option && g->w_pixel_minimap ) {
+#if defined(TILES)
+                // Mark minimap dirty so beacon colors keep cycling
+                if( tilecontext->has_blinking_minimap() ) {
+                    werase( g->w_pixel_minimap );
+                }
+#endif
                 wnoutrefresh( g->w_pixel_minimap );
             }
 

--- a/src/pixel_minimap.cpp
+++ b/src/pixel_minimap.cpp
@@ -496,6 +496,8 @@ void pixel_minimap::render_cache( const tripoint_bub_ms &center )
 
 void pixel_minimap::render_critters( const tripoint_bub_ms &center )
 {
+    has_blinking_beacons_ = false;
+
     const map &m = get_map();
 
     //handles the enemy faction red highlights
@@ -546,6 +548,9 @@ void pixel_minimap::render_critters( const tripoint_bub_ms &center )
             const SDL_Rect critter_rect = SDL_Rect{ critter_pos.x, critter_pos.y, beacon_size.x, beacon_size.y };
             const SDL_Color critter_color = get_critter_color( critter, flicker, mixture );
 
+            if( indicator_length > 0 ) {
+                has_blinking_beacons_ = true;
+            }
             draw_beacon( critter_rect, critter_color );
         }
     }

--- a/src/pixel_minimap.h
+++ b/src/pixel_minimap.h
@@ -43,6 +43,11 @@ class pixel_minimap
 
         void draw( const SDL_Rect &screen_rect, const tripoint_bub_ms &center );
 
+        // True if the last draw() rendered any critters with blinking beacons.
+        bool has_blinking_beacons() const {
+            return has_blinking_beacons_;
+        }
+
     private:
         struct submap_cache;
 
@@ -90,6 +95,8 @@ class pixel_minimap
         std::unique_ptr<shared_texture_pool> tex_pool;
 
         std::map<tripoint_abs_sm, submap_cache> cache;
+
+        bool has_blinking_beacons_ = false;
 };
 
 #endif // CATA_SRC_PIXEL_MINIMAP_H


### PR DESCRIPTION
#### Summary
Bugfixes "Fix minimap enemy beacon colors freezing when idle"

#### Purpose of change

Fixes #86415. #86183 replaced the minimap's unconditional `invalidate_main_ui_adaptor` with a direct `wnoutrefresh`, but nothing marks the minimap window dirty during idle, so beacon color cycling stopped.

#### Describe the solution

`pixel_minimap` tracks whether it rendered any blinking beacons. When the flag is set, the idle loop marks the minimap window dirty before the existing `wnoutrefresh`. Only the minimap redraws -- no main UI invalidation.

#### Describe alternatives you've considered

N/A

#### Testing

Verified in-game. Beacon colors cycle smoothly when idle.

#### Additional context

N/A