### PR TITLE
Fix chain-spawned overmaps skipping unique special deck draws

### DIFF
--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -3121,6 +3121,11 @@ bool overmap::place_special_attempt(
                 continue;
             }
             const overmap_special_placement_constraints &constraints = special.get_constraints();
+            // Deck-draw losers are kept in the batch for chain-spawned descendants
+            // but must not be placed on this overmap.
+            if( iter->instances_placed >= constraints.occurrences.max ) {
+                continue;
+            }
             // If we haven't finished placing minimum instances of all specials,
             // skip specials that are at their minimum count already.
             if( !place_optional && iter->instances_placed >= constraints.occurrences.min ) {
@@ -3267,14 +3272,21 @@ void overmap::place_specials( overmap_special_batch &enabled_specials )
                 // Allow exactly one placement attempt on this overmap.
                 iter->instances_placed = constraints.occurrences.max - 1;
             } else {
-                iter = enabled_specials.erase( iter );
-                continue;
+                // Sentinel: max marks "deck said no for this overmap" while keeping
+                // the entry alive for chain-spawned descendants to draw fresh.
+                iter->instances_placed = constraints.occurrences.max;
             }
         }
         ++iter;
     }
-    // Bail out early if we have nothing to place.
-    if( enabled_specials.empty() ) {
+    // Bail out early if we have nothing to place.  Deck-draw losers stay in
+    // the batch (instances_placed == max) for chain-spawned descendants, so
+    // check for actual candidates rather than batch emptiness.
+    const bool any_candidates = std::any_of( enabled_specials.begin(), enabled_specials.end(),
+    []( const overmap_special_placement & p ) {
+        return p.instances_placed < p.special_details->get_constraints().occurrences.max;
+    } );
+    if( !any_candidates ) {
         return;
     }
     om_special_sectors sectors = get_sectors( OMSPEC_FREQ );


### PR DESCRIPTION
#### Summary
Bugfixes "Fix unique overmap specials being starved on chain-spawned overmaps"

#### Purpose of change

When `place_specials` draws from the unique special deck and gets a "no", it erases that special from `enabled_specials`. The chain-spawn batch (`custom_overmap_specials`) is then snapshotted from this already-filtered list, so chain-spawned overmaps never get a fresh draw for those erased specials. Reported in https://github.com/CleverRaven/Cataclysm-DDA/pull/85849#issuecomment-4219527350 -- in ocean-heavy generation, this starves oil platforms and similar rare specials because most ocean overmaps are chain-spawned (mandatory land specials can't place, triggering the chain).

This is technically a pre-existing bug -- the old x_in_y code had the same erase-before-snapshot pattern. But the deck algorithm from #85849 made it much more visible: the old formula's sqrt-boosted over-placement on non-chain overmaps compensated for the starvation, while the deck's exact rates do not.

#### Describe the solution

Instead of erasing deck-draw losers from the batch, mark them with `instances_placed = max` as a sentinel. This keeps them in the batch so chain-spawned descendants can draw fresh from the deck, while preventing any local placement:

- `place_special_attempt` gets an early `>= max` guard so losers are skipped during both mandatory and optional passes
- The `any_below_minimum` check at chain-spawn time sees `max >= min` and doesn't trigger unnecessary chain-spawning for deck losers
- The early-exit check switches from `empty()` to `any_of` looking for real candidates, since deck losers now stay in the batch
- When a child overmap runs its own `place_specials`, the deck draw logic fires again for these entries. A success resets `instances_placed` to `max - 1`; a failure leaves the sentinel for further descendants.

#### Describe alternatives you've considered

Reconstructing the child batch explicitly from a pre-draw snapshot with merged `instances_placed` from the post-mandatory-pass state. Cleaner semantically but more code, and you still need the `instances_placed = max` trick to suppress `any_below_minimum`. The sentinel approach gets the same result with fewer moving parts.

#### Testing

Existing `overmap_generation_is_deterministic` and `overmap_terrain_coverage` suites pass.

#### Additional context

N/A