### PR TITLE
TCL Mutant Chiropteran mutant line

### DIFF
--- a/data/json/npcs/NC_LAB_MUTANT
+++ b/data/json/npcs/NC_LAB_MUTANT
@@ -22,7 +22,8 @@
       { "group": "NC_MUTANT_INSECT" },
       { "group": "NC_MUTANT_SPIDER" },
       { "group": "NC_MUTANT_BEAST" },
-      { "group": "NC_MUTANT_MEDICAL" }
+      { "group": "NC_MUTANT_MEDICAL" },
+      { "group": "NC_MUTANT_CHIROPTERAN" }
     ]
   },
   {
@@ -391,6 +392,28 @@
       { "trait": "MOUTH_TENTACLES" },
       { "trait": "CEPH_EYES" },
       { "trait": "CEPH_VISION" }
+    ]
+  }
+  {
+    "//": "This group picks out a fixed set of traits to assign based on a random mutation tree.",
+    "type": "trait_group",
+    "id": "NC_MUTANT_CHIROPTERAN",
+    "subtype": "collection",
+    "traits": [
+      { "trait": "DEX_UP_2" },
+      { "trait": "FANGS" },
+      { "trait": "BATEARS" },
+      { "trait": "LEAFNOSE" },
+      { "trait": "SOCIAL1" },
+      { "trait": "LIGHTFUR" },
+      { "trait": "LIGHT_BONES" },
+      { "trait": "SOCIAL2" },
+      { "trait": "HEMOVORE" },
+      { "trait": "ARMS_BAT" },
+      { "trait": "TROGLO" },
+      { "trait": "MESOPIC" },
+      { "trait": "ANTIWHEAT" },
+      { "trait": "UGLY" }
     ]
   }
 ]

--- a/data/json/npcs/NC_LAB_MUTANT
+++ b/data/json/npcs/NC_LAB_MUTANT
@@ -393,7 +393,7 @@
       { "trait": "CEPH_EYES" },
       { "trait": "CEPH_VISION" }
     ]
-  }
+  },
   {
     "//": "This group picks out a fixed set of traits to assign based on a random mutation tree.",
     "type": "trait_group",

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -8601,5 +8601,36 @@
       "CEPH_EYES",
       "CEPH_VISION"
     ]
+  },
+  {
+    "type": "profession",
+    "id": "mutant_patient_chiropteran",
+    "name": "Chiropteran Mutant",
+    "description": "When power flickered, you didn't mind the dark. But mutants down here don't make for a great community, and you yearn to see the night-sky.",
+    "npc_background": "BG_survival_story_LAB_MUTANT",
+    "points": 3,
+    "items": {
+      "both": { "items": [ { "item": "jumpsuit_pocketless", "variant": "orange" } ] }
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
+    },
+    "flags": [ "SCEN_ONLY" ],
+    "age_lower": 16,
+    "traits": [
+      "DEX_UP_2",
+      "FANGS",
+      "BATEARS",
+      "LEAFNOSE",
+      "SOCIAL1",
+      "LIGHTFUR",
+      "LIGHT_BONES",
+      "SOCIAL2",
+      "HEMOVORE",
+      "ARMS_BAT",
+      "TROGLO",
+      "MESOPIC",
+      "ANTIWHEAT",
+      "UGLY"
+    ]
   }
 ]

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -8610,7 +8610,7 @@
     "npc_background": "BG_survival_story_LAB_MUTANT",
     "points": 3,
     "items": {
-      "both": { "items": [ { "item": "jumpsuit_pocketless", "variant": "orange" } ] }
+      "both": { "items": [ { "item": "jumpsuit_pocketless", "variant": "orange" } ] },
       "male": { "entries": [ { "item": "briefs" } ] },
       "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     },

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -8606,7 +8606,7 @@
     "type": "profession",
     "id": "mutant_patient_chiropteran",
     "name": "Chiropteran Mutant",
-    "description": "When power flickered, you didn't mind the dark. But mutants down here don't make for a great community, and you yearn to see the night-sky.",
+    "description": "When power flickered, you didn't mind the dark.  But mutants down here don't make for a great community, and you yearn to see the night-sky.",
     "npc_background": "BG_survival_story_LAB_MUTANT",
     "points": 3,
     "items": {

--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -532,7 +532,8 @@
       "mutant_patient_trog",
       "mutant_patient_elfa",
       "mutant_patient_bear",
-      "mutant_patient_lupine"
+      "mutant_patient_lupine",
+      "mutant_patient_chiropteran"
     ],
     "allowed_locs": [ "sloc_lab_medical" ],
     "map_extra": "mx_lab_concourse_area",


### PR DESCRIPTION
#### Summary
Content "TCL Mutant Chiropteran mutation line profession"

#### Purpose of change

The mutation line has a number of unique pre-threshold traits that I wanted it to be available as one of the professions in the TCL start.

#### Describe the solution

Adds a profession for the Trans-Coast Logistics Mutant scenario

#### Describe alternatives you've considered

Adding some of the other mutation lines as one larger PR.

#### Testing

Checked if the profession was linked to the scenario and was able to be loaded in, then loaded it and saw no errors.

#### Additional context

Not sure if the starting mutation spread is inline with what was expected with the original scenario PR. I tried to keep a spread of positive/negative traits, ideally those that have some impact on playstyle as that was a blocker for some other mutation lines in the initial PR.
