### PR TITLE
Fix zone sort viewport stuck when nothing to sort

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -13463,14 +13463,18 @@ void zone_sort_activity_actor::do_turn( player_activity &act, Character &you )
 
     // True completion: activity nulled AND no auto-move destination pending.
     // route_to_destination sets destination before nulling; true end does not.
-    // Use saved locals since this may be destroyed.
-    if( act.is_null() && !you.has_destination() && had_viewport ) {
+    // vp_active catches same-turn completion where had_viewport is stale.
+    avatar *const av = you.as_avatar();
+    const bool vp_active = av != nullptr && av->zone_sort_viewport.active;
+    if( act.is_null() && !you.has_destination() && ( had_viewport || vp_active ) ) {
         if( !test_mode ) {
-            g->set_zoom( saved_zoom );
+            const int restore_zoom = vp_active ?
+                                     av->zone_sort_viewport.saved_zoom : saved_zoom;
+            g->set_zoom( restore_zoom );
             g->mark_main_ui_adaptor_resize();
         }
-        if( you.is_avatar() ) {
-            you.as_avatar()->zone_sort_viewport = {};
+        if( vp_active ) {
+            av->zone_sort_viewport = {};
         }
     }
 }
@@ -13523,6 +13527,7 @@ void zone_sort_activity_actor::stage_init( player_activity &, Character &you )
         vp.active = true;
         vp.center = bbox.centroid;
         vp.target_zoom = target;
+        vp.saved_zoom = viewport_saved_zoom;
         vp.bbox_min = bbox.min_corner;
         vp.bbox_max = bbox.max_corner;
         if( !test_mode ) {

--- a/src/avatar.h
+++ b/src/avatar.h
@@ -98,6 +98,7 @@ class avatar : public Character
             bool active = false;
             tripoint_abs_ms center;
             int target_zoom = 0;
+            int saved_zoom = 0;
             tripoint_abs_ms bbox_min;
             tripoint_abs_ms bbox_max;
         };

--- a/tests/clzones_test.cpp
+++ b/tests/clzones_test.cpp
@@ -2640,6 +2640,45 @@ TEST_CASE( "zone_sort_viewport_lifecycle", "[zones][viewport][activities]" )
         }
     }
 
+    SECTION( "deactivates when nothing to sort" ) {
+        // Remove the apple so unsorted zone is empty.
+        map_stack items_at_src = here.i_at( src_pos );
+        items_at_src.clear();
+
+        CHECK_FALSE( dummy.zone_sort_viewport.active );
+
+        dummy.assign_activity( zone_sort_activity_actor() );
+
+        // Single turn: stage_init activates viewport, stage_think finds
+        // nothing sortable, activity ends in the same do_turn call.
+        dummy.mod_moves( dummy.get_speed() );
+        while( dummy.get_moves() > 0 && dummy.activity ) {
+            dummy.activity.do_turn( dummy );
+        }
+
+        CHECK_FALSE( dummy.activity );
+        CHECK_FALSE( dummy.zone_sort_viewport.active );
+    }
+
+    SECTION( "deactivates when no matching destination zone" ) {
+        // Replace apple with something that has no destination zone.
+        map_stack items_at_src = here.i_at( src_pos );
+        items_at_src.clear();
+        here.add_item_or_charges( src_pos, item( itype_test_heavy_boulder ) );
+
+        CHECK_FALSE( dummy.zone_sort_viewport.active );
+
+        dummy.assign_activity( zone_sort_activity_actor() );
+
+        dummy.mod_moves( dummy.get_speed() );
+        while( dummy.get_moves() > 0 && dummy.activity ) {
+            dummy.activity.do_turn( dummy );
+        }
+
+        CHECK_FALSE( dummy.activity );
+        CHECK_FALSE( dummy.zone_sort_viewport.active );
+    }
+
     SECTION( "viewport_saved_zoom survives serialize roundtrip" ) {
         dummy.assign_activity( zone_sort_activity_actor() );
 


### PR DESCRIPTION
#### Summary
Bugfixes "Fix zone sort viewport stuck when nothing to sort"

#### Purpose of change

Closes #86473

When the zone sort activity finds nothing sortable (empty unsorted zone, or items with no matching destination zone), the activity starts and ends within the same `do_turn` call. The viewport lock activates in `stage_init` but the cleanup in `do_turn` uses a stale local that was saved before `stage_init` ran, so the camera stays centered on the unsorted zone forever.

Regression from #86371 which moved viewport state to locals to fix an NPC use-after-free.

#### Describe the solution

Added `saved_zoom` to the avatar's `zone_sort_viewport_t` struct so the original zoom level survives actor destruction. The `do_turn` cleanup now checks the avatar viewport struct directly (which outlives the actor) instead of relying solely on the pre-call local.

#### Describe alternatives you've considered

Could have added a virtual `on_finish` hook in the base class called before `act.set_to_null()`, but that felt like overkill for one edge case.

#### Testing

Two new test sections in `zone_sort_viewport_lifecycle`: empty unsorted zone and no-matching-destination-zone. Both verify the viewport deactivates. Existing viewport lifecycle tests still pass. Verified in-game as well.

#### Additional context

None.