### PR TITLE
Allow copy-from, abstract, and using for recipe steps

### DIFF
--- a/doc/JSON/ITEM_CRAFT_AND_DISASSEMBLY.md
+++ b/doc/JSON/ITEM_CRAFT_AND_DISASSEMBLY.md
@@ -145,11 +145,17 @@ Recipes can optionally define a `"steps"` array to split the craft into named ph
 
 When `"steps"` is present, the following fields must appear per-step and must **not** appear at root level: `"time"`, `"activity_level"`, `"tools"`, `"qualities"`, `"proficiencies"`, `"batch_time_factors"`.
 
-`"using"` is also not allowed at root level for step recipes.  Step-level `"using"` is not yet supported.
+`"using"` is allowed at both root level and step level for step recipes.  Root-level `"using"` merges into whole-recipe requirements (tools, qualities, and components are all gated at craft start).  Step-level `"using"` merges into that step's requirements and also participates in tool speed resolution for that step.
 
 `"components"` remains at root level.  All other recipe fields (`"result"`, `"skill_used"`, `"difficulty"`, `"book_learn"`, `"autolearn"`, etc.) also remain at root.
 
-Step recipes cannot use `"copy-from"` or `"abstract"`.
+### Inheritance
+
+Step recipes support `"copy-from"` and `"abstract"`.
+
+- If a child recipe uses `"copy-from"` pointing to a step recipe and does **not** include a `"steps"` array, it inherits the base's steps.  The child can override root-level fields like `"difficulty"`, `"skill_used"`, `"components"`, etc.
+- If the child **does** include a `"steps"` array, its steps replace the base's.  Root-level `"using"` from the base is preserved; the child can override it by providing its own `"using"`.
+- An `"abstract"` recipe with steps serves as a template.  Concrete children inherit steps and provide their own `"components"` and `"result"`.
 
 ### Step fields
 
@@ -163,6 +169,7 @@ Each entry in the `"steps"` array is an object with these fields:
                       //             trained while the craft is in this step.
 "tools":              // (Optional)  Same format as recipe-level.
 "qualities":          // (Optional)  Same format as recipe-level.
+"using":              // (Optional)  Same format as recipe-level.  Merges into this step's requirements.
 "batch_time_factors": // (Optional)  Same format as recipe-level.
 ```
 

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -311,42 +311,23 @@ void recipe::load( const JsonObject &jo, const std::string_view src )
     }
 
     // --- Recipe steps detection and schema validation ---
-    // Capture whether inherited step state exists from copy-from base,
-    // then clear so copied state cannot leak on reload/override.
+    const bool child_has_steps = jo.has_array( "steps" );
     const bool had_inherited_steps = !steps_.empty();
-    steps_.clear();
+
+    if( child_has_steps ) {
+        // Child provides own steps -- discard any inherited ones
+        steps_.clear();
+    }
     aggregate_proficiencies_.clear();
 
-    const bool is_step_recipe = jo.has_array( "steps" );
+    const bool effectively_step_recipe = child_has_steps || had_inherited_steps;
 
-    // Clear legacy requirement state so a reload from stepless to step-based
-    // does not silently retain old root tools/components/proficiencies.
-    if( is_step_recipe ) {
-        requirements_ = requirement_data();
-        deduped_requirements_ = deduped_requirement_data();
-        reqs_external.clear();
-        reqs_internal.clear();
-        proficiencies.clear();
-        time = 0;
-        batch_info = batch_savings();
-        exertion = 0.0f;
-    }
-
-    if( had_inherited_steps && !is_step_recipe ) {
-        jo.throw_error( "non-step recipe cannot inherit from a step recipe base" );
-    }
-
-    if( is_step_recipe ) {
-        if( abstract ) {
-            jo.throw_error( "abstract recipes cannot have steps" );
-        }
-        if( jo.has_string( "copy-from" ) ) {
-            jo.throw_error( "step recipes cannot use copy-from" );
-        }
+    // Step recipes must not have stepless-only root fields
+    if( effectively_step_recipe ) {
         for( const char *field : {
                  "tools", "qualities", "proficiencies",
                  "batch_time_factors", "time",
-                 "activity_level", "using"
+                 "activity_level"
              } ) {
             if( jo.has_member( field ) ) {
                 jo.throw_error( string_format(
@@ -355,8 +336,24 @@ void recipe::load( const JsonObject &jo, const std::string_view src )
         }
     }
 
+    // Clear state for finalize rebuild.
+    // reqs_external NOT cleared: root "using" survives copy-from.
+    if( child_has_steps ) {
+        // Fresh step recipe or step override: full rebuild in finalize
+        requirements_ = requirement_data();
+        deduped_requirements_ = deduped_requirement_data();
+        reqs_internal.clear();
+        proficiencies.clear();
+        time = 0;
+        batch_info = batch_savings();
+        exertion = 0.0f;
+    } else if( had_inherited_steps ) {
+        // Inheriting steps from unfinalized copy-from base; just reset dedup.
+        deduped_requirements_ = deduped_requirement_data();
+    }
+
     // --- Fields that only apply to stepless recipes ---
-    if( !is_step_recipe ) {
+    if( !effectively_step_recipe ) {
         optional( jo, was_loaded, "time", time, time_duration_as_moves_reader{}, 0 );
     }
 
@@ -372,7 +369,7 @@ void recipe::load( const JsonObject &jo, const std::string_view src )
     optional( jo, false, "container_variant", container_variant );
     optional( jo, was_loaded, "sealed", sealed, true );
 
-    if( !is_step_recipe ) {
+    if( !effectively_step_recipe ) {
         optional( jo, was_loaded, "batch_time_factors", batch_info );
         if( batch_savings::linear *lin = std::get_if<batch_savings::linear>( &batch_info.data ) ) {
             if( lin->offset > time ) {
@@ -405,7 +402,7 @@ void recipe::load( const JsonObject &jo, const std::string_view src )
         }
     }
 
-    if( !is_step_recipe ) {
+    if( !effectively_step_recipe ) {
         jo.read( "proficiencies", proficiencies );
     }
 
@@ -423,7 +420,7 @@ void recipe::load( const JsonObject &jo, const std::string_view src )
     optional( jo, was_loaded, "morale_modifier", morale_modifier, {0, 0_seconds} );
 
     // Mandatory for stepless recipes; step recipes compute exertion during finalize
-    if( !is_step_recipe ) {
+    if( !effectively_step_recipe ) {
         mandatory( jo, was_loaded, "activity_level", exertion, activity_level_reader{} );
     }
 
@@ -461,10 +458,8 @@ void recipe::load( const JsonObject &jo, const std::string_view src )
         flags_to_delete = jo.get_tags<flag_id>( "delete_flags" );
     }
 
-    if( !is_step_recipe ) {
-        optional( jo, was_loaded, "using", reqs_external,
-                  weighted_string_id_reader<requirement_id, int> { 1 } );
-    }
+    optional( jo, was_loaded, "using", reqs_external,
+              weighted_string_id_reader<requirement_id, int> { 1 } );
 
     bool inherited_tools = false;
     bool inherited_qualities = false;
@@ -608,11 +603,13 @@ void recipe::load( const JsonObject &jo, const std::string_view src )
     }
 
     const requirement_id req_id( "inline_" + type + "_" + id.str() );
-    requirement_data::load_requirement( jo, req_id, false, abstract );
+    // Step recipes legitimately have root-level components; suppress abstract
+    // debugmsg for them (tools/qualities are already caught by field validation).
+    requirement_data::load_requirement( jo, req_id, false, abstract && !effectively_step_recipe );
     reqs_internal.emplace_back( req_id, 1 );
 
     // Parse recipe steps
-    if( is_step_recipe ) {
+    if( child_has_steps ) {
         int step_index = 0;
         for( JsonObject step_jo : jo.get_array( "steps" ) ) {
             recipe_step step;
@@ -624,7 +621,7 @@ void recipe::load( const JsonObject &jo, const std::string_view src )
         }
     }
 
-    if( !is_step_recipe ) {
+    if( !effectively_step_recipe ) {
         if( inherited_tools && !jo.has_member( "tools" ) ) {
             debugmsg( "Recipe %s inherits from recipe that has tools, but does not have any of its own.  "
                       "This is probably an error.", id.str() );
@@ -634,11 +631,10 @@ void recipe::load( const JsonObject &jo, const std::string_view src )
             debugmsg( "Recipe %s inherits from recipe that has qualities, but does not have any of its own.  "
                       "This is probably an error.", id.str() );
         }
-
-        if( inherited_components  && !jo.has_member( "components" ) ) {
-            debugmsg( "Recipe %s inherits from recipe that has components, but does not have any of its own.  "
-                      "This is probably an error.", id.str() );
-        }
+    }
+    if( inherited_components && !jo.has_member( "components" ) ) {
+        debugmsg( "Recipe %s inherits from recipe that has components, but does not have any of its own.  "
+                  "This is probably an error.", id.str() );
     }
 }
 
@@ -660,6 +656,10 @@ void recipe_step::load( const JsonObject &jo, const std::string &recipe_name, in
         jo.throw_error( "step recipes must not have per-step components; "
                         "use root-level components" );
     }
+
+    // Load external requirements via "using" syntax
+    optional( jo, false, "using", reqs_external,
+              weighted_string_id_reader<requirement_id, int> { 1 } );
 
     // Load inline tools/qualities for this step
     const requirement_id step_req_id( "inline_recipe_" + recipe_name + "_step_"
@@ -786,17 +786,23 @@ void recipe::finalize()
     if( !blueprint.is_empty() ) {
         incorporate_build_reqs();
     } else if( has_steps() ) {
-        // Step recipes: merge root components + per-step tools/qualities
+        // Step recipes: merge root using + root components + per-step tools/qualities
+        add_requirements( reqs_external );  // root using
         add_requirements( reqs_internal );  // root components
+        reqs_external.clear();
         reqs_internal.clear();
 
         for( recipe_step &step : steps_ ) {
-            // Resolve each step's inline requirements
+            // Resolve each step's external (using) + inline requirements
+            step.requirements = std::accumulate(
+                                    step.reqs_external.begin(), step.reqs_external.end(),
+                                    step.requirements );
             step.requirements = std::accumulate(
                                     step.reqs_internal.begin(), step.reqs_internal.end(),
                                     step.requirements );
             // Merge step requirements into recipe-level for whole-recipe gating
             requirements_ = requirements_ + step.requirements;
+            step.reqs_external.clear();
             step.reqs_internal.clear();
         }
 
@@ -1732,7 +1738,16 @@ bool recipe::will_be_blacklisted() const
         return std::any_of( reqs.begin(), reqs.end(), req_is_blacklisted );
     };
 
-    return any_is_blacklisted( reqs_internal ) || any_is_blacklisted( reqs_external );
+    if( any_is_blacklisted( reqs_internal ) || any_is_blacklisted( reqs_external ) ) {
+        return true;
+    }
+    for( const recipe_step &step : steps_ ) {
+        if( any_is_blacklisted( step.reqs_internal ) ||
+            any_is_blacklisted( step.reqs_external ) ) {
+            return true;
+        }
+    }
+    return false;
 }
 
 std::function<bool( const item & )> recipe::get_component_filter(

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -121,7 +121,9 @@ struct recipe_step {
     batch_savings batch_info;
     // Stored as requirement_id refs during load, resolved during finalize
     std::vector<std::pair<requirement_id, int>> reqs_internal;
-    // Populated during finalize from reqs_internal
+    // External requirements via "using" syntax, resolved during finalize
+    std::vector<std::pair<requirement_id, int>> reqs_external;
+    // Populated during finalize from reqs_internal + reqs_external
     requirement_data requirements;
 
     void load( const JsonObject &jo, const std::string &recipe_name, int step_index );

--- a/tests/recipe_steps_test.cpp
+++ b/tests/recipe_steps_test.cpp
@@ -498,8 +498,8 @@ TEST_CASE( "step_recipe_schema_rejection", "[recipe][steps]" )
         })" );
     }
 
-    SECTION( "root-level using" ) {
-        check_step_recipe_throws( R"({
+    SECTION( "root-level using is allowed" ) {
+        const std::string json = R"({
             "type": "recipe", "result": "cudgel", "id_suffix": "test_using",
             "category": "CC_WEAPON", "subcategory": "CSC_WEAPON_BASHING",
             "skill_used": "fabrication", "difficulty": 1,
@@ -508,21 +508,33 @@ TEST_CASE( "step_recipe_schema_rejection", "[recipe][steps]" )
             "steps": [
                 { "name": "Work", "time": "5 m", "activity_level": "NO_EXERCISE" }
             ]
-        })" );
+        })";
+        JsonObject jo = json_loader::from_string( json );
+        recipe r;
+        CHECK_NOTHROW( r.load( jo, "dda" ) );
     }
 
-    SECTION( "abstract step recipe" ) {
-        check_step_recipe_throws( R"({
+    SECTION( "abstract step recipe is allowed" ) {
+        const std::string json = R"({
             "abstract": "test_abstract_step",
             "type": "recipe",
+            "category": "CC_WEAPON",
+            "subcategory": "CSC_WEAPON_BASHING",
+            "skill_used": "fabrication",
+            "difficulty": 1,
             "steps": [
                 { "name": "Work", "time": "5 m", "activity_level": "NO_EXERCISE" }
             ]
-        })" );
+        })";
+        JsonObject jo = json_loader::from_string( json );
+        recipe r;
+        CHECK_NOTHROW( r.load( jo, "dda" ) );
     }
 
-    SECTION( "copy-from on step recipe" ) {
-        check_step_recipe_throws( R"({
+    SECTION( "copy-from on step recipe is allowed" ) {
+        // copy-from is consumed by recipe_dictionary::load(), not recipe::load().
+        // allow_omitted_members() suppresses the unread-data error.
+        const std::string json = R"({
             "type": "recipe",
             "result": "cudgel",
             "id_suffix": "test_copyfrom",
@@ -535,8 +547,104 @@ TEST_CASE( "step_recipe_schema_rejection", "[recipe][steps]" )
             "steps": [
                 { "name": "Work", "time": "5 m", "activity_level": "NO_EXERCISE" }
             ]
-        })" );
+        })";
+        JsonObject jo = json_loader::from_string( json );
+        jo.allow_omitted_members();
+        recipe r;
+        CHECK_NOTHROW( r.load( jo, "dda" ) );
     }
+}
+
+// Helper: load + finalize an inline recipe
+static recipe load_and_finalize( const std::string &json )
+{
+    JsonObject jo = json_loader::from_string( json );
+    recipe r;
+    r.load( jo, "dda" );
+    r.finalize();
+    return r;
+}
+
+TEST_CASE( "step_recipe_root_using_merges_into_simple_requirements", "[recipe][steps]" )
+{
+    // sewing_standard has qualities SEW/1, CUT/2, FABRIC_CUT/1 and component filament
+    const recipe r = load_and_finalize( R"({
+        "type": "recipe", "result": "cudgel", "id_suffix": "test_root_using_merge",
+        "category": "CC_WEAPON", "subcategory": "CSC_WEAPON_BASHING",
+        "skill_used": "fabrication", "difficulty": 1,
+        "using": [ [ "sewing_standard", 1 ] ],
+        "components": [[ [ "2x4", 1 ] ]],
+        "steps": [
+            { "name": "Work", "time": "5 m", "activity_level": "NO_EXERCISE" }
+        ]
+    })" );
+
+    const requirement_data &reqs = r.simple_requirements();
+
+    bool has_sew = false;
+    for( const std::vector<quality_requirement> &qual_group : reqs.get_qualities() ) {
+        for( const quality_requirement &qual : qual_group ) {
+            if( qual.type.str() == "SEW" ) {
+                has_sew = true;
+            }
+        }
+    }
+    CHECK( has_sew );
+
+    // filament is a LIST requirement that expands to thread, sinew, etc.
+    bool has_thread = false;
+    for( const std::vector<item_comp> &comp_group : reqs.get_components() ) {
+        for( const item_comp &comp : comp_group ) {
+            if( comp.type.str() == "thread" ) {
+                has_thread = true;
+            }
+        }
+    }
+    CHECK( has_thread );
+}
+
+TEST_CASE( "step_recipe_step_using_merges_into_step_requirements", "[recipe][steps]" )
+{
+    // sewing_standard has qualities SEW/1, CUT/2, FABRIC_CUT/1
+    const recipe r = load_and_finalize( R"({
+        "type": "recipe", "result": "cudgel", "id_suffix": "test_step_using_merge",
+        "category": "CC_WEAPON", "subcategory": "CSC_WEAPON_BASHING",
+        "skill_used": "fabrication", "difficulty": 1,
+        "components": [[ [ "2x4", 1 ] ]],
+        "steps": [
+            {
+                "name": "Sew",
+                "time": "5 m",
+                "activity_level": "NO_EXERCISE",
+                "using": [ [ "sewing_standard", 1 ] ]
+            }
+        ]
+    })" );
+
+    REQUIRE( r.has_steps() );
+    const recipe_step &step = r.steps()[0];
+
+    bool step_has_sew = false;
+    for( const std::vector<quality_requirement> &qual_group : step.requirements.get_qualities() ) {
+        for( const quality_requirement &qual : qual_group ) {
+            if( qual.type.str() == "SEW" ) {
+                step_has_sew = true;
+            }
+        }
+    }
+    CHECK( step_has_sew );
+
+    // Recipe-level requirements should also include SEW (merged from step)
+    bool recipe_has_sew = false;
+    for( const std::vector<quality_requirement> &qual_group :
+         r.simple_requirements().get_qualities() ) {
+        for( const quality_requirement &qual : qual_group ) {
+            if( qual.type.str() == "SEW" ) {
+                recipe_has_sew = true;
+            }
+        }
+    }
+    CHECK( recipe_has_sew );
 }
 
 // ---- End-to-end craft ----
@@ -1232,49 +1340,323 @@ TEST_CASE( "stepless_recipe_step_state_unchanged", "[recipe][steps][crafting]" )
     CHECK( msg->find( "Finish" ) == std::string::npos );
 }
 
-// ---- Edge case: inherited steps on non-step child ----
-
-TEST_CASE( "step_recipe_inherited_steps_rejected", "[recipe][steps]" )
+// Simulate copy-from: load base, then child onto same object.
+// Matches recipe_dictionary::load() behavior.
+static recipe load_base_then_child( const std::string &base_json,
+                                    const std::string &child_json )
 {
-    // Load a step recipe to populate steps_, then load non-step JSON onto the
-    // same object. This simulates a non-step child that copy-from'd a step base.
     recipe r;
-    REQUIRE( r.steps().empty() );
     {
-        const std::string step_json = R"({
-            "type": "recipe",
-            "result": "cudgel",
-            "id_suffix": "test_inherit_base",
-            "category": "CC_WEAPON",
-            "subcategory": "CSC_WEAPON_BASHING",
-            "skill_used": "fabrication",
-            "difficulty": 1,
-            "components": [[ [ "2x4", 1 ] ]],
-            "steps": [
-                { "name": "Work", "time": "10 m", "activity_level": "MODERATE_EXERCISE" }
-            ]
-        })";
-        JsonObject jo = json_loader::from_string( step_json );
+        JsonObject jo = json_loader::from_string( base_json );
         jo.allow_omitted_members();
         r.load( jo, "dda" );
     }
-    REQUIRE( r.has_steps() );
+    // Mark as loaded so optional() preserves inherited values
+    r.was_loaded = true;
+    {
+        JsonObject jo = json_loader::from_string( child_json );
+        jo.allow_omitted_members();
+        r.load( jo, "dda" );
+    }
+    return r;
+}
 
-    const std::string child_json = R"({
+// Base fixture with steps + step-level using (reused across tests)
+static const std::string step_base_json = R"({
+    "type": "recipe",
+    "result": "cudgel",
+    "id_suffix": "test_copyfrom_base",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_BASHING",
+    "skill_used": "fabrication",
+    "difficulty": 1,
+    "using": [ [ "sewing_standard", 1 ] ],
+    "components": [[ [ "2x4", 1 ] ]],
+    "steps": [
+        {
+            "name": "Shape",
+            "time": "10 m",
+            "activity_level": "MODERATE_EXERCISE",
+            "using": [ [ "sewing_standard", 1 ] ]
+        },
+        { "name": "Finish", "time": "5 m", "activity_level": "NO_EXERCISE" }
+    ]
+})";
+
+TEST_CASE( "step_recipe_inherited_steps_with_root_fields_rejected", "[recipe][steps]" )
+{
+    // Child inherits steps but declares stepless-only root fields -> error
+    SECTION( "root time" ) {
+        CHECK_THROWS_AS( load_base_then_child( step_base_json, R"({
+            "type": "recipe", "result": "cudgel", "id_suffix": "test_inherit_time",
+            "category": "CC_WEAPON", "subcategory": "CSC_WEAPON_BASHING",
+            "skill_used": "fabrication", "difficulty": 1,
+            "time": "10 m", "activity_level": "MODERATE_EXERCISE",
+            "components": [[ [ "2x4", 1 ] ]]
+        })" ), JsonError );
+    }
+
+    SECTION( "root tools" ) {
+        CHECK_THROWS_AS( load_base_then_child( step_base_json, R"({
+            "type": "recipe", "result": "cudgel", "id_suffix": "test_inherit_tools",
+            "category": "CC_WEAPON", "subcategory": "CSC_WEAPON_BASHING",
+            "skill_used": "fabrication", "difficulty": 1,
+            "tools": [[ [ "hammer", -1 ] ]],
+            "components": [[ [ "2x4", 1 ] ]]
+        })" ), JsonError );
+    }
+
+    SECTION( "root qualities" ) {
+        CHECK_THROWS_AS( load_base_then_child( step_base_json, R"({
+            "type": "recipe", "result": "cudgel", "id_suffix": "test_inherit_qual",
+            "category": "CC_WEAPON", "subcategory": "CSC_WEAPON_BASHING",
+            "skill_used": "fabrication", "difficulty": 1,
+            "qualities": [ { "id": "CUT", "level": 1 } ],
+            "components": [[ [ "2x4", 1 ] ]]
+        })" ), JsonError );
+    }
+
+    SECTION( "root proficiencies" ) {
+        CHECK_THROWS_AS( load_base_then_child( step_base_json, R"({
+            "type": "recipe", "result": "cudgel", "id_suffix": "test_inherit_prof",
+            "category": "CC_WEAPON", "subcategory": "CSC_WEAPON_BASHING",
+            "skill_used": "fabrication", "difficulty": 1,
+            "proficiencies": [ { "proficiency": "prof_test_step_a" } ],
+            "components": [[ [ "2x4", 1 ] ]]
+        })" ), JsonError );
+    }
+
+    SECTION( "root batch_time_factors" ) {
+        CHECK_THROWS_AS( load_base_then_child( step_base_json, R"({
+            "type": "recipe", "result": "cudgel", "id_suffix": "test_inherit_batch",
+            "category": "CC_WEAPON", "subcategory": "CSC_WEAPON_BASHING",
+            "skill_used": "fabrication", "difficulty": 1,
+            "batch_time_factors": [ 50, 4 ],
+            "components": [[ [ "2x4", 1 ] ]]
+        })" ), JsonError );
+    }
+
+    SECTION( "root activity_level" ) {
+        CHECK_THROWS_AS( load_base_then_child( step_base_json, R"({
+            "type": "recipe", "result": "cudgel", "id_suffix": "test_inherit_act",
+            "category": "CC_WEAPON", "subcategory": "CSC_WEAPON_BASHING",
+            "skill_used": "fabrication", "difficulty": 1,
+            "activity_level": "MODERATE_EXERCISE",
+            "components": [[ [ "2x4", 1 ] ]]
+        })" ), JsonError );
+    }
+}
+
+TEST_CASE( "step_recipe_copy_from_inherits_steps", "[recipe][steps]" )
+{
+    // Child inherits steps from base (no "steps" in child JSON).
+    // Base has step-level using to verify reqs_external carriage.
+    recipe r = load_base_then_child( step_base_json, R"({
+        "type": "recipe", "result": "cudgel", "id_suffix": "test_inherit_steps",
+        "category": "CC_WEAPON", "subcategory": "CSC_WEAPON_BASHING",
+        "skill_used": "fabrication", "difficulty": 2,
+        "components": [[ [ "2x4", 1 ] ]]
+    })" );
+
+    CHECK( r.has_steps() );
+    REQUIRE( r.steps().size() == 2 );
+    CHECK( r.steps()[0].name.translated() == "Shape" );
+    CHECK( r.steps()[1].name.translated() == "Finish" );
+    CHECK( r.difficulty == 2 );
+
+    // Finalize and verify step-level using resolved
+    r.finalize();
+    bool step_has_sew = false;
+    for( const std::vector<quality_requirement> &qual_group :
+         r.steps()[0].requirements.get_qualities() ) {
+        for( const quality_requirement &qual : qual_group ) {
+            if( qual.type.str() == "SEW" ) {
+                step_has_sew = true;
+            }
+        }
+    }
+    CHECK( step_has_sew );
+}
+
+TEST_CASE( "step_recipe_copy_from_overrides_steps", "[recipe][steps]" )
+{
+    recipe r = load_base_then_child( step_base_json, R"({
+        "type": "recipe", "result": "cudgel", "id_suffix": "test_override_steps",
+        "category": "CC_WEAPON", "subcategory": "CSC_WEAPON_BASHING",
+        "skill_used": "fabrication", "difficulty": 1,
+        "components": [[ [ "2x4", 1 ] ]],
+        "steps": [
+            { "name": "Cut", "time": "3 m", "activity_level": "LIGHT_EXERCISE" }
+        ]
+    })" );
+
+    CHECK( r.has_steps() );
+    REQUIRE( r.steps().size() == 1 );
+    CHECK( r.steps()[0].name.translated() == "Cut" );
+}
+
+TEST_CASE( "step_recipe_copy_from_inherits_root_using", "[recipe][steps]" )
+{
+    // Base has root using (sewing_standard). Child inherits steps, no own using.
+    recipe r = load_base_then_child( step_base_json, R"({
+        "type": "recipe", "result": "cudgel", "id_suffix": "test_inherit_using",
+        "category": "CC_WEAPON", "subcategory": "CSC_WEAPON_BASHING",
+        "skill_used": "fabrication", "difficulty": 1,
+        "components": [[ [ "2x4", 1 ] ]]
+    })" );
+    r.finalize();
+
+    bool has_sew = false;
+    for( const std::vector<quality_requirement> &qual_group :
+         r.simple_requirements().get_qualities() ) {
+        for( const quality_requirement &qual : qual_group ) {
+            if( qual.type.str() == "SEW" ) {
+                has_sew = true;
+            }
+        }
+    }
+    CHECK( has_sew );
+}
+
+TEST_CASE( "step_recipe_copy_from_preserves_root_using_when_steps_overridden", "[recipe][steps]" )
+{
+    recipe r = load_base_then_child( step_base_json, R"({
+        "type": "recipe", "result": "cudgel", "id_suffix": "test_override_keep_using",
+        "category": "CC_WEAPON", "subcategory": "CSC_WEAPON_BASHING",
+        "skill_used": "fabrication", "difficulty": 1,
+        "components": [[ [ "2x4", 1 ] ]],
+        "steps": [
+            { "name": "Cut", "time": "3 m", "activity_level": "LIGHT_EXERCISE" }
+        ]
+    })" );
+    r.finalize();
+
+    bool has_sew = false;
+    for( const std::vector<quality_requirement> &qual_group :
+         r.simple_requirements().get_qualities() ) {
+        for( const quality_requirement &qual : qual_group ) {
+            if( qual.type.str() == "SEW" ) {
+                has_sew = true;
+            }
+        }
+    }
+    CHECK( has_sew );
+}
+
+TEST_CASE( "step_recipe_copy_from_child_using_replaces_base_using", "[recipe][steps]" )
+{
+    // Use a base with root sewing_standard but NO step-level using.
+    // This way, SEW only appears if root using survives.
+    // Child replaces root using with welding_standard (has GLARE, not SEW).
+    // If replacement works: GLARE present, SEW absent.
+    // If it regressed to merge: both GLARE and SEW present.
+    static const std::string root_only_using_base = R"({
+        "type": "recipe", "result": "cudgel", "id_suffix": "test_root_only_using_base",
+        "category": "CC_WEAPON", "subcategory": "CSC_WEAPON_BASHING",
+        "skill_used": "fabrication", "difficulty": 1,
+        "using": [ [ "sewing_standard", 1 ] ],
+        "components": [[ [ "2x4", 1 ] ]],
+        "steps": [
+            { "name": "Work", "time": "5 m", "activity_level": "NO_EXERCISE" }
+        ]
+    })";
+
+    recipe r = load_base_then_child( root_only_using_base, R"({
+        "type": "recipe", "result": "cudgel", "id_suffix": "test_replace_using",
+        "category": "CC_WEAPON", "subcategory": "CSC_WEAPON_BASHING",
+        "skill_used": "fabrication", "difficulty": 1,
+        "using": [ [ "welding_standard", 1 ] ],
+        "components": [[ [ "2x4", 1 ] ]]
+    })" );
+    r.finalize();
+
+    const requirement_data &reqs = r.simple_requirements();
+    bool has_glare = false;
+    bool has_sew = false;
+    for( const std::vector<quality_requirement> &qual_group : reqs.get_qualities() ) {
+        for( const quality_requirement &qual : qual_group ) {
+            if( qual.type.str() == "GLARE" ) {
+                has_glare = true;
+            }
+            if( qual.type.str() == "SEW" ) {
+                has_sew = true;
+            }
+        }
+    }
+    CHECK( has_glare );
+    CHECK_FALSE( has_sew );
+}
+
+TEST_CASE( "step_recipe_copy_from_missing_components_absent", "[recipe][steps]" )
+{
+    // Base has root components (2x4). Child omits components.
+    // The debugmsg about missing components is expected.
+    recipe r;
+    capture_debugmsg_during( [&]() {
+        r = load_base_then_child( step_base_json, R"({
+            "type": "recipe", "result": "cudgel", "id_suffix": "test_no_comp",
+            "category": "CC_WEAPON", "subcategory": "CSC_WEAPON_BASHING",
+            "skill_used": "fabrication", "difficulty": 1
+        })" );
+    } );
+    r.finalize();
+
+    bool has_2x4 = false;
+    for( const std::vector<item_comp> &comp_group :
+         r.simple_requirements().get_components() ) {
+        for( const item_comp &comp : comp_group ) {
+            if( comp.type == itype_2x4 ) {
+                has_2x4 = true;
+            }
+        }
+    }
+    CHECK_FALSE( has_2x4 );
+}
+
+TEST_CASE( "step_recipe_abstract_base_to_concrete_child", "[recipe][steps]" )
+{
+    static const std::string abstract_base = R"({
+        "abstract": "test_abstract_step_base",
         "type": "recipe",
-        "result": "cudgel",
-        "id_suffix": "test_inherit_child",
         "category": "CC_WEAPON",
         "subcategory": "CSC_WEAPON_BASHING",
         "skill_used": "fabrication",
         "difficulty": 1,
-        "time": "10 m",
-        "activity_level": "MODERATE_EXERCISE",
-        "components": [[ [ "2x4", 1 ] ]]
+        "steps": [
+            { "name": "Shape", "time": "10 m", "activity_level": "MODERATE_EXERCISE" },
+            { "name": "Finish", "time": "5 m", "activity_level": "NO_EXERCISE" }
+        ]
     })";
-    JsonObject jo2 = json_loader::from_string( child_json );
-    jo2.allow_omitted_members();
-    CHECK_THROWS_AS( r.load( jo2, "dda" ), JsonError );
+
+    recipe r = load_base_then_child( abstract_base, R"({
+        "type": "recipe", "result": "cudgel", "id_suffix": "test_from_abstract",
+        "category": "CC_WEAPON", "subcategory": "CSC_WEAPON_BASHING",
+        "skill_used": "fabrication", "difficulty": 3,
+        "components": [[ [ "2x4", 1 ] ]]
+    })" );
+
+    CHECK( r.has_steps() );
+    REQUIRE( r.steps().size() == 2 );
+    CHECK( r.steps()[0].name.translated() == "Shape" );
+    CHECK( r.steps()[1].name.translated() == "Finish" );
+    CHECK( r.difficulty == 3 );
+
+    r.finalize();
+    bool has_2x4 = false;
+    for( const std::vector<item_comp> &comp_group :
+         r.simple_requirements().get_components() ) {
+        for( const item_comp &comp : comp_group ) {
+            if( comp.type == itype_2x4 ) {
+                has_2x4 = true;
+            }
+        }
+    }
+    CHECK( has_2x4 );
+
+    // Time should be sum of steps
+    CHECK( r.time_to_craft_moves( get_player_character(), {},
+                                  recipe_time_flag::ignore_proficiencies ) ==
+           to_moves<int64_t>( 15_minutes ) );
 }
 
 // ---- Edge case: required/optional proficiency conflict across steps ----


### PR DESCRIPTION
#### Summary
Features "Allow copy-from, abstract, and using for recipe steps"

#### Purpose of change

Step recipes shipped with bans on `copy-from`, `abstract`, and `using` to keep initial scope small. Now that content is landing (#86455, #86459), those bans are the main friction - similar recipes can't share steps, abstract templates can't define them, and `using` sets like `sewing_standard` can't go on steps.

#### Describe the solution

`using` works at both root and step level. Root merges into whole-recipe gating, step-level merges into that step's requirements and participates in tool speed. Finalize resolves `reqs_external` alongside `reqs_internal` at both levels.

`copy-from` just works. Child without `"steps"` inherits the base's steps. Child with `"steps"` replaces them. Root `using` survives either way - `reqs_external` isn't cleared, so the child inherits or replaces via normal `optional(jo, was_loaded, ...)` semantics.

`abstract` ban removed. An abstract with steps is a template, children bring their own components and result.

The loader uses `effectively_step_recipe = child_has_steps || had_inherited_steps` and applies the same field validation regardless of how the recipe got its steps. `will_be_blacklisted()` extended to check step-level reqs.

#### Describe alternatives you've considered

Duplicate step definitions across every bread variant. Kind of defeats the point.

#### Testing

20 new tests. Existing [recipe] and [crafting] suites pass. Verified in-game with bread.

#### Additional context

`will_be_blacklisted()` step-level check is structurally identical to the root-level one but untested - no test infra for setting `requirement_data::blacklisted` on a registered requirement.