### PR TITLE
Limbify Feline Eyes

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -1030,6 +1030,11 @@
     "info": "This clothing <good>performs well</good> even when <info>soaking wet</info>.  This can feel good."
   },
   {
+    "id": "HIGH_GLARE",
+    "type": "json_flag",
+    "//": "Glare lasts twice as long."
+  },
+  {
     "id": "ITEM_BROKEN",
     "type": "json_flag",
     "info": "This item was broken and <bad>won't activate anymore</bad>."

--- a/data/json/mutations/limbs_body_parts.json
+++ b/data/json/mutations/limbs_body_parts.json
@@ -40,7 +40,23 @@
     "encumbrance_text": "Your vision is impaired!",
     "opposite_part": "eyes_fey_full",
     "limb_scores": [ [ "vision", 1.4 ], [ "night_vis", 4.5 ], [ "reaction", 0.85 ] ],
+    "similar_bodypart": "eyes",
     "sub_parts": [ "eyes_fey_full_left", "eyes_fey_full_right" ]
+  },
+  {
+    "type": "body_part",
+    "id": "eyes_feline",
+    "copy-from": "eyes",
+    "name": "feline eyes",
+    "accusative": { "ctxt": "bodypart_accusative", "str": "feline eyes" },
+    "heading": "eyes",
+    "heading_multiple": "eyes",
+    "encumbrance_text": "Your vision is impaired!",
+    "opposite_part": "eyes_fey_full",
+    "limb_scores": [ [ "vision", 0.8 ], [ "night_vis", 3.0 ], [ "reaction", 1.25 ] ],
+    "sub_parts": [ "eyes_feline_left", "eyes_feline_right" ],
+    "similar_bodypart": "eyes",
+    "flags": [ "HIGH_GLARE", "HYPEROPIC", "LIMB_UPPER" ]
   },
   {
     "id": "muzzle",

--- a/data/json/mutations/limbs_body_parts.json
+++ b/data/json/mutations/limbs_body_parts.json
@@ -52,7 +52,7 @@
     "heading": "eyes",
     "heading_multiple": "eyes",
     "encumbrance_text": "Your vision is impaired!",
-    "opposite_part": "eyes_fey_full",
+    "opposite_part": "eyes_feline",
     "limb_scores": [ [ "vision", 0.8 ], [ "night_vis", 3.0 ], [ "reaction", 1.25 ] ],
     "sub_parts": [ "eyes_feline_left", "eyes_feline_right" ],
     "similar_bodypart": "eyes",

--- a/data/json/mutations/limbs_sublimbs.json
+++ b/data/json/mutations/limbs_sublimbs.json
@@ -29,7 +29,8 @@
     "side": "left",
     "opposite": "eyes_fey_right",
     "name_multiple": "eyes",
-    "name": "left eye"
+    "name": "left eye",
+    "similar_bodypart": "eyes_left"
   },
   {
     "id": "eyes_fey_right",
@@ -39,7 +40,8 @@
     "side": "right",
     "opposite": "eyes_fey_left",
     "name_multiple": "eyes",
-    "name": "right eye"
+    "name": "right eye",
+    "similar_bodypart": "eyes_right"
   },
   {
     "id": "eyes_fey_full_left",
@@ -49,7 +51,8 @@
     "side": "left",
     "opposite": "eyes_fey_full_right",
     "name_multiple": "eyes",
-    "name": "left eye"
+    "name": "left eye",
+    "similar_bodypart": "eyes_left"
   },
   {
     "id": "eyes_fey_full_right",
@@ -59,7 +62,30 @@
     "side": "right",
     "opposite": "eyes_fey_full_left",
     "name_multiple": "eyes",
-    "name": "right eye"
+    "name": "right eye",
+    "similar_bodypart": "eyes_right"
+  },
+  {
+    "id": "eyes_feline_left",
+    "type": "sub_body_part",
+    "max_coverage": 50,
+    "parent": "eyes_feline",
+    "side": "left",
+    "opposite": "eyes_feline_right",
+    "name_multiple": "eyes",
+    "name": "left eye",
+    "similar_bodypart": "eyes_left"
+  },
+  {
+    "id": "eyes_feline_right",
+    "type": "sub_body_part",
+    "max_coverage": 50,
+    "parent": "eyes_feline",
+    "side": "right",
+    "opposite": "eyes_feline_left",
+    "name_multiple": "eyes",
+    "name": "right eye",
+    "similar_bodypart": "eyes_right"
   },
   {
     "id": "muzzle_lips",

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -4414,9 +4414,8 @@
     "types": [ "VISION" ],
     "prereqs": [ "FEL_EYE" ],
     "points": 4,
-    "active": true,
-    "starts_active": true,
-    "vitamin_cost": 160
+    "vitamin_cost": 160,
+    "enchantments": [ { "condition": "ALWAYS", "modified_bodyparts": [ { "lose": "eyes" }, { "gain": "eyes_feline" } ] } ]
   },
   {
     "type": "mutation",

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -5724,7 +5724,8 @@
     "points": 3,
     "active": true,
     "starts_active": true,
-    "vitamin_cost": 160
+    "vitamin_cost": 160,
+    "flags": [ "HIGH_GLARE" ]
   },
   {
     "type": "mutation",

--- a/doc/JSON/JSON_FLAGS.md
+++ b/doc/JSON/JSON_FLAGS.md
@@ -352,6 +352,7 @@ Character flags can be `trait_id`, `json_flag_id` or `flag_id`.  Some of these a
 - ```BLEEDSLOW``` When bleeding, lose blood at 2/3 of the normal rate.
 - ```BLEEDSLOW2``` When bleeding, lose blood at 1/3 of the normal rate.
 - ```BLIND``` Makes you blind.
+- ```BLOCK_HUGE_ATTACKS``` Size limitations on blocking are ignored
 - ```BLOCK_SUPERNATURAL_HEALING``` Blocks supernatural healing effects, like magical healing spells, from taking effect.  This flag does not block EoC-based healing like using the u_hp() effect.
 - ```BULLET_IMMUNE``` You are immune to bullet damage.
 - ```CANNIBAL``` Butcher humans, eat foods with the `CANNIBALISM` and `STRICT_HUMANITARIANISM` flags without a morale penalty.
@@ -394,8 +395,8 @@ Character flags can be `trait_id`, `json_flag_id` or `flag_id`.  Some of these a
 - ```HEATSINK``` You are resistant to extreme heat.
 - ```HEAT_IMMUNE``` Immune to very hot temperatures and fire damage.
 - ```HERITAGE``` Turns a mutation with this flag light cyan on the list.  Currently used in mods for mutations that indicate non-human ancestry.
+- ```HIGH_GLARE``` Glare lasts twice as long
 - ```HUGE``` Changes your size to `creature_size::huge`.  Checked last of the size category flags, if no size flags are found your size defaults to `creature_size::medium`.
-- ```BLOCK_HUGE_ATTACKS``` Size limitations on blocking are ignored
 - ```HYPEROPIC``` You are far-sighted: close combat is hampered and reading is impossible without glasses.
 - ```INHALED_TOXIN_IMMUNE``` You are immune to any inhaled toxin that mouth environmental resistance would also protect against.
 - ```IMMUNE_HEARING_DAMAGE``` Immune to hearing damage from loud sounds.

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -341,7 +341,6 @@ static const trait_id trait_EATHEALTH( "EATHEALTH" );
 static const trait_id trait_FACIAL_HAIR_NONE( "FACIAL_HAIR_NONE" );
 static const trait_id trait_FAERIECREATURE( "FAERIECREATURE" );
 static const trait_id trait_FAT( "FAT" );
-static const trait_id trait_FEL_NV( "FEL_NV" );
 static const trait_id trait_GILLS( "GILLS" );
 static const trait_id trait_GILLS_CEPH( "GILLS_CEPH" );
 static const trait_id trait_HIBERNATE( "HIBERNATE" );
@@ -2481,9 +2480,6 @@ void Character::recalc_sight_limits()
     if( has_active_mutation( trait_NIGHTVISION2 ) ) {
         vision_mode_cache.set( NIGHTVISION_2 );
     }
-    if( has_active_mutation( trait_FEL_NV ) ) {
-        vision_mode_cache.set( FELINE_VISION );
-    }
     if( has_active_mutation( trait_URSINE_EYE ) ) {
         vision_mode_cache.set( URSINE_VISION );
     }
@@ -2524,8 +2520,7 @@ float Character::get_vision_threshold( float light_level ) const
     float range = get_per() / 3.0f;
     if( vision_mode_cache[NIGHTVISION_3] || vision_mode_cache[CEPH_VISION] ) {
         range += 10;
-    } else if( vision_mode_cache[NIGHTVISION_2] || vision_mode_cache[FELINE_VISION] ||
-               vision_mode_cache[URSINE_VISION] ) {
+    } else if( vision_mode_cache[NIGHTVISION_2] || vision_mode_cache[URSINE_VISION] ) {
         range += 4.5;
     } else if( vision_mode_cache[NIGHTVISION_1] ) {
         range += 2;

--- a/src/character.h
+++ b/src/character.h
@@ -146,8 +146,6 @@ enum vision_modes {
     NIGHTVISION_2,
     NIGHTVISION_3,
     CEPH_VISION,
-    /// mutate w/ id "FEL_NV" & name "Feline Vision" see pretty well at night
-    FELINE_VISION,
     /// Bird mutation named "Avian Eyes": Perception +4
     BIRD_EYE,
     /// mutate w/ id "URSINE_EYE" & name "Ursine Vision" see better in dark, nearsight in light

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -635,15 +635,15 @@ void flashbang( const tripoint_bub_ms &p, bool player_immune, const int radius )
                            guy.is_wearing( itype_rm13_armor_on ) ) {
                     flash_mod = radius / 1.3f;
                 } else if( guy.has_flag( json_flag_HIGH_GLARE ) ) {
-                flash_mod /= 2;
-                dur_mod = 2;
+                    flash_mod /= 2;
+                    dur_mod = 2;
                 } else if( guy.worn_with_flag( json_flag_BLIND ) ||
                            guy.worn_with_flag( json_flag_FLASH_PROTECTION ) ) {
                     flash_mod = radius / 2.6f; // Not really proper flash protection, but better than nothing
                 }
                 guy.add_env_effect( effect_blind, bodypart_id( "eyes" ),
                                     ( radius * 1.5f - flash_mod - dist ) / 2,
-                                    time_duration::from_turns( 10 - dist ) );
+                                    time_duration::from_turns( 10 - dist ) * dur_mod );
             }
         }
     };

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -89,6 +89,7 @@ static const itype_id itype_rm13_armor_on( "rm13_armor_on" );
 static const json_character_flag json_flag_EMP_ENERGYDRAIN_IMMUNE( "EMP_ENERGYDRAIN_IMMUNE" );
 static const json_character_flag json_flag_EMP_IMMUNE( "EMP_IMMUNE" );
 static const json_character_flag json_flag_GLARE_RESIST( "GLARE_RESIST" );
+static const json_character_flag json_flag_HIGH_GLARE( "HIGH_GLARE" );
 static const json_character_flag json_flag_IMMUNE_HEARING_DAMAGE( "IMMUNE_HEARING_DAMAGE" );
 
 static const mongroup_id GROUP_NETHER( "GROUP_NETHER" );
@@ -623,6 +624,7 @@ void flashbang( const tripoint_bub_ms &p, bool player_immune, const int radius )
             }
             if( here.sees( guy.pos_bub(), p, radius ) ) {
                 int flash_mod = 0;
+                int dur_mod = 1;
                 if( guy.has_trait( trait_PER_SLIME ) ) {
                     if( one_in( 2 ) ) {
                         flash_mod = radius / 2.6f; // Yay, you weren't looking!
@@ -632,6 +634,9 @@ void flashbang( const tripoint_bub_ms &p, bool player_immune, const int radius )
                 } else if( guy.has_flag( json_flag_GLARE_RESIST ) ||
                            guy.is_wearing( itype_rm13_armor_on ) ) {
                     flash_mod = radius / 1.3f;
+                } else if( guy.has_flag( json_flag_HIGH_GLARE ) ) {
+                flash_mod /= 2;
+                dur_mod = 2;
                 } else if( guy.worn_with_flag( json_flag_BLIND ) ||
                            guy.worn_with_flag( json_flag_FLASH_PROTECTION ) ) {
                     flash_mod = radius / 2.6f; // Not really proper flash protection, but better than nothing

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -635,8 +635,8 @@ void flashbang( const tripoint_bub_ms &p, bool player_immune, const int radius )
                            guy.is_wearing( itype_rm13_armor_on ) ) {
                     flash_mod = radius / 1.3f;
                 } else if( guy.has_flag( json_flag_HIGH_GLARE ) ) {
-                flash_mod /= 2;
-                dur_mod = 2;
+                    flash_mod /= 2;
+                    dur_mod = 2;
                 } else if( guy.worn_with_flag( json_flag_BLIND ) ||
                            guy.worn_with_flag( json_flag_FLASH_PROTECTION ) ) {
                     flash_mod = radius / 2.6f; // Not really proper flash protection, but better than nothing

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -64,6 +64,7 @@ static const flag_id json_flag_SUN_GLASSES( "SUN_GLASSES" );
 static const itype_id itype_water( "water" );
 
 static const json_character_flag json_flag_GLARE_RESIST( "GLARE_RESIST" );
+static const json_character_flag json_flag_HIGH_GLARE( "HIGH_GLARE" );
 static const json_character_flag json_flag_RAIN_IMMUNE( "RAIN_IMMUNE" );
 
 static const oter_type_str_id oter_type_forest( "forest" );
@@ -71,7 +72,6 @@ static const oter_type_str_id oter_type_forest_water( "forest_water" );
 
 static const ter_str_id ter_t_greenhouse_tilled( "t_greenhouse_tilled" );
 
-static const trait_id trait_CEPH_VISION( "CEPH_VISION" );
 static const trait_id trait_FEATHERS( "FEATHERS" );
 
 /**
@@ -132,7 +132,7 @@ void glare( const weather_type_id &w )
     //apply final glare effect
     if( dur > 0_turns && effect != nullptr ) {
         //enhance/reduce by some traits
-        if( player_character.has_trait( trait_CEPH_VISION ) ) {
+        if( player_character.has_flag( json_flag_HIGH_GLARE ) ) {
             dur = dur * 2;
         }
         // Glare in all your eyes


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "Limbify Feline Eyes"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Continued limbification

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Turn Feline Eyes into a bodypart. It has worse close-in detail vision, but you get much better night vision and reaction times.

Add the HIGH_GLARE flag (`glare` lasts twice as long) and apply it to Feline Vision and Cephalopod Vision (which already did this but through hardcoded ID check).

Remove Feline Vision vision mode check. 

Also make sure all the limbified eyes so far have appropriate `eyes` similar_bodyparts. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Feline Nightvision:

<img width="607" height="541" alt="Untitled" src="https://github.com/user-attachments/assets/625f9592-115a-4734-a604-e2abf2d64e21" />

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
