### PR TITLE
Two new faults for clothing

### DIFF
--- a/data/json/faults/fault_fixes_armor.json
+++ b/data/json/faults/fault_fixes_armor.json
@@ -288,10 +288,7 @@
     "mod_degradation": -25,
     "time": "10 m",
     "skills": { "tailor": 1 },
-    "requirements": [
-      [ "filament", 1 ],
-      { "qualities": [ { "id": "SEW", "level": 1 } ] }
-    ]
+    "requirements": [ [ "filament", 1 ], { "qualities": [ { "id": "SEW", "level": 1 } ] } ]
   },
   {
     "type": "fault_fix",

--- a/data/json/faults/fault_fixes_armor.json
+++ b/data/json/faults/fault_fixes_armor.json
@@ -277,5 +277,36 @@
       [ "rivet_replacement", 4 ],
       { "qualities": [ { "id": "FABRIC_CUT", "level": 2 }, { "id": "LEATHER_AWL", "level": 1 } ] }
     ]
+  },
+  {
+    "type": "fault_fix",
+    "id": "mend_armor_cotton_tear_stitch",
+    "name": "Stitch the fabric back together",
+    "faults_removed": [ "fault_cotton_torn" ],
+    "success_msg": "You stitch the tear in %s back up.",
+    "mod_damage": -1000,
+    "mod_degradation": -25,
+    "time": "10 m",
+    "skills": { "tailor": 1 },
+    "requirements": [
+      [ "thread", 5 ],
+      { "qualities": [ { "id": "SEW", "level": 1 } ] }
+    ]
+  },
+  {
+    "type": "fault_fix",
+    "id": "mend_armor_cotton_hole_close",
+    "name": "Patch the hole.",
+    "faults_removed": [ "fault_cotton_hole" ],
+    "success_msg": "You patch the hole in %s.",
+    "mod_damage": -1000,
+    "mod_degradation": -25,
+    "time": "20 m",
+    "skills": { "tailor": 1 },
+    "requirements": [
+      [ "thread", 15 ],
+      [ "cotton_patchwork", 1 ],
+      { "qualities": [ { "id": "SEW", "level": 1 } ] }
+    ]
   }
 ]

--- a/data/json/faults/fault_fixes_armor.json
+++ b/data/json/faults/fault_fixes_armor.json
@@ -300,10 +300,6 @@
     "mod_degradation": -25,
     "time": "20 m",
     "skills": { "tailor": 1 },
-    "requirements": [
-      [ "filament", 3 ],
-      [ "fabric_standard_small", 1 ],
-      { "qualities": [ { "id": "SEW", "level": 1 } ] }
-    ]
+    "requirements": [ [ "filament", 3 ], [ "fabric_standard_small", 1 ], { "qualities": [ { "id": "SEW", "level": 1 } ] } ]
   }
 ]

--- a/data/json/faults/fault_fixes_armor.json
+++ b/data/json/faults/fault_fixes_armor.json
@@ -289,7 +289,7 @@
     "time": "10 m",
     "skills": { "tailor": 1 },
     "requirements": [
-      [ "thread", 5 ],
+      [ "filament", 1 ],
       { "qualities": [ { "id": "SEW", "level": 1 } ] }
     ]
   },
@@ -304,8 +304,8 @@
     "time": "20 m",
     "skills": { "tailor": 1 },
     "requirements": [
-      [ "thread", 15 ],
-      [ "cotton_patchwork", 1 ],
+      [ "filament", 3 ],
+      [ "fabric_standard_small", 1 ],
       { "qualities": [ { "id": "SEW", "level": 1 } ] }
     ]
   }

--- a/data/json/faults/fault_groups_armor.json
+++ b/data/json/faults/fault_groups_armor.json
@@ -23,5 +23,10 @@
     "type": "fault_group",
     "id": "plate_qt",
     "group": [ { "fault": "fault_armor_qt_dented", "weight": 100 }, { "fault": "fault_armor_qt_punctured", "weight": 5 } ]
+  },
+  {
+    "type": "fault_group",
+    "id": "fabric_cotton",
+    "group": [ { "fault": "fault_cotton_torn", "weight": 100 }, { "fault": "fault_cotton_hole", "weight": 75 } ]
   }
 ]

--- a/data/json/faults/faults_armor.json
+++ b/data/json/faults/faults_armor.json
@@ -124,6 +124,7 @@
     "description": "There's a tear in the fabric.",
     "item_prefix": "torn",
     "message": "%s's fabric was torn!",
+    "fault_type": "mechanical_damage",
     "degradation_mod": 25,
     "price_modifier": 0.7,
     "armor_mod": [
@@ -138,6 +139,7 @@
     "name": { "str": "Hole" },
     "description": "There's a big hole in the fabric.",
     "message": "A hole is ripped into the %s!",
+    "fault_type": "mechanical_damage",
     "affected_by_degradation": true,
     "degradation_mod": 5,
     "price_modifier": 0.7,

--- a/data/json/faults/faults_armor.json
+++ b/data/json/faults/faults_armor.json
@@ -116,5 +116,35 @@
       { "damage_id": "cut", "multiply": 0.9 },
       { "damage_id": "stab", "multiply": 0.9 }
     ]
+  },
+  {
+    "type": "fault",
+    "id": "fault_cotton_torn",
+    "name": { "str": "Torn cotton" },
+    "description": "There's a tear in the fabric.",
+    "item_prefix": "torn",
+    "message": "%s's fabric was torn!",
+    "degradation_mod": 25,
+    "price_modifier": 0.7,
+    "armor_mod": [
+      { "damage_id": "bash", "multiply": 0.9 },
+      { "damage_id": "cut", "multiply": 0.9 },
+      { "damage_id": "stab", "multiply": 0.9 }
+    ]
+  },
+  {
+    "type": "fault",
+    "id": "fault_cotton_hole",
+    "name": { "str": "Hole" },
+    "description": "There's a big hole in the fabric.",
+    "message": "A hole is ripped into the %s!",
+    "affected_by_degradation": true,
+    "degradation_mod": 5,
+    "price_modifier": 0.7,
+    "armor_mod": [
+      { "damage_id": "bash", "multiply": 0.85 },
+      { "damage_id": "cut", "multiply": 0.85 },
+      { "damage_id": "stab", "multiply": 0.85 }
+    ]
   }
 ]

--- a/data/json/items/armor/torso_clothes.json
+++ b/data/json/items/armor/torso_clothes.json
@@ -11,6 +11,7 @@
     "price": "10 USD",
     "material": [ "cotton" ],
     "color": "white",
+    "faults": [ { "fault_group": "fabric_cotton" } ],
     "armor": [
       { "covers": [ "torso" ], "specifically_covers": [ "torso_waist" ], "coverage": 100, "encumbrance": [ 1, 1 ] },
       {


### PR DESCRIPTION

#### Summary
Features "Added two new faults that can be implemented on armor/clothes made from cotton"

#### Purpose of change
Many armor and clothing types still don't have any faults attached to them. I wanted to add a few of them, specifically for cotton clothing/armor. This addition is related to issues #80881 and #64528 .


#### Describe the solution
I added two new faults, fault_cotton_torn and fault_cotton_hole, which can be applied to armors and clothes. Fault_cotton_torn is supposed to be a simple tear in the fabric, which can be mended with just thread. Fault_cotton_hole is supposed to represent a piece of fabric being ripped off of the clothing article, so it requires a bit more thread and also some kind of patchwork to repair. I also added a fault group for these two faults. For testing purposes, I attached this fault group to the long waist apron.

#### Describe alternatives you've considered
Leave the situation as it was, or add different/other types of faults.

#### Testing
I spawned in a long waist apron in debug mode and equipped it. I then gave it the two faults I added in debug mode to see if they worked as intended. 


#### Additional context

<img width="186" height="112" alt="Screenshot 2026-04-16 172028" src="https://github.com/user-attachments/assets/331ad25a-a26b-4adf-b3da-69bdb92efc2a" />


<img width="578" height="465" alt="Screenshot 2026-04-16 172043" src="https://github.com/user-attachments/assets/7d64e0c7-f103-464c-929b-1d2c24fab749" />







