### PR TITLE
Remove extra semicolon in newcharacter.cpp

### DIFF
--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -137,7 +137,7 @@ static bool cities_enabled()
 static void draw_spacer()
 {
     ImGui::NewLine();
-};
+}
 
 static void set_detail_scroll()
 {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

`draw_spacer()` has an extra semicolon after the closing brace, which upsets `-Wpedantic` and currently breaks the GCC 9 Curses LTO CI job.

#### Describe the solution

Removed it.

#### Describe alternatives you've considered

N/A

#### Testing

N/A

#### Additional context

None.