### PR TITLE
Fix multi-zone O-tasks auto-resuming after cancelling non-resumable sub

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -5341,6 +5341,12 @@ void Character::cancel_activity()
         // cancel_activity) to push to backlog, so this is safe.
         activity.auto_resume = false;
         backlog.push_front( activity );
+    } else if( !backlog.empty() && backlog.front().auto_resume ) {
+        // Activity can't resume (can_resume=false) so no guard entry
+        // was pushed.  Clear auto_resume on the front backlog item to
+        // prevent resume_backlog_activity() from immediately restoring
+        // a parent multi-zone activity.
+        backlog.front().auto_resume = false;
     }
     sfx::end_activity_sounds(); // kill activity sounds when canceled
     activity = player_activity();

--- a/tests/clzones_test.cpp
+++ b/tests/clzones_test.cpp
@@ -2340,6 +2340,37 @@ TEST_CASE( "cancel_activity_clears_auto_resume_for_multi_type",
              !dummy.backlog.front().auto_resume ) );
 }
 
+// When a multi-zone activity spawns a sub with can_resume=false, cancelling
+// the sub doesn't push a guard entry.  cancel_activity() must still block
+// the parent multi-zone from auto-resuming.
+TEST_CASE( "cancel_non_resumable_sub_blocks_parent_auto_resume",
+           "[zones][activities][cancel]" )
+{
+    avatar &dummy = get_avatar();
+    clear_avatar();
+    clear_map_without_vision();
+
+    // Parent multi-zone in backlog with auto_resume=true, as if it had
+    // pushed itself when assigning a sub-activity.
+    dummy.assign_activity( multi_chop_planks_activity_actor() );
+    REQUIRE( dummy.activity.is_multi_type() );
+    REQUIRE( dummy.activity.auto_resume );
+    player_activity parent = dummy.activity;
+    dummy.backlog.push_front( parent );
+
+    // Sub-activity with can_resume=false (ACT_CHOP_PLANKS).
+    dummy.activity = player_activity(
+                         chop_planks_activity_actor( 100 ) );
+    REQUIRE( !dummy.activity.can_resume() );
+    REQUIRE( dummy.backlog.front().auto_resume );
+
+    // cancel + resume -- mirrors cancel_activity_query().
+    dummy.cancel_activity();
+    dummy.resume_backlog_activity();
+
+    CHECK( !dummy.activity );
+}
+
 // #85853: selecting Vehicle Repair from zone activities freezes the game
 // when the VEHICLE_REPAIR zone is large and repair items are unavailable.
 // simulate_turn must bound per-frame work and prune checked sources.


### PR DESCRIPTION
#### Summary
Bugfixes "Fix zone O-tasks restarting after player cancels a non-resumable sub-activity"

#### Purpose of change

Closes #86527

Some zone tasks may loop endlessly when the player tries to cancel with '.'. The parent multi-zone activity sits in the backlog with `auto_resume=true`, and when the sub-activity has `can_resume=false` (like ACT_CHOP_PLANKS), nothing blocks the parent from being immediately restored.

#### Describe the solution

When `cancel_activity()` can't push a guard entry (because `can_resume=false`), clear `auto_resume` on the front backlog item so it won't get picked up by `resume_backlog_activity()`.

#### Describe alternatives you've considered

Could nuke `resume_backlog_activity()` from `cancel_activity_query()` altogether, but that breaks stamina-wait resume flows.

#### Testing

Existing `[cancel]` suite passes. Added a regression test for this specific scenario.

#### Additional context

Follow-up to #85844 which fixed the `can_resume=true` case.