### PR TITLE
Update EOD hot stick prices

### DIFF
--- a/data/json/items/tool/firefighting.json
+++ b/data/json/items/tool/firefighting.json
@@ -210,7 +210,10 @@
     "color": "yellow",
     "copy-from": "pike_pole",
     "name": { "str": "EOD hot stick" },
-    "description": "A durable tool consisting of a sturdy fiberglass shaft tipped with a set of 3 hooks, one large opposed by two small.  Hot sticks are used to maintain some standoff distance when manual manipulation of explosives is necessary, and robot assistance is unavailable."
+    "description": "A durable tool consisting of a sturdy fiberglass shaft tipped with a set of 3 hooks, one large opposed by two small.  Hot sticks are used to maintain some standoff distance when manual manipulation of explosives is necessary, and robot assistance is unavailable.",
+    "price": "500 USD",
+    "//": "postapoc pricing was determined based off the pricing guide, which states that rare items with no utility are ~10-50 USD, and rare items with some theoreticaly utility are ~100-500 USD, and while the EOD is very rare, it's utility in game is non-existent beyond being an okay melee weapon.",
+    "price_postapoc": "25 USD"
   },
   {
     "id": "ny_hook",


### PR DESCRIPTION
Prices were not set for post apoc, fixed.
Also adjusted price as 100 USD is too low for real models.

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Balance "Adjust EOD hot stick price and postapoc prices"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The EOD hot stick I noticed had a high post-apoc value. I dug into the JSON and found it was just copy_from'ing the pike_pole. The pike pole coincidentally has no post-apoc price set, and so neither did the eod hot stick. 100 USD is high compared to other spears, but it is within the value set by the pricing guide. I erred on the side of consistency among other similar weapons, although that may be a flawed approach. As for the pre-apoc price, I did some research and found values around 500-750usd for the type of hot stick described in the item description.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
I set the price to 500 usd reflecting this source https://detonationtechnology.com/product/ghs-4-hot-stick-kit/. It's not exactly the same but I was not finding great matches. There are plenty of more advanced tools that have electronics, use cameras, motors etc that are around 5000 USD but those seem to be more than this item.
I also set the post-apoc value to 25. I came to this number in two ways. First, is that other similar reach weapons are around 10-50 usd. The utility of the eod hot stick is middling-fair, but the pricing guide suggests that rare items like this should be 10-50 for no utility and 100-500 for some utility. I wasn't sure which to really align with.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I considered making the price closer to 5k usd, but unless the description and properties change, it didn't seem right.
I also considered changing to stats of the tool as they're literally 1-1 from the pike pole, but that was beyond the scope of this change.
I considered the pricing guide's suggestions of 10-50 usd for rare no utlity, and 100-500 for some utility. While by the letter this item fits the rare some utility category, I feel like that's still too much for this specific item given it's basically a long 3 pronged stick. I'll happily change it back to 100 if others disagree with my approach.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I loaded my testing directory with my changes, spawned a hot stick, looked at it's stats, no issues.
<img width="367" height="64" alt="image" src="https://github.com/user-attachments/assets/4aed647c-82bf-4d4b-bcb8-64a019e278c8" />

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
The pike pole likely should be adjusted as well, unless it's considered to be purely post-apoc.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
