### PR TITLE
(XE) Minor typo/grammar fixes

### DIFF
--- a/data/mods/Xedra_Evolved/items/ammo_type.json
+++ b/data/mods/Xedra_Evolved/items/ammo_type.json
@@ -2,7 +2,7 @@
   {
     "type": "ammunition_type",
     "id": "aetheric_charge",
-    "name": "aetheric_charge",
+    "name": "aetheric charge",
     "default": "aetheric_charge"
   },
   {

--- a/data/mods/Xedra_Evolved/items/inventor/armor.json
+++ b/data/mods/Xedra_Evolved/items/inventor/armor.json
@@ -320,7 +320,7 @@
       {
         "target": "aura_force_on",
         "need_charges": 1,
-        "msg": "The torus start to emit an invisible waves.",
+        "msg": "The torus starts to emit invisible waves.",
         "need_charges_msg": "The batteries are dead.",
         "type": "transform"
       }

--- a/data/mods/Xedra_Evolved/items/inventor/gun.json
+++ b/data/mods/Xedra_Evolved/items/inventor/gun.json
@@ -724,7 +724,7 @@
     "type": "ITEM",
     "subtypes": [ "GUN" ],
     "name": { "str": "sonic gun" },
-    "description": "A small, square tube with a pistol grip that can emit a sonic waves, creating cavitation and tissue damage inside living creatures.  It's pretty weak as a weapon, but using extremely high frequency sounds makes it silent for most creatures you can met.  It would be fun to listen some music using it, but alas.",
+    "description": "A small, square tube with a pistol grip that can emit a sonic waves, creating cavitation and tissue damage inside living creatures.  It's pretty weak as a weapon, but using extremely high frequency sounds makes it silent for most creatures you can meet.  It would be fun to listen some music using it, but alas.",
     "weight": "890 g",
     "volume": "658 ml",
     "longest_side": "998 mm",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
none

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Several XE items or descriptions had minor issues, like aetheric_charge being unlocalized, or a minor grammar issue.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Various typos, grammar fixes, and localizing one XE ammo type.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
None.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded my binaries from 4/14, no related errors (only one about a 4x4 car not working right which I did not touch.)
I spawned a death ray, a sonic gun, and a force shield.
<img width="344" height="28" alt="image" src="https://github.com/user-attachments/assets/48d80ef1-c8db-4a4d-aee6-50a5b7c576f3" />
<img width="337" height="39" alt="image" src="https://github.com/user-attachments/assets/1d54f01d-3356-4ec2-8aeb-1e6f3bb5a4f6" />
<img width="634" height="92" alt="image" src="https://github.com/user-attachments/assets/b8b09be2-c846-468f-a54e-52d42981afc8" />
All changes look to be working properly.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
