### PR TITLE
Remove safemode menu setting and restore safe mode persistence

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -590,18 +590,6 @@
   },
   {
     "type": "keybinding",
-    "id": "SWITCH_SAFEMODE_OPTION",
-    "category": "SAFEMODE",
-    "name": "Enable safemode option",
-    "bindings": [
-      { "input_method": "keyboard_any", "key": "s" },
-      { "input_method": "keyboard_char", "key": "S" },
-      { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] },
-      { "input_method": "gamepad", "key": "R_RADIAL_N" }
-    ]
-  },
-  {
-    "type": "keybinding",
     "id": "QUIT",
     "category": "SAFEMODE",
     "name": "Quit",

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -395,23 +395,12 @@ bool avatar_action::move( avatar &you, map &m, const tripoint_rel_ms &d )
                                           _( "You're too pacified to strike anything…" ) ) ) {
                 return false;
             }
-            bool safe_mode = ( get_option<bool>( "SAFEMODE" ) ? SAFE_MODE_ON : SAFE_MODE_OFF );
-            if( safe_mode ) {
-                // If safe mode is enabled, only allow attacking neutral creatures when it is inactive
-                if( critter.attitude_to( you ) == Creature::Attitude::NEUTRAL &&
-                    g->safe_mode != SAFE_MODE_OFF ) {
-                    const std::string msg_safe_mode = press_x( ACTION_TOGGLE_SAFEMODE );
-                    add_msg( m_warning,
-                             _( "Not attacking the %1$s -- safe mode is on!  (%2$s to turn it off)" ), critter.name(),
-                             msg_safe_mode );
-                    return false;
-                }
-            } else {
-                // If safe mode is disabled, ask for confirmation before attacking a neutral creature
-                if( critter.attitude_to( you ) == Creature::Attitude::NEUTRAL &&
-                    !query_yn( _( "You may be attacked!  Proceed?" ) ) ) {
-                    return false;
-                }
+            if( g->safe_mode == SAFE_MODE_ON && critter.attitude_to( you ) == Creature::Attitude::NEUTRAL ) {
+                const std::string msg_safe_mode = press_x( ACTION_TOGGLE_SAFEMODE );
+                add_msg( m_warning,
+                         _( "Not attacking the %1$s -- safe mode is on!  (%2$s to turn it off)" ), critter.name(),
+                         msg_safe_mode );
+                return false;
             }
             you.melee_attack( critter, true );
             if( critter.is_hallucination() ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -766,7 +766,7 @@ bool game::start_game()
     new_game = true;
     start_calendar();
     weather.nextweather = calendar::turn;
-    safe_mode = ( get_option<bool>( "SAFEMODE" ) ? SAFE_MODE_ON : SAFE_MODE_OFF );
+    safe_mode = SAFE_MODE_ON;
     mostseen = 0; // ...and mostseen is 0, we haven't seen any monsters yet.
     get_safemode().load_global();
 

--- a/src/game_io.cpp
+++ b/src/game_io.cpp
@@ -412,7 +412,6 @@ bool game::load( const save_t &name )
                         gamemode = std::make_unique<special_game>();
                     }
 
-                    safe_mode = get_option<bool>( "SAFEMODE" ) ? SAFE_MODE_ON : SAFE_MODE_OFF;
                     mostseen = 0; // ...and mostseen is 0, we haven't seen any monsters yet.
 
                     init_autosave();

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1605,11 +1605,6 @@ void options_manager::add_options_general()
     add_option_group( "general", Group( "safe_mode_opts", to_translation( "Safe mode options" ),
                                         to_translation( "Options regarding safe mode." ) ),
     [&]( const std::string & page_id ) {
-        add( "SAFEMODE", page_id, to_translation( "Safe mode" ),
-             to_translation( "If true, will hold the game and display a warning if a hostile monster/NPC is approaching." ),
-             true
-           );
-
         add( "SAFEMODEPROXIMITY", page_id, to_translation( "Safe mode proximity distance" ),
              to_translation( "If safe mode is enabled, distance to hostiles at which safe mode should show a warning.  0 = Max player view distance.  This option only has effect when no safe mode rule is specified.  Otherwise, edit the default rule in Safe mode manager instead of this value." ),
              0, MAX_VIEW_DISTANCE, 0
@@ -3980,7 +3975,7 @@ void options_manager::deserialize( const JsonArray &ja )
         joOptions.allow_omitted_members();
 
         // yay hardcoded list! remove after 0.J
-        std::vector<std::string> removed_options = { "DISTANCE_INITIAL_VISIBILITY", "FOV_3D_Z_RANGE",
+        std::vector<std::string> removed_options = { "DISTANCE_INITIAL_VISIBILITY", "FOV_3D_Z_RANGE", "SAFEMODE",
                                                      "INITIAL_STAT_POINTS", "INITIAL_TRAIT_POINTS", "INITIAL_SKILL_POINTS", "MAX_TRAIT_POINTS",
                                                      "SKILL_TRAINING_SPEED", "PROFICIENCY_TRAINING_SPEED", "CITY_SPACING", "CITY_SIZE"
                                                    };

--- a/src/safemode_ui.cpp
+++ b/src/safemode_ui.cpp
@@ -5,6 +5,7 @@
 #include <fstream>
 #include <functional>
 #include <map>
+#include <memory>
 #include <string>
 #include <utility>
 
@@ -17,6 +18,7 @@
 #include "debug.h"
 #include "filesystem.h"
 #include "flexbuffer_json.h"
+#include "game.h"
 #include "input_context.h"
 #include "json.h"
 #include "json_loader.h"
@@ -114,7 +116,6 @@ void safemode::show( const std::string &custom_name_in, bool is_safemode_in )
     ctxt.register_action( "HELP_KEYBINDINGS" );
 
     if( is_safemode_in ) {
-        ctxt.register_action( "SWITCH_SAFEMODE_OPTION" );
         ctxt.register_action( "SWAP_RULE_GLOBAL_CHAR" );
     }
 
@@ -182,10 +183,8 @@ void safemode::show( const std::string &custom_name_in, bool is_safemode_in )
         mvwprintz( w_header, point( locx, 2 ), c_white, safe_mode_enabled_text );
         locx += utf8_width( safe_mode_enabled_text );
         locx += shortcut_print( w_header, point( locx + 1, 2 ),
-                                ( get_option<bool>( "SAFEMODE" ) ? c_light_green : c_light_red ), c_white,
-                                ( get_option<bool>( "SAFEMODE" ) ? _( "True" ) : _( "False" ) ) );
-        locx += shortcut_print( w_header, point( locx + 1, 2 ), c_white, c_light_green, "  " );
-        locx += shortcut_print( w_header, point( locx, 2 ), c_white, c_light_green, _( "<S>witch" ) );
+                                ( g->safe_mode == SAFE_MODE_ON ? c_light_green : c_light_red ), c_white,
+                                ( g->safe_mode == SAFE_MODE_ON ? _( "True" ) : _( "False" ) ) );
 
         wattron( w_header, c_light_gray );
         for( auto &pos : column_pos ) {
@@ -471,9 +470,6 @@ void safemode::show( const std::string &custom_name_in, bool is_safemode_in )
             }
         } else if( action == "TEST_RULE" && !current_tab.empty() ) {
             test_pattern( tab, line );
-        } else if( action == "SWITCH_SAFEMODE_OPTION" ) {
-            get_options().get_option( "SAFEMODE" ).setNext();
-            get_options().save();
         }
     }
 
@@ -609,12 +605,6 @@ void safemode::add_rule( const std::string &rule_in, const Creature::Attitude at
     character_rules.emplace_back( rule_in, true, ( state_in == rule_state::WHITELISTED ),
                                   attitude_in, proximity_in, Categories::HOSTILE_SPOTTED, MovementModes::BOTH );
     create_rules();
-
-    if( !get_option<bool>( "SAFEMODE" ) &&
-        query_yn( _( "Safe mode is not enabled in the options.  Enable it now?" ) ) ) {
-        get_options().get_option( "SAFEMODE" ).setNext();
-        get_options().save();
-    }
 }
 
 bool safemode::has_rule( std::string_view rule_in, const Creature::Attitude attitude_in )

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -282,9 +282,6 @@ void game::unserialize_impl( const JsonObject &data )
     load_map( project_combine( com, lev ), /*pump_events=*/true );
 
     safe_mode = static_cast<safe_mode_type>( tmprun );
-    if( get_option<bool>( "SAFEMODE" ) && safe_mode == SAFE_MODE_OFF ) {
-        safe_mode = SAFE_MODE_ON;
-    }
 
     std::string linebuff;
     std::string linebuf;


### PR DESCRIPTION

#### Summary
Infrastructure "Remove safemode menu setting and restore safe mode persistence"

#### Purpose of change
Remove the confusing menu setting for enabling/disabling safemode, it did not actually control safe mode in game. Its primary purpose was force enabling safe mode on world load and the default safe mode status on a new world. Safe mode was properly serialized/deserialized but the menu setting was overriding that, now the game properly remembers your safe mode setting.

#### Describe the solution
Remove the menu setting and all references to it.

Save games with the setting will just silently drop it. They already serialized safe mode (in the `run_mode` property of the save) and will use that as expected.

The safe mode manager menu toggled the menu setting and now just displays the status of actual ingame safe mode. It does not toggle it since that would require a duplication of the code in the action handling code or more refactoring. This also removes the keybind from that menu for switching the now nonexistent option. Since this keybind did not toggle actual safe mode, no ingame functionality is lost with it's removal.

New games will start with safe mode enabled by default.

The menu setting caused a code fork when the player tries to move into a neutral enemy based on the status of the menu setting vs the actual safe mode value. Now it just stops the move and warns the player they're trying to attack a neutral when safe mode is enabled.

#### Describe alternatives you've considered
Not removing the menu setting and just removing the lines that forcibly changed safe mode on load. This would leave the menu setting in a position to just control the default mode a new game would start with and the strange code branch in `avatar_action::move`. I figured that it wasn't important to have a default safe mode setting for new worlds so I went with removing the settings bloat.

#### Testing
Safe mode works still in game and the setting properly persists across save/loads cycles.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
