### PR TITLE
Tweak the sewing tool requirements and clean up the animal hoodie recipes

### DIFF
--- a/data/json/recipes/armor/torso.json
+++ b/data/json/recipes/armor/torso.json
@@ -1005,20 +1005,15 @@
         "name": "Sew the pieces",
         "time": "2 h",
         "activity_level": "LIGHT_EXERCISE",
-        "qualities": [ { "id": "SEW", "level": 1 } ],
-        "tools": [ [ [ "sewing_tool", 120, "LIST" ] ] ]
+        "using": [ [ "sewing_tool", 120 ] ]
       }
     ]
   },
   {
     "type": "recipe",
+    "copy-from": "hoodie",
     "result": "hoodie",
     "variant": "shark",
-    "category": "CC_*",
-    "subcategory": "CSC_*_NESTED",
-    "skill_used": "tailor",
-    "difficulty": 3,
-    "autolearn": true,
     "components": [ [ [ "sheet_cotton", 40 ], [ "sheet_cotton_patchwork", 40 ] ], [ [ "filament", 200, "LIST" ] ], [ [ "faux_fur", 6 ] ] ],
     "steps": [
       {
@@ -1032,8 +1027,7 @@
         "name": "Sew the pieces",
         "time": "2 h",
         "activity_level": "LIGHT_EXERCISE",
-        "qualities": [ { "id": "SEW", "level": 1 } ],
-        "tools": [ [ [ "sewing_tool", 120, "LIST" ] ] ],
+        "using": [ [ "sewing_tool", 120 ] ],
         "proficiencies": [ { "proficiency": "prof_furriery", "time_multiplier": 1.2 } ]
       }
     ],
@@ -1041,235 +1035,51 @@
   },
   {
     "type": "recipe",
-    "result": "hoodie",
+    "copy-from": "hoodie_shark",
     "variant": "bear",
-    "category": "CC_*",
-    "subcategory": "CSC_*_NESTED",
-    "skill_used": "tailor",
-    "difficulty": 3,
-    "autolearn": true,
-    "components": [ [ [ "sheet_cotton", 40 ], [ "sheet_cotton_patchwork", 40 ] ], [ [ "filament", 200, "LIST" ] ], [ [ "faux_fur", 6 ] ] ],
-    "steps": [
-      {
-        "name": "Cut the fabric",
-        "time": "1 h",
-        "activity_level": "LIGHT_EXERCISE",
-        "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ],
-        "proficiencies": [ { "proficiency": "prof_furriery", "time_multiplier": 1 } ]
-      },
-      {
-        "name": "Sew the pieces",
-        "time": "2 h",
-        "activity_level": "LIGHT_EXERCISE",
-        "qualities": [ { "id": "SEW", "level": 1 } ],
-        "tools": [ [ [ "sewing_tool", 120, "LIST" ] ] ],
-        "proficiencies": [ { "proficiency": "prof_furriery", "time_multiplier": 1.2 } ]
-      }
-    ],
-    "byproducts": [ [ "scrap_faux_fur", 12 ] ]
+    "components": [ [ [ "sheet_cotton", 40 ], [ "sheet_cotton_patchwork", 40 ] ], [ [ "filament", 200, "LIST" ] ], [ [ "faux_fur", 6 ] ] ]
   },
   {
     "type": "recipe",
-    "result": "hoodie",
+    "copy-from": "hoodie_shark",
     "variant": "cat",
-    "category": "CC_*",
-    "subcategory": "CSC_*_NESTED",
-    "skill_used": "tailor",
-    "difficulty": 3,
-    "autolearn": true,
-    "components": [ [ [ "sheet_cotton", 40 ], [ "sheet_cotton_patchwork", 40 ] ], [ [ "filament", 200, "LIST" ] ], [ [ "faux_fur", 6 ] ] ],
-    "steps": [
-      {
-        "name": "Cut the fabric",
-        "time": "1 h",
-        "activity_level": "LIGHT_EXERCISE",
-        "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ],
-        "proficiencies": [ { "proficiency": "prof_furriery", "time_multiplier": 1 } ]
-      },
-      {
-        "name": "Sew the pieces",
-        "time": "2 h",
-        "activity_level": "LIGHT_EXERCISE",
-        "qualities": [ { "id": "SEW", "level": 1 } ],
-        "tools": [ [ [ "sewing_tool", 120, "LIST" ] ] ],
-        "proficiencies": [ { "proficiency": "prof_furriery", "time_multiplier": 1.2 } ]
-      }
-    ],
-    "byproducts": [ [ "scrap_faux_fur", 12 ] ]
+    "components": [ [ [ "sheet_cotton", 40 ], [ "sheet_cotton_patchwork", 40 ] ], [ [ "filament", 200, "LIST" ] ], [ [ "faux_fur", 6 ] ] ]
   },
   {
     "type": "recipe",
-    "result": "hoodie",
+    "copy-from": "hoodie_shark",
     "variant": "bunny",
-    "category": "CC_*",
-    "subcategory": "CSC_*_NESTED",
-    "skill_used": "tailor",
-    "difficulty": 3,
-    "autolearn": true,
-    "components": [ [ [ "sheet_cotton", 40 ], [ "sheet_cotton_patchwork", 40 ] ], [ [ "filament", 200, "LIST" ] ], [ [ "faux_fur", 6 ] ] ],
-    "steps": [
-      {
-        "name": "Cut the fabric",
-        "time": "1 h",
-        "activity_level": "LIGHT_EXERCISE",
-        "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ],
-        "proficiencies": [ { "proficiency": "prof_furriery", "time_multiplier": 1 } ]
-      },
-      {
-        "name": "Sew the pieces",
-        "time": "2 h",
-        "activity_level": "LIGHT_EXERCISE",
-        "qualities": [ { "id": "SEW", "level": 1 } ],
-        "tools": [ [ [ "sewing_tool", 120, "LIST" ] ] ],
-        "proficiencies": [ { "proficiency": "prof_furriery", "time_multiplier": 1.2 } ]
-      }
-    ],
-    "byproducts": [ [ "scrap_faux_fur", 12 ] ]
+    "components": [ [ [ "sheet_cotton", 40 ], [ "sheet_cotton_patchwork", 40 ] ], [ [ "filament", 200, "LIST" ] ], [ [ "faux_fur", 6 ] ] ]
   },
   {
     "type": "recipe",
-    "result": "hoodie",
+    "copy-from": "hoodie_shark",
     "variant": "wolf",
-    "category": "CC_*",
-    "subcategory": "CSC_*_NESTED",
-    "skill_used": "tailor",
-    "difficulty": 3,
-    "autolearn": true,
-    "components": [ [ [ "sheet_cotton", 40 ], [ "sheet_cotton_patchwork", 40 ] ], [ [ "filament", 200, "LIST" ] ], [ [ "faux_fur", 6 ] ] ],
-    "steps": [
-      {
-        "name": "Cut the fabric",
-        "time": "1 h",
-        "activity_level": "LIGHT_EXERCISE",
-        "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ],
-        "proficiencies": [ { "proficiency": "prof_furriery", "time_multiplier": 1 } ]
-      },
-      {
-        "name": "Sew the pieces",
-        "time": "2 h",
-        "activity_level": "LIGHT_EXERCISE",
-        "qualities": [ { "id": "SEW", "level": 1 } ],
-        "tools": [ [ [ "sewing_tool", 120, "LIST" ] ] ],
-        "proficiencies": [ { "proficiency": "prof_furriery", "time_multiplier": 1.2 } ]
-      }
-    ],
-    "byproducts": [ [ "scrap_faux_fur", 12 ] ]
+    "components": [ [ [ "sheet_cotton", 40 ], [ "sheet_cotton_patchwork", 40 ] ], [ [ "filament", 200, "LIST" ] ], [ [ "faux_fur", 6 ] ] ]
   },
   {
     "type": "recipe",
-    "result": "hoodie",
+    "copy-from": "hoodie_shark",
     "variant": "lizard",
-    "category": "CC_*",
-    "subcategory": "CSC_*_NESTED",
-    "skill_used": "tailor",
-    "difficulty": 3,
-    "autolearn": true,
-    "components": [ [ [ "sheet_cotton", 40 ], [ "sheet_cotton_patchwork", 40 ] ], [ [ "filament", 200, "LIST" ] ], [ [ "faux_fur", 6 ] ] ],
-    "steps": [
-      {
-        "name": "Cut the fabric",
-        "time": "1 h",
-        "activity_level": "LIGHT_EXERCISE",
-        "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ],
-        "proficiencies": [ { "proficiency": "prof_furriery", "time_multiplier": 1 } ]
-      },
-      {
-        "name": "Sew the pieces",
-        "time": "2 h",
-        "activity_level": "LIGHT_EXERCISE",
-        "qualities": [ { "id": "SEW", "level": 1 } ],
-        "tools": [ [ [ "sewing_tool", 120, "LIST" ] ] ],
-        "proficiencies": [ { "proficiency": "prof_furriery", "time_multiplier": 1.2 } ]
-      }
-    ],
-    "byproducts": [ [ "scrap_faux_fur", 12 ] ]
+    "components": [ [ [ "sheet_cotton", 40 ], [ "sheet_cotton_patchwork", 40 ] ], [ [ "filament", 200, "LIST" ] ], [ [ "faux_fur", 6 ] ] ]
   },
   {
     "type": "recipe",
-    "result": "hoodie",
+    "copy-from": "hoodie_shark",
     "variant": "dog",
-    "category": "CC_*",
-    "subcategory": "CSC_*_NESTED",
-    "skill_used": "tailor",
-    "difficulty": 3,
-    "autolearn": true,
-    "components": [ [ [ "sheet_cotton", 40 ], [ "sheet_cotton_patchwork", 40 ] ], [ [ "filament", 200, "LIST" ] ], [ [ "faux_fur", 6 ] ] ],
-    "steps": [
-      {
-        "name": "Cut the fabric",
-        "time": "1 h",
-        "activity_level": "LIGHT_EXERCISE",
-        "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ],
-        "proficiencies": [ { "proficiency": "prof_furriery", "time_multiplier": 1 } ]
-      },
-      {
-        "name": "Sew the pieces",
-        "time": "2 h",
-        "activity_level": "LIGHT_EXERCISE",
-        "qualities": [ { "id": "SEW", "level": 1 } ],
-        "tools": [ [ [ "sewing_tool", 120, "LIST" ] ] ],
-        "proficiencies": [ { "proficiency": "prof_furriery", "time_multiplier": 1.2 } ]
-      }
-    ],
-    "byproducts": [ [ "scrap_faux_fur", 12 ] ]
+    "components": [ [ [ "sheet_cotton", 40 ], [ "sheet_cotton_patchwork", 40 ] ], [ [ "filament", 200, "LIST" ] ], [ [ "faux_fur", 6 ] ] ]
   },
   {
     "type": "recipe",
-    "result": "hoodie",
+    "copy-from": "hoodie_shark",
     "variant": "panda",
-    "category": "CC_*",
-    "subcategory": "CSC_*_NESTED",
-    "skill_used": "tailor",
-    "difficulty": 3,
-    "autolearn": true,
-    "components": [ [ [ "sheet_cotton", 40 ], [ "sheet_cotton_patchwork", 40 ] ], [ [ "filament", 200, "LIST" ] ], [ [ "faux_fur", 6 ] ] ],
-    "steps": [
-      {
-        "name": "Cut the fabric",
-        "time": "1 h",
-        "activity_level": "LIGHT_EXERCISE",
-        "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ],
-        "proficiencies": [ { "proficiency": "prof_furriery", "time_multiplier": 1 } ]
-      },
-      {
-        "name": "Sew the pieces",
-        "time": "2 h",
-        "activity_level": "LIGHT_EXERCISE",
-        "qualities": [ { "id": "SEW", "level": 1 } ],
-        "tools": [ [ [ "sewing_tool", 120, "LIST" ] ] ],
-        "proficiencies": [ { "proficiency": "prof_furriery", "time_multiplier": 1.2 } ]
-      }
-    ],
-    "byproducts": [ [ "scrap_faux_fur", 12 ] ]
+    "components": [ [ [ "sheet_cotton", 40 ], [ "sheet_cotton_patchwork", 40 ] ], [ [ "filament", 200, "LIST" ] ], [ [ "faux_fur", 6 ] ] ]
   },
   {
     "type": "recipe",
-    "result": "hoodie",
+    "copy-from": "hoodie_shark",
     "variant": "frog",
-    "category": "CC_*",
-    "subcategory": "CSC_*_NESTED",
-    "skill_used": "tailor",
-    "difficulty": 3,
-    "autolearn": true,
-    "components": [ [ [ "sheet_cotton", 40 ], [ "sheet_cotton_patchwork", 40 ] ], [ [ "filament", 200, "LIST" ] ], [ [ "faux_fur", 6 ] ] ],
-    "steps": [
-      {
-        "name": "Cut the fabric",
-        "time": "1 h",
-        "activity_level": "LIGHT_EXERCISE",
-        "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ],
-        "proficiencies": [ { "proficiency": "prof_furriery", "time_multiplier": 1 } ]
-      },
-      {
-        "name": "Sew the pieces",
-        "time": "2 h",
-        "activity_level": "LIGHT_EXERCISE",
-        "qualities": [ { "id": "SEW", "level": 1 } ],
-        "tools": [ [ [ "sewing_tool", 120, "LIST" ] ] ],
-        "proficiencies": [ { "proficiency": "prof_furriery", "time_multiplier": 1.2 } ]
-      }
-    ],
-    "byproducts": [ [ "scrap_faux_fur", 12 ] ]
+    "components": [ [ [ "sheet_cotton", 40 ], [ "sheet_cotton_patchwork", 40 ] ], [ [ "filament", 200, "LIST" ] ], [ [ "faux_fur", 6 ] ] ]
   },
   {
     "type": "recipe",
@@ -1291,8 +1101,7 @@
         "name": "Sew the pieces",
         "time": "1 h 45 m",
         "activity_level": "LIGHT_EXERCISE",
-        "qualities": [ { "id": "SEW", "level": 1 } ],
-        "tools": [ [ [ "sewing_tool", 105, "LIST" ] ] ]
+        "using": [ [ "sewing_tool", 105 ] ]
       }
     ]
   },
@@ -1312,13 +1121,9 @@
   },
   {
     "type": "recipe",
+    "copy-from": "hoodie_cropped",
     "result": "hoodie_cropped",
     "variant": "shark",
-    "category": "CC_*",
-    "subcategory": "CSC_*_NESTED",
-    "skill_used": "tailor",
-    "difficulty": 3,
-    "autolearn": true,
     "components": [ [ [ "sheet_cotton", 30 ], [ "sheet_cotton_patchwork", 30 ] ], [ [ "filament", 150, "LIST" ] ], [ [ "faux_fur", 4 ] ] ],
     "steps": [
       {
@@ -1332,8 +1137,7 @@
         "name": "Sew the pieces",
         "time": "1 h 45 m",
         "activity_level": "LIGHT_EXERCISE",
-        "qualities": [ { "id": "SEW", "level": 1 } ],
-        "tools": [ [ [ "sewing_tool", 105, "LIST" ] ] ],
+        "using": [ [ "sewing_tool", 105 ] ],
         "proficiencies": [ { "proficiency": "prof_furriery", "time_multiplier": 1.2 } ]
       }
     ],
@@ -1341,235 +1145,51 @@
   },
   {
     "type": "recipe",
-    "result": "hoodie_cropped",
+    "copy-from": "hoodie_cropped_shark",
     "variant": "bear",
-    "category": "CC_*",
-    "subcategory": "CSC_*_NESTED",
-    "skill_used": "tailor",
-    "difficulty": 3,
-    "autolearn": true,
-    "components": [ [ [ "sheet_cotton", 30 ], [ "sheet_cotton_patchwork", 30 ] ], [ [ "filament", 150, "LIST" ] ], [ [ "faux_fur", 4 ] ] ],
-    "steps": [
-      {
-        "name": "Cut the fabric",
-        "time": "1 h",
-        "activity_level": "LIGHT_EXERCISE",
-        "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ],
-        "proficiencies": [ { "proficiency": "prof_furriery", "time_multiplier": 1 } ]
-      },
-      {
-        "name": "Sew the pieces",
-        "time": "1 h 45 m",
-        "activity_level": "LIGHT_EXERCISE",
-        "qualities": [ { "id": "SEW", "level": 1 } ],
-        "tools": [ [ [ "sewing_tool", 105, "LIST" ] ] ],
-        "proficiencies": [ { "proficiency": "prof_furriery", "time_multiplier": 1.2 } ]
-      }
-    ],
-    "byproducts": [ [ "scrap_faux_fur", 8 ] ]
+    "components": [ [ [ "sheet_cotton", 30 ], [ "sheet_cotton_patchwork", 30 ] ], [ [ "filament", 150, "LIST" ] ], [ [ "faux_fur", 4 ] ] ]
   },
   {
     "type": "recipe",
-    "result": "hoodie_cropped",
+    "copy-from": "hoodie_cropped_shark",
     "variant": "cat",
-    "category": "CC_*",
-    "subcategory": "CSC_*_NESTED",
-    "skill_used": "tailor",
-    "difficulty": 3,
-    "autolearn": true,
-    "components": [ [ [ "sheet_cotton", 30 ], [ "sheet_cotton_patchwork", 30 ] ], [ [ "filament", 150, "LIST" ] ], [ [ "faux_fur", 4 ] ] ],
-    "steps": [
-      {
-        "name": "Cut the fabric",
-        "time": "1 h",
-        "activity_level": "LIGHT_EXERCISE",
-        "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ],
-        "proficiencies": [ { "proficiency": "prof_furriery", "time_multiplier": 1 } ]
-      },
-      {
-        "name": "Sew the pieces",
-        "time": "1 h 45 m",
-        "activity_level": "LIGHT_EXERCISE",
-        "qualities": [ { "id": "SEW", "level": 1 } ],
-        "tools": [ [ [ "sewing_tool", 105, "LIST" ] ] ],
-        "proficiencies": [ { "proficiency": "prof_furriery", "time_multiplier": 1.2 } ]
-      }
-    ],
-    "byproducts": [ [ "scrap_faux_fur", 8 ] ]
+    "components": [ [ [ "sheet_cotton", 30 ], [ "sheet_cotton_patchwork", 30 ] ], [ [ "filament", 150, "LIST" ] ], [ [ "faux_fur", 4 ] ] ]
   },
   {
     "type": "recipe",
-    "result": "hoodie_cropped",
+    "copy-from": "hoodie_cropped_shark",
     "variant": "bunny",
-    "category": "CC_*",
-    "subcategory": "CSC_*_NESTED",
-    "skill_used": "tailor",
-    "difficulty": 3,
-    "autolearn": true,
-    "components": [ [ [ "sheet_cotton", 30 ], [ "sheet_cotton_patchwork", 30 ] ], [ [ "filament", 150, "LIST" ] ], [ [ "faux_fur", 4 ] ] ],
-    "steps": [
-      {
-        "name": "Cut the fabric",
-        "time": "1 h",
-        "activity_level": "LIGHT_EXERCISE",
-        "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ],
-        "proficiencies": [ { "proficiency": "prof_furriery", "time_multiplier": 1 } ]
-      },
-      {
-        "name": "Sew the pieces",
-        "time": "1 h 45 m",
-        "activity_level": "LIGHT_EXERCISE",
-        "qualities": [ { "id": "SEW", "level": 1 } ],
-        "tools": [ [ [ "sewing_tool", 105, "LIST" ] ] ],
-        "proficiencies": [ { "proficiency": "prof_furriery", "time_multiplier": 1.2 } ]
-      }
-    ],
-    "byproducts": [ [ "scrap_faux_fur", 8 ] ]
+    "components": [ [ [ "sheet_cotton", 30 ], [ "sheet_cotton_patchwork", 30 ] ], [ [ "filament", 150, "LIST" ] ], [ [ "faux_fur", 4 ] ] ]
   },
   {
     "type": "recipe",
-    "result": "hoodie_cropped",
+    "copy-from": "hoodie_cropped_shark",
     "variant": "wolf",
-    "category": "CC_*",
-    "subcategory": "CSC_*_NESTED",
-    "skill_used": "tailor",
-    "difficulty": 3,
-    "autolearn": true,
-    "components": [ [ [ "sheet_cotton", 30 ], [ "sheet_cotton_patchwork", 30 ] ], [ [ "filament", 150, "LIST" ] ], [ [ "faux_fur", 4 ] ] ],
-    "steps": [
-      {
-        "name": "Cut the fabric",
-        "time": "1 h",
-        "activity_level": "LIGHT_EXERCISE",
-        "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ],
-        "proficiencies": [ { "proficiency": "prof_furriery", "time_multiplier": 1 } ]
-      },
-      {
-        "name": "Sew the pieces",
-        "time": "1 h 45 m",
-        "activity_level": "LIGHT_EXERCISE",
-        "qualities": [ { "id": "SEW", "level": 1 } ],
-        "tools": [ [ [ "sewing_tool", 105, "LIST" ] ] ],
-        "proficiencies": [ { "proficiency": "prof_furriery", "time_multiplier": 1.2 } ]
-      }
-    ],
-    "byproducts": [ [ "scrap_faux_fur", 8 ] ]
+    "components": [ [ [ "sheet_cotton", 30 ], [ "sheet_cotton_patchwork", 30 ] ], [ [ "filament", 150, "LIST" ] ], [ [ "faux_fur", 4 ] ] ]
   },
   {
     "type": "recipe",
-    "result": "hoodie_cropped",
+    "copy-from": "hoodie_cropped_shark",
     "variant": "lizard",
-    "category": "CC_*",
-    "subcategory": "CSC_*_NESTED",
-    "skill_used": "tailor",
-    "difficulty": 3,
-    "autolearn": true,
-    "components": [ [ [ "sheet_cotton", 30 ], [ "sheet_cotton_patchwork", 30 ] ], [ [ "filament", 150, "LIST" ] ], [ [ "faux_fur", 4 ] ] ],
-    "steps": [
-      {
-        "name": "Cut the fabric",
-        "time": "1 h",
-        "activity_level": "LIGHT_EXERCISE",
-        "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ],
-        "proficiencies": [ { "proficiency": "prof_furriery", "time_multiplier": 1 } ]
-      },
-      {
-        "name": "Sew the pieces",
-        "time": "1 h 45 m",
-        "activity_level": "LIGHT_EXERCISE",
-        "qualities": [ { "id": "SEW", "level": 1 } ],
-        "tools": [ [ [ "sewing_tool", 105, "LIST" ] ] ],
-        "proficiencies": [ { "proficiency": "prof_furriery", "time_multiplier": 1.2 } ]
-      }
-    ],
-    "byproducts": [ [ "scrap_faux_fur", 8 ] ]
+    "components": [ [ [ "sheet_cotton", 30 ], [ "sheet_cotton_patchwork", 30 ] ], [ [ "filament", 150, "LIST" ] ], [ [ "faux_fur", 4 ] ] ]
   },
   {
     "type": "recipe",
-    "result": "hoodie_cropped",
+    "copy-from": "hoodie_cropped_shark",
     "variant": "dog",
-    "category": "CC_*",
-    "subcategory": "CSC_*_NESTED",
-    "skill_used": "tailor",
-    "difficulty": 3,
-    "autolearn": true,
-    "components": [ [ [ "sheet_cotton", 30 ], [ "sheet_cotton_patchwork", 30 ] ], [ [ "filament", 150, "LIST" ] ], [ [ "faux_fur", 4 ] ] ],
-    "steps": [
-      {
-        "name": "Cut the fabric",
-        "time": "1 h",
-        "activity_level": "LIGHT_EXERCISE",
-        "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ],
-        "proficiencies": [ { "proficiency": "prof_furriery", "time_multiplier": 1 } ]
-      },
-      {
-        "name": "Sew the pieces",
-        "time": "1 h 45 m",
-        "activity_level": "LIGHT_EXERCISE",
-        "qualities": [ { "id": "SEW", "level": 1 } ],
-        "tools": [ [ [ "sewing_tool", 105, "LIST" ] ] ],
-        "proficiencies": [ { "proficiency": "prof_furriery", "time_multiplier": 1.2 } ]
-      }
-    ],
-    "byproducts": [ [ "scrap_faux_fur", 8 ] ]
+    "components": [ [ [ "sheet_cotton", 30 ], [ "sheet_cotton_patchwork", 30 ] ], [ [ "filament", 150, "LIST" ] ], [ [ "faux_fur", 4 ] ] ]
   },
   {
     "type": "recipe",
-    "result": "hoodie_cropped",
+    "copy-from": "hoodie_cropped_shark",
     "variant": "panda",
-    "category": "CC_*",
-    "subcategory": "CSC_*_NESTED",
-    "skill_used": "tailor",
-    "difficulty": 3,
-    "autolearn": true,
-    "components": [ [ [ "sheet_cotton", 30 ], [ "sheet_cotton_patchwork", 30 ] ], [ [ "filament", 150, "LIST" ] ], [ [ "faux_fur", 4 ] ] ],
-    "steps": [
-      {
-        "name": "Cut the fabric",
-        "time": "1 h",
-        "activity_level": "LIGHT_EXERCISE",
-        "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ],
-        "proficiencies": [ { "proficiency": "prof_furriery", "time_multiplier": 1 } ]
-      },
-      {
-        "name": "Sew the pieces",
-        "time": "1 h 45 m",
-        "activity_level": "LIGHT_EXERCISE",
-        "qualities": [ { "id": "SEW", "level": 1 } ],
-        "tools": [ [ [ "sewing_tool", 105, "LIST" ] ] ],
-        "proficiencies": [ { "proficiency": "prof_furriery", "time_multiplier": 1.2 } ]
-      }
-    ],
-    "byproducts": [ [ "scrap_faux_fur", 8 ] ]
+    "components": [ [ [ "sheet_cotton", 30 ], [ "sheet_cotton_patchwork", 30 ] ], [ [ "filament", 150, "LIST" ] ], [ [ "faux_fur", 4 ] ] ]
   },
   {
     "type": "recipe",
-    "result": "hoodie_cropped",
+    "copy-from": "hoodie_cropped_shark",
     "variant": "frog",
-    "category": "CC_*",
-    "subcategory": "CSC_*_NESTED",
-    "skill_used": "tailor",
-    "difficulty": 3,
-    "autolearn": true,
-    "components": [ [ [ "sheet_cotton", 30 ], [ "sheet_cotton_patchwork", 30 ] ], [ [ "filament", 150, "LIST" ] ], [ [ "faux_fur", 4 ] ] ],
-    "steps": [
-      {
-        "name": "Cut the fabric",
-        "time": "1 h",
-        "activity_level": "LIGHT_EXERCISE",
-        "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ],
-        "proficiencies": [ { "proficiency": "prof_furriery", "time_multiplier": 1 } ]
-      },
-      {
-        "name": "Sew the pieces",
-        "time": "1 h 45 m",
-        "activity_level": "LIGHT_EXERCISE",
-        "qualities": [ { "id": "SEW", "level": 1 } ],
-        "tools": [ [ [ "sewing_tool", 105, "LIST" ] ] ],
-        "proficiencies": [ { "proficiency": "prof_furriery", "time_multiplier": 1.2 } ]
-      }
-    ],
-    "byproducts": [ [ "scrap_faux_fur", 8 ] ]
+    "components": [ [ [ "sheet_cotton", 30 ], [ "sheet_cotton_patchwork", 30 ] ], [ [ "filament", 150, "LIST" ] ], [ [ "faux_fur", 4 ] ] ]
   },
   {
     "result": "sweatshirt",

--- a/data/json/recipes/armor/torso.json
+++ b/data/json/recipes/armor/torso.json
@@ -993,19 +993,18 @@
     "skill_used": "tailor",
     "difficulty": 3,
     "autolearn": true,
+    "components": [ [ [ "sheet_cotton", 40 ], [ "sheet_cotton_patchwork", 40 ] ], [ [ "filament", 200, "LIST" ] ] ],
     "steps": [
       {
         "name": "Cut the fabric",
         "time": "1 h",
         "activity_level": "LIGHT_EXERCISE",
-        "components": [ [ [ "sheet_cotton", 40 ], [ "sheet_cotton_patchwork", 40 ] ] ],
         "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ]
       },
       {
         "name": "Sew the pieces",
         "time": "2 h",
         "activity_level": "LIGHT_EXERCISE",
-        "components": [ [ [ "filament", 200, "LIST" ] ] ],
         "using": [ [ "sewing_tool", 120 ] ]
       }
     ]
@@ -1015,13 +1014,13 @@
     "copy-from": "hoodie",
     "result": "hoodie",
     "variant": "shark",
+    "components": [ [ [ "sheet_cotton", 40 ], [ "sheet_cotton_patchwork", 40 ] ], [ [ "filament", 200, "LIST" ] ], [ [ "faux_fur", 6 ] ] ],
     "steps": [
       {
         "name": "Cut the fabric",
         "time": "1 h",
         "activity_level": "LIGHT_EXERCISE",
         "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ],
-        "components": [ [ [ "sheet_cotton", 40 ], [ "sheet_cotton_patchwork", 40 ] ], [ [ "faux_fur", 6 ] ] ],
         "proficiencies": [ { "proficiency": "prof_furriery", "time_multiplier": 1 } ]
       },
       {
@@ -1029,7 +1028,6 @@
         "time": "2 h",
         "activity_level": "LIGHT_EXERCISE",
         "using": [ [ "sewing_tool", 120 ] ],
-        "components": [ [ [ "filament", 200, "LIST" ] ] ],
         "proficiencies": [ { "proficiency": "prof_furriery", "time_multiplier": 1.2 } ]
       }
     ],
@@ -1038,42 +1036,50 @@
   {
     "type": "recipe",
     "copy-from": "hoodie_shark",
-    "variant": "bear"
+    "variant": "bear",
+    "components": [ [ [ "sheet_cotton", 40 ], [ "sheet_cotton_patchwork", 40 ] ], [ [ "filament", 200, "LIST" ] ], [ [ "faux_fur", 6 ] ] ]
   },
   {
     "type": "recipe",
     "copy-from": "hoodie_shark",
-    "variant": "cat"
+    "variant": "cat",
+    "components": [ [ [ "sheet_cotton", 40 ], [ "sheet_cotton_patchwork", 40 ] ], [ [ "filament", 200, "LIST" ] ], [ [ "faux_fur", 6 ] ] ]
   },
   {
     "type": "recipe",
     "copy-from": "hoodie_shark",
-    "variant": "bunny"
+    "variant": "bunny",
+    "components": [ [ [ "sheet_cotton", 40 ], [ "sheet_cotton_patchwork", 40 ] ], [ [ "filament", 200, "LIST" ] ], [ [ "faux_fur", 6 ] ] ]
   },
   {
     "type": "recipe",
     "copy-from": "hoodie_shark",
-    "variant": "wolf"
+    "variant": "wolf",
+    "components": [ [ [ "sheet_cotton", 40 ], [ "sheet_cotton_patchwork", 40 ] ], [ [ "filament", 200, "LIST" ] ], [ [ "faux_fur", 6 ] ] ]
   },
   {
     "type": "recipe",
     "copy-from": "hoodie_shark",
-    "variant": "lizard"
+    "variant": "lizard",
+    "components": [ [ [ "sheet_cotton", 40 ], [ "sheet_cotton_patchwork", 40 ] ], [ [ "filament", 200, "LIST" ] ], [ [ "faux_fur", 6 ] ] ]
   },
   {
     "type": "recipe",
     "copy-from": "hoodie_shark",
-    "variant": "dog"
+    "variant": "dog",
+    "components": [ [ [ "sheet_cotton", 40 ], [ "sheet_cotton_patchwork", 40 ] ], [ [ "filament", 200, "LIST" ] ], [ [ "faux_fur", 6 ] ] ]
   },
   {
     "type": "recipe",
     "copy-from": "hoodie_shark",
-    "variant": "panda"
+    "variant": "panda",
+    "components": [ [ [ "sheet_cotton", 40 ], [ "sheet_cotton_patchwork", 40 ] ], [ [ "filament", 200, "LIST" ] ], [ [ "faux_fur", 6 ] ] ]
   },
   {
     "type": "recipe",
     "copy-from": "hoodie_shark",
-    "variant": "frog"
+    "variant": "frog",
+    "components": [ [ [ "sheet_cotton", 40 ], [ "sheet_cotton_patchwork", 40 ] ], [ [ "filament", 200, "LIST" ] ], [ [ "faux_fur", 6 ] ] ]
   },
   {
     "type": "recipe",
@@ -1083,19 +1089,18 @@
     "skill_used": "tailor",
     "difficulty": 3,
     "autolearn": true,
+    "components": [ [ [ "sheet_cotton", 30 ], [ "sheet_cotton_patchwork", 30 ] ], [ [ "filament", 150, "LIST" ] ] ],
     "steps": [
       {
         "name": "Cut the fabric",
         "time": "1 h",
         "activity_level": "LIGHT_EXERCISE",
-        "components": [ [ [ "sheet_cotton", 30 ], [ "sheet_cotton_patchwork", 30 ] ] ],
         "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ]
       },
       {
         "name": "Sew the pieces",
         "time": "1 h 45 m",
         "activity_level": "LIGHT_EXERCISE",
-        "components": [ [ [ "filament", 150, "LIST" ] ] ],
         "using": [ [ "sewing_tool", 105 ] ]
       }
     ]
@@ -1119,13 +1124,13 @@
     "copy-from": "hoodie_cropped",
     "result": "hoodie_cropped",
     "variant": "shark",
+    "components": [ [ [ "sheet_cotton", 30 ], [ "sheet_cotton_patchwork", 30 ] ], [ [ "filament", 150, "LIST" ] ], [ [ "faux_fur", 4 ] ] ],
     "steps": [
       {
         "name": "Cut the fabric",
         "time": "1 h",
         "activity_level": "LIGHT_EXERCISE",
         "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ],
-        "components": [ [ [ "sheet_cotton", 30 ], [ "sheet_cotton_patchwork", 30 ] ], [ [ "faux_fur", 4 ] ] ],
         "proficiencies": [ { "proficiency": "prof_furriery", "time_multiplier": 1 } ]
       },
       {
@@ -1133,7 +1138,6 @@
         "time": "1 h 45 m",
         "activity_level": "LIGHT_EXERCISE",
         "using": [ [ "sewing_tool", 105 ] ],
-        "components": [ [ [ "filament", 150, "LIST" ] ] ],
         "proficiencies": [ { "proficiency": "prof_furriery", "time_multiplier": 1.2 } ]
       }
     ],
@@ -1142,42 +1146,50 @@
   {
     "type": "recipe",
     "copy-from": "hoodie_cropped_shark",
-    "variant": "bear"
+    "variant": "bear",
+    "components": [ [ [ "sheet_cotton", 30 ], [ "sheet_cotton_patchwork", 30 ] ], [ [ "filament", 150, "LIST" ] ], [ [ "faux_fur", 4 ] ] ]
   },
   {
     "type": "recipe",
     "copy-from": "hoodie_cropped_shark",
-    "variant": "cat"
+    "variant": "cat",
+    "components": [ [ [ "sheet_cotton", 30 ], [ "sheet_cotton_patchwork", 30 ] ], [ [ "filament", 150, "LIST" ] ], [ [ "faux_fur", 4 ] ] ]
   },
   {
     "type": "recipe",
     "copy-from": "hoodie_cropped_shark",
-    "variant": "bunny"
+    "variant": "bunny",
+    "components": [ [ [ "sheet_cotton", 30 ], [ "sheet_cotton_patchwork", 30 ] ], [ [ "filament", 150, "LIST" ] ], [ [ "faux_fur", 4 ] ] ]
   },
   {
     "type": "recipe",
     "copy-from": "hoodie_cropped_shark",
-    "variant": "wolf"
+    "variant": "wolf",
+    "components": [ [ [ "sheet_cotton", 30 ], [ "sheet_cotton_patchwork", 30 ] ], [ [ "filament", 150, "LIST" ] ], [ [ "faux_fur", 4 ] ] ]
   },
   {
     "type": "recipe",
     "copy-from": "hoodie_cropped_shark",
-    "variant": "lizard"
+    "variant": "lizard",
+    "components": [ [ [ "sheet_cotton", 30 ], [ "sheet_cotton_patchwork", 30 ] ], [ [ "filament", 150, "LIST" ] ], [ [ "faux_fur", 4 ] ] ]
   },
   {
     "type": "recipe",
     "copy-from": "hoodie_cropped_shark",
-    "variant": "dog"
+    "variant": "dog",
+    "components": [ [ [ "sheet_cotton", 30 ], [ "sheet_cotton_patchwork", 30 ] ], [ [ "filament", 150, "LIST" ] ], [ [ "faux_fur", 4 ] ] ]
   },
   {
     "type": "recipe",
     "copy-from": "hoodie_cropped_shark",
-    "variant": "panda"
+    "variant": "panda",
+    "components": [ [ [ "sheet_cotton", 30 ], [ "sheet_cotton_patchwork", 30 ] ], [ [ "filament", 150, "LIST" ] ], [ [ "faux_fur", 4 ] ] ]
   },
   {
     "type": "recipe",
     "copy-from": "hoodie_cropped_shark",
-    "variant": "frog"
+    "variant": "frog",
+    "components": [ [ [ "sheet_cotton", 30 ], [ "sheet_cotton_patchwork", 30 ] ], [ [ "filament", 150, "LIST" ] ], [ [ "faux_fur", 4 ] ] ]
   },
   {
     "result": "sweatshirt",

--- a/data/json/recipes/armor/torso.json
+++ b/data/json/recipes/armor/torso.json
@@ -993,18 +993,19 @@
     "skill_used": "tailor",
     "difficulty": 3,
     "autolearn": true,
-    "components": [ [ [ "sheet_cotton", 40 ], [ "sheet_cotton_patchwork", 40 ] ], [ [ "filament", 200, "LIST" ] ] ],
     "steps": [
       {
         "name": "Cut the fabric",
         "time": "1 h",
         "activity_level": "LIGHT_EXERCISE",
+        "components": [ [ [ "sheet_cotton", 40 ], [ "sheet_cotton_patchwork", 40 ] ] ],
         "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ]
       },
       {
         "name": "Sew the pieces",
         "time": "2 h",
         "activity_level": "LIGHT_EXERCISE",
+        "components": [ [ [ "filament", 200, "LIST" ] ] ],
         "using": [ [ "sewing_tool", 120 ] ]
       }
     ]
@@ -1014,13 +1015,13 @@
     "copy-from": "hoodie",
     "result": "hoodie",
     "variant": "shark",
-    "components": [ [ [ "sheet_cotton", 40 ], [ "sheet_cotton_patchwork", 40 ] ], [ [ "filament", 200, "LIST" ] ], [ [ "faux_fur", 6 ] ] ],
     "steps": [
       {
         "name": "Cut the fabric",
         "time": "1 h",
         "activity_level": "LIGHT_EXERCISE",
         "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ],
+        "components": [ [ [ "sheet_cotton", 40 ], [ "sheet_cotton_patchwork", 40 ] ], [ [ "faux_fur", 6 ] ] ],
         "proficiencies": [ { "proficiency": "prof_furriery", "time_multiplier": 1 } ]
       },
       {
@@ -1028,6 +1029,7 @@
         "time": "2 h",
         "activity_level": "LIGHT_EXERCISE",
         "using": [ [ "sewing_tool", 120 ] ],
+        "components": [ [ [ "filament", 200, "LIST" ] ] ],
         "proficiencies": [ { "proficiency": "prof_furriery", "time_multiplier": 1.2 } ]
       }
     ],
@@ -1036,50 +1038,42 @@
   {
     "type": "recipe",
     "copy-from": "hoodie_shark",
-    "variant": "bear",
-    "components": [ [ [ "sheet_cotton", 40 ], [ "sheet_cotton_patchwork", 40 ] ], [ [ "filament", 200, "LIST" ] ], [ [ "faux_fur", 6 ] ] ]
+    "variant": "bear"
   },
   {
     "type": "recipe",
     "copy-from": "hoodie_shark",
-    "variant": "cat",
-    "components": [ [ [ "sheet_cotton", 40 ], [ "sheet_cotton_patchwork", 40 ] ], [ [ "filament", 200, "LIST" ] ], [ [ "faux_fur", 6 ] ] ]
+    "variant": "cat"
   },
   {
     "type": "recipe",
     "copy-from": "hoodie_shark",
-    "variant": "bunny",
-    "components": [ [ [ "sheet_cotton", 40 ], [ "sheet_cotton_patchwork", 40 ] ], [ [ "filament", 200, "LIST" ] ], [ [ "faux_fur", 6 ] ] ]
+    "variant": "bunny"
   },
   {
     "type": "recipe",
     "copy-from": "hoodie_shark",
-    "variant": "wolf",
-    "components": [ [ [ "sheet_cotton", 40 ], [ "sheet_cotton_patchwork", 40 ] ], [ [ "filament", 200, "LIST" ] ], [ [ "faux_fur", 6 ] ] ]
+    "variant": "wolf"
   },
   {
     "type": "recipe",
     "copy-from": "hoodie_shark",
-    "variant": "lizard",
-    "components": [ [ [ "sheet_cotton", 40 ], [ "sheet_cotton_patchwork", 40 ] ], [ [ "filament", 200, "LIST" ] ], [ [ "faux_fur", 6 ] ] ]
+    "variant": "lizard"
   },
   {
     "type": "recipe",
     "copy-from": "hoodie_shark",
-    "variant": "dog",
-    "components": [ [ [ "sheet_cotton", 40 ], [ "sheet_cotton_patchwork", 40 ] ], [ [ "filament", 200, "LIST" ] ], [ [ "faux_fur", 6 ] ] ]
+    "variant": "dog"
   },
   {
     "type": "recipe",
     "copy-from": "hoodie_shark",
-    "variant": "panda",
-    "components": [ [ [ "sheet_cotton", 40 ], [ "sheet_cotton_patchwork", 40 ] ], [ [ "filament", 200, "LIST" ] ], [ [ "faux_fur", 6 ] ] ]
+    "variant": "panda"
   },
   {
     "type": "recipe",
     "copy-from": "hoodie_shark",
-    "variant": "frog",
-    "components": [ [ [ "sheet_cotton", 40 ], [ "sheet_cotton_patchwork", 40 ] ], [ [ "filament", 200, "LIST" ] ], [ [ "faux_fur", 6 ] ] ]
+    "variant": "frog"
   },
   {
     "type": "recipe",
@@ -1089,18 +1083,19 @@
     "skill_used": "tailor",
     "difficulty": 3,
     "autolearn": true,
-    "components": [ [ [ "sheet_cotton", 30 ], [ "sheet_cotton_patchwork", 30 ] ], [ [ "filament", 150, "LIST" ] ] ],
     "steps": [
       {
         "name": "Cut the fabric",
         "time": "1 h",
         "activity_level": "LIGHT_EXERCISE",
+        "components": [ [ [ "sheet_cotton", 30 ], [ "sheet_cotton_patchwork", 30 ] ] ],
         "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ]
       },
       {
         "name": "Sew the pieces",
         "time": "1 h 45 m",
         "activity_level": "LIGHT_EXERCISE",
+        "components": [ [ [ "filament", 150, "LIST" ] ] ],
         "using": [ [ "sewing_tool", 105 ] ]
       }
     ]
@@ -1124,13 +1119,13 @@
     "copy-from": "hoodie_cropped",
     "result": "hoodie_cropped",
     "variant": "shark",
-    "components": [ [ [ "sheet_cotton", 30 ], [ "sheet_cotton_patchwork", 30 ] ], [ [ "filament", 150, "LIST" ] ], [ [ "faux_fur", 4 ] ] ],
     "steps": [
       {
         "name": "Cut the fabric",
         "time": "1 h",
         "activity_level": "LIGHT_EXERCISE",
         "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ],
+        "components": [ [ [ "sheet_cotton", 30 ], [ "sheet_cotton_patchwork", 30 ] ], [ [ "faux_fur", 4 ] ] ],
         "proficiencies": [ { "proficiency": "prof_furriery", "time_multiplier": 1 } ]
       },
       {
@@ -1138,6 +1133,7 @@
         "time": "1 h 45 m",
         "activity_level": "LIGHT_EXERCISE",
         "using": [ [ "sewing_tool", 105 ] ],
+        "components": [ [ [ "filament", 150, "LIST" ] ] ],
         "proficiencies": [ { "proficiency": "prof_furriery", "time_multiplier": 1.2 } ]
       }
     ],
@@ -1146,50 +1142,42 @@
   {
     "type": "recipe",
     "copy-from": "hoodie_cropped_shark",
-    "variant": "bear",
-    "components": [ [ [ "sheet_cotton", 30 ], [ "sheet_cotton_patchwork", 30 ] ], [ [ "filament", 150, "LIST" ] ], [ [ "faux_fur", 4 ] ] ]
+    "variant": "bear"
   },
   {
     "type": "recipe",
     "copy-from": "hoodie_cropped_shark",
-    "variant": "cat",
-    "components": [ [ [ "sheet_cotton", 30 ], [ "sheet_cotton_patchwork", 30 ] ], [ [ "filament", 150, "LIST" ] ], [ [ "faux_fur", 4 ] ] ]
+    "variant": "cat"
   },
   {
     "type": "recipe",
     "copy-from": "hoodie_cropped_shark",
-    "variant": "bunny",
-    "components": [ [ [ "sheet_cotton", 30 ], [ "sheet_cotton_patchwork", 30 ] ], [ [ "filament", 150, "LIST" ] ], [ [ "faux_fur", 4 ] ] ]
+    "variant": "bunny"
   },
   {
     "type": "recipe",
     "copy-from": "hoodie_cropped_shark",
-    "variant": "wolf",
-    "components": [ [ [ "sheet_cotton", 30 ], [ "sheet_cotton_patchwork", 30 ] ], [ [ "filament", 150, "LIST" ] ], [ [ "faux_fur", 4 ] ] ]
+    "variant": "wolf"
   },
   {
     "type": "recipe",
     "copy-from": "hoodie_cropped_shark",
-    "variant": "lizard",
-    "components": [ [ [ "sheet_cotton", 30 ], [ "sheet_cotton_patchwork", 30 ] ], [ [ "filament", 150, "LIST" ] ], [ [ "faux_fur", 4 ] ] ]
+    "variant": "lizard"
   },
   {
     "type": "recipe",
     "copy-from": "hoodie_cropped_shark",
-    "variant": "dog",
-    "components": [ [ [ "sheet_cotton", 30 ], [ "sheet_cotton_patchwork", 30 ] ], [ [ "filament", 150, "LIST" ] ], [ [ "faux_fur", 4 ] ] ]
+    "variant": "dog"
   },
   {
     "type": "recipe",
     "copy-from": "hoodie_cropped_shark",
-    "variant": "panda",
-    "components": [ [ [ "sheet_cotton", 30 ], [ "sheet_cotton_patchwork", 30 ] ], [ [ "filament", 150, "LIST" ] ], [ [ "faux_fur", 4 ] ] ]
+    "variant": "panda"
   },
   {
     "type": "recipe",
     "copy-from": "hoodie_cropped_shark",
-    "variant": "frog",
-    "components": [ [ [ "sheet_cotton", 30 ], [ "sheet_cotton_patchwork", 30 ] ], [ [ "filament", 150, "LIST" ] ], [ [ "faux_fur", 4 ] ] ]
+    "variant": "frog"
   },
   {
     "result": "sweatshirt",

--- a/data/json/requirements/tailoring.json
+++ b/data/json/requirements/tailoring.json
@@ -572,6 +572,7 @@
     "type": "requirement",
     "//": "1 unit of 'sewing_tool' is 1 minute of sewing.",
     "//1": "Sewing maching is 84W, 1 charge is 1kj so that's 12s of use. I'm assuming the machine is only running 50% of the time so 24s. 60 / 24 = 2.5 rounded down to 2.",
+    "qualities": [ { "id": "SEW", "level": 1 } ],
     "tools": [
       [
         [ "sewing_machine", 2 ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
While converting the hoodie recipes to use crafting steps I had to remove the copy-from and repeat the exact same recipe almost 20 times, massively inflating the line counts and making the code much less readable. Thankfully crafting steps and `using` field support has been added since.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Tweak the requirement type object and clean up the hoodie recipes while am it.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I will freely admit some bias here since I am the one who added the animal hoodie variants. Technically using standalone recipes for variants is bad and stupid and ideally we would have some way to select a variant in the crafting menu instead.

**That being said**, this is not a thing yet and the animal hoodie recipes are different from the base one, requiring fur material and proficiency so I'd say a separate recipe is warranted and since you can't have an array of variants to randomly choose from, for the sake of consistency the player is allowed to have access to any variant instead of just the shark one or whatever.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded, recipes look fine to me.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
