### PR TITLE
Make pre_burn respect terrain and furniture combustibility

### DIFF
--- a/data/mods/TEST_DATA/mapgen-post-process-test.json
+++ b/data/mods/TEST_DATA/mapgen-post-process-test.json
@@ -75,5 +75,20 @@
     "type": "pp_generator",
     "id": "test_pp_custom",
     "sub_generators": [ { "type": "aftershock_ruin" } ]
+  },
+  {
+    "type": "pp_generator",
+    "id": "test_pp_pre_burn_only",
+    "//": "Isolated pre_burn for material immunity tests. 100% chance guarantees it fires.",
+    "sub_generators": [
+      {
+        "type": "pre_burn",
+        "attempts": 1,
+        "min_intensity": 100,
+        "max_intensity": 100,
+        "scaling_days_start": 0,
+        "scaling_days_end": 1
+      }
+    ]
   }
 ]

--- a/src/mapgen_post_process.cpp
+++ b/src/mapgen_post_process.cpp
@@ -496,19 +496,41 @@ static void execute_pre_burn( map &md,
                 md.has_flag_ter( ter_furn_flag::TFLAG_GOES_UP, current_tile ) ) {
                 continue;
             }
+
+            const bool is_flammable_ter =
+                md.has_flag_ter( ter_furn_flag::TFLAG_FLAMMABLE, current_tile ) ||
+                md.has_flag_ter( ter_furn_flag::TFLAG_FLAMMABLE_ASH, current_tile ) ||
+                md.has_flag_ter( ter_furn_flag::TFLAG_FLAMMABLE_HARD, current_tile );
+
             if( md.has_flag_ter( ter_furn_flag::TFLAG_WALL, current_tile ) ) {
-                md.ter_set( current_tile.xy(), ter_t_wall_burnt );
+                if( is_flammable_ter ) {
+                    md.ter_set( current_tile.xy(), ter_t_wall_burnt );
+                }
             } else if( md.has_flag_ter( ter_furn_flag::TFLAG_INDOORS, current_tile ) ||
                        md.has_flag_ter( ter_furn_flag::TFLAG_DOOR, current_tile ) ) {
-                md.ter_set( current_tile.xy(), ter_t_floor_burnt );
+                if( is_flammable_ter ) {
+                    md.ter_set( current_tile.xy(), ter_t_floor_burnt );
+                }
             } else if( !md.has_flag_ter( ter_furn_flag::TFLAG_INDOORS, current_tile ) ) {
                 if( current_tile.z() == 0 ) {
-                    md.ter_set( current_tile.xy(), ter_t_dirt );
+                    if( md.has_flag_ter( ter_furn_flag::TFLAG_DIGGABLE, current_tile ) ||
+                        is_flammable_ter ) {
+                        md.ter_set( current_tile.xy(), ter_t_dirt );
+                    }
                 }
             }
 
-            md.furn_set( current_tile.xy(), furn_str_id::NULL_ID() );
-            md.i_clear( current_tile.xy() );
+            if( md.has_furn( current_tile ) &&
+                ( md.has_flag_furn( ter_furn_flag::TFLAG_FLAMMABLE, current_tile ) ||
+                  md.has_flag_furn( ter_furn_flag::TFLAG_FLAMMABLE_ASH, current_tile ) ||
+                  md.has_flag_furn( ter_furn_flag::TFLAG_FLAMMABLE_HARD, current_tile ) ) ) {
+                md.furn_set( current_tile.xy(), furn_str_id::NULL_ID() );
+            }
+
+            if( !md.has_flag_ter( ter_furn_flag::TFLAG_SWIMMABLE, current_tile ) &&
+                !md.has_flag_ter( ter_furn_flag::TFLAG_LIQUID, current_tile ) ) {
+                md.i_clear( current_tile.xy() );
+            }
         }
     }
 }

--- a/tests/mapgen_post_process_test.cpp
+++ b/tests/mapgen_post_process_test.cpp
@@ -21,6 +21,7 @@
 static const field_type_str_id field_fd_blood( "fd_blood" );
 static const field_type_str_id field_fd_fire( "fd_fire" );
 
+static const furn_str_id furn_f_locker( "f_locker" );
 static const furn_str_id furn_f_planter_seedling( "f_planter_seedling" );
 static const furn_str_id furn_f_table( "f_table" );
 
@@ -33,15 +34,29 @@ static const oter_str_id oter_test_pp_riot_building( "test_pp_riot_building" );
 static const pp_generator_id pp_generator_riot_damage( "riot_damage" );
 static const pp_generator_id pp_generator_riot_damage_road( "riot_damage_road" );
 static const pp_generator_id pp_generator_test_pp_custom( "test_pp_custom" );
+static const pp_generator_id pp_generator_test_pp_pre_burn_only( "test_pp_pre_burn_only" );
 static const pp_generator_id pp_generator_test_pp_riot( "test_pp_riot" );
 static const pp_generator_id pp_generator_test_pp_road( "test_pp_road" );
 
+static const ter_str_id ter_t_concrete_wall( "t_concrete_wall" );
 static const ter_str_id ter_t_dirt( "t_dirt" );
+static const ter_str_id ter_t_door_c( "t_door_c" );
+static const ter_str_id ter_t_door_frame( "t_door_frame" );
+static const ter_str_id ter_t_door_locked( "t_door_locked" );
+static const ter_str_id ter_t_door_metal_c( "t_door_metal_c" );
+static const ter_str_id ter_t_door_metal_o( "t_door_metal_o" );
+static const ter_str_id ter_t_door_o( "t_door_o" );
 static const ter_str_id ter_t_floor( "t_floor" );
 static const ter_str_id ter_t_floor_burnt( "t_floor_burnt" );
+static const ter_str_id ter_t_grass( "t_grass" );
+static const ter_str_id ter_t_pavement( "t_pavement" );
 static const ter_str_id ter_t_rock_wall( "t_rock_wall" );
+static const ter_str_id ter_t_thconc_floor( "t_thconc_floor" );
+static const ter_str_id ter_t_wall( "t_wall" );
 static const ter_str_id ter_t_wall_burnt( "t_wall_burnt" );
+static const ter_str_id ter_t_wall_metal( "t_wall_metal" );
 static const ter_str_id ter_t_wall_wood( "t_wall_wood" );
+static const ter_str_id ter_t_water_dp( "t_water_dp" );
 static const ter_str_id ter_t_wood_stairs_up( "t_wood_stairs_up" );
 
 // Scan a 24x24 OMT area on a map and collect terrain/field statistics.
@@ -392,9 +407,10 @@ TEST_CASE( "post_process_stair_preservation", "[mapgen][post_process][characteri
 
     CHECK( here.ter( tripoint_bub_ms( 12, 12, 0 ) ) == ter_t_wood_stairs_up.id() );
 
-    // Furniture should be destroyed by pre_burn
+    // Flammable furniture destroyed by pre_burn, non-flammable survives.
+    // Layout has 2x f_table (FLAMMABLE) + 1x f_planter_seedling (not flammable).
     pp_scan_result result = scan_omt( here, 0 );
-    CHECK( result.furniture_count == 0 );
+    CHECK( result.furniture_count == 1 );
 
     clear_overmaps();
 }
@@ -468,6 +484,131 @@ TEST_CASE( "post_process_item_move_planter_preservation",
     }
     // Ensure we actually tested the invariant on at least some seeds
     CHECK( planter_survived_count > 0 );
+
+    clear_overmaps();
+}
+
+// Build a layout specifically for pre_burn material immunity testing.
+// Places a grid of different terrain types, doors, and furniture to verify
+// that pre_burn only affects flammable materials.
+static void build_pre_burn_immunity_layout( map &m, int z_level )
+{
+    for( int x = 0; x < SEEX * 2; x++ ) {
+        for( int y = 0; y < SEEY * 2; y++ ) {
+            tripoint_bub_ms p( x, y, z_level );
+            m.furn_set( p, furn_str_id::NULL_ID() );
+            m.i_clear( p );
+            m.clear_fields( p );
+            // Default to wood floor (flammable, should burn)
+            m.ter_set( p, ter_t_floor );
+        }
+    }
+
+    // Row 1 (y=1): walls -- wood vs concrete vs metal
+    m.ter_set( tripoint_bub_ms( 1, 1, z_level ), ter_t_wall );          // flammable
+    m.ter_set( tripoint_bub_ms( 3, 1, z_level ), ter_t_wall_wood );     // flammable
+    m.ter_set( tripoint_bub_ms( 5, 1, z_level ), ter_t_concrete_wall ); // immune
+    m.ter_set( tripoint_bub_ms( 7, 1, z_level ), ter_t_wall_metal );    // immune
+
+    // Row 2 (y=3): closed doors -- wood vs metal
+    m.ter_set( tripoint_bub_ms( 1, 3, z_level ), ter_t_door_c );        // flammable (DOOR flag)
+    m.ter_set( tripoint_bub_ms( 3, 3, z_level ), ter_t_door_metal_c );  // immune (DOOR flag)
+
+    // Row 3 (y=5): open/locked doors -- no DOOR flag, falls to outdoor branch
+    m.ter_set( tripoint_bub_ms( 1, 5, z_level ), ter_t_door_o );        // flammable outdoor
+    m.ter_set( tripoint_bub_ms( 3, 5, z_level ), ter_t_door_metal_o );  // immune outdoor
+    m.ter_set( tripoint_bub_ms( 5, 5, z_level ), ter_t_door_locked );   // flammable outdoor
+    m.ter_set( tripoint_bub_ms( 7, 5, z_level ), ter_t_door_frame );    // flammable outdoor
+
+    // Row 4 (y=7): floors -- wood vs concrete
+    m.ter_set( tripoint_bub_ms( 1, 7, z_level ), ter_t_floor );         // flammable
+    m.ter_set( tripoint_bub_ms( 3, 7, z_level ), ter_t_thconc_floor );  // immune
+
+    // Row 5 (y=9): outdoor ground -- grass vs pavement vs water
+    m.ter_set( tripoint_bub_ms( 1, 9, z_level ), ter_t_grass );         // diggable -> dirt
+    m.ter_set( tripoint_bub_ms( 3, 9, z_level ), ter_t_pavement );      // immune
+    m.ter_set( tripoint_bub_ms( 5, 9, z_level ), ter_t_water_dp );      // immune
+
+    // Furniture on concrete floor: metal locker (immune) + wood table (flammable)
+    m.ter_set( tripoint_bub_ms( 1, 11, z_level ), ter_t_thconc_floor );
+    m.furn_set( tripoint_bub_ms( 1, 11, z_level ), furn_f_locker );     // immune furn
+    m.ter_set( tripoint_bub_ms( 3, 11, z_level ), ter_t_thconc_floor );
+    m.furn_set( tripoint_bub_ms( 3, 11, z_level ),
+                furn_f_table );      // flammable furn on immune terrain
+
+    // Items on immune terrain vs water
+    m.ter_set( tripoint_bub_ms( 1, 13, z_level ), ter_t_thconc_floor );
+    m.add_item( tripoint_bub_ms( 1, 13, z_level ), item( itype_rock ) );
+    m.ter_set( tripoint_bub_ms( 3, 13, z_level ), ter_t_water_dp );
+    m.add_item( tripoint_bub_ms( 3, 13, z_level ), item( itype_rock ) );
+}
+
+TEST_CASE( "post_process_pre_burn_material_immunity", "[mapgen][post_process]" )
+{
+    clear_overmaps();
+    clear_map();
+    clear_avatar();
+    map &here = get_map();
+    const tripoint_abs_omt pos = project_to<coords::omt>( here.get_abs_sub() );
+
+    // Day 14, well past scaling_days_end=1 so pre_burn fires at 100%
+    calendar::turn = calendar::start_of_cataclysm + 14_days;
+
+    build_pre_burn_immunity_layout( here, 0 );
+    rng_set_engine_seed( 42424242 );
+    pp_generator_test_pp_pre_burn_only.obj().execute( here, pos );
+
+    SECTION( "walls: flammable burn, non-flammable survive" ) {
+        // Wood walls -> t_wall_burnt
+        CHECK( here.ter( tripoint_bub_ms( 1, 1, 0 ) ) == ter_t_wall_burnt.id() );
+        CHECK( here.ter( tripoint_bub_ms( 3, 1, 0 ) ) == ter_t_wall_burnt.id() );
+        // Concrete and metal walls unchanged
+        CHECK( here.ter( tripoint_bub_ms( 5, 1, 0 ) ) == ter_t_concrete_wall.id() );
+        CHECK( here.ter( tripoint_bub_ms( 7, 1, 0 ) ) == ter_t_wall_metal.id() );
+    }
+
+    SECTION( "closed doors: flammable burn, non-flammable survive" ) {
+        // Wood door -> t_floor_burnt (has DOOR flag + FLAMMABLE)
+        CHECK( here.ter( tripoint_bub_ms( 1, 3, 0 ) ) == ter_t_floor_burnt.id() );
+        // Metal door unchanged (has DOOR flag, no FLAMMABLE)
+        CHECK( here.ter( tripoint_bub_ms( 3, 3, 0 ) ) == ter_t_door_metal_c.id() );
+    }
+
+    SECTION( "open/locked doors: flammable burn to dirt, non-flammable survive" ) {
+        // Open wood door -> t_dirt (no DOOR flag, flammable outdoor)
+        CHECK( here.ter( tripoint_bub_ms( 1, 5, 0 ) ) == ter_t_dirt.id() );
+        // Open metal door unchanged (no DOOR flag, not flammable)
+        CHECK( here.ter( tripoint_bub_ms( 3, 5, 0 ) ) == ter_t_door_metal_o.id() );
+        // Locked wood door -> t_dirt
+        CHECK( here.ter( tripoint_bub_ms( 5, 5, 0 ) ) == ter_t_dirt.id() );
+        // Wood door frame -> t_dirt
+        CHECK( here.ter( tripoint_bub_ms( 7, 5, 0 ) ) == ter_t_dirt.id() );
+    }
+
+    SECTION( "floors: flammable burn, non-flammable survive" ) {
+        CHECK( here.ter( tripoint_bub_ms( 1, 7, 0 ) ) == ter_t_floor_burnt.id() );
+        CHECK( here.ter( tripoint_bub_ms( 3, 7, 0 ) ) == ter_t_thconc_floor.id() );
+    }
+
+    SECTION( "outdoor: grass to dirt, pavement and water survive" ) {
+        CHECK( here.ter( tripoint_bub_ms( 1, 9, 0 ) ) == ter_t_dirt.id() );
+        CHECK( here.ter( tripoint_bub_ms( 3, 9, 0 ) ) == ter_t_pavement.id() );
+        CHECK( here.ter( tripoint_bub_ms( 5, 9, 0 ) ) == ter_t_water_dp.id() );
+    }
+
+    SECTION( "furniture: flammable destroyed, non-flammable survives" ) {
+        // Metal locker on concrete floor: locker survives
+        CHECK( here.furn( tripoint_bub_ms( 1, 11, 0 ) ) == furn_f_locker.id() );
+        // Wood table on concrete floor: table destroyed (terrain immunity != furniture immunity)
+        CHECK( here.furn( tripoint_bub_ms( 3, 11, 0 ) ) == furn_str_id::NULL_ID().id() );
+    }
+
+    SECTION( "items: cleared on non-water tiles, preserved in water" ) {
+        // Items on concrete floor: cleared (fire chaos destroys contents)
+        CHECK( here.i_at( tripoint_bub_ms( 1, 13, 0 ) ).empty() );
+        // Items in water: preserved
+        CHECK_FALSE( here.i_at( tripoint_bub_ms( 3, 13, 0 ) ).empty() );
+    }
 
     clear_overmaps();
 }


### PR DESCRIPTION
#### Summary
Bugfixes "Pre-burn no longer destroys non-flammable terrain like concrete walls, metal doors, and pavement"

#### Purpose of change

Addresses #80884. pre_burn replaces all terrain blindly -- concrete parking garages get `t_wall_burnt`, ponds get `t_dirt`, metal doors get `t_floor_burnt`. Follows #86543.

#### Describe the solution

`execute_pre_burn` checks FLAMMABLE/FLAMMABLE_ASH/FLAMMABLE_HARD before each replacement. Three independent checks:

Terrain: wood walls burn (inherit FLAMMABLE from `t_abstract_wall_wood`), concrete/metal/glass/stone/brick don't. Same for floors (`t_floor` has FLAMMABLE_HARD, thick concrete and metal don't) and doors (wood has FLAMMABLE_ASH, metal/glass don't).

Outdoor z=0: only converts to `t_dirt` if DIGGABLE (grass, dirt) or flammable (open wood doors, shrubs). Pavement, water, concrete survive. Also fixes open/locked doors (no DOOR flag) wrongly becoming `t_dirt`.

Furniture: only destroyed if it has a flammable flag itself. Metal lockers survive, wood tables on concrete floors still burn.

Items: cleared on all non-water tiles. Water (SWIMMABLE/LIQUID) preserves items.

No new flags, no terrain JSON changes -- existing flag data already had everything needed.

#### Describe alternatives you've considered

Considered adding a `NON_COMBUSTIBLE` flag to non-flammable wall abstracts, but existing FLAMMABLE flags already encode this with zero JSON churn. Considered bash strength as a material proxy, but corrugated metal and wood walls both sit at str_min 30.

#### Testing

New `post_process_pre_burn_material_immunity` test with isolated pre_burn-only pp_generator covering walls, doors (closed/open/locked), floors, outdoor ground, furniture on immune terrain, and items. Updated `post_process_stair_preservation` for non-flammable furniture surviving. Existing `[post_process]` suite passes. Verified in-game.

<img width="817" height="878" alt="2026-04-17_17-12" src="https://github.com/user-attachments/assets/28487c2f-a559-48d4-8ce0-29bd424d0323" />
<img width="811" height="762" alt="2026-04-17_17-09" src="https://github.com/user-attachments/assets/859a45aa-a4ac-43a0-a7a8-10b37582a21a" />
<img width="771" height="900" alt="2026-04-17_17-07" src="https://github.com/user-attachments/assets/6597104a-43e1-47d7-a6a8-3928df29553c" />
<img width="822" height="481" alt="2026-04-17_17-04_1" src="https://github.com/user-attachments/assets/d82a0be7-689d-4201-a259-7796cc6ec229" />
<img width="772" height="609" alt="2026-04-17_17-04" src="https://github.com/user-attachments/assets/99f262cb-49c4-4af7-9864-b6492efae863" />


#### Additional context

N/A