### PR TITLE
Add post_process_generators field to oter_type_t, migrate PP_GENERATE_RIOT_DAMAGE

### DIFF
--- a/data/json/overmap/overmap_terrain/overmap_terrain.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain.json
@@ -43,7 +43,8 @@
     "extras": "build",
     "mondensity": 2,
     "see_cost": "high",
-    "flags": [ "RISK_HIGH", "GENERIC_LOOT", "PP_GENERATE_RIOT_DAMAGE" ]
+    "flags": [ "RISK_HIGH", "GENERIC_LOOT" ],
+    "post_process_generators": [ "riot_damage" ]
   },
   {
     "type": "overmap_terrain",
@@ -56,7 +57,7 @@
     "abstract": "generic_city_building_roof",
     "copy-from": "generic_city_building_no_sidewalk",
     "extend": { "flags": [ "SIDEWALK" ] },
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",
@@ -86,7 +87,7 @@
     "name": "garage roof",
     "sym": "O",
     "color": "white",
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",
@@ -952,7 +953,7 @@
     "sym": "B",
     "color": "brown",
     "extend": { "flags": [ "RISK_LOW", "SOURCE_SAFETY" ] },
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_agricultural.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_agricultural.json
@@ -30,7 +30,7 @@
     "sym": "#",
     "color": "i_brown",
     "vision_levels": "isolated_building",
-    "delete": { "flags": [ "RISK_HIGH", "PP_GENERATE_RIOT_DAMAGE" ] },
+    "delete": { "flags": [ "RISK_HIGH" ], "post_process_generators": [ "riot_damage" ] },
     "extend": { "flags": [ "SOURCE_FOOD", "RISK_LOW", "SOURCE_FARMING" ] }
   },
   {
@@ -50,8 +50,7 @@
     "copy-from": "generic_rural_building",
     "name": "sugar house",
     "spawns": { "group": "GROUP_WASP_FORAGER", "population": [ 1, 4 ], "chance": 20 },
-    "sym": "S",
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "sym": "S"
   },
   {
     "type": "overmap_terrain",
@@ -77,7 +76,7 @@
     "id": [ "pottery_cottage_basement", "farm_stills_3_basement", "ranch_camp_68_basement" ],
     "spawns": { "group": "GROUP_BASEMENT_HOUSE", "population": [ 1, 1 ], "chance": 80 },
     "copy-from": "generic_city_house_basement",
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",
@@ -424,7 +423,7 @@
     "sym": "#",
     "color": "i_green",
     "extend": { "flags": [ "SOURCE_FOOD" ] },
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_commercial.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_commercial.json
@@ -7,7 +7,7 @@
     "looks_like": "s_gas",
     "color": "light_blue",
     "spawns": { "group": "GROUP_ZOMBIE", "population": [ 6, 12 ], "chance": 100 },
-    "extend": { "flags": [ "SOURCE_FUEL", "SOURCE_VEHICLES", "PP_GENERATE_RIOT_DAMAGE" ] },
+    "extend": { "flags": [ "SOURCE_FUEL", "SOURCE_VEHICLES" ], "post_process_generators": [ "riot_damage" ] },
     "land_use_code": "commercial"
   },
   {
@@ -18,7 +18,7 @@
     "looks_like": "s_gas",
     "color": "light_blue",
     "spawns": { "group": "GROUP_ZOMBIE", "population": [ 6, 12 ], "chance": 100 },
-    "extend": { "flags": [ "SOURCE_FUEL", "SOURCE_VEHICLES", "PP_GENERATE_RIOT_DAMAGE" ] }
+    "extend": { "flags": [ "SOURCE_FUEL", "SOURCE_VEHICLES" ], "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",
@@ -28,7 +28,7 @@
     "looks_like": "s_gas",
     "color": "light_blue",
     "extend": { "flags": [ "SOURCE_FUEL", "SOURCE_VEHICLES" ] },
-    "delete": { "flags": [ "RISK_HIGH", "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "flags": [ "RISK_HIGH" ], "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",
@@ -49,7 +49,7 @@
     "copy-from": "generic_city_building",
     "name": "gas station roof",
     "color": "light_blue",
-    "delete": { "flags": [ "RISK_HIGH", "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "flags": [ "RISK_HIGH" ], "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",
@@ -197,7 +197,8 @@
     "color": "light_gray",
     "see_cost": "low",
     "mondensity": 2,
-    "flags": [ "SIDEWALK", "PP_GENERATE_RIOT_DAMAGE" ]
+    "flags": [ "SIDEWALK" ],
+    "post_process_generators": [ "riot_damage" ]
   },
   {
     "type": "overmap_terrain",
@@ -380,7 +381,7 @@
     "name": "gun store",
     "color": "red",
     "extend": { "flags": [ "SOURCE_GUN", "SOURCE_AMMO" ] },
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",
@@ -640,7 +641,8 @@
     "color": "light_gray",
     "see_cost": "high",
     "mondensity": 2,
-    "flags": [ "SIDEWALK", "SOURCE_LUXURY", "PP_GENERATE_RIOT_DAMAGE" ]
+    "flags": [ "SIDEWALK", "SOURCE_LUXURY" ],
+    "post_process_generators": [ "riot_damage" ]
   },
   {
     "type": "overmap_terrain",
@@ -804,7 +806,8 @@
     "color": "blue",
     "extras": "build",
     "see_cost": "full_high",
-    "flags": [ "PP_GENERATE_RIOT_DAMAGE" ]
+    "flags": [  ],
+    "post_process_generators": [ "riot_damage" ]
   },
   {
     "type": "overmap_terrain",
@@ -905,7 +908,7 @@
     "name": "hotel basement",
     "sym": "B",
     "color": "light_blue",
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",
@@ -980,7 +983,8 @@
     "sym": "H",
     "color": "light_green_yellow",
     "see_cost": "full_high",
-    "flags": [ "SIDEWALK", "PP_GENERATE_RIOT_DAMAGE" ]
+    "flags": [ "SIDEWALK" ],
+    "post_process_generators": [ "riot_damage" ]
   },
   {
     "type": "overmap_terrain",
@@ -1279,7 +1283,7 @@
     ],
     "copy-from": "s_shoppingplaza_a6",
     "name": "abandoned shopping plaza roof",
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",
@@ -1928,7 +1932,7 @@
     "id": "s_games_roof",
     "name": "gaming store roof",
     "copy-from": "s_games",
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_industrial.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_industrial.json
@@ -151,7 +151,7 @@
     "color": "i_green",
     "spawns": { "group": "GROUP_WASP_FORAGER", "population": [ 1, 3 ], "chance": 10 },
     "extend": { "flags": [ "SOURCE_CONSTRUCTION", "SOURCE_FABRICATION" ] },
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",
@@ -161,7 +161,7 @@
     "vision_levels": "industrial_building",
     "sym": "L",
     "color": "i_green",
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",
@@ -173,7 +173,7 @@
     "color": "i_green",
     "spawns": { "group": "GROUP_WASP_FORAGER", "population": [ 1, 3 ], "chance": 10 },
     "extend": { "flags": [ "SOURCE_CONSTRUCTION", "SOURCE_FABRICATION" ] },
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",
@@ -320,7 +320,7 @@
     "name": "steel mill",
     "sym": "S",
     "color": "dark_gray",
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",
@@ -344,7 +344,7 @@
     "name": "steel mill depot",
     "sym": "│",
     "color": "dark_gray",
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_mall.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_mall.json
@@ -8,15 +8,8 @@
     "sym": "M",
     "see_cost": "full_high",
     "mondensity": 2,
-    "flags": [
-      "SIDEWALK",
-      "RISK_EXTREME",
-      "SOURCE_FOOD",
-      "SOURCE_DRINK",
-      "SOURCE_MEDICINE",
-      "SOURCE_FABRICATION",
-      "PP_GENERATE_RIOT_DAMAGE"
-    ]
+    "flags": [ "SIDEWALK", "RISK_EXTREME", "SOURCE_FOOD", "SOURCE_DRINK", "SOURCE_MEDICINE", "SOURCE_FABRICATION" ],
+    "post_process_generators": [ "riot_damage" ]
   },
   {
     "type": "overmap_terrain",
@@ -103,14 +96,14 @@
     "copy-from": "generic_mall",
     "name": "mall - loading bay roof",
     "color": "i_light_red",
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",
     "id": "mall_upper_roof_4",
     "copy-from": "generic_mall",
     "name": "mall - loading bay roof",
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",
@@ -123,7 +116,7 @@
     "id": [ "mall_a_4_roof", "mall_a_5_roof" ],
     "copy-from": "generic_mall",
     "name": "mall - utilities roof",
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",
@@ -343,6 +336,6 @@
     "copy-from": "generic_mall",
     "name": "mall - subway station",
     "color": "i_light_red",
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   }
 ]

--- a/data/json/overmap/overmap_terrain/overmap_terrain_military.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_military.json
@@ -8,7 +8,8 @@
     "see_cost": "none",
     "spawns": { "group": "GROUP_ZOMBIE", "population": [ 6, 12 ], "chance": 100 },
     "travel_cost_type": "road",
-    "flags": [ "LINEAR", "PP_GENERATE_RIOT_DAMAGE" ]
+    "flags": [ "LINEAR" ],
+    "post_process_generators": [ "riot_damage" ]
   },
   {
     "type": "overmap_terrain",
@@ -19,7 +20,8 @@
     "color": "blue",
     "see_cost": "medium",
     "spawns": { "group": "GROUP_ZOMBIE", "population": [ 6, 12 ], "chance": 100 },
-    "flags": [ "SOURCE_FOOD", "RISK_EXTREME", "GENERIC_LOOT", "SOURCE_COOKING", "PP_GENERATE_RIOT_DAMAGE" ]
+    "flags": [ "SOURCE_FOOD", "RISK_EXTREME", "GENERIC_LOOT", "SOURCE_COOKING" ],
+    "post_process_generators": [ "riot_damage" ]
   },
   {
     "type": "overmap_terrain",
@@ -30,7 +32,8 @@
     "color": "red",
     "see_cost": "medium",
     "spawns": { "group": "GROUP_MIL_BASE", "population": [ 8, 14 ], "chance": 100 },
-    "flags": [ "RISK_EXTREME", "SOURCE_GUN", "SOURCE_AMMO", "SOURCE_FOOD", "PP_GENERATE_RIOT_DAMAGE" ]
+    "flags": [ "RISK_EXTREME", "SOURCE_GUN", "SOURCE_AMMO", "SOURCE_FOOD" ],
+    "post_process_generators": [ "riot_damage" ]
   },
   {
     "type": "overmap_terrain",
@@ -41,7 +44,8 @@
     "color": "light_blue",
     "see_cost": "medium",
     "spawns": { "group": "GROUP_VANILLA_DORMANT", "population": [ 3, 8 ], "chance": 100 },
-    "flags": [ "RISK_EXTREME", "GENERIC_LOOT", "SOURCE_COOKING", "SOURCE_FOOD", "PP_GENERATE_RIOT_DAMAGE" ]
+    "flags": [ "RISK_EXTREME", "GENERIC_LOOT", "SOURCE_COOKING", "SOURCE_FOOD" ],
+    "post_process_generators": [ "riot_damage" ]
   },
   {
     "type": "overmap_terrain",
@@ -52,7 +56,8 @@
     "color": "light_blue",
     "see_cost": "medium",
     "spawns": { "group": "GROUP_MIL_BASE", "population": [ 6, 16 ], "chance": 100 },
-    "flags": [ "RISK_EXTREME", "PP_GENERATE_RIOT_DAMAGE" ]
+    "flags": [ "RISK_EXTREME" ],
+    "post_process_generators": [ "riot_damage" ]
   },
   {
     "type": "overmap_terrain",
@@ -63,7 +68,8 @@
     "color": "dark_gray",
     "see_cost": "medium",
     "spawns": { "group": "GROUP_VANILLA_DORMANT", "population": [ 6, 16 ], "chance": 100 },
-    "flags": [ "RISK_EXTREME", "PP_GENERATE_RIOT_DAMAGE" ]
+    "flags": [ "RISK_EXTREME" ],
+    "post_process_generators": [ "riot_damage" ]
   },
   {
     "type": "overmap_terrain",
@@ -222,7 +228,8 @@
     "vision_levels": "isolated_building",
     "see_cost": "high",
     "extras": "build",
-    "flags": [ "RISK_EXTREME", "SOURCE_WEAPON", "SOURCE_AMMO", "PP_GENERATE_RIOT_DAMAGE" ]
+    "flags": [ "RISK_EXTREME", "SOURCE_WEAPON", "SOURCE_AMMO" ],
+    "post_process_generators": [ "riot_damage" ]
   },
   {
     "type": "overmap_terrain",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_public_institutional.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_public_institutional.json
@@ -102,14 +102,15 @@
     "color": "i_light_red",
     "see_cost": "full_high",
     "mondensity": 2,
-    "flags": [ "SIDEWALK", "PP_GENERATE_RIOT_DAMAGE" ]
+    "flags": [ "SIDEWALK" ],
+    "post_process_generators": [ "riot_damage" ]
   },
   {
     "type": "overmap_terrain",
     "id": [ "cathedral_b_NW", "cathedral_b_NE", "cathedral_b_SW", "cathedral_b_SE" ],
     "copy-from": "cathedral_1_NW",
     "name": "cathedral basement",
-    "delete": { "flags": [ "SIDEWALK", "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "flags": [ "SIDEWALK" ], "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",
@@ -125,7 +126,7 @@
     ],
     "copy-from": "cathedral_1_NW",
     "name": "cathedral tower",
-    "delete": { "flags": [ "SIDEWALK", "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "flags": [ "SIDEWALK" ], "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",
@@ -320,7 +321,8 @@
     "color": "light_blue",
     "see_cost": "full_high",
     "mondensity": 2,
-    "flags": [ "SIDEWALK", "RISK_EXTREME", "SOURCE_BOOKS", "PP_GENERATE_RIOT_DAMAGE" ]
+    "flags": [ "SIDEWALK", "RISK_EXTREME", "SOURCE_BOOKS" ],
+    "post_process_generators": [ "riot_damage" ]
   },
   {
     "type": "overmap_terrain",
@@ -331,7 +333,8 @@
     "color": "light_blue",
     "see_cost": "full_high",
     "mondensity": 2,
-    "flags": [ "SIDEWALK", "RISK_EXTREME", "SOURCE_BOOKS", "PP_GENERATE_RIOT_DAMAGE" ]
+    "flags": [ "SIDEWALK", "RISK_EXTREME", "SOURCE_BOOKS" ],
+    "post_process_generators": [ "riot_damage" ]
   },
   {
     "type": "overmap_terrain",
@@ -368,7 +371,8 @@
     "color": "light_blue",
     "see_cost": "full_high",
     "mondensity": 2,
-    "flags": [ "SOURCE_BOOKS", "RISK_EXTREME", "PP_GENERATE_RIOT_DAMAGE" ]
+    "flags": [ "SOURCE_BOOKS", "RISK_EXTREME" ],
+    "post_process_generators": [ "riot_damage" ]
   },
   {
     "type": "overmap_terrain",
@@ -570,7 +574,8 @@
     "color": "green",
     "see_cost": "high",
     "mondensity": 2,
-    "flags": [ "SIDEWALK", "PP_GENERATE_RIOT_DAMAGE" ]
+    "flags": [ "SIDEWALK" ],
+    "post_process_generators": [ "riot_damage" ]
   },
   {
     "type": "overmap_terrain",
@@ -589,7 +594,8 @@
     "color": "green",
     "see_cost": "high",
     "mondensity": 2,
-    "flags": [ "PP_GENERATE_RIOT_DAMAGE" ]
+    "flags": [  ],
+    "post_process_generators": [ "riot_damage" ]
   },
   {
     "type": "overmap_terrain",
@@ -599,7 +605,8 @@
     "sym": "^",
     "color": "i_black",
     "see_cost": "full_high",
-    "flags": [ "SIDEWALK", "PP_GENERATE_RIOT_DAMAGE" ]
+    "flags": [ "SIDEWALK" ],
+    "post_process_generators": [ "riot_damage" ]
   },
   {
     "type": "overmap_terrain",
@@ -610,7 +617,8 @@
     "color": "i_black",
     "see_cost": "full_high",
     "mondensity": 2,
-    "flags": [ "PP_GENERATE_RIOT_DAMAGE" ]
+    "flags": [  ],
+    "post_process_generators": [ "riot_damage" ]
   },
   {
     "type": "overmap_terrain",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_recreational.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_recreational.json
@@ -73,7 +73,8 @@
     "vision_levels": "single_water",
     "see_cost": "none",
     "mondensity": 2,
-    "flags": [ "SIDEWALK", "SOURCE_DRINK", "PP_GENERATE_RIOT_DAMAGE" ]
+    "flags": [ "SIDEWALK", "SOURCE_DRINK" ],
+    "post_process_generators": [ "riot_damage" ]
   },
   {
     "type": "overmap_terrain",
@@ -98,7 +99,7 @@
     "name": "state park",
     "sym": "S",
     "color": "i_green",
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",
@@ -187,8 +188,9 @@
     "vision_levels": "blends_till_details",
     "see_cost": "low",
     "mondensity": 2,
-    "flags": [ "SIDEWALK", "SOURCE_FARMING", "PP_GENERATE_RIOT_DAMAGE" ],
-    "extras": "park"
+    "flags": [ "SIDEWALK", "SOURCE_FARMING" ],
+    "extras": "park",
+    "post_process_generators": [ "riot_damage" ]
   },
   {
     "type": "overmap_terrain",
@@ -209,7 +211,8 @@
     "vision_levels": "city_building",
     "see_cost": "high",
     "mondensity": 2,
-    "flags": [ "SIDEWALK", "SOURCE_FARMING", "PP_GENERATE_RIOT_DAMAGE" ]
+    "flags": [ "SIDEWALK", "SOURCE_FARMING" ],
+    "post_process_generators": [ "riot_damage" ]
   },
   {
     "type": "overmap_terrain",
@@ -278,7 +281,7 @@
     "name": "miniature railway",
     "sym": "R",
     "color": "green",
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",
@@ -301,7 +304,7 @@
     "name": "miniature railway park",
     "sym": "P",
     "color": "light_green",
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",
@@ -322,7 +325,7 @@
     "name": "golf course",
     "sym": "G",
     "color": "green",
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",
@@ -332,7 +335,7 @@
     "vision_levels": "large_pavement",
     "sym": "G",
     "color": "light_gray",
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",
@@ -342,7 +345,7 @@
     "name": "golf course service building",
     "sym": "G",
     "color": "light_gray",
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",
@@ -351,7 +354,7 @@
     "name": "golf course bar",
     "sym": "G",
     "color": "light_gray",
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",
@@ -360,7 +363,7 @@
     "name": "golf course service building roof",
     "sym": "G",
     "color": "light_gray",
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",
@@ -408,7 +411,7 @@
     "name": "zoo cave",
     "sym": "Z",
     "color": "light_gray",
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",
@@ -685,7 +688,8 @@
     "color": "dark_gray",
     "see_cost": "none",
     "mondensity": 2,
-    "flags": [ "SIDEWALK", "PP_GENERATE_RIOT_DAMAGE" ]
+    "flags": [ "SIDEWALK" ],
+    "post_process_generators": [ "riot_damage" ]
   },
   {
     "type": "overmap_terrain",
@@ -1120,7 +1124,7 @@
     "name": "marina",
     "color": "cyan",
     "sym": "~",
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",
@@ -1138,7 +1142,7 @@
     "name": "marina",
     "color": "cyan",
     "sym": "m",
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",
@@ -1147,7 +1151,7 @@
     "name": "marina parking",
     "color": "cyan",
     "sym": "m",
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_residential.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_residential.json
@@ -31,7 +31,7 @@
     "copy-from": "generic_city_house_no_sidewalk",
     "name": "house roof",
     "spawns": { "group": "GROUP_ROOF_ANIMAL", "population": [ 0, 3 ], "chance": 2 },
-    "delete": { "flags": [ "GENERIC_LOOT", "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "flags": [ "GENERIC_LOOT" ], "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",
@@ -618,7 +618,8 @@
     "mondensity": 2,
     "extras": "build",
     "spawns": { "group": "GROUP_VANILLA", "population": [ 4, 10 ], "chance": 80 },
-    "flags": [ "SIDEWALK", "GENERIC_LOOT", "PP_GENERATE_RIOT_DAMAGE" ]
+    "flags": [ "SIDEWALK", "GENERIC_LOOT" ],
+    "post_process_generators": [ "riot_damage" ]
   },
   {
     "type": "overmap_terrain",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_robofac_locs.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_robofac_locs.json
@@ -6,7 +6,7 @@
     "sym": "v",
     "color": "light_red",
     "copy-from": "generic_city_building",
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_speedway.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_speedway.json
@@ -43,8 +43,7 @@
     "abstract": "speedway_track_abstract",
     "copy-from": "road_abstract",
     "vision_levels": "blends_till_outlines",
-    "name": "speedway",
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "name": "speedway"
   },
   {
     "type": "overmap_terrain",
@@ -149,7 +148,7 @@
     "name": "bleachers",
     "sym": "^",
     "color": "light_blue",
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",
@@ -218,7 +217,7 @@
     "name": "parking lot",
     "sym": "O",
     "color": "dark_gray",
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",
@@ -228,7 +227,7 @@
     "name": "garage",
     "sym": "O",
     "color": "white",
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_transportation.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_transportation.json
@@ -154,7 +154,8 @@
     "see_cost": "high",
     "extras": "build",
     "mondensity": 2,
-    "flags": [ "KNOWN_DOWN", "SIDEWALK", "PP_GENERATE_RIOT_DAMAGE" ]
+    "flags": [ "KNOWN_DOWN", "SIDEWALK" ],
+    "post_process_generators": [ "riot_damage" ]
   },
   {
     "type": "overmap_terrain",
@@ -177,7 +178,8 @@
     "color": "yellow",
     "see_cost": "full_high",
     "extras": "subway",
-    "flags": [ "KNOWN_UP", "KNOWN_DOWN", "NO_ROTATE", "PP_GENERATE_RIOT_DAMAGE" ]
+    "flags": [ "KNOWN_UP", "KNOWN_DOWN", "NO_ROTATE" ],
+    "post_process_generators": [ "riot_damage" ]
   },
   {
     "type": "overmap_terrain",
@@ -188,7 +190,8 @@
     "color": "yellow",
     "see_cost": "full_high",
     "extras": "subway",
-    "flags": [ "KNOWN_UP", "NO_ROTATE", "PP_GENERATE_RIOT_DAMAGE" ]
+    "flags": [ "KNOWN_UP", "NO_ROTATE" ],
+    "post_process_generators": [ "riot_damage" ]
   },
   {
     "type": "overmap_terrain",
@@ -505,7 +508,7 @@
     "sym": "O",
     "color": "dark_gray",
     "looks_like": "s_lot",
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_waste_junk.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_waste_junk.json
@@ -171,7 +171,7 @@
     "name": "dumpsite",
     "sym": "D",
     "color": "brown",
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",
@@ -198,7 +198,7 @@
     "sym": "R",
     "color": "i_green",
     "extend": { "flags": [ "SOURCE_FABRICATION", "SOURCE_CONSTRUCTION" ] },
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",
@@ -207,7 +207,7 @@
     "name": "recycle center roof",
     "sym": "R",
     "color": "i_green",
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",
@@ -234,7 +234,7 @@
     "sym": "J",
     "color": "i_brown",
     "extend": { "flags": [ "SOURCE_FABRICATION", "SOURCE_CONSTRUCTION", "SOURCE_VEHICLES" ] },
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",
@@ -316,7 +316,7 @@
     "sym": "d",
     "color": "i_brown",
     "extend": { "flags": [ "SOURCE_FABRICATION", "SOURCE_CONSTRUCTION", "SOURCE_VEHICLES" ] },
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",
@@ -345,6 +345,6 @@
     "name": "abandoned textile mill",
     "color": "light_blue",
     "extend": { "flags": [ "SOURCE_CONSTRUCTION" ] },
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   }
 ]

--- a/data/json/post_process_generators.json
+++ b/data/json/post_process_generators.json
@@ -2,7 +2,7 @@
   {
     "type": "pp_generator",
     "id": "riot_damage",
-    "//": "Applied to city buildings with PP_GENERATE_RIOT_DAMAGE flag.",
+    "//": "Applied to city buildings via post_process_generators field on oter_type_t.",
     "sub_generators": [
       { "type": "bash_damage", "attempts": 250, "chance": 10, "min_intensity": 6, "max_intensity": 60 },
       { "type": "move_items", "attempts": 250, "chance": 10, "max_intensity": 3 },

--- a/data/mods/MindOverMatter/overmap/overmap_terrain.json
+++ b/data/mods/MindOverMatter/overmap/overmap_terrain.json
@@ -57,7 +57,7 @@
     "looks_like": "office_cubical",
     "name": "office basement",
     "color": "light_gray",
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",
@@ -67,7 +67,7 @@
     "looks_like": "office_cubical",
     "name": "office subbasement",
     "color": "light_gray",
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",
@@ -307,7 +307,7 @@
       "phavan_office_skyscraper_lab_upper_se"
     ],
     "copy-from": "generic_office_skyscraper",
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",
@@ -319,7 +319,7 @@
     ],
     "looks_like": "generic_hospital",
     "copy-from": "generic_hospital",
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",

--- a/data/mods/TEST_DATA/mapgen-post-process-test.json
+++ b/data/mods/TEST_DATA/mapgen-post-process-test.json
@@ -10,7 +10,7 @@
   },
   {
     "type": "mapgen",
-    "om_terrain": [ "test_pp_riot_building" ],
+    "om_terrain": [ "test_pp_riot_building", "test_pp_field_building", "test_pp_field_and_flag_building", "test_pp_field_inherit_child" ],
     "object": {
       "fill_ter": "t_floor",
       "rows": [
@@ -42,6 +42,42 @@
       "terrain": { "W": "t_wall_wood", ".": "t_floor", "<": "t_wood_stairs_up" },
       "furniture": { "T": "f_table" }
     }
+  },
+  {
+    "type": "overmap_terrain",
+    "id": "test_pp_field_building",
+    "name": "PP field test building",
+    "sym": ".",
+    "color": "white",
+    "see_cost": "none",
+    "flags": [ "SHOULD_NOT_SPAWN", "NO_ROTATE" ],
+    "post_process_generators": [ "test_pp_riot" ]
+  },
+  {
+    "type": "overmap_terrain",
+    "id": "test_pp_field_and_flag_building",
+    "name": "PP field+flag test building",
+    "sym": ".",
+    "color": "white",
+    "see_cost": "none",
+    "flags": [ "SHOULD_NOT_SPAWN", "NO_ROTATE", "PP_GENERATE_RIOT_DAMAGE" ],
+    "post_process_generators": [ "test_pp_road" ]
+  },
+  {
+    "type": "overmap_terrain",
+    "abstract": "test_pp_field_base",
+    "name": "PP field base",
+    "sym": ".",
+    "color": "white",
+    "see_cost": "none",
+    "flags": [ "SHOULD_NOT_SPAWN", "NO_ROTATE" ],
+    "post_process_generators": [ "test_pp_riot", "test_pp_custom" ]
+  },
+  {
+    "type": "overmap_terrain",
+    "id": "test_pp_field_inherit_child",
+    "copy-from": "test_pp_field_base",
+    "delete": { "post_process_generators": [ "test_pp_custom" ] }
   },
   {
     "type": "pp_generator",

--- a/data/mods/Xedra_Evolved/mapgen/overmap_terrain.json
+++ b/data/mods/Xedra_Evolved/mapgen/overmap_terrain.json
@@ -41,7 +41,7 @@
       "field_office_20"
     ],
     "copy-from": "generic_large_office_tower",
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",
@@ -67,7 +67,7 @@
     "type": "overmap_terrain",
     "id": [ "safe_house" ],
     "copy-from": "generic_city_house",
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",
@@ -78,7 +78,7 @@
     "type": "overmap_terrain",
     "id": [ "safe_house_basement" ],
     "copy-from": "generic_city_house_basement",
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",
@@ -101,8 +101,7 @@
     "color": "i_light_red",
     "see_cost": "full_high",
     "mondensity": 2,
-    "flags": [ "SIDEWALK" ],
-    "delete": { "flags": [ "PP_GENERATE_RIOT_DAMAGE" ] }
+    "flags": [ "SIDEWALK" ]
   },
   {
     "type": "overmap_terrain",
@@ -119,14 +118,14 @@
     "copy-from": "cathedral_1_NW",
     "name": "cathedral tower",
     "vision_levels": "isolated_tower",
-    "delete": { "flags": [ "SIDEWALK", "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "flags": [ "SIDEWALK" ], "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",
     "id": [ "cathedralv_b_NW", "cathedralv_b_NE", "cathedralv_b_SW", "cathedralv_b_SE" ],
     "copy-from": "cathedral_1_NW",
     "name": "cathedral basement",
-    "delete": { "flags": [ "SIDEWALK", "PP_GENERATE_RIOT_DAMAGE" ] }
+    "delete": { "flags": [ "SIDEWALK" ], "post_process_generators": [ "riot_damage" ] }
   },
   {
     "type": "overmap_terrain",

--- a/doc/JSON/JSON_FLAGS.md
+++ b/doc/JSON/JSON_FLAGS.md
@@ -1376,7 +1376,7 @@ See [Character](#character)
 - ```REQUIRES_PREDECESSOR``` Mapgen for this will not start from scratch; it will update the mapgen from the terrain it replaced.  This allows the corresponding json mapgen to use the `expects_predecessor` feature.
 - ```LAKE``` Consider this location to be a valid lake terrain for mapgen purposes.
 - ```LAKE_SHORE``` Consider this location to be a valid lake shore terrain for mapgen purposes.
-- ```PP_GENERATE_RIOT_DAMAGE``` Applies randomized riot damage to the local map as a last stage in generating it. Furniture and terrain will be bashed, items moved around, blood spatters are placed, and rarely spawns fires.
+- ```PP_GENERATE_RIOT_DAMAGE``` **Deprecated.**  Use `"post_process_generators": ["riot_damage"]` on the overmap terrain instead.  See [Post-Process Generators](OVERMAP.md#post-process-generators).  Applies randomized riot damage to the local map as a last stage in generating it.  Furniture and terrain will be bashed, items moved around, blood spatters are placed, and rarely spawns fires.
 - ```SOURCE_FUEL``` For NPC AI, this location may contain fuel for looting.
 - ```SOURCE_FOOD``` For NPC AI, this location may contain food for looting.
 - ```SOURCE_FARMING``` For NPC AI, this location may contain useful farming supplies for looting.

--- a/doc/JSON/OVERMAP.md
+++ b/doc/JSON/OVERMAP.md
@@ -334,6 +334,7 @@ rotation for the referenced overmap terrains (e.g. the `_north` version for all)
 | `eoc`             | Supply an effect_on_condition id or an inline effect_on_condition.  The condition of the eoc will be tested to see if the special can be placed.  The effect of the eoc will be run when the special is placed.  See [effect_on_condition.md](EFFECT_ON_CONDITION.md). |
 | `entry_eoc`       | An effect on condition ID that will run when you enter this location.                            |
 | `exit_eoc`        | An effect on condition ID that will run when you exit this location.                             |
+| `post_process_generators` | Array of `pp_generator` ids applied after mapgen completes.  See [Post-Process Generators](#post-process-generators).  Supports `copy-from` inheritance and `delete`. |
 
 ### `see_cost` values
 
@@ -385,6 +386,84 @@ an exhaustive example...
     "exity_eoc": "EOC_LEFT_SECRET_FIELD"
 }
 ```
+
+## Post-Process Generators
+
+Post-process generators (`pp_generator`) are effects that run after normal mapgen completes for
+a given overmap tile.  They simulate cataclysm damage -- bashed furniture, displaced items, blood,
+fire, and full-OMT burns.
+
+Generators are defined in `data/json/post_process_generators.json` and referenced by id from the
+`post_process_generators` field on `overmap_terrain`.  When an overmap terrain has this field set,
+the listed generators run in order after mapgen finishes for that z-level.
+
+### Attaching generators to overmap terrain
+
+Use the `post_process_generators` field on an `overmap_terrain` definition:
+
+```json
+{
+    "type": "overmap_terrain",
+    "id": "my_building",
+    "post_process_generators": [ "riot_damage" ]
+}
+```
+
+The field supports `copy-from` inheritance.  To remove a generator inherited from a parent, use
+`delete`:
+
+```json
+{
+    "type": "overmap_terrain",
+    "id": "my_exempt_building",
+    "copy-from": "generic_city_building",
+    "delete": { "post_process_generators": [ "riot_damage" ] }
+}
+```
+
+Road overmap terrains currently use hardcoded dispatch for city roads and should not have
+`post_process_generators` set.
+
+### `pp_generator` definition
+
+|    Field         |                                           Description                                 |
+| ---------------- | ------------------------------------------------------------------------------------- |
+| `type`           | Must be `"pp_generator"`.                                                             |
+| `id`             | Unique id.                                                                            |
+| `sub_generators` | Array of sub-generator objects, executed in order.  See below.                         |
+
+### Sub-generator fields
+
+Each sub-generator object has the following fields:
+
+|    Field              |                                           Description                                 |
+| --------------------- | ------------------------------------------------------------------------------------- |
+| `type`                | Required.  One of the types listed below.                                             |
+| `attempts`            | Number of times this effect is attempted.  Default 0.                                 |
+| `chance`              | Per-attempt probability.  Meaning varies by type (see below).  Default 0.             |
+| `min_intensity`       | Minimum intensity for the effect.  Default 0.                                         |
+| `max_intensity`       | Maximum intensity for the effect.  Default 0.                                         |
+| `scaling_days_start`  | For time-scaled effects, day offset when scaling begins.  Default 0.                  |
+| `scaling_days_end`    | For time-scaled effects, day offset when scaling reaches full strength.  Default 0.   |
+
+### Sub-generator types
+
+| Type              | Description |
+| ----------------- | ----------- |
+| `bash_damage`     | Randomly bashes furniture and terrain.  `chance` is percent [0-100] per attempt.  `min_intensity`/`max_intensity` control bash strength (damage range). |
+| `move_items`      | Displaces items on the ground by a random distance.  `chance` is percent [0-100] per attempt.  `max_intensity` is the maximum displacement in tiles.  Respects SEALED/PLANT containers. |
+| `add_fire`        | Places fire fields.  Chance is computed from `scaling_days_end` (fires stop spawning after that many days since the cataclysm).  `min_intensity`/`max_intensity` control fire strength.  `chance` must be 0 (it is derived internally). |
+| `pre_burn`        | Replaces an entire OMT with burnt terrain variants -- walls become `t_wall_burnt`, floors become `t_floor_burnt`, furniture and items are destroyed.  Chance is computed from `scaling_days_start`/`scaling_days_end` and intensity.  Stairs (GOES_UP/GOES_DOWN) are preserved.  `chance` must be 0 (it is derived internally). |
+| `place_blood`     | Places blood streaks, pools, and splatter.  `chance` is permille [0-1000] per attempt.  Outdoor blood fades over 30 days. |
+| `aftershock_ruin`  | Runs the Aftershock ruin generator.  All numeric fields are ignored. |
+
+### Built-in generators
+
+| Id                   | Description | Used by |
+| -------------------- | ----------- | ------- |
+| `riot_damage`        | Full riot damage: bash, item displacement, fire, pre-burn, and blood.  | Most city buildings (via `generic_city_building`). |
+| `riot_damage_road`   | Same as `riot_damage` but without `pre_burn`.  | City roads (hardcoded dispatch). |
+| `aftershock_ruin`    | Aftershock ruin effect.  | Aftershock mod buildings with `PP_GENERATE_RUINED` flag. |
 
 ## Overmap Vision
 

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -349,13 +349,21 @@ void map::generate( const tripoint_abs_omt &p, const time_point &when, bool save
             if( any_missing || !save_results ) {
                 const tripoint_abs_omt omt_point = { p.x(), p.y(), gridz };
                 oter_id omt = overmap_buffer.ter( omt_point );
-                if( omt->has_flag( oter_flags::pp_generate_riot_damage ) && !omt->has_flag( oter_flags::road ) ) {
-                    pp_generator_riot_damage.obj().execute( *this, omt_point );
-                } else if( omt->has_flag( oter_flags::road ) && overmap_buffer.is_in_city( omt_point ) ) {
+                if( omt->has_flag( oter_flags::road ) && overmap_buffer.is_in_city( omt_point ) ) {
+                    // Roads use a dedicated generator; not yet migrated to oter_type_t field
                     pp_generator_riot_damage_road.obj().execute( *this, omt_point );
-                }
-                if( omt->has_flag( oter_flags::pp_generate_ruined ) && !omt->has_flag( oter_flags::road ) ) {
-                    pp_generator_aftershock_ruin.obj().execute( *this, omt_point );
+                } else if( !omt->get_post_process_generators().empty() ) {
+                    for( const pp_generator_id &gen_id : omt->get_post_process_generators() ) {
+                        gen_id.obj().execute( *this, omt_point );
+                    }
+                } else {
+                    // Legacy flag-based dispatch for unmigrated content
+                    if( omt->has_flag( oter_flags::pp_generate_riot_damage ) ) {
+                        pp_generator_riot_damage.obj().execute( *this, omt_point );
+                    }
+                    if( omt->has_flag( oter_flags::pp_generate_ruined ) ) {
+                        pp_generator_aftershock_ruin.obj().execute( *this, omt_point );
+                    }
                 }
             }
         }

--- a/src/omdata.h
+++ b/src/omdata.h
@@ -446,6 +446,8 @@ struct oter_type_t {
 
         oter_vision_id vision_levels;
 
+        std::vector<pp_generator_id> post_process_generators;
+
         std::string get_symbol() const;
 
         uint32_t get_uint32_symbol() const {
@@ -579,6 +581,10 @@ struct oter_t {
 
         const overmap_static_spawns &get_static_spawns() const {
             return type->static_spawns;
+        }
+
+        const std::vector<pp_generator_id> &get_post_process_generators() const {
+            return type->post_process_generators;
         }
 
         overmap_land_use_code_id get_land_use_code() const {

--- a/src/overmap_terrain.cpp
+++ b/src/overmap_terrain.cpp
@@ -665,6 +665,11 @@ void oter_type_t::check() const
                   "road OMTs use hardcoded dispatch and the field will be ignored",
                   id.str() );
     }
+    if( has_flag( oter_flags::pp_generate_riot_damage ) && post_process_generators.empty() ) {
+        DebugLog( D_WARNING, D_MAP_GEN ) <<
+                                         "oter_type " << id.str() << " uses deprecated PP_GENERATE_RIOT_DAMAGE flag; "
+                                         "use \"post_process_generators\": [\"riot_damage\"] instead";
+    }
     /* find omts without vision_levels assigned
     if( vision_levels == oter_vision_default && !has_flag( oter_flags::should_not_spawn ) ) {
         fprintf( stderr, "%s (%s)\n", id.c_str(), name.translated().c_str() );

--- a/src/overmap_terrain.cpp
+++ b/src/overmap_terrain.cpp
@@ -17,6 +17,8 @@
 #include "output.h"
 #include "string_formatter.h"
 
+class pp_generator;
+
 static const oter_str_id oter_road_nesw_manhole( "road_nesw_manhole" );
 
 static const oter_vision_id oter_vision_default( "default" );
@@ -611,6 +613,8 @@ void oter_type_t::load( const JsonObject &jo, const std::string_view )
 
 
     optional( jo, was_loaded, "vision_levels", vision_levels, oter_vision_default );
+    optional( jo, was_loaded, "post_process_generators", post_process_generators,
+              string_id_reader<pp_generator> {} );
     optional( jo, false, "uniform_terrain", uniform_terrain );
     if( uniform_terrain ) {
         return;
@@ -650,6 +654,16 @@ void oter_type_t::check() const
     }
     if( uniform_terrain && !uniform_terrain->is_valid() ) {
         debugmsg( "Invalid uniform_terrain id '%s' for '%s'", uniform_terrain->c_str(), id.str() );
+    }
+    for( const pp_generator_id &gen : post_process_generators ) {
+        if( !gen.is_valid() ) {
+            debugmsg( "Invalid post_process_generators id '%s' for '%s'", gen.str(), id.str() );
+        }
+    }
+    if( !post_process_generators.empty() && has_flag( oter_flags::road ) ) {
+        debugmsg( "'%s' has post_process_generators but road flag; "
+                  "road OMTs use hardcoded dispatch and the field will be ignored",
+                  id.str() );
     }
     /* find omts without vision_levels assigned
     if( vision_levels == oter_vision_default && !has_flag( oter_flags::should_not_spawn ) ) {

--- a/tests/mapgen_post_process_test.cpp
+++ b/tests/mapgen_post_process_test.cpp
@@ -30,6 +30,8 @@ static const itype_id itype_rock( "rock" );
 static const itype_id itype_seed_rose( "seed_rose" );
 
 static const oter_str_id oter_field( "field" );
+static const oter_str_id oter_s_gas_rural_north( "s_gas_rural_north" );
+static const oter_str_id oter_s_pharm_north( "s_pharm_north" );
 static const oter_str_id oter_test_pp_field_and_flag_building( "test_pp_field_and_flag_building" );
 static const oter_str_id oter_test_pp_field_building( "test_pp_field_building" );
 static const oter_str_id oter_test_pp_riot_building( "test_pp_riot_building" );
@@ -778,5 +780,77 @@ TEST_CASE( "post_process_oter_field_inherit_delete", "[mapgen][post_process]" )
     const oter_type_t &child = oter_type_test_pp_field_inherit_child.obj();
     REQUIRE( child.post_process_generators.size() == 1 );
     CHECK( child.post_process_generators[0] == pp_generator_test_pp_riot );
+}
+
+// Real-core smoke tests verifying the JSON migration didn't break inheritance.
+
+TEST_CASE( "post_process_real_core_inherited_riot", "[mapgen][post_process]" )
+{
+    // s_pharm inherits riot_damage from generic_city_building -> generic_city_building_no_sidewalk.
+    // After migration, the abstract has post_process_generators: ["riot_damage"].
+    clear_overmaps();
+    clear_map();
+    clear_avatar();
+    const tripoint_abs_omt pos( 50, 50, 0 );
+    overmap_buffer.ter_set( pos, oter_s_pharm_north.id() );
+    for( int dx = -1; dx <= 1; dx++ ) {
+        for( int dy = -1; dy <= 1; dy++ ) {
+            if( dx == 0 && dy == 0 ) {
+                continue;
+            }
+            overmap_buffer.ter_set( pos + tripoint( dx, dy, 0 ), oter_field.id() );
+        }
+    }
+
+    calendar::turn = calendar::start_of_cataclysm + 7_days;
+    rng_set_engine_seed( 42424242 );
+    MAPBUFFER.clear_outside_reality_bubble();
+
+    smallmap tm;
+    tm.generate( pos, calendar::turn, false, true );
+
+    pp_scan_result result = scan_omt( *tm.cast_to_map(), 0 );
+
+    // Riot damage ran: blood proves PP dispatch hit the field path
+    CHECK( result.blood_field_count > 0 );
+
+    tm.delete_unmerged_submaps();
+    clear_overmaps();
+}
+
+TEST_CASE( "post_process_real_core_exempt", "[mapgen][post_process]" )
+{
+    // s_gas_rural explicitly deletes riot_damage via post_process_generators.
+    // No PP should run on this OMT.
+    clear_overmaps();
+    clear_map();
+    clear_avatar();
+    const tripoint_abs_omt pos( 50, 50, 0 );
+    overmap_buffer.ter_set( pos, oter_s_gas_rural_north.id() );
+    for( int dx = -1; dx <= 1; dx++ ) {
+        for( int dy = -1; dy <= 1; dy++ ) {
+            if( dx == 0 && dy == 0 ) {
+                continue;
+            }
+            overmap_buffer.ter_set( pos + tripoint( dx, dy, 0 ), oter_field.id() );
+        }
+    }
+
+    calendar::turn = calendar::start_of_cataclysm + 14_days;
+    rng_set_engine_seed( 42424242 );
+    MAPBUFFER.clear_outside_reality_bubble();
+
+    smallmap tm;
+    tm.generate( pos, calendar::turn, false, true );
+
+    pp_scan_result result = scan_omt( *tm.cast_to_map(), 0 );
+
+    // No PP ran: no blood, no burn, no fire
+    CHECK( result.blood_field_count == 0 );
+    CHECK( result.wall_burnt_count == 0 );
+    CHECK( result.fire_field_count == 0 );
+
+    tm.delete_unmerged_submaps();
+    clear_overmaps();
 }
 

--- a/tests/mapgen_post_process_test.cpp
+++ b/tests/mapgen_post_process_test.cpp
@@ -12,6 +12,7 @@
 #include "map_scale_constants.h"
 #include "mapbuffer.h"
 #include "mapgen_post_process.h"
+#include "omdata.h"
 #include "overmapbuffer.h"
 #include "player_helpers.h"
 #include "point.h"
@@ -29,7 +30,12 @@ static const itype_id itype_rock( "rock" );
 static const itype_id itype_seed_rose( "seed_rose" );
 
 static const oter_str_id oter_field( "field" );
+static const oter_str_id oter_test_pp_field_and_flag_building( "test_pp_field_and_flag_building" );
+static const oter_str_id oter_test_pp_field_building( "test_pp_field_building" );
 static const oter_str_id oter_test_pp_riot_building( "test_pp_riot_building" );
+
+static const oter_type_str_id oter_type_test_pp_field_inherit_child(
+    "test_pp_field_inherit_child" );
 
 static const pp_generator_id pp_generator_riot_damage( "riot_damage" );
 static const pp_generator_id pp_generator_riot_damage_road( "riot_damage_road" );
@@ -653,5 +659,124 @@ TEST_CASE( "post_process_json_load_roundtrip", "[mapgen][post_process]" )
         REQUIRE( custom.sub_generators().size() == 1 );
         CHECK( custom.sub_generators()[0].type == sub_generator_type::aftershock_ruin );
     }
+}
+
+// Tests for post_process_generators field on oter_type_t.
+
+TEST_CASE( "post_process_oter_field_dispatch", "[mapgen][post_process]" )
+{
+    // test_pp_field_building has post_process_generators: ["test_pp_riot"], no flag.
+    // Field-based dispatch should execute the generator.
+    clear_overmaps();
+    clear_map();
+    clear_avatar();
+    const tripoint_abs_omt pos( 50, 50, 0 );
+    overmap_buffer.ter_set( pos, oter_test_pp_field_building.id() );
+    for( int dx = -1; dx <= 1; dx++ ) {
+        for( int dy = -1; dy <= 1; dy++ ) {
+            if( dx == 0 && dy == 0 ) {
+                continue;
+            }
+            overmap_buffer.ter_set( pos + tripoint( dx, dy, 0 ), oter_field.id() );
+        }
+    }
+
+    calendar::turn = calendar::start_of_cataclysm + 7_days;
+    rng_set_engine_seed( 42424242 );
+    MAPBUFFER.clear_outside_reality_bubble();
+
+    smallmap tm;
+    tm.generate( pos, calendar::turn, false, true );
+
+    pp_scan_result result = scan_omt( *tm.cast_to_map(), 0 );
+
+    // Blood proves PP dispatch ran via the field path (no flag on this OMT)
+    CHECK( result.blood_field_count > 0 );
+    CHECK( result.stairs_up_count == 1 );
+
+    tm.delete_unmerged_submaps();
+    clear_overmaps();
+}
+
+TEST_CASE( "post_process_field_over_flag", "[mapgen][post_process]" )
+{
+    // test_pp_field_and_flag_building has:
+    //   post_process_generators: ["test_pp_road"]  (no pre_burn)
+    //   flags: PP_GENERATE_RIOT_DAMAGE             (has pre_burn)
+    // Field should take precedence -- no pre_burn should fire.
+    //
+    // Both test OMTs share the same mapgen definition, so the RNG path
+    // through map::generate() is identical for the same seed.
+    clear_overmaps();
+    clear_map();
+    clear_avatar();
+
+    const tripoint_abs_omt pos( 50, 50, 0 );
+    calendar::turn = calendar::start_of_cataclysm + 14_days;
+
+    // Find a seed where pre_burn fires on test_pp_riot_building (flag-dispatched).
+    // Uses the full pipeline so RNG consumption matches the assertion below.
+    unsigned int burn_seed = 0;
+    bool found = false;
+    for( unsigned int seed = 100; seed < 200; seed++ ) {
+        overmap_buffer.ter_set( pos, oter_test_pp_riot_building.id() );
+        for( int dx = -1; dx <= 1; dx++ ) {
+            for( int dy = -1; dy <= 1; dy++ ) {
+                if( dx == 0 && dy == 0 ) {
+                    continue;
+                }
+                overmap_buffer.ter_set( pos + tripoint( dx, dy, 0 ), oter_field.id() );
+            }
+        }
+        rng_set_engine_seed( seed );
+        MAPBUFFER.clear_outside_reality_bubble();
+        smallmap probe;
+        probe.generate( pos, calendar::turn, false, true );
+        pp_scan_result r = scan_omt( *probe.cast_to_map(), 0 );
+        probe.delete_unmerged_submaps();
+        if( r.wall_burnt_count > 0 ) {
+            found = true;
+            burn_seed = seed;
+            break;
+        }
+    }
+    REQUIRE( found );
+
+    // Same seed, same mapgen, but field+flag OMT. If field dispatch wins,
+    // test_pp_road runs (no pre_burn). If flag wrongly wins, this seed burns.
+    overmap_buffer.ter_set( pos, oter_test_pp_field_and_flag_building.id() );
+    for( int dx = -1; dx <= 1; dx++ ) {
+        for( int dy = -1; dy <= 1; dy++ ) {
+            if( dx == 0 && dy == 0 ) {
+                continue;
+            }
+            overmap_buffer.ter_set( pos + tripoint( dx, dy, 0 ), oter_field.id() );
+        }
+    }
+
+    rng_set_engine_seed( burn_seed );
+    MAPBUFFER.clear_outside_reality_bubble();
+
+    smallmap tm;
+    tm.generate( pos, calendar::turn, false, true );
+
+    pp_scan_result result = scan_omt( *tm.cast_to_map(), 0 );
+
+    CHECK( result.wall_burnt_count == 0 );
+    CHECK( result.floor_burnt_count == 0 );
+    CHECK( result.dirt_count == 0 );
+
+    tm.delete_unmerged_submaps();
+    clear_overmaps();
+}
+
+TEST_CASE( "post_process_oter_field_inherit_delete", "[mapgen][post_process]" )
+{
+    // test_pp_field_inherit_child copies from test_pp_field_base and deletes test_pp_custom.
+    // Base has: ["test_pp_riot", "test_pp_custom"]
+    // Child should have: ["test_pp_riot"]
+    const oter_type_t &child = oter_type_test_pp_field_inherit_child.obj();
+    REQUIRE( child.post_process_generators.size() == 1 );
+    CHECK( child.post_process_generators[0] == pp_generator_test_pp_riot );
 }
 


### PR DESCRIPTION
#### Summary
Infrastructure "Replace PP_GENERATE_RIOT_DAMAGE flag with post_process_generators field on overmap terrain types"

#### Purpose of change

Follows #86553 and #86543. Replaces the hardcoded flag check with an explicit `post_process_generators` field on `oter_type_t`, so generators are attached directly to terrain types in JSON.

#### Describe the solution

New `vector<pp_generator_id>` field on `oter_type_t` with `extend`/`delete` support. Dispatch prefers the field, falls back to flags for unmigrated content. Road dispatch unchanged.

All vanilla core OMTs and in-repo mods (MoM, XE) migrated. Redundant double-deletes on `sugar_house` and `speedway_track_abstract` cleaned up. `test_pp_riot_building` keeps the flag as permanent compat fixture.

#### Describe alternatives you've considered

N/A

#### Testing

Six new tests: field dispatch, field-over-flag precedence, inheritance with delete, two real-core smokes (`s_pharm` inherited, `s_gas_rural` exempt). Existing `[post_process]` suite passes. Verified in-game.

#### Additional context

Depends on #86553. `PP_GENERATE_RUINED` / Aftershock not migrated here.