### PR TITLE
Bugfix for vehicle falling through floor

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1102,6 +1102,9 @@ vehicle *map::move_vehicle( vehicle &veh, const tripoint_rel_ms &dp, const tiler
     if( dp.z() != 0 && veh.is_rotorcraft( *this ) ) {
         can_move = true;
     }
+    if( vertical ) {
+        veh.check_falling_or_floating(); // fix for vehicle falling into floor
+    }
     units::angle coll_turn = 0_degrees;
     if( impulse > 0 ) {
         coll_turn = shake_vehicle( veh, velocity_before, facing.dir() );


### PR DESCRIPTION
#### Summary
Bugfixes "No more falling vehicle tunneling"

#### Purpose of change

Fixes bug I observed where a falling vehicle will fall through a solid surface (E.G: trash-can vehicle dropped from z=1 will fall to z=0, then phase through solid ground and end up buried in z=-1 of that square. Yes, really. (I dug it up)

#### Describe the solution

Adds a pre-movement check_falling_or_floating() to map.cpp on line 1105-1107 to update ground status prior to doing any actual movement. Note that this is gated behind a vertical check, so we are only calling it when something is actually falling.

Without this change, line 1153's if( can_move || ( vertical && veh.is_falling ) ) will fire off as true on a solid surface because vehicle_move.cpp's act_on_map() will set veh.is_falling back to true even if we evaluate it as false post-move (since we have still have velocity).

And we will go back into 1153 in the next fall update with is_falling being true.

Essentially, this change does two things: we are no longer having vehicle phase through solid ground while falling, and vehicle is also no longer taking an additional story of fall damage from falling that extra imaginary story.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

None. Other methods I had thought of were quite ugly. This is clean and efficient.

#### Testing

W/o fix:
1) Stand on roof(z=1)
2) Push vehicle off (trash bin). Wait 1 turn.
3) Hear crash. Expect trash bin at z=0. Nothing there.
4) Pull out shovel and start digging or pickaxe and mine ground.
5) Discover Trash can buried at z=-1. Fell 2 stories (along with 2 stories in fall damage). Fall damage confirmed to be 2 stories through debugging output.


W/ fix:
1) Stand on roof(z=1)
2) Push vehicle off (trash bin). Wait 1 turn
3) Hear crash. Expect trash bin at z=0.
4) Trash bin is laying on the square below at z=0. Fell 1 story(and as expected, took 1 story in fall damage). Fall damage confirmed to be 1 story through debugging output

Fix doesn't seem to affect anything else that I was able to observe.

#### Additional context

<img width="1255" height="639" alt="Buried trash can" src="https://github.com/user-attachments/assets/3458e8ec-67a1-474a-8d39-ae8cbe8f74de" />

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
