### PR TITLE
Fix labyrinth throwing palette errors & crashing

### DIFF
--- a/data/json/effects_on_condition/nether_eocs/labyrinth_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/labyrinth_effect_on_condition.json
@@ -89,7 +89,7 @@
         "u_location_variable": { "global_val": "original_labyrinth_portal_loc" },
         "target_params": { "om_terrain": "labyrinth_entrance", "om_special": "labyrinthine_structure" },
         "furniture": "f_scrap_antenna",
-        "target_max_radius": 250,
+        "target_max_radius": 2000,
         "x_adjust": 1
       },
       { "u_teleport": { "global_val": "original_labyrinth_portal_loc" }, "fail_message": "Nope!", "force": true },

--- a/data/json/effects_on_condition/nether_eocs/labyrinth_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/labyrinth_effect_on_condition.json
@@ -89,7 +89,7 @@
         "u_location_variable": { "global_val": "original_labyrinth_portal_loc" },
         "target_params": { "om_terrain": "labyrinth_entrance", "om_special": "labyrinthine_structure" },
         "furniture": "f_scrap_antenna",
-        "target_max_radius": 2000,
+        "target_max_radius": 24,
         "x_adjust": 1
       },
       { "u_teleport": { "global_val": "original_labyrinth_portal_loc" }, "fail_message": "Nope!", "force": true },

--- a/data/json/mapgen/netherum/labyrinth_mapgen_nests_2x2scatter.json
+++ b/data/json/mapgen/netherum/labyrinth_mapgen_nests_2x2scatter.json
@@ -8,16 +8,31 @@
         "¢c",
         "c¢"
       ],
-      "palettes": [
-        "labyrinthine_base_palette",
-        {
-          "distribution": [
-            "labyrinthine_item_palette_utility_tier0",
-            "labyrinthine_item_palette_dining_tier0",
-            "labyrinthine_item_palette_bunk_room_tier0"
-          ]
-        }
-      ]
+      "palettes": [ "labyrinthine_base_palette", "labyrinthine_item_palette_utility_tier0" ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "ls_2x2_furniture",
+    "object": {
+      "mapgensize": [ 2, 2 ],
+      "rows": [
+        "¢c",
+        "c¢"
+      ],
+      "palettes": [ "labyrinthine_base_palette", "labyrinthine_item_palette_dining_tier0" ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "ls_2x2_furniture",
+    "object": {
+      "mapgensize": [ 2, 2 ],
+      "rows": [
+        "¢c",
+        "c¢"
+      ],
+      "palettes": [ "labyrinthine_base_palette", "labyrinthine_item_palette_bunk_room_tier0" ]
     }
   },
   {
@@ -37,16 +52,31 @@
         "Ṫß",
         "(b"
       ],
-      "palettes": [
-        "labyrinthine_base_palette",
-        {
-          "distribution": [
-            "labyrinthine_item_palette_utility_tier0",
-            "labyrinthine_item_palette_dining_tier0",
-            "labyrinthine_item_palette_bunk_room_tier0"
-          ]
-        }
-      ]
+      "palettes": [ "labyrinthine_base_palette", "labyrinthine_item_palette_utility_tier0" ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "ls_2x2_furniture",
+    "object": {
+      "mapgensize": [ 2, 2 ],
+      "rows": [
+        "Ṫß",
+        "(b"
+      ],
+      "palettes": [ "labyrinthine_base_palette", "labyrinthine_item_palette_dining_tier0" ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "ls_2x2_furniture",
+    "object": {
+      "mapgensize": [ 2, 2 ],
+      "rows": [
+        "Ṫß",
+        "(b"
+      ],
+      "palettes": [ "labyrinthine_base_palette", "labyrinthine_item_palette_bunk_room_tier0" ]
     }
   },
   {
@@ -58,16 +88,33 @@
         "l2",
         "l "
       ],
-      "palettes": [
-        "labyrinthine_base_palette",
-        {
-          "distribution": [
-            "labyrinthine_item_palette_utility_tier0",
-            "labyrinthine_item_palette_dining_tier0",
-            "labyrinthine_item_palette_bunk_room_tier0"
-          ]
-        }
+      "palettes": [ "labyrinthine_base_palette", "labyrinthine_item_palette_utility_tier0" ],
+      "monsters": { "2": { "monster": "GROUP_Labyrinth_Turret", "density": 0.01 } }
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "ls_2x2_furniture",
+    "object": {
+      "mapgensize": [ 2, 2 ],
+      "rows": [
+        "l2",
+        "l "
       ],
+      "palettes": [ "labyrinthine_base_palette", "labyrinthine_item_palette_dining_tier0" ],
+      "monsters": { "2": { "monster": "GROUP_Labyrinth_Turret", "density": 0.01 } }
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "ls_2x2_furniture",
+    "object": {
+      "mapgensize": [ 2, 2 ],
+      "rows": [
+        "l2",
+        "l "
+      ],
+      "palettes": [ "labyrinthine_base_palette", "labyrinthine_item_palette_bunk_room_tier0" ],
       "monsters": { "2": { "monster": "GROUP_Labyrinth_Turret", "density": 0.01 } }
     }
   },
@@ -80,16 +127,33 @@
         "UU",
         " 2"
       ],
-      "palettes": [
-        "labyrinthine_base_palette",
-        {
-          "distribution": [
-            "labyrinthine_item_palette_utility_tier0",
-            "labyrinthine_item_palette_dining_tier0",
-            "labyrinthine_item_palette_bunk_room_tier0"
-          ]
-        }
+      "palettes": [ "labyrinthine_base_palette", "labyrinthine_item_palette_utility_tier0" ],
+      "monsters": { "2": { "monster": "GROUP_Labyrinth_Turret", "density": 0.01 } }
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "ls_2x2_furniture",
+    "object": {
+      "mapgensize": [ 2, 2 ],
+      "rows": [
+        "UU",
+        " 2"
       ],
+      "palettes": [ "labyrinthine_base_palette", "labyrinthine_item_palette_dining_tier0" ],
+      "monsters": { "2": { "monster": "GROUP_Labyrinth_Turret", "density": 0.01 } }
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "ls_2x2_furniture",
+    "object": {
+      "mapgensize": [ 2, 2 ],
+      "rows": [
+        "UU",
+        " 2"
+      ],
+      "palettes": [ "labyrinthine_base_palette", "labyrinthine_item_palette_bunk_room_tier0" ],
       "monsters": { "2": { "monster": "GROUP_Labyrinth_Turret", "density": 0.01 } }
     }
   },
@@ -102,16 +166,31 @@
         " L",
         "UU"
       ],
-      "palettes": [
-        "labyrinthine_base_palette",
-        {
-          "distribution": [
-            "labyrinthine_item_palette_utility_tier0",
-            "labyrinthine_item_palette_dining_tier0",
-            "labyrinthine_item_palette_bunk_room_tier0"
-          ]
-        }
-      ]
+      "palettes": [ "labyrinthine_base_palette", "labyrinthine_item_palette_utility_tier0" ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "ls_2x2_furniture",
+    "object": {
+      "mapgensize": [ 2, 2 ],
+      "rows": [
+        " L",
+        "UU"
+      ],
+      "palettes": [ "labyrinthine_base_palette", "labyrinthine_item_palette_dining_tier0" ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "ls_2x2_furniture",
+    "object": {
+      "mapgensize": [ 2, 2 ],
+      "rows": [
+        " L",
+        "UU"
+      ],
+      "palettes": [ "labyrinthine_base_palette", "labyrinthine_item_palette_bunk_room_tier0" ]
     }
   },
   {
@@ -123,7 +202,33 @@
         "ßß",
         "2ß"
       ],
-      "palettes": [ "labyrinthine_base_palette" ],
+      "palettes": [ "labyrinthine_base_palette", "labyrinthine_item_palette_utility_tier0" ],
+      "monsters": { "2": { "monster": "GROUP_Labyrinth_Turret", "density": 0.01 } }
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "ls_2x2_furniture",
+    "object": {
+      "mapgensize": [ 2, 2 ],
+      "rows": [
+        "ßß",
+        "2ß"
+      ],
+      "palettes": [ "labyrinthine_base_palette", "labyrinthine_item_palette_dining_tier0" ],
+      "monsters": { "2": { "monster": "GROUP_Labyrinth_Turret", "density": 0.01 } }
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "ls_2x2_furniture",
+    "object": {
+      "mapgensize": [ 2, 2 ],
+      "rows": [
+        "ßß",
+        "2ß"
+      ],
+      "palettes": [ "labyrinthine_base_palette", "labyrinthine_item_palette_bunk_room_tier0" ],
       "monsters": { "2": { "monster": "GROUP_Labyrinth_Turret", "density": 0.01 } }
     }
   }

--- a/data/json/mapgen/netherum/labyrinth_mapgen_nests_templated_rooms.json
+++ b/data/json/mapgen/netherum/labyrinth_mapgen_nests_templated_rooms.json
@@ -305,16 +305,75 @@
         "U_ßß_U          U____U",
         "UUṪṪUU          UUU_UU"
       ],
-      "palettes": [
-        "labyrinthine_base_palette",
-        {
-          "distribution": [
-            "labyrinthine_item_palette_utility_tier0",
-            "labyrinthine_item_palette_dining_tier0",
-            "labyrinthine_item_palette_bunk_room_tier0"
-          ]
-        }
+      "palettes": [ "labyrinthine_base_palette", "labyrinthine_item_palette_utility_tier0" ],
+      "monsters": { "1": { "monster": "GROUP_Labyrinth_Turret", "density": 0.01 } }
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "ls_straight_2basic_rooms_offset",
+    "//": "Two rooms full of general junk and monsters.  Set up for a door entry in the upper left and lower right.",
+    "object": {
+      "mapgensize": [ 22, 22 ],
+      "rows": [
+        "c____L          L1111L",
+        "cUU___          c__cCc",
+        "c_____          ______",
+        "cUU___          cCc__c",
+        "c_____          ______",
+        "cUU___          c__cCc",
+        "||||F|          ______",
+        "UUUU_l          cCc__c",
+        "L____l          |||++|",
+        "U____l          L_____",
+        "UUUU_l          ßß__ßß",
+        "||||F|          ṪṪ__ṪṪ",
+        "cc___c          |||_ßß",
+        "ccC¢Cc          __|+||",
+        "Cc¢¢¢¢          _____ß",
+        "CCC¢¢¢          ßṪ___L",
+        "||||F|          ßṪ___ß",
+        "U____L          |||+||",
+        "U_((_U          LUU_UU",
+        "U_((_U          U____U",
+        "U_ßß_U          U____U",
+        "UUṪṪUU          UUU_UU"
       ],
+      "palettes": [ "labyrinthine_base_palette", "labyrinthine_item_palette_dining_tier0" ],
+      "monsters": { "1": { "monster": "GROUP_Labyrinth_Turret", "density": 0.01 } }
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "ls_straight_2basic_rooms_offset",
+    "//": "Two rooms full of general junk and monsters.  Set up for a door entry in the upper left and lower right.",
+    "object": {
+      "mapgensize": [ 22, 22 ],
+      "rows": [
+        "c____L          L1111L",
+        "cUU___          c__cCc",
+        "c_____          ______",
+        "cUU___          cCc__c",
+        "c_____          ______",
+        "cUU___          c__cCc",
+        "||||F|          ______",
+        "UUUU_l          cCc__c",
+        "L____l          |||++|",
+        "U____l          L_____",
+        "UUUU_l          ßß__ßß",
+        "||||F|          ṪṪ__ṪṪ",
+        "cc___c          |||_ßß",
+        "ccC¢Cc          __|+||",
+        "Cc¢¢¢¢          _____ß",
+        "CCC¢¢¢          ßṪ___L",
+        "||||F|          ßṪ___ß",
+        "U____L          |||+||",
+        "U_((_U          LUU_UU",
+        "U_((_U          U____U",
+        "U_ßß_U          U____U",
+        "UUṪṪUU          UUU_UU"
+      ],
+      "palettes": [ "labyrinthine_base_palette", "labyrinthine_item_palette_bunk_room_tier0" ],
       "monsters": { "1": { "monster": "GROUP_Labyrinth_Turret", "density": 0.01 } }
     }
   },

--- a/data/json/overmap/overmap_special/netherum_labyrinth.json
+++ b/data/json/overmap/overmap_special/netherum_labyrinth.json
@@ -4,8 +4,9 @@
     "id": "labyrinthine_structure",
     "subtype": "mutable",
     "locations": [ "netherum_labyrinth_sparkling_chasm" ],
-    "occurrences": [ 0, 10 ],
-    "flags": [ "EXODII", "EXTRADIMENSIONAL", "NETHERUM_LABYRINTH" ],
+    "occurrences": [ 99, 100 ],
+    "priority": 3,
+    "flags": [ "EXODII", "EXTRADIMENSIONAL", "NETHERUM_LABYRINTH", "OVERMAP_UNIQUE" ],
     "check_for_locations_area": [ { "type": [ "netherum_labyrinth_sparkling_chasm" ], "from": [ 10, 10, 0 ], "to": [ -10, -10, 0 ] } ],
     "joins": [ "passage_to_passage" ],
     "overmaps": {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Exodii Labyrinth mapgen doesn't throw errors"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fixes #85149

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Following #85149 and #60395 it looks like the errors were the result of palette distributions.  The labyrinth is almost always made by EOC and teleporting shenanigans, hence why the error is thrown.

So, I just removed the palette distributions.  Instead of a single nested mapgen, there are now multiple nested mapgens, each with their own palette.  The labyrinth should be generating the same as before.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Jumped back and forth to labyrinth ~100 times.  No more errors.  No crashes.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

This does NOT fix the issue first described in #60395.  This just makes it so that the issue is no longer relevant to labyrinth mapgen.

Also, I know I should avoid scope creep, but while testing I noticed that, very rarely, a teleport could dump you in the wrong labyrinth room, because the furniture search radius was too large, and sometimes multiple labyrinths spawned close together.  Tweaked the EOC & made sure there is only ever 1 labyrinth per overmap.  Now, entering the labyrinth is always to the right location, and always error free. Yay.


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
