### PR TITLE
adjust batteries ASCII to match counterparts

### DIFF
--- a/data/json/ascii_art/battery.json
+++ b/data/json/ascii_art/battery.json
@@ -22,19 +22,19 @@
     "type": "ascii_art",
     "id": "medium_battery_cell",
     "picture": [
-      "<color_red>,<color_dark_gray>/]===.",
-      "|<color_yellow>< M ></color>|",
-      "'─────'"
+      "<color_c_light_blue>┌<color_light_gray>▬</color>┐",
+      "<color_c_light_blue>├<color_white>M</color>┤",
+      "<color_c_light_blue>│ │",
+      "<color_c_light_blue>└─┘"
     ]
   },
   {
     "type": "ascii_art",
     "id": "heavy_battery_cell",
     "picture": [
-      "   <color_yellow>_<color_dark_gray>_</color>_____",
-      " ,'<color_dark_gray>,└─────┤</color>",
-      "|<color_dark_gray>_|_<color_yellow>H</color>____,~<color_light_gray>:</color>",
-      "└──────────┘"
+      "<color_red>,<color_dark_gray>/]===.",
+      "|<color_yellow>< T ></color>|",
+      "'─────'"
     ]
   },
   {
@@ -43,7 +43,7 @@
     "picture": [
       "   <color_yellow>_<color_dark_gray>_</color>_______",
       " ,'<color_dark_gray>,└───────┤</color>",
-      "|<color_dark_gray>_|_<color_yellow>H+</color>_____,~<color_light_gray>:</color>",
+      "|<color_dark_gray>_|_<color_yellow>T+</color>_____,~<color_light_gray>:</color>",
       "└────────────┘"
     ]
   },


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Batteries types we changed a bit before, but ASCII pictures of them still use the old looks
#### Describe the solution
Shuffle a bit
#### Testing
medium battery:
|  Before | After |
|---|---|
| <img width="64" height="50" alt="image" src="https://github.com/user-attachments/assets/21732b83-7780-4968-8b95-37aff84ea22a" /> | <img width="38" height="82" alt="image" src="https://github.com/user-attachments/assets/b0fea59f-bd65-4b75-a78f-dfd534f1ec42" /> |

small tool battery:
|  Before | After |
|---|---|
| <img width="108" height="59" alt="image" src="https://github.com/user-attachments/assets/aee21d94-307a-401b-a3e1-39fe4c41d9ad" /> | <img width="70" height="57" alt="image" src="https://github.com/user-attachments/assets/2fb142ef-2dc9-47e8-a986-11b11a52a3af" /> |

large tool battery:
|  Before | After |
|---|---|
| <img width="122" height="56" alt="image" src="https://github.com/user-attachments/assets/44fc7bfb-c989-4bfd-a373-3cc4a82ba31c" /> | <img width="126" height="73" alt="image" src="https://github.com/user-attachments/assets/c3ee74da-edd1-4e92-9d48-9beaae843783" /> |

(white color weirdness is because "before" is taken from hhg, not from the game)
