### PR TITLE
Add sibling overlap detection to mapgen static check

### DIFF
--- a/data/json/mapgen/basecamps/base/fbmc_mansion/fbmc_mansion_+1.json
+++ b/data/json/mapgen/basecamps/base/fbmc_mansion/fbmc_mansion_+1.json
@@ -34,7 +34,8 @@
         "dddd    dddd"
       ],
       "terrain": { "d": "t_dirt" },
-      "furniture": { "d": "f_clear" }
+      "furniture": { "d": "f_clear" },
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {

--- a/data/json/mapgen/basecamps/base/fbmc_mansion/fbmc_mansion_+4.json
+++ b/data/json/mapgen/basecamps/base/fbmc_mansion/fbmc_mansion_+4.json
@@ -28,7 +28,8 @@
         "      "
       ],
       "terrain": { "d": "t_dirt" },
-      "furniture": { "d": "f_clear" }
+      "furniture": { "d": "f_clear" },
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {

--- a/data/json/mapgen/basecamps/base/fbmc_mansion/fbmc_mansion_common.json
+++ b/data/json/mapgen/basecamps/base/fbmc_mansion/fbmc_mansion_common.json
@@ -12,7 +12,8 @@
         "     "
       ],
       "terrain": { "f": "t_dirtmound" },
-      "furniture": { "f": "f_clear" }
+      "furniture": { "f": "f_clear" },
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {

--- a/data/json/mapgen/crater.json
+++ b/data/json/mapgen/crater.json
@@ -82,7 +82,7 @@
         { "chunks": [ "crater_bomb" ], "x": [ 12, 15 ], "y": [ 8, 11 ] },
         { "chunks": [ "crater_bomb" ], "x": [ 12, 15 ], "y": [ 12, 15 ] }
       ],
-      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ]
     }
   },
   {
@@ -132,7 +132,7 @@
         { "chunks": [ "crater_bomb" ], "x": [ 12, 15 ], "y": [ 8, 11 ] },
         { "chunks": [ "crater_bomb" ], "x": [ 12, 15 ], "y": [ 12, 15 ] }
       ],
-      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ]
     }
   },
   {
@@ -204,7 +204,7 @@
           "neighbors": { "north_west": "crater_core_large" }
         }
       ],
-      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ]
     }
   },
   {
@@ -240,7 +240,7 @@
         "                        "
       ],
       "palettes": [ "crater_palette" ],
-      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ]
     }
   },
   {
@@ -276,7 +276,7 @@
         "             ..........."
       ],
       "palettes": [ "crater_palette" ],
-      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ]
     }
   },
   {
@@ -312,7 +312,7 @@
         "........................"
       ],
       "palettes": [ "crater_palette" ],
-      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ]
     }
   },
   {
@@ -348,7 +348,7 @@
         "...........             "
       ],
       "palettes": [ "crater_palette" ],
-      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ]
     }
   },
   {
@@ -384,7 +384,7 @@
         "                        "
       ],
       "palettes": [ "crater_palette" ],
-      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ]
     }
   },
   {
@@ -420,7 +420,7 @@
         "             ..........."
       ],
       "palettes": [ "crater_palette" ],
-      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ]
     }
   },
   {
@@ -456,7 +456,7 @@
         "...........             "
       ],
       "palettes": [ "crater_palette" ],
-      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ]
     }
   },
   {
@@ -492,7 +492,7 @@
         "                        "
       ],
       "palettes": [ "crater_palette" ],
-      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ]
     }
   },
   {
@@ -528,7 +528,7 @@
         "       ??????????       "
       ],
       "palettes": [ "crater_palette" ],
-      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ]
     }
   },
   {
@@ -564,7 +564,7 @@
         "  ???????????           "
       ],
       "palettes": [ "crater_palette" ],
-      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ]
     }
   },
   {
@@ -600,7 +600,7 @@
         "                        "
       ],
       "palettes": [ "crater_palette" ],
-      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ]
     }
   },
   {
@@ -636,7 +636,7 @@
         "           ???????????  "
       ],
       "palettes": [ "crater_palette" ],
-      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ]
     }
   },
   {
@@ -672,7 +672,7 @@
         "                        "
       ],
       "palettes": [ "crater_palette" ],
-      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ]
     }
   },
   {
@@ -708,7 +708,7 @@
         "  ???????????           "
       ],
       "palettes": [ "crater_palette" ],
-      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ]
     }
   },
   {
@@ -744,7 +744,7 @@
         "           ???????????  "
       ],
       "palettes": [ "crater_palette" ],
-      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ]
     }
   },
   {
@@ -780,7 +780,7 @@
         "                        "
       ],
       "palettes": [ "crater_palette" ],
-      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ]
     }
   },
   {
@@ -816,7 +816,7 @@
         "                        "
       ],
       "palettes": [ "crater_palette" ],
-      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ]
     }
   },
   {
@@ -852,7 +852,7 @@
         "                        "
       ],
       "palettes": [ "crater_palette" ],
-      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ]
     }
   },
   {
@@ -888,7 +888,7 @@
         " ?????????????????????? "
       ],
       "palettes": [ "crater_palette" ],
-      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ]
     }
   },
   {
@@ -924,7 +924,7 @@
         "                        "
       ],
       "palettes": [ "crater_palette" ],
-      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA", "DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN" ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ]
     }
   }
 ]

--- a/data/json/mapgen/lab/lab_modular/lab_nests_modular/lab_nested_medical.json
+++ b/data/json/mapgen/lab/lab_modular/lab_nests_modular/lab_nested_medical.json
@@ -17,7 +17,8 @@
         "...ë....."
       ],
       "palettes": [ "lab_common_palette", "lab_medical_palette" ],
-      "place_nested": [ { "chunks": [ [ "lab_medical_6x6_open", 100 ] ], "x": 0, "y": 0 } ]
+      "place_nested": [ { "chunks": [ [ "lab_medical_6x6_open", 100 ] ], "x": 0, "y": 0 } ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -37,7 +38,8 @@
         ".........",
         "...ë....."
       ],
-      "palettes": [ "lab_common_palette", "lab_medical_palette" ]
+      "palettes": [ "lab_common_palette", "lab_medical_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -174,7 +176,8 @@
         "....ë...."
       ],
       "palettes": [ "lab_common_palette", "lab_medical_palette" ],
-      "vehicles": { "ւ": { "vehicle": "hospital_bed", "rotation": 270 } }
+      "vehicles": { "ւ": { "vehicle": "hospital_bed", "rotation": 270 } },
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -217,7 +220,8 @@
         "....ë...."
       ],
       "palettes": [ "lab_common_palette", "lab_medical_palette" ],
-      "vehicles": { "ƃ": { "vehicle": "wheelchair", "rotation": 90 } }
+      "vehicles": { "ƃ": { "vehicle": "wheelchair", "rotation": 90 } },
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -260,7 +264,8 @@
       ],
       "palettes": [ "lab_common_palette", "lab_medical_palette" ],
       "furniture": { "Ƨ": [ "f_treadmill", "f_treadmill_mechanical" ] },
-      "vehicles": { "ƃ": { "vehicle": "wheelchair", "rotation": 90 } }
+      "vehicles": { "ƃ": { "vehicle": "wheelchair", "rotation": 90 } },
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -334,7 +339,8 @@
       "place_monster": [
         { "group": "GROUP_LAB_MUTANT_BOSS", "x": [ 0, 5 ], "y": [ 0, 5 ], "repeat": [ 6, 8 ] },
         { "monster": "mon_mutant_alpha_boss", "x": 2, "y": 2 }
-      ]
+      ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   }
 ]

--- a/data/json/mapgen/map_extras/spider.json
+++ b/data/json/mapgen/map_extras/spider.json
@@ -48,7 +48,8 @@
         "o": { "chunks": [ [ "spider_webs", 2 ], [ "spider_webs_weak", 2 ], [ "null", 1 ] ] },
         ",": { "chunks": [ "spider_webs", "spider_webs_weak", "null" ] },
         ".": { "chunks": [ [ "spider_webs_weak", 1 ], [ "null", 2 ] ] }
-      }
+      },
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {

--- a/data/json/mapgen/nested/farm_nested.json
+++ b/data/json/mapgen/nested/farm_nested.json
@@ -106,7 +106,8 @@
         "P//////////////////////P",
         "PPPPPPPPPPPPPPPPPPPPPPPP"
       ],
-      "palettes": [ "farm_house" ]
+      "palettes": [ "farm_house" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -140,7 +141,8 @@
         "P//////////////////////P",
         "PPPP%%%%PPPPPPPP%%%%PPPP"
       ],
-      "palettes": [ "farm_house" ]
+      "palettes": [ "farm_house" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -174,7 +176,8 @@
         "P//////////////////////P",
         "PPPPPPPPPPPPPPPPPPPPPPPP"
       ],
-      "palettes": [ "farm_house" ]
+      "palettes": [ "farm_house" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -213,7 +216,8 @@
         "%//////////////////////%",
         "%%%%%%%%%%%//%%%%%%%%%%%"
       ],
-      "palettes": [ "farm_house" ]
+      "palettes": [ "farm_house" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {

--- a/data/json/mapgen/nested/mine_nested.json
+++ b/data/json/mapgen/nested/mine_nested.json
@@ -110,7 +110,8 @@
         "              ",
         "              "
       ],
-      "terrain": { "#": "t_rock", "№": [ [ "t_pillar", 10 ], [ "t_rock", 90 ] ] }
+      "terrain": { "#": "t_rock", "№": [ [ "t_pillar", 10 ], [ "t_rock", 90 ] ] },
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -135,7 +136,8 @@
         "              ",
         "              "
       ],
-      "terrain": { "#": "t_rock", "№": [ [ "t_pillar", 10 ], [ "t_rock", 90 ] ] }
+      "terrain": { "#": "t_rock", "№": [ [ "t_pillar", 10 ], [ "t_rock", 90 ] ] },
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -160,7 +162,8 @@
         "#             ",
         "#             "
       ],
-      "terrain": { "#": "t_rock", "№": [ [ "t_pillar", 10 ], [ "t_rock", 90 ] ] }
+      "terrain": { "#": "t_rock", "№": [ [ "t_pillar", 10 ], [ "t_rock", 90 ] ] },
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -185,7 +188,8 @@
         "              ",
         "              "
       ],
-      "terrain": { "#": "t_rock", "№": [ [ "t_pillar", 10 ], [ "t_rock", 90 ] ] }
+      "terrain": { "#": "t_rock", "№": [ [ "t_pillar", 10 ], [ "t_rock", 90 ] ] },
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {

--- a/data/json/mapgen/nested/nested_chunks_roof.json
+++ b/data/json/mapgen/nested/nested_chunks_roof.json
@@ -232,7 +232,8 @@
     "nested_mapgen_id": "roof_2x2_infrastructure_2",
     "object": {
       "mapgensize": [ 2, 2 ],
-      "place_terrain": [ { "ter": "t_switchgear_s", "x": 0, "y": 0 }, { "ter": "t_sai_box", "x": 0, "y": 1 } ]
+      "place_terrain": [ { "ter": "t_switchgear_s", "x": 0, "y": 0 }, { "ter": "t_sai_box", "x": 0, "y": 1 } ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {

--- a/data/json/mapgen/nested/office_nested.json
+++ b/data/json/mapgen/nested/office_nested.json
@@ -20,7 +20,8 @@
         "   h    h   h ",
         "dddx  dddx xdd"
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -44,7 +45,8 @@
         " h * h *   * f",
         "         h   f"
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -68,7 +70,8 @@
         " dxd* dxd* dxd",
         "  h *  h *  h "
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -92,7 +95,8 @@
         "dh d*dhhd*d hd",
         "x  x*x  x*x  x"
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -116,7 +120,8 @@
         "  h *  h *  h ",
         "dddx*dddx*dddx"
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -140,7 +145,8 @@
         "  *   * h *   ",
         "    h       h "
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -164,7 +170,8 @@
         "dxd *dxd *dxd ",
         "  h * h  * h  "
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -188,7 +195,8 @@
         "  h * h  * h  ",
         "xddd*xddd*xddd"
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -212,7 +220,8 @@
         "dh d*dh d*d hd",
         "x  x*x  x*x  x"
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -236,7 +245,8 @@
         " h    h    h  ",
         "ddx xddd  xddd"
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -260,7 +270,8 @@
         "              ",
         "              "
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -284,7 +295,8 @@
         "              ",
         "              "
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -308,7 +320,8 @@
         "              ",
         "              "
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -332,7 +345,8 @@
         "              ",
         "              "
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -356,7 +370,8 @@
         "              ",
         "              "
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -380,7 +395,8 @@
         "              ",
         "              "
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -404,7 +420,8 @@
         "              ",
         "              "
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -428,7 +445,8 @@
         "              ",
         "              "
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -452,7 +470,8 @@
         "              ",
         "              "
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -476,7 +495,8 @@
         "              ",
         "              "
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -620,7 +640,8 @@
         "     "
       ],
       "place_vehicles": [ { "vehicle": "swivel_chair", "x": [ 1, 4 ], "y": [ 1, 2 ] } ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -635,7 +656,8 @@
         " bttb",
         "     "
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -650,7 +672,8 @@
         "M n ?",
         "     "
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -666,7 +689,8 @@
         "     "
       ],
       "palettes": [ "office_palette" ],
-      "place_vehicles": [ { "vehicle": "swivel_chair", "x": [ 1, 3 ], "y": [ 1, 3 ], "repeat": [ 1, 2 ] } ]
+      "place_vehicles": [ { "vehicle": "swivel_chair", "x": [ 1, 3 ], "y": [ 1, 3 ], "repeat": [ 1, 2 ] } ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -681,7 +705,8 @@
         " h   ",
         "dddx "
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -696,7 +721,8 @@
         "d h  ",
         "dddx^"
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -711,7 +737,8 @@
         "? n ?",
         "?   ?"
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -726,7 +753,8 @@
         "c h  ",
         "  fff"
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -741,7 +769,8 @@
         "*dh d",
         "*x  x"
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -756,7 +785,8 @@
         "? n ?",
         "?   ?"
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -771,7 +801,8 @@
         "     ",
         "     "
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -786,7 +817,8 @@
         "     ",
         "     "
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -801,7 +833,8 @@
         "     ",
         "     "
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -816,7 +849,8 @@
         "     ",
         "     "
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -831,7 +865,8 @@
         "     ",
         "     "
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -846,7 +881,8 @@
         "     ",
         "     "
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -861,7 +897,8 @@
         "     ",
         "     "
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -876,7 +913,8 @@
         "     ",
         "     "
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -891,7 +929,8 @@
         "     ",
         "     "
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -906,7 +945,8 @@
         "     ",
         "     "
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -921,7 +961,8 @@
         "     ",
         "     "
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -936,7 +977,8 @@
         "     ",
         "     "
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -1162,7 +1204,8 @@
         "  V     ",
         "   ^ ***"
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -1180,7 +1223,8 @@
         "        ",
         "        "
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -1198,7 +1242,8 @@
         "  V *   ",
         "      ^^"
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -1216,7 +1261,8 @@
         "     V  ",
         "   ff   "
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -1234,7 +1280,8 @@
         "        ",
         " Y  a   "
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -1252,7 +1299,8 @@
         "     V  ",
         "ff  Y   "
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -1270,7 +1318,8 @@
         "     V  ",
         "fff Y   "
       ],
-      "palettes": [ "office_palette" ]
+      "palettes": [ "office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   }
 ]

--- a/data/json/mapgen/nested/skyscraper_nested.json
+++ b/data/json/mapgen/nested/skyscraper_nested.json
@@ -1419,7 +1419,8 @@
         "****************"
       ],
       "terrain": { ".": { "param": "linoleum_color", "fallback": "t_linoleum_gray" } },
-      "palettes": [ "parametrized_linoleum_palette", "skyscraper_office_palette" ]
+      "palettes": [ "parametrized_linoleum_palette", "skyscraper_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -1447,7 +1448,8 @@
         "****************"
       ],
       "terrain": { ".": { "param": "linoleum_color", "fallback": "t_linoleum_gray" } },
-      "palettes": [ "parametrized_linoleum_palette", "skyscraper_office_palette" ]
+      "palettes": [ "parametrized_linoleum_palette", "skyscraper_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -1485,7 +1487,8 @@
         "t": { "param": "linoleum_color", "fallback": "t_linoleum_white" },
         "Y": { "param": "linoleum_color", "fallback": "t_linoleum_white" }
       },
-      "palettes": [ "parametrized_linoleum_palette", "skyscraper_office_palette" ]
+      "palettes": [ "parametrized_linoleum_palette", "skyscraper_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -1513,7 +1516,8 @@
         "****************"
       ],
       "terrain": { ".": { "param": "linoleum_color", "fallback": "t_linoleum_gray" } },
-      "palettes": [ "parametrized_linoleum_palette", "skyscraper_office_palette" ]
+      "palettes": [ "parametrized_linoleum_palette", "skyscraper_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -1541,7 +1545,8 @@
         "****************"
       ],
       "terrain": { ".": { "param": "linoleum_color", "fallback": "t_linoleum_gray" } },
-      "palettes": [ "parametrized_linoleum_palette", "skyscraper_office_palette" ]
+      "palettes": [ "parametrized_linoleum_palette", "skyscraper_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -1581,7 +1586,8 @@
       },
       "furniture": { "å": "f_trashcan", "⌅": [ "f_indoor_plant", "f_indoor_plant_y" ] },
       "palettes": [ "parametrized_linoleum_palette", "skyscraper_office_palette", "parametrized_carpets_nest_palette" ],
-      "place_vehicles": [ { "vehicle": "swivel_chair", "x": [ 9, 12 ], "y": [ 7, 8 ], "rotation": 90, "chance": 75, "repeat": [ 1, 2 ] } ]
+      "place_vehicles": [ { "vehicle": "swivel_chair", "x": [ 9, 12 ], "y": [ 7, 8 ], "rotation": 90, "chance": 75, "repeat": [ 1, 2 ] } ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -1621,7 +1627,8 @@
       },
       "furniture": { "å": "f_trashcan", "⌅": [ "f_indoor_plant", "f_indoor_plant_y" ] },
       "palettes": [ "parametrized_linoleum_palette", "skyscraper_office_palette", "parametrized_carpets_nest_palette" ],
-      "place_vehicles": [ { "vehicle": "swivel_chair", "x": [ 9, 12 ], "y": [ 7, 8 ], "rotation": 90, "chance": 75, "repeat": [ 1, 2 ] } ]
+      "place_vehicles": [ { "vehicle": "swivel_chair", "x": [ 9, 12 ], "y": [ 7, 8 ], "rotation": 90, "chance": 75, "repeat": [ 1, 2 ] } ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -1661,7 +1668,8 @@
       },
       "furniture": { "å": "f_trashcan", "⌅": [ "f_indoor_plant", "f_indoor_plant_y" ] },
       "palettes": [ "parametrized_linoleum_palette", "skyscraper_office_palette", "parametrized_carpets_nest_palette" ],
-      "place_vehicles": [ { "vehicle": "swivel_chair", "x": [ 9, 12 ], "y": [ 7, 8 ], "rotation": 90, "chance": 75, "repeat": [ 1, 2 ] } ]
+      "place_vehicles": [ { "vehicle": "swivel_chair", "x": [ 9, 12 ], "y": [ 7, 8 ], "rotation": 90, "chance": 75, "repeat": [ 1, 2 ] } ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -1701,7 +1709,8 @@
       },
       "furniture": { "å": "f_trashcan", "⌅": [ "f_indoor_plant", "f_indoor_plant_y" ] },
       "palettes": [ "parametrized_linoleum_palette", "skyscraper_office_palette", "parametrized_carpets_nest_palette" ],
-      "place_vehicles": [ { "vehicle": "swivel_chair", "x": [ 9, 12 ], "y": [ 7, 8 ], "rotation": 90, "chance": 75, "repeat": [ 1, 2 ] } ]
+      "place_vehicles": [ { "vehicle": "swivel_chair", "x": [ 9, 12 ], "y": [ 7, 8 ], "rotation": 90, "chance": 75, "repeat": [ 1, 2 ] } ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -1729,7 +1738,8 @@
         "****************"
       ],
       "terrain": { ".": { "param": "linoleum_color", "fallback": "t_linoleum_gray" } },
-      "palettes": [ "parametrized_linoleum_palette", "skyscraper_office_palette" ]
+      "palettes": [ "parametrized_linoleum_palette", "skyscraper_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -1765,7 +1775,8 @@
         "d": { "param": "linoleum_color", "fallback": "t_linoleum_white" },
         "x": { "param": "linoleum_color", "fallback": "t_linoleum_white" }
       },
-      "palettes": [ "parametrized_linoleum_palette", "skyscraper_office_palette" ]
+      "palettes": [ "parametrized_linoleum_palette", "skyscraper_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -2035,7 +2046,8 @@
         "*V.............."
       ],
       "terrain": { ".": { "param": "linoleum_color", "fallback": "t_linoleum_gray" } },
-      "palettes": [ "parametrized_linoleum_palette", "skyscraper_office_palette" ]
+      "palettes": [ "parametrized_linoleum_palette", "skyscraper_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -2063,7 +2075,8 @@
         "*V.............."
       ],
       "terrain": { ".": { "param": "linoleum_color", "fallback": "t_linoleum_gray" } },
-      "palettes": [ "parametrized_linoleum_palette", "skyscraper_office_palette" ]
+      "palettes": [ "parametrized_linoleum_palette", "skyscraper_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -2091,7 +2104,8 @@
         "*V.............."
       ],
       "terrain": { ".": { "param": "linoleum_color", "fallback": "t_linoleum_gray" } },
-      "palettes": [ "parametrized_linoleum_palette", "skyscraper_office_palette" ]
+      "palettes": [ "parametrized_linoleum_palette", "skyscraper_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -2119,7 +2133,8 @@
         "*V.............."
       ],
       "terrain": { ".": { "param": "linoleum_color", "fallback": "t_linoleum_gray" } },
-      "palettes": [ "parametrized_linoleum_palette", "skyscraper_office_palette" ]
+      "palettes": [ "parametrized_linoleum_palette", "skyscraper_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -2157,7 +2172,8 @@
         "M": { "param": "linoleum_color", "fallback": "t_linoleum_white" },
         "t": { "param": "linoleum_color", "fallback": "t_linoleum_white" }
       },
-      "palettes": [ "parametrized_linoleum_palette", "skyscraper_office_palette" ]
+      "palettes": [ "parametrized_linoleum_palette", "skyscraper_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -2185,7 +2201,8 @@
         "..............V*"
       ],
       "terrain": { ".": { "param": "linoleum_color", "fallback": "t_linoleum_gray" } },
-      "palettes": [ "parametrized_linoleum_palette", "skyscraper_office_palette" ]
+      "palettes": [ "parametrized_linoleum_palette", "skyscraper_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -2213,7 +2230,8 @@
         "..............V*"
       ],
       "terrain": { ".": { "param": "linoleum_color", "fallback": "t_linoleum_gray" } },
-      "palettes": [ "parametrized_linoleum_palette", "skyscraper_office_palette" ]
+      "palettes": [ "parametrized_linoleum_palette", "skyscraper_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -2241,7 +2259,8 @@
         "..............V*"
       ],
       "terrain": { ".": { "param": "linoleum_color", "fallback": "t_linoleum_gray" } },
-      "palettes": [ "parametrized_linoleum_palette", "skyscraper_office_palette" ]
+      "palettes": [ "parametrized_linoleum_palette", "skyscraper_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -2269,7 +2288,8 @@
         "..............V*"
       ],
       "terrain": { ".": { "param": "linoleum_color", "fallback": "t_linoleum_gray" } },
-      "palettes": [ "parametrized_linoleum_palette", "skyscraper_office_palette" ]
+      "palettes": [ "parametrized_linoleum_palette", "skyscraper_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -2305,7 +2325,8 @@
         "x": { "param": "linoleum_color", "fallback": "t_linoleum_white" },
         "Y": { "param": "linoleum_color", "fallback": "t_linoleum_white" }
       },
-      "palettes": [ "parametrized_linoleum_palette", "skyscraper_office_palette" ]
+      "palettes": [ "parametrized_linoleum_palette", "skyscraper_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -2457,7 +2478,8 @@
         "*****",
         "*****"
       ],
-      "palettes": [ "skyscraper_office_palette" ]
+      "palettes": [ "skyscraper_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -2474,7 +2496,8 @@
         "*****"
       ],
       "terrain": { ".": { "param": "linoleum_color", "fallback": "t_linoleum_gray" } },
-      "palettes": [ "parametrized_linoleum_palette", "skyscraper_office_palette" ]
+      "palettes": [ "parametrized_linoleum_palette", "skyscraper_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -2490,7 +2513,8 @@
         "*****",
         "*****"
       ],
-      "palettes": [ "skyscraper_office_palette" ]
+      "palettes": [ "skyscraper_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -2507,7 +2531,8 @@
         "*****"
       ],
       "terrain": { ".": { "param": "linoleum_color", "fallback": "t_linoleum_gray" } },
-      "palettes": [ "parametrized_linoleum_palette", "skyscraper_office_palette" ]
+      "palettes": [ "parametrized_linoleum_palette", "skyscraper_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -2523,7 +2548,8 @@
         "*****",
         "*****"
       ],
-      "palettes": [ "skyscraper_office_palette" ]
+      "palettes": [ "skyscraper_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {

--- a/data/mods/Xedra_Evolved/mapgen/nested/field_office_nests.json
+++ b/data/mods/Xedra_Evolved/mapgen/nested/field_office_nests.json
@@ -149,7 +149,8 @@
         "....."
       ],
       "place_vehicles": [ { "vehicle": "swivel_chair", "x": [ 1, 4 ], "y": [ 1, 1 ], "rotation": 90, "chance": 75, "repeat": [ 1, 2 ] } ],
-      "palettes": [ "field_office_palette" ]
+      "palettes": [ "field_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -181,7 +182,8 @@
         "M.n.?",
         "....."
       ],
-      "palettes": [ "field_office_palette" ]
+      "palettes": [ "field_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -198,7 +200,8 @@
         "....."
       ],
       "palettes": [ "field_office_palette" ],
-      "place_vehicles": [ { "vehicle": "swivel_chair", "x": [ 1, 3 ], "y": [ 1, 2 ], "rotation": 90, "chance": 75, "repeat": [ 1, 2 ] } ]
+      "place_vehicles": [ { "vehicle": "swivel_chair", "x": [ 1, 3 ], "y": [ 1, 2 ], "rotation": 90, "chance": 75, "repeat": [ 1, 2 ] } ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -225,7 +228,8 @@
         "****************",
         "****************"
       ],
-      "palettes": [ "field_office_palette" ]
+      "palettes": [ "field_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -252,7 +256,8 @@
         "****************",
         "****************"
       ],
-      "palettes": [ "field_office_palette" ]
+      "palettes": [ "field_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -279,7 +284,8 @@
         "****************",
         "****************"
       ],
-      "palettes": [ "field_office_palette" ]
+      "palettes": [ "field_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -306,7 +312,8 @@
         "****************",
         "****************"
       ],
-      "palettes": [ "field_office_palette" ]
+      "palettes": [ "field_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -333,7 +340,8 @@
         "****************",
         "****************"
       ],
-      "palettes": [ "field_office_palette" ]
+      "palettes": [ "field_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -360,7 +368,8 @@
         "****************",
         "****************"
       ],
-      "palettes": [ "field_office_palette" ]
+      "palettes": [ "field_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -388,7 +397,8 @@
         "****************"
       ],
       "palettes": [ "field_office_palette" ],
-      "place_vehicles": [ { "vehicle": "swivel_chair", "x": [ 9, 12 ], "y": [ 7, 8 ], "rotation": 90, "chance": 75, "repeat": [ 1, 2 ] } ]
+      "place_vehicles": [ { "vehicle": "swivel_chair", "x": [ 9, 12 ], "y": [ 7, 8 ], "rotation": 90, "chance": 75, "repeat": [ 1, 2 ] } ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -415,7 +425,8 @@
         "****************",
         "****************"
       ],
-      "palettes": [ "field_office_palette" ]
+      "palettes": [ "field_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -442,7 +453,8 @@
         "****************",
         "****************"
       ],
-      "palettes": [ "field_office_palette" ]
+      "palettes": [ "field_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -469,7 +481,8 @@
         "****************",
         "****************"
       ],
-      "palettes": [ "field_office_palette" ]
+      "palettes": [ "field_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -496,7 +509,8 @@
         "****************",
         "****************"
       ],
-      "palettes": [ "field_office_palette" ]
+      "palettes": [ "field_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -523,7 +537,8 @@
         "****************",
         "****************"
       ],
-      "palettes": [ "field_office_palette" ]
+      "palettes": [ "field_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -540,7 +555,8 @@
         "FFF.."
       ],
       "palettes": [ "field_office_palette" ],
-      "place_vehicles": [ { "vehicle": "swivel_chair", "x": [ 0, 3 ], "y": [ 2, 3 ], "rotation": 90, "chance": 75, "repeat": [ 1, 2 ] } ]
+      "place_vehicles": [ { "vehicle": "swivel_chair", "x": [ 0, 3 ], "y": [ 2, 3 ], "rotation": 90, "chance": 75, "repeat": [ 1, 2 ] } ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -556,7 +572,8 @@
         ".h...",
         "ddcx."
       ],
-      "palettes": [ "field_office_palette" ]
+      "palettes": [ "field_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -572,7 +589,8 @@
         "d.h..",
         "dccx^"
       ],
-      "palettes": [ "field_office_palette" ]
+      "palettes": [ "field_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -588,7 +606,8 @@
         "?.n.?",
         "?...?"
       ],
-      "palettes": [ "field_office_palette" ]
+      "palettes": [ "field_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -615,7 +634,8 @@
         "*V..............",
         "*V.............."
       ],
-      "palettes": [ "field_office_palette" ]
+      "palettes": [ "field_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -642,7 +662,8 @@
         "*V..............",
         "*V.............."
       ],
-      "palettes": [ "field_office_palette" ]
+      "palettes": [ "field_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -669,7 +690,8 @@
         "*V..............",
         "*V.............."
       ],
-      "palettes": [ "field_office_palette" ]
+      "palettes": [ "field_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -696,7 +718,8 @@
         "*V..............",
         "*V.............."
       ],
-      "palettes": [ "field_office_palette" ]
+      "palettes": [ "field_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -723,7 +746,8 @@
         "*V..............",
         "*V.............."
       ],
-      "palettes": [ "field_office_palette" ]
+      "palettes": [ "field_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -750,7 +774,8 @@
         "..............V*",
         "..............V*"
       ],
-      "palettes": [ "field_office_palette" ]
+      "palettes": [ "field_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -777,7 +802,8 @@
         "..............V*",
         "..............V*"
       ],
-      "palettes": [ "field_office_palette" ]
+      "palettes": [ "field_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -804,7 +830,8 @@
         "..............V*",
         "..............V*"
       ],
-      "palettes": [ "field_office_palette" ]
+      "palettes": [ "field_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -831,7 +858,8 @@
         "..............V*",
         "..............V*"
       ],
-      "palettes": [ "field_office_palette" ]
+      "palettes": [ "field_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -858,7 +886,8 @@
         "..............V*",
         "..............V*"
       ],
-      "palettes": [ "field_office_palette" ]
+      "palettes": [ "field_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -874,7 +903,8 @@
         "d.h..",
         "..FFF"
       ],
-      "palettes": [ "field_office_palette" ]
+      "palettes": [ "field_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -890,7 +920,8 @@
         ".dh.d",
         ".xccx"
       ],
-      "palettes": [ "field_office_palette" ]
+      "palettes": [ "field_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -906,7 +937,8 @@
         "?.n.?",
         "?...?"
       ],
-      "palettes": [ "field_office_palette" ]
+      "palettes": [ "field_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -922,7 +954,8 @@
         "*****",
         "*****"
       ],
-      "palettes": [ "field_office_palette" ]
+      "palettes": [ "field_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -938,7 +971,8 @@
         "*****",
         "*****"
       ],
-      "palettes": [ "field_office_palette" ]
+      "palettes": [ "field_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -954,7 +988,8 @@
         "*****",
         "*****"
       ],
-      "palettes": [ "field_office_palette" ]
+      "palettes": [ "field_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -970,7 +1005,8 @@
         "*****",
         "*****"
       ],
-      "palettes": [ "field_office_palette" ]
+      "palettes": [ "field_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {
@@ -986,7 +1022,8 @@
         "*****",
         "*****"
       ],
-      "palettes": [ "field_office_palette" ]
+      "palettes": [ "field_office_palette" ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_FURNITURE" ]
     }
   },
   {

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -5075,10 +5075,25 @@ static std::set<ter_str_id> get_terrain_ids( const jmapgen_piece *piece,
 // Check if a terrain piece is effectively a no-op at runtime.
 // This covers both truly-null IDs and "t_null" which is not defined in JSON data
 // and resolves to the null terrain -- the apply() method returns early for it.
+// Conservatively returns false for region terrains that can't be resolved statically.
 static bool is_terrain_effectively_nop( const jmapgen_piece *piece,
                                         const mapgen_parameters &params )
 {
-    return get_terrain_ids( piece, params ).empty();
+    if( piece->is_nop() ) {
+        return true;
+    }
+    const std::set<ter_str_id> ids = get_terrain_ids( piece, params );
+    if( !ids.empty() ) {
+        return false;
+    }
+    // Empty IDs but still a terrain piece (e.g. region terrain) -- not a nop.
+    const jmapgen_piece *unwrapped = piece;
+    if( const auto *constrained =
+            dynamic_cast<const jmapgen_constrained<palette_id> *>( piece ) ) {
+        unwrapped = constrained->underlying_piece.get();
+    }
+    const auto *as_ter = dynamic_cast<const jmapgen_terrain *>( unwrapped );
+    return as_ter == nullptr;
 }
 
 // Same as above but for furniture. f_null is not defined in JSON data and
@@ -5121,6 +5136,38 @@ static bool flags_clear_furniture( const enum_bitset<jmapgen_flags> &flags )
 bool mapgen_function_json_base::has_furniture_clearing_flags() const
 {
     return flags_clear_furniture( flags_ );
+}
+
+// Like flags_clear_furniture but returns false for "dismantle" -- unbashable
+// furniture (e.g. f_rubble) survives dismantling and still triggers errors.
+static bool flags_reliably_clear_furniture( const enum_bitset<jmapgen_flags> &flags )
+{
+    enum class furn_action { none, allow, dismantle, erase };
+    furn_action act = furn_action::none;
+
+    // Shorthand flags, then specific overrides (same precedence as runtime)
+    if( flags.test( jmapgen_flags::allow_terrain_under_other_data ) ) {
+        act = furn_action::allow;
+    } else if( flags.test( jmapgen_flags::dismantle_all_before_placing_terrain ) ) {
+        act = furn_action::dismantle;
+    } else if( flags.test( jmapgen_flags::erase_all_before_placing_terrain ) ) {
+        act = furn_action::erase;
+    }
+
+    if( flags.test( jmapgen_flags::allow_terrain_under_furniture ) ) {
+        act = furn_action::allow;
+    } else if( flags.test( jmapgen_flags::dismantle_furniture_before_placing_terrain ) ) {
+        act = furn_action::dismantle;
+    } else if( flags.test( jmapgen_flags::erase_furniture_before_placing_terrain ) ) {
+        act = furn_action::erase;
+    }
+
+    return act == furn_action::allow || act == furn_action::erase;
+}
+
+bool mapgen_function_json_base::reliably_clears_furniture() const
+{
+    return flags_reliably_clear_furniture( flags_ );
 }
 
 point_rel_ms mapgen_function_json_base::get_mapgensize() const
@@ -5410,6 +5457,142 @@ void jmapgen_objects::collect_terrain_data(
     }
 }
 
+// Check if piece is jmapgen_make_rubble (place_rubble), unwrapping constraints.
+static bool is_rubble_piece( const jmapgen_piece *piece )
+{
+    if( dynamic_cast<const jmapgen_make_rubble *>( piece ) ) {
+        return true;
+    }
+    if( const auto *constrained =
+            dynamic_cast<const jmapgen_constrained<palette_id> *>( piece ) ) {
+        return is_rubble_piece( constrained->underlying_piece.get() );
+    }
+    return false;
+}
+
+void mapgen_function_json_base::collect_furniture_coords(
+    std::set<point_rel_ms> &coords, int depth_limit ) const
+{
+    if( depth_limit <= 0 ) {
+        return;
+    }
+    objects.collect_furniture_coords( coords, parameters, depth_limit );
+}
+
+void jmapgen_objects::collect_furniture_coords(
+    std::set<point_rel_ms> &coords,
+    const mapgen_parameters &params, int depth_limit ) const
+{
+    static std::unordered_map<nested_mapgen_id, std::set<point_rel_ms>> furn_cache;
+
+    // Direct furniture and rubble placements at z=0
+    for( const jmapgen_obj &obj : objects ) {
+        const jmapgen_place &where = obj.first;
+        if( where.z.val > 0 || where.z.valmax < 0 ) {
+            continue;
+        }
+        bool produces_furn = false;
+        if( obj.second->phase() == mapgen_phase::furniture &&
+            !is_furniture_effectively_nop( obj.second.get(), params ) ) {
+            produces_furn = true;
+        }
+        // place_rubble also produces furniture
+        if( obj.second->phase() == mapgen_phase::default_ &&
+            is_rubble_piece( obj.second.get() ) ) {
+            produces_furn = true;
+        }
+        if( produces_furn ) {
+            for( int x = where.x.val; x <= where.x.valmax; ++x ) {
+                for( int y = where.y.val; y <= where.y.valmax; ++y ) {
+                    coords.emplace( x, y );
+                }
+            }
+        }
+    }
+
+    // Furniture from nested mapgens (recursively)
+    if( depth_limit <= 0 ) {
+        return;
+    }
+    for( const jmapgen_obj &obj : objects ) {
+        if( obj.second->phase() != mapgen_phase::nested_mapgen ) {
+            continue;
+        }
+        const jmapgen_nested *nested = try_get_nested( obj.second.get() );
+        if( nested == nullptr ) {
+            continue;
+        }
+        const jmapgen_place &where = obj.first;
+        if( where.z.val > 0 || where.z.valmax < 0 ) {
+            continue;
+        }
+
+        auto process_entries = [&](
+        const weighted_dbl_or_var_list<mapgen_value<nested_mapgen_id>> &entry_list ) {
+            for( const std::pair<mapgen_value<nested_mapgen_id>, dbl_or_var> &entry :
+                 entry_list ) {
+                for( const nested_mapgen_id &nest_id :
+                     entry.first.all_possible_results( params ) ) {
+                    if( nest_id.is_null() ) {
+                        continue;
+                    }
+                    auto cache_it = furn_cache.find( nest_id );
+                    if( cache_it == furn_cache.end() ) {
+                        const auto map_it = nested_mapgens.find( nest_id );
+                        if( map_it == nested_mapgens.end() ) {
+                            furn_cache.emplace( nest_id, std::set<point_rel_ms>() );
+                            continue;
+                        }
+                        std::set<point_rel_ms> sub_coords;
+                        for( const std::pair<std::shared_ptr<mapgen_function_json_nested>, int>
+                             &variant_pair : map_it->second.funcs() ) {
+                            variant_pair.first->collect_furniture_coords(
+                                sub_coords, depth_limit - 1 );
+                        }
+                        cache_it = furn_cache.emplace( nest_id, std::move( sub_coords ) ).first;
+                    }
+                    const std::set<point_rel_ms> &sub_coords = cache_it->second;
+                    for( const point_rel_ms &sc : sub_coords ) {
+                        for( int nx = where.x.val; nx <= where.x.valmax; ++nx ) {
+                            for( int ny = where.y.val; ny <= where.y.valmax; ++ny ) {
+                                coords.emplace( nx + sc.x(), ny + sc.y() );
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        process_entries( nested->entries );
+        process_entries( nested->else_entries );
+    }
+}
+
+void jmapgen_objects::collect_terrain_coords_for_sibling(
+    std::set<point_rel_ms> &coords,
+    const mapgen_parameters &/*params*/ ) const
+{
+    for( const jmapgen_obj &obj : objects ) {
+        if( obj.second->phase() != mapgen_phase::terrain ) {
+            continue;
+        }
+        // Uses is_nop() instead of is_terrain_effectively_nop to catch
+        // region terrains that can't be resolved statically.
+        if( obj.second->is_nop() ) {
+            continue;
+        }
+        const jmapgen_place &where = obj.first;
+        if( where.z.val > 0 || where.z.valmax < 0 ) {
+            continue;
+        }
+        for( int x = where.x.val; x <= where.x.valmax; ++x ) {
+            for( int y = where.y.val; y <= where.y.valmax; ++y ) {
+                coords.emplace( x, y );
+            }
+        }
+    }
+}
+
 void jmapgen_objects::check_nested_overlaps(
     const std::string &context,
     const mapgen_parameters &parameters,
@@ -5435,11 +5618,137 @@ void jmapgen_objects::check_nested_overlaps(
         }
     }
 
-    if( furn_positions.empty() ) {
-        return;
-    }
+    // Phase 1: parent furniture vs nested terrain (skip if no parent furniture)
+    if( !furn_positions.empty() ) {
 
-    // For each nested piece, check if its actual terrain positions overlap furniture
+        // For each nested piece, check if its actual terrain positions overlap furniture
+        for( const jmapgen_obj &obj : objects ) {
+            if( obj.second->phase() != mapgen_phase::nested_mapgen ) {
+                continue;
+            }
+            const jmapgen_nested *nested = try_get_nested( obj.second.get() );
+            if( nested == nullptr ) {
+                continue;
+            }
+            const jmapgen_place &where = obj.first;
+            // Only check nests placed at z=0 (same level as the furniture we collected)
+            if( where.z.val > 0 || where.z.valmax < 0 ) {
+                continue;
+            }
+
+            auto check_entries = [&]( const weighted_dbl_or_var_list<mapgen_value<nested_mapgen_id>>
+            &entry_list ) -> bool {
+                for( const std::pair<mapgen_value<nested_mapgen_id>, dbl_or_var> &entry : entry_list )
+                {
+                    for( const nested_mapgen_id &nest_id :
+                         entry.first.all_possible_results( parameters ) ) {
+                        if( nest_id.is_null() ) {
+                            continue;
+                        }
+                        const auto it = nested_mapgens.find( nest_id );
+                        if( it == nested_mapgens.end() ) {
+                            continue;
+                        }
+                        for( const std::pair<std::shared_ptr<mapgen_function_json_nested>, int>
+                             &variant_pair : it->second.funcs() ) {
+                            const mapgen_function_json_nested &variant = *variant_pair.first;
+                            // Get terrain data (positions + IDs) from this nested mapgen
+                            terrain_coord_map nest_terrain;
+                            variant.collect_terrain_data( nest_terrain );
+                            if( nest_terrain.empty() ) {
+                                continue;
+                            }
+                            // Check each terrain coord offset by each possible nest position
+                            for( const auto &[tc, nest_ter_ids] : nest_terrain ) {
+                                for( int nx = where.x.val; nx <= where.x.valmax; ++nx ) {
+                                    for( int ny = where.y.val; ny <= where.y.valmax; ++ny ) {
+                                        const point_rel_ms abs_pos( nx + tc.x(), ny + tc.y() );
+                                        if( !furn_positions.count( abs_pos ) ) {
+                                            continue;
+                                        }
+
+                                        // Build effective parent terrain at this position
+                                        std::set<ter_str_id> parent_ter;
+                                        auto pit = parent_explicit_terrain.find( abs_pos );
+                                        if( pit != parent_explicit_terrain.end() ) {
+                                            parent_ter = pit->second;
+                                        } else if( fill_ter ) {
+                                            for( const ter_str_id &tid :
+                                                 fill_ter->all_possible_results( parameters ) ) {
+                                                parent_ter.insert( tid );
+                                            }
+                                        }
+
+                                        // Singleton-equality skip: if both parent and nest terrain
+                                        // resolve to exactly one ID and they match, the runtime
+                                        // chosen_id != terrain_here guard makes this a no-op
+                                        if( parent_ter.size() == 1 && nest_ter_ids.size() == 1 &&
+                                            *parent_ter.begin() == *nest_ter_ids.begin() ) {
+                                            continue;
+                                        }
+
+                                        // is_boring_wall skip: if all nest terrain IDs are walls
+                                        // without PLACE_ITEM, runtime auto-clears furniture
+                                        bool all_boring_walls = true;
+                                        for( const ter_str_id &tid : nest_ter_ids ) {
+                                            const ter_t &t = *tid.id();
+                                            if( !t.has_flag( ter_furn_flag::TFLAG_WALL ) ||
+                                                t.has_flag( ter_furn_flag::TFLAG_PLACE_ITEM ) ) {
+                                                all_boring_walls = false;
+                                                break;
+                                            }
+                                        }
+                                        if( all_boring_walls ) {
+                                            continue;
+                                        }
+
+                                        const point_rel_ms nest_size = variant.get_mapgensize();
+                                        debugmsg(
+                                            "In %s, nested mapgen %s (size %dx%d) placed at "
+                                            "(%d-%d, %d-%d) sets terrain at (%d, %d) which "
+                                            "overlaps with furniture.  Add a clearing flag "
+                                            "(e.g. ERASE_FURNITURE_BEFORE_PLACING_TERRAIN) to "
+                                            "the nested mapgen, or move the furniture.",
+                                            context,
+                                            nest_id.str(),
+                                            nest_size.x(), nest_size.y(),
+                                            where.x.val, where.x.valmax,
+                                            where.y.val, where.y.valmax,
+                                            abs_pos.x(), abs_pos.y() );
+                                        return true;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                return false;
+            };
+
+            if( check_entries( nested->entries ) ) {
+                return;
+            }
+            check_entries( nested->else_entries );
+        }
+    } // end Phase 1 furn_positions guard
+
+    // Phase 2: sibling nested mapgens whose furniture/terrain overlap.
+
+    struct sibling_info {
+        const jmapgen_place *where;
+        std::string nest_id_str;
+        point_rel_ms nest_size;
+        std::set<point_rel_ms> furniture;
+        std::set<point_rel_ms> terrain;
+        bool reliably_clears;
+        // Which place_nested entry this came from; alternatives within one
+        // entry are mutually exclusive at runtime, so same-index pairs skip.
+        size_t piece_index;
+    };
+
+    std::vector<sibling_info> siblings;
+    size_t current_piece_index = 0;
+
     for( const jmapgen_obj &obj : objects ) {
         if( obj.second->phase() != mapgen_phase::nested_mapgen ) {
             continue;
@@ -5449,15 +5758,16 @@ void jmapgen_objects::check_nested_overlaps(
             continue;
         }
         const jmapgen_place &where = obj.first;
-        // Only check nests placed at z=0 (same level as the furniture we collected)
         if( where.z.val > 0 || where.z.valmax < 0 ) {
             continue;
         }
 
-        auto check_entries = [&]( const weighted_dbl_or_var_list<mapgen_value<nested_mapgen_id>>
-        &entry_list ) -> bool {
-            for( const std::pair<mapgen_value<nested_mapgen_id>, dbl_or_var> &entry : entry_list )
-            {
+        const size_t this_piece_index = current_piece_index++;
+
+        auto process_nest = [&](
+        const weighted_dbl_or_var_list<mapgen_value<nested_mapgen_id>> &entry_list ) {
+            for( const std::pair<mapgen_value<nested_mapgen_id>, dbl_or_var> &entry :
+                 entry_list ) {
                 for( const nested_mapgen_id &nest_id :
                      entry.first.all_possible_results( parameters ) ) {
                     if( nest_id.is_null() ) {
@@ -5470,83 +5780,83 @@ void jmapgen_objects::check_nested_overlaps(
                     for( const std::pair<std::shared_ptr<mapgen_function_json_nested>, int>
                          &variant_pair : it->second.funcs() ) {
                         const mapgen_function_json_nested &variant = *variant_pair.first;
-                        // Get terrain data (positions + IDs) from this nested mapgen
-                        terrain_coord_map nest_terrain;
-                        variant.collect_terrain_data( nest_terrain );
-                        if( nest_terrain.empty() ) {
-                            continue;
+
+                        sibling_info info;
+                        info.where = &where;
+                        info.nest_id_str = nest_id.str();
+                        info.nest_size = variant.get_mapgensize();
+                        info.reliably_clears = variant.reliably_clears_furniture();
+
+                        // Collect terrain ignoring this nest's own clearing flags
+                        const mapgen_parameters &nest_params = variant.get_parameters();
+                        variant.jmapgen_objects_for_check().collect_terrain_coords_for_sibling(
+                            info.terrain, nest_params );
+                        variant.collect_furniture_coords( info.furniture, 3 );
+
+                        info.piece_index = this_piece_index;
+                        if( !info.terrain.empty() || !info.furniture.empty() ) {
+                            siblings.push_back( std::move( info ) );
                         }
-                        // Check each terrain coord offset by each possible nest position
-                        for( const auto &[tc, nest_ter_ids] : nest_terrain ) {
-                            for( int nx = where.x.val; nx <= where.x.valmax; ++nx ) {
-                                for( int ny = where.y.val; ny <= where.y.valmax; ++ny ) {
-                                    const point_rel_ms abs_pos( nx + tc.x(), ny + tc.y() );
-                                    if( !furn_positions.count( abs_pos ) ) {
-                                        continue;
-                                    }
+                    }
+                }
+            }
+        };
 
-                                    // Build effective parent terrain at this position
-                                    std::set<ter_str_id> parent_ter;
-                                    auto pit = parent_explicit_terrain.find( abs_pos );
-                                    if( pit != parent_explicit_terrain.end() ) {
-                                        parent_ter = pit->second;
-                                    } else if( fill_ter ) {
-                                        for( const ter_str_id &tid :
-                                             fill_ter->all_possible_results( parameters ) ) {
-                                            parent_ter.insert( tid );
+        process_nest( nested->entries );
+        process_nest( nested->else_entries );
+    }
+
+    // Check all sibling pairs for furniture/terrain overlap
+    for( size_t i = 0; i < siblings.size(); ++i ) {
+        for( size_t j = i + 1; j < siblings.size(); ++j ) {
+            // Same place_nested entry -- mutually exclusive at runtime
+            if( siblings[i].piece_index == siblings[j].piece_index ) {
+                continue;
+            }
+            auto check_pair = [&]( const sibling_info & furn_sib,
+            const sibling_info & ter_sib ) {
+                if( ter_sib.reliably_clears || ter_sib.terrain.empty() ||
+                    furn_sib.furniture.empty() ) {
+                    return;
+                }
+                const jmapgen_place &fw = *furn_sib.where;
+                const jmapgen_place &tw = *ter_sib.where;
+                for( const point_rel_ms &tc : ter_sib.terrain ) {
+                    for( int tnx = tw.x.val; tnx <= tw.x.valmax; ++tnx ) {
+                        for( int tny = tw.y.val; tny <= tw.y.valmax; ++tny ) {
+                            const point_rel_ms ter_abs( tnx + tc.x(), tny + tc.y() );
+                            for( const point_rel_ms &fc : furn_sib.furniture ) {
+                                for( int fnx = fw.x.val; fnx <= fw.x.valmax; ++fnx ) {
+                                    for( int fny = fw.y.val; fny <= fw.y.valmax; ++fny ) {
+                                        if( ter_abs == point_rel_ms( fnx + fc.x(),
+                                                                     fny + fc.y() ) ) {
+                                            debugmsg(
+                                                "In %s, sibling nested mapgens %s and %s "
+                                                "overlap at (%d, %d): %s places furniture "
+                                                "and %s places terrain without a reliable "
+                                                "clearing flag (ALLOW_TERRAIN_UNDER_FURNITURE "
+                                                "or ERASE_FURNITURE_BEFORE_PLACING_TERRAIN).  "
+                                                "Add a clearing flag to %s, or prevent the "
+                                                "overlap.",
+                                                context,
+                                                furn_sib.nest_id_str,
+                                                ter_sib.nest_id_str,
+                                                ter_abs.x(), ter_abs.y(),
+                                                furn_sib.nest_id_str,
+                                                ter_sib.nest_id_str,
+                                                ter_sib.nest_id_str );
+                                            return;
                                         }
                                     }
-
-                                    // Singleton-equality skip: if both parent and nest terrain
-                                    // resolve to exactly one ID and they match, the runtime
-                                    // chosen_id != terrain_here guard makes this a no-op
-                                    if( parent_ter.size() == 1 && nest_ter_ids.size() == 1 &&
-                                        *parent_ter.begin() == *nest_ter_ids.begin() ) {
-                                        continue;
-                                    }
-
-                                    // is_boring_wall skip: if all nest terrain IDs are walls
-                                    // without PLACE_ITEM, runtime auto-clears furniture
-                                    bool all_boring_walls = true;
-                                    for( const ter_str_id &tid : nest_ter_ids ) {
-                                        const ter_t &t = *tid.id();
-                                        if( !t.has_flag( ter_furn_flag::TFLAG_WALL ) ||
-                                            t.has_flag( ter_furn_flag::TFLAG_PLACE_ITEM ) ) {
-                                            all_boring_walls = false;
-                                            break;
-                                        }
-                                    }
-                                    if( all_boring_walls ) {
-                                        continue;
-                                    }
-
-                                    const point_rel_ms nest_size = variant.get_mapgensize();
-                                    debugmsg(
-                                        "In %s, nested mapgen %s (size %dx%d) placed at "
-                                        "(%d-%d, %d-%d) sets terrain at (%d, %d) which "
-                                        "overlaps with furniture.  Add a clearing flag "
-                                        "(e.g. ERASE_FURNITURE_BEFORE_PLACING_TERRAIN) to "
-                                        "the nested mapgen, or move the furniture.",
-                                        context,
-                                        nest_id.str(),
-                                        nest_size.x(), nest_size.y(),
-                                        where.x.val, where.x.valmax,
-                                        where.y.val, where.y.valmax,
-                                        abs_pos.x(), abs_pos.y() );
-                                    return true;
                                 }
                             }
                         }
                     }
                 }
-            }
-            return false;
-        };
-
-        if( check_entries( nested->entries ) ) {
-            return;
+            };
+            check_pair( siblings[i], siblings[j] );
+            check_pair( siblings[j], siblings[i] );
         }
-        check_entries( nested->else_entries );
     }
 }
 

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -415,6 +415,8 @@ struct jmapgen_objects {
                                      const mapgen_parameters &params, int depth_limit ) const;
         void collect_terrain_data( terrain_coord_map &data,
                                    const mapgen_parameters &params, int depth_limit ) const;
+        void collect_furniture_coords( std::set<point_rel_ms> &coords,
+                                       const mapgen_parameters &params, int depth_limit ) const;
         void check_nested_overlaps(
             const std::string &context,
             const mapgen_parameters &parameters,
@@ -432,6 +434,8 @@ struct jmapgen_objects {
          **/
         ret_val<void> has_vehicle_collision( const mapgendata &dat, const tripoint_rel_ms &offset ) const;
 
+        void collect_terrain_coords_for_sibling( std::set<point_rel_ms> &coords,
+                const mapgen_parameters &params ) const;
     private:
         /**
          * Combination of where to place something and what to place.
@@ -456,12 +460,15 @@ class mapgen_function_json_base
         void add_placement_coords_to( std::unordered_set<point_rel_ms> & ) const;
 
         bool has_furniture_clearing_flags() const;
+        bool reliably_clears_furniture() const;
         point_rel_ms get_mapgensize() const;
         bool has_unguarded_terrain_for_furniture( int depth_limit = 10 ) const;
         void collect_terrain_coords( std::set<point_rel_ms> &coords,
                                      int depth_limit = 10 ) const;
         void collect_terrain_data( terrain_coord_map &data,
                                    int depth_limit = 10 ) const;
+        void collect_furniture_coords( std::set<point_rel_ms> &coords,
+                                       int depth_limit = 10 ) const;
         void collect_setmap_terrain( terrain_coord_map &data ) const;
 
         virtual const mapgen_value<ter_id> *get_fill_ter() const {
@@ -470,6 +477,11 @@ class mapgen_function_json_base
 
         const mapgen_parameters &get_parameters() const {
             return parameters;
+        }
+
+        // For static sibling overlap checks
+        const jmapgen_objects &jmapgen_objects_for_check() const {
+            return objects;
         }
 
     private:


### PR DESCRIPTION
#### Summary
Infrastructure "Add sibling overlap detection to mapgen static check"

#### Purpose of change

The static overlap check from #85677 catches parent-child conflicts but not sibling-sibling ones -- when two `place_nested` entries in the same parent both fire and one's furniture clashes with the other's terrain. Crater mapgen had exactly this: overlapping chunks placed f_rubble via palette, and the sibling's terrain couldn't dismantle it (f_rubble has no bash/deconstruct). This produced thousands of stochastic runtime errors that made Windows CI flaky.

#### Describe the solution

Second pass in `check_nested_overlaps` that checks all sibling pairs from *different* `place_nested` entries. Same-entry pairs are skipped since the chunks list is a weighted alternative -- only one fires.

New helpers: `collect_furniture_coords` (recurses through nested chains including place_rubble), `collect_terrain_coords_for_sibling` (handles region terrains that can't be resolved statically), `reliably_clears_furniture` (ALLOW/ERASE work, DISMANTLE doesn't on unbashable furniture).

Crater fix: dropped `DISMANTLE_FURNITURE_BEFORE_PLACING_TERRAIN`, kept `ALLOW_TERRAIN_UNDER_OTHER_DATA`. The DISMANTLE was overriding ALLOW's act_furn=ignore, and f_rubble can't be dismantled.

124 nested mapgens got `ALLOW_TERRAIN_UNDER_FURNITURE` to resolve real overlaps -- 87 in vanilla (offices, skyscrapers, mines, labs, farms, etc.) and 37 in Xedra Evolved (field office nests).

#### Describe alternatives you've considered

Could've just fixed crater.json, but the same pattern lurks in dozens of other mapgens that haven't blown up yet only because their furniture happens to be bashable or their position ranges rarely overlap.

#### Testing

`[mapgen]` validation passes clean. Verified aftershock, MindOverMatter, Isolation Protocol, Xedra Evolved, Magiclysm, DinoMod, and classic_zombies individually -- all zero sibling errors. Also verified the all-mods combo that CI runs.

#### Additional context

The crater errors were seed-dependent -- `clear_overmaps()` sometimes spawns craters near the player, sometimes doesn't. 50% of recent Windows builds failed with 1-3 thousand errors in logs despite all assertions passing.