### PR TITLE
Fix spawned eoc and debug menu maps

### DIFF
--- a/data/mods/Xedra_Evolved/items/ethereal_items.json
+++ b/data/mods/Xedra_Evolved/items/ethereal_items.json
@@ -337,7 +337,7 @@
     "description": { "str": "The item for .", "//~": "NO_I18N" },
     "weight": "30 g",
     "volume": "250 ml",
-    "flags": [ "PAPER_SHAPED" ],
+    "flags": [ "PAPER_SHAPED", "PRESERVE_SPAWN_LOC" ],
     "price": "10 USD",
     "price_postapoc": "10 USD",
     "material": [ "elemental_water" ],

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -3760,8 +3760,8 @@ void receive_item( const itype_id &item_id, int count, const itype_id &container
                    const tripoint_abs_ms &p = tripoint_abs_ms::zero, bool force_equip = false )
 {
     item new_item = item( item_id, calendar::turn );
-    if (new_item.has_flag( flag_PRESERVE_SPAWN_LOC) ) {
-        new_item.preserve_location(p);
+    if( new_item.has_flag( flag_PRESERVE_SPAWN_LOC ) ) {
+        new_item.preserve_location( p );
     }
     for( const std::string &flag : flags ) {
         new_item.set_flag( flag_id( flag ) );
@@ -3825,8 +3825,8 @@ void receive_item_group( const item_group_id &group_id, const dialogue &d, bool 
         for( const std::string &flag : flags ) {
             new_item.set_flag( flag_id( flag ) );
         }
-        if ( new_item.has_flag( flag_PRESERVE_SPAWN_LOC ) ) {
-            new_item.preserve_location(p);
+        if( new_item.has_flag( flag_PRESERVE_SPAWN_LOC ) ) {
+            new_item.preserve_location( p );
         }
         if( add_talker ) {
             d.actor( false )->i_add_or_drop( new_item, force_equip );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -3760,8 +3760,8 @@ void receive_item( const itype_id &item_id, int count, const itype_id &container
                    const tripoint_abs_ms &p = tripoint_abs_ms::zero, bool force_equip = false )
 {
     item new_item = item( item_id, calendar::turn );
-    if (new_item.is_map()) {
-        new_item.preserve_location(p);
+    if( new_item.is_map() ) {
+        new_item.preserve_location( p );
     }
     for( const std::string &flag : flags ) {
         new_item.set_flag( flag_id( flag ) );
@@ -3825,8 +3825,8 @@ void receive_item_group( const item_group_id &group_id, const dialogue &d, bool 
         for( const std::string &flag : flags ) {
             new_item.set_flag( flag_id( flag ) );
         }
-        if (new_item.is_map()) {
-            new_item.preserve_location(p);
+        if( new_item.is_map() ) {
+            new_item.preserve_location( p );
         }
         if( add_talker ) {
             d.actor( false )->i_add_or_drop( new_item, force_equip );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -3760,6 +3760,9 @@ void receive_item( const itype_id &item_id, int count, const itype_id &container
                    const tripoint_abs_ms &p = tripoint_abs_ms::zero, bool force_equip = false )
 {
     item new_item = item( item_id, calendar::turn );
+    if (new_item.is_map()) {
+        new_item.preserve_location(p);
+    }
     for( const std::string &flag : flags ) {
         new_item.set_flag( flag_id( flag ) );
     }
@@ -3821,6 +3824,9 @@ void receive_item_group( const item_group_id &group_id, const dialogue &d, bool 
     for( item &new_item : new_items ) {
         for( const std::string &flag : flags ) {
             new_item.set_flag( flag_id( flag ) );
+        }
+        if (new_item.is_map()) {
+            new_item.preserve_location(p);
         }
         if( add_talker ) {
             d.actor( false )->i_add_or_drop( new_item, force_equip );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -3760,8 +3760,8 @@ void receive_item( const itype_id &item_id, int count, const itype_id &container
                    const tripoint_abs_ms &p = tripoint_abs_ms::zero, bool force_equip = false )
 {
     item new_item = item( item_id, calendar::turn );
-    if( new_item.is_map() ) {
-        new_item.preserve_location( p );
+    if (new_item.has_flag( flag_PRESERVE_SPAWN_LOC) ) {
+        new_item.preserve_location(p);
     }
     for( const std::string &flag : flags ) {
         new_item.set_flag( flag_id( flag ) );
@@ -3825,8 +3825,8 @@ void receive_item_group( const item_group_id &group_id, const dialogue &d, bool 
         for( const std::string &flag : flags ) {
             new_item.set_flag( flag_id( flag ) );
         }
-        if( new_item.is_map() ) {
-            new_item.preserve_location( p );
+        if ( new_item.has_flag( flag_PRESERVE_SPAWN_LOC ) ) {
+            new_item.preserve_location(p);
         }
         if( add_talker ) {
             d.actor( false )->i_add_or_drop( new_item, force_equip );

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -1195,8 +1195,8 @@ void debug_menu::wishitem( Character *you, const tripoint_bub_ms &pos )
                 canceled = popup.canceled();
             }
             if( !canceled ) {
-                if (granted.is_map()) {
-                    granted.preserve_location(you->pos_abs());
+                if( granted.is_map() ) {
+                    granted.preserve_location( you->pos_abs() );
                 }
                 did_amount_prompt = true;
                 if( you != nullptr ) {

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -1195,6 +1195,9 @@ void debug_menu::wishitem( Character *you, const tripoint_bub_ms &pos )
                 canceled = popup.canceled();
             }
             if( !canceled ) {
+                if (granted.is_map()) {
+                    granted.preserve_location(you->pos_abs());
+                }
                 did_amount_prompt = true;
                 if( you != nullptr ) {
                     if( amount > 0 ) {

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -26,6 +26,7 @@
 #include "debug_menu.h"
 #include "effect.h"
 #include "enums.h"
+#include "flag.h"
 #include "game.h"
 #include "game_constants.h"
 #include "imgui/imgui.h"
@@ -1195,7 +1196,7 @@ void debug_menu::wishitem( Character *you, const tripoint_bub_ms &pos )
                 canceled = popup.canceled();
             }
             if( !canceled ) {
-                if( granted.is_map() ) {
+                if ( granted.has_flag( flag_PRESERVE_SPAWN_LOC ) ) {
                     granted.preserve_location( you->pos_abs() );
                 }
                 did_amount_prompt = true;

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -1196,7 +1196,7 @@ void debug_menu::wishitem( Character *you, const tripoint_bub_ms &pos )
                 canceled = popup.canceled();
             }
             if( !canceled ) {
-                if ( granted.has_flag( flag_PRESERVE_SPAWN_LOC ) ) {
+                if( granted.has_flag( flag_PRESERVE_SPAWN_LOC ) ) {
                     granted.preserve_location( you->pos_abs() );
                 }
                 did_amount_prompt = true;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Fixes maps spawned by EOC and debug menu being unreadable"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #86397 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Check if an item ~~is a map~~ has the `PRESERVE_SPAWN_LOC` flag when the EOC spawns it and if it does, preserve its location. Added PRESERVE_SPAWN_LOC flag to Undine Waters map to allow it to take advantage of this

#### Describe alternatives you've considered
N/A - Bugfix

#### Testing
<img width="345" height="54" alt="image" src="https://github.com/user-attachments/assets/f6e51c1a-8a4f-475b-bee8-ad2927ed79ed" />
<img width="906" height="804" alt="image" src="https://github.com/user-attachments/assets/00fa4a33-af56-4960-909e-19c865204b6a" />

Tested undine waters maps. They seem to work

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
