### PR TITLE
Fix duplicate mod lists in get_all_mods.py

### DIFF
--- a/build-scripts/get_all_mods.py
+++ b/build-scripts/get_all_mods.py
@@ -98,7 +98,9 @@ for r, d, f in os.walk('data/mods'):
 
 mods_remaining = set(all_mod_dependencies)
 
-print_modlist(mods_this_time, mods_remaining)
+# Remove mods already covered by mod_interactions lists above
+for ml in mods_lists:
+    mods_remaining -= set(ml.split(','))
 
 while mods_remaining:
     for mod in mods_remaining:
@@ -109,5 +111,9 @@ while mods_remaining:
             'mods remain ({}) but none could be added'.format(mods_remaining))
     print_modlist(mods_this_time, mods_remaining)
 
-for list in sorted(mods_lists, key=len, reverse=True):
-    print(list)
+seen = set()
+for entry in sorted(mods_lists, key=len, reverse=True):
+    key = frozenset(entry.split(','))
+    if entry and key not in seen:
+        seen.add(key)
+        print(entry)


### PR DESCRIPTION
#### Summary
Infrastructure "Fix duplicate mod lists in get_all_mods.py"

#### Purpose of change

`get_all_mods.py` produces duplicate lines, wasting ~25-30s of CI time per duplicate. The `mod_interactions` loop populates `mods_lists` but never subtracts those mods from `mods_remaining`, so the packing loop below re-adds them.

#### Describe the solution

- Subtract `mod_interactions`-covered mods from `mods_remaining` before the packing loop
- Remove a no-op `print_modlist` call (operated on already-cleared list)
- Deduplicate output via `frozenset` to catch order-variant dupes

~24 lines with dupes down to ~19 unique.

#### Describe alternatives you've considered

N/A

#### Testing

Ran the script three times, zero duplicates in any run.

#### Additional context

N/A