### PR TITLE
Make Rc car accept medium batteries

### DIFF
--- a/data/json/items/tool/radio_tools.json
+++ b/data/json/items/tool/radio_tools.json
@@ -11,7 +11,7 @@
     "faults": [ { "fault_group": "electronic_general" } ],
     "material": [ "plastic" ],
     "charges_per_use": 1,
-    "turns_per_charge": 5,
+    "turns_per_charge": 20,
     "weight": "670 g",
     "volume": "500 ml",
     "price": "60 USD",
@@ -55,8 +55,8 @@
       {
         "pocket_type": "MAGAZINE_WELL",
         "rigid": true,
-        "flag_restriction": [ "BATTERY_ULTRA_LIGHT" ],
-        "default_magazine": "light_minus_disposable_cell"
+        "flag_restriction": [ "BATTERY_MEDIUM" ],
+        "default_magazine": "medium_battery_cell"
       }
     ],
     "tool_ammo": [ "battery" ]
@@ -68,7 +68,7 @@
     "subtypes": [ "TOOL" ],
     "name": { "str": "RC car (on)", "str_pl": "RC cars (on)" },
     "description": "A remote-controlled toy car.  It is turned on and draining its batteries just like a real electric car!  Use a remote control to drive it around.",
-    "turns_per_charge": 5,
+    "turns_per_charge": 12,
     "revert_to": "radio_car",
     "use_action": { "type": "transform", "target": "radio_car", "msg": "You turned off your RC car.", "menu_text": "Turn off" },
     "tick_action": [


### PR DESCRIPTION
#### Summary

Balance "Fix high power drain of RC car and controller. Made RC car accept medium batteries."

#### Purpose of change

RC cars and controllers IRL have a very respectable run time of 20 - 30 minutes, even when using the smaller battery cells available. I wanted to bring the game version more in line with that.

#### Describe the solution

Change RC car power draw to 12 turns per charge, to simulate the ~12 minutes an RC car would run for on a 56 Kj medium battery. Changed controller to match that at 20 turns per charge. 

#### Describe alternatives you've considered

Let the RC car run out of charge within the minute.

#### Testing

Booted up and used the improved RC car. Vroom vroom!

#### Additional context

Reference on how long RC car batteries last and justification for the usage of medium batteries (besides the discussion on discord):

https://www.eurorc.com/news/334/rc-battery-life 
