### PR TITLE
[Magiclysm] Minor fixes

### DIFF
--- a/data/mods/Magiclysm/Spells/item_only.json
+++ b/data/mods/Magiclysm/Spells/item_only.json
@@ -931,7 +931,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_SUMMON_STAG_BEETLE",
-    "//": "Targetted to prevent failure due to monster placement",
+    "//": "Targeted to prevent failure due to monster placement",
     "effect": [
       { "u_cast_spell": { "id": "mag_call_stag_beetle_real", "min_level": 1 }, "targeted": true },
       {

--- a/data/mods/Magiclysm/Spells/mana_upgrades.json
+++ b/data/mods/Magiclysm/Spells/mana_upgrades.json
@@ -2,7 +2,7 @@
   {
     "id": "mana_upgrade_efficiency_01",
     "type": "SPELL",
-    "name": { "str": "First Circle: Lesser Mana Efficiency." },
+    "name": { "str": "First Circle: Lesser Mana Efficiency" },
     "description": "Perform a magical ritual to increase the efficiency by which your body processes mana, granting you the Lesser Mana Efficiency trait.  The ritual must end when the sun is in the sky and you are at least one story above the ground.\n\nThe chance of the ritual's success depends in your spell level and Spellcraft skill.",
     "valid_targets": [ "self" ],
     "shape": "blast",
@@ -60,7 +60,7 @@
   {
     "id": "mana_upgrade_efficiency_02",
     "type": "SPELL",
-    "name": { "str": "Second Circle: Mana Efficiency." },
+    "name": { "str": "Second Circle: Mana Efficiency" },
     "description": "Perform a magical ritual to increase the efficiency by which your body processes mana, granting you the Mana Efficiency trait.  You must already have the Lesser Mana Efficiency trait for the spell to take full effect.  The ritual must end within one hour of noon and you are at least four stories above the ground.\n\nThe chance of the ritual's success depends in your spell level and Spellcraft skill.",
     "valid_targets": [ "self" ],
     "shape": "blast",
@@ -125,7 +125,7 @@
   {
     "id": "mana_upgrade_regeneration_01",
     "type": "SPELL",
-    "name": { "str": "First Circle: Lesser Mana Regeneration." },
+    "name": { "str": "First Circle: Lesser Mana Regeneration" },
     "description": "Perform a magical ritual to increase the speed by which your body restores its mana, granting you the Lesser Mana Regeneration trait.  The ritual must be performed while standing in a river or a stream.\n\nThe chance of the ritual's success depends in your spell level and Spellcraft skill.",
     "valid_targets": [ "self" ],
     "shape": "blast",
@@ -195,7 +195,7 @@
   {
     "id": "mana_upgrade_regeneration_02",
     "type": "SPELL",
-    "name": { "str": "Second Circle: Mana Regeneration." },
+    "name": { "str": "Second Circle: Mana Regeneration" },
     "description": "Perform a magical ritual to increase the speed by which your body restores its mana, granting you the Mana Regeneration trait.  You must already have the Lesser Mana Regeneration trait for the spell to take full effect.  The ritual must be performed while standing in a river.\n\nThe chance of the ritual's success depends in your spell level and Spellcraft skill.",
     "valid_targets": [ "self" ],
     "shape": "blast",
@@ -278,7 +278,7 @@
   {
     "id": "mana_upgrade_sensitivity_01",
     "type": "SPELL",
-    "name": { "str": "First Circle: Lesser Mana Sensitivity." },
+    "name": { "str": "First Circle: Lesser Mana Sensitivity" },
     "description": "Perform a magical ritual to increase the sensitivity that your body has to mana, granting you the Lesser Mana Sensitivity trait.  The ritual must take place in a natural location away (at least 4 OM tiles) from buildings, roads, or other evidence of civilization.\n\nThe chance of the ritual's success depends in your spell level and Spellcraft skill.",
     "valid_targets": [ "self" ],
     "shape": "blast",
@@ -346,7 +346,7 @@
   {
     "id": "mana_upgrade_sensitivity_02",
     "type": "SPELL",
-    "name": { "str": "Second Circle: Mana Sensitivity." },
+    "name": { "str": "Second Circle: Mana Sensitivity" },
     "description": "Perform a magical ritual to increase the sensitivity that your body has to mana, granting you the Mana Sensitivity trait.  You must already have the Lesser Mana Sensitivity trait for the spell to take full effect.  The ritual must take place in a natural location far away (at least 15 OM tiles) from buildings, roads, or other evidence of civilization.\n\nThe chance of the ritual's success depends in your spell level and Spellcraft skill.",
     "valid_targets": [ "self" ],
     "shape": "blast",

--- a/data/mods/Magiclysm/itemgroups/itemgroups.json
+++ b/data/mods/Magiclysm/itemgroups/itemgroups.json
@@ -406,7 +406,6 @@
       [ "mana_potion_lesser", 90 ],
       [ "mana_potion", 5 ],
       [ "mana_potion_greater", 1 ],
-      [ "manatouched_serum", 1 ],
       [ "flask_illumination", 10 ],
       [ "flask_rebreather", 10 ],
       { "group": "potions_uncommon", "prob": 1 }

--- a/data/mods/Magiclysm/npc/TALK_FORGE_MERCHANT.json
+++ b/data/mods/Magiclysm/npc/TALK_FORGE_MERCHANT.json
@@ -63,7 +63,6 @@
       { "group": "enchanted_rings_common", "prob": 20 },
       { "group": "enchanted_rings_uncommon", "prob": 5 },
       { "group": "enchanted_arrows", "prob": 15, "count": [ 1, 2 ] },
-      { "group": "group_potion_fruits", "prob": 10, "count": [ 1, 4 ] },
       { "group": "enchanted_bracelets", "prob": 4 },
       { "group": "enchanted_belts", "prob": 2 },
       { "group": "items_of_elvenkind", "prob": 1 },

--- a/data/mods/Magiclysm/species.json
+++ b/data/mods/Magiclysm/species.json
@@ -101,14 +101,14 @@
   {
     "type": "SPECIES",
     "id": "AIR_SPIRIT",
-    "description": "A magical being of wind and rain.",
+    "description": "a magical being of wind and rain",
     "anger_triggers": [ "HURT", "FRIEND_ATTACKED" ],
     "bleeds": "fd_cold_air1"
   },
   {
     "type": "SPECIES",
     "id": "FOREST_SPIRIT",
-    "description": "A magical being of the forest.",
+    "description": "a magical being of the forest",
     "flags": [ "NEVER_WANDER", "PATH_AVOID_FIRE" ],
     "fear_triggers": [ "FIRE" ],
     "bleeds": "fd_blood_veggy"
@@ -116,14 +116,14 @@
   {
     "type": "SPECIES",
     "id": "EARTH_SPIRIT",
-    "description": "A magical being of rock and stone.",
+    "description": "a magical being of rock and stone",
     "flags": [ "NEVER_WANDER", "NO_FUNG_DMG" ],
     "anger_triggers": [ "FRIEND_ATTACKED" ]
   },
   {
     "type": "SPECIES",
     "id": "WIND_SPIRIT",
-    "description": "A magical being of wind and gale.",
+    "description": "a magical being of wind and gale",
     "flags": [ "NEVER_WANDER", "NO_FUNG_DMG" ],
     "anger_triggers": [ "FRIEND_ATTACKED" ]
   }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Some small changes to and typo fixes"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

- First and Second Circle spells had dots at the end of their names, which no other spell did, so now they are more in-line with the rest of the spells.
- Brackenwright and similar creatures had 'It is A magical being of the forest..' in their description, now they are more in line with base game.
- Valzain was giving away potion fruits for free, same for mana mutagen for Former Pirate merchant. I checked and it made sense to me to fully remove mana mutagen from the potion_common itemgroup.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
