### PR TITLE
Add lighting conditions warning to Crafting UI

### DIFF
--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1147,7 +1147,7 @@ void crafting_ui_impl::draw_recipe_info_panel()
         }
         ImGui::Separator();
 
-        // Warnings (right after stats)     
+        // Warnings (right after stats)
         if( avail.can_craft && avail.would_use_rotten ) {
             cataimgui::TextColoredParagraphNewline( c_red, _( "Will use rotten ingredients" ) );
         }

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1136,9 +1136,18 @@ void crafting_ui_impl::draw_recipe_info_panel()
                 cataimgui::draw_colored_text( colored, c_light_gray );
             }
         }
+
+        if( avail.can_craft && crafter->lighting_craft_speed_multiplier( recp ) <= 0.0f ) {
+            const char *lighting_str = _( "Lighting conditions are too poor to craft this." );
+            float line_w = ImGui::CalcTextSize( lighting_str ).x;
+            if( line_w < region_w ) {
+                ImGui::SetCursorPosX( ImGui::GetCursorPosX() + ( region_w - line_w ) / 2.f );
+            }
+            cataimgui::draw_colored_text( lighting_str, c_red );
+        }
         ImGui::Separator();
 
-        // Warnings (right after stats)
+        // Warnings (right after stats)     
         if( avail.can_craft && avail.would_use_rotten ) {
             cataimgui::TextColoredParagraphNewline( c_red, _( "Will use rotten ingredients" ) );
         }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Interface "Add lighting conditions warning to Crafting UI"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
In the crafting UI, lighting conditions preventing crafting are not immediately visible.  It's hidden away in the details section which some players prefer to keep collapsed and may miss it entirely.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add a warning directly below the crafting stats when lighting conditions prevent crafting the selected recipe.

Before:
<img width="715" height="240" alt="Screenshot 2026-04-19 003220" src="https://github.com/user-attachments/assets/9f0e3885-ce5b-4595-aad3-bf41603adb45" />

After:
<img width="713" height="251" alt="Screenshot 2026-04-19 002831" src="https://github.com/user-attachments/assets/433c1b2d-d5fa-43d5-b0de-9562b8d6726d" />

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Compiled in Windows
Loaded game and verified message
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
