### PR TITLE
Gender change artifact active

### DIFF
--- a/data/json/artifact/legacy_artifact_active.json
+++ b/data/json/artifact/legacy_artifact_active.json
@@ -624,5 +624,20 @@
     "effect": "noise",
     "shape": "blast",
     "extra_effects": [ { "id": "AEA_PULSE_bash_terrain" }, { "id": "AEA_PULSE_bash_terrain" }, { "id": "AEA_PULSE_bash_terrain" } ]
+  },
+  {
+    "type": "SPELL",
+    "id": "AEA_GENDER",
+    "name": { "str": "Artifact Gender Change", "//~": "NO_I18N" },
+    "description": { "str": "Changes the gender.", "//~": "NO_I18N" },
+    "valid_targets": [ "self" ],
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_change_gender",
+    "flags": [ "NO_PROJECTILE", "NO_EXPLOSION_SFX" ],
+    "shape": "blast",
+    "base_casting_time": 100,
+    "min_aoe": 1,
+    "max_aoe": 1,
+    "message": "You've changed."
   }
 ]

--- a/data/json/artifact/relic_procgen_data.json
+++ b/data/json/artifact/relic_procgen_data.json
@@ -14,6 +14,7 @@
     ],
     "active_procgen_values": [
       { "weight": 100, "spell_id": "AEA_ADRENALINE", "base_power": 250 },
+      { "weight": 100, "spell_id": "AEA_GENDER", "base_power": 250 },
       { "weight": 100, "spell_id": "AEA_BLOOD", "base_power": 0 },
       { "weight": 100, "spell_id": "AEA_HEAL", "base_power": 500 },
       { "weight": 100, "spell_id": "AEA_CONFUSED", "base_power": 250 },
@@ -240,6 +241,7 @@
     "active_procgen_values": [
       { "weight": 100, "spell_id": "AEA_BLOOD", "base_power": -25 },
       { "weight": 100, "spell_id": "AEA_HEAL", "base_power": 500 },
+      { "weight": 100, "spell_id": "AEA_GENDER", "base_power": 250 },
       { "weight": 100, "spell_id": "AEA_CONFUSED", "base_power": 250 },
       { "weight": 100, "spell_id": "AEA_PAIN", "base_power": -150 },
       { "weight": 100, "spell_id": "AEA_TELEPORT", "base_power": -50 },
@@ -465,6 +467,7 @@
     ],
     "active_procgen_values": [
       { "weight": 100, "spell_id": "AEA_ADRENALINE", "base_power": 250 },
+      { "weight": 100, "spell_id": "AEA_GENDER", "base_power": 250 },
       { "weight": 100, "spell_id": "AEA_BLOOD", "base_power": -25 },
       { "weight": 100, "spell_id": "AEA_HEAL", "base_power": 400 },
       { "weight": 100, "spell_id": "AEA_CONFUSED", "base_power": 200 },

--- a/data/json/effects_on_condition/misc_effect_on_condition.json
+++ b/data/json/effects_on_condition/misc_effect_on_condition.json
@@ -527,5 +527,12 @@
         "run_eoc_selector": [ "EOC_DRAW_TAROT_FULL", "EOC_DRAW_TAROT_MAJOR" ]
       }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_change_gender",
+    "condition": { "and": [ "u_is_character", { "math": [ "u_gender() == 1" ] } ] },
+    "effect": [ { "math": [ "u_gender() = 0" ] } ],
+    "false_effect": [ { "math": [ "u_gender() = 1" ] } ]
   }
 ]


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Revival of #86560

#### Describe the solution
Pull the branch, re-submit it.

Although gender is not *sex* and we do not represent sex ingame, this is an artifact that completely warps the character's mind and changes how they think of themself... an appropriately esoteric effect for a reality-bending artifact.

Two comments expressed concerns that this would be a 'dud', but *that is a good thing!*. Not all artifacts are meant to be wondrous and powerful.

Yes, the player can 'override' it and other cosmetics through the @ screen. This is intentional.

#### Describe alternatives you've considered
Artifact effects that change other cosmetics, such as facial hair or skin tone.

#### Testing
Ran the EOC manually a few times, confirmed it flipped the status screen from showing male-->female and female-->male.

#### Additional context

