### PR TITLE
Correct tile rotations

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -4317,7 +4317,7 @@ bool cata_tiles::draw_vpart( const tripoint_bub_ms &p, lit_level ll, int &height
         const vpart_display vd = veh.get_display_of_tile( ovp->mount_pos() );
         if( !vd.id.is_null() ) {
             const int subtile = vd.is_open ? open_ : vd.is_broken ? broken : 0;
-            const int rotation = angle_to_dir4( 270_degrees - veh.face.dir() );
+            const int rotation = angle_to_dir4( veh.face.dir() - 270_degrees );
             avatar &you = get_avatar();
             if( !veh.forward_velocity() && !veh.player_in_control( here, you )
                 && !( you.get_grab_type() == object_type::VEHICLE
@@ -4354,7 +4354,7 @@ bool cata_tiles::draw_vpart( const tripoint_bub_ms &p, lit_level ll, int &height
         if( vp2 ) {
             const char part_mod = std::get<1>( override->second );
             const int subtile = part_mod == 1 ? open_ : part_mod == 2 ? broken : 0;
-            const int rotation = angle_to_dir4( 270_degrees - std::get<2>( override->second ) );
+            const int rotation = angle_to_dir4( std::get<2>( override->second ) - 270_degrees );
             const int draw_highlight = std::get<3>( override->second );
             const std::string vpname = "vp_" + vp2.str();
             // tile overrides are never memorized

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -3489,13 +3489,13 @@ bool cata_tiles::draw_sprite_at(
         } else if( !iso ) {
             switch( rota % 4 ) {
                 case 1:
-                    render_angle = -90;
+                    render_angle = 90;
                     break;
                 case 2:
                     render_flip = static_cast<CataFlipMode>( SDL_FLIP_HORIZONTAL | SDL_FLIP_VERTICAL );
                     break;
                 case 3:
-                    render_angle = 90;
+                    render_angle = -90;
                     break;
                 default:
                     break;
@@ -3537,7 +3537,7 @@ bool cata_tiles::draw_sprite_at(
 #endif
                     if( !iso ) {
                         // never rotate isometric tiles
-                        ret = sprite_tex->render_copy_ex( renderer, &destination, -90, nullptr,
+                        ret = sprite_tex->render_copy_ex( renderer, &destination, 90, nullptr,
                                                           SDL_FLIP_NONE );
                     } else {
                         ret = sprite_tex->render_copy_ex( renderer, &destination, 0, nullptr,
@@ -3567,7 +3567,7 @@ bool cata_tiles::draw_sprite_at(
 #endif
                     if( !iso ) {
                         // never rotate isometric tiles
-                        ret = sprite_tex->render_copy_ex( renderer, &destination, 90, nullptr,
+                        ret = sprite_tex->render_copy_ex( renderer, &destination, -90, nullptr,
                                                           SDL_FLIP_NONE );
                     } else {
                         ret = sprite_tex->render_copy_ex( renderer, &destination, 0, nullptr,
@@ -5516,19 +5516,19 @@ void cata_tiles::get_rotation_and_subtile( const char val, const char rot_to, in
             // horizontal end piece E
             subtile = end_piece;
             if( no_rotation ) {
-                rotation = 3;
+                rotation = 1;
                 break;
             }
-            rotation = 3 + 4 * get_rotation_edge_ew( rot_to );
+            rotation = 1 + 4 * get_rotation_edge_ew( rot_to );
             break;
         case 2:
             // horizontal end piece W
             subtile = end_piece;
             if( no_rotation ) {
-                rotation = 1;
+                rotation = 3;
                 break;
             }
-            rotation = 1 + 4 * get_rotation_edge_ew( rot_to );
+            rotation = 3 + 4 * get_rotation_edge_ew( rot_to );
             break;
         case 1:
             // vertical end piece N
@@ -5574,7 +5574,7 @@ void cata_tiles::get_rotation_and_subtile( const char val, const char rot_to, in
             break;
         case 10:
             subtile = corner;
-            rotation = 1;
+            rotation = 3;
             break;
         case 3:
             subtile = corner;
@@ -5582,7 +5582,7 @@ void cata_tiles::get_rotation_and_subtile( const char val, const char rot_to, in
             break;
         case 5:
             subtile = corner;
-            rotation = 3;
+            rotation = 1;
             break;
         // all t_connections
         case 14:
@@ -5591,7 +5591,7 @@ void cata_tiles::get_rotation_and_subtile( const char val, const char rot_to, in
             break;
         case 11:
             subtile = t_connection;
-            rotation = 1;
+            rotation = 3;
             break;
         case 7:
             subtile = t_connection;
@@ -5599,7 +5599,7 @@ void cata_tiles::get_rotation_and_subtile( const char val, const char rot_to, in
             break;
         case 13:
             subtile = t_connection;
-            rotation = 3;
+            rotation = 1;
             break;
     }
 }
@@ -5663,26 +5663,26 @@ int cata_tiles::get_rotation_unconnected( const char rot_to )
             rotation = 2;
             break;
         case static_cast<int>( NEIGHBOUR::EAST ):
-            rotation = 3;
+            rotation = 1;
             break;
         case static_cast<int>( NEIGHBOUR::SOUTH ):
             rotation = 0;
             break;
         case static_cast<int>( NEIGHBOUR::WEST ):
-            rotation = 1;
+            rotation = 3;
             break;
         // Two tiles, resulting in diagonal
         case 10: // NE
             rotation = 6;
             break;
         case 3: // SE
-            rotation = 7;
+            rotation = 5;
             break;
         case 5: // SW
             rotation = 4;
             break;
         case 12: // NW
-            rotation = 5;
+            rotation = 7;
             break;
         // Cases for three tiles to rotate to -> easy
         // Arranged to fallback / modulo to fitting index 0-4
@@ -5690,13 +5690,13 @@ int cata_tiles::get_rotation_unconnected( const char rot_to )
             rotation = 10;
             break;
         case 11: // 3 but west --> modulo = east
-            rotation = 11;
+            rotation = 9;
             break;
         case 7: // 3 but north --> modulo = south
             rotation = 8;
             break;
         case 13: // 3 but east --> modulo = west
-            rotation = 9;
+            rotation = 11;
             break;
         // Two opposing tiles, (No tiles, all tiles; see first cases)
         case 9: // N-S

--- a/src/overmap_terrain.cpp
+++ b/src/overmap_terrain.cpp
@@ -835,7 +835,7 @@ void oter_t::get_rotation_and_subtile( int &rotation, int &subtile ) const
 {
     if( is_linear() ) {
         const om_lines::type &t = om_lines::all[line];
-        rotation = t.rotation;
+        rotation = ( 4 - t.rotation ) % 4;;
         subtile = t.subtile;
     } else if( is_rotatable() ) {
         rotation = static_cast<int>( get_dir() );

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -4181,7 +4181,7 @@ void mm_submap::deserialize( int version, const JsonArray &ja )
                             // legacy vehicle rotation needs to be converted from 0-360 degrees
                             // to 0-3 tileset rotation
                             const units::angle legacy_angle = units::from_degrees( legacy_rotation );
-                            tile.set_dec_rotation( angle_to_dir4( 270_degrees - legacy_angle ) );
+                            tile.set_dec_rotation( angle_to_dir4( legacy_angle - 270_degrees ) );
                         } else {
                             tile.set_dec_rotation( legacy_rotation );
                         }

--- a/tests/connect_rotate_test.cpp
+++ b/tests/connect_rotate_test.cpp
@@ -100,7 +100,7 @@ TEST_CASE( "walls_should_connect_to_walls_as_end_pieces", "[multitile][connects]
             cata_tiles_test_helper::get_connect_values( pos.raw(), subtile, rotation,
                     wall, none );
             CHECK( subtile == end_piece );
-            CHECK( rotation == 1 );
+            CHECK( rotation == 3 );
         }
     }
     WHEN( "connecting neighbour north" ) {
@@ -126,7 +126,7 @@ TEST_CASE( "walls_should_connect_to_walls_as_end_pieces", "[multitile][connects]
             cata_tiles_test_helper::get_connect_values( pos.raw(), subtile, rotation,
                     wall, none );
             CHECK( subtile == end_piece );
-            CHECK( rotation == 3 );
+            CHECK( rotation == 1 );
         }
     }
 }
@@ -169,7 +169,7 @@ TEST_CASE( "walls_should_connect_to_walls_as_corners", "[multitile][connects]" )
             cata_tiles_test_helper::get_connect_values( pos.raw(), subtile, rotation,
                     wall, none );
             CHECK( subtile == corner );
-            CHECK( rotation == 1 );
+            CHECK( rotation == 3 );
         }
     }
     WHEN( "connecting neighbour north and west" ) {
@@ -195,7 +195,7 @@ TEST_CASE( "walls_should_connect_to_walls_as_corners", "[multitile][connects]" )
             cata_tiles_test_helper::get_connect_values( pos.raw(), subtile, rotation,
                     wall, none );
             CHECK( subtile == corner );
-            CHECK( rotation == 3 );
+            CHECK( rotation == 1 );
         }
     }
 }
@@ -281,7 +281,7 @@ TEST_CASE( "walls_should_connect_to_walls_as_t-connections_and_fully", "[multiti
             cata_tiles_test_helper::get_connect_values( pos.raw(), subtile, rotation,
                     wall, none );
             CHECK( subtile == t_connection );
-            CHECK( rotation == 1 );
+            CHECK( rotation == 3 );
         }
     }
     WHEN( "connecting neighbour all but south" ) {
@@ -307,7 +307,7 @@ TEST_CASE( "walls_should_connect_to_walls_as_t-connections_and_fully", "[multiti
             cata_tiles_test_helper::get_connect_values( pos.raw(), subtile, rotation,
                     wall, none );
             CHECK( subtile == t_connection );
-            CHECK( rotation == 3 );
+            CHECK( rotation == 1 );
         }
     }
     // All
@@ -503,7 +503,7 @@ TEST_CASE( "unconnected_windows_rotate_to_indoor_floor", "[multitile][rotates]" 
             cata_tiles_test_helper::get_connect_values( pos.raw(), subtile, rotation,
                     none, floor );
             CHECK( subtile == unconnected );
-            CHECK( rotation == 3 );
+            CHECK( rotation == 1 );
         }
     }
     WHEN( "indoor floor to the south" ) {
@@ -529,7 +529,7 @@ TEST_CASE( "unconnected_windows_rotate_to_indoor_floor", "[multitile][rotates]" 
             cata_tiles_test_helper::get_connect_values( pos.raw(), subtile, rotation,
                     none, floor );
             CHECK( subtile == unconnected );
-            CHECK( rotation == 1 );
+            CHECK( rotation == 3 );
         }
     }
 }


### PR DESCRIPTION
#### Summary
Bugfixes "Correct tile rotations"

#### Purpose of change
Followup for #86335
That PR reverted an old bandaid fix for rotations and revealed to me other rotation related problems. This PR addresses those rotational problems.

#### Describe the solution
`om_direction::type` defines the rotational directions `N = 0, E = 1, S = 2, W = 3`, a clockwise rotation.
The engine rotates tiles in `cata_tiles::draw_sprite_at` when finally drawing them onscreen but was rotating direction `1 (east)` in reverse by -90 degrees and `3 (west)` in reverse by 90 degrees. So it was rotating tiles in a counter clockwise direction.
The fix was easy here, just flip the signs on the angles in `cata_tiles::draw_sprite_at`. 

That fix broke `multitile` definitions since they were reliant on the reverse rotation. Fixing this was simply flipping the rotations in `cata_tiles::get_rotation_unconnected` and `cata_tiles::get_rotation_and_subtile` for east/west rotations.

Line drawings use a different set of rotations in `om_lines::all` that I did not entirely understand. In `oter_t::get_rotation` there is a comment about line drawings doing rotations in reverse and using the code from there to reverse line drawing rotations in  `oter_t::get_rotation_and_subtile` and it fixed all the line drawings as well.

#### Describe alternatives you've considered
Taking the time to figure out how `om_lines::all` rotations work making it use the same rotation order but that is for a future PR if I do tackle it.

#### Testing
Building and loading up the game to verify the changes.

One of the obvious things this fixes is streams in MSX. The bends are defined with a single tile that *should* just be rotated properly and the change that the previous PR reverted rotated all the tiles in reverse order to compensate for the bug this PR fixes finally.

<details>
<summary>MSX Stream before and after</summary>
Definition:

```jsonc
[
  {
    "id": "stream",
    "fg": [
      { "sprite": "stream_north", "weight": 6 },
      { "sprite": "stream_north_1", "weight": 6 },
      { "sprite": "stream_north_2", "weight": 6 },
      { "sprite": "stream_north_3", "weight": 6 },
      { "sprite": "stream_north_4", "weight": 1 },
      { "sprite": "stream_north_5", "weight": 1 }
    ],
    "bg": [
      { "weight": 25, "sprite": "field" },
      { "weight": 40, "sprite": "field_1" },
      { "weight": 10, "sprite": "field_2" },
      { "weight": 25, "sprite": "field_3" }
    ],
    "rotates": true
  },
  {
    "id": "stream_end",
    "fg": [
      { "sprite": "stream_end_north", "weight": 3 },
      { "sprite": "stream_end_north_1", "weight": 3 },
      { "sprite": "stream_end_north_2", "weight": 1 }
    ],
    "bg": [
      { "weight": 25, "sprite": "field" },
      { "weight": 40, "sprite": "field_1" },
      { "weight": 10, "sprite": "field_2" },
      { "weight": 25, "sprite": "field_3" }
    ],
    "rotates": true
  },
  {
    "id": "stream_corner",
    "fg": [
      { "sprite": "stream_corner_north", "weight": 1 },
      { "sprite": "stream_corner_north_1", "weight": 1 },
      { "sprite": "stream_corner_north_2", "weight": 1 },
      { "sprite": "stream_corner_north_3", "weight": 1 },
      { "sprite": "stream_corner_north_4", "weight": 1 }
    ],
    "bg": [
      { "weight": 25, "sprite": "field" },
      { "weight": 40, "sprite": "field_1" },
      { "weight": 10, "sprite": "field_2" },
      { "weight": 25, "sprite": "field_3" }
    ],
    "rotates": true
  }
]
```

Before:
<img width="1858" height="1932" alt="image" src="https://github.com/user-attachments/assets/21576e67-1a21-4b01-8eef-b972e3354081" />


After:
<img width="1858" height="1932" alt="image" src="https://github.com/user-attachments/assets/3512dbdf-ada6-43e1-8c4a-16813ebf89fe" />


</details>

#### Additional context
Tilesets *will* need to be updated for this, particularly for line drawings like roads. Some tilesets are defined in a way that will need minimal changes, others may need extensive changes. Some can be trimmed down as well. 

There no longer **needs** to be multiple rotations defined for each of the directions anymore. Just define the the default (north) direction and the game will rotate the tile in all four directions if needed. However existing definitions will still work and where they're used to display altered versions of large overmap specials for each rotation they should stay in place.

<details>
<summary>MSX Sandpit single tile example</summary>

```jsonc
[
  {
    "id": "sand_pit_NW",
    "fg": [ "sand_pit_NW_north" ],
    "rotates": true
  },
  {
    "id": "sand_pit_N",
    "fg": [ "sand_pit_N_north" ],
    "rotates": true
  },
  {
    "id": "sand_pit_NE",
    "fg": [ "sand_pit_NE_north" ],
    "rotates": true
  },
  {
    "id": "sand_pit_W",
    "fg": [ "sand_pit_W_north" ],
    "rotates": true
  },
  {
    "id": "sand_pit_M",
    "fg": [ "sand_pit_M_north" ],
    "rotates": true
  },
  {
    "id": "sand_pit_E",
    "fg": [ "sand_pit_E_north" ],
    "rotates": true
  },
  {
    "id": "sand_pit_SW",
    "fg": [ "sand_pit_SW_north" ],
    "rotates": true
  },
  {
    "id": "sand_pit_S",
    "fg": [ "sand_pit_S_north" ],
    "rotates": true
  },
  {
    "id": "sand_pit_SE",
    "fg": [ "sand_pit_SE_north" ],
    "rotates": true
  }
]
```
<img width="540" height="534" alt="image" src="https://github.com/user-attachments/assets/6a498be0-6c43-462b-97f8-801459d765af" />
</details>

-----

#### How to fix tilesets

The fix for the tilesets is relatively simple but tedious and time consuming. It can actually probably be automated.
Every tile definition that defines the rotation for every direction has to have the definitions in index 1 (east) and index 3 (west) swapped. 

I used this regex in vscodes search combined with only search a specific folder to find all of the relevant files with all four rotations specified `([fb]g|sprite)":[\s\n]*\[[\s\n]*"[^"]+"([\s\n]*,[\s\n]*"[^"]+"){3}[\s\n]*\]`

I did the fixes for MSX, NeoDays, RetroDays, and Ultica. Their PRs mention this one and are linked below. This also covers ChibiUltica and Altica (nothing for player or monster sprites needs to be changed afaik).
Larwick Overmap and Pen And Paper were already fixed after the previous PR and remain fixed.

<details>
<summary>JSON fix example</summary>

```jsonc
{
  "id": "t_wall",
  "fg": "t_wall_unconnected",
  "multitile": true,
  "additional_tiles": [
    { "id": "center", "fg": "t_wall_center" },
    { "id": "corner", "fg": [ "t_wall_corner_nw", "t_wall_corner_sw", "t_wall_corner_se", "t_wall_corner_ne" ] },
    {
      "id": "t_connection",
      "fg": [ "t_wall_t_connection_n", "t_wall_t_connection_w", "t_wall_t_connection_s", "t_wall_t_connection_e" ]
    },
    { "id": "edge", "fg": [ "t_wall_edge_ns", "t_wall_edge_ew" ] },
    {
      "id": "end_piece",
      "fg": [ "t_wall_end_piece_n", "t_wall_end_piece_w", "t_wall_end_piece_s", "t_wall_end_piece_e" ]
    },
    { "id": "unconnected", "fg": [ "t_wall_unconnected", "t_wall_unconnected" ] }
  ]
}
```
needs to be changed to this
```jsonc
{
  "id": "t_wall",
  "fg": "t_wall_unconnected",
  "multitile": true,
  "additional_tiles": [
    { "id": "center", "fg": "t_wall_center" },
    { "id": "corner", "fg": [ "t_wall_corner_nw", "t_wall_corner_ne", "t_wall_corner_se", "t_wall_corner_sw" ] },
    {
      "id": "t_connection",
      "fg": [ "t_wall_t_connection_n", "t_wall_t_connection_e", "t_wall_t_connection_s", "t_wall_t_connection_w" ]
    },
    { "id": "edge", "fg": [ "t_wall_edge_ns", "t_wall_edge_ew" ] },
    {
      "id": "end_piece",
      "fg": [ "t_wall_end_piece_n", "t_wall_end_piece_e", "t_wall_end_piece_s", "t_wall_end_piece_w" ]
    },
    { "id": "unconnected", "fg": [ "t_wall_unconnected", "t_wall_unconnected" ] }
  ]
}
```

</details>