### PR TITLE
Persist post-process decisions per overmap_special so multi-story buildings burn consistently

### DIFF
--- a/data/json/overmap/overmap_terrain/overmap_terrain_commercial.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_commercial.json
@@ -1837,13 +1837,16 @@
       "city_block2_flr2_1",
       "city_block2_flr2_2",
       "city_block2_flr2_3",
-      "city_block2_flr2_4",
-      "city_block2_roof_1",
-      "city_block2_roof_2",
-      "city_block2_roof_3",
-      "city_block2_roof_4"
+      "city_block2_flr2_4"
     ],
     "copy-from": "generic_city_building",
+    "name": "urban city block",
+    "color": "light_blue"
+  },
+  {
+    "type": "overmap_terrain",
+    "id": [ "city_block2_roof_1", "city_block2_roof_2", "city_block2_roof_3", "city_block2_roof_4" ],
+    "copy-from": "generic_city_building_roof",
     "name": "urban city block",
     "color": "light_blue"
   },

--- a/data/json/post_process_generators.json
+++ b/data/json/post_process_generators.json
@@ -9,6 +9,7 @@
       { "type": "add_fire", "attempts": 2, "min_intensity": 1, "max_intensity": 3, "scaling_days_end": 14 },
       {
         "type": "pre_burn",
+        "scope": "overmap_special",
         "attempts": 1,
         "min_intensity": 6,
         "max_intensity": 28,

--- a/data/mods/TEST_DATA/mapgen-post-process-test.json
+++ b/data/mods/TEST_DATA/mapgen-post-process-test.json
@@ -10,7 +10,13 @@
   },
   {
     "type": "mapgen",
-    "om_terrain": [ "test_pp_riot_building", "test_pp_field_building", "test_pp_field_and_flag_building", "test_pp_field_inherit_child" ],
+    "om_terrain": [
+      "test_pp_riot_building",
+      "test_pp_field_building",
+      "test_pp_field_and_flag_building",
+      "test_pp_field_inherit_child",
+      "test_pp_field_building_upper"
+    ],
     "object": {
       "fill_ter": "t_floor",
       "rows": [
@@ -55,6 +61,27 @@
   },
   {
     "type": "overmap_terrain",
+    "id": "test_pp_field_building_upper",
+    "name": "PP field test building upper",
+    "sym": ".",
+    "color": "white",
+    "see_cost": "none",
+    "flags": [ "SHOULD_NOT_SPAWN", "NO_ROTATE" ],
+    "post_process_generators": [ "test_pp_riot" ]
+  },
+  {
+    "type": "overmap_special",
+    "id": "test_pp_multi_z_special",
+    "locations": [ "land" ],
+    "occurrences": [ 0, 0 ],
+    "flags": [ "SHOULD_NOT_SPAWN" ],
+    "overmaps": [
+      { "point": [ 0, 0, 0 ], "overmap": "test_pp_field_building" },
+      { "point": [ 0, 0, 1 ], "overmap": "test_pp_field_building_upper" }
+    ]
+  },
+  {
+    "type": "overmap_terrain",
     "id": "test_pp_field_and_flag_building",
     "name": "PP field+flag test building",
     "sym": ".",
@@ -88,6 +115,7 @@
       { "type": "add_fire", "attempts": 1, "min_intensity": 1, "max_intensity": 2, "scaling_days_end": 7 },
       {
         "type": "pre_burn",
+        "scope": "overmap_special",
         "attempts": 1,
         "min_intensity": 10,
         "max_intensity": 40,

--- a/doc/JSON/OVERMAP.md
+++ b/doc/JSON/OVERMAP.md
@@ -445,6 +445,44 @@ Each sub-generator object has the following fields:
 | `max_intensity`       | Maximum intensity for the effect.  Default 0.                                         |
 | `scaling_days_start`  | For time-scaled effects, day offset when scaling begins.  Default 0.                  |
 | `scaling_days_end`    | For time-scaled effects, day offset when scaling reaches full strength.  Default 0.   |
+| `scope`               | `"omt"` (default) or `"overmap_special"`.  See [Scope](#scope) below.                 |
+
+### Scope
+
+Controls when a sub-generator's apply/skip decision is made, and whether it
+is shared across OMTs of the same `overmap_special`.
+
+| Value             | Behavior |
+| ----------------- | -------- |
+| `omt` (default)   | Decision rolled fresh at each OMT's mapgen.  Not persisted.  This is the original per-OMT behavior. |
+| `overmap_special` | Decision rolled once for the whole `overmap_special`, shared across every OMT it occupies.  Resolved lazily when the first OMT reaches mapgen.  Result is persisted on the overmap and survives save/load. |
+
+`overmap_special` scope is how a multi-OMT or multi-z-level building gets a
+single consistent burn decision instead of independent rolls per floor.
+
+#### Supported combinations
+
+Only `pre_burn` and `aftershock_ruin` support `overmap_special` scope.  Other
+sub-generator types operate per-tile, where a shared all-or-nothing decision
+would make the entire special either all-damaged or all-untouched.
+
+For `pre_burn`, `attempts` must be `<= 1` when scope is `overmap_special`.  A
+single shared bool cannot represent "at least one of N attempts succeeded".
+
+At most one sub-generator of a given `type` may use `overmap_special` scope in
+a given `pp_generator`.  If any entry of a type uses `overmap_special`, it must
+be the only entry of that type in the generator.  This keeps persisted
+decisions stably matched by `(type, ordinal)` across JSON edits.
+
+Mapping of `applied` / `skipped` status is per type:
+
+| Type              | `applied` | `skipped` |
+| ----------------- | --------- | --------- |
+| `pre_burn`        | Burn the building. | Building is untouched (no-op).  Other sub-generators in the same `pp_generator` still run. |
+| `aftershock_ruin` | Fully ruined path. | Smashed-up path.  Never a no-op. |
+
+Old saves predating this feature have no persisted decisions.  Loading them
+falls through to the original per-OMT fresh-roll behavior.  No migration needed.
 
 ### Sub-generator types
 
@@ -461,7 +499,7 @@ Each sub-generator object has the following fields:
 
 | Id                   | Description | Used by |
 | -------------------- | ----------- | ------- |
-| `riot_damage`        | Full riot damage: bash, item displacement, fire, pre-burn, and blood.  | Most city buildings (via `generic_city_building`). |
+| `riot_damage`        | Full riot damage: bash, item displacement, fire, pre-burn, and blood.  `pre_burn` uses `overmap_special` scope.  | Most city buildings (via `generic_city_building`). |
 | `riot_damage_road`   | Same as `riot_damage` but without `pre_burn`.  | City roads (hardcoded dispatch). |
 | `aftershock_ruin`    | Aftershock ruin effect.  | Aftershock mod buildings with `PP_GENERATE_RUINED` flag. |
 

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -349,20 +349,31 @@ void map::generate( const tripoint_abs_omt &p, const time_point &when, bool save
             if( any_missing || !save_results ) {
                 const tripoint_abs_omt omt_point = { p.x(), p.y(), gridz };
                 oter_id omt = overmap_buffer.ter( omt_point );
+                std::vector<pp_resolved_generator> *stored_decisions =
+                    overmap_buffer.pp_decisions( omt_point );
                 if( omt->has_flag( oter_flags::road ) && overmap_buffer.is_in_city( omt_point ) ) {
                     // Roads use a dedicated generator; not yet migrated to oter_type_t field
-                    pp_generator_riot_damage_road.obj().execute( *this, omt_point );
+                    pp_generator_riot_damage_road.obj().execute( *this, omt_point, nullptr );
                 } else if( !omt->get_post_process_generators().empty() ) {
                     for( const pp_generator_id &gen_id : omt->get_post_process_generators() ) {
-                        gen_id.obj().execute( *this, omt_point );
+                        std::vector<pp_sub_decision> *gen_decisions = nullptr;
+                        if( stored_decisions ) {
+                            for( pp_resolved_generator &rg : *stored_decisions ) {
+                                if( rg.generator == gen_id ) {
+                                    gen_decisions = &rg.sub_decisions;
+                                    break;
+                                }
+                            }
+                        }
+                        gen_id.obj().execute( *this, omt_point, gen_decisions );
                     }
                 } else {
                     // Legacy flag-based dispatch for unmigrated content
                     if( omt->has_flag( oter_flags::pp_generate_riot_damage ) ) {
-                        pp_generator_riot_damage.obj().execute( *this, omt_point );
+                        pp_generator_riot_damage.obj().execute( *this, omt_point, nullptr );
                     }
                     if( omt->has_flag( oter_flags::pp_generate_ruined ) ) {
-                        pp_generator_aftershock_ruin.obj().execute( *this, omt_point );
+                        pp_generator_aftershock_ruin.obj().execute( *this, omt_point, nullptr );
                     }
                 }
             }

--- a/src/mapgen_post_process.cpp
+++ b/src/mapgen_post_process.cpp
@@ -527,67 +527,80 @@ static void execute_add_fire( map &md,
 
 }
 
-static void execute_pre_burn( map &md,
-                              std::list<tripoint_bub_ms> &all_points_in_map,
-                              int days_since_cataclysm,
-                              const pp_sub_generator &sg )
+// Apply pre_burn effects to every tile, skipping the probability gate.
+static void apply_pre_burn_tiles( map &md,
+                                  std::list<tripoint_bub_ms> &all_points_in_map )
 {
-    double lerp_scalar = static_cast<double>(
-                             static_cast<double>( days_since_cataclysm - sg.scaling_days_start ) /
-                             static_cast<double>( sg.scaling_days_end - sg.scaling_days_start ) );
+    for( tripoint_bub_ms current_tile : all_points_in_map ) {
+        if( md.has_flag_ter( ter_furn_flag::TFLAG_NATURAL_UNDERGROUND, current_tile ) ||
+            md.has_flag_ter( ter_furn_flag::TFLAG_GOES_DOWN, current_tile ) ||
+            md.has_flag_ter( ter_furn_flag::TFLAG_GOES_UP, current_tile ) ) {
+            continue;
+        }
+
+        const bool is_flammable_ter =
+            md.has_flag_ter( ter_furn_flag::TFLAG_FLAMMABLE, current_tile ) ||
+            md.has_flag_ter( ter_furn_flag::TFLAG_FLAMMABLE_ASH, current_tile ) ||
+            md.has_flag_ter( ter_furn_flag::TFLAG_FLAMMABLE_HARD, current_tile );
+
+        if( md.has_flag_ter( ter_furn_flag::TFLAG_WALL, current_tile ) ) {
+            if( is_flammable_ter ) {
+                md.ter_set( current_tile.xy(), ter_t_wall_burnt );
+            }
+        } else if( md.has_flag_ter( ter_furn_flag::TFLAG_INDOORS, current_tile ) ||
+                   md.has_flag_ter( ter_furn_flag::TFLAG_DOOR, current_tile ) ) {
+            if( is_flammable_ter ) {
+                md.ter_set( current_tile.xy(), ter_t_floor_burnt );
+            }
+        } else if( !md.has_flag_ter( ter_furn_flag::TFLAG_INDOORS, current_tile ) ) {
+            if( current_tile.z() == 0 ) {
+                if( md.has_flag_ter( ter_furn_flag::TFLAG_DIGGABLE, current_tile ) ||
+                    is_flammable_ter ) {
+                    md.ter_set( current_tile.xy(), ter_t_dirt );
+                }
+            }
+        }
+
+        if( md.has_furn( current_tile ) &&
+            ( md.has_flag_furn( ter_furn_flag::TFLAG_FLAMMABLE, current_tile ) ||
+              md.has_flag_furn( ter_furn_flag::TFLAG_FLAMMABLE_ASH, current_tile ) ||
+              md.has_flag_furn( ter_furn_flag::TFLAG_FLAMMABLE_HARD, current_tile ) ) ) {
+            md.furn_set( current_tile.xy(), furn_str_id::NULL_ID() );
+        }
+
+        if( !md.has_flag_ter( ter_furn_flag::TFLAG_SWIMMABLE, current_tile ) &&
+            !md.has_flag_ter( ter_furn_flag::TFLAG_LIQUID, current_tile ) ) {
+            md.i_clear( current_tile.xy() );
+        }
+    }
+}
+
+// Compute the time-dependent pre_burn probability as a percent in [0, 100].
+static int pre_burn_percent_chance( const pp_sub_generator &sg, int days_since_cataclysm )
+{
+    const double lerp_scalar = static_cast<double>(
+                                   days_since_cataclysm - sg.scaling_days_start ) /
+                               static_cast<double>( sg.scaling_days_end - sg.scaling_days_start );
     int percent_chance = lerp( sg.min_intensity, sg.max_intensity, lerp_scalar );
     if( days_since_cataclysm < sg.scaling_days_start ) {
         percent_chance = 0;
     } else if( days_since_cataclysm >= sg.scaling_days_end ) {
         percent_chance = sg.max_intensity;
     }
+    return percent_chance;
+}
 
+static void execute_pre_burn( map &md,
+                              std::list<tripoint_bub_ms> &all_points_in_map,
+                              int days_since_cataclysm,
+                              const pp_sub_generator &sg )
+{
+    const int percent_chance = pre_burn_percent_chance( sg, days_since_cataclysm );
     for( int i = 0; i < sg.attempts; i++ ) {
         if( !x_in_y( percent_chance, 100 ) ) {
             continue;
         }
-        for( tripoint_bub_ms current_tile : all_points_in_map ) {
-            if( md.has_flag_ter( ter_furn_flag::TFLAG_NATURAL_UNDERGROUND, current_tile ) ||
-                md.has_flag_ter( ter_furn_flag::TFLAG_GOES_DOWN, current_tile ) ||
-                md.has_flag_ter( ter_furn_flag::TFLAG_GOES_UP, current_tile ) ) {
-                continue;
-            }
-
-            const bool is_flammable_ter =
-                md.has_flag_ter( ter_furn_flag::TFLAG_FLAMMABLE, current_tile ) ||
-                md.has_flag_ter( ter_furn_flag::TFLAG_FLAMMABLE_ASH, current_tile ) ||
-                md.has_flag_ter( ter_furn_flag::TFLAG_FLAMMABLE_HARD, current_tile );
-
-            if( md.has_flag_ter( ter_furn_flag::TFLAG_WALL, current_tile ) ) {
-                if( is_flammable_ter ) {
-                    md.ter_set( current_tile.xy(), ter_t_wall_burnt );
-                }
-            } else if( md.has_flag_ter( ter_furn_flag::TFLAG_INDOORS, current_tile ) ||
-                       md.has_flag_ter( ter_furn_flag::TFLAG_DOOR, current_tile ) ) {
-                if( is_flammable_ter ) {
-                    md.ter_set( current_tile.xy(), ter_t_floor_burnt );
-                }
-            } else if( !md.has_flag_ter( ter_furn_flag::TFLAG_INDOORS, current_tile ) ) {
-                if( current_tile.z() == 0 ) {
-                    if( md.has_flag_ter( ter_furn_flag::TFLAG_DIGGABLE, current_tile ) ||
-                        is_flammable_ter ) {
-                        md.ter_set( current_tile.xy(), ter_t_dirt );
-                    }
-                }
-            }
-
-            if( md.has_furn( current_tile ) &&
-                ( md.has_flag_furn( ter_furn_flag::TFLAG_FLAMMABLE, current_tile ) ||
-                  md.has_flag_furn( ter_furn_flag::TFLAG_FLAMMABLE_ASH, current_tile ) ||
-                  md.has_flag_furn( ter_furn_flag::TFLAG_FLAMMABLE_HARD, current_tile ) ) ) {
-                md.furn_set( current_tile.xy(), furn_str_id::NULL_ID() );
-            }
-
-            if( !md.has_flag_ter( ter_furn_flag::TFLAG_SWIMMABLE, current_tile ) &&
-                !md.has_flag_ter( ter_furn_flag::TFLAG_LIQUID, current_tile ) ) {
-                md.i_clear( current_tile.xy() );
-            }
-        }
+        apply_pre_burn_tiles( md, all_points_in_map );
     }
 }
 
@@ -622,7 +635,8 @@ static void execute_place_blood( map &md,
     }
 }
 
-static void execute_aftershock_ruin( map &md, const tripoint_abs_omt &p )
+static void execute_aftershock_ruin( map &md, const tripoint_abs_omt &p,
+                                     pp_sub_decision *dec )
 {
     std::list<tripoint_bub_ms> all_points_in_map;
 
@@ -637,9 +651,18 @@ static void execute_aftershock_ruin( map &md, const tripoint_abs_omt &p )
     bool above_ruined = overmap_buffer.ter( tripoint_abs_omt( p.x(), p.y(),
                                             p.z() + 1 ) ) == oter_afs_ruins_dynamic;
 
+    // applied -> fully ruined, skipped -> smashed-up, otherwise 50% roll.
+    bool full_ruin_roll;
+    if( dec && dec->st == pp_sub_decision::status::applied ) {
+        full_ruin_roll = true;
+    } else if( dec && dec->st == pp_sub_decision::status::skipped ) {
+        full_ruin_roll = false;
+    } else {
+        full_ruin_roll = x_in_y( 1, 2 );
+    }
 
     //fully ruined
-    if( ( x_in_y( 1, 2 ) && above_open_air ) || above_ruined ) {
+    if( ( full_ruin_roll && above_open_air ) || above_ruined ) {
         overmap_buffer.ter_set( p, oter_afs_ruins_dynamic );
 
         for( const tripoint_bub_ms &current_tile : all_points_in_map ) {
@@ -764,11 +787,47 @@ void pp_resolved_generator::deserialize( const JsonValue &jv )
     jo.read( "sub_decisions", sub_decisions );
 }
 
+// Mismatch on (type, ordinal) means a stale or not-yet-written entry; callers
+// fall back to fresh rolling.
+static pp_sub_decision *find_decision( std::vector<pp_sub_decision> *decisions,
+                                       sub_generator_type type, uint8_t ordinal )
+{
+    if( !decisions ) {
+        return nullptr;
+    }
+    for( pp_sub_decision &dec : *decisions ) {
+        if( dec.type == type && dec.ordinal == ordinal ) {
+            return &dec;
+        }
+    }
+    return nullptr;
+}
+
+// Uses rng_sequence (deterministic seeded sequence from rng.h) so the resolve
+// step doesn't depend on global RNG state at first-visit time.
+static bool resolve_pp_decision( const pp_sub_generator &sg, int days_since_cataclysm,
+                                 uint32_t seed )
+{
+    const int seed_int = static_cast<int>( seed );
+    switch( sg.type ) {
+        case sub_generator_type::pre_burn: {
+            const int percent_chance = pre_burn_percent_chance( sg, days_since_cataclysm );
+            const std::vector<int> seq = rng_sequence( 1, 0, 99, seed_int );
+            return seq[0] < percent_chance;
+        }
+        case sub_generator_type::aftershock_ruin: {
+            // Fresh x_in_y(1, 2): fully-ruined rolls at 50%.
+            const std::vector<int> seq = rng_sequence( 1, 0, 1, seed_int );
+            return seq[0] == 0;
+        }
+        default:
+            return true;
+    }
+}
+
 void pp_generator::execute( map &md, const tripoint_abs_omt &p,
                             std::vector<pp_sub_decision> *decisions ) const
 {
-    ( void )decisions;
-
     std::list<tripoint_bub_ms> all_points_in_map;
 
     for( int i = 0; i < SEEX * 2; i++ ) {
@@ -779,7 +838,21 @@ void pp_generator::execute( map &md, const tripoint_abs_omt &p,
 
     const int days_since_cataclysm = to_days<int>( calendar::turn - calendar::start_of_cataclysm );
 
+    std::map<sub_generator_type, uint8_t> type_counts;
     for( const pp_sub_generator &sg : sub_generators_ ) {
+        const uint8_t ordinal = type_counts[sg.type]++;
+
+        // applied/skipped mapping is type-specific and lives in each case below.
+        pp_sub_decision *dec = nullptr;
+        if( sg.scope == pp_sub_generator_scope::overmap_special ) {
+            dec = find_decision( decisions, sg.type, ordinal );
+            if( dec && dec->st == pp_sub_decision::status::not_evaluated ) {
+                const bool applied = resolve_pp_decision( sg, days_since_cataclysm, dec->seed );
+                dec->st = applied ? pp_sub_decision::status::applied
+                          : pp_sub_decision::status::skipped;
+            }
+        }
+
         switch( sg.type ) {
             case sub_generator_type::bash_damage:
                 execute_bash_damage( md, all_points_in_map, sg );
@@ -791,13 +864,19 @@ void pp_generator::execute( map &md, const tripoint_abs_omt &p,
                 execute_add_fire( md, all_points_in_map, days_since_cataclysm, sg );
                 break;
             case sub_generator_type::pre_burn:
-                execute_pre_burn( md, all_points_in_map, days_since_cataclysm, sg );
+                if( dec && dec->st == pp_sub_decision::status::applied ) {
+                    apply_pre_burn_tiles( md, all_points_in_map );
+                } else if( dec && dec->st == pp_sub_decision::status::skipped ) {
+                    // Building rolled not-burned for this special.
+                } else {
+                    execute_pre_burn( md, all_points_in_map, days_since_cataclysm, sg );
+                }
                 break;
             case sub_generator_type::place_blood:
                 execute_place_blood( md, all_points_in_map, days_since_cataclysm, sg );
                 break;
             case sub_generator_type::aftershock_ruin:
-                execute_aftershock_ruin( md, p );
+                execute_aftershock_ruin( md, p, dec );
                 break;
             case sub_generator_type::last:
                 debugmsg( "Invalid sub_generator_type in pp_generator '%s'", id.str() );

--- a/src/mapgen_post_process.cpp
+++ b/src/mapgen_post_process.cpp
@@ -4,18 +4,22 @@
 #include <cstddef>
 #include <functional>
 #include <list>
+#include <map>
 #include <string>
 #include <string_view>
+#include <utility>
 
 #include "calendar.h"
 #include "cata_utility.h"
 #include "coordinates.h"
 #include "debug.h"
 #include "drawing_primitives.h"
+#include "enum_conversions.h"
 #include "flexbuffer_json.h"
 #include "generic_factory.h"
 #include "item.h"
 #include "item_stack.h"
+#include "json.h"
 #include "map.h"
 #include "map_scale_constants.h"
 #include "mapdata.h"
@@ -98,6 +102,20 @@ std::string enum_to_string<sub_generator_type>( sub_generator_type data )
     }
     cata_fatal( "Invalid sub_generator_type" );
 }
+
+template<>
+std::string enum_to_string<pp_sub_generator_scope>( pp_sub_generator_scope data )
+{
+    switch( data ) {
+        // *INDENT-OFF*
+        case pp_sub_generator_scope::omt: return "omt";
+        case pp_sub_generator_scope::overmap_special: return "overmap_special";
+        // *INDENT-ON*
+        case pp_sub_generator_scope::last:
+            break;
+    }
+    cata_fatal( "Invalid pp_sub_generator_scope" );
+}
 } // namespace io
 
 void pp_generator::load( const JsonObject &jo, std::string_view )
@@ -123,6 +141,7 @@ void pp_sub_generator::load( const JsonObject &jo )
     optional( jo, false, "max_intensity", max_intensity, 0 );
     optional( jo, false, "scaling_days_start", scaling_days_start, 0 );
     optional( jo, false, "scaling_days_end", scaling_days_end, 0 );
+    optional( jo, false, "scope", scope, pp_sub_generator_scope::omt );
 }
 
 void pp_generator::check() const
@@ -132,6 +151,29 @@ void pp_generator::check() const
     }
     for( const pp_sub_generator &sg : sub_generators_ ) {
         sg.check( id.str() );
+    }
+    // Uniqueness rule: when a sub_generator_type has any overmap_special-scoped
+    // entry, it must be the ONLY entry of that type in this generator. This
+    // guarantees the persisted (type, ordinal=0) identity is stable across
+    // reorders and additions of omt-scoped entries.
+    std::map<sub_generator_type, int> total_counts;
+    std::map<sub_generator_type, int> special_counts;
+    for( const pp_sub_generator &sg : sub_generators_ ) {
+        total_counts[sg.type]++;
+        if( sg.scope == pp_sub_generator_scope::overmap_special ) {
+            special_counts[sg.type]++;
+        }
+    }
+    for( const std::pair<const sub_generator_type, int> &entry : special_counts ) {
+        const sub_generator_type t = entry.first;
+        const int total = total_counts[t];
+        if( entry.second > 1 || total > 1 ) {
+            debugmsg( "pp_generator '%s': sub_generator_type '%s' has an overmap_special-"
+                      "scoped entry but also %d other entries of the same type.  "
+                      "When scope is overmap_special, only one entry of that type is "
+                      "allowed in a generator.",
+                      id.str(), io::enum_to_string( t ), total - 1 );
+        }
     }
 }
 
@@ -220,6 +262,20 @@ void pp_sub_generator::check( const std::string &ctx ) const
     if( min_intensity > max_intensity && max_intensity != 0 ) {
         debugmsg( "pp_generator '%s' %s: min_intensity > max_intensity",
                   ctx, tname );
+    }
+
+    if( scope == pp_sub_generator_scope::overmap_special ) {
+        // Only pre_burn and aftershock_ruin fit the single-bool shared-decision model.
+        if( type != sub_generator_type::pre_burn &&
+            type != sub_generator_type::aftershock_ruin ) {
+            debugmsg( "pp_generator '%s' %s: scope 'overmap_special' not supported "
+                      "for this sub-generator type", ctx, tname );
+        }
+        // Multi-attempt semantics cannot be encoded as one shared bool decision.
+        if( type == sub_generator_type::pre_burn && attempts > 1 ) {
+            debugmsg( "pp_generator '%s' %s: scope 'overmap_special' requires "
+                      "attempts<=1, got %d", ctx, tname, attempts );
+        }
     }
 }
 
@@ -663,8 +719,56 @@ static void execute_aftershock_ruin( map &md, const tripoint_abs_omt &p )
     }
 }
 
-void pp_generator::execute( map &md, const tripoint_abs_omt &p ) const
+void pp_sub_decision::serialize( JsonOut &jsout ) const
 {
+    jsout.start_array();
+    jsout.write( io::enum_to_string( type ) );
+    jsout.write( static_cast<int>( ordinal ) );
+    jsout.write( static_cast<int>( st ) );
+    jsout.write( seed );
+    jsout.end_array();
+}
+
+void pp_sub_decision::deserialize( const JsonValue &jv )
+{
+    JsonArray ja = jv;
+    std::string type_str = ja.next_string();
+    type = io::string_to_enum<sub_generator_type>( type_str );
+    ordinal = static_cast<uint8_t>( ja.next_int() );
+    const int raw_st = ja.next_int();
+    // Clamp unknown future enum values to not_evaluated for forward compat.
+    if( raw_st >= 0 && raw_st <= static_cast<int>( status::skipped ) ) {
+        st = static_cast<status>( raw_st );
+    } else {
+        st = status::not_evaluated;
+    }
+    // Read seed as full uint32_t. JsonValue::read(unsigned int&) handles
+    // the full unsigned range; next_int() would truncate values above INT_MAX.
+    unsigned int seed_raw = 0;
+    ja.read_next( seed_raw, true );
+    seed = static_cast<uint32_t>( seed_raw );
+}
+
+void pp_resolved_generator::serialize( JsonOut &jsout ) const
+{
+    jsout.start_object();
+    jsout.member( "generator", generator );
+    jsout.member( "sub_decisions", sub_decisions );
+    jsout.end_object();
+}
+
+void pp_resolved_generator::deserialize( const JsonValue &jv )
+{
+    JsonObject jo = jv;
+    jo.read( "generator", generator );
+    jo.read( "sub_decisions", sub_decisions );
+}
+
+void pp_generator::execute( map &md, const tripoint_abs_omt &p,
+                            std::vector<pp_sub_decision> *decisions ) const
+{
+    ( void )decisions;
+
     std::list<tripoint_bub_ms> all_points_in_map;
 
     for( int i = 0; i < SEEX * 2; i++ ) {

--- a/src/mapgen_post_process.cpp
+++ b/src/mapgen_post_process.cpp
@@ -570,7 +570,23 @@ static void apply_pre_burn_tiles( map &md,
 
         if( !md.has_flag_ter( ter_furn_flag::TFLAG_SWIMMABLE, current_tile ) &&
             !md.has_flag_ter( ter_furn_flag::TFLAG_LIQUID, current_tile ) ) {
-            md.i_clear( current_tile.xy() );
+            // Mirrors seed preservation in execute_move_items.
+            const bool preserve_seed =
+                md.has_flag_ter_or_furn( ter_furn_flag::TFLAG_SEALED, current_tile ) &&
+                md.has_flag_ter_or_furn( ter_furn_flag::TFLAG_CONTAINER, current_tile ) &&
+                md.has_flag_ter_or_furn( ter_furn_flag::TFLAG_PLANT, current_tile );
+            if( preserve_seed ) {
+                map_stack items = md.i_at( current_tile.xy() );
+                for( auto it = items.begin(); it != items.end(); ) {
+                    if( it->is_seed() ) {
+                        ++it;
+                    } else {
+                        it = items.erase( it );
+                    }
+                }
+            } else {
+                md.i_clear( current_tile.xy() );
+            }
         }
     }
 }

--- a/src/mapgen_post_process.h
+++ b/src/mapgen_post_process.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_MAPGEN_POST_PROCESS_H
 #define CATA_SRC_MAPGEN_POST_PROCESS_H
 
+#include <cstdint>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -10,6 +11,8 @@
 #include "type_id.h"
 
 class JsonObject;
+class JsonOut;
+class JsonValue;
 class map;
 template<typename E> struct enum_traits;
 template<typename T> class generic_factory;
@@ -30,6 +33,22 @@ struct enum_traits<sub_generator_type> {
     static constexpr sub_generator_type last = sub_generator_type::last;
 };
 
+// Scope of a sub-generator decision.
+// omt: fresh roll per OMT each mapgen (current behavior, not persisted).
+// overmap_special: rolled once for whole special at place_special() time,
+// shared across all OMTs of the special. Fixes multi-OMT and multi-z-level
+// inconsistency for building-wide effects like pre_burn.
+enum class pp_sub_generator_scope : int {
+    omt = 0,
+    overmap_special,
+    last
+};
+
+template<>
+struct enum_traits<pp_sub_generator_scope> {
+    static constexpr pp_sub_generator_scope last = pp_sub_generator_scope::last;
+};
+
 // A single sub-generator entry within a pp_generator.
 // Not a generic_factory type -- loaded as an embedded sub-object of pp_generator.
 struct pp_sub_generator {
@@ -42,9 +61,37 @@ struct pp_sub_generator {
     int max_intensity = 0;
     int scaling_days_start = 0;
     int scaling_days_end = 0;
+    pp_sub_generator_scope scope = pp_sub_generator_scope::omt;
 
     void load( const JsonObject &jo );
     void check( const std::string &ctx ) const;
+};
+
+// Persisted decision for a single overmap_special-scoped sub-generator.
+// Keyed by (type, ordinal_within_type) so stored entries survive JSON
+// reorders and unrelated type swaps. pp_generator::check() enforces that
+// only one entry per type exists when any entry of that type uses
+// overmap_special scope, so ordinal is structurally always 0 today.
+// The field exists for forward-compat if that uniqueness rule ever relaxes.
+struct pp_sub_decision {
+    enum class status : uint8_t { not_evaluated = 0, applied, skipped };
+
+    sub_generator_type type = sub_generator_type::last;
+    uint8_t ordinal = 0;
+    status st = status::not_evaluated;
+    uint32_t seed = 0;
+
+    void serialize( JsonOut &jsout ) const;
+    void deserialize( const JsonValue &jv );
+};
+
+// All persisted decisions for one pp_generator on a given overmap_special.
+struct pp_resolved_generator {
+    pp_generator_id generator;
+    std::vector<pp_sub_decision> sub_decisions;
+
+    void serialize( JsonOut &jsout ) const;
+    void deserialize( const JsonValue &jv );
 };
 
 // A pp_generator: a named collection of sub-generators applied as a group.
@@ -59,7 +106,11 @@ class pp_generator
         }
 
         // Execute this generator on the given map at the given overmap position.
-        void execute( map &md, const tripoint_abs_omt &p ) const;
+        // decisions: persisted gate decisions for overmap_special-scoped sub-generators,
+        // or nullptr when no decisions are stored for this OMT. When nullptr, every
+        // sub-generator rolls fresh per OMT.
+        void execute( map &md, const tripoint_abs_omt &p,
+                      std::vector<pp_sub_decision> *decisions = nullptr ) const;
 
     private:
         void load( const JsonObject &jo, std::string_view src );

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -3070,6 +3070,46 @@ std::vector<tripoint_om_omt> overmap::place_special(
             safe_at_worldgen.emplace( location );
         }
     }
+
+    // Collect unique pp_generators referenced by any OMT of this special.
+    std::set<pp_generator_id> special_pp_gens;
+    for( const tripoint_om_omt &location : result.omts_used ) {
+        for( const pp_generator_id &gen_id : ter( location )->get_post_process_generators() ) {
+            special_pp_gens.insert( gen_id );
+        }
+    }
+    if( !special_pp_gens.empty() ) {
+        std::vector<pp_resolved_generator> decisions;
+        for( const pp_generator_id &gen_id : special_pp_gens ) {
+            const pp_generator &gen = gen_id.obj();
+            pp_resolved_generator resolved;
+            resolved.generator = gen_id;
+            std::map<sub_generator_type, uint8_t> type_counts;
+            for( const pp_sub_generator &sg : gen.sub_generators() ) {
+                const uint8_t ord = type_counts[sg.type];
+                if( sg.scope == pp_sub_generator_scope::overmap_special ) {
+                    pp_sub_decision dec;
+                    dec.type = sg.type;
+                    dec.ordinal = ord;
+                    dec.st = pp_sub_decision::status::not_evaluated;
+                    dec.seed = rng_bits();
+                    resolved.sub_decisions.push_back( dec );
+                }
+                type_counts[sg.type]++;
+            }
+            if( !resolved.sub_decisions.empty() ) {
+                decisions.push_back( std::move( resolved ) );
+            }
+        }
+        if( !decisions.empty() ) {
+            std::vector<pp_resolved_generator> *decisions_p =
+                &*pp_decision_storage.emplace( std::move( decisions ) );
+            for( const tripoint_om_omt &location : result.omts_used ) {
+                pp_decisions_index[location] = decisions_p;
+            }
+        }
+    }
+
     // Place spawns.
     const overmap_special_spawns &spawns = special.get_monster_spawns();
     if( spawns.group ) {

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -34,6 +34,7 @@
 #include "map_extras.h"
 #include "map_iterator.h"
 #include "mapbuffer.h"
+#include "mapgen_post_process.h"
 #include "math_defines.h"
 #include "messages.h"
 #include "mongroup.h"
@@ -392,6 +393,15 @@ std::optional<mapgen_arguments> *overmap::mapgen_args( const tripoint_om_omt &p 
 {
     auto it = mapgen_args_index.find( p );
     if( it == mapgen_args_index.end() ) {
+        return nullptr;
+    }
+    return it->second;
+}
+
+std::vector<pp_resolved_generator> *overmap::pp_decisions( const tripoint_om_omt &p )
+{
+    auto it = pp_decisions_index.find( p );
+    if( it == pp_decisions_index.end() ) {
         return nullptr;
     }
     return it->second;

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -58,6 +58,7 @@ class monster;
 class npc;
 class overmap_connection;
 struct horde_entity;
+struct pp_resolved_generator;
 struct map_data_summary;
 struct region_settings;
 template <typename T> struct enum_traits;
@@ -493,6 +494,9 @@ class overmap
         // ter_unsafe is UB when out of bounds.
         const oter_id &ter_unsafe( const tripoint_om_omt &p ) const;
         std::optional<mapgen_arguments> *mapgen_args( const tripoint_om_omt & );
+        // Persisted PP decisions for this OMT, or nullptr if this OMT is not part of
+        // a special with any overmap_special-scoped sub-generators.
+        std::vector<pp_resolved_generator> *pp_decisions( const tripoint_om_omt & );
         std::string *join_used_at( const om_pos_dir & );
         std::vector<oter_id> predecessors( const tripoint_om_omt & );
         void set_seen( const tripoint_om_omt &p, om_vision_level val, bool force = false );
@@ -687,6 +691,11 @@ class overmap
         std::unordered_map<tripoint_om_omt, std::optional<mapgen_arguments> *> mapgen_args_index;
         // Records mapgen parameters required at the omt level, fixed at the same values vertically
         std::unordered_map<point_abs_omt, mapgen_arguments> omt_stack_arguments_map;
+
+        // Persisted post-process decisions at overmap_special scope.
+        // Colony provides stable pointers so all OMTs of a special share one allocation.
+        cata::colony<std::vector<pp_resolved_generator>> pp_decision_storage;
+        std::unordered_map<tripoint_om_omt, std::vector<pp_resolved_generator> *> pp_decisions_index;
 
         // Records the joins that were chosen during placement of a mutable
         // special, so that it can be queried later by mapgen

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -926,6 +926,12 @@ std::optional<mapgen_arguments> *overmapbuffer::mapgen_args( const tripoint_abs_
     return om_loc.om->mapgen_args( om_loc.local );
 }
 
+std::vector<pp_resolved_generator> *overmapbuffer::pp_decisions( const tripoint_abs_omt &p )
+{
+    const overmap_with_local_coords om_loc = get_om_global( p );
+    return om_loc.om->pp_decisions( om_loc.local );
+}
+
 std::string *overmapbuffer::join_used_at( const std::pair<tripoint_abs_omt, cube_direction> &p )
 {
     const overmap_with_local_coords om_loc = get_om_global( p.first );

--- a/src/overmapbuffer.h
+++ b/src/overmapbuffer.h
@@ -37,6 +37,7 @@ class monster;
 class npc;
 class overmap_special;
 class vehicle;
+struct pp_resolved_generator;
 enum class cube_direction : int;
 enum class oter_travel_cost_type : int;
 namespace om_direction
@@ -230,6 +231,9 @@ class overmapbuffer
         const oter_id &ter_existing( const tripoint_abs_omt &p );
         void ter_set( const tripoint_abs_omt &p, const oter_id &id );
         std::optional<mapgen_arguments> *mapgen_args( const tripoint_abs_omt & );
+        // Persisted PP decisions for this OMT, or nullptr if not associated with a
+        // special with any overmap_special-scoped sub-generators.
+        std::vector<pp_resolved_generator> *pp_decisions( const tripoint_abs_omt & );
         std::string *join_used_at( const std::pair<tripoint_abs_omt, cube_direction> & );
         std::vector<oter_id> predecessors( const tripoint_abs_omt & );
         // pick an OMT, scan it from z level 10, and return the first level that is not air

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -17,6 +17,7 @@
 #include "cata_io.h"
 #include "cata_path.h"
 #include "city.h"
+#include "colony.h"
 #include "coordinates.h"
 #include "creature_tracker.h"
 #include "debug.h"
@@ -28,6 +29,7 @@
 #include "json_loader.h"
 #include "kill_tracker.h"
 #include "map.h"
+#include "mapgen_post_process.h"
 #include "messages.h"
 #include "mission.h"
 #include "mongroup.h"
@@ -476,6 +478,17 @@ void overmap::unserialize( const JsonObject &jsobj )
         jsobj.read( "omt_stack_arguments_map", flat_omt_stack_arguments_map, true );
         for( const std::pair<point_abs_omt, mapgen_arguments> &p : flat_omt_stack_arguments_map ) {
             omt_stack_arguments_map.emplace( p );
+        }
+    }
+    if( jsobj.has_member( "pp_decision_storage" ) ) {
+        jsobj.read( "pp_decision_storage", pp_decision_storage, true );
+    }
+    if( jsobj.has_member( "pp_decisions_index" ) ) {
+        std::vector<std::pair<tripoint_om_omt, int>> flat_index;
+        jsobj.read( "pp_decisions_index", flat_index, true );
+        for( const std::pair<tripoint_om_omt, int> &p : flat_index ) {
+            auto it = pp_decision_storage.get_iterator_from_index( p.second );
+            pp_decisions_index.emplace( p.first, &*it );
         }
     }
     std::vector<tripoint_abs_omt> camps_to_place;
@@ -1555,6 +1568,22 @@ void overmap::serialize( std::ostream &fout ) const
         json.start_array();
         json.write( p.first );
         p.second.serialize( json );
+        json.end_array();
+    }
+    json.end_array();
+    fout << std::endl;
+
+    json.member( "pp_decision_storage", pp_decision_storage );
+    fout << std::endl;
+    json.member( "pp_decisions_index" );
+    json.start_array();
+    for( const std::pair<const tripoint_om_omt, std::vector<pp_resolved_generator> *> &p :
+         pp_decisions_index ) {
+        json.start_array();
+        json.write( p.first );
+        auto it = pp_decision_storage.get_iterator_from_pointer( p.second );
+        int index = pp_decision_storage.get_index_from_iterator( it );
+        json.write( index );
         json.end_array();
     }
     json.end_array();

--- a/tests/mapgen_post_process_test.cpp
+++ b/tests/mapgen_post_process_test.cpp
@@ -1,4 +1,5 @@
 #include <cstddef>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -6,7 +7,10 @@
 #include "cata_catch.h"
 #include "coordinates.h"
 #include "field.h"
+#include "flexbuffer_json.h"
 #include "item.h"
+#include "json.h"
+#include "json_loader.h"
 #include "map.h"
 #include "map_helpers.h"
 #include "map_scale_constants.h"
@@ -853,4 +857,150 @@ TEST_CASE( "post_process_real_core_exempt", "[mapgen][post_process]" )
     tm.delete_unmerged_submaps();
     clear_overmaps();
 }
+
+TEST_CASE( "post_process_scope_field_loading", "[mapgen][post_process]" )
+{
+    // test_pp_riot is defined without explicit scope -- all sub-generators default to omt.
+    SECTION( "default scope is omt" ) {
+        const pp_generator &riot = pp_generator_test_pp_riot.obj();
+        for( const pp_sub_generator &sg : riot.sub_generators() ) {
+            CHECK( sg.scope == pp_sub_generator_scope::omt );
+        }
+    }
+}
+
+static std::string serialize_sub_decision( const pp_sub_decision &dec )
+{
+    std::ostringstream os;
+    JsonOut jsout( os );
+    dec.serialize( jsout );
+    return os.str();
+}
+
+static pp_sub_decision deserialize_sub_decision( const std::string &json_str )
+{
+    pp_sub_decision dec;
+    JsonValue jv = json_loader::from_string( json_str );
+    dec.deserialize( jv );
+    return dec;
+}
+
+TEST_CASE( "post_process_sub_decision_roundtrip", "[mapgen][post_process]" )
+{
+    SECTION( "not_evaluated + seed 0" ) {
+        pp_sub_decision a;
+        a.type = sub_generator_type::pre_burn;
+        a.ordinal = 0;
+        a.st = pp_sub_decision::status::not_evaluated;
+        a.seed = 0;
+        pp_sub_decision b = deserialize_sub_decision( serialize_sub_decision( a ) );
+        CHECK( b.type == a.type );
+        CHECK( b.ordinal == a.ordinal );
+        CHECK( b.st == a.st );
+        CHECK( b.seed == a.seed );
+    }
+    SECTION( "applied + INT_MAX seed" ) {
+        pp_sub_decision a;
+        a.type = sub_generator_type::aftershock_ruin;
+        a.ordinal = 0;
+        a.st = pp_sub_decision::status::applied;
+        a.seed = 0x7FFFFFFF;
+        pp_sub_decision b = deserialize_sub_decision( serialize_sub_decision( a ) );
+        CHECK( b.type == a.type );
+        CHECK( b.ordinal == a.ordinal );
+        CHECK( b.st == a.st );
+        CHECK( b.seed == a.seed );
+    }
+    SECTION( "applied + seed above INT_MAX (upper half of uint32_t range)" ) {
+        // FNV-1a over typical inputs can produce seeds in [INT_MAX+1, UINT_MAX].
+        // Naive next_int() deserialization would fail or truncate these.
+        pp_sub_decision a;
+        a.type = sub_generator_type::pre_burn;
+        a.ordinal = 0;
+        a.st = pp_sub_decision::status::applied;
+        a.seed = 0x80000001u;
+        pp_sub_decision b = deserialize_sub_decision( serialize_sub_decision( a ) );
+        CHECK( b.seed == a.seed );
+    }
+    SECTION( "applied + UINT_MAX seed" ) {
+        pp_sub_decision a;
+        a.type = sub_generator_type::pre_burn;
+        a.ordinal = 0;
+        a.st = pp_sub_decision::status::applied;
+        a.seed = 0xFFFFFFFFu;
+        pp_sub_decision b = deserialize_sub_decision( serialize_sub_decision( a ) );
+        CHECK( b.seed == a.seed );
+    }
+    SECTION( "skipped + arbitrary ordinal" ) {
+        pp_sub_decision a;
+        a.type = sub_generator_type::pre_burn;
+        a.ordinal = 3;
+        a.st = pp_sub_decision::status::skipped;
+        a.seed = 12345;
+        pp_sub_decision b = deserialize_sub_decision( serialize_sub_decision( a ) );
+        CHECK( b.type == a.type );
+        CHECK( b.ordinal == a.ordinal );
+        CHECK( b.st == a.st );
+        CHECK( b.seed == a.seed );
+    }
+    SECTION( "unknown status value clamps to not_evaluated" ) {
+        // Hand-crafted JSON with an out-of-range status int (future enum value).
+        const std::string json_str = "[\"pre_burn\", 0, 99, 42]";
+        pp_sub_decision b = deserialize_sub_decision( json_str );
+        CHECK( b.st == pp_sub_decision::status::not_evaluated );
+        CHECK( b.seed == 42 );
+    }
+}
+
+TEST_CASE( "post_process_resolved_generator_roundtrip", "[mapgen][post_process]" )
+{
+    pp_resolved_generator a;
+    a.generator = pp_generator_test_pp_riot;
+    pp_sub_decision d1;
+    d1.type = sub_generator_type::pre_burn;
+    d1.ordinal = 0;
+    d1.st = pp_sub_decision::status::applied;
+    d1.seed = 1111;
+    a.sub_decisions.push_back( d1 );
+    pp_sub_decision d2;
+    d2.type = sub_generator_type::aftershock_ruin;
+    d2.ordinal = 0;
+    d2.st = pp_sub_decision::status::skipped;
+    d2.seed = 2222;
+    a.sub_decisions.push_back( d2 );
+
+    std::ostringstream os;
+    JsonOut jsout( os );
+    a.serialize( jsout );
+    pp_resolved_generator b;
+    JsonValue jv = json_loader::from_string( os.str() );
+    b.deserialize( jv );
+
+    CHECK( b.generator == a.generator );
+    REQUIRE( b.sub_decisions.size() == a.sub_decisions.size() );
+    for( size_t i = 0; i < a.sub_decisions.size(); i++ ) {
+        CHECK( b.sub_decisions[i].type == a.sub_decisions[i].type );
+        CHECK( b.sub_decisions[i].ordinal == a.sub_decisions[i].ordinal );
+        CHECK( b.sub_decisions[i].st == a.sub_decisions[i].st );
+        CHECK( b.sub_decisions[i].seed == a.sub_decisions[i].seed );
+    }
+}
+
+TEST_CASE( "post_process_resolved_generator_empty_sub_decisions", "[mapgen][post_process]" )
+{
+    pp_resolved_generator a;
+    a.generator = pp_generator_test_pp_riot;
+    // sub_decisions intentionally empty
+
+    std::ostringstream os;
+    JsonOut jsout( os );
+    a.serialize( jsout );
+    pp_resolved_generator b;
+    JsonValue jv = json_loader::from_string( os.str() );
+    b.deserialize( jv );
+
+    CHECK( b.generator == a.generator );
+    CHECK( b.sub_decisions.empty() );
+}
+
 

--- a/tests/mapgen_post_process_test.cpp
+++ b/tests/mapgen_post_process_test.cpp
@@ -1,4 +1,5 @@
 #include <cstddef>
+#include <memory>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -11,12 +12,14 @@
 #include "item.h"
 #include "json.h"
 #include "json_loader.h"
+#include "city.h"
 #include "map.h"
 #include "map_helpers.h"
 #include "map_scale_constants.h"
 #include "mapbuffer.h"
 #include "mapgen_post_process.h"
 #include "omdata.h"
+#include "overmap.h"
 #include "overmapbuffer.h"
 #include "player_helpers.h"
 #include "point.h"
@@ -42,6 +45,9 @@ static const oter_str_id oter_test_pp_riot_building( "test_pp_riot_building" );
 
 static const oter_type_str_id oter_type_test_pp_field_inherit_child(
     "test_pp_field_inherit_child" );
+
+static const overmap_special_id
+overmap_special_test_pp_multi_z_special( "test_pp_multi_z_special" );
 
 static const pp_generator_id pp_generator_riot_damage( "riot_damage" );
 static const pp_generator_id pp_generator_riot_damage_road( "riot_damage_road" );
@@ -860,12 +866,24 @@ TEST_CASE( "post_process_real_core_exempt", "[mapgen][post_process]" )
 
 TEST_CASE( "post_process_scope_field_loading", "[mapgen][post_process]" )
 {
-    // test_pp_riot is defined without explicit scope -- all sub-generators default to omt.
-    SECTION( "default scope is omt" ) {
-        const pp_generator &riot = pp_generator_test_pp_riot.obj();
+    const pp_generator &riot = pp_generator_test_pp_riot.obj();
+    SECTION( "sub-generators without scope default to omt" ) {
+        // Only pre_burn is annotated; other sub-generators retain default scope.
         for( const pp_sub_generator &sg : riot.sub_generators() ) {
-            CHECK( sg.scope == pp_sub_generator_scope::omt );
+            if( sg.type != sub_generator_type::pre_burn ) {
+                CHECK( sg.scope == pp_sub_generator_scope::omt );
+            }
         }
+    }
+    SECTION( "pre_burn reads explicit overmap_special scope" ) {
+        bool found_pre_burn = false;
+        for( const pp_sub_generator &sg : riot.sub_generators() ) {
+            if( sg.type == sub_generator_type::pre_burn ) {
+                found_pre_burn = true;
+                CHECK( sg.scope == pp_sub_generator_scope::overmap_special );
+            }
+        }
+        CHECK( found_pre_burn );
     }
 }
 
@@ -1001,6 +1019,172 @@ TEST_CASE( "post_process_resolved_generator_empty_sub_decisions", "[mapgen][post
 
     CHECK( b.generator == a.generator );
     CHECK( b.sub_decisions.empty() );
+}
+
+// execute() with decisions=nullptr must fall back to the gated probability roll,
+// not silently noop or unconditionally apply.
+TEST_CASE( "post_process_null_decisions_falls_back_to_fresh_roll", "[mapgen][post_process]" )
+{
+    clear_overmaps();
+    clear_map();
+    clear_avatar();
+    map &here = get_map();
+    const tripoint_abs_omt pos = project_to<coords::omt>( here.get_abs_sub() );
+
+    calendar::turn = calendar::start_of_cataclysm + 14_days;
+
+    bool found = false;
+    for( unsigned int seed = 100; seed < 200; seed++ ) {
+        build_pp_test_layout( here, 0, false );
+        rng_set_engine_seed( seed );
+        pp_generator_riot_damage.obj().execute( here, pos, nullptr );
+        pp_scan_result r = scan_omt( here, 0 );
+        if( r.wall_burnt_count > 0 ) {
+            found = true;
+            break;
+        }
+    }
+    CHECK( found );
+
+    clear_overmaps();
+}
+
+// skipped pre_burn must be per-type: no burn here, but sibling sub-generators
+// (blood, bash, fire) in the same generator must still run.
+TEST_CASE( "post_process_pre_burn_skipped_is_noop_and_preserves_others",
+           "[mapgen][post_process]" )
+{
+    clear_overmaps();
+    clear_map();
+    clear_avatar();
+    map &here = get_map();
+    const tripoint_abs_omt pos = project_to<coords::omt>( here.get_abs_sub() );
+
+    calendar::turn = calendar::start_of_cataclysm + 14_days;
+
+    build_pp_test_layout( here, 0, false );
+    rng_set_engine_seed( 4242 );
+
+    // Construct a decision vector marking pre_burn as skipped.
+    std::vector<pp_sub_decision> decisions;
+    pp_sub_decision dec;
+    dec.type = sub_generator_type::pre_burn;
+    dec.ordinal = 0;
+    dec.st = pp_sub_decision::status::skipped;
+    dec.seed = 0;
+    decisions.push_back( dec );
+
+    pp_generator_riot_damage.obj().execute( here, pos, &decisions );
+    pp_scan_result r = scan_omt( here, 0 );
+
+    // Skipped pre_burn: no burnt terrain, no dirt from outdoor burn.
+    CHECK( r.wall_burnt_count == 0 );
+    CHECK( r.floor_burnt_count == 0 );
+    CHECK( r.dirt_count == 0 );
+    // Other sub-generators still run: blood proves they did.
+    CHECK( r.blood_field_count > 0 );
+
+    clear_overmaps();
+}
+
+// Guard: an applied overmap_special-scope pre_burn decision always burns,
+// regardless of time gate.
+TEST_CASE( "post_process_pre_burn_applied_runs_unconditionally",
+           "[mapgen][post_process]" )
+{
+    clear_overmaps();
+    clear_map();
+    clear_avatar();
+    map &here = get_map();
+    const tripoint_abs_omt pos = project_to<coords::omt>( here.get_abs_sub() );
+
+    // Before scaling_days_start: normal path would skip pre_burn entirely.
+    // Applied decision should still burn.
+    calendar::turn = calendar::start_of_cataclysm + 0_turns;
+
+    build_pp_test_layout( here, 0, false );
+    rng_set_engine_seed( 4242 );
+
+    std::vector<pp_sub_decision> decisions;
+    pp_sub_decision dec;
+    dec.type = sub_generator_type::pre_burn;
+    dec.ordinal = 0;
+    dec.st = pp_sub_decision::status::applied;
+    dec.seed = 0;
+    decisions.push_back( dec );
+
+    pp_generator_riot_damage.obj().execute( here, pos, &decisions );
+    pp_scan_result r = scan_omt( here, 0 );
+
+    // Applied: wood walls -> burnt, wood floor -> burnt.
+    CHECK( r.wall_burnt_count > 0 );
+    CHECK( r.floor_burnt_count > 0 );
+
+    clear_overmaps();
+}
+
+// All OMTs of a multi-z special must index to the same decision slot so the
+// first-to-mapgen OMT resolves the decision for every other z-level.
+TEST_CASE( "post_process_multi_z_special_shares_decisions", "[mapgen][post_process]" )
+{
+    const overmap_special &special = *overmap_special_test_pp_multi_z_special;
+    const city cit;
+
+    // Fresh overmap off the global grid keeps the test isolated from real state.
+    std::unique_ptr<overmap> om = std::make_unique<overmap>( point_abs_om::zero );
+
+    std::vector<tripoint_om_omt> placed;
+    for( int trial = 0; trial < 2000 && placed.empty(); trial++ ) {
+        tripoint_om_omt try_pos( rng( 1, OMAPX - 2 ), rng( 1, OMAPY - 2 ), 0 );
+        const om_direction::type dir = om_direction::type::north;
+        if( om->can_place_special( special, try_pos, dir, false ) ) {
+            placed = om->place_special( special, try_pos, dir, cit, false, false );
+        }
+    }
+    REQUIRE_FALSE( placed.empty() );
+    REQUIRE( placed.size() == 2 );
+
+    tripoint_om_omt z0_omt;
+    tripoint_om_omt z1_omt;
+    bool found_z0 = false;
+    bool found_z1 = false;
+    for( const tripoint_om_omt &p : placed ) {
+        if( p.z() == 0 ) {
+            z0_omt = p;
+            found_z0 = true;
+        } else if( p.z() == 1 ) {
+            z1_omt = p;
+            found_z1 = true;
+        }
+    }
+    REQUIRE( found_z0 );
+    REQUIRE( found_z1 );
+
+    CHECK_FALSE( om->ter( z0_omt )->get_post_process_generators().empty() );
+    CHECK_FALSE( om->ter( z1_omt )->get_post_process_generators().empty() );
+
+    std::vector<pp_resolved_generator> *z0_decisions = om->pp_decisions( z0_omt );
+    std::vector<pp_resolved_generator> *z1_decisions = om->pp_decisions( z1_omt );
+    REQUIRE( z0_decisions != nullptr );
+    REQUIRE( z1_decisions != nullptr );
+    CHECK( z0_decisions == z1_decisions );
+
+    bool found_riot = false;
+    bool found_pre_burn = false;
+    for( const pp_resolved_generator &rg : *z0_decisions ) {
+        if( rg.generator == pp_generator_test_pp_riot ) {
+            found_riot = true;
+            for( const pp_sub_decision &dec : rg.sub_decisions ) {
+                if( dec.type == sub_generator_type::pre_burn ) {
+                    found_pre_burn = true;
+                    CHECK( dec.ordinal == 0 );
+                    CHECK( dec.st == pp_sub_decision::status::not_evaluated );
+                }
+            }
+        }
+    }
+    CHECK( found_riot );
+    CHECK( found_pre_burn );
 }
 
 


### PR DESCRIPTION
#### Summary
Features "Multi-story and multi-OMT buildings now burn consistently across all of their tiles"

#### Purpose of change

Follows #86558. Addresses #80826. Pre-burn rolled a fresh probability at each OMT's mapgen, so multi-story buildings got the ground floor burnt and the upper floor untouched (or vice versa), and wide buildings got a checkerboard burn across their footprint.

#### Describe the solution

New `scope` field on sub-generators: `omt` (default, fresh per-OMT roll) or `overmap_special` (rolled once for the whole special, shared across every OMT of it). Persisted on the overmap at `place_special()` time, resolved lazily when the first OMT reaches mapgen, cached for the rest. Applied to `pre_burn` in `riot_damage` so any building placed as an overmap_special is now all-burnt or all-untouched.

Old saves without stored decisions fall through to fresh per-OMT rolls, no migration needed.

`overmap_special` scope is strictly validated: allowed only on `pre_burn` and `aftershock_ruin`; `pre_burn` requires `attempts <= 1`; a type using the scope must be the only entry of that type in its generator.

`aftershock_ruin` gets an optional decision pointer so it keeps working unchanged and the mod can opt in later.

#### Describe alternatives you've considered

Resolving the decision eagerly at `place_special()` and storing `applied`/`skipped` directly, instead of a seed plus lazy resolve. Doesn't work because `days_since_cataclysm` isn't known at worldgen time and pre_burn's probability curve depends on it. The decision has to resolve at first mapgen.

#### Testing

Four new tests: null-decisions fallback to the gated probability roll, `skipped` pre_burn as a per-type noop (sibling sub-generators still run), `applied` pre_burn running without the time gate, and an end-to-end check that a multi-z `overmap_special` indexes every z-level to the same decision slot. Existing `[post_process]` suite passes. Verified in-game.

#### Additional context

Unrelated quirk you may notice: burnt buildings with untouched wooden furniture on the roof. `generic_city_building_roof` explicitly deletes `riot_damage`, which is separate from this change.