### PR TITLE
Nobody wants to cooperate with psychopaths

### DIFF
--- a/data/json/npcs/common_chat/TALK_COMMON_OTHER.json
+++ b/data/json/npcs/common_chat/TALK_COMMON_OTHER.json
@@ -103,7 +103,11 @@
         "switch": true,
         "default": true,
         "text": "I can keep you safe.",
-        "trial": { "type": "PERSUADE", "difficulty": 20, "mod": [ [ "FEAR", 8 ], [ "VALUE", 2 ], [ "TRUST", 2 ], [ "BRAVERY", -2 ] ] },
+        "trial": {
+          "type": "PERSUADE",
+          "difficulty": 20,
+          "mod": [ [ "FEAR", 8 ], [ "VALUE", 2 ], [ "TRUST", 2 ], [ "BRAVERY", -2 ], [ "u_has_trait: PSYCHOPATH", -40 ] ]
+        },
         "success": {
           "topic": "TALK_AGREE_FOLLOW",
           "effect": [
@@ -123,7 +127,14 @@
         "trial": {
           "type": "PERSUADE",
           "difficulty": 0,
-          "mod": [ [ "ALTRUISM", 6 ], [ "POS_FEAR", -6 ], [ "BRAVERY", 2 ], [ "ANGER", -6 ], [ "VALUE", 2 ] ]
+          "mod": [
+            [ "ALTRUISM", 6 ],
+            [ "POS_FEAR", -6 ],
+            [ "BRAVERY", 2 ],
+            [ "ANGER", -6 ],
+            [ "VALUE", 2 ],
+            [ "u_has_trait: PSYCHOPATH", -40 ]
+          ]
         },
         "success": {
           "topic": "TALK_AGREE_FOLLOW",
@@ -141,7 +152,11 @@
         "switch": true,
         "default": true,
         "text": "We're friends, aren't we?",
-        "trial": { "type": "PERSUADE", "difficulty": 0, "mod": [ [ "TRUST", 3 ], [ "VALUE", 3 ], [ "ANGER", -3 ] ] },
+        "trial": {
+          "type": "PERSUADE",
+          "difficulty": 0,
+          "mod": [ [ "TRUST", 3 ], [ "VALUE", 3 ], [ "ANGER", -3 ], [ "u_has_trait: PSYCHOPATH", -40 ] ]
+        },
         "success": {
           "topic": "TALK_AGREE_FOLLOW",
           "effect": [
@@ -158,7 +173,11 @@
         "switch": true,
         "default": true,
         "text": "I'll kill you if you don't.",
-        "trial": { "type": "INTIMIDATE", "difficulty": 20, "mod": [ [ "FEAR", 8 ], [ "VALUE", 2 ], [ "TRUST", 2 ], [ "BRAVERY", -2 ] ] },
+        "trial": {
+          "type": "INTIMIDATE",
+          "difficulty": 20,
+          "mod": [ [ "FEAR", 8 ], [ "VALUE", 2 ], [ "TRUST", 2 ], [ "BRAVERY", -2 ], [ "u_has_trait: PSYCHOPATH", -30 ] ]
+        },
         "success": {
           "topic": "TALK_AGREE_FOLLOW",
           "effect": [
@@ -442,7 +461,11 @@
         "text": "Because I'm your friend!",
         "switch": true,
         "default": true,
-        "trial": { "type": "PERSUADE", "difficulty": 10, "mod": [ [ "TRUST", 1 ], [ "VALUE", 3 ], [ "ALTRUISM", 2 ] ] },
+        "trial": {
+          "type": "PERSUADE",
+          "difficulty": 10,
+          "mod": [ [ "TRUST", 1 ], [ "VALUE", 3 ], [ "ALTRUISM", 2 ], [ "u_has_trait: PSYCHOPATH", -10 ] ]
+        },
         "success": {
           "topic": "TALK_GIVE_EQUIPMENT",
           "effect": { "give_equipment": { "allowance": [ [ "TRUST", 1 ], [ "VALUE", 3 ], [ "ALTRUISM", 2 ], [ "TOTAL", 300 ] ] } },
@@ -458,7 +481,7 @@
         "trial": {
           "type": "PERSUADE",
           "difficulty": 12,
-          "mod": [ [ "TRUST", 1 ], [ "VALUE", 2 ], [ "ALTRUISM", 1 ], [ "MISSIONS", 1 ] ]
+          "mod": [ [ "TRUST", 1 ], [ "VALUE", 2 ], [ "ALTRUISM", 1 ], [ "MISSIONS", 1 ], [ "u_has_trait: PSYCHOPATH", -10 ] ]
         },
         "success": { "topic": "TALK_GIVE_EQUIPMENT", "effect": "give_equipment" },
         "failure": { "topic": "TALK_DENY_EQUIPMENT", "opinion": { "value": -1, "anger": 2 } }
@@ -467,7 +490,11 @@
         "text": "I'll give it back!",
         "switch": true,
         "default": true,
-        "trial": { "type": "LIE", "difficulty": 0, "mod": [ [ "TRUST", 2 ], [ "VALUE", 5 ], [ "ALTRUISM", 3 ] ] },
+        "trial": {
+          "type": "LIE",
+          "difficulty": 0,
+          "mod": [ [ "TRUST", 2 ], [ "VALUE", 5 ], [ "ALTRUISM", 3 ], [ "u_has_trait: PSYCHOPATH", -10 ] ]
+        },
         "success": {
           "topic": "TALK_GIVE_EQUIPMENT",
           "effect": { "give_equipment": { "allowance": [ [ "TRUST", 1 ], [ "VALUE", 3 ], [ "ALTRUISM", 2 ], [ "TOTAL", 300 ] ] } },
@@ -532,21 +559,29 @@
       {
         "text": "No, I'm keeping it.  Try and take it off me, I dare you.",
         "condition": "u_has_stolen_item",
-        "trial": { "type": "INTIMIDATE", "difficulty": 30, "mod": [ [ "FEAR", 8 ], [ "VALUE", 2 ], [ "TRUST", 2 ], [ "BRAVERY", -2 ] ] },
+        "trial": {
+          "type": "INTIMIDATE",
+          "difficulty": 30,
+          "mod": [ [ "FEAR", 8 ], [ "VALUE", 2 ], [ "TRUST", 2 ], [ "BRAVERY", -2 ], [ "u_has_trait: PSYCHOPATH", -25 ] ]
+        },
         "success": { "topic": "TALK_KEEPING_ITEM", "effect": { "u_faction_rep": -2 } },
         "failure": { "topic": "TALK_DONE", "effect": [ "hostile", { "u_faction_rep": -75 } ] }
       },
       {
         "text": "Look, I really need this.  Please let me have it.",
         "condition": "u_has_stolen_item",
-        "trial": { "type": "PERSUADE", "difficulty": 20, "mod": [ [ "TRUST", 3 ], [ "VALUE", 3 ], [ "ANGER", -3 ] ] },
+        "trial": {
+          "type": "PERSUADE",
+          "difficulty": 20,
+          "mod": [ [ "TRUST", 3 ], [ "VALUE", 3 ], [ "ANGER", -3 ], [ "u_has_trait: PSYCHOPATH", -25 ] ]
+        },
         "success": { "topic": "TALK_ALLOW_KEEP_ITEM", "effect": { "u_faction_rep": -1 } },
         "failure": { "topic": "TALK_DISALLOW_KEEP_ITEM", "opinion": { "trust": -3, "anger": 2 }, "effect": { "u_faction_rep": -15 } }
       },
       {
         "text": "What, this?  It's not the same one, you are mistaken.",
         "condition": "u_has_stolen_item",
-        "trial": { "type": "LIE", "difficulty": 25, "mod": [ [ "TRUST", 3 ] ] },
+        "trial": { "type": "LIE", "difficulty": 25, "mod": [ [ "TRUST", 3 ], [ "u_has_trait: PSYCHOPATH", -25 ] ] },
         "success": { "topic": "TALK_DONE", "effect": "remove_stolen_status" },
         "failure": { "topic": "TALK_DISALLOW_KEEP_ITEM", "opinion": { "trust": -3, "value": -1, "anger": 2 } }
       },

--- a/doc/JSON/NPCs.md
+++ b/doc/JSON/NPCs.md
@@ -752,19 +752,48 @@ Optional, if not defined, `"NONE"` is used. Otherwise one of `"NONE"`, `"LIE"`, 
 
 The `difficulty` is only required if type is not `"NONE"` or `"CONDITION"` and, for most trials, specifies the success chance in percent (it is however modified by various things like mutations).  Higher difficulties are easier to pass. `"SKILL_CHECK"` trials are unique, and use the difficulty as a flat comparison.
 
-An optional `mod` array takes any of the following modifiers and increases the difficulty by the NPC's opinion of your character or personality trait for that modifier multiplied by the value: `"ANGER"`, `"FEAR"`, `"TRUST"`, `"VALUE"`, `"AGGRESSION"`, `"ALTRUISM"`, `"BRAVERY"`, `"COLLECTOR"`. The special `"POS_FEAR"` modifier treats NPC's fear of your character below 0 as though it were 0.  The special `"TOTAL"` modifier sums all previous modifiers and then multiplies the result by its value and is used when setting the owed value.
-
 `"CONDITION"` trials take a mandatory `condition` instead of `difficulty`.  The `success` object is chosen if the `condition` is true and the `failure` is chosen otherwise.
 
 `"SKILL_CHECK"` trials check the user's level in a skill, whose ID is read from the string object `skill_required`. The `success` object is chosen if the skill level is equal to or greater than `difficulty`, and `failure` is chosen otherwise.
 
 Sample trials:
 ```jsonc
-"trial": { "type": "PERSUADE", "difficulty": 0, "mod": [ [ "TRUST", 3 ], [ "VALUE", 3 ], [ "ANGER", -3 ] ] }
+"trial": { "type": "PERSUADE", "difficulty": 0, "mod": [ [ "TRUST", 3 ], [ "VALUE", 3 ], [ "ANGER", -3 ], [ "u_has_trait: PSYCHOPATH", -40 ] ] }
 "trial": { "type": "INTIMIDATE", "difficulty": 20, "mod": [ [ "FEAR", 8 ], [ "VALUE", 2 ], [ "TRUST", 2 ], [ "BRAVERY", -2 ] ] }
 "trial": { "type": "CONDITION", "condition": { "npc_has_trait": "FARMER" } }
 "trial": { "type": "SKILL_CHECK", "difficulty": 3, "skill_required": "swimming" }
 ```
+
+#### `mod`
+`mod` is an array of modifiers to the trial's chances. Each mod is comprised of two values, the modifier and a factor. These are multiplied together to get the total change to the % chance. A modifier of -10 and a factor of 2 would produce a total mod of -20 to the chances, taking a chance of 64% down to 44%.
+
+Note that *there is no check that mod types are valid*. Invalid mod types will always count as 0(being totally ignored). Check your spelling.
+
+Valid mod types are:
+
+### `ANGER` / `FEAR` / `TRUST` / `VALUE`
+Uses the NPC's specific opinion value of the player as the modifier.
+
+### `POS_FEAR`
+The special `"POS_FEAR"` modifier treats NPC's fear of your character below 0 as though it were 0.
+
+### `AGGRESSION` / `ALTRUISM` / `BRAVERY` / `COLLECTOR`
+Uses the NPC's specific personality value as the modifier.
+
+### `MISSIONS`
+Uses the value of all previously completed missions given by that NPC as a value. Missions may define a specific value that they are 'worth'.
+
+### `U_INTIMIDATE` / `NPC_INTIMIDATE`
+U_INTIMIDATE does a C++ calculation to estimate how intimidating the player character looks.
+NPC_INTIMIDATE does the same thing to estimate the NPC's intimidation factor.
+
+### `u_has_trait: ` / `npc_has_trait: `
+u_has_trait checks if the player character has the specified trait.
+npc_has_trait checks if the NPC has the specified trait.
+Modifier is 1 if they have the trait, 0 otherwise.
+
+### `TOTAL`
+The special `"TOTAL"` modifier sums all previous modifiers and then multiplies the result by its value and is used when setting the owed value.
 
 #### `success` and `failure`
 The `success` and `failure` objects define the outcome, depending on the result of the trial.  Both objects have the same structure; the `failure` object is used if the trial fails, the `success` object is used otherwise.

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -2218,8 +2218,10 @@ void dialogue::gen_responses( const talk_topic &the_topic )
 
 static int parse_mod( const_dialogue const &d, const std::string &attribute, const int factor )
 {
-    return d.const_actor( true )->parse_mod( attribute, factor ) +
-           d.const_actor( false )->parse_mod( attribute, factor );
+    const int alpha_mod = d.const_actor( true )->parse_mod( attribute, factor );
+    const int beta_mod = d.const_actor( false )->parse_mod( attribute, factor );
+    add_msg_debug( debugmode::DF_NPC, "Parsed %d and %d", alpha_mod, beta_mod );
+    return alpha_mod + beta_mod;
 }
 
 static int total_price( const_talker const &seller, const itype_id &item_type )
@@ -2278,8 +2280,13 @@ int talk_trial::calc_chance( const_dialogue const &d ) const
                       d.const_actor( true )->trial_chance_mod( "intimidate" );
             break;
     }
+    add_msg_debug( debugmode::DF_NPC, "\nBase trial chance %d", chance );
     for( const auto &this_mod : modifiers ) {
-        chance += parse_mod( d, this_mod.first, this_mod.second );
+        const int trial_mod_int = parse_mod( d, this_mod.first, this_mod.second );
+        chance += trial_mod_int;
+        // Extra spaces at start for legibility.
+        add_msg_debug( debugmode::DF_NPC, "    %s modified trial chance by %d, now %d",
+                       this_mod.first, trial_mod_int, chance );
     }
 
     return std::max( 0, std::min( 100, chance ) );

--- a/src/talker_avatar.cpp
+++ b/src/talker_avatar.cpp
@@ -43,6 +43,13 @@ int talker_avatar_const::parse_mod( const std::string &attribute, const int fact
     int modifier = 0;
     if( attribute == "U_INTIMIDATE" ) {
         modifier = me_chr->intimidation();
+    } else if( attribute.find( "u_has_trait" ) != std::string::npos ) {
+        // shim/hack, reusing the syntax from EOCs
+
+        // Nasty string handling.
+        const std::string after = "u_has_trait: ";
+        trait_id checked_trait = trait_id( attribute.substr( after.size() ) );
+        modifier = me_chr->has_trait( checked_trait ) ? 1 : 0;
     }
     modifier *= factor;
     return modifier;

--- a/src/talker_npc.cpp
+++ b/src/talker_npc.cpp
@@ -263,7 +263,15 @@ int talker_npc_const::parse_mod( const std::string &attribute, const int factor 
         modifier = me_npc->assigned_missions_value() / OWED_VAL;
     } else if( attribute == "NPC_INTIMIDATE" ) {
         modifier = me_npc->intimidation();
+    } else if( attribute.find( "npc_has_trait" ) != std::string::npos ) {
+        // shim/hack, reusing the syntax from EOCs
+
+        // Nasty string handling.
+        const std::string after = "npc_has_trait: ";
+        trait_id checked_trait = trait_id( attribute.substr( after.size() ) );
+        modifier = me_npc->has_trait( checked_trait ) ? 1 : 0;
     }
+
     modifier *= factor;
     return modifier;
 }


### PR DESCRIPTION
#### Summary
Balance "Nobody wants to cooperate with psychopaths"

#### Purpose of change
The UNCARING trait remains a free "gimme", with essentially no downsides but invalidating large portions of our intended gameplay. (See the *many, many* previous discussions for examples)

#### Describe the solution
Add even more penalties. This is for common trials where being a psychopath is a huge red warning flag.

Asking for items: minor penalty if PC is UNCARING

Convincing you didn't steal item: moderate penalty

For recruitment: large penalty

It's very difficult to convince someone that they should work with you when it's obvious that you don't care about them at all, in a *literally psychopathic* way.

Basically this was done by adding a new `u_has_trait`/`npc_has_trait` entry to the trial mods, and doing the subsequent trait lookup.

UNCARING has an existing `social_modifiers` value of -5 for persuasion-type trials. This is a *miniscule* penalty, and applies to all persuasion-type trials (even one a psychopath should have no penalties for). Instead, this technically creates a two-tier system where a trait can modify "all X-type dialogue trials" by an amount, but each specific trial of that type can manually define a separate value which also applies in addition to the existing modifier.


#### Describe alternatives you've considered
Removing the UNCARING trait remains a very real alternative.

#### Testing
See included debugmsgs

#### Additional context

