### PR TITLE
The golden rule for psychopaths

### DIFF
--- a/data/json/effects_on_condition/misc_effect_on_condition.json
+++ b/data/json/effects_on_condition/misc_effect_on_condition.json
@@ -55,9 +55,23 @@
     "type": "effect_on_condition",
     "eoc_type": "AVATAR_DEATH",
     "condition": {
-      "and": [ { "npc_allies_global": 1 }, { "u_query": "You have died.  Continue as one of your followers?", "default": false } ]
+      "and": [
+        { "not": { "u_has_trait": "PSYCHOPATH" } },
+        { "npc_allies_global": 1 },
+        { "u_query": "You have died.  Continue as one of your followers?", "default": false }
+      ]
     },
-    "effect": [ "take_control_menu" ]
+    "effect": [ "take_control_menu" ],
+    "false_effect": [
+      {
+        "if": { "and": [ { "u_has_trait": "PSYCHOPATH" }, { "npc_allies_global": 1 } ] },
+        "then": {
+          "u_message": "You have died.  Just like you, nobody cares to have carried on your legacy.  You can not continue as a follower.",
+          "popup": true,
+          "type": "bad"
+        }
+      }
+    ]
   },
   {
     "type": "effect_on_condition",


### PR DESCRIPTION
#### Summary
Balance "Psychopaths cannot continue as a follower on death."

#### Purpose of change
The UNCARING trait remains a free "gimme", with essentially no downsides but invalidating large portions of our intended gameplay. (See the *many, many* previous discussions for examples)

#### Describe the solution
Add even more penalties. 

This prevents UNCARING characters from continuing as a follower on death. You didn't care - they don't care.

#### Describe alternatives you've considered

#### Testing
<img width="2560" height="1400" alt="image" src="https://github.com/user-attachments/assets/493ad37f-5a40-470d-bdd9-178c7af3dcd6" />

<img width="2560" height="1400" alt="image" src="https://github.com/user-attachments/assets/88bef890-2189-4558-9689-3323189f98ab" />


#### Additional context
