### PR TITLE
Infrastructure "Wrap remaining SDL names at the CATA_* boundary"

### DIFF
--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -616,10 +616,10 @@ void cataimgui::client::process_input( void *input )
         bool no_mouse = ImGui::GetIO().ConfigFlags & ImGuiConfigFlags_NoMouse;
         if( no_mouse ) {
             switch( evt->type ) {
-                case SDL_MOUSEMOTION:
-                case SDL_MOUSEWHEEL:
-                case SDL_MOUSEBUTTONDOWN:
-                case SDL_MOUSEBUTTONUP:
+                case CATA_MOUSEMOTION:
+                case CATA_MOUSEWHEEL:
+                case CATA_MOUSEBUTTONDOWN:
+                case CATA_MOUSEBUTTONUP:
                     return;
             }
         }

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -606,7 +606,7 @@ void tileset_cache::loader::load_tileset( const cata_path &img_path, const bool 
 
     if( R >= 0 && R <= 255 && G >= 0 && G <= 255 && B >= 0 && B <= 255 ) {
         const Uint32 key = MapRGB( tile_atlas, 0, 0, 0 );
-        throwErrorIf( SetColorKey( tile_atlas, SDL_TRUE, key ) != 0,
+        throwErrorIf( SetColorKey( tile_atlas, 1, key ) != 0,
                       "SDL_SetColorKey failed" );
         throwErrorIf( SetSurfaceRLE( tile_atlas, 1 ), "SDL_SetSurfaceRLE failed" );
     }
@@ -2061,7 +2061,7 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
                                     rec.destination.h
                                 };
                                 sil->render_copy_ex( renderer, &mask_dest, rec.angle, nullptr,
-                                                     static_cast<SDL_RendererFlip>( rec.flip ) );
+                                                     static_cast<CataFlipMode>( rec.flip ) );
                             }
                         }
 
@@ -3482,7 +3482,7 @@ bool cata_tiles::draw_sprite_at(
     // and for recording into tint_sprites (which replays the sprite as a white
     // silhouette during the tint overlay pass). Compute them once here.
     double render_angle = 0;
-    SDL_RendererFlip render_flip = SDL_FLIP_NONE;
+    CataFlipMode render_flip = SDL_FLIP_NONE;
     if( rotate_sprite ) {
         if( rota == -1 ) {
             render_flip = SDL_FLIP_HORIZONTAL;
@@ -3492,7 +3492,7 @@ bool cata_tiles::draw_sprite_at(
                     render_angle = -90;
                     break;
                 case 2:
-                    render_flip = static_cast<SDL_RendererFlip>( SDL_FLIP_HORIZONTAL | SDL_FLIP_VERTICAL );
+                    render_flip = static_cast<CataFlipMode>( SDL_FLIP_HORIZONTAL | SDL_FLIP_VERTICAL );
                     break;
                 case 3:
                     render_angle = 90;
@@ -3517,7 +3517,7 @@ bool cata_tiles::draw_sprite_at(
             // flip horizontally
             ret = sprite_tex->render_copy_ex(
                       renderer, &destination, 0, nullptr,
-                      static_cast<SDL_RendererFlip>( SDL_FLIP_HORIZONTAL ) );
+                      static_cast<CataFlipMode>( SDL_FLIP_HORIZONTAL ) );
         } else {
             switch( rota % 4 ) {
                 default:
@@ -3550,7 +3550,7 @@ bool cata_tiles::draw_sprite_at(
                         // never flip isometric tiles vertically
                         ret = sprite_tex->render_copy_ex(
                                   renderer, &destination, 0, nullptr,
-                                  static_cast<SDL_RendererFlip>( SDL_FLIP_HORIZONTAL | SDL_FLIP_VERTICAL ) );
+                                  static_cast<CataFlipMode>( SDL_FLIP_HORIZONTAL | SDL_FLIP_VERTICAL ) );
                     } else {
                         ret = sprite_tex->render_copy_ex( renderer, &destination, 0, nullptr,
                                                           SDL_FLIP_NONE );

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -166,7 +166,7 @@ class texture
         /// the stored source rectangle. Other parameters are simply passed through.
         int render_copy_ex( const SDL_Renderer_Ptr &renderer, const SDL_Rect *const dstrect,
                             const double angle,
-                            const SDL_Point *const center, const SDL_RendererFlip flip ) const {
+                            const SDL_Point *const center, const CataFlipMode flip ) const {
             RenderCopyEx( renderer, sdl_texture_ptr.get(), &srcrect, dstrect, angle, center, flip );
             return 0;
         }

--- a/src/map.h
+++ b/src/map.h
@@ -345,7 +345,7 @@ struct tint_sprite_record {
         int x, y, w, h;
     } destination;         // screen-space destination rect at time of draw
     double angle;          // rotation angle (0, -90, 90)
-    int flip;              // SDL_RendererFlip cast to int (avoids SDL include)
+    int flip;              // CataFlipMode cast to int (avoids SDL include)
 };
 
 struct tile_render_info {

--- a/src/sdl_font.cpp
+++ b/src/sdl_font.cpp
@@ -297,7 +297,7 @@ CachedTTFFont::CachedTTFFont(
     }
     font = OpenFontIndex( typeface.c_str(), fontsize, faceIndex );
     if( !font ) {
-        throw std::runtime_error( TTF_GetError() );
+        throw std::runtime_error( SDL_GetError() );
     }
     SetFontStyle( font, TTF_STYLE_NORMAL );
 }
@@ -311,7 +311,7 @@ SDL_Texture_Ptr CachedTTFFont::create_glyph( const SDL_Renderer_Ptr &renderer,
                              ? RenderUTF8_Blended( font, ch.c_str(), windowsPalette[color] )
                              : RenderUTF8_Solid( font, ch.c_str(), windowsPalette[color] );
     if( !sglyph ) {
-        dbg( D_ERROR ) << "Failed to create glyph for " << ch << ": " << TTF_GetError();
+        dbg( D_ERROR ) << "Failed to create glyph for " << ch << ": " << SDL_GetError();
         return nullptr;
     }
     const int wf = utf8_width( ch );
@@ -402,7 +402,7 @@ BitmapFont::BitmapFont(
         throw std::runtime_error( "bitmap for font is to small" );
     }
     Uint32 key = MapRGB( asciiload, 0xFF, 0, 0xFF );
-    SetColorKey( asciiload, SDL_TRUE, key );
+    SetColorKey( asciiload, 1, key );
     std::array<SDL_Surface_Ptr, std::tuple_size<decltype( ascii )>::value> ascii_surf;
     ascii_surf[0] = ConvertSurfaceFormat( asciiload, pixel_format );
     SetSurfaceRLE( ascii_surf[0], 1 );

--- a/src/sdl_wrappers.cpp
+++ b/src/sdl_wrappers.cpp
@@ -264,7 +264,7 @@ void SetTextureAlphaMod( const std::shared_ptr<SDL_Texture> &texture, const Uint
 void RenderCopyEx( const SDL_Renderer_Ptr &renderer, SDL_Texture *const texture,
                    const SDL_Rect *const srcrect, const SDL_Rect *const dstrect,
                    const double angle, const SDL_Point *const center,
-                   const SDL_RendererFlip flip )
+                   const CataFlipMode flip )
 {
     if( !renderer ) {
         dbg( D_ERROR ) << "Tried to render to a null renderer";
@@ -304,7 +304,7 @@ bool RenderIsClipEnabled( const SDL_Renderer_Ptr &renderer )
         dbg( D_ERROR ) << "Tried to use a null renderer";
         return false;
     }
-    return SDL_RenderIsClipEnabled( renderer.get() ) == SDL_TRUE;
+    return SDL_RenderIsClipEnabled( renderer.get() );
 }
 
 int BlitSurface( const SDL_Surface_Ptr &src, const SDL_Rect *const srcrect,
@@ -421,7 +421,7 @@ TTF_Font_Ptr OpenFontIndex( const char *const file, const int ptsize, const int6
 {
     // NOLINTNEXTLINE(cata-no-long)
     TTF_Font_Ptr result( TTF_OpenFontIndex( file, ptsize, static_cast<long>( index ) ) );
-    // Callers check the result and may call TTF_GetError themselves.
+    // Callers check the result and may call SDL_GetError themselves.
     return result;
 }
 
@@ -769,7 +769,7 @@ void StopTextInput( SDL_Window */*window*/ )
 bool IsTextInputActive( SDL_Window */*window*/ )
 {
     // SDL3: SDL_TextInputActive(window). SDL2: no window param.
-    return SDL_IsTextInputActive() == SDL_TRUE;
+    return SDL_IsTextInputActive();
 }
 
 

--- a/src/sdl_wrappers.h
+++ b/src/sdl_wrappers.h
@@ -27,6 +27,13 @@
 
 struct point;
 
+// SDL3 renames SDL_RendererFlip to SDL_FlipMode. Use CataFlipMode at call sites.
+#if SDL_MAJOR_VERSION >= 3
+using CataFlipMode = SDL_FlipMode;
+#else
+using CataFlipMode = SDL_RendererFlip;
+#endif
+
 struct SDL_Renderer_deleter {
     void operator()( SDL_Renderer *const renderer ) {
         SDL_DestroyRenderer( renderer );
@@ -108,7 +115,7 @@ void SetTextureAlphaMod( const SDL_Texture_Ptr &texture, Uint8 alpha );
 void SetTextureAlphaMod( const std::shared_ptr<SDL_Texture> &texture, Uint8 alpha );
 void RenderCopyEx( const SDL_Renderer_Ptr &renderer, SDL_Texture *texture,
                    const SDL_Rect *srcrect, const SDL_Rect *dstrect,
-                   double angle, const SDL_Point *center, SDL_RendererFlip flip );
+                   double angle, const SDL_Point *center, CataFlipMode flip );
 void RenderSetClipRect( const SDL_Renderer_Ptr &renderer, const SDL_Rect *rect );
 void RenderGetClipRect( const SDL_Renderer_Ptr &renderer, SDL_Rect *rect );
 bool RenderIsClipEnabled( const SDL_Renderer_Ptr &renderer );
@@ -309,6 +316,29 @@ inline constexpr Uint32 CATA_FINGERUP     = SDL_EVENT_FINGER_UP;
 inline constexpr Uint32 CATA_FINGERMOTION = SDL_FINGERMOTION;
 inline constexpr Uint32 CATA_FINGERDOWN   = SDL_FINGERDOWN;
 inline constexpr Uint32 CATA_FINGERUP     = SDL_FINGERUP;
+#endif
+
+// Input and quit event renames. SDL3: SDL_KEYDOWN -> SDL_EVENT_KEY_DOWN etc.
+#if SDL_MAJOR_VERSION >= 3
+inline constexpr Uint32 CATA_KEYDOWN         = SDL_EVENT_KEY_DOWN;
+inline constexpr Uint32 CATA_KEYUP           = SDL_EVENT_KEY_UP;
+inline constexpr Uint32 CATA_TEXTINPUT       = SDL_EVENT_TEXT_INPUT;
+inline constexpr Uint32 CATA_TEXTEDITING     = SDL_EVENT_TEXT_EDITING;
+inline constexpr Uint32 CATA_MOUSEMOTION     = SDL_EVENT_MOUSE_MOTION;
+inline constexpr Uint32 CATA_MOUSEBUTTONDOWN = SDL_EVENT_MOUSE_BUTTON_DOWN;
+inline constexpr Uint32 CATA_MOUSEBUTTONUP   = SDL_EVENT_MOUSE_BUTTON_UP;
+inline constexpr Uint32 CATA_MOUSEWHEEL      = SDL_EVENT_MOUSE_WHEEL;
+inline constexpr Uint32 CATA_QUIT            = SDL_EVENT_QUIT;
+#else
+inline constexpr Uint32 CATA_KEYDOWN         = SDL_KEYDOWN;
+inline constexpr Uint32 CATA_KEYUP           = SDL_KEYUP;
+inline constexpr Uint32 CATA_TEXTINPUT       = SDL_TEXTINPUT;
+inline constexpr Uint32 CATA_TEXTEDITING     = SDL_TEXTEDITING;
+inline constexpr Uint32 CATA_MOUSEMOTION     = SDL_MOUSEMOTION;
+inline constexpr Uint32 CATA_MOUSEBUTTONDOWN = SDL_MOUSEBUTTONDOWN;
+inline constexpr Uint32 CATA_MOUSEBUTTONUP   = SDL_MOUSEBUTTONUP;
+inline constexpr Uint32 CATA_MOUSEWHEEL      = SDL_MOUSEWHEEL;
+inline constexpr Uint32 CATA_QUIT            = SDL_QUIT;
 #endif
 
 // SDL3 removes SDL_Keysym from key events: ev.key.keysym.sym -> ev.key.key,

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -3182,7 +3182,7 @@ static void CheckMessages()
                 case CATA_RENDER_TARGETS_RESET:
                     render_target_reset = true;
                     break;
-                case SDL_KEYDOWN: {
+                case CATA_KEYDOWN: {
 #if defined(__ANDROID__)
                     // Toggle virtual keyboard with Android back button. For some reason I get double inputs, so ignore everything once it's already down.
                     if( GetKeysym( ev ).sym == SDLK_AC_BACK && ac_back_down_time == 0 ) {
@@ -3238,7 +3238,7 @@ static void CheckMessages()
                     }
                 }
                 break;
-                case SDL_KEYUP: {
+                case CATA_KEYUP: {
 #if defined(__ANDROID__)
                     // Toggle virtual keyboard with Android back button
                     if( GetKeysym( ev ).sym == SDLK_AC_BACK ) {
@@ -3273,7 +3273,7 @@ static void CheckMessages()
                     }
                 }
                 break;
-                case SDL_TEXTINPUT:
+                case CATA_TEXTINPUT:
                     if( !add_alt_code( *ev.text.text ) ) {
                         if( strlen( ev.text.text ) > 0 ) {
                             const unsigned lc = UTF8_getch( ev.text.text );
@@ -3307,7 +3307,7 @@ static void CheckMessages()
                         text_refresh = true;
                     }
                     break;
-                case SDL_TEXTEDITING: {
+                case CATA_TEXTEDITING: {
                     if( strlen( ev.edit.text ) > 0 ) {
                         const unsigned lc = UTF8_getch( ev.edit.text );
                         last_input = input_event( lc, input_event_t::keyboard_char );
@@ -3345,7 +3345,7 @@ static void CheckMessages()
                     break;
                 }
 #endif
-                case SDL_MOUSEMOTION:
+                case CATA_MOUSEMOTION:
                     if( ! mouse.enabled ) {
                         break;
                     }
@@ -3360,7 +3360,7 @@ static void CheckMessages()
                     }
                     break;
 
-                case SDL_MOUSEBUTTONDOWN:
+                case CATA_MOUSEBUTTONDOWN:
                     if( ! mouse.enabled ) {
                         break;
                     }
@@ -3380,7 +3380,7 @@ static void CheckMessages()
                     }
                     break;
 
-                case SDL_MOUSEBUTTONUP:
+                case CATA_MOUSEBUTTONUP:
                     if( ! mouse.enabled ) {
                         break;
                     }
@@ -3400,7 +3400,7 @@ static void CheckMessages()
                     }
                     break;
 
-                case SDL_MOUSEWHEEL:
+                case CATA_MOUSEWHEEL:
                     if( ! mouse.enabled ) {
                         break;
                     }
@@ -3661,7 +3661,7 @@ static void CheckMessages()
                     break;
 #endif
 
-                case SDL_QUIT:
+                case CATA_QUIT:
                     quit = true;
                     break;
                 default:


### PR DESCRIPTION
#### Summary
Infrastructure "Wrap remaining SDL names at the CATA_* boundary"

#### Purpose of change

Follows #86362. Extends the CATA_* boundary to keyboard, text, mouse, and quit events, the renderer flip type, and the SDL_TRUE literal. Pure prep, no behavior change on SDL2.

#### Describe the solution

New constexpr aliases CATA_KEYDOWN, CATA_KEYUP, CATA_TEXTINPUT, CATA_TEXTEDITING, CATA_MOUSE*, CATA_QUIT, and a CataFlipMode typedef in sdl_wrappers.h. Call sites in sdltiles.cpp, cata_imgui.cpp, and cata_tiles.cpp migrated.

SetColorKey flag uses 1 instead of SDL_TRUE. `== SDL_TRUE` comparisons dropped. TTF_GetError routed through SDL_GetError.

#### Describe alternatives you've considered

N/A.

#### Testing

N/A.

#### Additional context

N/A.