### PR TITLE
Update use_action messages, part 3

### DIFF
--- a/data/json/items/armor/head_attachments.json
+++ b/data/json/items/armor/head_attachments.json
@@ -272,7 +272,7 @@
       "ammo_scale": 0,
       "type": "transform",
       "menu_text": "Turn off",
-      "msg": "Your %s deactivates.",
+      "msg": "You deactivate your %s.",
       "target": "military_nvg"
     },
     "armor": [ { "covers": [ "eyes" ], "coverage": 100, "encumbrance": 20, "rigid_layer_only": true } ]
@@ -337,7 +337,7 @@
       "ammo_scale": 0,
       "type": "transform",
       "menu_text": "Turn off",
-      "msg": "Your %s deactivates.",
+      "msg": "You deactivate your %s.",
       "target": "advanced_gpnvg"
     },
     "armor": [
@@ -405,7 +405,7 @@
       "ammo_scale": 0,
       "type": "transform",
       "menu_text": "Turn off",
-      "msg": "Your %s deactivates.",
+      "msg": "You deactivate your %s.",
       "target": "enhanced_nvg"
     },
     "armor": [

--- a/data/json/items/gunmod/rail.json
+++ b/data/json/items/gunmod/rail.json
@@ -77,7 +77,8 @@
     "flags": [ "LASER_SIGHT" ],
     "use_action": {
       "type": "transform",
-      "msg": "You turn the army flashlight-laser module flashlight on.",
+      "menu_text": "Turn on flashlight",
+      "msg": "You turn the module's flashlight on.",
       "target": "mipim_on",
       "need_charges": 1,
       "need_charges_msg": "The batteries are dead."
@@ -102,9 +103,9 @@
     "power_draw": "31 W",
     "revert_to": "mipim",
     "use_action": {
-      "menu_text": "Turn off",
+      "menu_text": "Turn off flashlight",
       "type": "transform",
-      "msg": "You turn the army flashlight-laser module off.",
+      "msg": "You turn the module's flashlight off.",
       "target": "mipim",
       "ammo_scale": 0
     },

--- a/data/json/items/melee/bludgeons.json
+++ b/data/json/items/melee/bludgeons.json
@@ -446,7 +446,7 @@
     "charges_per_use": 1,
     "use_action": {
       "type": "transform",
-      "msg": "You turn the wizard cane on.",
+      "msg": "You turn on the %s.",
       "target": "wizard_cane_cheap_on",
       "need_charges": 1,
       "need_charges_msg": "The batteries are dead."
@@ -474,7 +474,7 @@
     "use_action": {
       "menu_text": "Turn off",
       "type": "transform",
-      "msg": "You turn the wizard cane off.",
+      "msg": "You turn off the %s.",
       "target": "wizard_cane_cheap",
       "ammo_scale": 0
     },
@@ -499,7 +499,7 @@
     "charges_per_use": 1,
     "use_action": {
       "type": "transform",
-      "msg": "You turn the wizard cane on.",
+      "msg": "You turn on the %s.",
       "target": "wizard_cane_on",
       "need_charges": 1,
       "need_charges_msg": "The batteries are dead."
@@ -527,7 +527,7 @@
     "use_action": {
       "menu_text": "Turn off",
       "type": "transform",
-      "msg": "You turn the wizard cane off.",
+      "msg": "You turn off the %s.",
       "target": "wizard_cane",
       "ammo_scale": 0
     },
@@ -1644,7 +1644,7 @@
     "techniques": [ "WBLOCK_2", "RAPID", "PRECISE" ],
     "flags": [ "DURABLE_MELEE", "BELT_CLIP", "NONCONDUCTIVE" ],
     "weapon_category": [ "BATONS" ],
-    "use_action": { "menu_text": "Retract", "type": "transform", "target": "PR24-retracted", "msg": "You collapse your PR-24 baton." },
+    "use_action": { "menu_text": "Retract", "type": "transform", "target": "PR24-retracted", "msg": "You collapse your baton." },
     "volume": "2 L",
     "longest_side": "60 cm",
     "to_hit": { "grip": "weapon", "length": "long", "surface": "any", "balance": "good" },
@@ -1664,7 +1664,7 @@
     "material": [ "aluminum", "plastic" ],
     "techniques": [ "WBLOCK_1" ],
     "flags": [ "DURABLE_MELEE", "BELT_CLIP", "NONCONDUCTIVE" ],
-    "use_action": { "menu_text": "Extend", "type": "transform", "target": "PR24-extended", "msg": "You snap open your PR-24 baton." },
+    "use_action": { "menu_text": "Extend", "type": "transform", "target": "PR24-extended", "msg": "You snap open your baton." },
     "volume": "1 L",
     "longest_side": "20 cm",
     "to_hit": { "grip": "weapon", "length": "short", "surface": "any", "balance": "neutral" },

--- a/data/json/items/tool/electronics.json
+++ b/data/json/items/tool/electronics.json
@@ -189,7 +189,7 @@
         "ammo_scale": 0,
         "target": "cell_phone",
         "msg": "You turn off the screen.",
-        "menu_text": "Turn off",
+        "menu_text": "Turn off the screen",
         "type": "transform"
       },
       { "type": "link_up", "cable_length": 3, "charge_rate": "20 W" }
@@ -290,7 +290,7 @@
         "ammo_scale": 0,
         "type": "transform",
         "menu_text": "Turn off the screen",
-        "msg": "You power down the screen.",
+        "msg": "You turn off the screen.",
         "target": "eink_tablet_pc"
       },
       { "type": "link_up", "cable_length": 4, "charge_rate": "10 W" }
@@ -728,7 +728,12 @@
     "revert_to": "mp3",
     "tick_action": [ "MP3_ON" ],
     "use_action": [
-      { "type": "mp3", "transform": "mp3", "message": "The mp3 player turns off.", "activate": false },
+      {
+        "type": "mp3",
+        "transform": "mp3",
+        "message": "You stop listening to music and take your earbuds out.",
+        "activate": false
+      },
       { "type": "link_up", "cable_length": 2, "charge_rate": "5 W" }
     ],
     "faults": [ { "fault_group": "electronic_general" } ],
@@ -749,7 +754,7 @@
     "symbol": ";",
     "color": "yellow",
     "charges_per_use": 1,
-    "use_action": { "target": "noise_emitter_on", "msg": "You turn the noise emitter on.", "menu_text": "Turn on", "type": "transform" },
+    "use_action": { "target": "noise_emitter_on", "msg": "You turn on the %s.", "menu_text": "Turn on", "type": "transform" },
     "flags": [ "RADIO_MODABLE", "RADIO_INVOKE_PROC", "WATER_BREAK" ],
     "pocket_data": [
       {
@@ -799,7 +804,7 @@
     "charges_per_use": 1,
     "use_action": {
       "type": "transform",
-      "msg": "You turn the EMF detector on.",
+      "msg": "You turn on the %s.",
       "target": "emf_detector_on",
       "need_charges_msg": "The batteries are dead."
     },
@@ -922,7 +927,12 @@
       "E_FILE_DEVICE",
       "EBOOKSAVE",
       "PORTABLE_GAME",
-      { "type": "mp3", "transform": "smart_phone", "message": "The phone turns off.", "activate": false },
+      {
+        "type": "mp3",
+        "transform": "smart_phone",
+        "message": "You stop listening to music and take your earbuds out.",
+        "activate": false
+      },
       { "type": "link_up", "cable_length": 3, "charge_rate": "20 W" }
     ],
     "tick_action": [ "MP3_ON" ],
@@ -1063,13 +1073,7 @@
       }
     ],
     "charges_per_use": 1,
-    "use_action": {
-      "ammo_scale": 0,
-      "target": "UPS_OFF",
-      "msg": "The charger is turned off.",
-      "menu_text": "Turn off",
-      "type": "transform"
-    },
+    "use_action": { "ammo_scale": 0, "target": "UPS_OFF", "msg": "You turn off the %s.", "menu_text": "Turn off", "type": "transform" },
     "melee_damage": { "bash": 8 },
     "tool_ammo": [ "battery" ]
   },
@@ -1099,7 +1103,7 @@
     "use_action": {
       "ammo_scale": 0,
       "target": "UPS_ON",
-      "msg": "You turn the charger on.",
+      "msg": "You turn on the %s.",
       "need_charges": 1,
       "need_charges_msg": "The batteries are dead.",
       "type": "transform"
@@ -1184,7 +1188,7 @@
     "charges_per_use": 1,
     "use_action": {
       "target": "gas_charger_on",
-      "msg": "You turn the charger on.",
+      "msg": "You turn on the %s.",
       "need_charges": 1,
       "need_charges_msg": "The charger's tank is empty.",
       "type": "transform"
@@ -1228,12 +1232,7 @@
     "symbol": ";",
     "color": "yellow",
     "charges_per_use": 1,
-    "use_action": {
-      "target": "noise_emitter_super_on",
-      "msg": "You turn the super noise emitter on.",
-      "menu_text": "Turn on",
-      "type": "transform"
-    },
+    "use_action": { "target": "noise_emitter_super_on", "msg": "You turn on the %s.", "type": "transform" },
     "flags": [ "RADIO_MODABLE", "RADIO_INVOKE_PROC", "WATER_BREAK" ],
     "pocket_data": [
       {
@@ -1257,7 +1256,7 @@
     "revert_to": "noise_emitter_super",
     "use_action": {
       "target": "noise_emitter_super",
-      "msg": "The infernal racket dies as the super noise emitter turns off.",
+      "msg": "The infernal racket dies as the noise emitter turns off.",
       "ammo_scale": 0,
       "menu_text": "Turn off",
       "type": "transform"

--- a/data/json/items/tool/lighting.json
+++ b/data/json/items/tool/lighting.json
@@ -16,7 +16,13 @@
     "color": "white",
     "charges_per_use": 1,
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "candle_wax": 100 }, "rigid": true } ],
-    "use_action": { "target": "candle_lit", "msg": "You light the candle.", "need_fire": 1, "menu_text": "Light", "type": "transform" },
+    "use_action": {
+      "target": "candle_lit",
+      "msg": "You light the candle.",
+      "need_fire": 1,
+      "menu_text": { "str": "Light", "ctxt": "verb" },
+      "type": "transform"
+    },
     "flags": [ "BURNOUT", "NO_RELOAD", "NO_UNLOAD" ]
   },
   {
@@ -433,7 +439,8 @@
     "charges_per_use": 1,
     "use_action": {
       "target": "gasoline_lantern_on",
-      "msg": "You turn the lamp on.",
+      "menu_text": { "str": "Light", "ctxt": "verb" },
+      "msg": "You light the lamp.",
       "need_fire": 1,
       "need_charges": 1,
       "need_charges_msg": "The lamp is empty.",
@@ -457,7 +464,7 @@
       {
         "ammo_scale": 0,
         "target": "gasoline_lantern",
-        "msg": "The lantern is extinguished.",
+        "msg": "The lamp is extinguished.",
         "menu_text": "Turn off",
         "type": "transform"
       },
@@ -690,7 +697,8 @@
     "charges_per_use": 1,
     "use_action": {
       "target": "oil_lamp_on",
-      "msg": "You turn the lamp on.",
+      "menu_text": { "str": "Light", "ctxt": "verb" },
+      "msg": "You light the lamp.",
       "need_fire": 1,
       "need_charges": 1,
       "need_charges_msg": "The lamp is empty.",
@@ -714,7 +722,7 @@
       {
         "ammo_scale": 0,
         "target": "oil_lamp",
-        "msg": "The lantern is extinguished.",
+        "msg": "The lamp is extinguished.",
         "menu_text": "Turn off",
         "type": "transform"
       },
@@ -740,6 +748,7 @@
     "charges_per_use": 1,
     "use_action": {
       "target": "oil_lamp_clay_on",
+      "menu_text": { "str": "Light", "ctxt": "verb" },
       "msg": "You light the lamp.",
       "need_fire": 1,
       "need_charges": 1,
@@ -767,7 +776,7 @@
         "ammo_scale": 0,
         "target": "oil_lamp_clay",
         "msg": "The lamp is extinguished.",
-        "menu_text": "Turn off",
+        "menu_text": "Extinguish",
         "type": "transform"
       },
       { "type": "firestarter", "moves": 500, "moves_slow": 6000 }
@@ -791,10 +800,11 @@
     "charges_per_use": 1,
     "use_action": {
       "type": "transform",
-      "msg": "You light the %s.",
+      "menu_text": { "str": "Light", "ctxt": "verb" },
+      "msg": "You light the lamp.",
       "target": "oxylamp_on",
       "need_charges": 1,
-      "need_charges_msg": "The %s must be attached to a gas cylinder to light."
+      "need_charges_msg": "The lamp must be attached to a welding tank to light."
     },
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "tinyweldtank", "weldtank", "smallweldtank" ] } ],
     "tool_ammo": [ "weldgas" ]
@@ -809,7 +819,13 @@
     "revert_to": "oxylamp",
     "//COMMENT": "Open flame or effectively so. ~5 seconds to transfer flame assuming optimal conditions, a minute at worst.",
     "use_action": [
-      { "ammo_scale": 0, "menu_text": "Turn off", "type": "transform", "msg": "The %s is extinguished", "target": "oxylamp" },
+      {
+        "ammo_scale": 0,
+        "menu_text": "Turn off",
+        "type": "transform",
+        "msg": "The lamp is extinguished.",
+        "target": "oxylamp"
+      },
       { "type": "firestarter", "moves": 500, "moves_slow": 6000 }
     ],
     "light": 30,
@@ -956,7 +972,7 @@
       "target": "torch_lit",
       "msg": "You light the torch.",
       "need_fire": 1,
-      "menu_text": "Light torch",
+      "menu_text": { "str": "Light", "ctxt": "verb" },
       "type": "transform"
     },
     "flags": [ "BURNOUT" ],
@@ -1009,7 +1025,8 @@
     "charges_per_use": 1,
     "use_action": {
       "target": "propane_lantern_on",
-      "msg": "You turn the lamp on.",
+      "menu_text": { "str": "Light", "ctxt": "verb" },
+      "msg": "You light the lamp.",
       "need_charges": 1,
       "need_charges_msg": "The lamp is empty.",
       "type": "transform"
@@ -1032,7 +1049,7 @@
       {
         "ammo_scale": 0,
         "target": "propane_lantern",
-        "msg": "The lantern is extinguished.",
+        "msg": "The lamp is extinguished.",
         "menu_text": "Turn off",
         "type": "transform"
       },
@@ -1058,11 +1075,11 @@
     "charges_per_use": 1,
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "candle_wax": 100 }, "rigid": true } ],
     "use_action": {
+      "type": "transform",
       "target": "candle_small_lit",
+      "menu_text": { "str": "Light", "ctxt": "verb" },
       "msg": "You light the candle.",
-      "need_fire": 1,
-      "menu_text": "Light",
-      "type": "transform"
+      "need_fire": 1
     },
     "flags": [ "BURNOUT", "NO_RELOAD", "NO_UNLOAD" ]
   },

--- a/data/mods/CrazyCataclysm/crazy_items.json
+++ b/data/mods/CrazyCataclysm/crazy_items.json
@@ -332,7 +332,7 @@
       "target": "battletorch_lit",
       "msg": "You light the Louisville Slaughterer.",
       "need_fire": 1,
-      "menu_text": "Light",
+      "menu_text": { "str": "Light", "ctxt": "verb" },
       "type": "transform"
     },
     "flags": [ "DURABLE_MELEE" ],

--- a/data/mods/Magiclysm/items/alchemy_items.json
+++ b/data/mods/Magiclysm/items/alchemy_items.json
@@ -155,12 +155,7 @@
     "material": [ "glass" ],
     "symbol": ",",
     "color": "light_blue",
-    "use_action": {
-      "target": "glow_light_off",
-      "msg": "You close the nightlight's cover.",
-      "menu_text": "Close cover",
-      "type": "transform"
-    },
+    "use_action": { "target": "glow_light_off", "msg": "You close the lamp's cover.", "menu_text": "Close cover", "type": "transform" },
     "light": 5,
     "flags": [ "ALLOWS_REMOTE_USE" ]
   },
@@ -176,7 +171,7 @@
     "material": [ "glass" ],
     "symbol": ",",
     "color": "light_blue",
-    "use_action": { "target": "glow_light", "msg": "You open the nightlight's cover.", "menu_text": "Open cover", "type": "transform" },
+    "use_action": { "target": "glow_light", "msg": "You open the lamp's cover.", "menu_text": "Open cover", "type": "transform" },
     "flags": [ "ALLOWS_REMOTE_USE" ]
   },
   {

--- a/data/mods/Magiclysm/items/caster_level_boosters.json
+++ b/data/mods/Magiclysm/items/caster_level_boosters.json
@@ -127,7 +127,7 @@
       "target": "kelvinist_booster_1_active",
       "msg": "You light the candle.",
       "need_fire": 1,
-      "menu_text": "Light",
+      "menu_text": { "str": "Light", "ctxt": "verb" },
       "type": "transform"
     },
     "flags": [ "BURNOUT", "NO_RELOAD", "NO_UNLOAD" ]
@@ -173,6 +173,7 @@
     "charges_per_use": 1,
     "use_action": {
       "target": "kelvinist_booster_2_active",
+      "menu_text": { "str": "Light", "ctxt": "verb" },
       "msg": "You light the lamp.",
       "need_fire": 1,
       "need_charges": 1,
@@ -198,7 +199,7 @@
         "ammo_scale": 0,
         "target": "kelvinist_booster_2",
         "msg": "The lamp is extinguished.",
-        "menu_text": "Turn off",
+        "menu_text": "Extinguish",
         "type": "transform"
       },
       { "type": "firestarter", "moves": 100 }

--- a/data/mods/Magiclysm/items/enchanted_misc.json
+++ b/data/mods/Magiclysm/items/enchanted_misc.json
@@ -81,7 +81,12 @@
     "color": "brown",
     "techniques": [ "WBLOCK_1" ],
     "flags": [ "DURABLE_MELEE" ],
-    "use_action": { "target": "mtorch_everburning_lit", "msg": "You light the torch.", "menu_text": "Light torch", "type": "transform" },
+    "use_action": {
+      "target": "mtorch_everburning_lit",
+      "msg": "You light the torch.",
+      "menu_text": { "str": "Light", "ctxt": "verb" },
+      "type": "transform"
+    },
     "melee_damage": { "bash": 8 }
   },
   {

--- a/data/mods/MindOverMatter/items/armor/head.json
+++ b/data/mods/MindOverMatter/items/armor/head.json
@@ -102,7 +102,7 @@
       "ammo_scale": 0,
       "type": "transform",
       "menu_text": "Turn off",
-      "msg": "Your %s deactivates.",
+      "msg": "You deactivate your %s.",
       "target": "psionic_mindsight_glasses"
     },
     "extend": { "flags": [ "SPAWN_ACTIVE" ] },

--- a/data/mods/MindOverMatter/items/tools/travel.json
+++ b/data/mods/MindOverMatter/items/tools/travel.json
@@ -75,7 +75,7 @@
       {
         "ammo_scale": 0,
         "target": "psionic_transporter_remote",
-        "msg": "You turn the transporter remote off.",
+        "msg": "You turn off the %s.",
         "menu_text": "Turn off",
         "type": "transform"
       },

--- a/data/mods/Xedra_Evolved/items/inventor/armor.json
+++ b/data/mods/Xedra_Evolved/items/inventor/armor.json
@@ -64,7 +64,15 @@
     "name": { "str": "helmet of creative juices (on)", "str_pl": "helmets of creative juices (on)" },
     "power_draw": "7 W",
     "revert_to": "helmet_inventor",
-    "use_action": [ { "ammo_scale": 0, "target": "helmet_inventor", "msg": "The helmet turns off.", "type": "transform" } ]
+    "use_action": [
+      {
+        "ammo_scale": 0,
+        "target": "helmet_inventor",
+        "menu_text": "Turn off",
+        "msg": "You turn off the %s.",
+        "type": "transform"
+      }
+    ]
   },
   {
     "id": "inventor_backpack",
@@ -171,7 +179,7 @@
     "looks_like": "legguard_hard",
     "color": "light_red",
     "flags": [ "MORPHIC", "STURDY", "OUTER", "BELTED", "MUNDANE", "INVENTOR_CRAFTED" ],
-    "use_action": { "target": "inventor_leg_weight_on", "msg": "You turn on the weight suspension system.", "type": "transform" },
+    "use_action": { "target": "inventor_leg_weight_on", "msg": "You turn on the %s.", "type": "transform" },
     "pocket_data": [
       {
         "pocket_type": "MAGAZINE_WELL",
@@ -213,7 +221,7 @@
     "subtypes": [ "TOOL", "ARMOR" ],
     "power_draw": "5 W",
     "revert_to": "inventor_leg_weight",
-    "use_action": { "target": "inventor_leg_weight", "msg": "You turn off the weight suspension system.", "type": "transform" }
+    "use_action": { "target": "inventor_leg_weight", "menu_text": "Turn off", "msg": "You turn off the %s.", "type": "transform" }
   },
   {
     "id": "inventor_jump_boots",
@@ -350,7 +358,9 @@
     "name": { "str": "force shield (on)", "str_pl": "force shields (on)" },
     "power_draw": "250 W",
     "revert_to": "aura_force",
-    "use_action": [ { "ammo_scale": 0, "target": "aura_force", "msg": "Torus stops working.", "type": "transform" } ]
+    "use_action": [
+      { "ammo_scale": 0, "target": "aura_force", "menu_text": "Turn off", "msg": "Torus stops working.", "type": "transform" }
+    ]
   },
   {
     "id": "vision_halo",
@@ -373,7 +383,7 @@
       "EBOOKSAVE",
       {
         "target": "vision_halo_on",
-        "msg": "Turn on.",
+        "msg": "You turn on the %s.",
         "menu_text": "Turn on a battle mode",
         "need_charges": 1,
         "need_charges_msg": "The batteries are dead.",
@@ -457,7 +467,7 @@
       "EBOOKSAVE",
       {
         "target": "vision_halo",
-        "msg": "Turn off.",
+        "msg": "You turn off the %s.",
         "menu_text": "Turn off battle mode",
         "need_charges": 0,
         "type": "transform"
@@ -584,8 +594,7 @@
     "use_action": [
       {
         "target": "inventor_electric_fist_act",
-        "msg": "Turn on.",
-        "menu_text": "Turn on the overture",
+        "msg": "You turn on the %s.",
         "need_charges": 1,
         "need_charges_msg": "The batteries are dead.",
         "type": "transform"
@@ -621,7 +630,15 @@
     "name": { "str": "\"Overture\" (on)", "str_pl": "\"Overtures\" (on)" },
     "power_draw": "50 W",
     "revert_to": "inventor_electric_fist",
-    "use_action": [ { "ammo_scale": 0, "target": "inventor_electric_fist", "msg": "The fist turns off.", "type": "transform" } ]
+    "use_action": [
+      {
+        "ammo_scale": 0,
+        "target": "inventor_electric_fist",
+        "menu_text": "Turn off",
+        "msg": "You turn off the %s.",
+        "type": "transform"
+      }
+    ]
   },
   {
     "id": "wolf_mask",
@@ -658,8 +675,7 @@
     "use_action": [
       {
         "target": "wolf_mask_act",
-        "msg": "Turn on.",
-        "menu_text": "Turn on the mask",
+        "msg": "You turn on the %s.",
         "need_charges": 1,
         "need_charges_msg": "The batteries are dead.",
         "type": "transform"
@@ -678,7 +694,9 @@
     "power_draw": "5 W",
     "environmental_protection": 25,
     "revert_to": "wolf_mask",
-    "use_action": [ { "ammo_scale": 0, "target": "wolf_mask", "msg": "The mask stops working.", "type": "transform" } ]
+    "use_action": [
+      { "ammo_scale": 0, "target": "wolf_mask", "menu_text": "Turn off", "msg": "You turn off the %s.", "type": "transform" }
+    ]
   },
   {
     "id": "magnetic_holster",
@@ -762,6 +780,7 @@
       {
         "ammo_scale": 0,
         "target": "crafting_assistant",
+        "menu_text": "Turn off",
         "msg": "The assistant retracts and recycles its arms.",
         "type": "transform"
       }

--- a/data/mods/Xedra_Evolved/items/inventor/explosive.json
+++ b/data/mods/Xedra_Evolved/items/inventor/explosive.json
@@ -19,7 +19,7 @@
       "target": "portable_dark_age_apct",
       "msg": "You activate the portable dark age.",
       "target_timer": "50 seconds",
-      "menu_text": "Activate bomb",
+      "menu_text": "Activate",
       "type": "transform"
     },
     "flags": [ "RADIO_MODABLE", "RADIO_INVOKE_PROC", "BOMB", "GRENADE", "WATER_BREAK" ],

--- a/data/mods/Xedra_Evolved/items/inventor/melee.json
+++ b/data/mods/Xedra_Evolved/items/inventor/melee.json
@@ -40,7 +40,7 @@
     "weapon_category": [ "POLEARMS", "SPEARS" ],
     "use_action": {
       "target": "combatsaw_spear_on",
-      "msg": "You turn on the chainsaw spear.",
+      "msg": "You turn on the %s.",
       "type": "transform",
       "need_charges": 1,
       "need_charges_msg": "The batteries are dead."
@@ -78,7 +78,7 @@
     "melee_damage": { "bash": 8, "cut": 36 },
     "power_draw": "350 W",
     "revert_to": "combatsaw_spear_off",
-    "use_action": { "target": "combatsaw_spear_off", "msg": "You turn off the chainsaw spear.", "type": "transform" },
+    "use_action": { "target": "combatsaw_spear_off", "menu_text": "Turn off", "msg": "You turn off the %s.", "type": "transform" },
     "extend": { "flags": [ "MESSY", "SPAWN_ACTIVE" ] }
   },
   {
@@ -144,7 +144,7 @@
     "color": "light_gray",
     "use_action": {
       "target": "inventor_plasma_axe",
-      "msg": "You turn on your \"Neon Angle\".",
+      "msg": "You turn on the %s.",
       "type": "transform",
       "need_charges": 1,
       "need_charges_msg": "The batteries are dead."
@@ -175,6 +175,6 @@
     "melee_damage": { "bash": 8, "heat": 46 },
     "power_draw": "900 W",
     "revert_to": "inventor_plasma_axe_off",
-    "use_action": { "target": "inventor_plasma_axe_off", "msg": "You turn off your \"Neon Angle\".", "type": "transform" }
+    "use_action": { "target": "inventor_plasma_axe_off", "menu_text": "Turn off", "msg": "You turn off the %s.", "type": "transform" }
   }
 ]

--- a/data/mods/aftershock_exoplanet/items/armor/exosuit/exosuit_underlayers.json
+++ b/data/mods/aftershock_exoplanet/items/armor/exosuit/exosuit_underlayers.json
@@ -72,7 +72,7 @@
       "type": "transform",
       "ammo_scale": 0,
       "menu_text": "Turn off",
-      "msg": "Your %s deactivates.",
+      "msg": "You deactivate your %s.",
       "target": "afs_exo_standard_underlayer"
     },
     "extend": { "flags": [ "ACTIVE_CRYOSUIT", "SPAWN_ACTIVE" ] }
@@ -150,7 +150,7 @@
       "type": "transform",
       "ammo_scale": 0,
       "menu_text": "Turn off",
-      "msg": "Your %s deactivates.",
+      "msg": "You deactivate your %s.",
       "target": "afs_exo_combat_underlayer"
     },
     "extend": { "flags": [ "ACTIVE_CRYOSUIT", "SPAWN_ACTIVE" ] }
@@ -230,7 +230,7 @@
       "type": "transform",
       "ammo_scale": 0,
       "menu_text": "Turn off",
-      "msg": "Your %s deactivates.",
+      "msg": "You deactivate your %s.",
       "target": "afs_exo_eva_underlayer"
     },
     "extend": { "flags": [ "ACTIVE_CRYOSUIT", "SPAWN_ACTIVE" ] }
@@ -310,7 +310,7 @@
       "type": "transform",
       "ammo_scale": 0,
       "menu_text": "Turn off",
-      "msg": "Your %s deactivates.",
+      "msg": "You deactivate your %s.",
       "target": "afs_exo_hazard_underlayer"
     },
     "extend": { "flags": [ "ACTIVE_CRYOSUIT", "SPAWN_ACTIVE" ] }

--- a/data/mods/aftershock_exoplanet/items/armor/winter_suits.json
+++ b/data/mods/aftershock_exoplanet/items/armor/winter_suits.json
@@ -85,7 +85,7 @@
       "type": "transform",
       "ammo_scale": 0,
       "menu_text": "Turn off",
-      "msg": "Your %s deactivates.",
+      "msg": "You deactivate your %s.",
       "target": "afs_magellan_suit"
     },
     "extend": { "flags": [ "ACTIVE_CRYOSUIT", "SPAWN_ACTIVE" ] }
@@ -173,7 +173,7 @@
       "type": "transform",
       "ammo_scale": 0,
       "menu_text": "Turn off",
-      "msg": "Your %s deactivates.",
+      "msg": "You deactivate your %s.",
       "target": "afs_frontier_cryo"
     }
   },
@@ -249,7 +249,7 @@
       "type": "transform",
       "ammo_scale": 0,
       "menu_text": "Turn off",
-      "msg": "Your %s deactivates.",
+      "msg": "You deactivate your %s.",
       "target": "afs_combat_cryo"
     },
     "extend": { "flags": [ "ACTIVE_CRYOSUIT", "SPAWN_ACTIVE" ] }
@@ -283,7 +283,7 @@
       "type": "transform",
       "ammo_scale": 0,
       "menu_text": "Turn off",
-      "msg": "Your %s deactivates.",
+      "msg": "You deactivate your %s.",
       "target": "afs_combat_cryo_xl"
     },
     "extend": { "flags": [ "OVERSIZE", "PREFIX_XL", "ACTIVE_CRYOSUIT", "SPAWN_ACTIVE" ] }
@@ -361,7 +361,7 @@
       "type": "transform",
       "ammo_scale": 0,
       "menu_text": "Turn off",
-      "msg": "Your %s deactivates.",
+      "msg": "You deactivate your %s.",
       "target": "afs_cryopod_bodyglove"
     },
     "flags": [

--- a/data/mods/aftershock_exoplanet/items/grenades.json
+++ b/data/mods/aftershock_exoplanet/items/grenades.json
@@ -58,7 +58,7 @@
       "target": "afs_demo_charge_act",
       "msg": "You activate the demolition charge.",
       "target_timer": "1 seconds",
-      "menu_text": "Activate charge",
+      "menu_text": "Activate",
       "type": "transform"
     },
     "flags": [ "RADIO_ACTIVATION", "RADIO_INVOKE_PROC", "RADIOSIGNAL_1", "BOMB" ]

--- a/data/mods/aftershock_exoplanet/items/tools.json
+++ b/data/mods/aftershock_exoplanet/items/tools.json
@@ -231,7 +231,12 @@
       "PORTABLE_GAME",
       "E_FILE_DEVICE",
       "EBOOKSAVE",
-      { "type": "mp3", "transform": "afs_atomic_smartphone", "message": "The phone turns off.", "activate": false }
+      {
+        "type": "mp3",
+        "transform": "afs_atomic_smartphone",
+        "message": "You stop listening to music and take your earbuds out.",
+        "activate": false
+      }
     ],
     "tick_action": [ "MP3_ON" ],
     "extend": { "flags": [ "TRADER_AVOID", "SPAWN_ACTIVE" ] }
@@ -305,7 +310,12 @@
       "PORTABLE_GAME",
       "E_FILE_DEVICE",
       "EBOOKSAVE",
-      { "type": "mp3", "transform": "afs_wraitheon_smartphone", "message": "The phone turns off.", "activate": false }
+      {
+        "type": "mp3",
+        "transform": "afs_wraitheon_smartphone",
+        "message": "You stop listening to music and take your earbuds out.",
+        "activate": false
+      }
     ],
     "extend": { "flags": [ "TRADER_AVOID", "SPAWN_ACTIVE" ] },
     "tick_action": [ "MP3_ON" ]
@@ -573,7 +583,7 @@
     "revert_to": "control_laptop",
     "use_action": {
       "target": "control_laptop",
-      "msg": "You stop lighting up the screen.",
+      "msg": "You turn off the screen.",
       "ammo_scale": 0,
       "menu_text": "Turn off",
       "type": "transform"
@@ -1048,7 +1058,7 @@
     "color": "light_green",
     "use_action": {
       "target": "afs_atomic_light_off",
-      "msg": "You close the nightlight's cover.",
+      "msg": "You close the lamp's cover.",
       "menu_text": "Close cover",
       "type": "transform"
     },
@@ -1063,12 +1073,7 @@
     "category": "tools",
     "name": { "str": "atomic reading light (covered)", "str_pl": "atomic reading lights (covered)" },
     "description": "A commercially produced reading light, with the gimmick of never having to replace batteries thanks to its nuclear decay powered power source.  Instead of having an on/off switch, there is instead a cover you close over it.",
-    "use_action": {
-      "target": "afs_atomic_light",
-      "msg": "You open the nightlight's cover.",
-      "menu_text": "Open cover",
-      "type": "transform"
-    },
+    "use_action": { "target": "afs_atomic_light", "msg": "You open the lamp's cover.", "menu_text": "Open cover", "type": "transform" },
     "flags": [ "LEAK_DAM", "RADIOACTIVE", "ALLOWS_REMOTE_USE" ]
   },
   {

--- a/data/mods/innawood/items/lighting.json
+++ b/data/mods/innawood/items/lighting.json
@@ -10,8 +10,8 @@
       {
         "ammo_scale": 0,
         "target": "oil_lamp",
-        "msg": "The lantern is extinguished.",
-        "menu_text": "Turn off",
+        "msg": "The lamp is extinguished.",
+        "menu_text": "Extinguish",
         "type": "transform"
       },
       { "type": "firestarter", "moves": 100 }
@@ -32,7 +32,7 @@
         "ammo_scale": 0,
         "target": "oil_lamp_clay",
         "msg": "The lamp is extinguished.",
-        "menu_text": "Turn off",
+        "menu_text": "Extinguish",
         "type": "transform"
       },
       { "type": "firestarter", "moves": 100 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Continutaion of #84179
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
1. `Light` now uses the `verb` context.
2. More items now use standard activation messages: `You turn on/off the %s.`
3. Some similar strings have been merged into a single variant.
4. Missing `menu_text`s  have been added.
5. `menu_text`s  with the value `Turn on` have been removed, as this is the default value (only when `"type": "transform"`).
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
<img width="728" height="136" alt="tool-msg1" src="https://github.com/user-attachments/assets/6d62ce83-72d2-400c-8e7d-edff18ad48a1" />

---

<img width="713" height="203" alt="tool-msg2" src="https://github.com/user-attachments/assets/5c4d661f-0741-4603-8c2b-fbf8a94be2c4" />
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
