### PR TITLE
Separate the vanilla and XE "deck of tarot" items

### DIFF
--- a/data/json/uncraft/recipe_deconstruction.json
+++ b/data/json/uncraft/recipe_deconstruction.json
@@ -6098,7 +6098,8 @@
   {
     "result": "deck_of_tarot_cards",
     "copy-from": "deck_of_cards",
-    "type": "uncraft"
+    "type": "uncraft",
+    "components": [ [ [ "cardboard", 5 ] ] ]
   },
   {
     "result": "kevlar_shears",

--- a/data/json/uncraft/recipe_deconstruction.json
+++ b/data/json/uncraft/recipe_deconstruction.json
@@ -6092,14 +6092,13 @@
     "type": "uncraft",
     "activity_level": "NO_EXERCISE",
     "time": "2 s",
-    "components": [ [ [ "cardboard", 20 ] ] ],
+    "components": [ [ [ "cardboard", 5 ] ] ],
     "flags": [ "BLIND_EASY" ]
   },
   {
     "result": "deck_of_tarot_cards",
     "copy-from": "deck_of_cards",
-    "type": "uncraft",
-    "components": [ [ [ "cardboard", 20 ] ] ]
+    "type": "uncraft"
   },
   {
     "result": "kevlar_shears",

--- a/data/mods/TEST_DATA/known_bad_uncrafts.json
+++ b/data/mods/TEST_DATA/known_bad_uncrafts.json
@@ -765,7 +765,6 @@
       "cutlass_fake",
       "dairy_book",
       "daypack",
-      "deck_of_cards",
       "decoy_anarch",
       "decoy_elfa",
       "denim_overalls",

--- a/data/mods/TEST_DATA/known_bad_uncrafts.json
+++ b/data/mods/TEST_DATA/known_bad_uncrafts.json
@@ -766,7 +766,6 @@
       "dairy_book",
       "daypack",
       "deck_of_cards",
-      "deck_of_tarot_cards",
       "decoy_anarch",
       "decoy_elfa",
       "denim_overalls",

--- a/data/mods/Xedra_Evolved/itemgroups/spell_artifacts/eater.json
+++ b/data/mods/Xedra_Evolved/itemgroups/spell_artifacts/eater.json
@@ -85,7 +85,7 @@
     "type": "item_group",
     "id": "xe_eater_spell_tier0",
     "subtype": "distribution",
-    "entries": [ { "item": "deck_of_tarot_cards", "prob": 50 }, { "item": "hurricane_lamp_thorns", "prob": 100 } ]
+    "entries": [ { "item": "deck_of_tarot_cards_xe", "prob": 50 }, { "item": "hurricane_lamp_thorns", "prob": 100 } ]
   },
   {
     "type": "item_group",

--- a/data/mods/Xedra_Evolved/items/spell_learning_items/spell_learning_items_eater.json
+++ b/data/mods/Xedra_Evolved/items/spell_learning_items/spell_learning_items_eater.json
@@ -1,10 +1,10 @@
 [
   {
-    "id": "deck_of_tarot_cards",
+    "id": "deck_of_tarot_cards_xe",
     "type": "ITEM",
     "category": "artifacts",
     "looks_like": "deck_of_cards",
-    "name": { "str": "deck of tarot cards", "str_pl": "decks of tarot cards" },
+    "name": { "str": "deck of eater tarot cards", "str_pl": "decks of eater tarot cards" },
     "description": "A deck of intricately designed tarot cards.  When you lay out your future they seem to be trying to tell you to take a leap of faith.",
     "weight": "50 g",
     "volume": "50 ml",

--- a/data/mods/Xedra_Evolved/items/spell_learning_items/spell_learning_items_eater.json
+++ b/data/mods/Xedra_Evolved/items/spell_learning_items/spell_learning_items_eater.json
@@ -4,7 +4,7 @@
     "type": "ITEM",
     "category": "artifacts",
     "looks_like": "deck_of_cards",
-    "name": { "str": "deck of eater tarot cards", "str_pl": "decks of eater tarot cards" },
+    "name": { "str": "deck of esoteric tarot cards", "str_pl": "decks of esoteric tarot cards" },
     "description": "A deck of intricately designed tarot cards.  When you lay out your future they seem to be trying to tell you to take a leap of faith.",
     "weight": "50 g",
     "volume": "50 ml",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
When I added the deck of tarot item to vanilla I didn't notice that XE had the exact same id for its deck of tarot item. This means that if you use XE you can't find "normal" decks of tarot cards and there's also apparently a possibility to craft the magic ones.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

- Change the id of the XE deck of tarot cards from `deck_of_tarot_cards` to `deck_of_tarot_cards_xe`.
- Change the name of the XE deck of tarot cards from `"deck of tarot cards"` to `"deck of eater tarot cards"`
- Fix the uncraft recipes from the decks of cards while I'm at it, it's a micro change so I hope it's fine even if out of scope.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
This will turn the XE deck of tarot items into regular decks of tarot in existing saves (I think), which is annoying but I don't think there's a way to cleanly migrate them since they share an id.

I'm also unsure if the name of the XE deck of tarot is lore appropriate.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded fine in vanilla. Loaded fine in XE, spawned both decks there, seemed fine.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Fixes #86598.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
