### PR TITLE
fix cellar nest error

### DIFF
--- a/data/json/mapgen/nested/cabin_cellar_nested.json
+++ b/data/json/mapgen/nested/cabin_cellar_nested.json
@@ -18,6 +18,7 @@
         "          "
       ],
       "palettes": [ "cabin_cellar" ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "place_nested": [ { "chunks": [ "cabin_cellar" ], "x": 0, "y": 0, "z": -1 } ]
     }
   },


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Found in CI: `In nested mapgen cabin_cellar_stairs in mapgen cabin_5 on cabin_5_south, setting terrain to t_wood_stairs_down (from t_region_groundcover) at (13,14,0) when item pebble existed.  Resolve this either by removing the terrain from this mapgen, adding suitable removal commands to the mapgen, or by adding an appropriate clearing flag to the innermost layered mapgen.  Consult the "mapgen flags" section in MAPGEN.md for options. `
#### Describe the solution
Add flag
#### Testing
CI