### PR TITLE
Setting power CBMs to use torso slots

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -1069,6 +1069,7 @@
     "capacity": "100 kJ",
     "dupes_allowed": true,
     "description": "Upgrades your bionic power capacity by 100 kJ.  It can be recharged via other CBMs that function as power supplies.",
+    "occupied_bodyparts": [ [ "torso", 2 ] ],
     "flags": [ "BIONIC_NPC_USABLE" ]
   },
   {
@@ -1078,6 +1079,7 @@
     "capacity": "250 kJ",
     "dupes_allowed": true,
     "description": "Upgrades your bionic power capacity by 250 kJ.  It can be recharged via other CBMs that function as power supplies.",
+    "occupied_bodyparts": [ [ "torso", 2 ] ],
     "flags": [ "BIONIC_NPC_USABLE" ]
   },
   {

--- a/data/json/body_parts.json
+++ b/data/json/body_parts.json
@@ -26,7 +26,7 @@
     "base_hp": 60,
     "drench_capacity": 4000,
     "smash_message": "You smash the %s with a powerful shoulder-check.",
-    "bionic_slots": 80,
+    "bionic_slots": 84,
     "bmi_encumbrance_threshold": 9,
     "bmi_encumbrance_scalar": 0.8,
     "windage_effect": "winded",


### PR DESCRIPTION
Currently if you use the Bionic Slots mod, power CBMs are still free.

It is not too difficult to end up with 10K power slotted.  That seems unreasonable when all other bionics takes up limited room, and it drastically increases the value of power hungry cbms such as invisibility or hydraulic muscles.

Specific numbers aren't that important.  I went with 2 slots for a power cbm, but I upped the number of torso slots so the first 2 are free. These numbers can be fudged as deemed necessary for balance, but it feels like some limit needs to be in place, at least for players who use the Bionic Slots mod.


#### Summary
Balance "Power CBMs using Slots"

This sets Power CBMs to use 2 torso slots if the Bionic Slots mod is active.  It also boosts torso slots by 4, so a player with two power CBMs is unaffected by this change.

#### Purpose of change

It is not too difficult to get thousands, or even over ten thousand bionic power loaded up.  This drastically buffs the power hungry CBMs such as invisibility or hydraulic muscles.  For most players, who can already load up every single CBM they find, that may be fine.  But for those players who want more balanced bionics and thus use the Bionic Slots mod, it doesn't make much sense.  You end up with situations where you need to balance which normal CBMs are used, but at the same time have dozens and dozens of power CBMs installed.

#### Describe the solution

Power CBMs (both the basic 100 power version and the Mk II 250 power version) now take up two torso slots.  To not overly punish characters, the torso slots are also upped to 84, to make the first two free.

#### Describe alternatives you've considered

I contemplated only 1 slot per CBM, but that seemed to make it not too hard to end up with thousands of power.  I also contemplated more or less bonus torso slots.  Zero would be an overall nerf to bionics with the Bionic Slots mod enabled.  I thought 500 power was a good number to shoot for, so I initially thought 10 free slots would be best.  The Bionic Professions mod has a number of professions that max out at 500 power, making my choice seem appropriate.  However, those all used Mk II CBMs to get that 500 power with only two CBMs.  So I opted to go with that less generous number of free slots. 

One other existing benchmark to consider is the different recharge options.  Of the ones that only use torso slots and have no encumbrance, all use 20 slots except the cable charger at 7.  So cyborgs who want more power available for power hungry CBMs can opt to only be able to recharge at home or their car, and boost their power by effectively 650.  Even without finding Mk II cbms, players have options to enable over a minute of fighting with hydraulic muscles, or 20 seconds of invisibly running away but they need to make other tradeoffs to do so.

I also contemplated boosting the drop rates of Mk II power supplies, and I may still if this PR gets merged.  I looked at my run where I gave up on adding power after I hit 10K power, and even though I had found well over 120 regular power CBMs, I had only found a single Mk II CBM.  They should certainly remain a rare find, but less than 1% of all power cbms may be too rare.  For the time being though, I kept this change minimal and did not affect any drop rates.


#### Testing

I created cyborg characters via the Bionic professions mod.  Worked as expected.
I had Rubik install power supplies cbms, which worked as expected.
I used an AutoDoc to install power supply cbms, which worked as expected.

#### Additional context

