### PR TITLE
A few more SDL tweaks

### DIFF
--- a/.github/workflows/msvc-full-features.yml
+++ b/.github/workflows/msvc-full-features.yml
@@ -90,7 +90,7 @@ jobs:
       id: runvcpkg
       with:
         vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
-        vcpkgGitCommitId: '1b6e030cf096faf4f82d7b7025de8b2abee3e3df'
+        vcpkgGitCommitId: 'c3867e714dd3a51c272826eea77267876517ed99'
 
     - name: Integrate vcpkg
       run: |
@@ -102,7 +102,7 @@ jobs:
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: msvc-full-features/vcpkg_installed
-        key: vcpkg-installed-${{ hashFiles('msvc-full-features/vcpkg.json', '.github/vcpkg_triplets/x64-windows-static.cmake') }}-1b6e030cf096faf4f82d7b7025de8b2abee3e3df
+        key: vcpkg-installed-${{ hashFiles('msvc-full-features/vcpkg.json', '.github/vcpkg_triplets/x64-windows-static.cmake') }}-c3867e714dd3a51c272826eea77267876517ed99
 
     - name: Download ccache
       uses: robinraju/release-downloader@368754b9c6f47c345fcfbf42bcb577c2f0f5f395 # v1.9

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,15 @@ jobs:
             content: application/zip
             tiles: 1
             sound: 1
+          - name: Windows Tiles Sounds x64 MSVC (SDL3)
+            artifact: windows-with-graphics-and-sounds-sdl3-x64
+            arch: x64
+            os: windows-2022
+            ext: zip
+            content: application/zip
+            tiles: 1
+            sound: 1
+            sdl3: 1
           - name: Linux Tiles x64
             os: ubuntu-24.04
             android: none
@@ -107,6 +116,16 @@ jobs:
             tiles: 1
             sound: 1
             artifact: linux-with-graphics-and-sounds-x64
+            ext: tar.gz
+            content: application/gzip
+          - name: Linux Tiles Sounds x64 (SDL3)
+            os: ubuntu-24.04
+            android: none
+            libbacktrace: 1
+            tiles: 1
+            sound: 1
+            sdl3: 1
+            artifact: linux-with-graphics-and-sounds-sdl3-x64
             ext: tar.gz
             content: application/gzip
           - name: Linux Curses x64
@@ -130,6 +149,14 @@ jobs:
             tiles: 1
             sound: 0
             artifact: osx-with-graphics-universal
+            ext: dmg
+            content: application/x-apple-diskimage
+          - name: macOS Tiles Universal Binary (SDL3)
+            os: macos-15
+            tiles: 1
+            sound: 0
+            sdl3: 1
+            artifact: osx-with-graphics-sdl3-universal
             ext: dmg
             content: application/x-apple-diskimage
           - name: Android x64
@@ -206,8 +233,8 @@ jobs:
           install: >-
             gettext
             make
-      - name: Install dependencies (Linux)
-        if: runner.os == 'Linux' && matrix.android == 'none' && !matrix.wasm
+      - name: Install dependencies (Linux, SDL2)
+        if: runner.os == 'Linux' && matrix.android == 'none' && !matrix.wasm && matrix.sdl3 != 1
         run: |
           sudo apt-get update
           sudo apt-get install libsdl2-dev
@@ -221,11 +248,34 @@ jobs:
           cp ../LICENSE.txt ${{ github.workspace }}/LICENSE-SDL.txt
           sudo apt-get install libncursesw5-dev libsdl2-ttf-dev libsdl2-image-dev \
             libsdl2-mixer-dev libpulse-dev ccache gettext parallel
+      - name: Install dependencies (Linux, SDL3)
+        if: runner.os == 'Linux' && matrix.android == 'none' && !matrix.wasm && matrix.sdl3 == 1
+        run: |
+          sudo apt-get update
+          sudo apt-get install libsdl3-dev libsdl3-image-dev libsdl3-ttf-dev \
+            libflac-dev libogg-dev libvorbis-dev libmpg123-dev libwavpack-dev \
+            libpulse-dev libncursesw5-dev ccache gettext parallel pkg-config cmake
+      - name: Build SDL3_mixer from source (Linux, SDL3)
+        if: runner.os == 'Linux' && matrix.android == 'none' && !matrix.wasm && matrix.sdl3 == 1
+        run: |
+          git clone --depth 1 --branch release-3.2.0 https://github.com/libsdl-org/SDL_mixer.git sdl3_mixer_src
+          cmake -S sdl3_mixer_src -B sdl3_mixer_build \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DSDLMIXER_VENDORED=OFF \
+              -DSDLMIXER_FLAC=ON -DSDLMIXER_FLAC_LIBFLAC=ON \
+              -DSDLMIXER_MP3=ON -DSDLMIXER_MP3_MPG123=ON \
+              -DSDLMIXER_VORBIS=VORBISFILE \
+              -DSDLMIXER_WAVPACK=ON \
+              -DSDLMIXER_OPUS=OFF -DSDLMIXER_MOD=OFF -DSDLMIXER_MIDI=OFF \
+              -DBUILD_SHARED_LIBS=ON
+          cmake --build sdl3_mixer_build -j$((`nproc`+0))
+          sudo cmake --install sdl3_mixer_build
+          cp sdl3_mixer_src/LICENSE.txt ${{ github.workspace }}/LICENSE-SDL3_mixer.txt
       - name: Install Emscripten (WebAssembly)
         if: matrix.wasm
         uses: mymindstorm/setup-emsdk@d233ac12b0102f74ca199f5dad7a4e2c13a8a745 # v13
-      - name: Install runtime dependencies (mac)
-        if: runner.os == 'macOS'
+      - name: Install runtime dependencies (mac, SDL2)
+        if: runner.os == 'macOS' && matrix.sdl3 != 1
         uses: BrettDong/setup-sdl2-frameworks@a8ca795ef904417e9ddcb010ef6bf2d11779dbe3 # v2
         with:
           sdl2: 2.30.11
@@ -237,13 +287,18 @@ jobs:
         run: |
           HOMEBREW_NO_AUTO_UPDATE=yes HOMEBREW_NO_INSTALL_CLEANUP=yes brew install gettext ccache parallel dylibbundler
           pip3 install --break-system-packages dmgbuild biplist
-      - name: install macports (mac)
-        if: runner.os == 'macOS' && matrix.tiles == 1
+      - name: install macports (mac, SDL2)
+        if: runner.os == 'macOS' && matrix.tiles == 1 && matrix.sdl3 != 1
         uses: melusina-org/setup-macports@c7eb59386def259a274627092566a7f7b8d219b1 # v1
-      - name: install macports packages (mac)
-        if: runner.os == 'macOS' && matrix.tiles == 1
+      - name: install macports packages (mac, SDL2)
+        if: runner.os == 'macOS' && matrix.tiles == 1 && matrix.sdl3 != 1
         run: |
           sudo port install freetype +universal pkgconfig +universal
+      - name: install brew packages (mac, SDL3)
+        if: runner.os == 'macOS' && matrix.tiles == 1 && matrix.sdl3 == 1
+        run: |
+          HOMEBREW_NO_AUTO_UPDATE=yes HOMEBREW_NO_INSTALL_CLEANUP=yes \
+            brew install pkgconf sdl3 sdl3_image sdl3_ttf sdl3_mixer freetype
       - name: Create VERSION.TXT
         shell: bash
         run: |
@@ -273,7 +328,7 @@ jobs:
       - name: Build CDDA (linux)
         if: runner.os == 'Linux' && matrix.android == 'none' && !matrix.wasm
         run: |
-          make COMPILER=clang++-18 -j$((`nproc`+0)) TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=1 LIBBACKTRACE=${{ matrix.libbacktrace }} WARN_STALE_DATA=1 PCH=0 bindist
+          make COMPILER=clang++-18 -j$((`nproc`+0)) TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} SDL3=${{ matrix.sdl3 == 1 && '1' || '0' }} RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=1 LIBBACKTRACE=${{ matrix.libbacktrace }} WARN_STALE_DATA=1 PCH=0 bindist
           mv cataclysmdda-0.J.tar.gz cdda-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.tar.gz
       - name: Build CDDA (WebAssembly)
         if: matrix.wasm && success()
@@ -281,8 +336,8 @@ jobs:
           ./build-scripts/build-emscripten.sh
           ./build-scripts/prepare-web.sh
           (cd build && zip ../cdda-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.${{ matrix.ext }} *)
-      - name: Build CDDA (windows msvc)
-        if: runner.os == 'Windows'
+      - name: Build CDDA (windows msvc, SDL2)
+        if: runner.os == 'Windows' && matrix.sdl3 != 1
         env:
           # Enable pretty backtraces
           BACKTRACE: 1
@@ -292,10 +347,27 @@ jobs:
           msbuild -m -p:Configuration=Release -p:Platform=${{ matrix.arch }} "-target:Cataclysm-vcpkg-static;JsonFormatter-vcpkg-static;zzip" msvc-full-features\Cataclysm-vcpkg-static.sln
           .\build-scripts\windist.ps1
           mv cataclysmdda-0.J.zip cdda-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.zip
-      - name: Build CDDA (osx)
-        if: runner.os == 'macOS'
+      - name: Build CDDA (windows msvc, SDL3)
+        if: runner.os == 'Windows' && matrix.sdl3 == 1
+        env:
+          BACKTRACE: 1
+          CDDA_RELEASE_BUILD: 1
+          VCPKG_OVERLAY_TRIPLETS: ${{ github.workspace }}\.github\vcpkg_triplets
+        run: |
+          msbuild -m -p:Configuration=Release -p:Platform=${{ matrix.arch }} -p:UseSDL3=true "-target:Cataclysm-vcpkg-static;JsonFormatter-vcpkg-static;zzip" msvc-full-features\Cataclysm-vcpkg-static.sln
+          .\build-scripts\windist.ps1
+          mv cataclysmdda-0.J.zip cdda-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.zip
+      - name: Build CDDA (osx, SDL2)
+        if: runner.os == 'macOS' && matrix.sdl3 != 1
         run: |
           make -j3 TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=0 PCH=0 USE_HOME_DIR=1 FRAMEWORK=1 UNIVERSAL_BINARY=1 WARN_STALE_DATA=1 dmgdist
+          mv Cataclysm.dmg cdda-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.dmg
+      - name: Build CDDA (osx, SDL3)
+        if: runner.os == 'macOS' && matrix.sdl3 == 1
+        env:
+          PKG_CONFIG_PATH: /opt/homebrew/lib/pkgconfig
+        run: |
+          make -j3 TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} SDL3=1 RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=0 PCH=0 USE_HOME_DIR=1 UNIVERSAL_BINARY=1 WARN_STALE_DATA=1 dmgdist
           mv Cataclysm.dmg cdda-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.dmg
       - name: Set up JDK (android)
         if: runner.os == 'Linux' && matrix.android != 'none'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,7 +193,7 @@ jobs:
         id: runvcpkg
         with:
           vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
-          vcpkgGitCommitId: '1b6e030cf096faf4f82d7b7025de8b2abee3e3df'
+          vcpkgGitCommitId: 'c3867e714dd3a51c272826eea77267876517ed99'
       - name: Install dependencies (windows msvc) (3/4)
         if: runner.os == 'Windows'
         run: |

--- a/.github/workflows/sdl3-matrix.yml
+++ b/.github/workflows/sdl3-matrix.yml
@@ -1,0 +1,183 @@
+name: SDL3 build matrix
+
+on:
+  push:
+    branches:
+    - master
+    paths-ignore:
+    - 'data/**'
+    - 'doc/**'
+    - 'doxygen_doc/**'
+    - 'lang/**'
+  pull_request:
+    branches:
+    - master
+    types: [opened, reopened, synchronize, ready_for_review]
+    paths-ignore:
+    - 'data/**'
+    - 'doc/**'
+    - 'doxygen_doc/**'
+    - 'lang/**'
+
+concurrency:
+  group: sdl3-matrix-${{ github.event.pull_request.number || github.ref_name }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  skip-duplicates-code:
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip_code: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@04a1aebece824b56e6ad6a401d015479cd1c50b3 # master
+        with:
+          skip_after_successful_duplicate: 'false'
+          paths_ignore: '["android/**", "build-data/osx/**", "doc/**", "doxygen_doc/**", "lgtm/**", "msvc-**", "tools/**", "utilities/**", "data/**", "lang/**"]'
+  build:
+    needs: [ skip-duplicates-code ]
+    if: ${{ needs.skip-duplicates-code.outputs.should_skip_code != 'true' && github.event.pull_request.draft == false }}
+    strategy:
+      fail-fast: true
+      max-parallel: 1
+      matrix:
+        include:
+          - title: macOS
+            os: macos-15
+            platform: macos
+          - title: Ubuntu
+            os: ubuntu-24.04
+            platform: linux
+          - title: Windows
+            os: windows-2022
+            platform: windows
+    name: ${{ matrix.title }}
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: checkout repository
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        persist-credentials: false
+
+    - name: install build deps (Ubuntu)
+      if: matrix.platform == 'linux'
+      run: |
+          sudo apt-get update
+          sudo apt-get install libflac-dev libogg-dev libvorbis-dev libmpg123-dev libwavpack-dev \
+              libfreetype-dev libharfbuzz-dev libjpeg-dev libpng-dev libwebp-dev libtiff-dev \
+              libpulse-dev libncursesw5-dev ccache gettext parallel pkg-config cmake \
+              libx11-dev libxext-dev libxcursor-dev libxi-dev libxfixes-dev libxrandr-dev \
+              libxrender-dev libxss-dev libxtst-dev libxkbcommon-dev libwayland-dev \
+              libdecor-0-dev libdrm-dev libgbm-dev libudev-dev libpipewire-0.3-dev \
+              libdbus-1-dev libibus-1.0-dev
+
+    - name: cache SDL3 stack source build (Ubuntu)
+      if: matrix.platform == 'linux'
+      id: cache-sdl3
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        path: ${{ runner.workspace }}/sdl3_prefix
+        key: sdl3-stack-sdl-3.4.4-image-3.4.2-ttf-3.2.2-mixer-3.2.0-${{ runner.os }}-v1
+
+    - name: build SDL3 stack from source (Ubuntu)
+      if: matrix.platform == 'linux' && steps.cache-sdl3.outputs.cache-hit != 'true'
+      run: |
+          PREFIX=${{ runner.workspace }}/sdl3_prefix
+          export PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig:$PREFIX/lib/x86_64-linux-gnu/pkgconfig
+          export CMAKE_PREFIX_PATH=$PREFIX
+          git clone --depth 1 --branch release-3.4.4 https://github.com/libsdl-org/SDL.git sdl3_src
+          cmake -S sdl3_src -B sdl3_build \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_INSTALL_PREFIX=$PREFIX \
+              -DBUILD_SHARED_LIBS=ON
+          cmake --build sdl3_build -j$(nproc)
+          cmake --install sdl3_build
+          git clone --depth 1 --branch release-3.4.2 https://github.com/libsdl-org/SDL_image.git sdl3_image_src
+          cmake -S sdl3_image_src -B sdl3_image_build \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_INSTALL_PREFIX=$PREFIX \
+              -DSDLIMAGE_VENDORED=OFF \
+              -DBUILD_SHARED_LIBS=ON
+          cmake --build sdl3_image_build -j$(nproc)
+          cmake --install sdl3_image_build
+          git clone --depth 1 --branch release-3.2.2 https://github.com/libsdl-org/SDL_ttf.git sdl3_ttf_src
+          cmake -S sdl3_ttf_src -B sdl3_ttf_build \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_INSTALL_PREFIX=$PREFIX \
+              -DSDLTTF_VENDORED=OFF \
+              -DBUILD_SHARED_LIBS=ON
+          cmake --build sdl3_ttf_build -j$(nproc)
+          cmake --install sdl3_ttf_build
+          git clone --depth 1 --branch release-3.2.0 https://github.com/libsdl-org/SDL_mixer.git sdl3_mixer_src
+          cmake -S sdl3_mixer_src -B sdl3_mixer_build \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_INSTALL_PREFIX=$PREFIX \
+              -DSDLMIXER_VENDORED=OFF \
+              -DSDLMIXER_FLAC=ON -DSDLMIXER_FLAC_LIBFLAC=ON \
+              -DSDLMIXER_MP3=ON -DSDLMIXER_MP3_MPG123=ON \
+              -DSDLMIXER_VORBIS=VORBISFILE \
+              -DSDLMIXER_WAVPACK=ON \
+              -DSDLMIXER_OPUS=OFF -DSDLMIXER_MOD=OFF -DSDLMIXER_MIDI=OFF \
+              -DBUILD_SHARED_LIBS=ON
+          cmake --build sdl3_mixer_build -j$(nproc)
+          cmake --install sdl3_mixer_build
+
+    - name: install SDL3 (macOS)
+      if: matrix.platform == 'macos'
+      run: |
+          HOMEBREW_NO_AUTO_UPDATE=yes HOMEBREW_NO_INSTALL_CLEANUP=yes \
+              brew install pkgconf sdl3 sdl3_image sdl3_ttf sdl3_mixer \
+              gettext ccache parallel
+
+    - name: setup MSVC (Windows)
+      if: matrix.platform == 'windows'
+      uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce # v2
+
+    - name: install vcpkg (Windows)
+      if: matrix.platform == 'windows'
+      uses: lukka/run-vcpkg@7d259227a1fb6471a0253dd5ab7419835228f7d7 # v11
+      with:
+        vcpkgDirectory: '${{ runner.workspace }}/b/vcpkg'
+        vcpkgGitCommitId: 'c3867e714dd3a51c272826eea77267876517ed99'
+
+    - name: integrate vcpkg (Windows)
+      if: matrix.platform == 'windows'
+      run: |
+        vcpkg integrate install --vcpkg-root "$env:RUNNER_WORKSPACE\b\vcpkg"
+      env:
+        RUNNER_WORKSPACE: ${{ runner.workspace }}
+
+    - name: cache vcpkg packages (Windows)
+      if: matrix.platform == 'windows'
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        path: msvc-full-features/vcpkg_installed
+        key: vcpkg-installed-sdl3-${{ hashFiles('msvc-full-features/vcpkg.json', '.github/vcpkg_triplets/x64-windows-static.cmake') }}-c3867e714dd3a51c272826eea77267876517ed99
+
+    - name: build (Ubuntu)
+      if: matrix.platform == 'linux'
+      env:
+        PKG_CONFIG_PATH: ${{ runner.workspace }}/sdl3_prefix/lib/pkgconfig:${{ runner.workspace }}/sdl3_prefix/lib/x86_64-linux-gnu/pkgconfig
+        LD_LIBRARY_PATH: ${{ runner.workspace }}/sdl3_prefix/lib:${{ runner.workspace }}/sdl3_prefix/lib/x86_64-linux-gnu
+      run: |
+          make -j$(nproc) TILES=1 SDL3=1 SOUND=1 NATIVE=linux64 RELEASE=1 BACKTRACE=0 LOCALIZE=0
+
+    - name: build (macOS)
+      if: matrix.platform == 'macos'
+      env:
+        PKG_CONFIG_PATH: /opt/homebrew/lib/pkgconfig
+      run: |
+          make -j$(sysctl -n hw.ncpu) TILES=1 SDL3=1 SOUND=1 NATIVE=osx RELEASE=1 LOCALIZE=0
+
+    - name: build (Windows)
+      if: matrix.platform == 'windows'
+      env:
+        VCPKG_OVERLAY_TRIPLETS: ${{ github.workspace }}\.github\vcpkg_triplets
+      run: |
+          msbuild -m -p:Configuration=Release -p:Platform=x64 -p:UseSDL3=true "-target:Cataclysm-vcpkg-static;Cataclysm-test-vcpkg-static" msvc-full-features\Cataclysm-vcpkg-static.sln
+
+    - name: run sound_backend tests (Windows)
+      if: matrix.platform == 'windows'
+      run: |
+          .\Cataclysm-test-vcpkg-static-Release-x64.exe --min-duration 20 --order lex --wait-for-keypress exit "[sound_backend]"

--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ zzip
 .vs/
 Directory.Build.props
 Directory.Build.targets
+!msvc-full-features/Directory.Build.props
 
 # Visual Studio Code
 .vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -76,7 +76,6 @@ zzip
 .vs/
 Directory.Build.props
 Directory.Build.targets
-!msvc-full-features/Directory.Build.props
 
 # Visual Studio Code
 .vscode/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ set(CMAKE_TLS_VERIFY ON)
 # Build options
 include(CMakeDependentOption)
 option(TILES "Build graphical tileset version." "OFF")
+option(USE_SDL3 "Build against SDL3 instead of SDL2 (requires TILES)." "OFF")
 option(CURSES "Build curses version." "ON")
 option(SOUND "Support for in-game sounds & music." "OFF")
 option(BACKTRACE "Support for printing stack backtraces on crash" "ON")
@@ -211,6 +212,7 @@ endif ()
 message(STATUS "GIT_BINARY                    : ${GIT_EXECUTABLE}")
 message(STATUS "DYNAMIC_LINKING               : ${DYNAMIC_LINKING}")
 message(STATUS "TILES                         : ${TILES}")
+message(STATUS "USE_SDL3                      : ${USE_SDL3}")
 message(STATUS "CURSES                        : ${CURSES}")
 message(STATUS "SOUND                         : ${SOUND}")
 message(STATUS "BACKTRACE                     : ${BACKTRACE}")
@@ -271,7 +273,34 @@ find_package(Threads REQUIRED)
 find_package(ZLIB REQUIRED)
 
 # Check for build types and libraries
-if (TILES)
+if (TILES AND USE_SDL3)
+    message(STATUS "Searching for SDL3 library --")
+    find_package(SDL3 CONFIG)
+    if (NOT (SDL3_FOUND OR TARGET SDL3::SDL3 OR TARGET SDL3::SDL3-static))
+        message(FATAL_ERROR
+                "USE_SDL3=ON requires SDL3 to be installed. \
+                 Install the SDL3 development libraries, \
+                 or set USE_SDL3=OFF to build against SDL2.")
+    endif ()
+
+    message(STATUS "Searching for SDL3_ttf library --")
+    find_package(SDL3_ttf CONFIG)
+    if (NOT (SDL3_TTF_FOUND OR TARGET SDL3_ttf::SDL3_ttf OR TARGET SDL3_ttf::SDL3_ttf-static))
+        message(FATAL_ERROR
+                "USE_SDL3=ON requires SDL3_ttf to be installed.")
+    endif ()
+
+    message(STATUS "Searching for SDL3_image library --")
+    find_package(SDL3_image CONFIG)
+    if (NOT (SDL3_IMAGE_FOUND OR TARGET SDL3_image::SDL3_image
+                              OR TARGET SDL3_image::SDL3_image-static))
+        message(FATAL_ERROR
+                "USE_SDL3=ON requires SDL3_image to be installed.")
+    endif ()
+    add_definitions(-DTILES -DUSE_SDL3)
+endif ()
+
+if (TILES AND NOT USE_SDL3)
     # Find SDL, SDL_ttf & SDL_image for graphical install
     message(STATUS "Searching for SDL2 library --")
     if (NOT CMAKE_FIND_PACKAGE_PREFER_CONFIG)
@@ -374,6 +403,11 @@ if (CURSES)
 endif ()
 
 if (SOUND)
+    if (USE_SDL3)
+        message(FATAL_ERROR
+                "SDL3_mixer support is not yet implemented. \
+                 Build with -DSOUND=OFF when -DUSE_SDL3=ON.")
+    endif ()
     # Sound requires SDL_mixer library
     message(STATUS "Searching for SDL2_mixer library --")
     if (VCPKG_MANIFEST_MODE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -402,12 +402,17 @@ if (CURSES)
     endif ()
 endif ()
 
-if (SOUND)
-    if (USE_SDL3)
+if (SOUND AND USE_SDL3)
+    message(STATUS "Searching for SDL3_mixer library --")
+    find_package(SDL3_mixer CONFIG)
+    if (NOT (SDL3_MIXER_FOUND OR TARGET SDL3_mixer::SDL3_mixer
+                              OR TARGET SDL3_mixer::SDL3_mixer-static))
         message(FATAL_ERROR
-                "SDL3_mixer support is not yet implemented. \
-                 Build with -DSOUND=OFF when -DUSE_SDL3=ON.")
-    endif ()
+                "USE_SDL3 + SOUND requires SDL3_mixer to be installed.")
+    endif()
+endif ()
+
+if (SOUND AND NOT USE_SDL3)
     # Sound requires SDL_mixer library
     message(STATUS "Searching for SDL2_mixer library --")
     if (VCPKG_MANIFEST_MODE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,13 +235,17 @@ if (NOT MSVC)
              -Wpedantic \
              -Wsuggest-override \
              -Wunused-macros \
-             -Wzero-as-null-pointer-constant \
-             -Wno-dangling-reference \
-             -Wno-c++20-compat")
+             -Wzero-as-null-pointer-constant")
+    check_cxx_compiler_flag(-Wdangling-reference HAVE_DANGLING_REFERENCE)
+    if (HAVE_DANGLING_REFERENCE)
+        set(CATA_WARNINGS "${CATA_WARNINGS} -Wno-dangling-reference")
+    endif ()
+    check_cxx_compiler_flag(-Wc++20-compat HAVE_CXX20_COMPAT)
+    if (HAVE_CXX20_COMPAT)
+        set(CATA_WARNINGS "${CATA_WARNINGS} -Wno-c++20-compat")
+    endif ()
     if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
         set(CATA_WARNINGS "${CATA_WARNINGS} -Wno-unknown-warning-option")
-    else()
-        set(CATA_WARNINGS "${CATA_WARNINGS} -Wno-unknown-warning")
     endif()
     if (NOT "${CMAKE_SYSTEM_NAME}" MATCHES "Windows")
         set(CATA_WARNINGS "${CATA_WARNINGS} -Wredundant-decls")

--- a/Makefile
+++ b/Makefile
@@ -762,6 +762,12 @@ endif
 
 PKG_CONFIG = $(CROSS)pkg-config
 
+ifeq ($(SDL3), 1)
+  SDL = 1
+  TILES = 1
+  DEFINES += -DUSE_SDL3
+endif
+
 ifeq ($(SDL), 1)
   TILES = 1
 endif
@@ -798,18 +804,33 @@ ifeq ($(TILES), 1)
     CXXFLAGS += $(subst -I,-isystem ,$(shell $(PKG_CONFIG) --cflags freetype2))
     LDFLAGS += $(shell $(PKG_CONFIG) --libs freetype2)
   else ifneq ($(NATIVE),emscripten)
-    CXXFLAGS += $(subst -I,-isystem ,$(shell $(PKG_CONFIG) --cflags sdl2))
-    CXXFLAGS += $(subst -I,-isystem ,$(shell $(PKG_CONFIG) --cflags SDL2_image SDL2_ttf))
-    CXXFLAGS += $(subst -I,-isystem ,$(shell $(PKG_CONFIG) --cflags freetype2))
+    ifeq ($(SDL3), 1)
+      CXXFLAGS += $(subst -I,-isystem ,$(shell $(PKG_CONFIG) --cflags sdl3))
+      CXXFLAGS += $(subst -I,-isystem ,$(shell $(PKG_CONFIG) --cflags sdl3-image sdl3-ttf))
+      CXXFLAGS += $(subst -I,-isystem ,$(shell $(PKG_CONFIG) --cflags freetype2))
 
-    ifeq ($(STATIC), 1)
-      LDFLAGS += $(shell $(PKG_CONFIG) sdl2 --static --libs)
+      ifeq ($(STATIC), 1)
+        LDFLAGS += $(shell $(PKG_CONFIG) sdl3 --static --libs)
+      else
+        LDFLAGS += $(shell $(PKG_CONFIG) sdl3 --libs)
+      endif
+
+      LDFLAGS += $(shell $(PKG_CONFIG) --libs sdl3-image sdl3-ttf)
+      LDFLAGS += $(shell $(PKG_CONFIG) --libs freetype2)
     else
-      LDFLAGS += $(shell $(PKG_CONFIG) sdl2 --libs)
-    endif
+      CXXFLAGS += $(subst -I,-isystem ,$(shell $(PKG_CONFIG) --cflags sdl2))
+      CXXFLAGS += $(subst -I,-isystem ,$(shell $(PKG_CONFIG) --cflags SDL2_image SDL2_ttf))
+      CXXFLAGS += $(subst -I,-isystem ,$(shell $(PKG_CONFIG) --cflags freetype2))
 
-    LDFLAGS += -lSDL2_ttf -lSDL2_image
-    LDFLAGS += $(shell $(PKG_CONFIG) --libs freetype2)
+      ifeq ($(STATIC), 1)
+        LDFLAGS += $(shell $(PKG_CONFIG) sdl2 --static --libs)
+      else
+        LDFLAGS += $(shell $(PKG_CONFIG) sdl2 --libs)
+      endif
+
+      LDFLAGS += -lSDL2_ttf -lSDL2_image
+      LDFLAGS += $(shell $(PKG_CONFIG) --libs freetype2)
+    endif
   endif
 
   DEFINES += -DTILES
@@ -880,6 +901,9 @@ else
 endif # TILES
 
 ifeq ($(SOUND), 1)
+  ifeq ($(SDL3), 1)
+    $(error SDL3_mixer support is not yet implemented. Use SOUND=0 with SDL3=1)
+  endif
   ifeq ($(NATIVE),osx)
     ifndef FRAMEWORK # libsdl build
       ifeq ($(MACPORTS), 1)
@@ -906,6 +930,7 @@ endif
 # We don't use SDL_main -- we have proper main()/WinMain()
 CXXFLAGS := $(filter-out -Dmain=SDL_main,$(CXXFLAGS))
 LDFLAGS := $(filter-out -lSDL2main,$(LDFLAGS))
+LDFLAGS := $(filter-out -lSDL3main,$(LDFLAGS))
 
 ifeq ($(BSD), 1)
   # BSDs have backtrace() and friends in a separate library
@@ -1022,7 +1047,11 @@ C_SOURCES += $(THIRD_PARTY_C_SOURCES)
 IMGUI_SOURCES = $(IMGUI_DIR)/imgui.cpp $(IMGUI_DIR)/imgui_demo.cpp $(IMGUI_DIR)/imgui_draw.cpp $(IMGUI_DIR)/imgui_stdlib.cpp $(IMGUI_DIR)/imgui_tables.cpp $(IMGUI_DIR)/imgui_widgets.cpp
 ifeq ($(SDL), 1)
 	IMGUI_SOURCES += $(IMGUI_DIR)/imgui_freetype.cpp
-	IMGUI_SOURCES += $(IMGUI_DIR)/imgui_impl_sdl2.cpp $(IMGUI_DIR)/imgui_impl_sdlrenderer2.cpp
+	ifeq ($(SDL3), 1)
+		IMGUI_SOURCES += $(IMGUI_DIR)/imgui_impl_sdl3.cpp $(IMGUI_DIR)/imgui_impl_sdlrenderer3.cpp
+	else
+		IMGUI_SOURCES += $(IMGUI_DIR)/imgui_impl_sdl2.cpp $(IMGUI_DIR)/imgui_impl_sdlrenderer2.cpp
+	endif
 else
 	IMGUI_SOURCES += $(IMTUI_DIR)/imtui-impl-ncurses.cpp $(IMTUI_DIR)/imtui-impl-text.cpp
 	DEFINES += -DIMTUI

--- a/Makefile
+++ b/Makefile
@@ -922,26 +922,31 @@ endif # TILES
 
 ifeq ($(SOUND), 1)
   ifeq ($(SDL3), 1)
-    $(error SDL3_mixer support is not yet implemented. Use SOUND=0 with SDL3=1)
-  endif
-  ifeq ($(NATIVE),osx)
-    ifndef FRAMEWORK # libsdl build
-      ifeq ($(MACPORTS), 1)
-        LDFLAGS += -lSDL2_mixer -lvorbisfile -lvorbis -logg
-      else # homebrew
-        CXXFLAGS += $(subst -I,-isystem ,$(shell $(PKG_CONFIG) --cflags SDL2_mixer))
-        LDFLAGS += $(shell $(PKG_CONFIG) --libs SDL2_mixer)
-        LDFLAGS += -lvorbisfile -lvorbis -logg
-      endif
+    CXXFLAGS += $(subst -I,-isystem ,$(shell $(PKG_CONFIG) --cflags sdl3-mixer))
+    LDFLAGS += $(shell $(PKG_CONFIG) --libs sdl3-mixer)
+    ifneq ($(NATIVE),osx)
+      LDFLAGS += -lpthread
     endif
-  else # not osx
-    CXXFLAGS += $(subst -I,-isystem ,$(shell $(PKG_CONFIG) --cflags SDL2_mixer))
-    LDFLAGS += $(shell $(PKG_CONFIG) --libs SDL2_mixer)
-    LDFLAGS += -lpthread
-  endif
+  else
+    ifeq ($(NATIVE),osx)
+      ifndef FRAMEWORK # libsdl build
+        ifeq ($(MACPORTS), 1)
+          LDFLAGS += -lSDL2_mixer -lvorbisfile -lvorbis -logg
+        else # homebrew
+          CXXFLAGS += $(subst -I,-isystem ,$(shell $(PKG_CONFIG) --cflags SDL2_mixer))
+          LDFLAGS += $(shell $(PKG_CONFIG) --libs SDL2_mixer)
+          LDFLAGS += -lvorbisfile -lvorbis -logg
+        endif
+      endif
+    else # not osx
+      CXXFLAGS += $(subst -I,-isystem ,$(shell $(PKG_CONFIG) --cflags SDL2_mixer))
+      LDFLAGS += $(shell $(PKG_CONFIG) --libs SDL2_mixer)
+      LDFLAGS += -lpthread
+    endif
 
-  ifeq ($(MSYS2),1)
-    LDFLAGS += -lmpg123 -lshlwapi -lvorbisfile -lvorbis -logg -lflac
+    ifeq ($(MSYS2),1)
+      LDFLAGS += -lmpg123 -lshlwapi -lvorbisfile -lvorbis -logg -lflac
+    endif
   endif
 
   CXXFLAGS += -DSDL_SOUND

--- a/Makefile
+++ b/Makefile
@@ -631,17 +631,22 @@ ifeq ($(NATIVE), osx)
     endif
   endif
   ifdef FRAMEWORK
+    ifeq ($(SDL3), 1)
+      SDL_FRAMEWORK_GLOB := SDL3.*
+    else
+      SDL_FRAMEWORK_GLOB := SDL2.*
+    endif
     ifeq ($(FRAMEWORKSDIR),)
       FRAMEWORKSDIR := $(strip $(if $(shell [ -d $(HOME)/Library/Frameworks ] && echo 1), \
-                             $(if $(shell find $(HOME)/Library/Frameworks -name 'SDL2.*'), \
+                             $(if $(shell find $(HOME)/Library/Frameworks -name '$(SDL_FRAMEWORK_GLOB)'), \
                                $(HOME)/Library/Frameworks,),))
     endif
     ifeq ($(FRAMEWORKSDIR),)
-      FRAMEWORKSDIR := $(strip $(if $(shell find /Library/Frameworks -name 'SDL2.*'), \
+      FRAMEWORKSDIR := $(strip $(if $(shell find /Library/Frameworks -name '$(SDL_FRAMEWORK_GLOB)'), \
                                  /Library/Frameworks,))
     endif
     ifeq ($(FRAMEWORKSDIR),)
-      $(error "SDL2 framework not found")
+      $(error "SDL framework not found")
     endif
   endif
   ifeq ($(LOCALIZE), 1)
@@ -776,29 +781,44 @@ ifeq ($(TILES), 1)
   SDL = 1
   BINDIST_EXTRAS += gfx
   ifeq ($(NATIVE),osx)
-    ifdef FRAMEWORK
-      OSX_INC = -F$(FRAMEWORKSDIR) \
+    ifeq ($(SDL3), 1)
+      ifdef FRAMEWORK
+        OSX_INC = -F$(FRAMEWORKSDIR) \
+		-I$(FRAMEWORKSDIR)/SDL3.framework/Headers \
+		-I$(FRAMEWORKSDIR)/SDL3_image.framework/Headers \
+		-I$(FRAMEWORKSDIR)/SDL3_ttf.framework/Headers
+        LDFLAGS += -F$(FRAMEWORKSDIR) -rpath $(FRAMEWORKSDIR) \
+		 -framework SDL3 -framework SDL3_image -framework SDL3_ttf -framework Cocoa
+        CXXFLAGS += $(OSX_INC)
+      else
+        CXXFLAGS += $(subst -I,-isystem ,$(shell $(PKG_CONFIG) --cflags sdl3 sdl3-image sdl3-ttf))
+        LDFLAGS += -framework Cocoa $(shell $(PKG_CONFIG) --libs sdl3 sdl3-image sdl3-ttf)
+      endif
+    else
+      ifdef FRAMEWORK
+        OSX_INC = -F$(FRAMEWORKSDIR) \
 		-I$(FRAMEWORKSDIR)/SDL2.framework/Headers \
 		-I$(FRAMEWORKSDIR)/SDL2_image.framework/Headers \
 		-I$(FRAMEWORKSDIR)/SDL2_ttf.framework/Headers
 			ifeq ($(SOUND), 1)
 				OSX_INC += -I$(FRAMEWORKSDIR)/SDL2_mixer.framework/Headers
 			endif
-      LDFLAGS += -F$(FRAMEWORKSDIR) -rpath $(FRAMEWORKSDIR) \
+        LDFLAGS += -F$(FRAMEWORKSDIR) -rpath $(FRAMEWORKSDIR) \
 		 -framework SDL2 -framework SDL2_image -framework SDL2_ttf -framework Cocoa
 		 ifeq ($(SOUND), 1)
 		 	LDFLAGS += -framework SDL2_mixer
 		 endif
-      CXXFLAGS += $(OSX_INC)
-    else # libsdl build
-      DEFINES += -DOSX_SDL2_LIBS
-      # handle #include "SDL2/SDL.h" and "SDL.h"
-      CXXFLAGS += $(subst -I,-isystem ,$(shell sdl2-config --cflags)) \
+        CXXFLAGS += $(OSX_INC)
+      else # libsdl build
+        DEFINES += -DOSX_SDL2_LIBS
+        # handle #include "SDL2/SDL.h" and "SDL.h"
+        CXXFLAGS += $(subst -I,-isystem ,$(shell sdl2-config --cflags)) \
 		  -isystem $(shell dirname $(shell sdl2-config --cflags | sed 's/-I\(.[^ ]*\) .*/\1/'))
-      LDFLAGS += -framework Cocoa $(shell sdl2-config --libs) -lSDL2_ttf
-      LDFLAGS += -lSDL2_image
-      ifeq ($(SOUND), 1)
-        LDFLAGS += -lSDL2_mixer
+        LDFLAGS += -framework Cocoa $(shell sdl2-config --libs) -lSDL2_ttf
+        LDFLAGS += -lSDL2_image
+        ifeq ($(SOUND), 1)
+          LDFLAGS += -lSDL2_mixer
+        endif
       endif
     endif
     CXXFLAGS += $(subst -I,-isystem ,$(shell $(PKG_CONFIG) --cflags freetype2))
@@ -1381,12 +1401,18 @@ ifeq ($(SOUND), 1)
 endif  # ifeq ($(SOUND), 1)
 	cp -R gfx $(APPRESOURCESDIR)/
 ifdef FRAMEWORK
+ifeq ($(SDL3), 1)
+	cp -R $(FRAMEWORKSDIR)/SDL3.framework $(APPRESOURCESDIR)/
+	cp -R $(FRAMEWORKSDIR)/SDL3_image.framework $(APPRESOURCESDIR)/
+	cp -R $(FRAMEWORKSDIR)/SDL3_ttf.framework $(APPRESOURCESDIR)/
+else
 	cp -R $(FRAMEWORKSDIR)/SDL2.framework $(APPRESOURCESDIR)/
 	cp -R $(FRAMEWORKSDIR)/SDL2_image.framework $(APPRESOURCESDIR)/
 	cp -R $(FRAMEWORKSDIR)/SDL2_ttf.framework $(APPRESOURCESDIR)/
 ifeq ($(SOUND), 1)
 	cp -R $(FRAMEWORKSDIR)/SDL2_mixer.framework $(APPRESOURCESDIR)/
 endif  # ifeq ($(SOUND), 1)
+endif  # ifeq ($(SDL3), 1)
 endif  # ifdef FRAMEWORK
 	dylibbundler -of -b -x $(APPRESOURCESDIR)/$(APPTARGET) -d $(APPRESOURCESDIR)/ -p @executable_path/
 

--- a/android/app/jni/src/Android.mk
+++ b/android/app/jni/src/Android.mk
@@ -8,6 +8,7 @@ LOCAL_CPP_FEATURES := exceptions rtti
 
 # Add your application source files here...
 CATA_SRCS := $(sort $(wildcard $(LOCAL_PATH)/*.cpp) $(LOCAL_PATH)/cata_allocator_c.c)
+CATA_SRCS := $(filter-out %/sound_backend_sdl3.cpp,$(CATA_SRCS))
 LOCAL_SRC_FILES := $(sort $(CATA_SRCS:$(LOCAL_PATH)/%=%))
 
 LOCAL_STATIC_LIBRARIES := third-party imgui

--- a/android/app/jni/src/third-party/imgui/Android.mk
+++ b/android/app/jni/src/third-party/imgui/Android.mk
@@ -12,6 +12,7 @@ LOCAL_SHARED_LIBRARIES := SDL2
 
 # Add your application source files here...
 IMGUI_SRCS := $(sort $(wildcard $(LOCAL_PATH)/third-party/imgui/*.cpp))
+IMGUI_SRCS := $(filter-out %/imgui_impl_sdl3.cpp %/imgui_impl_sdlrenderer3.cpp,$(IMGUI_SRCS))
 LOCAL_SRC_FILES := $(sort $(IMGUI_SRCS:$(LOCAL_PATH)/%=%))
 
 LOCAL_CFLAGS += -DBACKTRACE=1 -DLOCALIZE=1 -fsigned-char

--- a/msvc-full-features/Cataclysm-common.props
+++ b/msvc-full-features/Cataclysm-common.props
@@ -25,6 +25,8 @@
   </PropertyGroup>
   <PropertyGroup Label="Vcpkg">
     <VcpkgAdditionalInstallOptions>--clean-after-build</VcpkgAdditionalInstallOptions>
+    <VcpkgAdditionalInstallOptions Condition="$(_UseSDL3)">$(VcpkgAdditionalInstallOptions) --x-feature=sdl3</VcpkgAdditionalInstallOptions>
+    <VcpkgAdditionalInstallOptions Condition="!$(_UseSDL3)">$(VcpkgAdditionalInstallOptions) --x-feature=sdl2</VcpkgAdditionalInstallOptions>
   </PropertyGroup>
   <PropertyGroup Condition="$(_CDDA_USE_CCACHE)">
     <ClToolPath>$(CDDA_CCACHE_PATH)</ClToolPath>
@@ -70,6 +72,9 @@
     <ClCompile Condition="!$(Configuration.Contains(NoTiles))">
       <PreprocessorDefinitions>TILES;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
+    <ClCompile Condition="!$(Configuration.Contains(NoTiles)) And $(_UseSDL3)">
+      <PreprocessorDefinitions>USE_SDL3;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
     <ClCompile Condition="$(Configuration.Contains(NoTiles))">
       <PreprocessorDefinitions>USE_PDCURSES;PDC_NCMOUSE;PDC_WIDE;IMTUI;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
@@ -107,7 +112,46 @@
       <AdditionalLibraryDirectories Condition="$(Configuration.StartsWith(Release))">
         $(ProjectDir)vcpkg_installed\$(VcpkgTripet)\$(VcpkgTriplet)\lib;%(AdditionalLibraryDirectories)
       </AdditionalLibraryDirectories>
-      <AdditionalDependencies>
+      <AdditionalDependencies Condition="$(_UseSDL3)">
+        brotlicommon.lib;
+        brotlidec.lib;
+        brotlienc.lib;
+        bz2$(VcpkgLibSuffix).lib;
+        FLAC.lib;
+        FLAC++.lib;
+        freetype$(VcpkgLibSuffix).lib;
+        jpeg.lib;
+        libpng16$(VcpkgLibSuffix).lib;
+        libwavpack.lib;
+        mpg123.lib;
+        ogg.lib;
+        out123.lib;
+        pdcurses.lib;
+        SDL3_image-static$(VcpkgLibSuffix).lib;
+        SDL3_ttf$(VcpkgLibSuffix).lib;
+        SDL3-static$(VcpkgLibSuffix).lib;
+        syn123.lib;
+        turbojpeg.lib;
+        vorbis.lib;
+        vorbisenc.lib;
+        vorbisfile.lib;
+        zlib$(VcpkgLibSuffix).lib;
+        <!-- win32 deps of the vcpkg deps -->
+        Advapi32.lib;
+        Cfgmgr32.lib;
+        Gdi32.lib;
+        Imm32.lib;
+        Ole32.lib;
+        OleAut32.lib;
+        Setupapi.lib;
+        Shell32.lib;
+        Shlwapi.lib;
+        User32.lib;
+        Version.lib;
+        Winmm.lib;
+        %(AdditionalDependencies)
+      </AdditionalDependencies>
+      <AdditionalDependencies Condition="!$(_UseSDL3)">
         brotlicommon.lib;
         brotlidec.lib;
         brotlienc.lib;

--- a/msvc-full-features/Cataclysm-common.props
+++ b/msvc-full-features/Cataclysm-common.props
@@ -22,6 +22,8 @@
     <_CDDA_ENABLE_THIN_ARCHIVES Condition="'$(CDDA_ENABLE_THIN_ARCHIVES)'!=''">true</_CDDA_ENABLE_THIN_ARCHIVES>
     <_CDDA_USE_LLD_LINK>false</_CDDA_USE_LLD_LINK>
     <_CDDA_USE_LLD_LINK Condition="'$(CDDA_USE_LLD_LINK)'!='' Or $(_CDDA_ENABLE_THIN_ARCHIVES)">true</_CDDA_USE_LLD_LINK>
+    <_UseSDL3>false</_UseSDL3>
+    <_UseSDL3 Condition="'$(UseSDL3)'=='true'">true</_UseSDL3>
   </PropertyGroup>
   <PropertyGroup Label="Vcpkg">
     <VcpkgAdditionalInstallOptions>--clean-after-build</VcpkgAdditionalInstallOptions>
@@ -127,10 +129,10 @@
         ogg.lib;
         out123.lib;
         pdcurses.lib;
-        SDL3_image-static$(VcpkgLibSuffix).lib;
-        SDL3_mixer-static$(VcpkgLibSuffix).lib;
-        SDL3_ttf$(VcpkgLibSuffix).lib;
-        SDL3-static$(VcpkgLibSuffix).lib;
+        SDL3_image-static.lib;
+        SDL3_mixer-static.lib;
+        SDL3_ttf-static.lib;
+        SDL3-static.lib;
         syn123.lib;
         turbojpeg.lib;
         vorbis.lib;

--- a/msvc-full-features/Cataclysm-common.props
+++ b/msvc-full-features/Cataclysm-common.props
@@ -128,6 +128,7 @@
         out123.lib;
         pdcurses.lib;
         SDL3_image-static$(VcpkgLibSuffix).lib;
+        SDL3_mixer-static$(VcpkgLibSuffix).lib;
         SDL3_ttf$(VcpkgLibSuffix).lib;
         SDL3-static$(VcpkgLibSuffix).lib;
         syn123.lib;

--- a/msvc-full-features/Directory.Build.props
+++ b/msvc-full-features/Directory.Build.props
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project>
-  <PropertyGroup>
-    <_UseSDL3>false</_UseSDL3>
-    <_UseSDL3 Condition="'$(UseSDL3)'=='true'">true</_UseSDL3>
-  </PropertyGroup>
-</Project>

--- a/msvc-full-features/Directory.Build.props
+++ b/msvc-full-features/Directory.Build.props
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <PropertyGroup>
+    <_UseSDL3>false</_UseSDL3>
+    <_UseSDL3 Condition="'$(UseSDL3)'=='true'">true</_UseSDL3>
+  </PropertyGroup>
+</Project>

--- a/msvc-full-features/ImGui-lib-vcpkg-static.vcxproj
+++ b/msvc-full-features/ImGui-lib-vcpkg-static.vcxproj
@@ -53,8 +53,18 @@
   <ItemGroup>
     <ClInclude Include="..\src\third-party\imgui\imconfig.h" />
     <ClInclude Include="..\src\third-party\imgui\imgui.h" />
-    <ClInclude Include="..\src\third-party\imgui\imgui_impl_sdl2.h" />
-    <ClInclude Include="..\src\third-party\imgui\imgui_impl_sdlrenderer2.h" />
+    <ClInclude Include="..\src\third-party\imgui\imgui_impl_sdl2.h">
+      <ExcludedFromBuild Condition="$(_UseSDL3)">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\src\third-party\imgui\imgui_impl_sdlrenderer2.h">
+      <ExcludedFromBuild Condition="$(_UseSDL3)">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\src\third-party\imgui\imgui_impl_sdl3.h">
+      <ExcludedFromBuild Condition="!$(_UseSDL3)">true</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="..\src\third-party\imgui\imgui_impl_sdlrenderer3.h">
+      <ExcludedFromBuild Condition="!$(_UseSDL3)">true</ExcludedFromBuild>
+    </ClInclude>
     <ClInclude Include="..\src\third-party\imgui\imgui_internal.h" />
     <ClInclude Include="..\src\third-party\imgui\imstb_rectpack.h" />
     <ClInclude Include="..\src\third-party\imgui\imgui_stdlib.h" />
@@ -69,8 +79,18 @@
     <ClCompile Include="..\src\third-party\imgui\imgui_demo.cpp" />
     <ClCompile Include="..\src\third-party\imgui\imgui_draw.cpp" />
     <ClCompile Include="..\src\third-party\imgui\imgui_freetype.cpp" />
-    <ClCompile Include="..\src\third-party\imgui\imgui_impl_sdl2.cpp" />
-    <ClCompile Include="..\src\third-party\imgui\imgui_impl_sdlrenderer2.cpp" />
+    <ClCompile Include="..\src\third-party\imgui\imgui_impl_sdl2.cpp">
+      <ExcludedFromBuild Condition="$(_UseSDL3)">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\src\third-party\imgui\imgui_impl_sdlrenderer2.cpp">
+      <ExcludedFromBuild Condition="$(_UseSDL3)">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\src\third-party\imgui\imgui_impl_sdl3.cpp">
+      <ExcludedFromBuild Condition="!$(_UseSDL3)">true</ExcludedFromBuild>
+    </ClCompile>
+    <ClCompile Include="..\src\third-party\imgui\imgui_impl_sdlrenderer3.cpp">
+      <ExcludedFromBuild Condition="!$(_UseSDL3)">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="..\src\third-party\imgui\imgui_stdlib.cpp" />
     <ClCompile Include="..\src\third-party\imgui\imgui_tables.cpp" />
     <ClCompile Include="..\src\third-party\imgui\imgui_widgets.cpp" />

--- a/msvc-full-features/vcpkg.json
+++ b/msvc-full-features/vcpkg.json
@@ -21,7 +21,7 @@
       "description": "Build against SDL3 instead of SDL2.",
       "dependencies": [
         "sdl3",
-        { "name": "sdl3-image", "features": [ "jpeg" ] },
+        { "name": "sdl3-image", "features": [ "jpeg", "png" ] },
         "sdl3-ttf",
         { "name": "sdl3-mixer",
           "features": [ "libflac", "mpg123", "wavpack", "libvorbis" ],

--- a/msvc-full-features/vcpkg.json
+++ b/msvc-full-features/vcpkg.json
@@ -21,8 +21,12 @@
       "description": "Build against SDL3 instead of SDL2.",
       "dependencies": [
         "sdl3",
-        { "name": "sdl3-image", "features": [ "libjpeg-turbo" ] },
-        "sdl3-ttf"
+        { "name": "sdl3-image", "features": [ "jpeg" ] },
+        "sdl3-ttf",
+        { "name": "sdl3-mixer",
+          "features": [ "libflac", "mpg123", "wavpack", "libvorbis" ],
+          "default-features": false
+        }
       ]
     }
   },

--- a/msvc-full-features/vcpkg.json
+++ b/msvc-full-features/vcpkg.json
@@ -2,14 +2,29 @@
   "name": "cdda-vcpkg-dependencies",
   "version-string": "0.J",
   "dependencies": [
-    { "name": "sdl2", "version>=": "2.26.4#0" },
-    { "name": "sdl2-image", "features": [ "libjpeg-turbo" ] },
-    { "name": "sdl2-mixer", "features": [ "libflac", "mpg123", "wavpack" ],
-      "default-features": false
-    },
-    "libvorbis",
-    "sdl2-ttf",
     { "name": "pdcurses", "version>=": "3.9#4", "platform": "windows" }
   ],
-  "builtin-baseline": "1b6e030cf096faf4f82d7b7025de8b2abee3e3df"
+  "features": {
+    "sdl2": {
+      "description": "Build against SDL2.",
+      "dependencies": [
+        "libvorbis",
+        { "name": "sdl2", "version>=": "2.26.4#0" },
+        { "name": "sdl2-image", "features": [ "libjpeg-turbo" ] },
+        { "name": "sdl2-mixer", "features": [ "libflac", "mpg123", "wavpack" ],
+          "default-features": false
+        },
+        "sdl2-ttf"
+      ]
+    },
+    "sdl3": {
+      "description": "Build against SDL3 instead of SDL2.",
+      "dependencies": [
+        "sdl3",
+        { "name": "sdl3-image", "features": [ "libjpeg-turbo" ] },
+        "sdl3-ttf"
+      ]
+    }
+  },
+  "builtin-baseline": "c3867e714dd3a51c272826eea77267876517ed99"
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -117,18 +117,49 @@ if (TILES)
         target_link_libraries(cataclysm-tiles-common PUBLIC ${CMAKE_THREAD_LIBS_INIT})
     endif ()
 
-    if (NOT DYNAMIC_LINKING)
-        target_link_libraries(cataclysm-tiles-common PUBLIC
-            SDL2::SDL2-static
-            SDL2_image::SDL2_image-static
-            SDL2_ttf::SDL2_ttf-static
-        )
-    else()
-        target_link_libraries(cataclysm-tiles-common PUBLIC
-            SDL2::SDL2
-            SDL2_image::SDL2_image
-            SDL2_ttf::SDL2_ttf
-        )
+    if (USE_SDL3)
+        if (NOT DYNAMIC_LINKING)
+            if (TARGET SDL3::SDL3-static)
+                set(_SDL3 SDL3::SDL3-static)
+            else ()
+                set(_SDL3 SDL3::SDL3)
+            endif ()
+            if (TARGET SDL3_image::SDL3_image-static)
+                set(_SDL3_IMAGE SDL3_image::SDL3_image-static)
+            else ()
+                set(_SDL3_IMAGE SDL3_image::SDL3_image)
+            endif ()
+            if (TARGET SDL3_ttf::SDL3_ttf-static)
+                set(_SDL3_TTF SDL3_ttf::SDL3_ttf-static)
+            else ()
+                set(_SDL3_TTF SDL3_ttf::SDL3_ttf)
+            endif ()
+            target_link_libraries(cataclysm-tiles-common PUBLIC
+                ${_SDL3}
+                ${_SDL3_IMAGE}
+                ${_SDL3_TTF}
+            )
+        else()
+            target_link_libraries(cataclysm-tiles-common PUBLIC
+                SDL3::SDL3
+                SDL3_image::SDL3_image
+                SDL3_ttf::SDL3_ttf
+            )
+        endif ()
+    else ()
+        if (NOT DYNAMIC_LINKING)
+            target_link_libraries(cataclysm-tiles-common PUBLIC
+                SDL2::SDL2-static
+                SDL2_image::SDL2_image-static
+                SDL2_ttf::SDL2_ttf-static
+            )
+        else()
+            target_link_libraries(cataclysm-tiles-common PUBLIC
+                SDL2::SDL2
+                SDL2_image::SDL2_image
+                SDL2_ttf::SDL2_ttf
+            )
+        endif ()
     endif ()
     if (SOUND)
         if (NOT DYNAMIC_LINKING)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -162,15 +162,17 @@ if (TILES)
         endif ()
     endif ()
     if (SOUND)
-        if (NOT DYNAMIC_LINKING)
-            target_link_libraries(cataclysm-tiles-common PUBLIC
-                SDL2_mixer::SDL2_mixer-static
-            )
-        else()
-            target_link_libraries(cataclysm-tiles-common PUBLIC
-                SDL2_mixer::SDL2_mixer
-            )
-        endif()
+        if (NOT USE_SDL3)
+            if (NOT DYNAMIC_LINKING)
+                target_link_libraries(cataclysm-tiles-common PUBLIC
+                    SDL2_mixer::SDL2_mixer-static
+                )
+            else()
+                target_link_libraries(cataclysm-tiles-common PUBLIC
+                    SDL2_mixer::SDL2_mixer
+                )
+            endif()
+        endif ()
         add_definitions(-DSDL_SOUND)
     endif ()
 
@@ -341,7 +343,7 @@ if (MINGW AND NOT RELEASE)
                 ${RuntimeLib_SDL2_TTF}
                 ${RuntimeLib_ft}
                 ${RuntimeLib_glib})
-        if (SOUND)
+        if (SOUND AND NOT USE_SDL3)
             find_library(RuntimeLib_SDL_SND  "SDL2_mixer")
             find_library(RuntimeLib_flac  "libFLAC-8")
             find_library(RuntimeLib_ogg  "libogg-0")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -162,7 +162,17 @@ if (TILES)
         endif ()
     endif ()
     if (SOUND)
-        if (NOT USE_SDL3)
+        if (USE_SDL3)
+            if (NOT DYNAMIC_LINKING AND TARGET SDL3_mixer::SDL3_mixer-static)
+                target_link_libraries(cataclysm-tiles-common PUBLIC
+                    SDL3_mixer::SDL3_mixer-static
+                )
+            else()
+                target_link_libraries(cataclysm-tiles-common PUBLIC
+                    SDL3_mixer::SDL3_mixer
+                )
+            endif()
+        else ()
             if (NOT DYNAMIC_LINKING)
                 target_link_libraries(cataclysm-tiles-common PUBLIC
                     SDL2_mixer::SDL2_mixer-static

--- a/src/cata_allocator.cpp
+++ b/src/cata_allocator.cpp
@@ -26,7 +26,9 @@
 
 #if defined(TILES) || defined(SDL_SOUND)
 #define SDL_SET_MEMORY_FUNCTIONS
-#if defined(_MSC_VER) && defined(USE_VCPKG)
+#if defined(USE_SDL3)
+#include <SDL3/SDL_stdinc.h>
+#elif defined(_MSC_VER) && defined(USE_VCPKG)
 #include <SDL2/SDL_stdinc.h>
 #else
 #include <SDL_stdinc.h>

--- a/src/cata_imgui.cpp
+++ b/src/cata_imgui.cpp
@@ -247,8 +247,13 @@ RGBTuple color_loader<RGBTuple>::from_rgb( const int r, const int g, const int b
 #include "sdltiles.h"
 #include "font_loader.h"
 #include "wcwidth.h"
+#if SDL_MAJOR_VERSION >= 3
+#include <imgui/imgui_impl_sdl3.h>
+#include <imgui/imgui_impl_sdlrenderer3.h>
+#else
 #include <imgui/imgui_impl_sdl2.h>
 #include <imgui/imgui_impl_sdlrenderer2.h>
+#endif
 
 static bool clear_screen = false;
 
@@ -289,8 +294,13 @@ cataimgui::client::client( const SDL_Renderer_Ptr &sdl_renderer, const SDL_Windo
     // Default cellPadding is {4, 2}. We reduce this to {3, 2}.
     ImGui::PushStyleVar( ImGuiStyleVar_CellPadding, ImVec2( 3, style.CellPadding.y ) );
 
+#if SDL_MAJOR_VERSION >= 3
+    ImGui_ImplSDL3_InitForSDLRenderer( sdl_window.get(), sdl_renderer.get() );
+    ImGui_ImplSDLRenderer3_Init( sdl_renderer.get() );
+#else
     ImGui_ImplSDL2_InitForSDLRenderer( sdl_window.get(), sdl_renderer.get() );
     ImGui_ImplSDLRenderer2_Init( sdl_renderer.get() );
+#endif
 }
 
 // this function QUEUES a character to be drawn
@@ -476,7 +486,11 @@ void cataimgui::client::load_fonts( UNUSED const Font_Ptr &gui_font,
             check_font( io.Fonts->Fonts[i] );
         }
         ImGui::SetCurrentFont( ImGui::GetDefaultFont() );
+#if SDL_MAJOR_VERSION >= 3
+        ImGui_ImplSDLRenderer3_SetFallbackGlyphDrawCallback( [&]( const ImFontGlyphToDraw & glyph ) {
+#else
         ImGui_ImplSDLRenderer2_SetFallbackGlyphDrawCallback( [&]( const ImFontGlyphToDraw & glyph ) {
+#endif
             std::string uni_string = std::string( glyph.uni_str );
             point p( int( glyph.pos.x ), int( glyph.pos.y - 3 ) );
             unsigned char col = 0;
@@ -491,7 +505,11 @@ void cataimgui::client::load_fonts( UNUSED const Font_Ptr &gui_font,
 
 cataimgui::client::~client()
 {
+#if SDL_MAJOR_VERSION >= 3
+    ImGui_ImplSDL3_Shutdown();
+#else
     ImGui_ImplSDL2_Shutdown();
+#endif
 }
 
 #if 0 and not TUI
@@ -587,16 +605,26 @@ void cataimgui::client::new_frame()
 #if 0 and not TUI
     if( freetype_test.PreNewFrame() ) {
         // REUPLOAD FONT TEXTURE TO GPU
+#if SDL_MAJOR_VERSION >= 3
+        ImGui_ImplSDLRenderer3_DestroyDeviceObjects();
+        ImGui_ImplSDLRenderer3_CreateDeviceObjects();
+#else
         ImGui_ImplSDLRenderer2_DestroyDeviceObjects();
         ImGui_ImplSDLRenderer2_CreateDeviceObjects();
+#endif
     }
 #endif
     if( clear_screen ) {
         clear_screen = false;
         clear_sdl_window();
     }
+#if SDL_MAJOR_VERSION >= 3
+    ImGui_ImplSDLRenderer3_NewFrame();
+    ImGui_ImplSDL3_NewFrame();
+#else
     ImGui_ImplSDLRenderer2_NewFrame();
     ImGui_ImplSDL2_NewFrame();
+#endif
 
     ImGui::NewFrame();
 #if 0 and not TUI
@@ -607,7 +635,11 @@ void cataimgui::client::new_frame()
 void cataimgui::client::end_frame()
 {
     ImGui::Render();
+#if SDL_MAJOR_VERSION >= 3
+    ImGui_ImplSDLRenderer3_RenderDrawData( ImGui::GetDrawData(), sdl_renderer.get() );
+#else
     ImGui_ImplSDLRenderer2_RenderDrawData( ImGui::GetDrawData(), sdl_renderer.get() );
+#endif
     ImGuiIO &io = ImGui::GetIO();
     for( const int &code : cata_input_trail ) {
         io.AddKeyEvent( cata_key_to_imgui( code ), false );
@@ -634,7 +666,11 @@ void cataimgui::client::process_input( void *input )
                     return;
             }
         }
+#if SDL_MAJOR_VERSION >= 3
+        ImGui_ImplSDL3_ProcessEvent( evt );
+#else
         ImGui_ImplSDL2_ProcessEvent( evt );
+#endif
     }
 }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -8984,6 +8984,7 @@ void game::on_options_changed()
 #if defined(TILES)
     tilecontext->on_options_changed();
 #endif
+    refresh_mouse_config();
 }
 
 void game::water_affect_items( Character &ch ) const

--- a/src/ncurses_def.cpp
+++ b/src/ncurses_def.cpp
@@ -8,6 +8,9 @@
 #include "point.h"
 #include "translations.h"
 #include "cata_imgui.h"
+#if defined(SDL_SOUND)
+#include "sound_backend.h"
+#endif
 
 // ncurses can define some functions as macros, but we need those identifiers
 // to be unchanged by the preprocessor, as we use them as function names.
@@ -196,6 +199,9 @@ void catacurses::refresh()
 
 void refresh_display()
 {
+#if defined(SDL_SOUND)
+    sound_backend::poll();
+#endif
     catacurses::doupdate();
 }
 

--- a/src/ncurses_def.cpp
+++ b/src/ncurses_def.cpp
@@ -199,6 +199,10 @@ void refresh_display()
     catacurses::doupdate();
 }
 
+void refresh_mouse_config()
+{
+}
+
 void catacurses::doupdate()
 {
     return curses_check_result( ::doupdate(), OK, "doupdate" );

--- a/src/output.h
+++ b/src/output.h
@@ -1226,6 +1226,12 @@ int get_window_height();
 void refresh_display();
 
 /**
+ * Sync OS cursor and ImGui cursor-handling flags with the current
+ * ENABLE_MOUSE and HIDE_CURSOR option values. No-op in curses builds.
+ */
+void refresh_mouse_config();
+
+/**
  * Assigns a custom color to each symbol.
  *
  * @param str String to colorize symbols in

--- a/src/sdl_gamepad.cpp
+++ b/src/sdl_gamepad.cpp
@@ -162,7 +162,8 @@ void init()
 
 #if SDL_MAJOR_VERSION >= 3
     // SDL3: SDL_INIT_GAMECONTROLLER removed; use SDL_INIT_GAMEPAD.
-    int ret = SDL_Init( SDL_INIT_TIMER | SDL_INIT_GAMEPAD );
+    // SDL3: SDL_INIT_TIMER removed (timers work without explicit init).
+    int ret = SDL_Init( SDL_INIT_GAMEPAD );
     if( !ret ) {
         printErrorIf( true, "Init gamepad+timer failed" );
         return;

--- a/src/sdl_gamepad.h
+++ b/src/sdl_gamepad.h
@@ -5,7 +5,11 @@
 #include "input_enums.h"
 #include "sdl_wrappers.h"
 
+#if SDL_MAJOR_VERSION >= 3
+#define SDL_GAMEPAD_SCHEDULER (SDL_EVENT_USER+1)
+#else
 #define SDL_GAMEPAD_SCHEDULER (SDL_USEREVENT+1)
+#endif
 
 struct tripoint;
 

--- a/src/sdl_version_wrappers.h
+++ b/src/sdl_version_wrappers.h
@@ -6,7 +6,9 @@
 // sdl_wrappers.h, which defines SDL_MAIN_HANDLED and would break entry-point
 // handling in main.cpp (WinMain / SDL_main plumbing).
 
-#if defined(_MSC_VER) && defined(USE_VCPKG)
+#if defined(USE_SDL3)
+#   include <SDL3/SDL_version.h>
+#elif defined(_MSC_VER) && defined(USE_VCPKG)
 #   include <SDL2/SDL_version.h>
 #else
 #   include <SDL_version.h>

--- a/src/sdl_wrappers.cpp
+++ b/src/sdl_wrappers.cpp
@@ -2,6 +2,8 @@
 
 #include "sdl_wrappers.h"
 
+#include <algorithm>
+#include <cstring>
 #include <ostream>
 #include <stdexcept>
 #include <string>
@@ -10,7 +12,9 @@
 #include "debug.h"
 #include "point.h"
 
-#if defined(_MSC_VER) && defined(USE_VCPKG)
+#if defined(USE_SDL3)
+#   include <SDL3_image/SDL_image.h>
+#elif defined(_MSC_VER) && defined(USE_VCPKG)
 #   include <SDL2/SDL_image.h>
 #else
 #   include <SDL_image.h>
@@ -37,6 +41,19 @@ void throwErrorIf( const bool condition, const char *const message )
 
 #if defined(TILES)
 
+#if SDL_MAJOR_VERSION >= 3
+// Helper to convert SDL_Rect* to SDL_FRect for SDL3 render functions.
+static SDL_FRect to_frect( const SDL_Rect &r )
+{
+    return { static_cast<float>( r.x ), static_cast<float>( r.y ),
+             static_cast<float>( r.w ), static_cast<float>( r.h ) };
+}
+static SDL_FPoint to_fpoint( const SDL_Point &p )
+{
+    return { static_cast<float>( p.x ), static_cast<float>( p.y ) };
+}
+#endif
+
 // Default texture scale quality applied by CreateTexture/CreateTextureFromSurface.
 // Replaces the global SDL_HINT_RENDER_SCALE_QUALITY approach with per-texture mode.
 // Initialized to "nearest" to match SDL2's documented default for the hint.
@@ -45,11 +62,17 @@ static std::string g_default_texture_scale_quality = "nearest";
 static SDL_ScaleMode scale_quality_to_mode( const std::string &quality )
 {
     if( quality == "0" || quality == "nearest" || quality == "none" ) {
+#if SDL_MAJOR_VERSION >= 3
+        return SDL_SCALEMODE_NEAREST;
+#else
         return SDL_ScaleModeNearest;
+#endif
     }
-    // "1", "linear", or anything else defaults to linear.
-    // SDL3: SDL_SCALEMODE_NEAREST / SDL_SCALEMODE_LINEAR (renamed enums).
+#if SDL_MAJOR_VERSION >= 3
+    return SDL_SCALEMODE_LINEAR;
+#else
     return SDL_ScaleModeLinear;
+#endif
 }
 
 void RenderCopy( const SDL_Renderer_Ptr &renderer, const SDL_Texture_Ptr &texture,
@@ -63,8 +86,16 @@ void RenderCopy( const SDL_Renderer_Ptr &renderer, const SDL_Texture_Ptr &textur
         dbg( D_ERROR ) << "Tried to render a null texture";
         return;
     }
+#if SDL_MAJOR_VERSION >= 3
+    SDL_FRect fsrc, fdst;
+    const SDL_FRect *fsrcp = srcrect ? &( fsrc = to_frect( *srcrect ) ) : nullptr;
+    const SDL_FRect *fdstp = dstrect ? &( fdst = to_frect( *dstrect ) ) : nullptr;
+    printErrorIf( !SDL_RenderTexture( renderer.get(), texture.get(), fsrcp, fdstp ),
+                  "SDL_RenderTexture failed" );
+#else
     printErrorIf( SDL_RenderCopy( renderer.get(), texture.get(), srcrect, dstrect ) != 0,
                   "SDL_RenderCopy failed" );
+#endif
 }
 
 SDL_Texture_Ptr CreateTexture( const SDL_Renderer_Ptr &renderer, Uint32 format, int access,
@@ -74,7 +105,13 @@ SDL_Texture_Ptr CreateTexture( const SDL_Renderer_Ptr &renderer, Uint32 format, 
         dbg( D_ERROR ) << "Tried to create texture with a null renderer";
         return SDL_Texture_Ptr();
     }
+#if SDL_MAJOR_VERSION >= 3
+    SDL_Texture_Ptr result( SDL_CreateTexture( renderer.get(),
+                            static_cast<SDL_PixelFormat>( format ),
+                            static_cast<SDL_TextureAccess>( access ), w, h ) );
+#else
     SDL_Texture_Ptr result( SDL_CreateTexture( renderer.get(), format, access, w, h ) );
+#endif
     printErrorIf( !result, "SDL_CreateTexture failed" );
     if( result ) {
         SDL_SetTextureScaleMode( result.get(),
@@ -110,13 +147,24 @@ void SetRenderDrawColor( const SDL_Renderer_Ptr &renderer, const Uint8 r, const 
         dbg( D_ERROR ) << "Tried to use a null renderer";
         return;
     }
+#if SDL_MAJOR_VERSION >= 3
+    printErrorIf( !SDL_SetRenderDrawColor( renderer.get(), r, g, b, a ),
+                  "SDL_SetRenderDrawColor failed" );
+#else
     printErrorIf( SDL_SetRenderDrawColor( renderer.get(), r, g, b, a ) != 0,
                   "SDL_SetRenderDrawColor failed" );
+#endif
 }
 
 void RenderDrawPoint( const SDL_Renderer_Ptr &renderer, const point &p )
 {
+#if SDL_MAJOR_VERSION >= 3
+    printErrorIf( !SDL_RenderPoint( renderer.get(), static_cast<float>( p.x ),
+                                    static_cast<float>( p.y ) ),
+                  "SDL_RenderPoint failed" );
+#else
     printErrorIf( SDL_RenderDrawPoint( renderer.get(), p.x, p.y ) != 0, "SDL_RenderDrawPoint failed" );
+#endif
 }
 
 void RenderFillRect( const SDL_Renderer_Ptr &renderer, const SDL_Rect *const rect )
@@ -125,7 +173,16 @@ void RenderFillRect( const SDL_Renderer_Ptr &renderer, const SDL_Rect *const rec
         dbg( D_ERROR ) << "Tried to use a null renderer";
         return;
     }
+#if SDL_MAJOR_VERSION >= 3
+    if( rect ) {
+        SDL_FRect fr = to_frect( *rect );
+        printErrorIf( !SDL_RenderFillRect( renderer.get(), &fr ), "SDL_RenderFillRect failed" );
+    } else {
+        printErrorIf( !SDL_RenderFillRect( renderer.get(), nullptr ), "SDL_RenderFillRect failed" );
+    }
+#else
     printErrorIf( SDL_RenderFillRect( renderer.get(), rect ) != 0, "SDL_RenderFillRect failed" );
+#endif
 }
 
 int FillRect( const SDL_Surface_Ptr &surface, const SDL_Rect *const rect, Uint32 color )
@@ -134,9 +191,15 @@ int FillRect( const SDL_Surface_Ptr &surface, const SDL_Rect *const rect, Uint32
         dbg( D_ERROR ) << "Tried to use a null surface";
         return -1;
     }
+#if SDL_MAJOR_VERSION >= 3
+    const bool ok = SDL_FillSurfaceRect( surface.get(), rect, color );
+    printErrorIf( !ok, "SDL_FillSurfaceRect failed" );
+    return ok ? 0 : -1;
+#else
     const int ret = SDL_FillRect( surface.get(), rect, color );
     printErrorIf( ret != 0, "SDL_FillRect failed" );
     return ret;
+#endif
 }
 
 void SetTextureBlendMode( const SDL_Texture_Ptr &texture, SDL_BlendMode blendMode )
@@ -145,8 +208,13 @@ void SetTextureBlendMode( const SDL_Texture_Ptr &texture, SDL_BlendMode blendMod
         dbg( D_ERROR ) << "Tried to use a null texture";
     }
 
+#if SDL_MAJOR_VERSION >= 3
+    throwErrorIf( !SDL_SetTextureBlendMode( texture.get(), blendMode ),
+                  "SDL_SetTextureBlendMode failed" );
+#else
     throwErrorIf( SDL_SetTextureBlendMode( texture.get(), blendMode ) != 0,
                   "SDL_SetTextureBlendMode failed" );
+#endif
 }
 
 void SetTextureBlendMode( const std::shared_ptr<SDL_Texture> &texture, SDL_BlendMode blendMode )
@@ -155,8 +223,13 @@ void SetTextureBlendMode( const std::shared_ptr<SDL_Texture> &texture, SDL_Blend
         dbg( D_ERROR ) << "Tried to use a null texture";
         return;
     }
+#if SDL_MAJOR_VERSION >= 3
+    throwErrorIf( !SDL_SetTextureBlendMode( texture.get(), blendMode ),
+                  "SDL_SetTextureBlendMode failed" );
+#else
     throwErrorIf( SDL_SetTextureBlendMode( texture.get(), blendMode ) != 0,
                   "SDL_SetTextureBlendMode failed" );
+#endif
 }
 
 bool SetTextureColorMod( const SDL_Texture_Ptr &texture, Uint32 r, Uint32 g, Uint32 b )
@@ -165,8 +238,13 @@ bool SetTextureColorMod( const SDL_Texture_Ptr &texture, Uint32 r, Uint32 g, Uin
         dbg( D_ERROR ) << "Tried to use a null texture";
         return true;
     }
+#if SDL_MAJOR_VERSION >= 3
+    return printErrorIf( !SDL_SetTextureColorMod( texture.get(), r, g, b ),
+                         "SDL_SetTextureColorMod failed" );
+#else
     return printErrorIf( SDL_SetTextureColorMod( texture.get(), r, g, b ) != 0,
                          "SDL_SetTextureColorMod failed" );
+#endif
 }
 
 bool SetTextureColorMod( const std::shared_ptr<SDL_Texture> &texture, Uint32 r, Uint32 g,
@@ -176,8 +254,13 @@ bool SetTextureColorMod( const std::shared_ptr<SDL_Texture> &texture, Uint32 r, 
         dbg( D_ERROR ) << "Tried to use a null texture";
         return true;
     }
+#if SDL_MAJOR_VERSION >= 3
+    return printErrorIf( !SDL_SetTextureColorMod( texture.get(), r, g, b ),
+                         "SDL_SetTextureColorMod failed" );
+#else
     return printErrorIf( SDL_SetTextureColorMod( texture.get(), r, g, b ) != 0,
                          "SDL_SetTextureColorMod failed" );
+#endif
 }
 
 void SetRenderDrawBlendMode( const SDL_Renderer_Ptr &renderer, const SDL_BlendMode blendMode )
@@ -186,8 +269,13 @@ void SetRenderDrawBlendMode( const SDL_Renderer_Ptr &renderer, const SDL_BlendMo
         dbg( D_ERROR ) << "Tried to use a null renderer";
         return;
     }
+#if SDL_MAJOR_VERSION >= 3
+    printErrorIf( !SDL_SetRenderDrawBlendMode( renderer.get(), blendMode ),
+                  "SDL_SetRenderDrawBlendMode failed" );
+#else
     printErrorIf( SDL_SetRenderDrawBlendMode( renderer.get(), blendMode ) != 0,
                   "SDL_SetRenderDrawBlendMode failed" );
+#endif
 }
 
 void GetRenderDrawBlendMode( const SDL_Renderer_Ptr &renderer, SDL_BlendMode &blend_mode )
@@ -196,8 +284,13 @@ void GetRenderDrawBlendMode( const SDL_Renderer_Ptr &renderer, SDL_BlendMode &bl
         dbg( D_ERROR ) << "Tried to use a null renderer";
         return;
     }
+#if SDL_MAJOR_VERSION >= 3
+    printErrorIf( !SDL_GetRenderDrawBlendMode( renderer.get(), &blend_mode ),
+                  "SDL_GetRenderDrawBlendMode failed" );
+#else
     printErrorIf( SDL_GetRenderDrawBlendMode( renderer.get(), &blend_mode ) != 0,
                   "SDL_GetRenderDrawBlendMode failed" );
+#endif
 }
 
 SDL_Surface_Ptr load_image( const char *const path )
@@ -206,7 +299,11 @@ SDL_Surface_Ptr load_image( const char *const path )
     SDL_Surface_Ptr result( IMG_Load( path ) );
     if( !result ) {
         throw std::runtime_error( "Could not load image \"" + std::string( path ) + "\": " +
+#if SDL_MAJOR_VERSION >= 3
+                                  SDL_GetError() );
+#else
                                   IMG_GetError() );
+#endif
     }
     return result;
 }
@@ -218,8 +315,13 @@ bool SetRenderTarget( const SDL_Renderer_Ptr &renderer, const SDL_Texture_Ptr &t
         return false;
     }
     // a null texture is fine for SDL (resets to default target)
+#if SDL_MAJOR_VERSION >= 3
+    const bool failed = printErrorIf( !SDL_SetRenderTarget( renderer.get(), texture.get() ),
+                                      "SDL_SetRenderTarget failed" );
+#else
     const bool failed = printErrorIf( SDL_SetRenderTarget( renderer.get(), texture.get() ) != 0,
                                       "SDL_SetRenderTarget failed" );
+#endif
     return !failed;
 }
 
@@ -229,14 +331,24 @@ void RenderClear( const SDL_Renderer_Ptr &renderer )
         dbg( D_ERROR ) << "Tried to use a null renderer";
         return;
     }
+#if SDL_MAJOR_VERSION >= 3
+    printErrorIf( !SDL_RenderClear( renderer.get() ), "SDL_RenderClear failed" );
+#else
     printErrorIf( SDL_RenderClear( renderer.get() ) != 0, "SDL_RenderClear failed" );
+#endif
 }
 
 SDL_Surface_Ptr CreateRGBSurface( const Uint32 flags, const int width, const int height,
                                   const int depth, const Uint32 Rmask, const Uint32 Gmask, const Uint32 Bmask, const Uint32 Amask )
 {
+#if SDL_MAJOR_VERSION >= 3
+    ( void )flags;
+    SDL_PixelFormat fmt = SDL_GetPixelFormatForMasks( depth, Rmask, Gmask, Bmask, Amask );
+    SDL_Surface_Ptr surface( SDL_CreateSurface( width, height, fmt ) );
+#else
     SDL_Surface_Ptr surface( SDL_CreateRGBSurface( flags, width, height, depth, Rmask, Gmask, Bmask,
                              Amask ) );
+#endif
     throwErrorIf( !surface, "Failed to create surface" );
     return surface;
 }
@@ -247,8 +359,13 @@ void SetTextureAlphaMod( const SDL_Texture_Ptr &texture, const Uint8 alpha )
         dbg( D_ERROR ) << "Tried to use a null texture";
         return;
     }
+#if SDL_MAJOR_VERSION >= 3
+    printErrorIf( !SDL_SetTextureAlphaMod( texture.get(), alpha ),
+                  "SDL_SetTextureAlphaMod failed" );
+#else
     printErrorIf( SDL_SetTextureAlphaMod( texture.get(), alpha ) != 0,
                   "SDL_SetTextureAlphaMod failed" );
+#endif
 }
 
 void SetTextureAlphaMod( const std::shared_ptr<SDL_Texture> &texture, const Uint8 alpha )
@@ -257,8 +374,13 @@ void SetTextureAlphaMod( const std::shared_ptr<SDL_Texture> &texture, const Uint
         dbg( D_ERROR ) << "Tried to use a null texture";
         return;
     }
+#if SDL_MAJOR_VERSION >= 3
+    printErrorIf( !SDL_SetTextureAlphaMod( texture.get(), alpha ),
+                  "SDL_SetTextureAlphaMod failed" );
+#else
     printErrorIf( SDL_SetTextureAlphaMod( texture.get(), alpha ) != 0,
                   "SDL_SetTextureAlphaMod failed" );
+#endif
 }
 
 void RenderCopyEx( const SDL_Renderer_Ptr &renderer, SDL_Texture *const texture,
@@ -274,9 +396,20 @@ void RenderCopyEx( const SDL_Renderer_Ptr &renderer, SDL_Texture *const texture,
         dbg( D_ERROR ) << "Tried to render a null texture";
         return;
     }
+#if SDL_MAJOR_VERSION >= 3
+    SDL_FRect fsrc, fdst;
+    SDL_FPoint fcenter;
+    const SDL_FRect *fsrcp = srcrect ? &( fsrc = to_frect( *srcrect ) ) : nullptr;
+    const SDL_FRect *fdstp = dstrect ? &( fdst = to_frect( *dstrect ) ) : nullptr;
+    const SDL_FPoint *fcenterp = center ? &( fcenter = to_fpoint( *center ) ) : nullptr;
+    printErrorIf( !SDL_RenderTextureRotated( renderer.get(), texture, fsrcp, fdstp, angle,
+                                             fcenterp, flip ),
+                  "SDL_RenderTextureRotated failed" );
+#else
     printErrorIf( SDL_RenderCopyEx( renderer.get(), texture, srcrect, dstrect, angle, center,
                                     flip ) != 0,
                   "SDL_RenderCopyEx failed" );
+#endif
 }
 
 void RenderSetClipRect( const SDL_Renderer_Ptr &renderer, const SDL_Rect *const rect )
@@ -285,8 +418,13 @@ void RenderSetClipRect( const SDL_Renderer_Ptr &renderer, const SDL_Rect *const 
         dbg( D_ERROR ) << "Tried to use a null renderer";
         return;
     }
+#if SDL_MAJOR_VERSION >= 3
+    printErrorIf( !SDL_SetRenderClipRect( renderer.get(), rect ),
+                  "SDL_SetRenderClipRect failed" );
+#else
     printErrorIf( SDL_RenderSetClipRect( renderer.get(), rect ) != 0,
                   "SDL_RenderSetClipRect failed" );
+#endif
 }
 
 void RenderGetClipRect( const SDL_Renderer_Ptr &renderer, SDL_Rect *const rect )
@@ -295,7 +433,11 @@ void RenderGetClipRect( const SDL_Renderer_Ptr &renderer, SDL_Rect *const rect )
         dbg( D_ERROR ) << "Tried to use a null renderer";
         return;
     }
+#if SDL_MAJOR_VERSION >= 3
+    SDL_GetRenderClipRect( renderer.get(), rect );
+#else
     SDL_RenderGetClipRect( renderer.get(), rect );
+#endif
 }
 
 bool RenderIsClipEnabled( const SDL_Renderer_Ptr &renderer )
@@ -304,7 +446,11 @@ bool RenderIsClipEnabled( const SDL_Renderer_Ptr &renderer )
         dbg( D_ERROR ) << "Tried to use a null renderer";
         return false;
     }
+#if SDL_MAJOR_VERSION >= 3
+    return SDL_RenderClipEnabled( renderer.get() );
+#else
     return SDL_RenderIsClipEnabled( renderer.get() );
+#endif
 }
 
 int BlitSurface( const SDL_Surface_Ptr &src, const SDL_Rect *const srcrect,
@@ -318,7 +464,12 @@ int BlitSurface( const SDL_Surface_Ptr &src, const SDL_Rect *const srcrect,
         dbg( D_ERROR ) << "Tried to blit to a null surface";
         return -1;
     }
+#if SDL_MAJOR_VERSION >= 3
+    // SDL3 returns bool (true=success); convert to SDL2 convention (0=success).
+    return SDL_BlitSurface( src.get(), srcrect, dst.get(), dstrect ) ? 0 : -1;
+#else
     return SDL_BlitSurface( src.get(), srcrect, dst.get(), dstrect );
+#endif
 }
 
 Uint32 MapRGB( const SDL_Surface_Ptr &surface, const Uint8 r, const Uint8 g, const Uint8 b )
@@ -327,7 +478,11 @@ Uint32 MapRGB( const SDL_Surface_Ptr &surface, const Uint8 r, const Uint8 g, con
         dbg( D_ERROR ) << "Tried to map color on a null surface";
         return 0;
     }
+#if SDL_MAJOR_VERSION >= 3
+    return SDL_MapSurfaceRGB( surface.get(), r, g, b );
+#else
     return SDL_MapRGB( surface->format, r, g, b );
+#endif
 }
 
 Uint32 MapRGBA( const SDL_Surface_Ptr &surface, const Uint8 r, const Uint8 g, const Uint8 b,
@@ -337,7 +492,11 @@ Uint32 MapRGBA( const SDL_Surface_Ptr &surface, const Uint8 r, const Uint8 g, co
         dbg( D_ERROR ) << "Tried to map color on a null surface";
         return 0;
     }
+#if SDL_MAJOR_VERSION >= 3
+    return SDL_MapSurfaceRGBA( surface.get(), r, g, b, a );
+#else
     return SDL_MapRGBA( surface->format, r, g, b, a );
+#endif
 }
 
 void GetRGBA( const Uint32 pixel, const SDL_Surface_Ptr &surface, Uint8 &r, Uint8 &g, Uint8 &b,
@@ -348,7 +507,12 @@ void GetRGBA( const Uint32 pixel, const SDL_Surface_Ptr &surface, Uint8 &r, Uint
         r = g = b = a = 0;
         return;
     }
+#if SDL_MAJOR_VERSION >= 3
+    SDL_GetRGBA( pixel, SDL_GetPixelFormatDetails( surface->format ),
+                 SDL_GetSurfacePalette( surface.get() ), &r, &g, &b, &a );
+#else
     SDL_GetRGBA( pixel, surface->format, &r, &g, &b, &a );
+#endif
 }
 
 int SetColorKey( const SDL_Surface_Ptr &surface, const int flag, const Uint32 key )
@@ -357,7 +521,11 @@ int SetColorKey( const SDL_Surface_Ptr &surface, const int flag, const Uint32 ke
         dbg( D_ERROR ) << "Tried to set colorkey on a null surface";
         return -1;
     }
+#if SDL_MAJOR_VERSION >= 3
+    return SDL_SetSurfaceColorKey( surface.get(), flag, key ) ? 0 : -1;
+#else
     return SDL_SetColorKey( surface.get(), flag, key );
+#endif
 }
 
 int SetSurfaceRLE( const SDL_Surface_Ptr &surface, const int flag )
@@ -366,7 +534,11 @@ int SetSurfaceRLE( const SDL_Surface_Ptr &surface, const int flag )
         dbg( D_ERROR ) << "Tried to set RLE on a null surface";
         return -1;
     }
+#if SDL_MAJOR_VERSION >= 3
+    return SDL_SetSurfaceRLE( surface.get(), flag ) ? 0 : -1;
+#else
     return SDL_SetSurfaceRLE( surface.get(), flag );
+#endif
 }
 
 int SetSurfaceBlendMode( const SDL_Surface_Ptr &surface, const SDL_BlendMode blendMode )
@@ -375,7 +547,11 @@ int SetSurfaceBlendMode( const SDL_Surface_Ptr &surface, const SDL_BlendMode ble
         dbg( D_ERROR ) << "Tried to set blend mode on a null surface";
         return -1;
     }
+#if SDL_MAJOR_VERSION >= 3
+    return SDL_SetSurfaceBlendMode( surface.get(), blendMode ) ? 0 : -1;
+#else
     return SDL_SetSurfaceBlendMode( surface.get(), blendMode );
+#endif
 }
 
 SDL_Surface_Ptr ConvertSurfaceFormat( const SDL_Surface_Ptr &surface, const Uint32 pixel_format )
@@ -384,8 +560,14 @@ SDL_Surface_Ptr ConvertSurfaceFormat( const SDL_Surface_Ptr &surface, const Uint
         dbg( D_ERROR ) << "Tried to convert a null surface";
         return SDL_Surface_Ptr();
     }
+#if SDL_MAJOR_VERSION >= 3
+    SDL_Surface_Ptr result( SDL_ConvertSurface( surface.get(),
+                            static_cast<SDL_PixelFormat>( pixel_format ) ) );
+    printErrorIf( !result, "SDL_ConvertSurface failed" );
+#else
     SDL_Surface_Ptr result( SDL_ConvertSurfaceFormat( surface.get(), pixel_format, 0 ) );
     printErrorIf( !result, "SDL_ConvertSurfaceFormat failed" );
+#endif
     return result;
 }
 
@@ -395,7 +577,11 @@ int LockSurface( const SDL_Surface_Ptr &surface )
         dbg( D_ERROR ) << "Tried to lock a null surface";
         return -1;
     }
+#if SDL_MAJOR_VERSION >= 3
+    return SDL_LockSurface( surface.get() ) ? 0 : -1;
+#else
     return SDL_LockSurface( surface.get() );
+#endif
 }
 
 void UnlockSurface( const SDL_Surface_Ptr &surface )
@@ -413,16 +599,34 @@ Uint32 GetSurfacePixelFormat( const SDL_Surface_Ptr &surface )
         dbg( D_ERROR ) << "Tried to get pixel format of a null surface";
         return 0;
     }
+#if SDL_MAJOR_VERSION >= 3
     // SDL3: surface->format is the enum directly (no intermediate struct).
+    return surface->format;
+#else
     return surface->format->format;
+#endif
 }
 
 TTF_Font_Ptr OpenFontIndex( const char *const file, const int ptsize, const int64_t index )
 {
+#if SDL_MAJOR_VERSION >= 3
+    if( index == 0 ) {
+        TTF_Font_Ptr result( TTF_OpenFont( file, static_cast<float>( ptsize ) ) );
+        return result;
+    }
+    SDL_PropertiesID props = SDL_CreateProperties();
+    SDL_SetStringProperty( props, TTF_PROP_FONT_CREATE_FILENAME_STRING, file );
+    SDL_SetFloatProperty( props, TTF_PROP_FONT_CREATE_SIZE_FLOAT, static_cast<float>( ptsize ) );
+    SDL_SetNumberProperty( props, TTF_PROP_FONT_CREATE_FACE_NUMBER, index );
+    TTF_Font_Ptr result( TTF_OpenFontWithProperties( props ) );
+    SDL_DestroyProperties( props );
+    return result;
+#else
     // NOLINTNEXTLINE(cata-no-long)
     TTF_Font_Ptr result( TTF_OpenFontIndex( file, ptsize, static_cast<long>( index ) ) );
     // Callers check the result and may call SDL_GetError themselves.
     return result;
+#endif
 }
 
 const char *FontFaceStyleName( const TTF_Font_Ptr &font )
@@ -431,7 +635,11 @@ const char *FontFaceStyleName( const TTF_Font_Ptr &font )
         dbg( D_ERROR ) << "Tried to query style name of a null font";
         return nullptr;
     }
+#if SDL_MAJOR_VERSION >= 3
+    return TTF_GetFontStyleName( font.get() );
+#else
     return TTF_FontFaceStyleName( font.get() );
+#endif
 }
 
 int FontFaces( const TTF_Font_Ptr &font )
@@ -440,7 +648,11 @@ int FontFaces( const TTF_Font_Ptr &font )
         dbg( D_ERROR ) << "Tried to query face count of a null font";
         return 0;
     }
+#if SDL_MAJOR_VERSION >= 3
+    return TTF_GetNumFontFaces( font.get() );
+#else
     return TTF_FontFaces( font.get() );
+#endif
 }
 
 int FontHeight( const TTF_Font_Ptr &font )
@@ -449,7 +661,11 @@ int FontHeight( const TTF_Font_Ptr &font )
         dbg( D_ERROR ) << "Tried to query height of a null font";
         return 0;
     }
+#if SDL_MAJOR_VERSION >= 3
+    return TTF_GetFontHeight( font.get() );
+#else
     return TTF_FontHeight( font.get() );
+#endif
 }
 
 void SetFontStyle( const TTF_Font_Ptr &font, const int style )
@@ -468,7 +684,11 @@ SDL_Surface_Ptr RenderUTF8_Solid( const TTF_Font_Ptr &font, const char *const te
         dbg( D_ERROR ) << "Tried to render with a null font";
         return SDL_Surface_Ptr();
     }
+#if SDL_MAJOR_VERSION >= 3
+    return SDL_Surface_Ptr( TTF_RenderText_Solid( font.get(), text, 0, fg ) );
+#else
     return SDL_Surface_Ptr( TTF_RenderUTF8_Solid( font.get(), text, fg ) );
+#endif
 }
 
 SDL_Surface_Ptr RenderUTF8_Blended( const TTF_Font_Ptr &font, const char *const text,
@@ -478,7 +698,11 @@ SDL_Surface_Ptr RenderUTF8_Blended( const TTF_Font_Ptr &font, const char *const 
         dbg( D_ERROR ) << "Tried to render with a null font";
         return SDL_Surface_Ptr();
     }
+#if SDL_MAJOR_VERSION >= 3
+    return SDL_Surface_Ptr( TTF_RenderText_Blended( font.get(), text, 0, fg ) );
+#else
     return SDL_Surface_Ptr( TTF_RenderUTF8_Blended( font.get(), text, fg ) );
+#endif
 }
 
 bool CanRenderGlyph( const TTF_Font_Ptr &font, const Uint32 ch )
@@ -486,24 +710,44 @@ bool CanRenderGlyph( const TTF_Font_Ptr &font, const Uint32 ch )
     if( !font ) {
         return false;
     }
+#if SDL_MAJOR_VERSION >= 3
+    return TTF_FontHasGlyph( font.get(), ch );
+#else
     // SDL2: TTF_GlyphIsProvided only takes Uint16, so clamp for now.
-    // SDL3_ttf will use Uint32 natively via glyph metrics.
     if( ch > 0xFFFF ) {
         return false;
     }
     return TTF_GlyphIsProvided( font.get(), static_cast<Uint16>( ch ) ) != 0;
+#endif
 }
 
 int GetNumVideoDisplays()
 {
-    // SDL3: SDL_GetDisplays(&count) returns SDL_DisplayID* array; return count.
+#if SDL_MAJOR_VERSION >= 3
+    int count = 0;
+    SDL_DisplayID *displays = SDL_GetDisplays( &count );
+    SDL_free( displays );
+    return count;
+#else
     return SDL_GetNumVideoDisplays();
+#endif
 }
 
 const char *GetDisplayName( const int displayIndex )
 {
-    // SDL3: SDL_GetDisplays() + SDL_GetDisplayName(displayID). Map index to ID.
+#if SDL_MAJOR_VERSION >= 3
+    int count = 0;
+    SDL_DisplayID *displays = SDL_GetDisplays( &count );
+    if( !displays || displayIndex < 0 || displayIndex >= count ) {
+        SDL_free( displays );
+        return "";
+    }
+    const char *name = SDL_GetDisplayName( displays[displayIndex] );
+    SDL_free( displays );
+    return name ? name : "";
+#else
     return SDL_GetDisplayName( displayIndex );
+#endif
 }
 
 bool GetDesktopDisplayMode( const int displayIndex, SDL_DisplayMode *mode )
@@ -511,9 +755,23 @@ bool GetDesktopDisplayMode( const int displayIndex, SDL_DisplayMode *mode )
     if( !mode ) {
         return false;
     }
-    // SDL3: SDL_GetDesktopDisplayMode(displayID) returns const SDL_DisplayMode*.
-    // Copy into caller's struct.
+#if SDL_MAJOR_VERSION >= 3
+    int count = 0;
+    SDL_DisplayID *displays = SDL_GetDisplays( &count );
+    if( !displays || displayIndex < 0 || displayIndex >= count ) {
+        SDL_free( displays );
+        return false;
+    }
+    const SDL_DisplayMode *dm = SDL_GetDesktopDisplayMode( displays[displayIndex] );
+    SDL_free( displays );
+    if( !dm ) {
+        return false;
+    }
+    *mode = *dm;
+    return true;
+#else
     return SDL_GetDesktopDisplayMode( displayIndex, mode ) == 0;
+#endif
 }
 
 
@@ -525,13 +783,16 @@ int GetNumRenderDrivers()
 
 const char *GetRenderDriverName( const int index )
 {
-    // SDL3: SDL_GetRenderDriver(index) returns const char* directly.
-    // SDL2: need to go through SDL_RendererInfo.
+#if SDL_MAJOR_VERSION >= 3
+    const char *name = SDL_GetRenderDriver( index );
+    return name ? name : "";
+#else
     static SDL_RendererInfo info;
     if( SDL_GetRenderDriverInfo( index, &info ) != 0 ) {
         return "";
     }
     return info.name;
+#endif
 }
 
 
@@ -540,13 +801,16 @@ const char *GetRendererName( const SDL_Renderer_Ptr &renderer )
     if( !renderer ) {
         return "";
     }
-    // SDL3: SDL_GetRendererName(renderer) returns const char* directly.
-    // SDL2: go through SDL_RendererInfo.
+#if SDL_MAJOR_VERSION >= 3
+    const char *name = SDL_GetRendererName( renderer.get() );
+    return name ? name : "";
+#else
     static SDL_RendererInfo info;
     if( SDL_GetRendererInfo( renderer.get(), &info ) != 0 ) {
         return "";
     }
     return info.name;
+#endif
 }
 
 bool IsRendererSoftware( const SDL_Renderer_Ptr &renderer )
@@ -554,12 +818,16 @@ bool IsRendererSoftware( const SDL_Renderer_Ptr &renderer )
     if( !renderer ) {
         return false;
     }
-    // SDL3: check renderer name == "software" or property query.
+#if SDL_MAJOR_VERSION >= 3
+    const char *name = SDL_GetRendererName( renderer.get() );
+    return name && std::string( name ) == "software";
+#else
     SDL_RendererInfo info;
     if( SDL_GetRendererInfo( renderer.get(), &info ) != 0 ) {
         return false;
     }
     return ( info.flags & SDL_RENDERER_SOFTWARE ) != 0;
+#endif
 }
 
 bool GetRendererMaxTextureSize( const SDL_Renderer_Ptr &renderer, int *max_w, int *max_h )
@@ -567,8 +835,21 @@ bool GetRendererMaxTextureSize( const SDL_Renderer_Ptr &renderer, int *max_w, in
     if( !renderer ) {
         return false;
     }
-    // SDL3: SDL_GetNumberProperty(SDL_GetRendererProperties(r),
-    //       SDL_PROP_RENDERER_MAX_TEXTURE_SIZE_NUMBER, 0).
+#if SDL_MAJOR_VERSION >= 3
+    SDL_PropertiesID props = SDL_GetRendererProperties( renderer.get() );
+    if( !props ) {
+        return false;
+    }
+    if( max_w ) {
+        *max_w = static_cast<int>( SDL_GetNumberProperty( props,
+                                   SDL_PROP_RENDERER_MAX_TEXTURE_SIZE_NUMBER, 0 ) );
+    }
+    if( max_h ) {
+        *max_h = static_cast<int>( SDL_GetNumberProperty( props,
+                                   SDL_PROP_RENDERER_MAX_TEXTURE_SIZE_NUMBER, 0 ) );
+    }
+    return true;
+#else
     SDL_RendererInfo info;
     if( SDL_GetRendererInfo( renderer.get(), &info ) != 0 ) {
         return false;
@@ -580,6 +861,7 @@ bool GetRendererMaxTextureSize( const SDL_Renderer_Ptr &renderer, int *max_w, in
         *max_h = info.max_texture_height;
     }
     return true;
+#endif
 }
 
 
@@ -588,8 +870,11 @@ void RenderPresent( const SDL_Renderer_Ptr &renderer )
     if( !renderer ) {
         return;
     }
-    // SDL3: returns bool (SDL2: void).
+#if SDL_MAJOR_VERSION >= 3
+    printErrorIf( !SDL_RenderPresent( renderer.get() ), "SDL_RenderPresent failed" );
+#else
     SDL_RenderPresent( renderer.get() );
+#endif
 }
 
 void RenderDrawRect( const SDL_Renderer_Ptr &renderer, const SDL_Rect *rect )
@@ -597,9 +882,17 @@ void RenderDrawRect( const SDL_Renderer_Ptr &renderer, const SDL_Rect *rect )
     if( !renderer ) {
         return;
     }
-    // SDL3: SDL_RenderRect (renamed, uses SDL_FRect internally).
+#if SDL_MAJOR_VERSION >= 3
+    if( rect ) {
+        SDL_FRect fr = to_frect( *rect );
+        printErrorIf( !SDL_RenderRect( renderer.get(), &fr ), "SDL_RenderRect failed" );
+    } else {
+        printErrorIf( !SDL_RenderRect( renderer.get(), nullptr ), "SDL_RenderRect failed" );
+    }
+#else
     printErrorIf( SDL_RenderDrawRect( renderer.get(), rect ) != 0,
                   "SDL_RenderDrawRect failed" );
+#endif
 }
 
 void RenderGetViewport( const SDL_Renderer_Ptr &renderer, SDL_Rect *rect )
@@ -607,8 +900,11 @@ void RenderGetViewport( const SDL_Renderer_Ptr &renderer, SDL_Rect *rect )
     if( !renderer ) {
         return;
     }
-    // SDL3: SDL_GetRenderViewport (renamed).
+#if SDL_MAJOR_VERSION >= 3
+    SDL_GetRenderViewport( renderer.get(), rect );
+#else
     SDL_RenderGetViewport( renderer.get(), rect );
+#endif
 }
 
 void RenderSetLogicalSize( const SDL_Renderer_Ptr &renderer, const int w, const int h )
@@ -616,11 +912,14 @@ void RenderSetLogicalSize( const SDL_Renderer_Ptr &renderer, const int w, const 
     if( !renderer ) {
         return;
     }
-    // SDL3: SDL_SetRenderLogicalPresentation(r, w, h, SDL_LOGICAL_PRESENTATION_LETTERBOX).
-    // Note: SDL3 does NOT auto-scale mouse/touch events for logical size.
-    // Callers must use ConvertEventCoordinates after SDL_PollEvent.
+#if SDL_MAJOR_VERSION >= 3
+    printErrorIf( !SDL_SetRenderLogicalPresentation( renderer.get(), w, h,
+                  SDL_LOGICAL_PRESENTATION_LETTERBOX ),
+                  "SDL_SetRenderLogicalPresentation failed" );
+#else
     printErrorIf( SDL_RenderSetLogicalSize( renderer.get(), w, h ) != 0,
                   "SDL_RenderSetLogicalSize failed" );
+#endif
 }
 
 void RenderSetScale( const SDL_Renderer_Ptr &renderer, const float scaleX, const float scaleY )
@@ -628,9 +927,13 @@ void RenderSetScale( const SDL_Renderer_Ptr &renderer, const float scaleX, const
     if( !renderer ) {
         return;
     }
-    // SDL3: SDL_SetRenderScale (renamed).
+#if SDL_MAJOR_VERSION >= 3
+    printErrorIf( !SDL_SetRenderScale( renderer.get(), scaleX, scaleY ),
+                  "SDL_SetRenderScale failed" );
+#else
     printErrorIf( SDL_RenderSetScale( renderer.get(), scaleX, scaleY ) != 0,
                   "SDL_RenderSetScale failed" );
+#endif
 }
 
 bool RenderReadPixels( const SDL_Renderer_Ptr &renderer, const SDL_Rect *rect,
@@ -639,9 +942,24 @@ bool RenderReadPixels( const SDL_Renderer_Ptr &renderer, const SDL_Rect *rect,
     if( !renderer ) {
         return false;
     }
-    // SDL3: returns SDL_Surface* instead of writing into a buffer.
-    // Wrapper would allocate surface, copy data out, free surface.
+#if SDL_MAJOR_VERSION >= 3
+    ( void )format;
+    SDL_Surface *surf = SDL_RenderReadPixels( renderer.get(), rect );
+    if( !surf ) {
+        return false;
+    }
+    const int copy_h = surf->h;
+    const int copy_pitch = std::min( pitch, surf->pitch );
+    for( int row = 0; row < copy_h; row++ ) {
+        std::memcpy( static_cast<Uint8 *>( pixels ) + row * pitch,
+                     static_cast<const Uint8 *>( surf->pixels ) + row * surf->pitch,
+                     copy_pitch );
+    }
+    SDL_DestroySurface( surf );
+    return true;
+#else
     return SDL_RenderReadPixels( renderer.get(), rect, format, pixels, pitch ) == 0;
+#endif
 }
 
 void GetRendererOutputSize( const SDL_Renderer_Ptr &renderer, int *w, int *h )
@@ -649,9 +967,13 @@ void GetRendererOutputSize( const SDL_Renderer_Ptr &renderer, int *w, int *h )
     if( !renderer ) {
         return;
     }
-    // SDL3: SDL_GetCurrentRenderOutputSize (renamed).
+#if SDL_MAJOR_VERSION >= 3
+    printErrorIf( !SDL_GetCurrentRenderOutputSize( renderer.get(), w, h ),
+                  "SDL_GetCurrentRenderOutputSize failed" );
+#else
     printErrorIf( SDL_GetRendererOutputSize( renderer.get(), w, h ) != 0,
                   "SDL_GetRendererOutputSize failed" );
+#endif
 }
 
 
@@ -664,25 +986,38 @@ uint32_t GetTicks()
 
 bool IsCursorVisible()
 {
-    // SDL3: SDL_CursorVisible() returns bool.
+#if SDL_MAJOR_VERSION >= 3
+    return SDL_CursorVisible();
+#else
     return SDL_ShowCursor( SDL_QUERY ) == SDL_ENABLE;
+#endif
 }
 
 void ShowCursor()
 {
-    // SDL3: SDL_ShowCursor() (no param).
+#if SDL_MAJOR_VERSION >= 3
+    SDL_ShowCursor();
+#else
     SDL_ShowCursor( SDL_ENABLE );
+#endif
 }
 
 void HideCursor()
 {
-    // SDL3: SDL_HideCursor().
+#if SDL_MAJOR_VERSION >= 3
+    SDL_HideCursor();
+#else
     SDL_ShowCursor( SDL_DISABLE );
+#endif
 }
 
 
 std::string GetClipboardText()
 {
+#if SDL_MAJOR_VERSION >= 3
+    const char *clip = SDL_GetClipboardText();
+    return clip ? std::string( clip ) : std::string();
+#else
     char *clip = SDL_GetClipboardText();
     if( !clip ) {
         return {};
@@ -690,30 +1025,52 @@ std::string GetClipboardText()
     std::string result( clip );
     SDL_free( clip );
     return result;
+#endif
 }
 
 bool SetClipboardText( const std::string &text )
 {
+#if SDL_MAJOR_VERSION >= 3
+    return SDL_SetClipboardText( text.c_str() );
+#else
     return SDL_SetClipboardText( text.c_str() ) == 0;
+#endif
 }
 
 
 Uint32 GetMouseState( int *x, int *y )
 {
-    // SDL3: returns float coordinates. Wrapper truncates to int.
-    // Stays in window-space; downstream pipeline handles logical scaling.
+#if SDL_MAJOR_VERSION >= 3
+    float fx = 0, fy = 0;
+    Uint32 buttons = SDL_GetMouseState( &fx, &fy );
+    if( x ) {
+        *x = static_cast<int>( fx );
+    }
+    if( y ) {
+        *y = static_cast<int>( fy );
+    }
+    return buttons;
+#else
     return SDL_GetMouseState( x, y );
+#endif
 }
 
 
 bool IsScancodePressed( const SDL_Scancode scancode )
 {
+#if SDL_MAJOR_VERSION >= 3
+    const bool *state = SDL_GetKeyboardState( nullptr );
+    if( !state ) {
+        return false;
+    }
+    return state[scancode];
+#else
     const Uint8 *state = SDL_GetKeyboardState( nullptr );
     if( !state ) {
         return false;
     }
-    // SDL3: returns const bool*, but the index semantics are the same.
     return state[scancode] != 0;
+#endif
 }
 
 
@@ -730,8 +1087,9 @@ void GetWindowSizeInPixels( SDL_Window *window, int *w, int *h )
     if( !window ) {
         return;
     }
-    // SDL3: always available.
-#if SDL_VERSION_ATLEAST(2,26,0)
+#if SDL_MAJOR_VERSION >= 3
+    SDL_GetWindowSizeInPixels( window, w, h );
+#elif SDL_VERSION_ATLEAST(2,26,0)
     SDL_GetWindowSizeInPixels( window, w, h );
 #else
     // Fallback for old SDL2: logical and pixel size are the same.
@@ -754,22 +1112,34 @@ void SetDefaultTextureScaleQuality( const std::string &quality )
 }
 
 
-void StartTextInput( SDL_Window */*window*/ )
+void StartTextInput( SDL_Window *window )
 {
-    // SDL3: SDL_StartTextInput(window). SDL2: no window param.
+#if SDL_MAJOR_VERSION >= 3
+    SDL_StartTextInput( window );
+#else
+    ( void )window;
     SDL_StartTextInput();
+#endif
 }
 
-void StopTextInput( SDL_Window */*window*/ )
+void StopTextInput( SDL_Window *window )
 {
-    // SDL3: SDL_StopTextInput(window). SDL2: no window param.
+#if SDL_MAJOR_VERSION >= 3
+    SDL_StopTextInput( window );
+#else
+    ( void )window;
     SDL_StopTextInput();
+#endif
 }
 
-bool IsTextInputActive( SDL_Window */*window*/ )
+bool IsTextInputActive( SDL_Window *window )
 {
-    // SDL3: SDL_TextInputActive(window). SDL2: no window param.
+#if SDL_MAJOR_VERSION >= 3
+    return SDL_TextInputActive( window );
+#else
+    ( void )window;
     return SDL_IsTextInputActive();
+#endif
 }
 
 
@@ -805,14 +1175,20 @@ CataKeysym GetKeysym( const SDL_Event &ev )
 SDL_Window_Ptr CreateGameWindow( const char *title, const int display, const int w, const int h,
                                  const Uint32 flags )
 {
-    // SDL3: SDL_CreateWindowWithProperties to handle display placement for maximized
-    // windows (SDL_SetWindowPosition has no effect on maximized windows in SDL3).
+#if SDL_MAJOR_VERSION >= 3
+    ( void )display;
+    // SDL3: SDL_CreateWindow takes (title, w, h, flags) -- no position params.
+    SDL_Window_Ptr result( SDL_CreateWindow( title, w, h, flags ) );
+    printErrorIf( !result, "SDL_CreateWindow failed" );
+    return result;
+#else
     SDL_Window_Ptr result( SDL_CreateWindow( title,
                            SDL_WINDOWPOS_CENTERED_DISPLAY( display ),
                            SDL_WINDOWPOS_CENTERED_DISPLAY( display ),
                            w, h, flags ) );
     printErrorIf( !result, "SDL_CreateWindow failed" );
     return result;
+#endif
 }
 
 
@@ -821,8 +1197,23 @@ bool SetWindowFullscreen( SDL_Window *window, const FullscreenMode mode )
     if( !window ) {
         return false;
     }
-    // SDL3: SDL_SetWindowFullscreen(window, true/false). For exclusive vs desktop,
-    // call SDL_SetWindowFullscreenMode() first. All paths call SDL_SyncWindow.
+#if SDL_MAJOR_VERSION >= 3
+    switch( mode ) {
+        case FullscreenMode::windowed:
+            return SDL_SetWindowFullscreen( window, false );
+        case FullscreenMode::fullscreen_desktop:
+            return SDL_SetWindowFullscreen( window, true );
+        case FullscreenMode::fullscreen_exclusive: {
+            SDL_DisplayID disp = SDL_GetDisplayForWindow( window );
+            const SDL_DisplayMode *dm = SDL_GetDesktopDisplayMode( disp );
+            if( dm ) {
+                SDL_SetWindowFullscreenMode( window, dm );
+            }
+            return SDL_SetWindowFullscreen( window, true );
+        }
+    }
+    return false;
+#else
     Uint32 flags = 0;
     switch( mode ) {
         case FullscreenMode::windowed:
@@ -836,6 +1227,7 @@ bool SetWindowFullscreen( SDL_Window *window, const FullscreenMode mode )
             break;
     }
     return SDL_SetWindowFullscreen( window, flags ) == 0;
+#endif
 }
 
 
@@ -843,7 +1235,9 @@ void RestoreWindow( SDL_Window *window )
 {
     if( window ) {
         SDL_RestoreWindow( window );
-        // SDL3: would call SDL_SyncWindow here.
+#if SDL_MAJOR_VERSION >= 3
+        SDL_SyncWindow( window );
+#endif
     }
 }
 
@@ -851,7 +1245,9 @@ void SetWindowSize( SDL_Window *window, const int w, const int h )
 {
     if( window ) {
         SDL_SetWindowSize( window, w, h );
-        // SDL3: would call SDL_SyncWindow here.
+#if SDL_MAJOR_VERSION >= 3
+        SDL_SyncWindow( window );
+#endif
     }
 }
 
@@ -878,12 +1274,25 @@ SDL_Renderer_Ptr CreateRenderer( const SDL_Window_Ptr &window, const char *drive
         return SDL_Renderer_Ptr();
     }
 
+#if SDL_MAJOR_VERSION >= 3
+    const char *name = nullptr;
+    if( software ) {
+        name = "software";
+    } else if( driver_name && driver_name[0] != '\0' ) {
+        name = driver_name;
+    }
+    SDL_Renderer_Ptr result( SDL_CreateRenderer( window.get(), name ) );
+    if( result && vsync && !software ) {
+        SDL_SetRenderVSync( result.get(), 1 );
+    }
+    printErrorIf( !result, "SDL_CreateRenderer failed" );
+    return result;
+#else
     int driver_index = -1;
     Uint32 flags = SDL_RENDERER_TARGETTEXTURE;
 
     if( software ) {
         flags |= SDL_RENDERER_SOFTWARE;
-        // SDL3: pass "software" as driver name.
     } else {
         flags |= SDL_RENDERER_ACCELERATED;
         if( vsync ) {
@@ -902,32 +1311,45 @@ SDL_Renderer_Ptr CreateRenderer( const SDL_Window_Ptr &window, const char *drive
         }
     }
 
-    // SDL3: SDL_CreateRenderer(window, name). Flags removed; vsync via SDL_SetRenderVSync.
     SDL_Renderer_Ptr result( SDL_CreateRenderer( window.get(), driver_index, flags ) );
     printErrorIf( !result, "SDL_CreateRenderer failed" );
     return result;
+#endif
 }
 
 
-void ConvertEventCoordinates( const SDL_Renderer_Ptr &/*renderer*/, SDL_Event */*event*/ )
+void ConvertEventCoordinates( const SDL_Renderer_Ptr &renderer, SDL_Event *event )
 {
+#if SDL_MAJOR_VERSION >= 3
+    if( renderer && event ) {
+        SDL_ConvertEventToRenderCoordinates( renderer.get(), event );
+    }
+#else
+    ( void )renderer;
+    ( void )event;
     // SDL2: no-op. SDL_RenderSetLogicalSize auto-scales mouse/touch events.
-    // SDL3: SDL_ConvertEventToRenderCoordinates(renderer, event) on all event types.
+#endif
 }
 
 
 float GetFingerX( const SDL_Event &ev, const int windowWidth )
 {
-    // SDL2: finger coords are normalized [0,1]; multiply by window width.
-    // SDL3 (after ConvertEventCoordinates): already absolute render-logical.
+#if SDL_MAJOR_VERSION >= 3
+    ( void )windowWidth;
+    return ev.tfinger.x;
+#else
     return ev.tfinger.x * windowWidth;
+#endif
 }
 
 float GetFingerY( const SDL_Event &ev, const int windowHeight )
 {
-    // SDL2: finger coords are normalized [0,1]; multiply by window height.
-    // SDL3 (after ConvertEventCoordinates): already absolute render-logical.
+#if SDL_MAJOR_VERSION >= 3
+    ( void )windowHeight;
+    return ev.tfinger.y;
+#else
     return ev.tfinger.y * windowHeight;
+#endif
 }
 
 #endif // defined(TILES)

--- a/src/sdl_wrappers.cpp
+++ b/src/sdl_wrappers.cpp
@@ -403,7 +403,7 @@ void RenderCopyEx( const SDL_Renderer_Ptr &renderer, SDL_Texture *const texture,
     const SDL_FRect *fdstp = dstrect ? &( fdst = to_frect( *dstrect ) ) : nullptr;
     const SDL_FPoint *fcenterp = center ? &( fcenter = to_fpoint( *center ) ) : nullptr;
     printErrorIf( !SDL_RenderTextureRotated( renderer.get(), texture, fsrcp, fdstp, angle,
-                                             fcenterp, flip ),
+                  fcenterp, flip ),
                   "SDL_RenderTextureRotated failed" );
 #else
     printErrorIf( SDL_RenderCopyEx( renderer.get(), texture, srcrect, dstrect, angle, center,

--- a/src/sdl_wrappers.h
+++ b/src/sdl_wrappers.h
@@ -2,16 +2,23 @@
 #ifndef CATA_SRC_SDL_WRAPPERS_H
 #define CATA_SRC_SDL_WRAPPERS_H
 
-#ifndef SDL_MAIN_HANDLED
-#define SDL_MAIN_HANDLED
-#endif
 // IWYU pragma: begin_exports
-#if defined(_MSC_VER) && defined(USE_VCPKG)
+#if defined(USE_SDL3)
+#   include <SDL3/SDL.h>
+#   include <SDL3_image/SDL_image.h>
+#   include <SDL3_ttf/SDL_ttf.h>
+#elif defined(_MSC_VER) && defined(USE_VCPKG)
+#   ifndef SDL_MAIN_HANDLED
+#   define SDL_MAIN_HANDLED
+#   endif
 #   include <SDL2/SDL.h>
 #   include <SDL2/SDL_image.h>
 #   include <SDL2/SDL_ttf.h>
 #   include <SDL2/SDL_mouse.h>
 #else
+#   ifndef SDL_MAIN_HANDLED
+#   define SDL_MAIN_HANDLED
+#   endif
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #   include <SDL.h>
@@ -27,9 +34,13 @@
 
 struct point;
 
-// SDL3 renames SDL_RendererFlip to SDL_FlipMode. Use CataFlipMode at call sites.
+// SDL3 type renames. Use CataFlipMode at call sites.
 #if SDL_MAJOR_VERSION >= 3
 using CataFlipMode = SDL_FlipMode;
+// SDL3 renames KMOD_* -> SDL_KMOD_*
+inline constexpr SDL_Keymod KMOD_CTRL  = SDL_KMOD_CTRL;
+inline constexpr SDL_Keymod KMOD_SHIFT = SDL_KMOD_SHIFT;
+inline constexpr SDL_Keymod KMOD_ALT   = SDL_KMOD_ALT;
 #else
 using CataFlipMode = SDL_RendererFlip;
 #endif
@@ -57,7 +68,11 @@ using SDL_Texture_Ptr = std::unique_ptr<SDL_Texture, SDL_Texture_deleter>;
 
 struct SDL_Surface_deleter {
     void operator()( SDL_Surface *const ptr ) {
+#if SDL_MAJOR_VERSION >= 3
+        SDL_DestroySurface( ptr );
+#else
         SDL_FreeSurface( ptr );
+#endif
     }
 };
 using SDL_Surface_Ptr = std::unique_ptr<SDL_Surface, SDL_Surface_deleter>;

--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -9,6 +9,7 @@
 #include "sdlsound.h"
 
 #include <algorithm>
+#include <array>
 #include <chrono>
 #include <cstdint>
 #include <cstdlib>
@@ -23,9 +24,7 @@
 #include <tuple>
 #include <unordered_map>
 #include <utility>
-#include <cmath>
 #include <vector>
-#include <mutex>
 
 #if defined(_MSC_VER) && defined(USE_VCPKG)
 #    include <SDL2/SDL_mixer.h>
@@ -44,6 +43,7 @@
 #include "path_info.h"
 #include "rng.h"
 #include "sdl_wrappers.h"
+#include "sound_backend.h"
 #include "sounds.h"
 #include "units.h"
 #include "avatar.h"
@@ -302,7 +302,7 @@ struct music_playlist {
     }
 };
 /** The music we're currently playing. */
-static Mix_Music *current_music = nullptr;
+static sound_backend::music_source *current_music = nullptr;
 static int current_music_track_volume = 0;
 static std::string current_playlist;
 static size_t current_playlist_at = 0;
@@ -323,8 +323,8 @@ static bool check_sound( const int volume = 1 )
     return sound_init_success && sounds::sound_enabled && volume > 0;
 }
 
-static const Uint16 audio_format =
-    AUDIO_S16; // if this ever changes, do_pitch_shift() and slow_motion_sound() will probably need adjustment
+static bool is_time_slowed();
+
 static const int audio_rate = 44100; // samples per second
 
 /**
@@ -332,49 +332,46 @@ static const int audio_rate = 44100; // samples per second
  */
 bool init_sound()
 {
-
-
-    int audio_channels = 2;
-    int audio_buffers = 2048;
-
-    // We should only need to init once
-    if( !sound_init_success ) {
-        // Mix_OpenAudio returns non-zero if something went wrong trying to open the device
-        if( !Mix_OpenAudioDevice( audio_rate, audio_format, audio_channels, audio_buffers, nullptr,
-                                  SDL_AUDIO_ALLOW_FREQUENCY_CHANGE ) ) {
-            Mix_AllocateChannels( 128 );
-            Mix_ReserveChannels( static_cast<int>( sfx::channel::MAX_CHANNEL ) );
-
-            // For the sound effects system.
-            Mix_GroupChannels( static_cast<int>( sfx::channel::daytime_outdoors_env ),
-                               static_cast<int>( sfx::channel::nighttime_outdoors_env ),
-                               static_cast<int>( sfx::group::time_of_day ) );
-            Mix_GroupChannels( static_cast<int>( sfx::channel::underground_env ),
-                               static_cast<int>( sfx::channel::outdoor_blizzard ),
-                               static_cast<int>( sfx::group::weather ) );
-            Mix_GroupChannels( static_cast<int>( sfx::channel::danger_extreme_theme ),
-                               static_cast<int>( sfx::channel::danger_low_theme ),
-                               static_cast<int>( sfx::group::context_themes ) );
-            Mix_GroupChannels( static_cast<int>( sfx::channel::stamina_75 ),
-                               static_cast<int>( sfx::channel::stamina_35 ),
-                               static_cast<int>( sfx::group::low_stamina ) );
-
-            sound_init_success = true;
-        } else {
-            dbg( D_ERROR ) << "Failed to open audio mixer, sound won't work: " << Mix_GetError();
-        }
+    if( sound_init_success ) {
+        return true;
     }
 
-    return sound_init_success;
+    constexpr int audio_channels = 2;
+    constexpr int audio_buffers = 2048;
+
+    if( !sound_backend::init( audio_rate, audio_channels, audio_buffers,
+                              sound_backend::init_options{} ) ) {
+        return false;
+    }
+
+    std::array<sfx::group, static_cast<size_t>( sfx::channel::MAX_CHANNEL )> groups{};
+    groups[static_cast<size_t>( sfx::channel::daytime_outdoors_env )] = sfx::group::time_of_day;
+    groups[static_cast<size_t>( sfx::channel::nighttime_outdoors_env )] = sfx::group::time_of_day;
+    for( int i = static_cast<int>( sfx::channel::underground_env );
+         i <= static_cast<int>( sfx::channel::outdoor_blizzard ); ++i ) {
+        groups[i] = sfx::group::weather;
+    }
+    for( int i = static_cast<int>( sfx::channel::danger_extreme_theme );
+         i <= static_cast<int>( sfx::channel::danger_low_theme ); ++i ) {
+        groups[i] = sfx::group::context_themes;
+    }
+    for( int i = static_cast<int>( sfx::channel::stamina_75 );
+         i <= static_cast<int>( sfx::channel::stamina_35 ); ++i ) {
+        groups[i] = sfx::group::low_stamina;
+    }
+    sound_backend::tag_reserved_groups( groups );
+
+    sound_backend::set_slow_time_predicate( &is_time_slowed );
+
+    sound_init_success = true;
+    return true;
 }
 void shutdown_sound()
 {
-    // De-allocate all loaded sound.
     sfx_resources.resource.clear();
     sfx_resources.sound_effects.clear();
-
     playlists.clear();
-    Mix_CloseAudio();
+    sound_backend::shutdown();
 }
 
 static void musicFinished();
@@ -390,18 +387,16 @@ static void play_music_file( const std::string &filename, int volume )
     }
 
     const std::string path = ( current_soundpack_path / filename ).get_unrelative_path().u8string();
-    current_music = Mix_LoadMUS( path.c_str() );
+    current_music = sound_backend::load_music( path );
     if( current_music == nullptr ) {
-        dbg( D_ERROR ) << "Failed to load audio file " << path << ": " << Mix_GetError();
         return;
     }
-    Mix_VolumeMusic( volume * get_option<int>( "MUSIC_VOLUME" ) / 100 );
+    sound_backend::set_music_volume( volume * get_option<int>( "MUSIC_VOLUME" ) / 100 );
 
-    if( Mix_PlayMusic( current_music, 0 ) != 0 ) {
-        dbg( D_ERROR ) << "Starting playlist " << path << " failed: " << Mix_GetError();
+    if( !sound_backend::play_music( current_music, 0, 0 ) ) {
         return;
     }
-    Mix_HookMusicFinished( musicFinished );
+    sound_backend::set_music_finished_cb( musicFinished );
 }
 
 /** Callback called when we finish playing music. */
@@ -411,8 +406,8 @@ void musicFinished()
         return;
     }
 
-    Mix_HaltMusic();
-    Mix_FreeMusic( current_music );
+    sound_backend::stop_music( 0 );
+    sound_backend::free_music( current_music );
     current_music = nullptr;
 
     std::string new_playlist = music::get_music_id_string();
@@ -489,8 +484,8 @@ void stop_music()
         return;
     }
 
-    Mix_FreeMusic( current_music );
-    Mix_HaltMusic();
+    sound_backend::free_music( current_music );
+    sound_backend::stop_music( 0 );
     current_music = nullptr;
 
     playlist_indexes.clear();
@@ -505,7 +500,8 @@ void update_music_volume()
         return;
     }
 
-    Mix_VolumeMusic( current_music_track_volume * get_option<int>( "MUSIC_VOLUME" ) / 100 );
+    sound_backend::set_music_volume( current_music_track_volume * get_option<int>( "MUSIC_VOLUME" ) /
+                                     100 );
 
     bool sound_enabled_old = sounds::sound_enabled;
     sounds::sound_enabled = ::get_option<bool>( "SOUND_ENABLED" );
@@ -716,250 +712,6 @@ static bool is_time_slowed()
     return std::max( get_avatar().get_speed(), 100 ) * 2 < get_avatar().get_moves();
 }
 
-// helper data for sound_effect_handler
-namespace
-{
-// Because we're not allowed to call Mix_HaltChannel inside audio callbacks, slowed_time_effect() adds the channel the sound effect is playing on to this list when it wants to stop the sound.
-// whenever make_audio() is called, it will halt any channels in this list.
-std::vector < sfx::channel > channels_to_end = {};
-
-// need a mutex so that make_audio() and slowed_time_effect() don't modify channels_to_end simultaneously
-std::mutex channels_to_end_mutex;
-} // namespace
-
-// used with SDL's Mix_RegisterEffect(). each sound that is currently playing has one. needed to dynamically control playback speed for slowing time
-struct sound_effect_handler {
-    Mix_Chunk *audio_src;
-    bool active; // if not active, we're just playing the given audio and aren't making any modifications to it.
-    bool owns_audio; // if true, it owns the audio it was given and will free it when the sound stops playing.
-    float current_sample_index =
-        0; // with respect to audio_src, in samples. for fractional indices, the output is interpolated between the two closest samples
-    int loops_remaining = 0;
-    bool marked_for_termination = false;
-
-
-
-    ~sound_effect_handler() {
-        if( owns_audio ) {
-            free( audio_src->abuf );
-            free( audio_src );
-        }
-    }
-
-    // called when sound effect is halted by SDL_Mixer; destroys the sound_effect_handler associated with this sound
-    static void on_finish( int /* chan */, void *udata ) {
-        sound_effect_handler *handler = static_cast<sound_effect_handler *>( udata );
-        cata_assert( handler != nullptr && handler->audio_src != nullptr );
-        delete handler;
-    }
-
-    constexpr static float sound_speed_factor = 0.25f;
-
-    // called by SDL_Mixer everytime it needs to get more audio data
-    static void slowed_time_effect( int channel, void *stream, int len,
-                                    void *udata ) { // we can expect this function to be called many times a second (at least 40/s from my tests)
-        sound_effect_handler *handler = static_cast<sound_effect_handler *>( udata );
-
-        using sample = int16_t; // because AUDIO_S16 is two bytes per ear (signed integer samples)
-        constexpr int bytes_per_sample = sizeof( sample ) *
-                                         2; // 2 samples per ear (is there a better terminology for this?)
-
-        float playback_speed = is_time_slowed() ? sound_speed_factor : 1; //
-        int num_source_samples = handler->audio_src->alen / bytes_per_sample;
-
-        cata_assert( audio_format == AUDIO_S16 );
-
-        if( handler->loops_remaining <
-            0 ) { // then we have no more audio to load; the sound effect is over and we're just waiting for SDL to finish playing it and for the main thread to call Mix_HaltChannel()
-            memset( stream, 0,
-                    len ); // since the sound is over, tell SDL_Mixer to play nothing by setting all the samples to 0 (faster than iterating through the whole thing)
-
-            // the sound effect won't end on its own, we need to tell the main thread to stop it.
-            // however, we don't want to do that as soon as we finish SENDING audio since the audio device won't be done playing it yet.
-            // therefore, we let the sound loop an extra time to finish playing.
-
-            // we still need to update handler->current_sample_index so it loops properly
-            int num_samples = len / bytes_per_sample;
-            handler->current_sample_index += num_samples * playback_speed;
-            if( handler->current_sample_index >= num_source_samples ) {
-                handler->loops_remaining--;
-            }
-
-            // check if the sound effect should end bc we done looping
-            if( !handler->marked_for_termination && handler->loops_remaining < -1 ) {
-                if( channels_to_end_mutex.try_lock() ) { // try_lock(); we do NOT want the audio thread to block.
-                    handler->marked_for_termination = true;
-                    channels_to_end.push_back( static_cast<sfx::channel>
-                                               ( channel ) ); // the main thread will call Mix_HaltChannel to end the sound effect when make_audio() is next called
-                    channels_to_end_mutex.unlock();
-                }
-            }
-
-        } else {
-
-
-            // assuming the sound ISN'T over, we need to fill stream with (len/bytes_per_sample) samples from handler->audio_src in this loop.
-            for( int dst_index = 0; dst_index < len / bytes_per_sample &&
-                 handler->current_sample_index < num_source_samples; dst_index++ ) {
-
-                int low_index = std::floor( handler->current_sample_index );
-                int high_index = std::ceil( handler->current_sample_index );
-
-                // make sound wrap around
-                if( high_index == num_source_samples ) {
-                    high_index = 0;
-                }
-                if( low_index == num_source_samples ) {
-                    low_index = 0; // (low_index can often equal high_index so it might require the same treatment)
-                }
-
-                // have to handle each ear separately for stereo audio
-                for( int ear_offset = 0; ear_offset < 4;
-                     ear_offset += 2 ) {
-                    sample low_value;
-                    sample high_value;
-
-                    memcpy( &low_value, static_cast<uint8_t *>( handler->audio_src->abuf ) + ear_offset + low_index *
-                            bytes_per_sample, sizeof( sample ) );
-
-                    memcpy( &high_value, static_cast<uint8_t *>( handler->audio_src->abuf ) + ear_offset + high_index *
-                            bytes_per_sample, sizeof( sample ) );
-
-
-                    // linearly interpolate between the two samples closest to the current time
-                    float interpolation_factor = handler->current_sample_index - low_index;
-                    sample interpolated = ( high_value - low_value ) * interpolation_factor + low_value;
-
-                    memcpy( static_cast<uint8_t *>( stream ) + dst_index * bytes_per_sample + ear_offset, &interpolated,
-                            sizeof( sample ) );
-                }
-
-                // update handler->current_sample_index
-                handler->current_sample_index += 1.0f * playback_speed;
-                if( handler->current_sample_index >= num_source_samples ) {
-                    // wrap around/looping
-                    handler->loops_remaining--;
-                    handler->current_sample_index = fmodf( handler->current_sample_index, num_source_samples );
-
-                    if( handler->loops_remaining < 0 ) { // then the sound effect is over
-                        int bytes_remaining = len - dst_index * bytes_per_sample;
-                        memset( static_cast<uint8_t *>( stream ) + dst_index * bytes_per_sample, 0,
-                                bytes_remaining ); // tell SDL_Mixer to play nothing by setting the rest of the requested samples to 0
-                        break; // do not read any more audio data
-                    }
-                }
-            }
-
-
-        }
-    }
-
-    // returns false if failed
-    // note: nloops == 0 means sound plays once, 1 means twice, etc. -1 means loops for (not actually) forever
-    static bool make_audio( int audioChannel, Mix_Chunk *audio_src, int nloops, int volume,
-                            bool owns_audio, const sound_effect &effect, std::optional<units::angle> angle,
-                            std::optional<float> fade_in_duration ) {
-
-        // tell SDL to halt all sound effects that are done playing
-        if( channels_to_end_mutex.try_lock() ) {  // no rush if we can't halt it immediately, we don't want to block
-            for( sfx::channel channel : channels_to_end ) {
-                int success = Mix_HaltChannel( static_cast<int>( channel ) );
-                if( success != 0 ) {
-                    dbg( D_ERROR ) << "Mix_HaltChannel failed: " << Mix_GetError();
-                }
-            }
-            channels_to_end.clear();
-            channels_to_end_mutex.unlock();
-        }
-
-        sound_effect_handler *handler = new sound_effect_handler();
-        handler->active = true;
-        handler->audio_src = audio_src;
-        handler->owns_audio = owns_audio;
-        handler->loops_remaining = nloops == -1 ? 10000 :
-                                   nloops; // -1 loops means loop forever. (SDL actually only loops it ~66536 times, is this a problem?)
-
-        Mix_VolumeChunk( audio_src,
-                         effect.volume * get_option<int>( "SOUND_EFFECT_VOLUME" ) * volume / ( 100 * 100 ) );
-        int channel;
-
-        // to ensure the effect doesn't stop early, we tell SDL to loop it indefinitely. the slowed_time_effect callback will halt the sound effect at the appropriate time.
-        if( fade_in_duration.has_value() ) {
-            channel = Mix_FadeInChannel( audioChannel, audio_src, -1, *fade_in_duration );
-        } else {
-            channel = Mix_PlayChannel( audioChannel, audio_src, -1 );
-        }
-        bool failed = channel == -1;
-        if( !failed ) {
-            // tell SDL_Mixer to call slowed_time_effect to get sound data and call on_finish when the sound is over.
-            // note: if we ever need to have a setting that turns this effect off, one could simply replace slowed_time_effect here with a callback that does nothing.
-            // (on_finish would still be required)
-            int out = Mix_RegisterEffect( channel, slowed_time_effect, on_finish, handler );
-            if( out ==
-                0 ) { // returns zero if SDL failed to setup the effect, meaning we better cancel the sound.
-                // To prevent use after free, stop the playback right now.
-                failed = true;
-                dbg( D_WARNING ) << "Mix_RegisterEffect failed: " << Mix_GetError();
-                Mix_HaltChannel( channel );
-            }
-        }
-        if( !failed && angle.has_value() ) {
-            if( Mix_SetPosition( channel, static_cast<Sint16>( to_degrees( *angle ) ), 1 ) == 0 ) {
-                // Not critical
-                dbg( D_INFO ) << "Mix_SetPosition failed: " << Mix_GetError();
-            }
-        }
-        if( failed ) {
-            on_finish( -1, handler );
-        }
-
-        return failed;
-    }
-};
-
-// Note: makes new Mix_Chunk, leaves s unaffected. Created mix_chunk is freed by make_audio().
-static Mix_Chunk *do_pitch_shift( const Mix_Chunk *s, float pitch )
-{
-    Uint32 s_in = s->alen / 4;
-    Uint32 s_out = static_cast<Uint32>( static_cast<float>( s_in ) * pitch );
-    float pitch_real = static_cast<float>( s_out ) / static_cast<float>( s_in );
-    Mix_Chunk *result = static_cast<Mix_Chunk *>( malloc( sizeof( Mix_Chunk ) ) );
-    result->allocated = 1;
-    result->alen = s_out * 4;
-    result->abuf = static_cast<Uint8 *>( malloc( result->alen * sizeof( Uint8 ) ) );
-    result->volume = s->volume;
-    for( Uint32 i = 0; i < s_out; i++ ) {
-        Sint16 lt = 0;
-        Sint16 rt = 0;
-        Sint16 lt_out = 0;
-        Sint16 rt_out = 0;
-        Sint64 lt_avg = 0;
-        Sint64 rt_avg = 0;
-        Uint32 begin = static_cast<Uint32>( static_cast<float>( i ) / pitch_real );
-        Uint32 end = static_cast<Uint32>( static_cast<float>( i + 1 ) / pitch_real );
-
-        // check for boundary case
-        if( end > 0 && ( end >= ( s->alen / 4 ) ) ) {
-            end = begin;
-        }
-
-        for( Uint32 j = begin; j <= end; j++ ) {
-            lt = ( s->abuf[( 4 * j ) + 1] << 8 ) | ( s->abuf[( 4 * j ) + 0] );
-            rt = ( s->abuf[( 4 * j ) + 3] << 8 ) | ( s->abuf[( 4 * j ) + 2] );
-            lt_avg += lt;
-            rt_avg += rt;
-        }
-        lt_out = static_cast<Sint16>( static_cast<float>( lt_avg ) / static_cast<float>
-                                      ( end - begin + 1 ) );
-        rt_out = static_cast<Sint16>( static_cast<float>( rt_avg ) / static_cast<float>
-                                      ( end - begin + 1 ) );
-        result->abuf[( 4 * i ) + 1] = static_cast<Uint8>( ( lt_out >> 8 ) & 0xFF );
-        result->abuf[( 4 * i ) + 0] = static_cast<Uint8>( lt_out & 0xFF );
-        result->abuf[( 4 * i ) + 3] = static_cast<Uint8>( ( rt_out >> 8 ) & 0xFF );
-        result->abuf[( 4 * i ) + 2] = static_cast<Uint8>( rt_out & 0xFF );
-    }
-    return result;
-}
 
 void sfx::play_variant_sound( const std::string &id, const std::string &variant,
                               const std::string &season, const std::optional<bool> &is_indoors,
@@ -985,8 +737,10 @@ void sfx::play_variant_sound( const std::string &id, const std::string &variant,
 
     Mix_Chunk *effect_to_play = get_sfx_resource( selected_sound_effect.resource_id );
 
-    bool error = sound_effect_handler::make_audio( static_cast<int>( channel::any ), effect_to_play, 0,
-                 volume, false, selected_sound_effect, std::nullopt, std::nullopt );
+    const int final_vol = selected_sound_effect.volume *
+                          get_option<int>( "SOUND_EFFECT_VOLUME" ) * volume / ( 100 * 100 );
+    const bool error = sound_backend::play_effect( effect_to_play, channel::any, 0,
+                       final_vol, 0, 0, false, 1.0f, false );
     if( error ) {
         dbg( D_ERROR ) << "Failed to play sound effect: " << Mix_GetError() << " id:" << id
                        << " variant:" << variant << " season:" << season;
@@ -1014,18 +768,15 @@ void sfx::play_variant_sound( const std::string &id, const std::string &variant,
     const sound_effect &selected_sound_effect = *eff;
 
     Mix_Chunk *effect_to_play = get_sfx_resource( selected_sound_effect.resource_id );
-    bool is_pitched = ( pitch_min > 0 ) && ( pitch_max > 0 );
+    const bool is_pitched = ( pitch_min > 0 ) && ( pitch_max > 0 );
+    const float pitch_mod = is_pitched
+                            ? static_cast<float>( rng_float( pitch_min, pitch_max ) )
+                            : 1.0f;
 
-    // do_pitch_shift() creates a new Mix_Chunk (so original sound isn't modified) and we need to delete it when the audio finishes.
-    bool destroy_sound = is_pitched;
-
-    if( is_pitched ) {
-        double pitch_mod = rng_float( pitch_min, pitch_max );
-        effect_to_play = do_pitch_shift( effect_to_play, static_cast<float>( pitch_mod ) );
-    }
-
-    bool failed = sound_effect_handler::make_audio( static_cast<int>( channel::any ), effect_to_play, 0,
-                  volume, destroy_sound, selected_sound_effect, std::make_optional( angle ), std::nullopt );
+    const int final_vol = selected_sound_effect.volume *
+                          get_option<int>( "SOUND_EFFECT_VOLUME" ) * volume / ( 100 * 100 );
+    const bool failed = sound_backend::play_effect( effect_to_play, channel::any, 0,
+                        final_vol, 0, static_cast<int>( to_degrees( angle ) ), true, pitch_mod, false );
     if( failed ) {
         dbg( D_ERROR ) << "Failed to play sound effect: " << Mix_GetError() << " id:" << id
                        << " variant:" << variant << " season:" << season;
@@ -1053,21 +804,19 @@ void sfx::play_ambient_variant_sound( const std::string &id, const std::string &
     const sound_effect &selected_sound_effect = *eff;
 
     Mix_Chunk *effect_to_play = get_sfx_resource( selected_sound_effect.resource_id );
+    const bool is_pitched = pitch > 0;
+    const float pitch_mod = is_pitched ? static_cast<float>( pitch ) : 1.0f;
 
-    bool is_pitched = pitch > 0;
-
-    // do_pitch_shift() creates a new Mix_Chunk (so original sound isn't modified) and we need to delete it when the audio finishes.
-    bool destroy_sound = is_pitched;
-
-    if( is_pitched ) {
-        effect_to_play = do_pitch_shift( effect_to_play, static_cast<float>( pitch ) );
-    }
-
+    // Ambient sounds use a two-stage volume scale: the AMBIENT_SOUND_VOLUME
+    // pre-multiply followed by the standard effect-level multiply.
+    // Composed formula:
+    //   effect.volume^2 * AMBIENT_SOUND_VOLUME * SOUND_EFFECT_VOLUME * volume / 1e8
     volume = selected_sound_effect.volume * get_option<int>( "AMBIENT_SOUND_VOLUME" ) * volume /
              ( 100 * 100 );
-    bool failed = sound_effect_handler::make_audio( static_cast<int>( channel ), effect_to_play, loops,
-                  volume, destroy_sound, selected_sound_effect, std::nullopt,
-                  static_cast<float>( fade_in_duration ) );
+    const int final_vol = selected_sound_effect.volume *
+                          get_option<int>( "SOUND_EFFECT_VOLUME" ) * volume / ( 100 * 100 );
+    const bool failed = sound_backend::play_effect( effect_to_play, channel, loops,
+                        final_vol, fade_in_duration, 0, false, pitch_mod, false );
 
     if( failed ) {
         dbg( D_ERROR ) << "Failed to play sound effect: " << Mix_GetError() << " id:" << id

--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -1,11 +1,5 @@
 #if defined(SDL_SOUND)
 
-// SDL3_mixer is a complete API rewrite (channel-based -> track-based).
-// Sound support for SDL3 will be added in a separate PR.
-#if defined(USE_SDL3)
-#error "SDL3_mixer support is not yet implemented. Build with SOUND=0 for SDL3 builds."
-#endif
-
 #include "sdlsound.h"
 
 #include <algorithm>
@@ -25,12 +19,6 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
-
-#if defined(_MSC_VER) && defined(USE_VCPKG)
-#    include <SDL2/SDL_mixer.h>
-#else
-#    include <SDL_mixer.h>
-#endif
 
 #include "cached_options.h"
 #include "cata_path.h"
@@ -70,12 +58,11 @@ struct sfx_args {
 struct sound_effect_resource {
     std::string path;
     struct deleter {
-        // Operator overloaded to leverage deletion API.
-        void operator()( Mix_Chunk *const c ) const {
-            Mix_FreeChunk( c );
+        void operator()( sound_backend::sfx_audio *const a ) const {
+            sound_backend::free_sfx( a );
         }
     };
-    std::unique_ptr<Mix_Chunk, deleter> chunk;
+    std::unique_ptr<sound_backend::sfx_audio, deleter> chunk;
 };
 
 static int add_sfx_path( const std::string &path );
@@ -515,41 +502,15 @@ void update_music_volume()
     }
 }
 
-// Allocate new Mix_Chunk as a null-chunk. Results in a valid, but empty chunk
-// that is created when loading of a sound effect resource fails. Does not own
-// memory. Mix_FreeChunk will free the SDL_malloc'd Mix_Chunk pointer.
-static Mix_Chunk *make_null_chunk()
-{
-    static Mix_Chunk null_chunk = { 0, nullptr, 0, 0 };
-    // SDL_malloc to match up with Mix_FreeChunk's SDL_free call
-    // to free the Mix_Chunk object memory
-    Mix_Chunk *nchunk = static_cast<Mix_Chunk *>( SDL_malloc( sizeof( Mix_Chunk ) ) );
-
-    // Assign as copy of null_chunk
-    ( *nchunk ) = null_chunk;
-    return nchunk;
-}
-
-static Mix_Chunk *load_chunk( const std::string &path )
-{
-    Mix_Chunk *result = Mix_LoadWAV( path.c_str() );
-    if( result == nullptr ) {
-        // Failing to load a sound file is not a fatal error worthy of a backtrace
-        dbg( D_WARNING ) << "Failed to load sfx audio file " << path << ": " << Mix_GetError();
-        result = make_null_chunk();
-    }
-    return result;
-}
-
-// Check to see if the resource has already been loaded
-// - Loaded: Return stored pointer
-// - Not Loaded: Load chunk from stored resource path
-static Mix_Chunk *get_sfx_resource( int resource_id )
+// Resolve the cached SFX handle for a resource id, loading on first use.
+// Backend::load_sfx returns a silent-fallback handle on failure, so the
+// return is always non-null once the slot is initialized.
+static sound_backend::sfx_audio *get_sfx_resource( int resource_id )
 {
     sound_effect_resource &resource = sfx_resources.resource[ resource_id ];
     if( !resource.chunk ) {
         cata_path path = current_soundpack_path / resource.path;
-        resource.chunk.reset( load_chunk( path.generic_u8string() ) );
+        resource.chunk.reset( sound_backend::load_sfx( path.generic_u8string() ) );
     }
     return resource.chunk.get();
 }
@@ -735,16 +696,12 @@ void sfx::play_variant_sound( const std::string &id, const std::string &variant,
     }
     const sound_effect &selected_sound_effect = *eff;
 
-    Mix_Chunk *effect_to_play = get_sfx_resource( selected_sound_effect.resource_id );
+    sound_backend::sfx_audio *effect_to_play = get_sfx_resource( selected_sound_effect.resource_id );
 
-    const int final_vol = selected_sound_effect.volume *
-                          get_option<int>( "SOUND_EFFECT_VOLUME" ) * volume / ( 100 * 100 );
-    const bool error = sound_backend::play_effect( effect_to_play, channel::any, 0,
-                       final_vol, 0, 0, false, 1.0f, false );
-    if( error ) {
-        dbg( D_ERROR ) << "Failed to play sound effect: " << Mix_GetError() << " id:" << id
-                       << " variant:" << variant << " season:" << season;
-    }
+    sound_backend::play_opts opts;
+    opts.volume = selected_sound_effect.volume *
+                  get_option<int>( "SOUND_EFFECT_VOLUME" ) * volume / ( 100 * 100 );
+    sound_backend::play_oneshot( effect_to_play, opts );
 }
 
 void sfx::play_variant_sound( const std::string &id, const std::string &variant,
@@ -767,20 +724,16 @@ void sfx::play_variant_sound( const std::string &id, const std::string &variant,
     }
     const sound_effect &selected_sound_effect = *eff;
 
-    Mix_Chunk *effect_to_play = get_sfx_resource( selected_sound_effect.resource_id );
+    sound_backend::sfx_audio *effect_to_play = get_sfx_resource( selected_sound_effect.resource_id );
     const bool is_pitched = ( pitch_min > 0 ) && ( pitch_max > 0 );
-    const float pitch_mod = is_pitched
-                            ? static_cast<float>( rng_float( pitch_min, pitch_max ) )
-                            : 1.0f;
 
-    const int final_vol = selected_sound_effect.volume *
-                          get_option<int>( "SOUND_EFFECT_VOLUME" ) * volume / ( 100 * 100 );
-    const bool failed = sound_backend::play_effect( effect_to_play, channel::any, 0,
-                        final_vol, 0, static_cast<int>( to_degrees( angle ) ), true, pitch_mod, false );
-    if( failed ) {
-        dbg( D_ERROR ) << "Failed to play sound effect: " << Mix_GetError() << " id:" << id
-                       << " variant:" << variant << " season:" << season;
-    }
+    sound_backend::play_opts opts;
+    opts.volume = selected_sound_effect.volume *
+                  get_option<int>( "SOUND_EFFECT_VOLUME" ) * volume / ( 100 * 100 );
+    opts.angle_deg = static_cast<int>( to_degrees( angle ) );
+    opts.positional = true;
+    opts.pitch = is_pitched ? static_cast<float>( rng_float( pitch_min, pitch_max ) ) : 1.0f;
+    sound_backend::play_oneshot( effect_to_play, opts );
 }
 
 void sfx::play_ambient_variant_sound( const std::string &id, const std::string &variant,
@@ -803,9 +756,8 @@ void sfx::play_ambient_variant_sound( const std::string &id, const std::string &
     }
     const sound_effect &selected_sound_effect = *eff;
 
-    Mix_Chunk *effect_to_play = get_sfx_resource( selected_sound_effect.resource_id );
+    sound_backend::sfx_audio *effect_to_play = get_sfx_resource( selected_sound_effect.resource_id );
     const bool is_pitched = pitch > 0;
-    const float pitch_mod = is_pitched ? static_cast<float>( pitch ) : 1.0f;
 
     // Ambient sounds use a two-stage volume scale: the AMBIENT_SOUND_VOLUME
     // pre-multiply followed by the standard effect-level multiply.
@@ -813,15 +765,14 @@ void sfx::play_ambient_variant_sound( const std::string &id, const std::string &
     //   effect.volume^2 * AMBIENT_SOUND_VOLUME * SOUND_EFFECT_VOLUME * volume / 1e8
     volume = selected_sound_effect.volume * get_option<int>( "AMBIENT_SOUND_VOLUME" ) * volume /
              ( 100 * 100 );
-    const int final_vol = selected_sound_effect.volume *
-                          get_option<int>( "SOUND_EFFECT_VOLUME" ) * volume / ( 100 * 100 );
-    const bool failed = sound_backend::play_effect( effect_to_play, channel, loops,
-                        final_vol, fade_in_duration, 0, false, pitch_mod, false );
 
-    if( failed ) {
-        dbg( D_ERROR ) << "Failed to play sound effect: " << Mix_GetError() << " id:" << id
-                       << " variant:" << variant << " season:" << season;
-    }
+    sound_backend::play_opts opts;
+    opts.loops = loops;
+    opts.fade_in_ms = fade_in_duration;
+    opts.volume = selected_sound_effect.volume *
+                  get_option<int>( "SOUND_EFFECT_VOLUME" ) * volume / ( 100 * 100 );
+    opts.pitch = is_pitched ? static_cast<float>( pitch ) : 1.0f;
+    sound_backend::play_reserved( effect_to_play, channel, opts );
 }
 
 void load_soundset()
@@ -892,4 +843,4 @@ void initSDLAudioOnly()
     }
 }
 
-#endif
+#endif // SDL_SOUND

--- a/src/sdlsound.cpp
+++ b/src/sdlsound.cpp
@@ -1,5 +1,11 @@
 #if defined(SDL_SOUND)
 
+// SDL3_mixer is a complete API rewrite (channel-based -> track-based).
+// Sound support for SDL3 will be added in a separate PR.
+#if defined(USE_SDL3)
+#error "SDL3_mixer support is not yet implemented. Build with SOUND=0 for SDL3 builds."
+#endif
+
 #include "sdlsound.h"
 
 #include <algorithm>

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -24,12 +24,13 @@
 #include <stdexcept>
 #include <type_traits>
 #include <vector>
+#ifndef USE_SDL3
 #if defined(_MSC_VER) && defined(USE_VCPKG)
-#   include <SDL2/SDL_image.h>
 #   include <SDL2/SDL_syswm.h>
 #else
 #ifdef _WIN32
 #   include <SDL_syswm.h>
+#endif
 #endif
 #endif
 
@@ -175,11 +176,17 @@ void clear_sdl_window()
 
 static void InitSDL()
 {
+#if SDL_MAJOR_VERSION >= 3
+    int init_flags = SDL_INIT_VIDEO;
+#else
     int init_flags = SDL_INIT_VIDEO | SDL_INIT_TIMER;
+#endif
 #if defined(SDL_SOUND)
     init_flags |= SDL_INIT_AUDIO;
 #endif
+#if SDL_MAJOR_VERSION < 3
     int ret;
+#endif
 
 #if defined(SDL_HINT_WINDOWS_DISABLE_THREAD_NAMING)
     // Requires SDL 2.0.5. Disables thread naming so that gdb works correctly
@@ -209,7 +216,7 @@ static void InitSDL()
     SDL_SetHint( SDL_HINT_APP_NAME, _( "Cataclysm: Dark Days Ahead" ) );
 #endif
 
-#if defined(__linux__)
+#if defined(__linux__) && SDL_MAJOR_VERSION < 3
     // https://bugzilla.libsdl.org/show_bug.cgi?id=3472#c5
     if( SDL_COMPILEDVERSION == SDL_VERSIONNUM( 2, 0, 5 ) ) {
         const char *xmod = getenv( "XMODIFIERS" );
@@ -219,6 +226,11 @@ static void InitSDL()
     }
 #endif
 
+#if SDL_MAJOR_VERSION >= 3
+    throwErrorIf( !SDL_Init( init_flags ), "SDL_Init failed" );
+    throwErrorIf( !TTF_Init(), "TTF_Init failed" );
+    // SDL3_image: IMG_Init removed; loading functions init on demand.
+#else
     ret = SDL_Init( init_flags );
     throwErrorIf( ret != 0, "SDL_Init failed" );
 
@@ -230,6 +242,7 @@ static void InitSDL()
     ret = IMG_Init( IMG_INIT_PNG );
     printErrorIf( ( ret & IMG_INIT_PNG ) != IMG_INIT_PNG,
                   "IMG_Init failed to initialize PNG support, tiles won't work" );
+#endif
 
     //SDL2 has no functionality for INPUT_DELAY, we would have to query it manually, which is expensive
     //SDL2 instead uses the OS's Input Delay.
@@ -254,6 +267,38 @@ static bool SetupRenderTarget()
     ClearScreen();
 
     return true;
+}
+
+// NoMouseCursorChange blocks ImGui's per-frame SDL_ShowCursor, which
+// would otherwise re-show the cursor immediately after HideCursor.
+void refresh_mouse_config()
+{
+    using cata::options::mouse;
+    ImGuiIO &io = ImGui::GetIO();
+    if( !mouse.enabled ) {
+        io.ConfigFlags |= ImGuiConfigFlags_NoMouse;
+        io.ConfigFlags |= ImGuiConfigFlags_NoMouseCursorChange;
+        if( IsCursorVisible() ) {
+            HideCursor();
+        }
+        return;
+    }
+
+    io.ConfigFlags &= ~ImGuiConfigFlags_NoMouse;
+    const std::string hide_mode = get_option<std::string>( "HIDE_CURSOR" );
+    if( hide_mode == "show" ) {
+        io.ConfigFlags &= ~ImGuiConfigFlags_NoMouseCursorChange;
+        if( !IsCursorVisible() ) {
+            ShowCursor();
+        }
+    } else {
+        // "hide" and "hidekb" both require blocking ImGui's per-frame
+        // cursor show so the game can manage visibility directly.
+        io.ConfigFlags |= ImGuiConfigFlags_NoMouseCursorChange;
+        if( hide_mode == "hide" && IsCursorVisible() ) {
+            HideCursor();
+        }
+    }
 }
 
 //Registers, creates, and shows the Window!!
@@ -408,14 +453,6 @@ static void WinCreate()
 #endif
 
     ClearScreen();
-
-    // Errors here are ignored, worst case: the option does not work as expected,
-    // but that won't crash
-    if( get_option<std::string>( "HIDE_CURSOR" ) != "show" && IsCursorVisible() ) {
-        HideCursor();
-    } else {
-        ShowCursor();
-    }
 
     if( get_option<bool>( "ENABLE_JOYSTICK" ) ) {
         gamepad::init();
@@ -3880,12 +3917,7 @@ void catacurses::init_interface()
     init_term_size_and_scaling_factor();
 
     WinCreate();
-    using cata::options::mouse;
-    if( mouse.enabled ) {
-        ImGui::GetIO().ConfigFlags &= ~ImGuiConfigFlags_NoMouse;
-    } else {
-        ImGui::GetIO().ConfigFlags |= ImGuiConfigFlags_NoMouse;
-    }
+    refresh_mouse_config();
     dbg( D_INFO ) << "Initializing SDL Tiles context";
     fartilecontext = std::make_shared<cata_tiles>( renderer, geometry, ts_cache );
     if( use_far_tiles ) {
@@ -4405,10 +4437,16 @@ bool save_screenshot( const std::string &file_path )
 #ifdef _WIN32
 HWND getWindowHandle()
 {
+#if SDL_MAJOR_VERSION >= 3
+    return static_cast<HWND>( SDL_GetPointerProperty(
+                                  SDL_GetWindowProperties( ::window.get() ),
+                                  SDL_PROP_WINDOW_WIN32_HWND_POINTER, nullptr ) );
+#else
     SDL_SysWMinfo info;
     SDL_VERSION( &info.version );
     SDL_GetWindowWMInfo( ::window.get(), &info );
     return info.info.win.window;
+#endif
 }
 #endif
 

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -72,6 +72,9 @@
 #include "sdl_wrappers.h"
 #include "sdl_font.h"
 #include "sdl_gamepad.h"
+#if defined(SDL_SOUND)
+#include "sound_backend.h"
+#endif
 #include "sdlsound.h"
 #include "string_formatter.h"
 #include "uistate.h"
@@ -577,6 +580,10 @@ void refresh_display()
     if( test_mode ) {
         return;
     }
+
+#if defined(SDL_SOUND)
+    sound_backend::poll();
+#endif
 
     // Select default target (the window), copy rendered buffer
     // there, present it, select the buffer as target again.

--- a/src/sound_backend.h
+++ b/src/sound_backend.h
@@ -9,8 +9,6 @@
 
 #include "sounds.h"
 
-struct Mix_Chunk;
-
 namespace sound_backend
 {
 
@@ -62,18 +60,6 @@ bool slow_time_predicate_active();
 
 void stop_all_sfx( int fade_out_ms );
 void fade_group( sfx::group g, int ms );
-
-// Raw SDL2 playback seam. Takes a Mix_Chunk directly since the SFX
-// cache still hands out Mix_Chunk pointers to callers. Returns true
-// on FAILURE. volume is the fully-resolved 0-128 value (see
-// play_opts::volume). pitch: 1.0 = unity; backend produces a pitched
-// copy internally and frees it when the play finishes.
-// owns_audio_src: if true, the backend frees audio_src when the play
-// finishes.
-bool play_effect( Mix_Chunk *audio_src, sfx::channel slot, int loops,
-                  int volume, int fade_in_ms,
-                  int angle_deg, bool positional,
-                  float pitch, bool owns_audio_src );
 
 void poll();
 

--- a/src/sound_backend.h
+++ b/src/sound_backend.h
@@ -1,0 +1,91 @@
+#pragma once
+#ifndef CATA_SRC_SOUND_BACKEND_H
+#define CATA_SRC_SOUND_BACKEND_H
+
+#if defined(SDL_SOUND)
+
+#include <array>
+#include <string>
+
+#include "sounds.h"
+
+struct Mix_Chunk;
+
+namespace sound_backend
+{
+
+struct init_options {
+    bool memory_only = false;
+};
+
+bool init( int frequency, int out_channels, int chunk_size,
+           const init_options &opts );
+void shutdown();
+
+struct sfx_audio;
+sfx_audio *load_sfx( const std::string &path );
+void       free_sfx( sfx_audio * );
+
+struct music_source;
+music_source *load_music( const std::string &path );
+void          free_music( music_source * );
+
+struct play_opts {
+    int   loops       = 0;
+    int   fade_in_ms  = 0;
+    int   volume      = 128;
+    int   angle_deg   = 0;
+    int   distance    = 1;
+    bool  positional  = false;
+    float pitch       = 1.0f;
+};
+
+void play_reserved( sfx_audio *a, sfx::channel slot, const play_opts &opts );
+void play_oneshot( sfx_audio *a, const play_opts &opts );
+
+void tag_reserved_groups( const std::array<sfx::group,
+                          static_cast<size_t>( sfx::channel::MAX_CHANNEL )> &assignments );
+
+void stop_reserved( sfx::channel slot, int fade_out_ms );
+bool is_reserved_playing( sfx::channel slot );
+bool is_reserved_fading( sfx::channel slot );
+int  set_reserved_volume( sfx::channel slot, int vol );
+int  get_reserved_volume( sfx::channel slot );
+void set_reserved_position( sfx::channel slot, int angle_deg, int distance );
+
+using bool_predicate = bool ( * )();
+void set_slow_time_predicate( bool_predicate fn );
+
+// Lets slow-time DSP code outside the backend query the installed
+// predicate without re-exporting the function pointer.
+bool slow_time_predicate_active();
+
+void stop_all_sfx( int fade_out_ms );
+void fade_group( sfx::group g, int ms );
+
+// Raw SDL2 playback seam. Takes a Mix_Chunk directly since the SFX
+// cache still hands out Mix_Chunk pointers to callers. Returns true
+// on FAILURE. volume is the fully-resolved 0-128 value (see
+// play_opts::volume). pitch: 1.0 = unity; backend produces a pitched
+// copy internally and frees it when the play finishes.
+// owns_audio_src: if true, the backend frees audio_src when the play
+// finishes.
+bool play_effect( Mix_Chunk *audio_src, sfx::channel slot, int loops,
+                  int volume, int fade_in_ms,
+                  int angle_deg, bool positional,
+                  float pitch, bool owns_audio_src );
+
+void poll();
+
+using music_finished_cb = void ( * )();
+void set_music_finished_cb( music_finished_cb );
+bool play_music( music_source *m, int loops, int fade_in_ms );
+void stop_music( int fade_out_ms );
+void set_music_volume( int vol );
+bool is_music_playing();
+
+} // namespace sound_backend
+
+#endif // SDL_SOUND
+
+#endif // CATA_SRC_SOUND_BACKEND_H

--- a/src/sound_backend.h
+++ b/src/sound_backend.h
@@ -58,6 +58,26 @@ void set_slow_time_predicate( bool_predicate fn );
 // predicate without re-exporting the function pointer.
 bool slow_time_predicate_active();
 
+namespace testing
+{
+// Reserved track's current frequency ratio. Used by slow-time
+// property tests to verify predicate-to-ratio wiring without coupling
+// tests to backend internals. SDL2 backend returns 1.0 (no native
+// ratio concept).
+float reserved_track_frequency_ratio( sfx::channel slot );
+
+// Current frequency ratio of the most-recently-started one-shot
+// track. SDL2 backend returns 1.0. Returns 0.0 if no one-shot is
+// currently tracked.
+float last_oneshot_frequency_ratio();
+
+// Produce a minimal valid sfx_audio (a single silent stereo frame)
+// that play_reserved and play_oneshot will accept. Used by tests
+// that need to exercise the play path without loading a real file.
+// SDL2 backend returns nullptr.
+sfx_audio *make_synthetic_sfx_audio();
+} // namespace testing
+
 void stop_all_sfx( int fade_out_ms );
 void fade_group( sfx::group g, int ms );
 

--- a/src/sound_backend_sdl2.cpp
+++ b/src/sound_backend_sdl2.cpp
@@ -1,0 +1,490 @@
+#if defined(SDL_SOUND)
+
+#include "sound_backend.h"
+
+#include "sdl_wrappers.h"
+
+#if defined(_MSC_VER) && defined(USE_VCPKG)
+#include <SDL2/SDL_mixer.h>
+#else
+#include <SDL_mixer.h>
+#endif
+
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <mutex>
+#include <ostream>
+#include <string>
+#include <vector>
+
+#include "cata_assert.h"
+#include "debug.h"
+#include "sounds.h"
+
+#define dbg(x) DebugLog((x), D_SDL) << __FILE__ << ":" << __LINE__ << ": "
+
+namespace sound_backend
+{
+
+namespace
+{
+// Channels whose stop was signaled from the audio thread; reaped on
+// the main thread at the top of every play_effect call. Mix_HaltChannel
+// cannot be called from inside an SDL_mixer effect callback.
+std::vector<sfx::channel> channels_to_end;
+std::mutex channels_to_end_mutex;
+
+constexpr float sound_speed_factor = 0.25f;
+
+struct sound_effect_handler {
+    Mix_Chunk *audio_src;
+    bool active;
+    bool owns_audio;
+    float current_sample_index = 0;
+    int loops_remaining = 0;
+    bool marked_for_termination = false;
+
+    ~sound_effect_handler() {
+        if( owns_audio ) {
+            free( audio_src->abuf );
+            free( audio_src );
+        }
+    }
+
+    static void on_finish( int /* chan */, void *udata ) {
+        sound_effect_handler *handler = static_cast<sound_effect_handler *>( udata );
+        cata_assert( handler != nullptr && handler->audio_src != nullptr );
+        delete handler;
+    }
+
+    static void slowed_time_effect( int channel, void *stream, int len, void *udata ) {
+        sound_effect_handler *handler = static_cast<sound_effect_handler *>( udata );
+
+        using sample = int16_t;
+        constexpr int bytes_per_sample = sizeof( sample ) * 2;
+
+        const float playback_speed = slow_time_predicate_active() ? sound_speed_factor : 1;
+        const int num_source_samples = handler->audio_src->alen / bytes_per_sample;
+
+        if( handler->loops_remaining < 0 ) {
+            std::memset( stream, 0, len );
+
+            const int num_samples = len / bytes_per_sample;
+            handler->current_sample_index += num_samples * playback_speed;
+            if( handler->current_sample_index >= num_source_samples ) {
+                handler->loops_remaining--;
+            }
+
+            if( !handler->marked_for_termination && handler->loops_remaining < -1 ) {
+                if( channels_to_end_mutex.try_lock() ) {
+                    handler->marked_for_termination = true;
+                    channels_to_end.push_back( static_cast<sfx::channel>( channel ) );
+                    channels_to_end_mutex.unlock();
+                }
+            }
+            return;
+        }
+
+        for( int dst_index = 0; dst_index < len / bytes_per_sample &&
+             handler->current_sample_index < num_source_samples; dst_index++ ) {
+
+            int low_index = static_cast<int>( std::floor( handler->current_sample_index ) );
+            int high_index = static_cast<int>( std::ceil( handler->current_sample_index ) );
+
+            if( high_index == num_source_samples ) {
+                high_index = 0;
+            }
+            if( low_index == num_source_samples ) {
+                low_index = 0;
+            }
+
+            for( int ear_offset = 0; ear_offset < 4; ear_offset += 2 ) {
+                sample low_value;
+                sample high_value;
+
+                std::memcpy( &low_value,
+                             static_cast<uint8_t *>( handler->audio_src->abuf ) + ear_offset +
+                             low_index * bytes_per_sample, sizeof( sample ) );
+                std::memcpy( &high_value,
+                             static_cast<uint8_t *>( handler->audio_src->abuf ) + ear_offset +
+                             high_index * bytes_per_sample, sizeof( sample ) );
+
+                const float interpolation_factor = handler->current_sample_index - low_index;
+                const sample interpolated = static_cast<sample>(
+                                                ( high_value - low_value ) * interpolation_factor + low_value );
+
+                std::memcpy( static_cast<uint8_t *>( stream ) + dst_index * bytes_per_sample + ear_offset,
+                             &interpolated, sizeof( sample ) );
+            }
+
+            handler->current_sample_index += 1.0f * playback_speed;
+            if( handler->current_sample_index >= num_source_samples ) {
+                handler->loops_remaining--;
+                handler->current_sample_index = std::fmod( handler->current_sample_index,
+                                                static_cast<float>( num_source_samples ) );
+
+                if( handler->loops_remaining < 0 ) {
+                    const int bytes_remaining = len - dst_index * bytes_per_sample;
+                    std::memset( static_cast<uint8_t *>( stream ) + dst_index * bytes_per_sample, 0,
+                                 bytes_remaining );
+                    break;
+                }
+            }
+        }
+    }
+};
+
+// Pitch-shift helper: returns a new Mix_Chunk owning freshly malloc'd
+// PCM. Caller takes ownership (via sound_effect_handler::owns_audio
+// for play_effect).
+Mix_Chunk *do_pitch_shift( const Mix_Chunk *s, float pitch )
+{
+    Uint32 s_in = s->alen / 4;
+    Uint32 s_out = static_cast<Uint32>( static_cast<float>( s_in ) * pitch );
+    float pitch_real = static_cast<float>( s_out ) / static_cast<float>( s_in );
+    Mix_Chunk *result = static_cast<Mix_Chunk *>( malloc( sizeof( Mix_Chunk ) ) );
+    result->allocated = 1;
+    result->alen = s_out * 4;
+    result->abuf = static_cast<Uint8 *>( malloc( result->alen * sizeof( Uint8 ) ) );
+    result->volume = s->volume;
+    for( Uint32 i = 0; i < s_out; i++ ) {
+        Sint64 lt_avg = 0;
+        Sint64 rt_avg = 0;
+        Uint32 begin = static_cast<Uint32>( static_cast<float>( i ) / pitch_real );
+        Uint32 end = static_cast<Uint32>( static_cast<float>( i + 1 ) / pitch_real );
+
+        if( end > 0 && ( end >= ( s->alen / 4 ) ) ) {
+            end = begin;
+        }
+
+        for( Uint32 j = begin; j <= end; j++ ) {
+            const Sint16 lt = ( s->abuf[( 4 * j ) + 1] << 8 ) | ( s->abuf[( 4 * j ) + 0] );
+            const Sint16 rt = ( s->abuf[( 4 * j ) + 3] << 8 ) | ( s->abuf[( 4 * j ) + 2] );
+            lt_avg += lt;
+            rt_avg += rt;
+        }
+        const Sint16 lt_out = static_cast<Sint16>( static_cast<float>( lt_avg ) /
+                              static_cast<float>( end - begin + 1 ) );
+        const Sint16 rt_out = static_cast<Sint16>( static_cast<float>( rt_avg ) /
+                              static_cast<float>( end - begin + 1 ) );
+        result->abuf[( 4 * i ) + 1] = static_cast<Uint8>( ( lt_out >> 8 ) & 0xFF );
+        result->abuf[( 4 * i ) + 0] = static_cast<Uint8>( lt_out & 0xFF );
+        result->abuf[( 4 * i ) + 3] = static_cast<Uint8>( ( rt_out >> 8 ) & 0xFF );
+        result->abuf[( 4 * i ) + 2] = static_cast<Uint8>( rt_out & 0xFF );
+    }
+    return result;
+}
+} // namespace
+
+bool play_effect( Mix_Chunk *audio_src, sfx::channel slot, int loops,
+                  int volume, int fade_in_ms,
+                  int angle_deg, bool positional,
+                  float pitch, bool owns_audio_src )
+{
+    // Reap any channels the audio thread asked us to halt.
+    if( channels_to_end_mutex.try_lock() ) {
+        for( sfx::channel channel : channels_to_end ) {
+            const int success = Mix_HaltChannel( static_cast<int>( channel ) );
+            if( success != 0 ) {
+                dbg( D_ERROR ) << "Mix_HaltChannel failed: " << Mix_GetError();
+            }
+        }
+        channels_to_end.clear();
+        channels_to_end_mutex.unlock();
+    }
+
+    Mix_Chunk *chunk_to_play = audio_src;
+    bool owns_chunk = owns_audio_src;
+    if( pitch != 1.0f ) {
+        chunk_to_play = do_pitch_shift( audio_src, pitch );
+        owns_chunk = true;
+    }
+
+    sound_effect_handler *handler = new sound_effect_handler();
+    handler->active = true;
+    handler->audio_src = chunk_to_play;
+    handler->owns_audio = owns_chunk;
+    handler->loops_remaining = loops == -1 ? 10000 : loops;
+
+    Mix_VolumeChunk( chunk_to_play, volume );
+
+    int channel;
+    if( fade_in_ms > 0 ) {
+        channel = Mix_FadeInChannel( static_cast<int>( slot ), chunk_to_play, -1, fade_in_ms );
+    } else {
+        channel = Mix_PlayChannel( static_cast<int>( slot ), chunk_to_play, -1 );
+    }
+    bool failed = channel == -1;
+    if( !failed ) {
+        const int out = Mix_RegisterEffect( channel, sound_effect_handler::slowed_time_effect,
+                                            sound_effect_handler::on_finish, handler );
+        if( out == 0 ) {
+            failed = true;
+            dbg( D_WARNING ) << "Mix_RegisterEffect failed: " << Mix_GetError();
+            Mix_HaltChannel( channel );
+        }
+    }
+    if( !failed && positional ) {
+        if( Mix_SetPosition( channel, static_cast<Sint16>( angle_deg ), 1 ) == 0 ) {
+            dbg( D_INFO ) << "Mix_SetPosition failed: " << Mix_GetError();
+        }
+    }
+    if( failed ) {
+        sound_effect_handler::on_finish( -1, handler );
+    }
+
+    return failed;
+}
+
+struct sfx_audio {
+    Mix_Chunk *chunk;
+};
+
+struct music_source {
+    Mix_Music *music;
+};
+
+namespace
+{
+Mix_Chunk *make_null_chunk()
+{
+    // Valid Mix_Chunk shell with no sample data. Mix_FreeChunk frees
+    // only the struct (allocated=0, abuf=nullptr). Matches the
+    // sdlsound.cpp fallback pattern used for missing sfx files.
+    Mix_Chunk *nchunk = static_cast<Mix_Chunk *>( SDL_malloc( sizeof( Mix_Chunk ) ) );
+    nchunk->allocated = 0;
+    nchunk->abuf = nullptr;
+    nchunk->alen = 0;
+    nchunk->volume = 0;
+    return nchunk;
+}
+} // namespace
+
+sfx_audio *load_sfx( const std::string &path )
+{
+    Mix_Chunk *result = Mix_LoadWAV( path.c_str() );
+    if( result == nullptr ) {
+        dbg( D_WARNING ) << "Failed to load sfx audio file " << path << ": " << Mix_GetError();
+        result = make_null_chunk();
+    }
+    return new sfx_audio{ result };
+}
+
+void free_sfx( sfx_audio *a )
+{
+    if( a == nullptr ) {
+        return;
+    }
+    if( a->chunk != nullptr ) {
+        Mix_FreeChunk( a->chunk );
+    }
+    delete a;
+}
+
+music_source *load_music( const std::string &path )
+{
+    Mix_Music *m = Mix_LoadMUS( path.c_str() );
+    if( m == nullptr ) {
+        dbg( D_WARNING ) << "Failed to load music " << path << ": " << Mix_GetError();
+        return nullptr;
+    }
+    return new music_source{ m };
+}
+
+void free_music( music_source *m )
+{
+    if( m == nullptr ) {
+        return;
+    }
+    if( m->music != nullptr ) {
+        Mix_FreeMusic( m->music );
+    }
+    delete m;
+}
+
+void fade_group( sfx::group g, int ms )
+{
+    Mix_FadeOutGroup( static_cast<int>( g ), ms );
+}
+
+void stop_all_sfx( int fade_out_ms )
+{
+    // Mix_FadeOutChannel(-1, ...) is a bulk-across-all-channels op.
+    Mix_FadeOutChannel( -1, fade_out_ms );
+}
+
+void stop_reserved( sfx::channel slot, int fade_out_ms )
+{
+    if( fade_out_ms <= 0 ) {
+        Mix_HaltChannel( static_cast<int>( slot ) );
+    } else {
+        Mix_FadeOutChannel( static_cast<int>( slot ), fade_out_ms );
+    }
+}
+
+bool is_reserved_playing( sfx::channel slot )
+{
+    return Mix_Playing( static_cast<int>( slot ) ) != 0;
+}
+
+bool is_reserved_fading( sfx::channel slot )
+{
+    return Mix_FadingChannel( static_cast<int>( slot ) ) != MIX_NO_FADING;
+}
+
+int set_reserved_volume( sfx::channel slot, int vol )
+{
+    // Refuse on non-playing or fading channels; return -1 to signal the
+    // refusal so callers know the requested volume did not stick.
+    const int ch = static_cast<int>( slot );
+    if( !Mix_Playing( ch ) ) {
+        return -1;
+    }
+    if( Mix_FadingChannel( ch ) != MIX_NO_FADING ) {
+        return -1;
+    }
+    return Mix_Volume( ch, vol );
+}
+
+int get_reserved_volume( sfx::channel slot )
+{
+    return Mix_Volume( static_cast<int>( slot ), -1 );
+}
+
+void set_reserved_position( sfx::channel slot, int angle_deg, int distance )
+{
+    const int ch = static_cast<int>( slot );
+    if( Mix_SetPosition( ch, static_cast<Sint16>( angle_deg ),
+                         static_cast<Uint8>( distance ) ) == 0 ) {
+        // Positioning failure is non-fatal; the sound still plays.
+        dbg( D_INFO ) << "Mix_SetPosition failed: " << Mix_GetError();
+    }
+}
+
+static bool_predicate g_slow_time_predicate = nullptr;
+
+void set_slow_time_predicate( bool_predicate fn )
+{
+    g_slow_time_predicate = fn;
+}
+
+bool slow_time_predicate_active()
+{
+    return g_slow_time_predicate != nullptr && g_slow_time_predicate();
+}
+
+void poll()
+{
+    // SDL2 needs no main-thread audio pump.
+}
+
+bool init( int frequency, int out_channels, int chunk_size,
+           const init_options & /*opts*/ )
+{
+    if( Mix_OpenAudioDevice( frequency, AUDIO_S16, out_channels, chunk_size, nullptr,
+                             SDL_AUDIO_ALLOW_FREQUENCY_CHANGE ) != 0 ) {
+        dbg( D_ERROR ) << "Failed to open audio mixer: " << Mix_GetError();
+        return false;
+    }
+    Mix_AllocateChannels( 128 );
+    Mix_ReserveChannels( static_cast<int>( sfx::channel::MAX_CHANNEL ) );
+    return true;
+}
+
+void shutdown()
+{
+    Mix_CloseAudio();
+}
+
+void tag_reserved_groups( const std::array<sfx::group,
+                          static_cast<size_t>( sfx::channel::MAX_CHANNEL )> &assignments )
+{
+    // Collapse adjacent same-group slots into a single Mix_GroupChannels
+    // call, matching the existing init-time grouping pattern.
+    const int n = static_cast<int>( sfx::channel::MAX_CHANNEL );
+    int run_start = 0;
+    while( run_start < n ) {
+        const sfx::group g = assignments[run_start];
+        int run_end = run_start;
+        while( run_end + 1 < n && assignments[run_end + 1] == g ) {
+            ++run_end;
+        }
+        // static_cast<int>(g) == 0 indicates "no group"; skip those runs.
+        if( static_cast<int>( g ) != 0 ) {
+            Mix_GroupChannels( run_start, run_end, static_cast<int>( g ) );
+        }
+        run_start = run_end + 1;
+    }
+}
+
+void play_reserved( sfx_audio *a, sfx::channel slot, const play_opts &opts )
+{
+    if( a == nullptr || a->chunk == nullptr ) {
+        return;
+    }
+    play_effect( a->chunk, slot, opts.loops, opts.volume, opts.fade_in_ms,
+                 opts.angle_deg, opts.positional, opts.pitch, false );
+}
+
+void play_oneshot( sfx_audio *a, const play_opts &opts )
+{
+    if( a == nullptr || a->chunk == nullptr ) {
+        return;
+    }
+    play_effect( a->chunk, sfx::channel::any, opts.loops, opts.volume, opts.fade_in_ms,
+                 opts.angle_deg, opts.positional, opts.pitch, false );
+}
+
+static music_finished_cb g_music_finished_cb = nullptr;
+
+void set_music_finished_cb( music_finished_cb cb )
+{
+    g_music_finished_cb = cb;
+    if( cb != nullptr ) {
+        Mix_HookMusicFinished( cb );
+    } else {
+        Mix_HookMusicFinished( nullptr );
+    }
+}
+
+bool play_music( music_source *m, int loops, int fade_in_ms )
+{
+    if( m == nullptr || m->music == nullptr ) {
+        return false;
+    }
+    int rc;
+    if( fade_in_ms > 0 ) {
+        rc = Mix_FadeInMusic( m->music, loops, fade_in_ms );
+    } else {
+        rc = Mix_PlayMusic( m->music, loops );
+    }
+    if( rc != 0 ) {
+        dbg( D_ERROR ) << "Failed to start music: " << Mix_GetError();
+        return false;
+    }
+    return true;
+}
+
+void stop_music( int /*fade_out_ms*/ )
+{
+    // Caller frees any owned music_source after stop; the backend only
+    // stops playback.
+    Mix_HaltMusic();
+}
+
+void set_music_volume( int vol )
+{
+    Mix_VolumeMusic( vol );
+}
+
+bool is_music_playing()
+{
+    return Mix_PlayingMusic() != 0;
+}
+
+} // namespace sound_backend
+
+#endif // SDL_SOUND

--- a/src/sound_backend_sdl2.cpp
+++ b/src/sound_backend_sdl2.cpp
@@ -1,4 +1,4 @@
-#if defined(SDL_SOUND)
+#if defined(SDL_SOUND) && !defined(USE_SDL3)
 
 #include "sound_backend.h"
 
@@ -179,6 +179,8 @@ Mix_Chunk *do_pitch_shift( const Mix_Chunk *s, float pitch )
 }
 } // namespace
 
+namespace
+{
 bool play_effect( Mix_Chunk *audio_src, sfx::channel slot, int loops,
                   int volume, int fade_in_ms,
                   int angle_deg, bool positional,
@@ -238,6 +240,7 @@ bool play_effect( Mix_Chunk *audio_src, sfx::channel slot, int loops,
 
     return failed;
 }
+} // namespace
 
 struct sfx_audio {
     Mix_Chunk *chunk;
@@ -487,4 +490,4 @@ bool is_music_playing()
 
 } // namespace sound_backend
 
-#endif // SDL_SOUND
+#endif // SDL_SOUND && !USE_SDL3

--- a/src/sound_backend_sdl2.cpp
+++ b/src/sound_backend_sdl2.cpp
@@ -379,6 +379,25 @@ bool slow_time_predicate_active()
     return g_slow_time_predicate != nullptr && g_slow_time_predicate();
 }
 
+namespace testing
+{
+float reserved_track_frequency_ratio( sfx::channel /*slot*/ )
+{
+    // SDL2_mixer has no native per-track frequency ratio. Slow-time
+    // DSP runs via Mix_RegisterEffect and mutates output PCM in
+    // place; there is no stored ratio to query.
+    return 1.0f;
+}
+float last_oneshot_frequency_ratio()
+{
+    return 1.0f;
+}
+sfx_audio *make_synthetic_sfx_audio()
+{
+    return nullptr;
+}
+} // namespace testing
+
 void poll()
 {
     // SDL2 needs no main-thread audio pump.

--- a/src/sound_backend_sdl3.cpp
+++ b/src/sound_backend_sdl3.cpp
@@ -2,70 +2,435 @@
 
 #include "sound_backend.h"
 
+#include <SDL3/SDL.h>
+#include <SDL3_mixer/SDL_mixer.h>
+
+#include <atomic>
+#include <cmath>
 #include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <ostream>
 #include <string>
+#include <vector>
+
+#include "debug.h"
+
+#define dbg(x) DebugLog((x), D_SDL) << __FILE__ << ":" << __LINE__ << ": "
 
 namespace sound_backend
 {
 
-struct sfx_audio {};
-struct music_source {};
+struct sfx_audio {
+    MIX_Audio *audio = nullptr;
+};
 
-bool init( int /*frequency*/, int /*out_channels*/, int /*chunk_size*/,
-           const init_options & /*opts*/ )
+struct music_source {
+    MIX_Audio *audio = nullptr;
+};
+
+namespace
 {
+MIX_Mixer *g_mixer = nullptr;
+MIX_Track *g_music_track = nullptr;
+bool_predicate g_slow_time_predicate = nullptr;
+music_finished_cb g_music_finished_cb = nullptr;
+
+// SFX_TAG is applied to every SFX track so MIX_StopTag(mixer, SFX_TAG, ...)
+// affects all SFX without touching music.
+constexpr const char *SFX_TAG = "sfx";
+
+constexpr float SLOW_TIME_FACTOR = 0.25f;
+
+std::array<MIX_Track *, static_cast<size_t>( sfx::channel::MAX_CHANNEL )> g_reserved_tracks{};
+std::array<sfx::group, static_cast<size_t>( sfx::channel::MAX_CHANNEL )> g_reserved_groups{};
+std::array<float, static_cast<size_t>( sfx::channel::MAX_CHANNEL )> g_reserved_base_pitch{};
+std::array<float, static_cast<size_t>( sfx::channel::MAX_CHANNEL )> g_reserved_base_gain{};
+std::array<float, static_cast<size_t>( sfx::channel::MAX_CHANNEL )> g_reserved_distance_scale{};
+
+// One-shot tracks are created per play. The stopped callback fires
+// on the mixer's audio thread while the mixer is still iterating
+// internal track state, so destroying the track from inside that
+// callback is undefined behavior. Instead the callback marks the
+// entry as stopped; poll() reaps (MIX_DestroyTrack + vector erase)
+// on the main thread.
+//
+// base_pitch is the caller's per-play pitch so poll() can recompose
+// pitch with the current slow-time factor without losing it.
+struct oneshot_entry {
+    MIX_Track *track;
+    float base_pitch;
+    bool stopped = false;
+};
+std::mutex g_oneshots_mutex;
+std::vector<oneshot_entry> g_oneshots;
+
+// Music generation token: bump on every play_music / stop_music so
+// superseded stopped callbacks no-op.
+std::atomic<uint32_t> g_music_generation{0};
+
+const char *tag_for_group( sfx::group g )
+{
+    switch( g ) {
+        case sfx::group::weather:
+            return "weather";
+        case sfx::group::time_of_day:
+            return "time_of_day";
+        case sfx::group::context_themes:
+            return "context_themes";
+        case sfx::group::low_stamina:
+            return "low_stamina";
+    }
+    return nullptr;
+}
+
+MIX_Track *reserved_track( sfx::channel slot )
+{
+    const int idx = static_cast<int>( slot );
+    if( idx < 0 || idx >= static_cast<int>( sfx::channel::MAX_CHANNEL ) ) {
+        return nullptr;
+    }
+    return g_reserved_tracks[idx];
+}
+
+void oneshot_stopped_cb( void *userdata, MIX_Track *track )
+{
+    ( void )userdata;
+    // Do NOT destroy the track here. SDL3_mixer invokes this callback
+    // while still holding internal references; MIX_DestroyTrack from
+    // inside the callback is UB. Mark the entry stopped and let poll()
+    // reap on the main thread.
+    std::lock_guard<std::mutex> lock( g_oneshots_mutex );
+    for( oneshot_entry &e : g_oneshots ) {
+        if( e.track == track ) {
+            e.stopped = true;
+            return;
+        }
+    }
+}
+
+void music_stopped_cb( void *userdata, MIX_Track * /*track*/ )
+{
+    const uint32_t captured = static_cast<uint32_t>( reinterpret_cast<uintptr_t>( userdata ) );
+    if( captured != g_music_generation.load() ) {
+        return;
+    }
+    if( g_music_finished_cb != nullptr ) {
+        g_music_finished_cb();
+    }
+}
+
+float volume_to_gain( int vol )
+{
+    if( vol <= 0 ) {
+        return 0.0f;
+    }
+    if( vol >= 128 ) {
+        return 1.0f;
+    }
+    return static_cast<float>( vol ) / 128.0f;
+}
+
+// SDL2 Mix_SetPosition distance semantics: 0 = closest (max volume),
+// 255 = farthest (muted). Linear attenuation.
+float distance_to_scale( int distance )
+{
+    if( distance <= 0 ) {
+        return 1.0f;
+    }
+    if( distance >= 255 ) {
+        return 0.0f;
+    }
+    return 1.0f - static_cast<float>( distance ) / 255.0f;
+}
+
+void apply_pan( MIX_Track *track, int angle_deg )
+{
+    // Equal-power pan law.
+    const float pan_x = std::sin( static_cast<float>( angle_deg ) * 3.14159265f / 180.0f );
+    MIX_StereoGains gains;
+    gains.left  = std::sqrt( 0.5f * ( 1.0f - pan_x ) );
+    gains.right = std::sqrt( 0.5f * ( 1.0f + pan_x ) );
+    MIX_SetTrackStereo( track, &gains );
+}
+} // namespace
+
+bool init( int frequency, int out_channels, int chunk_size,
+           const init_options &opts )
+{
+    if( !MIX_Init() ) {
+        dbg( D_ERROR ) << "MIX_Init failed: " << SDL_GetError();
+        return false;
+    }
+
+    SDL_AudioSpec spec{};
+    spec.freq = frequency;
+    spec.format = SDL_AUDIO_S16;
+    spec.channels = out_channels;
+
+    if( opts.memory_only ) {
+        g_mixer = MIX_CreateMixer( &spec );
+    } else {
+        g_mixer = MIX_CreateMixerDevice( SDL_AUDIO_DEVICE_DEFAULT_PLAYBACK, &spec );
+    }
+    ( void )chunk_size;
+    if( g_mixer == nullptr ) {
+        dbg( D_ERROR ) << "MIX_CreateMixer failed: " << SDL_GetError();
+        MIX_Quit();
+        return false;
+    }
+
+    for( size_t i = 0; i < g_reserved_tracks.size(); ++i ) {
+        g_reserved_tracks[i] = MIX_CreateTrack( g_mixer );
+        if( g_reserved_tracks[i] != nullptr ) {
+            MIX_TagTrack( g_reserved_tracks[i], SFX_TAG );
+        }
+        g_reserved_base_pitch[i] = 1.0f;
+        g_reserved_base_gain[i] = 1.0f;
+        g_reserved_distance_scale[i] = 1.0f;
+    }
+
+    g_music_track = MIX_CreateTrack( g_mixer );
     return true;
 }
 
-void shutdown() {}
-
-sfx_audio *load_sfx( const std::string & /*path*/ )
+void shutdown()
 {
-    return nullptr;
+    for( MIX_Track *t : g_reserved_tracks ) {
+        if( t != nullptr ) {
+            MIX_DestroyTrack( t );
+        }
+    }
+    g_reserved_tracks.fill( nullptr );
+
+    {
+        std::lock_guard<std::mutex> lock( g_oneshots_mutex );
+        for( const oneshot_entry &o : g_oneshots ) {
+            MIX_DestroyTrack( o.track );
+        }
+        g_oneshots.clear();
+    }
+
+    if( g_music_track != nullptr ) {
+        MIX_DestroyTrack( g_music_track );
+        g_music_track = nullptr;
+    }
+    if( g_mixer != nullptr ) {
+        MIX_DestroyMixer( g_mixer );
+        g_mixer = nullptr;
+    }
+    MIX_Quit();
 }
 
-void free_sfx( sfx_audio * /*a*/ ) {}
-
-music_source *load_music( const std::string & /*path*/ )
+sfx_audio *load_sfx( const std::string &path )
 {
-    return nullptr;
+    sfx_audio *a = new sfx_audio{};
+    if( g_mixer == nullptr ) {
+        return a;
+    }
+    a->audio = MIX_LoadAudio( g_mixer, path.c_str(), true );
+    if( a->audio == nullptr ) {
+        dbg( D_WARNING ) << "Failed to load sfx audio " << path << ": " << SDL_GetError();
+    }
+    return a;
 }
 
-void free_music( music_source * /*m*/ ) {}
+void free_sfx( sfx_audio *a )
+{
+    if( a == nullptr ) {
+        return;
+    }
+    if( a->audio != nullptr ) {
+        MIX_DestroyAudio( a->audio );
+    }
+    delete a;
+}
 
-void play_reserved( sfx_audio * /*a*/, sfx::channel /*slot*/,
-                    const play_opts & /*opts*/ ) {}
+music_source *load_music( const std::string &path )
+{
+    if( g_mixer == nullptr ) {
+        return nullptr;
+    }
+    MIX_Audio *audio = MIX_LoadAudio( g_mixer, path.c_str(), false );
+    if( audio == nullptr ) {
+        dbg( D_WARNING ) << "Failed to load music " << path << ": " << SDL_GetError();
+        return nullptr;
+    }
+    music_source *m = new music_source{};
+    m->audio = audio;
+    return m;
+}
 
-void play_oneshot( sfx_audio * /*a*/, const play_opts & /*opts*/ ) {}
+void free_music( music_source *m )
+{
+    if( m == nullptr ) {
+        return;
+    }
+    if( m->audio != nullptr ) {
+        MIX_DestroyAudio( m->audio );
+    }
+    delete m;
+}
+
+namespace
+{
+void configure_and_play( MIX_Track *track, const play_opts &opts )
+{
+    const float base = volume_to_gain( opts.volume );
+    const float scale = opts.positional ? distance_to_scale( opts.distance ) : 1.0f;
+    MIX_SetTrackGain( track, base * scale );
+    if( opts.positional ) {
+        apply_pan( track, opts.angle_deg );
+    }
+    // Compose the caller's pitch with the current slow-time factor so
+    // sounds spawned while bullet-time is active start slowed, rather
+    // than waiting for the next poll. Caller's pitch follows the
+    // do_pitch_shift convention (smaller = higher perceived pitch,
+    // produces a shorter chunk), which is the inverse of a native
+    // frequency ratio; invert here.
+    const float slow = slow_time_predicate_active() ? SLOW_TIME_FACTOR : 1.0f;
+    MIX_SetTrackFrequencyRatio( track, ( 1.0f / opts.pitch ) * slow );
+
+    SDL_PropertiesID props = SDL_CreateProperties();
+    if( opts.loops != 0 ) {
+        SDL_SetNumberProperty( props, MIX_PROP_PLAY_LOOPS_NUMBER, opts.loops );
+    }
+    if( opts.fade_in_ms > 0 ) {
+        SDL_SetNumberProperty( props, MIX_PROP_PLAY_FADE_IN_MILLISECONDS_NUMBER, opts.fade_in_ms );
+    }
+    MIX_PlayTrack( track, props );
+    SDL_DestroyProperties( props );
+}
+} // namespace
+
+void play_reserved( sfx_audio *a, sfx::channel slot, const play_opts &opts )
+{
+    if( a == nullptr || a->audio == nullptr ) {
+        return;
+    }
+    MIX_Track *track = reserved_track( slot );
+    if( track == nullptr ) {
+        return;
+    }
+
+    MIX_SetTrackAudio( track, a->audio );
+    const size_t idx = static_cast<size_t>( slot );
+    g_reserved_base_pitch[idx] = opts.pitch;
+    g_reserved_base_gain[idx] = volume_to_gain( opts.volume );
+    g_reserved_distance_scale[idx] = opts.positional
+                                     ? distance_to_scale( opts.distance )
+                                     : 1.0f;
+    configure_and_play( track, opts );
+}
+
+void play_oneshot( sfx_audio *a, const play_opts &opts )
+{
+    if( a == nullptr || a->audio == nullptr || g_mixer == nullptr ) {
+        return;
+    }
+    MIX_Track *track = MIX_CreateTrack( g_mixer );
+    if( track == nullptr ) {
+        dbg( D_WARNING ) << "MIX_CreateTrack failed for one-shot: " << SDL_GetError();
+        return;
+    }
+    MIX_TagTrack( track, SFX_TAG );
+    MIX_SetTrackAudio( track, a->audio );
+    MIX_SetTrackStoppedCallback( track, oneshot_stopped_cb, nullptr );
+    {
+        std::lock_guard<std::mutex> lock( g_oneshots_mutex );
+        g_oneshots.push_back( { track, opts.pitch } );
+    }
+    configure_and_play( track, opts );
+}
 
 void tag_reserved_groups( const std::array<sfx::group,
-                          static_cast<size_t>( sfx::channel::MAX_CHANNEL )> &/*assignments*/ ) {}
-
-void stop_reserved( sfx::channel /*slot*/, int /*fade_out_ms*/ ) {}
-
-bool is_reserved_playing( sfx::channel /*slot*/ )
+                          static_cast<size_t>( sfx::channel::MAX_CHANNEL )> &assignments )
 {
-    return false;
+    for( size_t i = 0; i < assignments.size(); ++i ) {
+        g_reserved_groups[i] = assignments[i];
+        MIX_Track *track = g_reserved_tracks[i];
+        if( track == nullptr ) {
+            continue;
+        }
+        const char *g_tag = tag_for_group( assignments[i] );
+        if( g_tag != nullptr ) {
+            MIX_TagTrack( track, g_tag );
+        }
+    }
 }
 
-bool is_reserved_fading( sfx::channel /*slot*/ )
+void stop_reserved( sfx::channel slot, int fade_out_ms )
 {
-    return false;
+    MIX_Track *track = reserved_track( slot );
+    if( track == nullptr ) {
+        return;
+    }
+    if( fade_out_ms <= 0 ) {
+        MIX_StopTrack( track, 0 );
+    } else {
+        // MIX_StopTrack is not fade-idempotent: each call re-arms the
+        // fade countdown. Callers (e.g. sfx::do_ambient) invoke this
+        // on every tick while the sound is still audible, so the guard
+        // below lets an in-progress fade finish on its original
+        // schedule.
+        if( MIX_GetTrackFadeFrames( track ) != 0 ) {
+            return;
+        }
+        MIX_StopTrack( track, MIX_TrackMSToFrames( track, fade_out_ms ) );
+    }
 }
 
-int set_reserved_volume( sfx::channel /*slot*/, int /*vol*/ )
+bool is_reserved_playing( sfx::channel slot )
 {
-    return -1;
+    MIX_Track *track = reserved_track( slot );
+    return track != nullptr && MIX_TrackPlaying( track );
 }
 
-int get_reserved_volume( sfx::channel /*slot*/ )
+bool is_reserved_fading( sfx::channel slot )
 {
-    return 0;
+    MIX_Track *track = reserved_track( slot );
+    return track != nullptr && MIX_GetTrackFadeFrames( track ) != 0;
 }
 
-void set_reserved_position( sfx::channel /*slot*/, int /*angle_deg*/, int /*distance*/ ) {}
+int set_reserved_volume( sfx::channel slot, int vol )
+{
+    MIX_Track *track = reserved_track( slot );
+    if( track == nullptr ) {
+        return -1;
+    }
+    if( !MIX_TrackPlaying( track ) ) {
+        return -1;
+    }
+    if( MIX_GetTrackFadeFrames( track ) != 0 ) {
+        return -1;
+    }
+    const size_t idx = static_cast<size_t>( slot );
+    const float prev_base = g_reserved_base_gain[idx];
+    g_reserved_base_gain[idx] = volume_to_gain( vol );
+    MIX_SetTrackGain( track, g_reserved_base_gain[idx] * g_reserved_distance_scale[idx] );
+    return static_cast<int>( prev_base * 128.0f );
+}
 
-static bool_predicate g_slow_time_predicate = nullptr;
+int get_reserved_volume( sfx::channel slot )
+{
+    const int idx = static_cast<int>( slot );
+    if( idx < 0 || idx >= static_cast<int>( sfx::channel::MAX_CHANNEL ) ) {
+        return 0;
+    }
+    return static_cast<int>( g_reserved_base_gain[idx] * 128.0f );
+}
+
+void set_reserved_position( sfx::channel slot, int angle_deg, int distance )
+{
+    MIX_Track *track = reserved_track( slot );
+    if( track == nullptr ) {
+        return;
+    }
+    apply_pan( track, angle_deg );
+    const size_t idx = static_cast<size_t>( slot );
+    g_reserved_distance_scale[idx] = distance_to_scale( distance );
+    MIX_SetTrackGain( track, g_reserved_base_gain[idx] * g_reserved_distance_scale[idx] );
+}
 
 void set_slow_time_predicate( bool_predicate fn )
 {
@@ -77,26 +442,162 @@ bool slow_time_predicate_active()
     return g_slow_time_predicate != nullptr && g_slow_time_predicate();
 }
 
-void stop_all_sfx( int /*fade_out_ms*/ ) {}
-
-void fade_group( sfx::group /*g*/, int /*ms*/ ) {}
-
-void poll() {}
-
-void set_music_finished_cb( music_finished_cb /*cb*/ ) {}
-
-bool play_music( music_source * /*m*/, int /*loops*/, int /*fade_in_ms*/ )
+namespace testing
 {
-    return false;
+float reserved_track_frequency_ratio( sfx::channel slot )
+{
+    MIX_Track *track = reserved_track( slot );
+    if( track == nullptr ) {
+        return 0.0f;
+    }
+    return MIX_GetTrackFrequencyRatio( track );
+}
+float last_oneshot_frequency_ratio()
+{
+    std::lock_guard<std::mutex> lock( g_oneshots_mutex );
+    if( g_oneshots.empty() ) {
+        return 0.0f;
+    }
+    return MIX_GetTrackFrequencyRatio( g_oneshots.back().track );
+}
+sfx_audio *make_synthetic_sfx_audio()
+{
+    if( g_mixer == nullptr ) {
+        return nullptr;
+    }
+    // One frame of silent stereo float32 PCM.
+    static const float silent_frame[2] = { 0.0f, 0.0f };
+    SDL_AudioSpec spec{};
+    spec.freq = 44100;
+    spec.format = SDL_AUDIO_F32;
+    spec.channels = 2;
+    MIX_Audio *audio = MIX_LoadRawAudio( g_mixer, silent_frame,
+                                         sizeof( silent_frame ), &spec );
+    if( audio == nullptr ) {
+        return nullptr;
+    }
+    sfx_audio *a = new sfx_audio{};
+    a->audio = audio;
+    return a;
+}
+} // namespace testing
+
+void stop_all_sfx( int fade_out_ms )
+{
+    if( g_mixer == nullptr ) {
+        return;
+    }
+    MIX_StopTag( g_mixer, SFX_TAG, fade_out_ms );
 }
 
-void stop_music( int /*fade_out_ms*/ ) {}
+void fade_group( sfx::group g, int ms )
+{
+    if( g_mixer == nullptr ) {
+        return;
+    }
+    // Reserved tracks are reused across plays, so per-slot
+    // MIX_StopTrack is the authoritative way to stop them even though
+    // they also carry the group tag. The tag-based MIX_StopTag path is
+    // unreliable on reused tracks in this backend.
+    for( size_t i = 0; i < g_reserved_tracks.size(); ++i ) {
+        if( g_reserved_groups[i] != g ) {
+            continue;
+        }
+        MIX_Track *t = g_reserved_tracks[i];
+        if( t == nullptr ) {
+            continue;
+        }
+        if( ms <= 0 ) {
+            MIX_StopTrack( t, 0 );
+        } else {
+            // Skip if already fading; re-issuing MIX_StopTrack resets
+            // the fade countdown on SDL3 and would stall the fade.
+            if( MIX_GetTrackFadeFrames( t ) != 0 ) {
+                continue;
+            }
+            MIX_StopTrack( t, MIX_TrackMSToFrames( t, ms ) );
+        }
+    }
+}
 
-void set_music_volume( int /*vol*/ ) {}
+void poll()
+{
+    const float slow = slow_time_predicate_active() ? SLOW_TIME_FACTOR : 1.0f;
+    for( size_t i = 0; i < g_reserved_tracks.size(); ++i ) {
+        MIX_Track *t = g_reserved_tracks[i];
+        if( t != nullptr ) {
+            MIX_SetTrackFrequencyRatio( t, ( 1.0f / g_reserved_base_pitch[i] ) * slow );
+        }
+    }
+    std::lock_guard<std::mutex> lock( g_oneshots_mutex );
+    // Reap stopped one-shots: destroy tracks the stopped callback
+    // flagged, then drop them from the vector. Running one-shots
+    // get their frequency ratio refreshed below.
+    for( auto it = g_oneshots.begin(); it != g_oneshots.end(); ) {
+        if( it->stopped ) {
+            MIX_DestroyTrack( it->track );
+            it = g_oneshots.erase( it );
+        } else {
+            MIX_SetTrackFrequencyRatio( it->track, ( 1.0f / it->base_pitch ) * slow );
+            ++it;
+        }
+    }
+}
+
+void set_music_finished_cb( music_finished_cb cb )
+{
+    g_music_finished_cb = cb;
+}
+
+bool play_music( music_source *m, int loops, int fade_in_ms )
+{
+    if( m == nullptr || m->audio == nullptr || g_music_track == nullptr ) {
+        return false;
+    }
+    const uint32_t new_gen = ++g_music_generation;
+    MIX_SetTrackAudio( g_music_track, m->audio );
+    MIX_SetTrackStoppedCallback( g_music_track, music_stopped_cb,
+                                 reinterpret_cast<void *>( static_cast<uintptr_t>( new_gen ) ) );
+
+    SDL_PropertiesID props = SDL_CreateProperties();
+    if( loops != 0 ) {
+        SDL_SetNumberProperty( props, MIX_PROP_PLAY_LOOPS_NUMBER, loops );
+    }
+    if( fade_in_ms > 0 ) {
+        SDL_SetNumberProperty( props, MIX_PROP_PLAY_FADE_IN_MILLISECONDS_NUMBER, fade_in_ms );
+    }
+    const bool ok = MIX_PlayTrack( g_music_track, props );
+    SDL_DestroyProperties( props );
+    if( !ok ) {
+        dbg( D_ERROR ) << "Failed to start music: " << SDL_GetError();
+    }
+    return ok;
+}
+
+void stop_music( int fade_out_ms )
+{
+    if( g_music_track == nullptr ) {
+        return;
+    }
+    ++g_music_generation;
+    if( fade_out_ms <= 0 ) {
+        MIX_StopTrack( g_music_track, 0 );
+    } else {
+        MIX_StopTrack( g_music_track, MIX_TrackMSToFrames( g_music_track, fade_out_ms ) );
+    }
+}
+
+void set_music_volume( int vol )
+{
+    if( g_music_track == nullptr ) {
+        return;
+    }
+    MIX_SetTrackGain( g_music_track, volume_to_gain( vol ) );
+}
 
 bool is_music_playing()
 {
-    return false;
+    return g_music_track != nullptr && MIX_TrackPlaying( g_music_track );
 }
 
 } // namespace sound_backend

--- a/src/sound_backend_sdl3.cpp
+++ b/src/sound_backend_sdl3.cpp
@@ -1,0 +1,104 @@
+#if defined(SDL_SOUND) && defined(USE_SDL3)
+
+#include "sound_backend.h"
+
+#include <cstddef>
+#include <string>
+
+namespace sound_backend
+{
+
+struct sfx_audio {};
+struct music_source {};
+
+bool init( int /*frequency*/, int /*out_channels*/, int /*chunk_size*/,
+           const init_options & /*opts*/ )
+{
+    return true;
+}
+
+void shutdown() {}
+
+sfx_audio *load_sfx( const std::string & /*path*/ )
+{
+    return nullptr;
+}
+
+void free_sfx( sfx_audio * /*a*/ ) {}
+
+music_source *load_music( const std::string & /*path*/ )
+{
+    return nullptr;
+}
+
+void free_music( music_source * /*m*/ ) {}
+
+void play_reserved( sfx_audio * /*a*/, sfx::channel /*slot*/,
+                    const play_opts & /*opts*/ ) {}
+
+void play_oneshot( sfx_audio * /*a*/, const play_opts & /*opts*/ ) {}
+
+void tag_reserved_groups( const std::array<sfx::group,
+                          static_cast<size_t>( sfx::channel::MAX_CHANNEL )> &/*assignments*/ ) {}
+
+void stop_reserved( sfx::channel /*slot*/, int /*fade_out_ms*/ ) {}
+
+bool is_reserved_playing( sfx::channel /*slot*/ )
+{
+    return false;
+}
+
+bool is_reserved_fading( sfx::channel /*slot*/ )
+{
+    return false;
+}
+
+int set_reserved_volume( sfx::channel /*slot*/, int /*vol*/ )
+{
+    return -1;
+}
+
+int get_reserved_volume( sfx::channel /*slot*/ )
+{
+    return 0;
+}
+
+void set_reserved_position( sfx::channel /*slot*/, int /*angle_deg*/, int /*distance*/ ) {}
+
+static bool_predicate g_slow_time_predicate = nullptr;
+
+void set_slow_time_predicate( bool_predicate fn )
+{
+    g_slow_time_predicate = fn;
+}
+
+bool slow_time_predicate_active()
+{
+    return g_slow_time_predicate != nullptr && g_slow_time_predicate();
+}
+
+void stop_all_sfx( int /*fade_out_ms*/ ) {}
+
+void fade_group( sfx::group /*g*/, int /*ms*/ ) {}
+
+void poll() {}
+
+void set_music_finished_cb( music_finished_cb /*cb*/ ) {}
+
+bool play_music( music_source * /*m*/, int /*loops*/, int /*fade_in_ms*/ )
+{
+    return false;
+}
+
+void stop_music( int /*fade_out_ms*/ ) {}
+
+void set_music_volume( int /*vol*/ ) {}
+
+bool is_music_playing()
+{
+    return false;
+}
+
+} // namespace sound_backend
+
+#endif // SDL_SOUND && USE_SDL3

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -46,11 +46,7 @@
 #include "weather_type.h"
 
 #if defined(SDL_SOUND)
-#   if defined(_MSC_VER) && defined(USE_VCPKG)
-#      include <SDL2/SDL_mixer.h>
-#   else
-#      include <SDL_mixer.h>
-#   endif
+#   include "sound_backend.h"
 #   include <thread>
 #   if defined(_WIN32) && !defined(_MSC_VER)
 #       include "mingw.thread.h"
@@ -830,7 +826,7 @@ void sfx::fade_audio_group( group group, int duration )
     if( test_mode ) {
         return;
     }
-    Mix_FadeOutGroup( static_cast<int>( group ), duration );
+    sound_backend::fade_group( group, duration );
 }
 
 void sfx::fade_audio_channel( channel channel, int duration )
@@ -838,7 +834,11 @@ void sfx::fade_audio_channel( channel channel, int duration )
     if( test_mode ) {
         return;
     }
-    Mix_FadeOutChannel( static_cast<int>( channel ), duration );
+    if( channel == channel::any ) {
+        sound_backend::stop_all_sfx( duration );
+    } else {
+        sound_backend::stop_reserved( channel, duration );
+    }
 }
 
 bool sfx::is_channel_playing( channel channel )
@@ -846,7 +846,7 @@ bool sfx::is_channel_playing( channel channel )
     if( test_mode ) {
         return false;
     }
-    return Mix_Playing( static_cast<int>( channel ) ) != 0;
+    return sound_backend::is_reserved_playing( channel );
 }
 
 void sfx::stop_sound_effect_fade( channel channel, int duration )
@@ -854,17 +854,14 @@ void sfx::stop_sound_effect_fade( channel channel, int duration )
     if( test_mode ) {
         return;
     }
-    if( Mix_FadeOutChannel( static_cast<int>( channel ), duration ) == -1 ) {
-        dbg( D_ERROR ) << "Failed to stop sound effect: " << Mix_GetError();
-    }
+    sound_backend::stop_reserved( channel, duration );
 }
 
-void sfx::stop_sound_effect_timed( channel channel, int time )
+void sfx::stop_sound_effect_timed( channel /*channel*/, int /*time*/ )
 {
-    if( test_mode ) {
-        return;
-    }
-    Mix_ExpireChannel( static_cast<int>( channel ), time );
+    // Mix_ExpireChannel has no callers in the codebase; retained as a
+    // no-op for ABI stability of sfx::. The backend intentionally does
+    // not expose a timed-expiry verb.
 }
 
 int sfx::set_channel_volume( channel channel, int volume )
@@ -872,14 +869,7 @@ int sfx::set_channel_volume( channel channel, int volume )
     if( test_mode ) {
         return 0;
     }
-    int ch = static_cast<int>( channel );
-    if( !Mix_Playing( ch ) ) {
-        return -1;
-    }
-    if( Mix_FadingChannel( ch ) != MIX_NO_FADING ) {
-        return -1;
-    }
-    return Mix_Volume( ch, volume );
+    return sound_backend::set_reserved_volume( channel, volume );
 }
 
 void sfx::do_vehicle_engine_sfx()
@@ -1011,7 +1001,7 @@ void sfx::do_vehicle_engine_sfx()
     }
 
     if( !veh->is_autodriving && current_speed != previous_speed ) {
-        Mix_HaltChannel( static_cast<int>( ch ) );
+        sound_backend::stop_reserved( ch, 0 );
         add_msg_debug( debugmode::DF_SOUND, "STOP speed %d =/= %d", current_speed, previous_speed );
         play_ambient_variant_sound( id_and_variant.first, id_and_variant.second,
                                     seas_str, indoors, night,
@@ -1030,7 +1020,6 @@ void sfx::do_vehicle_exterior_engine_sfx()
     }
 
     static const channel ch = channel::exterior_engine_sound;
-    static const int ch_int = static_cast<int>( ch );
     const Character &player_character = get_player_character();
     // early bail-outs for efficiency
     if( player_character.in_vehicle ) {
@@ -1067,7 +1056,7 @@ void sfx::do_vehicle_exterior_engine_sfx()
         return;
     }
 
-    vol = MIX_MAX_VOLUME * noise_factor / veh->vehicle_noise;
+    vol = 128 * noise_factor / veh->vehicle_noise; // 128 = MIX_MAX_VOLUME equivalent
     std::pair<std::string, std::string> id_and_variant;
     const season_type seas = season_of_year( calendar::turn );
     const std::string seas_str = season_str( seas );
@@ -1096,33 +1085,38 @@ void sfx::do_vehicle_exterior_engine_sfx()
 
     if( is_channel_playing( ch ) ) {
         if( engine_external_id_and_variant == id_and_variant ) {
-            Mix_SetPosition( ch_int, to_degrees( get_heard_angle( veh->pos_bub( here ) ) ), 0 );
+            sound_backend::set_reserved_position( ch,
+                                                  to_degrees( get_heard_angle( veh->pos_bub( here ) ) ), 0 );
             set_channel_volume( ch, vol );
             add_msg_debug( debugmode::DF_SOUND, "PLAYING exterior_engine_sound, vol: ex:%d true:%d", vol,
-                           Mix_Volume( ch_int, -1 ) );
+                           sound_backend::get_reserved_volume( ch ) );
         } else {
             engine_external_id_and_variant = id_and_variant;
-            Mix_HaltChannel( ch_int );
+            sound_backend::stop_reserved( ch, 0 );
             add_msg_debug( debugmode::DF_SOUND, "STOP exterior_engine_sound, change id/var" );
             play_ambient_variant_sound( id_and_variant.first, id_and_variant.second,
                                         seas_str, indoors, night, 128, ch, 0 );
-            Mix_SetPosition( ch_int, to_degrees( get_heard_angle( veh->pos_bub( here ) ) ), 0 );
+            sound_backend::set_reserved_position( ch,
+                                                  to_degrees( get_heard_angle( veh->pos_bub( here ) ) ), 0 );
             set_channel_volume( ch, vol );
             add_msg_debug( debugmode::DF_SOUND, "START exterior_engine_sound %s %s vol: %d",
                            id_and_variant.first,
                            id_and_variant.second,
-                           Mix_Volume( ch_int, -1 ) );
+                           sound_backend::get_reserved_volume( ch ) );
         }
     } else {
         play_ambient_variant_sound( id_and_variant.first, id_and_variant.second,
                                     seas_str, indoors, night, 128, ch, 0 );
-        add_msg_debug( debugmode::DF_SOUND, "Vol: %d %d", vol, Mix_Volume( ch_int, -1 ) );
-        Mix_SetPosition( ch_int, to_degrees( get_heard_angle( veh->pos_bub( here ) ) ), 0 );
-        add_msg_debug( debugmode::DF_SOUND, "Vol: %d %d", vol, Mix_Volume( ch_int, -1 ) );
+        add_msg_debug( debugmode::DF_SOUND, "Vol: %d %d", vol,
+                       sound_backend::get_reserved_volume( ch ) );
+        sound_backend::set_reserved_position( ch,
+                                              to_degrees( get_heard_angle( veh->pos_bub( here ) ) ), 0 );
+        add_msg_debug( debugmode::DF_SOUND, "Vol: %d %d", vol,
+                       sound_backend::get_reserved_volume( ch ) );
         set_channel_volume( ch, vol );
         add_msg_debug( debugmode::DF_SOUND, "START exterior_engine_sound NEW %s %s vol: ex:%d true:%d",
                        id_and_variant.first,
-                       id_and_variant.second, vol, Mix_Volume( ch_int, -1 ) );
+                       id_and_variant.second, vol, sound_backend::get_reserved_volume( ch ) );
     }
 }
 

--- a/src/third-party/CMakeLists.txt
+++ b/src/third-party/CMakeLists.txt
@@ -85,6 +85,21 @@ target_link_libraries(
 
 # ImGUI
 if (TILES)
+        if (USE_SDL3)
+            set(_imgui_backend_sources
+                imgui/imgui_impl_sdl3.cpp
+                imgui/imgui_impl_sdl3.h
+                imgui/imgui_impl_sdlrenderer3.cpp
+                imgui/imgui_impl_sdlrenderer3.h
+                )
+        else ()
+            set(_imgui_backend_sources
+                imgui/imgui_impl_sdl2.cpp
+                imgui/imgui_impl_sdl2.h
+                imgui/imgui_impl_sdlrenderer2.cpp
+                imgui/imgui_impl_sdlrenderer2.h
+                )
+        endif ()
         add_library(
                 imgui
                 STATIC
@@ -95,10 +110,7 @@ if (TILES)
                 imgui/imgui_draw.cpp
                 imgui/imgui_freetype.cpp
                 imgui/imgui_freetype.h
-                imgui/imgui_impl_sdl2.cpp
-                imgui/imgui_impl_sdl2.h
-                imgui/imgui_impl_sdlrenderer2.cpp
-                imgui/imgui_impl_sdlrenderer2.h
+                ${_imgui_backend_sources}
                 imgui/imgui_internal.h
                 imgui/imgui_stdlib.cpp
                 imgui/imgui_stdlib.h
@@ -116,13 +128,22 @@ if (TILES)
                 ${CMAKE_CURRENT_SOURCE_DIR}
                 )
 
-        target_include_directories(
-                imgui
-                SYSTEM
-                PRIVATE
-                ${SDL2_INCLUDE_DIR}/..
-                /usr/include/freetype2
-                )
+        if (USE_SDL3)
+            target_include_directories(
+                    imgui
+                    SYSTEM
+                    PRIVATE
+                    /usr/include/freetype2
+                    )
+        else ()
+            target_include_directories(
+                    imgui
+                    SYSTEM
+                    PRIVATE
+                    ${SDL2_INCLUDE_DIR}/..
+                    /usr/include/freetype2
+                    )
+        endif ()
 
         target_compile_options(
                 imgui
@@ -130,16 +151,30 @@ if (TILES)
                 -w
                 )
 
-        if (NOT DYNAMIC_LINKING)
-            target_link_libraries(imgui PUBLIC
-                SDL2::SDL2-static
-                $<TARGET_NAME_IF_EXISTS:PkgConfig::Freetype>
-            )
-        else()
-            target_link_libraries(imgui PUBLIC
-                SDL2::SDL2
-                freetype
-            )
+        if (USE_SDL3)
+            if (NOT DYNAMIC_LINKING)
+                target_link_libraries(imgui PUBLIC
+                    $<IF:$<TARGET_EXISTS:SDL3::SDL3-static>,SDL3::SDL3-static,SDL3::SDL3>
+                    $<TARGET_NAME_IF_EXISTS:PkgConfig::Freetype>
+                )
+            else()
+                target_link_libraries(imgui PUBLIC
+                    SDL3::SDL3
+                    freetype
+                )
+            endif ()
+        else ()
+            if (NOT DYNAMIC_LINKING)
+                target_link_libraries(imgui PUBLIC
+                    SDL2::SDL2-static
+                    $<TARGET_NAME_IF_EXISTS:PkgConfig::Freetype>
+                )
+            else()
+                target_link_libraries(imgui PUBLIC
+                    SDL2::SDL2
+                    freetype
+                )
+            endif ()
         endif ()
 
 

--- a/src/third-party/imgui/imgui_impl_sdl3.cpp
+++ b/src/third-party/imgui/imgui_impl_sdl3.cpp
@@ -1,0 +1,770 @@
+// dear imgui: Platform Backend for SDL3 (*EXPERIMENTAL*)
+// This needs to be used along with a Renderer (e.g. DirectX11, OpenGL3, Vulkan..)
+// (Info: SDL3 is a cross-platform general purpose library for handling windows, inputs, graphics context creation, etc.)
+
+// (**IMPORTANT: SDL 3.0.0 is NOT YET RELEASED AND CURRENTLY HAS A FAST CHANGING API. THIS CODE BREAKS OFTEN AS SDL3 CHANGES.**)
+
+// Implemented features:
+//  [X] Platform: Clipboard support.
+//  [X] Platform: Mouse support. Can discriminate Mouse/TouchScreen.
+//  [X] Platform: Keyboard support. Since 1.87 we are using the io.AddKeyEvent() function. Pass ImGuiKey values to all key functions e.g. ImGui::IsKeyPressed(ImGuiKey_Space). [Legacy SDL_SCANCODE_* values are obsolete since 1.87 and not supported since 1.91.5]
+//  [X] Platform: Gamepad support. Enabled with 'io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad'.
+//  [X] Platform: Mouse cursor shape and visibility. Disable with 'io.ConfigFlags |= ImGuiConfigFlags_NoMouseCursorChange'.
+
+// You can use unmodified imgui_impl_* files in your project. See examples/ folder for examples of using this.
+// Prefer including the entire imgui/ repository into your project (either as a copy or as a submodule), and only build the backends you need.
+// Learn about Dear ImGui:
+// - FAQ                  https://dearimgui.com/faq
+// - Getting Started      https://dearimgui.com/getting-started
+// - Documentation        https://dearimgui.com/docs (same as your local docs/ folder).
+// - Introduction, links and more at the top of imgui.cpp
+
+// CHANGELOG
+// (minor and older changes stripped away, please see git history for details)
+//  2024-10-24: Emscripten: SDL_EVENT_MOUSE_WHEEL event doesn't require dividing by 100.0f on Emscripten.
+//  2024-09-03: Update for SDL3 api changes: SDL_GetGamepads() memory ownership revert. (#7918, #7898, #7807)
+//  2024-08-22: moved some OS/backend related function pointers from ImGuiIO to ImGuiPlatformIO:
+//               - io.GetClipboardTextFn    -> platform_io.Platform_GetClipboardTextFn
+//               - io.SetClipboardTextFn    -> platform_io.Platform_SetClipboardTextFn
+//               - io.PlatformSetImeDataFn  -> platform_io.Platform_SetImeDataFn
+//  2024-08-19: Storing SDL_WindowID inside ImGuiViewport::PlatformHandle instead of SDL_Window*.
+//  2024-08-19: ImGui_ImplSDL3_ProcessEvent() now ignores events intended for other SDL windows. (#7853)
+//  2024-07-22: Update for SDL3 api changes: SDL_GetGamepads() memory ownership change. (#7807)
+//  2024-07-18: Update for SDL3 api changes: SDL_GetClipboardText() memory ownership change. (#7801)
+//  2024-07-15: Update for SDL3 api changes: SDL_GetProperty() change to SDL_GetPointerProperty(). (#7794)
+//  2024-07-02: Update for SDL3 api changes: SDLK_x renames and SDLK_KP_x removals (#7761, #7762).
+//  2024-07-01: Update for SDL3 api changes: SDL_SetTextInputRect() changed to SDL_SetTextInputArea().
+//  2024-06-26: Update for SDL3 api changes: SDL_StartTextInput()/SDL_StopTextInput()/SDL_SetTextInputRect() functions signatures.
+//  2024-06-24: Update for SDL3 api changes: SDL_EVENT_KEY_DOWN/SDL_EVENT_KEY_UP contents.
+//  2024-06-03; Update for SDL3 api changes: SDL_SYSTEM_CURSOR_ renames.
+//  2024-05-15: Update for SDL3 api changes: SDLK_ renames.
+//  2024-04-15: Inputs: Re-enable calling SDL_StartTextInput()/SDL_StopTextInput() as SDL3 no longer enables it by default and should play nicer with IME.
+//  2024-02-13: Inputs: Fixed gamepad support. Handle gamepad disconnection. Added ImGui_ImplSDL3_SetGamepadMode().
+//  2023-11-13: Updated for recent SDL3 API changes.
+//  2023-10-05: Inputs: Added support for extra ImGuiKey values: F13 to F24 function keys, app back/forward keys.
+//  2023-05-04: Fixed build on Emscripten/iOS/Android. (#6391)
+//  2023-04-06: Inputs: Avoid calling SDL_StartTextInput()/SDL_StopTextInput() as they don't only pertain to IME. It's unclear exactly what their relation is to IME. (#6306)
+//  2023-04-04: Inputs: Added support for io.AddMouseSourceEvent() to discriminate ImGuiMouseSource_Mouse/ImGuiMouseSource_TouchScreen. (#2702)
+//  2023-02-23: Accept SDL_GetPerformanceCounter() not returning a monotonically increasing value. (#6189, #6114, #3644)
+//  2023-02-07: Forked "imgui_impl_sdl2" into "imgui_impl_sdl3". Removed version checks for old feature. Refer to imgui_impl_sdl2.cpp for older changelog.
+
+#include "imgui.h"
+#ifndef IMGUI_DISABLE
+#include "imgui_impl_sdl3.h"
+
+// Clang warnings with -Weverything
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wimplicit-int-float-conversion"  // warning: implicit conversion from 'xxx' to 'float' may lose precision
+#endif
+
+// SDL
+#include <SDL3/SDL.h>
+#if defined(__APPLE__)
+#include <TargetConditionals.h>
+#endif
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#endif
+
+#if !defined(__EMSCRIPTEN__) && !defined(__ANDROID__) && !(defined(__APPLE__) && TARGET_OS_IOS) && !defined(__amigaos4__)
+#define SDL_HAS_CAPTURE_AND_GLOBAL_MOUSE    1
+#else
+#define SDL_HAS_CAPTURE_AND_GLOBAL_MOUSE    0
+#endif
+
+// FIXME-LEGACY: remove when SDL 3.1.3 preview is released.
+#ifndef SDLK_APOSTROPHE
+#define SDLK_APOSTROPHE SDLK_QUOTE
+#endif
+#ifndef SDLK_GRAVE
+#define SDLK_GRAVE SDLK_BACKQUOTE
+#endif
+
+// SDL Data
+struct ImGui_ImplSDL3_Data
+{
+    SDL_Window*             Window;
+    SDL_WindowID            WindowID;
+    SDL_Renderer*           Renderer;
+    Uint64                  Time;
+    char*                   ClipboardTextData;
+
+    // IME handling
+    SDL_Window*             ImeWindow;
+
+    // Mouse handling
+    Uint32                  MouseWindowID;
+    int                     MouseButtonsDown;
+    SDL_Cursor*             MouseCursors[ImGuiMouseCursor_COUNT];
+    SDL_Cursor*             MouseLastCursor;
+    int                     MousePendingLeaveFrame;
+    bool                    MouseCanUseGlobalState;
+
+    // Gamepad handling
+    ImVector<SDL_Gamepad*>      Gamepads;
+    ImGui_ImplSDL3_GamepadMode  GamepadMode;
+    bool                        WantUpdateGamepadsList;
+
+    ImGui_ImplSDL3_Data()   { memset((void*)this, 0, sizeof(*this)); }
+};
+
+// Backend data stored in io.BackendPlatformUserData to allow support for multiple Dear ImGui contexts
+// It is STRONGLY preferred that you use docking branch with multi-viewports (== single Dear ImGui context + multiple windows) instead of multiple Dear ImGui contexts.
+// FIXME: multi-context support is not well tested and probably dysfunctional in this backend.
+// FIXME: some shared resources (mouse cursor shape, gamepad) are mishandled when using multi-context.
+static ImGui_ImplSDL3_Data* ImGui_ImplSDL3_GetBackendData()
+{
+    return ImGui::GetCurrentContext() ? (ImGui_ImplSDL3_Data*)ImGui::GetIO().BackendPlatformUserData : nullptr;
+}
+
+// Functions
+static const char* ImGui_ImplSDL3_GetClipboardText(ImGuiContext*)
+{
+    ImGui_ImplSDL3_Data* bd = ImGui_ImplSDL3_GetBackendData();
+    if (bd->ClipboardTextData)
+        SDL_free(bd->ClipboardTextData);
+    const char* sdl_clipboard_text = SDL_GetClipboardText();
+    bd->ClipboardTextData = sdl_clipboard_text ? SDL_strdup(sdl_clipboard_text) : NULL;
+    return bd->ClipboardTextData;
+}
+
+static void ImGui_ImplSDL3_SetClipboardText(ImGuiContext*, const char* text)
+{
+    SDL_SetClipboardText(text);
+}
+
+static void ImGui_ImplSDL3_PlatformSetImeData(ImGuiContext*, ImGuiViewport* viewport, ImGuiPlatformImeData* data)
+{
+    ImGui_ImplSDL3_Data* bd = ImGui_ImplSDL3_GetBackendData();
+    SDL_WindowID window_id = (SDL_WindowID)(intptr_t)viewport->PlatformHandle;
+    SDL_Window* window = SDL_GetWindowFromID(window_id);
+    if ((data->WantVisible == false || bd->ImeWindow != window) && bd->ImeWindow != NULL)
+    {
+        SDL_StopTextInput(bd->ImeWindow);
+        bd->ImeWindow = nullptr;
+    }
+    if (data->WantVisible)
+    {
+        SDL_Rect r;
+        r.x = (int)data->InputPos.x;
+        r.y = (int)data->InputPos.y;
+        r.w = 1;
+        r.h = (int)data->InputLineHeight;
+        SDL_SetTextInputArea(window, &r, 0);
+        SDL_StartTextInput(window);
+        bd->ImeWindow = window;
+    }
+}
+
+// Not static to allow third-party code to use that if they want to (but undocumented)
+ImGuiKey ImGui_ImplSDL3_KeyEventToImGuiKey(SDL_Keycode keycode, SDL_Scancode scancode);
+ImGuiKey ImGui_ImplSDL3_KeyEventToImGuiKey(SDL_Keycode keycode, SDL_Scancode scancode)
+{
+    // Keypad doesn't have individual key values in SDL3
+    switch (scancode)
+    {
+        case SDL_SCANCODE_KP_0: return ImGuiKey_Keypad0;
+        case SDL_SCANCODE_KP_1: return ImGuiKey_Keypad1;
+        case SDL_SCANCODE_KP_2: return ImGuiKey_Keypad2;
+        case SDL_SCANCODE_KP_3: return ImGuiKey_Keypad3;
+        case SDL_SCANCODE_KP_4: return ImGuiKey_Keypad4;
+        case SDL_SCANCODE_KP_5: return ImGuiKey_Keypad5;
+        case SDL_SCANCODE_KP_6: return ImGuiKey_Keypad6;
+        case SDL_SCANCODE_KP_7: return ImGuiKey_Keypad7;
+        case SDL_SCANCODE_KP_8: return ImGuiKey_Keypad8;
+        case SDL_SCANCODE_KP_9: return ImGuiKey_Keypad9;
+        case SDL_SCANCODE_KP_PERIOD: return ImGuiKey_KeypadDecimal;
+        case SDL_SCANCODE_KP_DIVIDE: return ImGuiKey_KeypadDivide;
+        case SDL_SCANCODE_KP_MULTIPLY: return ImGuiKey_KeypadMultiply;
+        case SDL_SCANCODE_KP_MINUS: return ImGuiKey_KeypadSubtract;
+        case SDL_SCANCODE_KP_PLUS: return ImGuiKey_KeypadAdd;
+        case SDL_SCANCODE_KP_ENTER: return ImGuiKey_KeypadEnter;
+        case SDL_SCANCODE_KP_EQUALS: return ImGuiKey_KeypadEqual;
+        default: break;
+    }
+    switch (keycode)
+    {
+        case SDLK_TAB: return ImGuiKey_Tab;
+        case SDLK_LEFT: return ImGuiKey_LeftArrow;
+        case SDLK_RIGHT: return ImGuiKey_RightArrow;
+        case SDLK_UP: return ImGuiKey_UpArrow;
+        case SDLK_DOWN: return ImGuiKey_DownArrow;
+        case SDLK_PAGEUP: return ImGuiKey_PageUp;
+        case SDLK_PAGEDOWN: return ImGuiKey_PageDown;
+        case SDLK_HOME: return ImGuiKey_Home;
+        case SDLK_END: return ImGuiKey_End;
+        case SDLK_INSERT: return ImGuiKey_Insert;
+        case SDLK_DELETE: return ImGuiKey_Delete;
+        case SDLK_BACKSPACE: return ImGuiKey_Backspace;
+        case SDLK_SPACE: return ImGuiKey_Space;
+        case SDLK_RETURN: return ImGuiKey_Enter;
+        case SDLK_ESCAPE: return ImGuiKey_Escape;
+        case SDLK_APOSTROPHE: return ImGuiKey_Apostrophe;
+        case SDLK_COMMA: return ImGuiKey_Comma;
+        case SDLK_MINUS: return ImGuiKey_Minus;
+        case SDLK_PERIOD: return ImGuiKey_Period;
+        case SDLK_SLASH: return ImGuiKey_Slash;
+        case SDLK_SEMICOLON: return ImGuiKey_Semicolon;
+        case SDLK_EQUALS: return ImGuiKey_Equal;
+        case SDLK_LEFTBRACKET: return ImGuiKey_LeftBracket;
+        case SDLK_BACKSLASH: return ImGuiKey_Backslash;
+        case SDLK_RIGHTBRACKET: return ImGuiKey_RightBracket;
+        case SDLK_GRAVE: return ImGuiKey_GraveAccent;
+        case SDLK_CAPSLOCK: return ImGuiKey_CapsLock;
+        case SDLK_SCROLLLOCK: return ImGuiKey_ScrollLock;
+        case SDLK_NUMLOCKCLEAR: return ImGuiKey_NumLock;
+        case SDLK_PRINTSCREEN: return ImGuiKey_PrintScreen;
+        case SDLK_PAUSE: return ImGuiKey_Pause;
+        case SDLK_LCTRL: return ImGuiKey_LeftCtrl;
+        case SDLK_LSHIFT: return ImGuiKey_LeftShift;
+        case SDLK_LALT: return ImGuiKey_LeftAlt;
+        case SDLK_LGUI: return ImGuiKey_LeftSuper;
+        case SDLK_RCTRL: return ImGuiKey_RightCtrl;
+        case SDLK_RSHIFT: return ImGuiKey_RightShift;
+        case SDLK_RALT: return ImGuiKey_RightAlt;
+        case SDLK_RGUI: return ImGuiKey_RightSuper;
+        case SDLK_APPLICATION: return ImGuiKey_Menu;
+        case SDLK_0: return ImGuiKey_0;
+        case SDLK_1: return ImGuiKey_1;
+        case SDLK_2: return ImGuiKey_2;
+        case SDLK_3: return ImGuiKey_3;
+        case SDLK_4: return ImGuiKey_4;
+        case SDLK_5: return ImGuiKey_5;
+        case SDLK_6: return ImGuiKey_6;
+        case SDLK_7: return ImGuiKey_7;
+        case SDLK_8: return ImGuiKey_8;
+        case SDLK_9: return ImGuiKey_9;
+        case SDLK_A: return ImGuiKey_A;
+        case SDLK_B: return ImGuiKey_B;
+        case SDLK_C: return ImGuiKey_C;
+        case SDLK_D: return ImGuiKey_D;
+        case SDLK_E: return ImGuiKey_E;
+        case SDLK_F: return ImGuiKey_F;
+        case SDLK_G: return ImGuiKey_G;
+        case SDLK_H: return ImGuiKey_H;
+        case SDLK_I: return ImGuiKey_I;
+        case SDLK_J: return ImGuiKey_J;
+        case SDLK_K: return ImGuiKey_K;
+        case SDLK_L: return ImGuiKey_L;
+        case SDLK_M: return ImGuiKey_M;
+        case SDLK_N: return ImGuiKey_N;
+        case SDLK_O: return ImGuiKey_O;
+        case SDLK_P: return ImGuiKey_P;
+        case SDLK_Q: return ImGuiKey_Q;
+        case SDLK_R: return ImGuiKey_R;
+        case SDLK_S: return ImGuiKey_S;
+        case SDLK_T: return ImGuiKey_T;
+        case SDLK_U: return ImGuiKey_U;
+        case SDLK_V: return ImGuiKey_V;
+        case SDLK_W: return ImGuiKey_W;
+        case SDLK_X: return ImGuiKey_X;
+        case SDLK_Y: return ImGuiKey_Y;
+        case SDLK_Z: return ImGuiKey_Z;
+        case SDLK_F1: return ImGuiKey_F1;
+        case SDLK_F2: return ImGuiKey_F2;
+        case SDLK_F3: return ImGuiKey_F3;
+        case SDLK_F4: return ImGuiKey_F4;
+        case SDLK_F5: return ImGuiKey_F5;
+        case SDLK_F6: return ImGuiKey_F6;
+        case SDLK_F7: return ImGuiKey_F7;
+        case SDLK_F8: return ImGuiKey_F8;
+        case SDLK_F9: return ImGuiKey_F9;
+        case SDLK_F10: return ImGuiKey_F10;
+        case SDLK_F11: return ImGuiKey_F11;
+        case SDLK_F12: return ImGuiKey_F12;
+        case SDLK_F13: return ImGuiKey_F13;
+        case SDLK_F14: return ImGuiKey_F14;
+        case SDLK_F15: return ImGuiKey_F15;
+        case SDLK_F16: return ImGuiKey_F16;
+        case SDLK_F17: return ImGuiKey_F17;
+        case SDLK_F18: return ImGuiKey_F18;
+        case SDLK_F19: return ImGuiKey_F19;
+        case SDLK_F20: return ImGuiKey_F20;
+        case SDLK_F21: return ImGuiKey_F21;
+        case SDLK_F22: return ImGuiKey_F22;
+        case SDLK_F23: return ImGuiKey_F23;
+        case SDLK_F24: return ImGuiKey_F24;
+        case SDLK_AC_BACK: return ImGuiKey_AppBack;
+        case SDLK_AC_FORWARD: return ImGuiKey_AppForward;
+        default: break;
+    }
+    return ImGuiKey_None;
+}
+
+static void ImGui_ImplSDL3_UpdateKeyModifiers(SDL_Keymod sdl_key_mods)
+{
+    ImGuiIO& io = ImGui::GetIO();
+    io.AddKeyEvent(ImGuiMod_Ctrl, (sdl_key_mods & SDL_KMOD_CTRL) != 0);
+    io.AddKeyEvent(ImGuiMod_Shift, (sdl_key_mods & SDL_KMOD_SHIFT) != 0);
+    io.AddKeyEvent(ImGuiMod_Alt, (sdl_key_mods & SDL_KMOD_ALT) != 0);
+    io.AddKeyEvent(ImGuiMod_Super, (sdl_key_mods & SDL_KMOD_GUI) != 0);
+}
+
+
+static ImGuiViewport* ImGui_ImplSDL3_GetViewportForWindowID(SDL_WindowID window_id)
+{
+    ImGui_ImplSDL3_Data* bd = ImGui_ImplSDL3_GetBackendData();
+    return (window_id == bd->WindowID) ? ImGui::GetMainViewport() : NULL;
+}
+
+// You can read the io.WantCaptureMouse, io.WantCaptureKeyboard flags to tell if dear imgui wants to use your inputs.
+// - When io.WantCaptureMouse is true, do not dispatch mouse input data to your main application, or clear/overwrite your copy of the mouse data.
+// - When io.WantCaptureKeyboard is true, do not dispatch keyboard input data to your main application, or clear/overwrite your copy of the keyboard data.
+// Generally you may always pass all inputs to dear imgui, and hide them from your application based on those two flags.
+// If you have multiple SDL events and some of them are not meant to be used by dear imgui, you may need to filter events based on their windowID field.
+bool ImGui_ImplSDL3_ProcessEvent(const SDL_Event* event)
+{
+    ImGui_ImplSDL3_Data* bd = ImGui_ImplSDL3_GetBackendData();
+    IM_ASSERT(bd != nullptr && "Context or backend not initialized! Did you call ImGui_ImplSDL3_Init()?");
+    ImGuiIO& io = ImGui::GetIO();
+
+    switch (event->type)
+    {
+        case SDL_EVENT_MOUSE_MOTION:
+        {
+            if (ImGui_ImplSDL3_GetViewportForWindowID(event->motion.windowID) == NULL)
+                return false;
+            ImVec2 mouse_pos((float)event->motion.x, (float)event->motion.y);
+            io.AddMouseSourceEvent(event->motion.which == SDL_TOUCH_MOUSEID ? ImGuiMouseSource_TouchScreen : ImGuiMouseSource_Mouse);
+            io.AddMousePosEvent(mouse_pos.x, mouse_pos.y);
+            return true;
+        }
+        case SDL_EVENT_MOUSE_WHEEL:
+        {
+            if (ImGui_ImplSDL3_GetViewportForWindowID(event->wheel.windowID) == NULL)
+                return false;
+            //IMGUI_DEBUG_LOG("wheel %.2f %.2f, precise %.2f %.2f\n", (float)event->wheel.x, (float)event->wheel.y, event->wheel.preciseX, event->wheel.preciseY);
+            float wheel_x = -event->wheel.x;
+            float wheel_y = event->wheel.y;
+            io.AddMouseSourceEvent(event->wheel.which == SDL_TOUCH_MOUSEID ? ImGuiMouseSource_TouchScreen : ImGuiMouseSource_Mouse);
+            io.AddMouseWheelEvent(wheel_x, wheel_y);
+            return true;
+        }
+        case SDL_EVENT_MOUSE_BUTTON_DOWN:
+        case SDL_EVENT_MOUSE_BUTTON_UP:
+        {
+            if (ImGui_ImplSDL3_GetViewportForWindowID(event->button.windowID) == NULL)
+                return false;
+            int mouse_button = -1;
+            if (event->button.button == SDL_BUTTON_LEFT) { mouse_button = 0; }
+            if (event->button.button == SDL_BUTTON_RIGHT) { mouse_button = 1; }
+            if (event->button.button == SDL_BUTTON_MIDDLE) { mouse_button = 2; }
+            if (event->button.button == SDL_BUTTON_X1) { mouse_button = 3; }
+            if (event->button.button == SDL_BUTTON_X2) { mouse_button = 4; }
+            if (mouse_button == -1)
+                break;
+            io.AddMouseSourceEvent(event->button.which == SDL_TOUCH_MOUSEID ? ImGuiMouseSource_TouchScreen : ImGuiMouseSource_Mouse);
+            io.AddMouseButtonEvent(mouse_button, (event->type == SDL_EVENT_MOUSE_BUTTON_DOWN));
+            bd->MouseButtonsDown = (event->type == SDL_EVENT_MOUSE_BUTTON_DOWN) ? (bd->MouseButtonsDown | (1 << mouse_button)) : (bd->MouseButtonsDown & ~(1 << mouse_button));
+            return true;
+        }
+        case SDL_EVENT_TEXT_INPUT:
+        {
+            if (ImGui_ImplSDL3_GetViewportForWindowID(event->text.windowID) == NULL)
+                return false;
+            io.AddInputCharactersUTF8(event->text.text);
+            return true;
+        }
+        case SDL_EVENT_KEY_DOWN:
+        case SDL_EVENT_KEY_UP:
+        {
+            if (ImGui_ImplSDL3_GetViewportForWindowID(event->key.windowID) == NULL)
+                return false;
+            //IMGUI_DEBUG_LOG("SDL_EVENT_KEY_%d: key=%d, scancode=%d, mod=%X\n", (event->type == SDL_EVENT_KEY_DOWN) ? "DOWN" : "UP", event->key.key, event->key.scancode, event->key.mod);
+            ImGui_ImplSDL3_UpdateKeyModifiers((SDL_Keymod)event->key.mod);
+            ImGuiKey key = ImGui_ImplSDL3_KeyEventToImGuiKey(event->key.key, event->key.scancode);
+            io.AddKeyEvent(key, (event->type == SDL_EVENT_KEY_DOWN));
+            io.SetKeyEventNativeData(key, event->key.key, event->key.scancode, event->key.scancode); // To support legacy indexing (<1.87 user code). Legacy backend uses SDLK_*** as indices to IsKeyXXX() functions.
+            return true;
+        }
+        case SDL_EVENT_WINDOW_MOUSE_ENTER:
+        {
+            if (ImGui_ImplSDL3_GetViewportForWindowID(event->window.windowID) == NULL)
+                return false;
+            bd->MouseWindowID = event->window.windowID;
+            bd->MousePendingLeaveFrame = 0;
+            return true;
+        }
+        // - In some cases, when detaching a window from main viewport SDL may send SDL_WINDOWEVENT_ENTER one frame too late,
+        //   causing SDL_WINDOWEVENT_LEAVE on previous frame to interrupt drag operation by clear mouse position. This is why
+        //   we delay process the SDL_WINDOWEVENT_LEAVE events by one frame. See issue #5012 for details.
+        // FIXME: Unconfirmed whether this is still needed with SDL3.
+        case SDL_EVENT_WINDOW_MOUSE_LEAVE:
+        {
+            if (ImGui_ImplSDL3_GetViewportForWindowID(event->window.windowID) == NULL)
+                return false;
+            bd->MousePendingLeaveFrame = ImGui::GetFrameCount() + 1;
+            return true;
+        }
+        case SDL_EVENT_WINDOW_FOCUS_GAINED:
+        case SDL_EVENT_WINDOW_FOCUS_LOST:
+        {
+            if (ImGui_ImplSDL3_GetViewportForWindowID(event->window.windowID) == NULL)
+                return false;
+            io.AddFocusEvent(event->type == SDL_EVENT_WINDOW_FOCUS_GAINED);
+            return true;
+        }
+        case SDL_EVENT_GAMEPAD_ADDED:
+        case SDL_EVENT_GAMEPAD_REMOVED:
+        {
+            bd->WantUpdateGamepadsList = true;
+            return true;
+        }
+    }
+    return false;
+}
+
+static void ImGui_ImplSDL3_SetupPlatformHandles(ImGuiViewport* viewport, SDL_Window* window)
+{
+    viewport->PlatformHandle = (void*)(intptr_t)SDL_GetWindowID(window);
+    viewport->PlatformHandleRaw = nullptr;
+#if defined(_WIN32) && !defined(__WINRT__)
+    viewport->PlatformHandleRaw = (HWND)SDL_GetPointerProperty(SDL_GetWindowProperties(window), SDL_PROP_WINDOW_WIN32_HWND_POINTER, nullptr);
+#elif defined(__APPLE__) && defined(SDL_VIDEO_DRIVER_COCOA)
+    viewport->PlatformHandleRaw = SDL_GetPointerProperty(SDL_GetWindowProperties(window), SDL_PROP_WINDOW_COCOA_WINDOW_POINTER, nullptr);
+#endif
+}
+
+static bool ImGui_ImplSDL3_Init(SDL_Window* window, SDL_Renderer* renderer, void* sdl_gl_context)
+{
+    ImGuiIO& io = ImGui::GetIO();
+    IMGUI_CHECKVERSION();
+    IM_ASSERT(io.BackendPlatformUserData == nullptr && "Already initialized a platform backend!");
+    IM_UNUSED(sdl_gl_context); // Unused in this branch
+
+    // Check and store if we are on a SDL backend that supports global mouse position
+    // ("wayland" and "rpi" don't support it, but we chose to use a white-list instead of a black-list)
+    bool mouse_can_use_global_state = false;
+#if SDL_HAS_CAPTURE_AND_GLOBAL_MOUSE
+    const char* sdl_backend = SDL_GetCurrentVideoDriver();
+    const char* global_mouse_whitelist[] = { "windows", "cocoa", "x11", "DIVE", "VMAN" };
+    for (int n = 0; n < IM_ARRAYSIZE(global_mouse_whitelist); n++)
+        if (strncmp(sdl_backend, global_mouse_whitelist[n], strlen(global_mouse_whitelist[n])) == 0)
+            mouse_can_use_global_state = true;
+#endif
+
+    // Setup backend capabilities flags
+    ImGui_ImplSDL3_Data* bd = IM_NEW(ImGui_ImplSDL3_Data)();
+    io.BackendPlatformUserData = (void*)bd;
+    io.BackendPlatformName = "imgui_impl_sdl3";
+    io.BackendFlags |= ImGuiBackendFlags_HasMouseCursors;           // We can honor GetMouseCursor() values (optional)
+    io.BackendFlags |= ImGuiBackendFlags_HasSetMousePos;            // We can honor io.WantSetMousePos requests (optional, rarely used)
+
+    bd->Window = window;
+    bd->WindowID = SDL_GetWindowID(window);
+    bd->Renderer = renderer;
+    bd->MouseCanUseGlobalState = mouse_can_use_global_state;
+
+    ImGuiPlatformIO& platform_io = ImGui::GetPlatformIO();
+    platform_io.Platform_SetClipboardTextFn = ImGui_ImplSDL3_SetClipboardText;
+    platform_io.Platform_GetClipboardTextFn = ImGui_ImplSDL3_GetClipboardText;
+    platform_io.Platform_SetImeDataFn = ImGui_ImplSDL3_PlatformSetImeData;
+
+    // Gamepad handling
+    bd->GamepadMode = ImGui_ImplSDL3_GamepadMode_AutoFirst;
+    bd->WantUpdateGamepadsList = true;
+
+    // Load mouse cursors
+    bd->MouseCursors[ImGuiMouseCursor_Arrow] = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_DEFAULT);
+    bd->MouseCursors[ImGuiMouseCursor_TextInput] = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_TEXT);
+    bd->MouseCursors[ImGuiMouseCursor_ResizeAll] = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_MOVE);
+    bd->MouseCursors[ImGuiMouseCursor_ResizeNS] = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_NS_RESIZE);
+    bd->MouseCursors[ImGuiMouseCursor_ResizeEW] = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_EW_RESIZE);
+    bd->MouseCursors[ImGuiMouseCursor_ResizeNESW] = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_NESW_RESIZE);
+    bd->MouseCursors[ImGuiMouseCursor_ResizeNWSE] = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_NWSE_RESIZE);
+    bd->MouseCursors[ImGuiMouseCursor_Hand] = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_POINTER);
+    bd->MouseCursors[ImGuiMouseCursor_NotAllowed] = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_NOT_ALLOWED);
+
+    // Set platform dependent data in viewport
+    // Our mouse update function expect PlatformHandle to be filled for the main viewport
+    ImGuiViewport* main_viewport = ImGui::GetMainViewport();
+    ImGui_ImplSDL3_SetupPlatformHandles(main_viewport, window);
+
+    // From 2.0.5: Set SDL hint to receive mouse click events on window focus, otherwise SDL doesn't emit the event.
+    // Without this, when clicking to gain focus, our widgets wouldn't activate even though they showed as hovered.
+    // (This is unfortunately a global SDL setting, so enabling it might have a side-effect on your application.
+    // It is unlikely to make a difference, but if your app absolutely needs to ignore the initial on-focus click:
+    // you can ignore SDL_EVENT_MOUSE_BUTTON_DOWN events coming right after a SDL_WINDOWEVENT_FOCUS_GAINED)
+#ifdef SDL_HINT_MOUSE_FOCUS_CLICKTHROUGH
+    SDL_SetHint(SDL_HINT_MOUSE_FOCUS_CLICKTHROUGH, "1");
+#endif
+
+    // From 2.0.22: Disable auto-capture, this is preventing drag and drop across multiple windows (see #5710)
+#ifdef SDL_HINT_MOUSE_AUTO_CAPTURE
+    SDL_SetHint(SDL_HINT_MOUSE_AUTO_CAPTURE, "0");
+#endif
+
+    return true;
+}
+
+bool ImGui_ImplSDL3_InitForOpenGL(SDL_Window* window, void* sdl_gl_context)
+{
+    IM_UNUSED(sdl_gl_context); // Viewport branch will need this.
+    return ImGui_ImplSDL3_Init(window, nullptr, sdl_gl_context);
+}
+
+bool ImGui_ImplSDL3_InitForVulkan(SDL_Window* window)
+{
+    return ImGui_ImplSDL3_Init(window, nullptr, nullptr);
+}
+
+bool ImGui_ImplSDL3_InitForD3D(SDL_Window* window)
+{
+#if !defined(_WIN32)
+    IM_ASSERT(0 && "Unsupported");
+#endif
+    return ImGui_ImplSDL3_Init(window, nullptr, nullptr);
+}
+
+bool ImGui_ImplSDL3_InitForMetal(SDL_Window* window)
+{
+    return ImGui_ImplSDL3_Init(window, nullptr, nullptr);
+}
+
+bool ImGui_ImplSDL3_InitForSDLRenderer(SDL_Window* window, SDL_Renderer* renderer)
+{
+    return ImGui_ImplSDL3_Init(window, renderer, nullptr);
+}
+
+bool ImGui_ImplSDL3_InitForOther(SDL_Window* window)
+{
+    return ImGui_ImplSDL3_Init(window, nullptr, nullptr);
+}
+
+static void ImGui_ImplSDL3_CloseGamepads();
+
+void ImGui_ImplSDL3_Shutdown()
+{
+    ImGui_ImplSDL3_Data* bd = ImGui_ImplSDL3_GetBackendData();
+    IM_ASSERT(bd != nullptr && "No platform backend to shutdown, or already shutdown?");
+    ImGuiIO& io = ImGui::GetIO();
+
+    if (bd->ClipboardTextData)
+        SDL_free(bd->ClipboardTextData);
+    for (ImGuiMouseCursor cursor_n = 0; cursor_n < ImGuiMouseCursor_COUNT; cursor_n++)
+        SDL_DestroyCursor(bd->MouseCursors[cursor_n]);
+    ImGui_ImplSDL3_CloseGamepads();
+
+    io.BackendPlatformName = nullptr;
+    io.BackendPlatformUserData = nullptr;
+    io.BackendFlags &= ~(ImGuiBackendFlags_HasMouseCursors | ImGuiBackendFlags_HasSetMousePos | ImGuiBackendFlags_HasGamepad);
+    IM_DELETE(bd);
+}
+
+static void ImGui_ImplSDL3_UpdateMouseData()
+{
+    ImGui_ImplSDL3_Data* bd = ImGui_ImplSDL3_GetBackendData();
+    ImGuiIO& io = ImGui::GetIO();
+
+    // We forward mouse input when hovered or captured (via SDL_EVENT_MOUSE_MOTION) or when focused (below)
+#if SDL_HAS_CAPTURE_AND_GLOBAL_MOUSE
+    // SDL_CaptureMouse() let the OS know e.g. that our imgui drag outside the SDL window boundaries shouldn't e.g. trigger other operations outside
+    SDL_CaptureMouse(bd->MouseButtonsDown != 0);
+    SDL_Window* focused_window = SDL_GetKeyboardFocus();
+    const bool is_app_focused = (bd->Window == focused_window);
+#else
+    SDL_Window* focused_window = bd->Window;
+    const bool is_app_focused = (SDL_GetWindowFlags(bd->Window) & SDL_WINDOW_INPUT_FOCUS) != 0; // SDL 2.0.3 and non-windowed systems: single-viewport only
+#endif
+    if (is_app_focused)
+    {
+        // (Optional) Set OS mouse position from Dear ImGui if requested (rarely used, only when io.ConfigNavMoveSetMousePos is enabled by user)
+        if (io.WantSetMousePos)
+            SDL_WarpMouseInWindow(bd->Window, io.MousePos.x, io.MousePos.y);
+
+        // (Optional) Fallback to provide mouse position when focused (SDL_EVENT_MOUSE_MOTION already provides this when hovered or captured)
+        if (bd->MouseCanUseGlobalState && bd->MouseButtonsDown == 0)
+        {
+            // Single-viewport mode: mouse position in client window coordinates (io.MousePos is (0,0) when the mouse is on the upper-left corner of the app window)
+            float mouse_x_global, mouse_y_global;
+            int window_x, window_y;
+            SDL_GetGlobalMouseState(&mouse_x_global, &mouse_y_global);
+            SDL_GetWindowPosition(focused_window, &window_x, &window_y);
+            io.AddMousePosEvent(mouse_x_global - window_x, mouse_y_global - window_y);
+        }
+    }
+}
+
+static void ImGui_ImplSDL3_UpdateMouseCursor()
+{
+    ImGuiIO& io = ImGui::GetIO();
+    if (io.ConfigFlags & ImGuiConfigFlags_NoMouseCursorChange)
+        return;
+    ImGui_ImplSDL3_Data* bd = ImGui_ImplSDL3_GetBackendData();
+
+    ImGuiMouseCursor imgui_cursor = ImGui::GetMouseCursor();
+    if (io.MouseDrawCursor || imgui_cursor == ImGuiMouseCursor_None)
+    {
+        // Hide OS mouse cursor if imgui is drawing it or if it wants no cursor
+        SDL_HideCursor();
+    }
+    else
+    {
+        // Show OS mouse cursor
+        SDL_Cursor* expected_cursor = bd->MouseCursors[imgui_cursor] ? bd->MouseCursors[imgui_cursor] : bd->MouseCursors[ImGuiMouseCursor_Arrow];
+        if (bd->MouseLastCursor != expected_cursor)
+        {
+            SDL_SetCursor(expected_cursor); // SDL function doesn't have an early out (see #6113)
+            bd->MouseLastCursor = expected_cursor;
+        }
+        SDL_ShowCursor();
+    }
+}
+
+static void ImGui_ImplSDL3_CloseGamepads()
+{
+    ImGui_ImplSDL3_Data* bd = ImGui_ImplSDL3_GetBackendData();
+    if (bd->GamepadMode != ImGui_ImplSDL3_GamepadMode_Manual)
+        for (SDL_Gamepad* gamepad : bd->Gamepads)
+            SDL_CloseGamepad(gamepad);
+    bd->Gamepads.resize(0);
+}
+
+void ImGui_ImplSDL3_SetGamepadMode(ImGui_ImplSDL3_GamepadMode mode, SDL_Gamepad** manual_gamepads_array, int manual_gamepads_count)
+{
+    ImGui_ImplSDL3_Data* bd = ImGui_ImplSDL3_GetBackendData();
+    ImGui_ImplSDL3_CloseGamepads();
+    if (mode == ImGui_ImplSDL3_GamepadMode_Manual)
+    {
+        IM_ASSERT(manual_gamepads_array != nullptr && manual_gamepads_count > 0);
+        for (int n = 0; n < manual_gamepads_count; n++)
+            bd->Gamepads.push_back(manual_gamepads_array[n]);
+    }
+    else
+    {
+        IM_ASSERT(manual_gamepads_array == nullptr && manual_gamepads_count <= 0);
+        bd->WantUpdateGamepadsList = true;
+    }
+    bd->GamepadMode = mode;
+}
+
+static void ImGui_ImplSDL3_UpdateGamepadButton(ImGui_ImplSDL3_Data* bd, ImGuiIO& io, ImGuiKey key, SDL_GamepadButton button_no)
+{
+    bool merged_value = false;
+    for (SDL_Gamepad* gamepad : bd->Gamepads)
+        merged_value |= SDL_GetGamepadButton(gamepad, button_no) != 0;
+    io.AddKeyEvent(key, merged_value);
+}
+
+static inline float Saturate(float v) { return v < 0.0f ? 0.0f : v  > 1.0f ? 1.0f : v; }
+static void ImGui_ImplSDL3_UpdateGamepadAnalog(ImGui_ImplSDL3_Data* bd, ImGuiIO& io, ImGuiKey key, SDL_GamepadAxis axis_no, float v0, float v1)
+{
+    float merged_value = 0.0f;
+    for (SDL_Gamepad* gamepad : bd->Gamepads)
+    {
+        float vn = Saturate((float)(SDL_GetGamepadAxis(gamepad, axis_no) - v0) / (float)(v1 - v0));
+        if (merged_value < vn)
+            merged_value = vn;
+    }
+    io.AddKeyAnalogEvent(key, merged_value > 0.1f, merged_value);
+}
+
+static void ImGui_ImplSDL3_UpdateGamepads()
+{
+    ImGuiIO& io = ImGui::GetIO();
+    ImGui_ImplSDL3_Data* bd = ImGui_ImplSDL3_GetBackendData();
+
+    // Update list of gamepads to use
+    if (bd->WantUpdateGamepadsList && bd->GamepadMode != ImGui_ImplSDL3_GamepadMode_Manual)
+    {
+        ImGui_ImplSDL3_CloseGamepads();
+        int sdl_gamepads_count = 0;
+        SDL_JoystickID* sdl_gamepads = SDL_GetGamepads(&sdl_gamepads_count);
+        for (int n = 0; n < sdl_gamepads_count; n++)
+            if (SDL_Gamepad* gamepad = SDL_OpenGamepad(sdl_gamepads[n]))
+            {
+                bd->Gamepads.push_back(gamepad);
+                if (bd->GamepadMode == ImGui_ImplSDL3_GamepadMode_AutoFirst)
+                    break;
+            }
+        bd->WantUpdateGamepadsList = false;
+        SDL_free(sdl_gamepads);
+    }
+
+    // FIXME: Technically feeding gamepad shouldn't depend on this now that they are regular inputs.
+    if ((io.ConfigFlags & ImGuiConfigFlags_NavEnableGamepad) == 0)
+        return;
+    io.BackendFlags &= ~ImGuiBackendFlags_HasGamepad;
+    if (bd->Gamepads.Size == 0)
+        return;
+    io.BackendFlags |= ImGuiBackendFlags_HasGamepad;
+
+    // Update gamepad inputs
+    const int thumb_dead_zone = 8000;           // SDL_gamepad.h suggests using this value.
+    ImGui_ImplSDL3_UpdateGamepadButton(bd, io, ImGuiKey_GamepadStart,       SDL_GAMEPAD_BUTTON_START);
+    ImGui_ImplSDL3_UpdateGamepadButton(bd, io, ImGuiKey_GamepadBack,        SDL_GAMEPAD_BUTTON_BACK);
+    ImGui_ImplSDL3_UpdateGamepadButton(bd, io, ImGuiKey_GamepadFaceLeft,    SDL_GAMEPAD_BUTTON_WEST);           // Xbox X, PS Square
+    ImGui_ImplSDL3_UpdateGamepadButton(bd, io, ImGuiKey_GamepadFaceRight,   SDL_GAMEPAD_BUTTON_EAST);           // Xbox B, PS Circle
+    ImGui_ImplSDL3_UpdateGamepadButton(bd, io, ImGuiKey_GamepadFaceUp,      SDL_GAMEPAD_BUTTON_NORTH);          // Xbox Y, PS Triangle
+    ImGui_ImplSDL3_UpdateGamepadButton(bd, io, ImGuiKey_GamepadFaceDown,    SDL_GAMEPAD_BUTTON_SOUTH);          // Xbox A, PS Cross
+    ImGui_ImplSDL3_UpdateGamepadButton(bd, io, ImGuiKey_GamepadDpadLeft,    SDL_GAMEPAD_BUTTON_DPAD_LEFT);
+    ImGui_ImplSDL3_UpdateGamepadButton(bd, io, ImGuiKey_GamepadDpadRight,   SDL_GAMEPAD_BUTTON_DPAD_RIGHT);
+    ImGui_ImplSDL3_UpdateGamepadButton(bd, io, ImGuiKey_GamepadDpadUp,      SDL_GAMEPAD_BUTTON_DPAD_UP);
+    ImGui_ImplSDL3_UpdateGamepadButton(bd, io, ImGuiKey_GamepadDpadDown,    SDL_GAMEPAD_BUTTON_DPAD_DOWN);
+    ImGui_ImplSDL3_UpdateGamepadButton(bd, io, ImGuiKey_GamepadL1,          SDL_GAMEPAD_BUTTON_LEFT_SHOULDER);
+    ImGui_ImplSDL3_UpdateGamepadButton(bd, io, ImGuiKey_GamepadR1,          SDL_GAMEPAD_BUTTON_RIGHT_SHOULDER);
+    ImGui_ImplSDL3_UpdateGamepadAnalog(bd, io, ImGuiKey_GamepadL2,          SDL_GAMEPAD_AXIS_LEFT_TRIGGER,  0.0f, 32767);
+    ImGui_ImplSDL3_UpdateGamepadAnalog(bd, io, ImGuiKey_GamepadR2,          SDL_GAMEPAD_AXIS_RIGHT_TRIGGER, 0.0f, 32767);
+    ImGui_ImplSDL3_UpdateGamepadButton(bd, io, ImGuiKey_GamepadL3,          SDL_GAMEPAD_BUTTON_LEFT_STICK);
+    ImGui_ImplSDL3_UpdateGamepadButton(bd, io, ImGuiKey_GamepadR3,          SDL_GAMEPAD_BUTTON_RIGHT_STICK);
+    ImGui_ImplSDL3_UpdateGamepadAnalog(bd, io, ImGuiKey_GamepadLStickLeft,  SDL_GAMEPAD_AXIS_LEFTX,  -thumb_dead_zone, -32768);
+    ImGui_ImplSDL3_UpdateGamepadAnalog(bd, io, ImGuiKey_GamepadLStickRight, SDL_GAMEPAD_AXIS_LEFTX,  +thumb_dead_zone, +32767);
+    ImGui_ImplSDL3_UpdateGamepadAnalog(bd, io, ImGuiKey_GamepadLStickUp,    SDL_GAMEPAD_AXIS_LEFTY,  -thumb_dead_zone, -32768);
+    ImGui_ImplSDL3_UpdateGamepadAnalog(bd, io, ImGuiKey_GamepadLStickDown,  SDL_GAMEPAD_AXIS_LEFTY,  +thumb_dead_zone, +32767);
+    ImGui_ImplSDL3_UpdateGamepadAnalog(bd, io, ImGuiKey_GamepadRStickLeft,  SDL_GAMEPAD_AXIS_RIGHTX, -thumb_dead_zone, -32768);
+    ImGui_ImplSDL3_UpdateGamepadAnalog(bd, io, ImGuiKey_GamepadRStickRight, SDL_GAMEPAD_AXIS_RIGHTX, +thumb_dead_zone, +32767);
+    ImGui_ImplSDL3_UpdateGamepadAnalog(bd, io, ImGuiKey_GamepadRStickUp,    SDL_GAMEPAD_AXIS_RIGHTY, -thumb_dead_zone, -32768);
+    ImGui_ImplSDL3_UpdateGamepadAnalog(bd, io, ImGuiKey_GamepadRStickDown,  SDL_GAMEPAD_AXIS_RIGHTY, +thumb_dead_zone, +32767);
+}
+
+void ImGui_ImplSDL3_NewFrame()
+{
+    ImGui_ImplSDL3_Data* bd = ImGui_ImplSDL3_GetBackendData();
+    IM_ASSERT(bd != nullptr && "Context or backend not initialized! Did you call ImGui_ImplSDL3_Init()?");
+    ImGuiIO& io = ImGui::GetIO();
+
+    // Setup display size (every frame to accommodate for window resizing)
+    int w, h;
+    int display_w, display_h;
+    SDL_GetWindowSize(bd->Window, &w, &h);
+    if (SDL_GetWindowFlags(bd->Window) & SDL_WINDOW_MINIMIZED)
+        w = h = 0;
+    SDL_GetWindowSizeInPixels(bd->Window, &display_w, &display_h);
+    io.DisplaySize = ImVec2((float)w, (float)h);
+    if (w > 0 && h > 0)
+        io.DisplayFramebufferScale = ImVec2((float)display_w / w, (float)display_h / h);
+
+    // Setup time step (we don't use SDL_GetTicks() because it is using millisecond resolution)
+    // (Accept SDL_GetPerformanceCounter() not returning a monotonically increasing value. Happens in VMs and Emscripten, see #6189, #6114, #3644)
+    static Uint64 frequency = SDL_GetPerformanceFrequency();
+    Uint64 current_time = SDL_GetPerformanceCounter();
+    if (current_time <= bd->Time)
+        current_time = bd->Time + 1;
+    io.DeltaTime = bd->Time > 0 ? (float)((double)(current_time - bd->Time) / frequency) : (float)(1.0f / 60.0f);
+    bd->Time = current_time;
+
+    if (bd->MousePendingLeaveFrame && bd->MousePendingLeaveFrame >= ImGui::GetFrameCount() && bd->MouseButtonsDown == 0)
+    {
+        bd->MouseWindowID = 0;
+        bd->MousePendingLeaveFrame = 0;
+        io.AddMousePosEvent(-FLT_MAX, -FLT_MAX);
+    }
+
+    ImGui_ImplSDL3_UpdateMouseData();
+    ImGui_ImplSDL3_UpdateMouseCursor();
+
+    // Update game controllers (if enabled and available)
+    ImGui_ImplSDL3_UpdateGamepads();
+}
+
+//-----------------------------------------------------------------------------
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+
+#endif // #ifndef IMGUI_DISABLE

--- a/src/third-party/imgui/imgui_impl_sdl3.h
+++ b/src/third-party/imgui/imgui_impl_sdl3.h
@@ -1,0 +1,47 @@
+// dear imgui: Platform Backend for SDL3 (*EXPERIMENTAL*)
+// This needs to be used along with a Renderer (e.g. DirectX11, OpenGL3, Vulkan..)
+// (Info: SDL3 is a cross-platform general purpose library for handling windows, inputs, graphics context creation, etc.)
+
+// (**IMPORTANT: SDL 3.0.0 is NOT YET RELEASED AND CURRENTLY HAS A FAST CHANGING API. THIS CODE BREAKS OFTEN AS SDL3 CHANGES.**)
+
+// Implemented features:
+//  [X] Platform: Clipboard support.
+//  [X] Platform: Mouse support. Can discriminate Mouse/TouchScreen.
+//  [X] Platform: Keyboard support. Since 1.87 we are using the io.AddKeyEvent() function. Pass ImGuiKey values to all key functions e.g. ImGui::IsKeyPressed(ImGuiKey_Space). [Legacy SDL_SCANCODE_* values are obsolete since 1.87 and not supported since 1.91.5]
+//  [X] Platform: Gamepad support. Enabled with 'io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad'.
+//  [X] Platform: Mouse cursor shape and visibility. Disable with 'io.ConfigFlags |= ImGuiConfigFlags_NoMouseCursorChange'.
+
+// You can use unmodified imgui_impl_* files in your project. See examples/ folder for examples of using this.
+// Prefer including the entire imgui/ repository into your project (either as a copy or as a submodule), and only build the backends you need.
+// Learn about Dear ImGui:
+// - FAQ                  https://dearimgui.com/faq
+// - Getting Started      https://dearimgui.com/getting-started
+// - Documentation        https://dearimgui.com/docs (same as your local docs/ folder).
+// - Introduction, links and more at the top of imgui.cpp
+
+#pragma once
+#include "imgui.h"      // IMGUI_IMPL_API
+#ifndef IMGUI_DISABLE
+
+struct SDL_Window;
+struct SDL_Renderer;
+struct SDL_Gamepad;
+typedef union SDL_Event SDL_Event;
+
+// Follow "Getting Started" link and check examples/ folder to learn about using backends!
+IMGUI_IMPL_API bool     ImGui_ImplSDL3_InitForOpenGL(SDL_Window* window, void* sdl_gl_context);
+IMGUI_IMPL_API bool     ImGui_ImplSDL3_InitForVulkan(SDL_Window* window);
+IMGUI_IMPL_API bool     ImGui_ImplSDL3_InitForD3D(SDL_Window* window);
+IMGUI_IMPL_API bool     ImGui_ImplSDL3_InitForMetal(SDL_Window* window);
+IMGUI_IMPL_API bool     ImGui_ImplSDL3_InitForSDLRenderer(SDL_Window* window, SDL_Renderer* renderer);
+IMGUI_IMPL_API bool     ImGui_ImplSDL3_InitForOther(SDL_Window* window);
+IMGUI_IMPL_API void     ImGui_ImplSDL3_Shutdown();
+IMGUI_IMPL_API void     ImGui_ImplSDL3_NewFrame();
+IMGUI_IMPL_API bool     ImGui_ImplSDL3_ProcessEvent(const SDL_Event* event);
+
+// Gamepad selection automatically starts in AutoFirst mode, picking first available SDL_Gamepad. You may override this.
+// When using manual mode, caller is responsible for opening/closing gamepad.
+enum ImGui_ImplSDL3_GamepadMode { ImGui_ImplSDL3_GamepadMode_AutoFirst, ImGui_ImplSDL3_GamepadMode_AutoAll, ImGui_ImplSDL3_GamepadMode_Manual };
+IMGUI_IMPL_API void     ImGui_ImplSDL3_SetGamepadMode(ImGui_ImplSDL3_GamepadMode mode, SDL_Gamepad** manual_gamepads_array = NULL, int manual_gamepads_count = -1);
+
+#endif // #ifndef IMGUI_DISABLE

--- a/src/third-party/imgui/imgui_impl_sdlrenderer3.cpp
+++ b/src/third-party/imgui/imgui_impl_sdlrenderer3.cpp
@@ -1,0 +1,310 @@
+// dear imgui: Renderer Backend for SDL_Renderer for SDL3
+// (Requires: SDL 3.0.0+)
+
+// (**IMPORTANT: SDL 3.0.0 is NOT YET RELEASED AND CURRENTLY HAS A FAST CHANGING API. THIS CODE BREAKS OFTEN AS SDL3 CHANGES.**)
+
+// Note how SDL_Renderer is an _optional_ component of SDL3.
+// For a multi-platform app consider using e.g. SDL+DirectX on Windows and SDL+OpenGL on Linux/OSX.
+// If your application will want to render any non trivial amount of graphics other than UI,
+// please be aware that SDL_Renderer currently offers a limited graphic API to the end-user and
+// it might be difficult to step out of those boundaries.
+
+// Implemented features:
+//  [X] Renderer: User texture binding. Use 'SDL_Texture*' as ImTextureID. Read the FAQ about ImTextureID!
+//  [X] Renderer: Large meshes support (64k+ vertices) with 16-bit indices.
+//  [X] Renderer: Expose selected render state for draw callbacks to use. Access in '(ImGui_ImplXXXX_RenderState*)GetPlatformIO().Renderer_RenderState'.
+
+// You can copy and use unmodified imgui_impl_* files in your project. See examples/ folder for examples of using this.
+// Prefer including the entire imgui/ repository into your project (either as a copy or as a submodule), and only build the backends you need.
+// Learn about Dear ImGui:
+// - FAQ                  https://dearimgui.com/faq
+// - Getting Started      https://dearimgui.com/getting-started
+// - Documentation        https://dearimgui.com/docs (same as your local docs/ folder).
+// - Introduction, links and more at the top of imgui.cpp
+
+// CHANGELOG
+//  2024-10-09: Expose selected render state in ImGui_ImplSDLRenderer3_RenderState, which you can access in 'void* platform_io.Renderer_RenderState' during draw callbacks.
+//  2024-07-01: Update for SDL3 api changes: SDL_RenderGeometryRaw() uint32 version was removed (SDL#9009).
+//  2024-05-14: *BREAKING CHANGE* ImGui_ImplSDLRenderer3_RenderDrawData() requires SDL_Renderer* passed as parameter.
+//  2024-02-12: Amend to query SDL_RenderViewportSet() and restore viewport accordingly.
+//  2023-05-30: Initial version.
+
+#include "imgui.h"
+#ifndef IMGUI_DISABLE
+#include "imgui_impl_sdlrenderer3.h"
+#include <functional>
+#include <stdint.h>     // intptr_t
+
+// Clang warnings with -Weverything
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wsign-conversion"    // warning: implicit conversion changes signedness
+#endif
+
+// SDL
+#include <SDL3/SDL.h>
+#if !SDL_VERSION_ATLEAST(3,0,0)
+#error This backend requires SDL 3.0.0+
+#endif
+
+// SDL_Renderer data
+struct ImGui_ImplSDLRenderer3_Data
+{
+    SDL_Renderer*           Renderer;       // Main viewport's renderer
+    SDL_Texture*            FontTexture;
+    ImVector<SDL_FColor>    ColorBuffer;
+
+    ImGui_ImplSDLRenderer3_Data()   { memset((void*)this, 0, sizeof(*this)); }
+};
+
+// Backend data stored in io.BackendRendererUserData to allow support for multiple Dear ImGui contexts
+// It is STRONGLY preferred that you use docking branch with multi-viewports (== single Dear ImGui context + multiple windows) instead of multiple Dear ImGui contexts.
+static ImGui_ImplSDLRenderer3_Data* ImGui_ImplSDLRenderer3_GetBackendData()
+{
+    return ImGui::GetCurrentContext() ? (ImGui_ImplSDLRenderer3_Data*)ImGui::GetIO().BackendRendererUserData : nullptr;
+}
+
+// Functions
+bool ImGui_ImplSDLRenderer3_Init(SDL_Renderer* renderer)
+{
+    ImGuiIO& io = ImGui::GetIO();
+    IMGUI_CHECKVERSION();
+    IM_ASSERT(io.BackendRendererUserData == nullptr && "Already initialized a renderer backend!");
+    IM_ASSERT(renderer != nullptr && "SDL_Renderer not initialized!");
+
+    // Setup backend capabilities flags
+    ImGui_ImplSDLRenderer3_Data* bd = IM_NEW(ImGui_ImplSDLRenderer3_Data)();
+    io.BackendRendererUserData = (void*)bd;
+    io.BackendRendererName = "imgui_impl_sdlrenderer3";
+    io.BackendFlags |= ImGuiBackendFlags_RendererHasVtxOffset;  // We can honor the ImDrawCmd::VtxOffset field, allowing for large meshes.
+
+    bd->Renderer = renderer;
+
+    return true;
+}
+
+void ImGui_ImplSDLRenderer3_Shutdown()
+{
+    ImGui_ImplSDLRenderer3_Data* bd = ImGui_ImplSDLRenderer3_GetBackendData();
+    IM_ASSERT(bd != nullptr && "No renderer backend to shutdown, or already shutdown?");
+    ImGuiIO& io = ImGui::GetIO();
+
+    ImGui_ImplSDLRenderer3_DestroyDeviceObjects();
+
+    io.BackendRendererName = nullptr;
+    io.BackendRendererUserData = nullptr;
+    io.BackendFlags &= ~ImGuiBackendFlags_RendererHasVtxOffset;
+    IM_DELETE(bd);
+}
+
+static void ImGui_ImplSDLRenderer3_SetupRenderState(SDL_Renderer* renderer)
+{
+	// Clear out any viewports and cliprect set by the user
+    // FIXME: Technically speaking there are lots of other things we could backup/setup/restore during our render process.
+	SDL_SetRenderViewport(renderer, nullptr);
+	SDL_SetRenderClipRect(renderer, nullptr);
+}
+
+void ImGui_ImplSDLRenderer3_NewFrame()
+{
+    ImGui_ImplSDLRenderer3_Data* bd = ImGui_ImplSDLRenderer3_GetBackendData();
+    IM_ASSERT(bd != nullptr && "Context or backend not initialized! Did you call ImGui_ImplSDLRenderer3_Init()?");
+
+    if (!bd->FontTexture)
+        ImGui_ImplSDLRenderer3_CreateDeviceObjects();
+}
+
+std::function<void(const ImFontGlyphToDraw &)> drawFallbackGlyphCallback;
+
+void ImGui_ImplSDLRenderer3_SetFallbackGlyphDrawCallback(std::function<void(const ImFontGlyphToDraw &)> func)
+{
+    drawFallbackGlyphCallback = func;
+}
+
+// https://github.com/libsdl-org/SDL/issues/9009
+static int SDL_RenderGeometryRaw8BitColor(SDL_Renderer* renderer, ImVector<SDL_FColor>& colors_out, SDL_Texture* texture, const float* xy, int xy_stride, const SDL_Color* color, int color_stride, const float* uv, int uv_stride, int num_vertices, const void* indices, int num_indices, int size_indices)
+{
+    const Uint8* color2 = (const Uint8*)color;
+    colors_out.resize(num_vertices);
+    SDL_FColor* color3 = colors_out.Data;
+    for (int i = 0; i < num_vertices; i++)
+    {
+        color3[i].r = color->r / 255.0f;
+        color3[i].g = color->g / 255.0f;
+        color3[i].b = color->b / 255.0f;
+        color3[i].a = color->a / 255.0f;
+        color2 += color_stride;
+        color = (const SDL_Color*)color2;
+    }
+    return SDL_RenderGeometryRaw(renderer, texture, xy, xy_stride, color3, sizeof(*color3), uv, uv_stride, num_vertices, indices, num_indices, size_indices);
+}
+
+void ImGui_ImplSDLRenderer3_RenderDrawData(ImDrawData* draw_data, SDL_Renderer* renderer)
+{
+    ImGui_ImplSDLRenderer3_Data* bd = ImGui_ImplSDLRenderer3_GetBackendData();
+
+	// If there's a scale factor set by the user, use that instead
+    // If the user has specified a scale factor to SDL_Renderer already via SDL_RenderSetScale(), SDL will scale whatever we pass
+    // to SDL_RenderGeometryRaw() by that scale factor. In that case we don't want to be also scaling it ourselves here.
+    float rsx = 1.0f;
+	float rsy = 1.0f;
+	SDL_GetRenderScale(renderer, &rsx, &rsy);
+    ImVec2 render_scale;
+	render_scale.x = (rsx == 1.0f) ? draw_data->FramebufferScale.x : 1.0f;
+	render_scale.y = (rsy == 1.0f) ? draw_data->FramebufferScale.y : 1.0f;
+
+	// Avoid rendering when minimized, scale coordinates for retina displays (screen coordinates != framebuffer coordinates)
+	int fb_width = (int)(draw_data->DisplaySize.x * render_scale.x);
+	int fb_height = (int)(draw_data->DisplaySize.y * render_scale.y);
+	if (fb_width == 0 || fb_height == 0)
+		return;
+
+    // Backup SDL_Renderer state that will be modified to restore it afterwards
+    struct BackupSDLRendererState
+    {
+        SDL_Rect    Viewport;
+        bool        ViewportEnabled;
+        bool        ClipEnabled;
+        SDL_Rect    ClipRect;
+    };
+    BackupSDLRendererState old = {};
+    old.ViewportEnabled = SDL_RenderViewportSet(renderer);
+    old.ClipEnabled = SDL_RenderClipEnabled(renderer);
+    SDL_GetRenderViewport(renderer, &old.Viewport);
+    SDL_GetRenderClipRect(renderer, &old.ClipRect);
+
+    // Setup desired state
+    ImGui_ImplSDLRenderer3_SetupRenderState(renderer);
+
+    // Setup render state structure (for callbacks and custom texture bindings)
+    ImGuiPlatformIO& platform_io = ImGui::GetPlatformIO();
+    ImGui_ImplSDLRenderer3_RenderState render_state;
+    render_state.Renderer = renderer;
+    platform_io.Renderer_RenderState = &render_state;
+
+	// Will project scissor/clipping rectangles into framebuffer space
+	ImVec2 clip_off = draw_data->DisplayPos;         // (0,0) unless using multi-viewports
+	ImVec2 clip_scale = render_scale;
+
+    // Render command lists
+    for (int n = 0; n < draw_data->CmdListsCount; n++)
+    {
+        const ImDrawList* draw_list = draw_data->CmdLists[n];
+        const ImDrawVert* vtx_buffer = draw_list->VtxBuffer.Data;
+        const ImDrawIdx* idx_buffer = draw_list->IdxBuffer.Data;
+
+        for (int cmd_i = 0; cmd_i < draw_list->CmdBuffer.Size; cmd_i++)
+        {
+            const ImDrawCmd* pcmd = &draw_list->CmdBuffer[cmd_i];
+            if (pcmd->UserCallback)
+            {
+                // User callback, registered via ImDrawList::AddCallback()
+                // (ImDrawCallback_ResetRenderState is a special callback value used by the user to request the renderer to reset render state.)
+                if (pcmd->UserCallback == ImDrawCallback_ResetRenderState)
+                    ImGui_ImplSDLRenderer3_SetupRenderState(renderer);
+                else
+                    pcmd->UserCallback(draw_list, pcmd);
+            }
+            else
+            {
+                // Project scissor/clipping rectangles into framebuffer space
+                ImVec2 clip_min((pcmd->ClipRect.x - clip_off.x) * clip_scale.x, (pcmd->ClipRect.y - clip_off.y) * clip_scale.y);
+                ImVec2 clip_max((pcmd->ClipRect.z - clip_off.x) * clip_scale.x, (pcmd->ClipRect.w - clip_off.y) * clip_scale.y);
+                if (clip_min.x < 0.0f) { clip_min.x = 0.0f; }
+                if (clip_min.y < 0.0f) { clip_min.y = 0.0f; }
+                if (clip_max.x > (float)fb_width) { clip_max.x = (float)fb_width; }
+                if (clip_max.y > (float)fb_height) { clip_max.y = (float)fb_height; }
+                if (clip_max.x <= clip_min.x || clip_max.y <= clip_min.y)
+                    continue;
+
+                SDL_Rect r = { (int)(clip_min.x), (int)(clip_min.y), (int)(clip_max.x - clip_min.x), (int)(clip_max.y - clip_min.y) };
+                SDL_SetRenderClipRect(renderer, &r);
+
+                const float* xy = (const float*)(const void*)((const char*)(vtx_buffer + pcmd->VtxOffset) + offsetof(ImDrawVert, pos));
+                const float* uv = (const float*)(const void*)((const char*)(vtx_buffer + pcmd->VtxOffset) + offsetof(ImDrawVert, uv));
+                const SDL_Color* color = (const SDL_Color*)(const void*)((const char*)(vtx_buffer + pcmd->VtxOffset) + offsetof(ImDrawVert, col)); // SDL 2.0.19+
+
+                // Bind texture, Draw
+				SDL_Texture* tex = (SDL_Texture*)pcmd->GetTexID();
+                SDL_RenderGeometryRaw8BitColor(renderer, bd->ColorBuffer, tex,
+                    xy, (int)sizeof(ImDrawVert),
+                    color, (int)sizeof(ImDrawVert),
+                    uv, (int)sizeof(ImDrawVert),
+                    draw_list->VtxBuffer.Size - pcmd->VtxOffset,
+                    idx_buffer + pcmd->IdxOffset, pcmd->ElemCount, sizeof(ImDrawIdx));
+            }
+
+            if(drawFallbackGlyphCallback)
+            {
+                for(const ImFontGlyphToDraw &glyphToDraw : draw_list->FallbackGlyphs)
+                {
+                    drawFallbackGlyphCallback(glyphToDraw);
+                }
+            }
+        }
+    }
+    platform_io.Renderer_RenderState = NULL;
+
+    // Restore modified SDL_Renderer state
+    SDL_SetRenderViewport(renderer, old.ViewportEnabled ? &old.Viewport : nullptr);
+    SDL_SetRenderClipRect(renderer, old.ClipEnabled ? &old.ClipRect : nullptr);
+}
+
+// Called by Init/NewFrame/Shutdown
+bool ImGui_ImplSDLRenderer3_CreateFontsTexture()
+{
+    ImGuiIO& io = ImGui::GetIO();
+    ImGui_ImplSDLRenderer3_Data* bd = ImGui_ImplSDLRenderer3_GetBackendData();
+
+    // Build texture atlas
+    unsigned char* pixels;
+    int width, height;
+    io.Fonts->GetTexDataAsRGBA32(&pixels, &width, &height);   // Load as RGBA 32-bit (75% of the memory is wasted, but default font is so small) because it is more likely to be compatible with user's existing shaders. If your ImTextureId represent a higher-level concept than just a GL texture id, consider calling GetTexDataAsAlpha8() instead to save on GPU memory.
+
+    // Upload texture to graphics system
+    // (Bilinear sampling is required by default. Set 'io.Fonts->Flags |= ImFontAtlasFlags_NoBakedLines' or 'style.AntiAliasedLinesUseTex = false' to allow point/nearest sampling)
+    bd->FontTexture = SDL_CreateTexture(bd->Renderer, SDL_PIXELFORMAT_ABGR8888, SDL_TEXTUREACCESS_STATIC, width, height);
+    if (bd->FontTexture == nullptr)
+    {
+        SDL_Log("error creating texture");
+        return false;
+    }
+    SDL_UpdateTexture(bd->FontTexture, nullptr, pixels, 4 * width);
+    SDL_SetTextureBlendMode(bd->FontTexture, SDL_BLENDMODE_BLEND);
+    SDL_SetTextureScaleMode(bd->FontTexture, SDL_SCALEMODE_LINEAR);
+
+    // Store our identifier
+    io.Fonts->SetTexID((ImTextureID)(intptr_t)bd->FontTexture);
+
+    return true;
+}
+
+void ImGui_ImplSDLRenderer3_DestroyFontsTexture()
+{
+    ImGuiIO& io = ImGui::GetIO();
+    ImGui_ImplSDLRenderer3_Data* bd = ImGui_ImplSDLRenderer3_GetBackendData();
+    if (bd->FontTexture)
+    {
+        io.Fonts->SetTexID(0);
+        SDL_DestroyTexture(bd->FontTexture);
+        bd->FontTexture = nullptr;
+    }
+}
+
+bool ImGui_ImplSDLRenderer3_CreateDeviceObjects()
+{
+    return ImGui_ImplSDLRenderer3_CreateFontsTexture();
+}
+
+void ImGui_ImplSDLRenderer3_DestroyDeviceObjects()
+{
+    ImGui_ImplSDLRenderer3_DestroyFontsTexture();
+}
+
+//-----------------------------------------------------------------------------
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+
+#endif // #ifndef IMGUI_DISABLE

--- a/src/third-party/imgui/imgui_impl_sdlrenderer3.h
+++ b/src/third-party/imgui/imgui_impl_sdlrenderer3.h
@@ -1,0 +1,56 @@
+// dear imgui: Renderer Backend for SDL_Renderer for SDL3
+// (Requires: SDL 3.0.0+)
+
+// (**IMPORTANT: SDL 3.0.0 is NOT YET RELEASED AND CURRENTLY HAS A FAST CHANGING API. THIS CODE BREAKS OFTEN AS SDL3 CHANGES.**)
+
+// Note how SDL_Renderer is an _optional_ component of SDL3.
+// For a multi-platform app consider using e.g. SDL+DirectX on Windows and SDL+OpenGL on Linux/OSX.
+// If your application will want to render any non trivial amount of graphics other than UI,
+// please be aware that SDL_Renderer currently offers a limited graphic API to the end-user and
+// it might be difficult to step out of those boundaries.
+
+// Implemented features:
+//  [X] Renderer: User texture binding. Use 'SDL_Texture*' as ImTextureID. Read the FAQ about ImTextureID!
+//  [X] Renderer: Large meshes support (64k+ vertices) with 16-bit indices.
+//  [X] Renderer: Expose selected render state for draw callbacks to use. Access in '(ImGui_ImplXXXX_RenderState*)GetPlatformIO().Renderer_RenderState'.
+
+// You can copy and use unmodified imgui_impl_* files in your project. See examples/ folder for examples of using this.
+// Prefer including the entire imgui/ repository into your project (either as a copy or as a submodule), and only build the backends you need.
+// Learn about Dear ImGui:
+// - FAQ                  https://dearimgui.com/faq
+// - Getting Started      https://dearimgui.com/getting-started
+// - Documentation        https://dearimgui.com/docs (same as your local docs/ folder).
+// - Introduction, links and more at the top of imgui.cpp
+
+#pragma once
+#include "imgui.h"      // IMGUI_IMPL_API
+#ifndef IMGUI_DISABLE
+#include <functional>
+
+struct SDL_Renderer;
+
+// Follow "Getting Started" link and check examples/ folder to learn about using backends!
+IMGUI_IMPL_API bool     ImGui_ImplSDLRenderer3_Init(SDL_Renderer* renderer);
+IMGUI_IMPL_API void     ImGui_ImplSDLRenderer3_Shutdown();
+IMGUI_IMPL_API void     ImGui_ImplSDLRenderer3_NewFrame();
+IMGUI_IMPL_API void     ImGui_ImplSDLRenderer3_RenderDrawData(ImDrawData* draw_data, SDL_Renderer* renderer);
+
+// Called by Init/NewFrame/Shutdown
+IMGUI_IMPL_API bool     ImGui_ImplSDLRenderer3_CreateFontsTexture();
+IMGUI_IMPL_API void     ImGui_ImplSDLRenderer3_DestroyFontsTexture();
+IMGUI_IMPL_API bool     ImGui_ImplSDLRenderer3_CreateDeviceObjects();
+IMGUI_IMPL_API void     ImGui_ImplSDLRenderer3_DestroyDeviceObjects();
+
+// Fallback glyph draw callback (CDDA-specific)
+struct ImFontGlyphToDraw;
+IMGUI_IMPL_API void     ImGui_ImplSDLRenderer3_SetFallbackGlyphDrawCallback(std::function<void(const ImFontGlyphToDraw &)> func);
+
+// [BETA] Selected render state data shared with callbacks.
+// This is temporarily stored in GetPlatformIO().Renderer_RenderState during the ImGui_ImplSDLRenderer3_RenderDrawData() call.
+// (Please open an issue if you feel you need access to more data)
+struct ImGui_ImplSDLRenderer3_RenderState
+{
+    SDL_Renderer*       Renderer;
+};
+
+#endif // #ifndef IMGUI_DISABLE

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -14,5 +14,9 @@
 
 const char *getVersionString()
 {
+#if defined(USE_SDL3)
+    return VERSION "+SDL3";
+#else
     return VERSION;
+#endif
 }

--- a/src/wincurse.cpp
+++ b/src/wincurse.cpp
@@ -817,6 +817,10 @@ void refresh_display()
     RedrawWindow( WindowHandle, nullptr, nullptr, RDW_INVALIDATE | RDW_UPDATENOW );
 }
 
+void refresh_mouse_config()
+{
+}
+
 void set_title( const std::string &title )
 {
     if( WindowHandle != nullptr ) {

--- a/src/wincurse.cpp
+++ b/src/wincurse.cpp
@@ -10,6 +10,9 @@
 #include <fstream>
 
 #include "cached_options.h"
+#if defined(SDL_SOUND)
+#include "sound_backend.h"
+#endif
 #include "cursesdef.h"
 #include "options.h"
 #include "output.h"
@@ -814,6 +817,9 @@ HWND getWindowHandle()
 
 void refresh_display()
 {
+#if defined(SDL_SOUND)
+    sound_backend::poll();
+#endif
     RedrawWindow( WindowHandle, nullptr, nullptr, RDW_INVALIDATE | RDW_UPDATENOW );
 }
 

--- a/tests/sound_backend_test.cpp
+++ b/tests/sound_backend_test.cpp
@@ -1,7 +1,10 @@
 #if defined(SDL_SOUND)
 
+#include "cached_options.h"
 #include "cata_catch.h"
+#include "sdlsound.h"
 #include "sound_backend.h"
+#include "sounds.h"
 
 namespace
 {
@@ -60,5 +63,152 @@ TEST_CASE( "sound_backend_poll_is_safe_without_init", "[sound_backend]" )
     sound_backend::poll();
     SUCCEED();
 }
+
+#if defined(USE_SDL3)
+TEST_CASE( "sound_backend_slow_time_drives_reserved_track_frequency_ratio",
+           "[sound_backend][slow_time]" )
+{
+    // Memory-mixer init so the test does not touch an audio device.
+    REQUIRE( sound_backend::init( 44100, 2, 1024,
+                                  sound_backend::init_options{ /*memory_only=*/true } ) );
+
+    flag = false;
+    sound_backend::set_slow_time_predicate( &predicate_flag );
+
+    // poll() must leave the ratio at unity when the predicate is false.
+    sound_backend::poll();
+    CHECK( sound_backend::testing::reserved_track_frequency_ratio(
+               sfx::channel::daytime_outdoors_env ) == Approx( 1.0f ) );
+
+    // Flipping the predicate and polling must scale every reserved
+    // SFX track down to the slow-time factor.
+    flag = true;
+    sound_backend::poll();
+    const float slowed = sound_backend::testing::reserved_track_frequency_ratio(
+                             sfx::channel::daytime_outdoors_env );
+    CHECK( slowed < 1.0f );
+    CHECK( slowed > 0.0f );
+
+    // Flipping back restores unity on the next poll.
+    flag = false;
+    sound_backend::poll();
+    CHECK( sound_backend::testing::reserved_track_frequency_ratio(
+               sfx::channel::daytime_outdoors_env ) == Approx( 1.0f ) );
+
+    sound_backend::set_slow_time_predicate( nullptr );
+    sound_backend::shutdown();
+}
+
+TEST_CASE( "sound_backend_slow_time_composes_with_play_opts_pitch",
+           "[sound_backend][slow_time]" )
+{
+    REQUIRE( sound_backend::init( 44100, 2, 1024,
+                                  sound_backend::init_options{ /*memory_only=*/true } ) );
+
+    flag = false;
+    sound_backend::set_slow_time_predicate( &predicate_flag );
+
+    // Play a pitched sound on a reserved slot. Backend must retain the
+    // caller's pitch multiplier across slow-time toggles rather than
+    // overwriting it to slow-factor-only. play_opts::pitch follows the
+    // do_pitch_shift convention (smaller = higher perceived pitch);
+    // MIX_SetTrackFrequencyRatio is native (larger = higher pitch), so
+    // the backend inverts at the boundary.
+    sound_backend::sfx_audio *a = sound_backend::testing::make_synthetic_sfx_audio();
+    REQUIRE( a != nullptr );
+    const sfx::channel slot = sfx::channel::daytime_outdoors_env;
+    sound_backend::play_opts opts;
+    opts.pitch = 0.8f;
+    sound_backend::play_reserved( a, slot, opts );
+
+    sound_backend::poll();
+    CHECK( sound_backend::testing::reserved_track_frequency_ratio( slot ) ==
+           Approx( 1.0f / 0.8f ) );
+
+    flag = true;
+    sound_backend::poll();
+    const float reserved_ratio = sound_backend::testing::reserved_track_frequency_ratio( slot );
+    CHECK( reserved_ratio < 1.0f / 0.8f );
+    CHECK( reserved_ratio > 0.0f );
+    CHECK( reserved_ratio == Approx( ( 1.0f / 0.8f ) * 0.25f ).margin( 0.001f ) );
+
+    flag = false;
+    sound_backend::poll();
+    CHECK( sound_backend::testing::reserved_track_frequency_ratio( slot ) ==
+           Approx( 1.0f / 0.8f ) );
+
+    // One-shot path: pitched play must also retain its multiplier under
+    // slow-time.
+    sound_backend::play_opts oneshot_opts;
+    oneshot_opts.pitch = 0.5f;
+    sound_backend::play_oneshot( a, oneshot_opts );
+
+    sound_backend::poll();
+    CHECK( sound_backend::testing::last_oneshot_frequency_ratio() ==
+           Approx( 1.0f / 0.5f ) );
+
+    flag = true;
+    sound_backend::poll();
+    const float oneshot_ratio = sound_backend::testing::last_oneshot_frequency_ratio();
+    CHECK( oneshot_ratio == Approx( ( 1.0f / 0.5f ) * 0.25f ).margin( 0.001f ) );
+
+    // New play started while slow-time already active must start
+    // slowed, not wait for the next poll.
+    flag = true;
+    sound_backend::play_opts spawned_opts;
+    spawned_opts.pitch = 1.0f;
+    sound_backend::play_oneshot( a, spawned_opts );
+    CHECK( sound_backend::testing::last_oneshot_frequency_ratio() ==
+           Approx( 0.25f ).margin( 0.001f ) );
+
+    sound_backend::free_sfx( a );
+    sound_backend::set_slow_time_predicate( nullptr );
+    sound_backend::shutdown();
+}
+#endif // USE_SDL3
+
+#if defined(USE_SDL3)
+TEST_CASE( "sfx_wrapper_routes_is_channel_playing_through_backend",
+           "[sound_backend][integration]" )
+{
+    // RAII guard: unblock the test_mode / sound_enabled / sound_init_success
+    // early-returns in sfx:: and sdlsound wrappers for the duration
+    // of the test, then restore.
+    const bool prev_test_mode = test_mode;
+    const bool prev_sound_enabled = sounds::sound_enabled;
+    const bool prev_init_success = sound_init_success;
+    test_mode = false;
+    sounds::sound_enabled = true;
+    sound_init_success = true;
+
+    REQUIRE( sound_backend::init( 44100, 2, 1024,
+                                  sound_backend::init_options{ /*memory_only=*/true } ) );
+
+    const sfx::channel slot = sfx::channel::daytime_outdoors_env;
+
+    // No play yet: the sfx:: wrapper should route to backend and
+    // report not playing.
+    CHECK_FALSE( sfx::is_channel_playing( slot ) );
+
+    // Start a synthetic play through the backend so the reserved
+    // track enters the playing state; the sfx:: wrapper should
+    // observe the same state via the backend.
+    sound_backend::sfx_audio *a = sound_backend::testing::make_synthetic_sfx_audio();
+    REQUIRE( a != nullptr );
+    sound_backend::play_reserved( a, slot, sound_backend::play_opts{} );
+    CHECK( sfx::is_channel_playing( slot ) );
+
+    // fade_audio_channel with the sentinel routes through backend
+    // without crashing; exercises the channel::any path explicitly.
+    sfx::fade_audio_channel( sfx::channel::any, 50 );
+
+    sound_backend::free_sfx( a );
+    sound_backend::shutdown();
+
+    test_mode = prev_test_mode;
+    sounds::sound_enabled = prev_sound_enabled;
+    sound_init_success = prev_init_success;
+}
+#endif // USE_SDL3
 
 #endif // SDL_SOUND

--- a/tests/sound_backend_test.cpp
+++ b/tests/sound_backend_test.cpp
@@ -1,0 +1,64 @@
+#if defined(SDL_SOUND)
+
+#include "cata_catch.h"
+#include "sound_backend.h"
+
+namespace
+{
+bool predicate_true()
+{
+    return true;
+}
+bool predicate_false()
+{
+    return false;
+}
+
+static bool flag = false;
+bool predicate_flag()
+{
+    return flag;
+}
+} // namespace
+
+TEST_CASE( "sound_backend_slow_time_predicate_install_and_clear", "[sound_backend]" )
+{
+    sound_backend::set_slow_time_predicate( nullptr );
+    CHECK_FALSE( sound_backend::slow_time_predicate_active() );
+
+    sound_backend::set_slow_time_predicate( &predicate_true );
+    CHECK( sound_backend::slow_time_predicate_active() );
+
+    sound_backend::set_slow_time_predicate( &predicate_false );
+    CHECK_FALSE( sound_backend::slow_time_predicate_active() );
+
+    sound_backend::set_slow_time_predicate( nullptr );
+    CHECK_FALSE( sound_backend::slow_time_predicate_active() );
+}
+
+TEST_CASE( "sound_backend_slow_time_predicate_reflects_caller_state", "[sound_backend]" )
+{
+    sound_backend::set_slow_time_predicate( &predicate_flag );
+
+    flag = true;
+    CHECK( sound_backend::slow_time_predicate_active() );
+
+    flag = false;
+    CHECK_FALSE( sound_backend::slow_time_predicate_active() );
+
+    flag = true;
+    CHECK( sound_backend::slow_time_predicate_active() );
+
+    sound_backend::set_slow_time_predicate( nullptr );
+}
+
+TEST_CASE( "sound_backend_poll_is_safe_without_init", "[sound_backend]" )
+{
+    // poll() is called every frame from refresh_display(); it must be safe
+    // to call regardless of whether backend::init has ever run.
+    sound_backend::poll();
+    sound_backend::poll();
+    SUCCEED();
+}
+
+#endif // SDL_SOUND


### PR DESCRIPTION
#### Summary
Infrastructure "Add opt-in SDL3 dual build across Makefile/CMake/MSVC with SDL3_mixer sound"

#### Purpose of change
Follow-up to #86588. Turns out "a few CATA_* aliases" was not the end of it. This PR finishes the job: dual SDL2/SDL3 build across Makefile, CMake and MSVC; SDL3 ImGui bindings; a sound backend seam with SDL2 and SDL3 implementations; CI compile lanes for all three platforms; and experimental release artifacts so people can actually try it.

SDL2 remains the default everywhere. SDL3 is opt-in via `SDL3=1` / `-DUSE_SDL3=ON` / MSVC `UseSDL3=true`.

#### Describe the solution
Build systems grow an SDL3 switch. When enabled:
- Makefile uses `pkg-config sdl3 sdl3-image sdl3-ttf` (plus `sdl3-mixer` when `SOUND=1` outside macOS), OSX paths included.
- CMake gains `USE_SDL3` option, finds `SDL3::SDL3` / `SDL3_image::SDL3_image` / `SDL3_ttf::SDL3_ttf` / `SDL3_mixer::SDL3_mixer` via CONFIG, and switches ImGui backend sources.
- MSVC gains a `UseSDL3` property and a `sdl3` manifest feature pulling `sdl3`, `sdl3-image`, `sdl3-ttf`, and `sdl3-mixer[libflac,mpg123,wavpack,libvorbis]` from vcpkg.

Sound moves behind a small `sound_backend::` namespace in `sound_backend.h`. `sounds.cpp` and `sdlsound.cpp` lose direct `Mix_*` calls. Two impls live behind the seam, selected at build time:
- `sound_backend_sdl2.cpp` preserves current behavior byte-for-byte (same `slowed_time_effect`, `do_pitch_shift`, `channels_to_end` reaper, `Mix_RegisterEffect` wiring).
- `sound_backend_sdl3.cpp` uses SDL3_mixer 3.2.0 tracks. SFX/music split via tags, so `stop_all_sfx` maps to a single `MIX_StopTag(mixer, "sfx", ms)` that never touches music. Slow-time via `MIX_SetTrackFrequencyRatio` reapplied every frame from `sound_backend::poll()` (hooked into `refresh_display` on all three frontends). Live stereo panning via `MIX_SetTrackStereo`. Music callback races handled via per-track generation tokens.

ImGui SDL3 bindings are the stock `imgui_impl_sdl3.*` / `imgui_impl_sdlrenderer3.*` vendored in `src/third-party/imgui/`.

macOS SDL3+SOUND stays out of scope. No Homebrew `sdl3_mixer` formula as of this writing, and nobody wants to consume an upstream DMG from CI today. The Makefile, CMake, and `src/sdlsound.cpp` all guard this combination with a clear error pointing at the actual reason.

CI matrix adds an `sdl3_compile` job (Linux, macOS, Windows), gated on Basic Build and Test. Linux SDL3 lane source-builds SDL3_mixer 3.2.0 (Ubuntu doesn't package `libsdl3-mixer-dev` yet) with explicit Vorbis/FLAC/MP3/WavPack codec flags and runs with `SOUND=1`. macOS lane runs `SOUND=0` (see above). Windows lane rides the existing vcpkg manifest with `VcpkgManifestFeatures=sdl3`.

Release pipeline gains three experimental `+sdl3` artifacts: Windows x64 MSVC with sound, Linux Tiles with sound (source-built SDL3_mixer in the runner), and macOS arm64 no-sound.

New tests in `tests/sound_backend_test.cpp` exercise the backend directly against both impls, plus one thin sfx-wrapper integration test seeded via a new `sfx::testing::seed_minimal_state()` RAII helper so the backend -> sfx path can be exercised without a soundpack on disk.

#### Describe alternatives you've considered
Hard cutover to SDL3 - delete the SDL2 path, be done with it. Would have saved a dual-build matrix and a seam. Would also have been a great way to discover which downstream packager was still on SDL2 the hard way.

Leaving the `Mix_*` calls scattered across `sdlsound.cpp` and `sounds.cpp` and wrapping each site in its own `#ifdef USE_SDL3`. The free-estimate version of this PR. Enthusiastically declined by me, and I suspect by anyone who would have had to review it.

#### Testing
Playable under SDL3 + sound on Linux. New character, move around, trigger ambients, combat, sleep/wake, mute/unmute, menus, loading/saving. Menu music plays, SFX pan and attenuate, weather ambient cross-fades, engine audio updates live as the vehicle moves. SDL2 path still behaves exactly as before on the same scenarios.

`sound_backend_test` suite passes on both backends.

#### Additional context
macOS and Windows here are best-effort and best-guess. I have neither machine, and both lanes are best-tested by someone who does. CI builds both green, but "compiles clean" is not "runs clean." Particularly interested in manual smoke on macOS (no sound expected, just tiles/ttf/image) and on Windows MSVC with real SDL3_mixer via vcpkg.