### PR TITLE
Let wandering creatures stumble up regular stairs

### DIFF
--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -2422,11 +2422,25 @@ void monster::stumble_base( const bool is_voluntary )
         }
     }
 
-    // When forced to stumble, monsters can't stumble-walk downstairs
+    // The same-z radius scan above cannot produce straight-up or straight-down
+    // candidates; add them here, gated by stair / climb / swim / fly rules.
     if( is_voluntary ) {
         const tripoint_bub_ms below( pos_bub() + tripoint::below );
         if( here.valid_move( pos_bub(), below, false, true ) ) {
             valid_stumbles.push_back( below );
+        }
+        const tripoint_bub_ms above( pos_bub() + tripoint::above );
+        const bool stair_up = here.has_flag( ter_furn_flag::TFLAG_GOES_UP, pos_bub() ) &&
+                              !here.has_flag( ter_furn_flag::TFLAG_DIFFICULT_Z, pos_bub() );
+        const bool ladder_up = here.has_flag( ter_furn_flag::TFLAG_DIFFICULT_Z, pos_bub() ) &&
+                               can_climb() &&
+                               here.has_floor_or_support( above );
+        const bool swim_up = swims() &&
+                             here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, pos_bub() ) &&
+                             here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, above );
+        if( ( flies() || stair_up || ladder_up || swim_up ) &&
+            here.valid_move( pos_bub(), above, false, flies() ) ) {
+            valid_stumbles.push_back( above );
         }
     }
 

--- a/tests/monster_stair_test.cpp
+++ b/tests/monster_stair_test.cpp
@@ -66,7 +66,8 @@ static void build_tower( map &here, const point_bub_ms &origin,
     }
 }
 
-// Run a creature in a tower for some turns, tracking which z-levels it visits.
+// Monster spawns on the stair tile with a destination one z-level away.
+// Exercises the on-stair climb-check exemption only; not pathing or wandering.
 static std::set<int> run_creature_in_tower( map &here, const point_bub_ms &tower_origin,
         const mtype_id &mon_type, int start_z, int dest_z, int turns )
 {
@@ -83,13 +84,7 @@ static std::set<int> run_creature_in_tower( map &here, const point_bub_ms &tower
     std::set<int> visited_z;
     visited_z.insert( mon.posz() );
 
-    const tripoint_abs_ms abs_dest = here.get_abs( dest );
     for( int turn = 0; turn < turns; ++turn ) {
-        // Re-assert destination each turn -- the movement code can clear it
-        // on stumble or when the creature thinks it has arrived.
-        mon.anger = 100;
-        mon.morale = 100;
-        mon.set_dest( abs_dest );
         move_monster_turn( mon );
         visited_z.insert( mon.posz() );
     }
@@ -234,4 +229,68 @@ TEST_CASE( "climbing_creatures_use_ladders", "[monster][z-level]" )
         }
         ++idx;
     }
+}
+
+// Three-story tower, walls everywhere except two adjacent stair columns:
+//   column A (1,1): stairs_up on z=0, stairs_down on z=1
+//   column B (2,1): stairs_up on z=1, stairs_down on z=2
+static void build_two_stair_tower( map &here, const point_bub_ms &origin )
+{
+    for( int dx = 0; dx < 4; ++dx ) {
+        for( int dy = 0; dy < 3; ++dy ) {
+            const tripoint_bub_ms p0( origin.x() + dx, origin.y() + dy, 0 );
+            const tripoint_bub_ms p1( origin.x() + dx, origin.y() + dy, 1 );
+            const tripoint_bub_ms p2( origin.x() + dx, origin.y() + dy, 2 );
+            const bool is_col_a = dx == 1 && dy == 1;
+            const bool is_col_b = dx == 2 && dy == 1;
+            here.ter_set( p0, is_col_a ? ter_t_stairs_up.id() : ter_t_wall.id() );
+            if( is_col_a ) {
+                here.ter_set( p1, ter_t_stairs_down.id() );
+            } else if( is_col_b ) {
+                here.ter_set( p1, ter_t_stairs_up.id() );
+            } else {
+                here.ter_set( p1, ter_t_wall.id() );
+            }
+            here.ter_set( p2, is_col_b ? ter_t_stairs_down.id() : ter_t_wall.id() );
+        }
+    }
+    for( int z = 0; z <= 2; ++z ) {
+        here.invalidate_map_cache( z );
+        here.build_map_cache( z, true );
+    }
+}
+
+// Wandering neutral creature on the middle floor must visit all three floors
+// via voluntary stumble alone. Budget is generous enough that stumble's 1-in-10
+// gate dominates realistic seed variance.
+TEST_CASE( "wandering_creature_traverses_three_story_tower", "[monster][z-level][stumble]" )
+{
+    clear_map( -2, 2 );
+    map &here = get_map();
+    get_player_character().setpos( here, tripoint_bub_ms( 60, 60, 0 ) );
+
+    const point_bub_ms tower_origin( 10, 10 );
+    build_two_stair_tower( here, tower_origin );
+
+    const tripoint_bub_ms spawn_pos( tower_origin.x() + 2, tower_origin.y() + 1, 1 );
+    monster &mon = spawn_test_monster( mon_dog.str(), spawn_pos, false );
+    mon.anger = 0;
+    mon.morale = 0;
+    REQUIRE( mon.is_wandering() );
+
+    std::set<int> visited_z;
+    visited_z.insert( mon.posz() );
+
+    constexpr int budget_turns = 1000;
+    for( int turn = 0; turn < budget_turns; ++turn ) {
+        move_monster_turn( mon );
+        visited_z.insert( mon.posz() );
+    }
+
+    g->remove_zombie( mon );
+
+    CAPTURE( visited_z );
+    CHECK( visited_z.count( 0 ) == 1 );
+    CHECK( visited_z.count( 1 ) == 1 );
+    CHECK( visited_z.count( 2 ) == 1 );
 }


### PR DESCRIPTION
#### Summary
Bugfixes "Let wandering creatures stumble up regular stairs"

#### Purpose of change

#86262 was incomplete. It only exempted regular stairs from the climb check in `monster::move()`. Neutral wandering critters don't use that path - they stumble, and `stumble_base` only ever injects a `below` candidate, never an `above`. Basements keep filling up with woodland fauna.

#### Describe the solution

Mirror the `below` injection in `stumble_base` with a symmetric `above` injection, gated to regular stairs, ladder + climber, swim column, or flight. Pass `flies()` to `valid_move` so ground creatures can't slip up through holes in the ceiling.

#### Describe alternatives you've considered

N/A.

#### Testing

New test in `tests/monster_stair_test.cpp`: wandering dog on middle floor of a 3-story tower must visit all three z-levels within the turn budget. Fails on master, passes here.

Existing `[monster]` suite still passes.

Verified in game - creatures finally ran off of my basement.

#### Additional context

N/A.