### PR TITLE
Step many leg armor recipes and minor tweaks along the way

### DIFF
--- a/data/json/mapgen/abandoned01.json
+++ b/data/json/mapgen/abandoned01.json
@@ -50,7 +50,7 @@
     "id": "cabin_suicide_legs",
     "type": "item_group",
     "subtype": "distribution",
-    "items": [ [ "jeans", 35 ], [ "pants", 40 ], [ "pants_cargo", 20 ], [ "pants_survivor", 5 ] ]
+    "items": [ [ "jeans", 35 ], [ "pants", 40 ], [ "pants_cargo", 20 ] ]
   },
   {
     "id": "cabin_suicide_shoes",

--- a/data/json/recipes/armor/legs.json
+++ b/data/json/recipes/armor/legs.json
@@ -105,36 +105,70 @@
   {
     "result": "boy_shorts",
     "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
     "category": "CC_ARMOR",
     "subcategory": "CSC_ARMOR_LEGS",
     "skill_used": "tailor",
     "difficulty": 2,
-    "time": "2 h",
     "autolearn": true,
     "book_learn": [ [ "mag_tailor", 1 ], [ "manual_tailor", 1 ] ],
     "using": [ [ "tailoring_cotton_patchwork", 2 ] ],
-    "byproducts": [ [ "scrap_cotton", 28 ] ]
+    "byproducts": [ [ "scrap_cotton", 28 ] ],
+    "steps": [
+      {
+        "name": "Cutting the pieces",
+        "time": "1 h",
+        "activity_level": "LIGHT_EXERCISE",
+        "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ]
+      },
+      {
+        "name": "Sewing the pieces together",
+        "time": "1 h",
+        "activity_level": "LIGHT_EXERCISE",
+        "using": [ [ "sewing_tool", 60 ] ]
+      }
+    ]
   },
   {
     "result": "xsboy_shorts",
     "type": "recipe",
     "copy-from": "boy_shorts",
-    "time": "1 h 30 m",
-    "using": [ [ "tailoring_cotton", 1 ], [ "filament", 7 ] ]
+    "using": [ [ "tailoring_cotton_patchwork", 1 ] ],
+    "byproducts": [ [ "scrap_cotton", 21 ] ],
+    "steps": [
+      {
+        "name": "Cutting the pieces",
+        "time": "45 m",
+        "activity_level": "LIGHT_EXERCISE",
+        "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ]
+      },
+      {
+        "name": "Sewing the pieces together",
+        "time": "45 m",
+        "activity_level": "LIGHT_EXERCISE",
+        "using": [ [ "sewing_tool", 45 ] ]
+      }
+    ]
   },
   {
     "result": "xlboy_shorts",
     "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
-    "category": "CC_ARMOR",
-    "subcategory": "CSC_ARMOR_LEGS",
-    "skill_used": "tailor",
-    "difficulty": 2,
-    "time": "1 h 30 m",
-    "autolearn": true,
-    "using": [ [ "tailoring_cotton", 3 ] ],
-    "byproducts": [ [ "cotton_patchwork", 6 ], [ "scrap_cotton", 3 ] ]
+    "copy-from": "boy_shorts",
+    "using": [ [ "tailoring_cotton_patchwork", 3 ] ],
+    "byproducts": [ [ "scrap_cotton", 35 ] ],
+    "steps": [
+      {
+        "name": "Cutting the pieces",
+        "time": "1 h 15 m",
+        "activity_level": "LIGHT_EXERCISE",
+        "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ]
+      },
+      {
+        "name": "Sewing the pieces together",
+        "time": "1 h 15 m",
+        "activity_level": "LIGHT_EXERCISE",
+        "using": [ [ "sewing_tool", 75 ] ]
+      }
+    ]
   },
   {
     "result": "boxer_briefs",
@@ -171,29 +205,53 @@
   {
     "result": "breeches",
     "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
     "category": "CC_ARMOR",
     "subcategory": "CSC_ARMOR_LEGS",
     "skill_used": "tailor",
     "difficulty": 3,
-    "time": "6 h",
     "book_learn": [ [ "textbook_tailor", 2 ], [ "tailor_portfolio", 2 ] ],
     "using": [ [ "tailoring_cotton_patchwork", 15 ] ],
-    "byproducts": [ [ "scrap_cotton", 5 ] ]
+    "byproducts": [ [ "scrap_cotton", 5 ] ],
+    "steps": [
+      {
+        "name": "Cutting the pieces",
+        "time": "3 h",
+        "activity_level": "LIGHT_EXERCISE",
+        "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ]
+      },
+      {
+        "name": "Sewing the pieces together",
+        "time": "3 h",
+        "activity_level": "LIGHT_EXERCISE",
+        "using": [ [ "sewing_tool", 180 ] ]
+      }
+    ]
   },
   {
     "result": "briefs",
     "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
     "category": "CC_ARMOR",
     "subcategory": "CSC_ARMOR_LEGS",
     "skill_used": "tailor",
     "difficulty": 2,
-    "time": "2 h",
     "autolearn": true,
     "book_learn": [ [ "mag_tailor", 1 ], [ "manual_tailor", 1 ] ],
-    "using": [ [ "tailoring_cotton", 1 ] ],
-    "byproducts": [ [ "scrap_cotton", 5 ] ]
+    "using": [ [ "tailoring_cotton_patchwork", 1 ] ],
+    "byproducts": [ [ "scrap_cotton", 5 ] ],
+    "steps": [
+      {
+        "name": "Cutting the pieces",
+        "time": "1 h",
+        "activity_level": "LIGHT_EXERCISE",
+        "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ]
+      },
+      {
+        "name": "Sewing the pieces together",
+        "time": "1 h",
+        "activity_level": "LIGHT_EXERCISE",
+        "using": [ [ "sewing_tool", 60 ] ]
+      }
+    ]
   },
   {
     "result": "chaps_leather",
@@ -217,15 +275,27 @@
   {
     "result": "hakama",
     "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
     "category": "CC_ARMOR",
     "subcategory": "CSC_ARMOR_LEGS",
     "skill_used": "tailor",
     "difficulty": 3,
-    "time": "3 h",
     "book_learn": [ [ "tailor_japanese", 3 ] ],
     "using": [ [ "tailoring_cotton_patchwork", 15 ] ],
-    "byproducts": [ [ "cotton_patchwork", 5 ] ]
+    "byproducts": [ [ "cotton_patchwork", 5 ] ],
+    "steps": [
+      {
+        "name": "Cutting the pieces",
+        "time": "1 h 30 m",
+        "activity_level": "LIGHT_EXERCISE",
+        "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ]
+      },
+      {
+        "name": "Sewing the pieces together",
+        "time": "1 h 30 m",
+        "activity_level": "LIGHT_EXERCISE",
+        "using": [ [ "sewing_tool", 90 ] ]
+      }
+    ]
   },
   {
     "result": "hot_pants",
@@ -322,31 +392,55 @@
   {
     "result": "canvas_pants_padded",
     "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
     "category": "CC_ARMOR",
     "subcategory": "CSC_ARMOR_LEGS",
     "skill_used": "tailor",
     "difficulty": 2,
-    "time": "40 m",
     "autolearn": true,
-    "proficiencies": [ { "proficiency": "prof_closures" } ],
-    "using": [ [ "tailoring_cotton", 15 ], [ "sewing_standard", 90 ] ],
+    "using": [ [ "tailoring_cotton", 15 ] ],
     "components": [ [ [ "technician_pants_gray", 1 ] ] ],
-    "byproducts": [ [ "scrap_cotton", 5 ], [ "cotton_patchwork", 4 ] ]
+    "byproducts": [ [ "scrap_cotton", 5 ], [ "cotton_patchwork", 4 ] ],
+    "steps": [
+      {
+        "name": "Cutting the padding",
+        "time": "20 m",
+        "activity_level": "LIGHT_EXERCISE",
+        "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ]
+      },
+      {
+        "name": "Sewing the padding to the pants",
+        "time": "20 m",
+        "activity_level": "LIGHT_EXERCISE",
+        "proficiencies": [ { "proficiency": "prof_closures" } ],
+        "using": [ [ "sewing_tool", 20 ] ]
+      }
+    ]
   },
   {
     "result": "skirt",
     "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
     "category": "CC_ARMOR",
     "subcategory": "CSC_ARMOR_LEGS",
     "skill_used": "tailor",
     "difficulty": 2,
-    "time": "6 h",
     "book_learn": [ [ "textbook_tailor", 3 ], [ "tailor_portfolio", 5 ], [ "manual_tailor", 3 ], [ "survival_book", 3 ] ],
-    "proficiencies": [ { "proficiency": "prof_closures" } ],
     "using": [ [ "tailoring_cotton_patchwork", 7 ], [ "fastener_small", 1 ] ],
-    "byproducts": [ [ "scrap_cotton", 10 ], [ "cotton_patchwork", 2 ] ]
+    "byproducts": [ [ "scrap_cotton", 10 ], [ "cotton_patchwork", 2 ] ],
+    "steps": [
+      {
+        "name": "Cutting the pieces",
+        "time": "3 h",
+        "activity_level": "LIGHT_EXERCISE",
+        "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ]
+      },
+      {
+        "name": "Sewing the pieces together",
+        "time": "3 h",
+        "activity_level": "LIGHT_EXERCISE",
+        "proficiencies": [ { "proficiency": "prof_closures" } ],
+        "using": [ [ "sewing_tool", 180 ] ]
+      }
+    ]
   },
   {
     "result": "skirt_leather",
@@ -365,15 +459,8 @@
   },
   {
     "result": "skirt_denim",
+    "copy-from": "skirt",
     "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
-    "category": "CC_ARMOR",
-    "subcategory": "CSC_ARMOR_LEGS",
-    "skill_used": "tailor",
-    "difficulty": 2,
-    "time": "6 h",
-    "book_learn": [ [ "textbook_tailor", 3 ], [ "tailor_portfolio", 5 ], [ "manual_tailor", 3 ], [ "survival_book", 3 ] ],
-    "proficiencies": [ { "proficiency": "prof_closures" } ],
     "using": [ [ "tailoring_denim_patchwork", 4 ], [ "fastener_small", 1 ] ],
     "byproducts": [ [ "scrap_denim", 8 ] ]
   },
@@ -395,15 +482,27 @@
   {
     "result": "kilt",
     "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
     "category": "CC_ARMOR",
     "subcategory": "CSC_ARMOR_LEGS",
     "skill_used": "tailor",
     "difficulty": 4,
-    "time": "6 h",
     "book_learn": [ [ "scots_tailor", 4 ], [ "scots_cookbook", 7 ] ],
-    "proficiencies": [ { "proficiency": "prof_closures" } ],
-    "using": [ [ "tailoring_felt_patchwork", 20 ], [ "strap_small", 1 ], [ "clasps", 1 ] ]
+    "using": [ [ "tailoring_felt_patchwork", 20 ], [ "strap_small", 1 ], [ "clasps", 1 ] ],
+    "steps": [
+      {
+        "name": "Cutting the pieces",
+        "time": "3 h",
+        "activity_level": "LIGHT_EXERCISE",
+        "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ]
+      },
+      {
+        "name": "Sewing the pieces together",
+        "time": "3 h",
+        "activity_level": "LIGHT_EXERCISE",
+        "proficiencies": [ { "proficiency": "prof_closures" } ],
+        "using": [ [ "sewing_tool", 180 ] ]
+      }
+    ]
   },
   {
     "result": "knee_pads",
@@ -421,36 +520,69 @@
   {
     "result": "leg_warmers",
     "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
     "category": "CC_ARMOR",
     "subcategory": "CSC_ARMOR_LEGS",
     "skill_used": "tailor",
     "difficulty": 1,
-    "time": "1 h 30 m",
     "autolearn": true,
     "reversible": true,
-    "using": [ [ "tailoring_cotton_patchwork", 2 ] ]
+    "using": [ [ "tailoring_cotton_patchwork", 2 ] ],
+    "steps": [
+      {
+        "name": "Cutting the pieces",
+        "time": "45 m",
+        "activity_level": "LIGHT_EXERCISE",
+        "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ]
+      },
+      {
+        "name": "Sewing the pieces together",
+        "time": "45 m",
+        "activity_level": "LIGHT_EXERCISE",
+        "using": [ [ "sewing_tool", 45 ] ]
+      }
+    ]
   },
   {
     "result": "leg_warmers_xs",
     "type": "recipe",
     "copy-from": "leg_warmers",
     "reversible": false,
-    "time": "1 h 30 m",
-    "using": [ [ "tailoring_cotton", 1 ] ]
+    "using": [ [ "tailoring_cotton_patchwork", 1 ] ],
+    "steps": [
+      {
+        "name": "Cutting the pieces",
+        "time": "30 m",
+        "activity_level": "LIGHT_EXERCISE",
+        "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ]
+      },
+      {
+        "name": "Sewing the pieces together",
+        "time": "30 m",
+        "activity_level": "LIGHT_EXERCISE",
+        "using": [ [ "sewing_tool", 30 ] ]
+      }
+    ]
   },
   {
     "result": "leg_warmers_xl",
     "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
-    "category": "CC_ARMOR",
-    "subcategory": "CSC_ARMOR_LEGS",
-    "skill_used": "tailor",
-    "difficulty": 1,
-    "time": "1 h 40 m",
-    "autolearn": true,
+    "copy-from": "leg_warmers",
+    "reversible": false,
     "using": [ [ "tailoring_cotton_patchwork", 3 ] ],
-    "byproducts": [ [ "cotton_patchwork", 2 ] ]
+    "steps": [
+      {
+        "name": "Cutting the pieces",
+        "time": "1 h",
+        "activity_level": "LIGHT_EXERCISE",
+        "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ]
+      },
+      {
+        "name": "Sewing the pieces together",
+        "time": "1 h",
+        "activity_level": "LIGHT_EXERCISE",
+        "using": [ [ "sewing_tool", 60 ] ]
+      }
+    ]
   },
   {
     "result": "leg_warmers_xlf",
@@ -469,17 +601,29 @@
   {
     "result": "leggings",
     "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
     "category": "CC_ARMOR",
     "subcategory": "CSC_ARMOR_LEGS",
     "skill_used": "tailor",
     "difficulty": 3,
-    "time": "3 h",
     "autolearn": true,
     "book_learn": [ [ "mag_tailor", 2 ], [ "manual_tailor", 2 ] ],
     "using": [ [ "tailoring_lycra_patchwork", 6 ] ],
     "byproducts": [ [ "lycra_patch", 5 ], [ "scrap_lycra", 9 ] ],
-    "proficiencies": [ { "proficiency": "prof_elastics" } ]
+    "steps": [
+      {
+        "name": "Cutting the pieces",
+        "time": "1 h 30 m",
+        "activity_level": "LIGHT_EXERCISE",
+        "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ]
+      },
+      {
+        "name": "Sewing the pieces together",
+        "time": "1 h 30 m",
+        "activity_level": "LIGHT_EXERCISE",
+        "proficiencies": [ { "proficiency": "prof_elastics" } ],
+        "using": [ [ "sewing_tool", 60 ] ]
+      }
+    ]
   },
   {
     "result": "legguard_hard",
@@ -843,7 +987,7 @@
     "time": "15 m",
     "autolearn": true,
     "reversible": true,
-    "using": [ [ "cordage_short", 1 ], [ "tailoring_cotton_patchwork_simple", 2 ] ]
+    "using": [ [ "cordage_short", 1 ], [ "tailoring_cotton", 2 ] ]
   },
   {
     "result": "loincloth_fur",
@@ -873,6 +1017,7 @@
     "autolearn": true,
     "book_learn": [ [ "mag_tailor", 1 ], [ "manual_tailor", 1 ] ],
     "using": [ [ "tailoring_cotton_patchwork", 3 ] ],
+    "byproducts": [ [ "cotton_patchwork", 1 ] ],
     "steps": [
       {
         "name": "Cutting the pieces",
@@ -886,8 +1031,7 @@
         "activity_level": "LIGHT_EXERCISE",
         "using": [ [ "sewing_tool", 45 ] ]
       }
-    ],
-    "byproducts": [ [ "cotton_patchwork", 1 ] ]
+    ]
   },
   {
     "result": "armor_mercenary_bottom",
@@ -911,31 +1055,55 @@
   {
     "result": "panties",
     "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
     "category": "CC_ARMOR",
     "subcategory": "CSC_ARMOR_LEGS",
     "skill_used": "tailor",
     "difficulty": 2,
-    "time": "1 h",
     "autolearn": true,
     "book_learn": [ [ "mag_tailor", 1 ], [ "manual_tailor", 1 ] ],
-    "using": [ [ "tailoring_cotton_patchwork", 1 ] ]
+    "using": [ [ "tailoring_cotton_patchwork", 1 ] ],
+    "steps": [
+      {
+        "name": "Cutting the pieces",
+        "time": "30 m",
+        "activity_level": "LIGHT_EXERCISE",
+        "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ]
+      },
+      {
+        "name": "Sewing the pieces together",
+        "time": "30 m",
+        "activity_level": "LIGHT_EXERCISE",
+        "using": [ [ "sewing_tool", 30 ] ]
+      }
+    ]
   },
   {
     "result": "pants_cargo",
     "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
     "category": "CC_ARMOR",
     "subcategory": "CSC_ARMOR_LEGS",
     "skill_used": "tailor",
     "difficulty": 3,
-    "time": "8 h",
     "decomp_learn": 2,
     "autolearn": true,
     "book_learn": [ [ "textbook_tailor", 2 ], [ "manual_tailor", 2 ] ],
     "using": [ [ "tailoring_cotton_patchwork", 20 ], [ "fastener_small", 3 ] ],
     "byproducts": [ [ "cotton_patchwork", 5 ] ],
-    "proficiencies": [ { "proficiency": "prof_closures" } ]
+    "steps": [
+      {
+        "name": "Cutting the pieces",
+        "time": "4 h",
+        "activity_level": "LIGHT_EXERCISE",
+        "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ]
+      },
+      {
+        "name": "Sewing the pieces together",
+        "time": "4 h",
+        "activity_level": "LIGHT_EXERCISE",
+        "proficiencies": [ { "proficiency": "prof_closures" } ],
+        "using": [ [ "sewing_tool", 240 ] ]
+      }
+    ]
   },
   {
     "type": "recipe",
@@ -1016,151 +1184,86 @@
     ]
   },
   {
-    "result": "pants_survivor",
-    "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
-    "category": "CC_*",
-    "subcategory": "CSC_*_NESTED",
-    "skill_used": "tailor",
-    "difficulty": 6,
-    "skills_required": [ "fabrication", 5 ],
-    "time": "14 h",
-    "autolearn": true,
-    "using": [
-      [ "tailoring_kevlar_fabric", 4 ],
-      [ "tailoring_cotton", 5 ],
-      [ "waterproofing_plastic_sheets", 8 ],
-      [ "fastener_small", 1 ]
-    ],
-    "proficiencies": [
-      { "proficiency": "prof_closures" },
-      { "proficiency": "prof_closures_waterproofing" },
-      { "proficiency": "prof_polymerworking" }
-    ],
-    "components": [
-      [ [ "pants_army", 1 ], [ "pants_cargo", 1 ] ],
-      [
-        [ "tacvest", 1 ],
-        [ "legrig", 1 ],
-        [ "vest", 1 ],
-        [ "tool_belt", 1 ],
-        [ "ragpouch", 4 ],
-        [ "leather_pouch", 2 ],
-        [ "dump_pouch", 1 ],
-        [ "purse", 2 ],
-        [ "fanny", 2 ]
-      ]
-    ]
-  },
-  {
-    "result": "xs_pants_survivor",
-    "type": "recipe",
-    "copy-from": "pants_survivor",
-    "time": "14 h",
-    "using": [
-      [ "tailoring_kevlar_fabric", 3 ],
-      [ "tailoring_cotton", 3 ],
-      [ "waterproofing_plastic_sheets", 6 ],
-      [ "fastener_small", 1 ]
-    ],
-    "components": [
-      [ [ "pants_army", 1 ], [ "pants_cargo", 1 ] ],
-      [
-        [ "tacvest", 1 ],
-        [ "legrig", 1 ],
-        [ "vest", 1 ],
-        [ "tool_belt", 1 ],
-        [ "ragpouch", 4 ],
-        [ "leather_pouch", 2 ],
-        [ "dump_pouch", 1 ],
-        [ "purse", 2 ],
-        [ "fanny", 2 ]
-      ]
-    ]
-  },
-  {
-    "result": "xl_pants_survivor",
-    "type": "recipe",
-    "copy-from": "pants_survivor",
-    "time": "15 h 45 m",
-    "using": [
-      [ "tailoring_kevlar_fabric", 6 ],
-      [ "tailoring_cotton", 7 ],
-      [ "waterproofing_plastic_sheets", 10 ],
-      [ "fastener_small", 1 ]
-    ],
-    "components": [
-      [ [ "pants_army", 2 ], [ "pants_cargo", 2 ] ],
-      [
-        [ "tacvest", 1 ],
-        [ "legrig", 1 ],
-        [ "vest", 1 ],
-        [ "tool_belt", 1 ],
-        [ "ragpouch", 4 ],
-        [ "leather_pouch", 2 ],
-        [ "dump_pouch", 1 ],
-        [ "purse", 2 ],
-        [ "fanny", 2 ]
-      ]
-    ]
-  },
-  {
     "result": "shorts",
     "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
     "category": "CC_ARMOR",
     "subcategory": "CSC_ARMOR_LEGS",
     "skill_used": "tailor",
     "difficulty": 1,
-    "time": "3 h 30m",
     "autolearn": true,
     "using": [ [ "tailoring_cotton_patchwork", 4 ], [ "fastener_small", 1 ] ],
     "byproducts": [ [ "cotton_patchwork", 2 ] ],
-    "proficiencies": [ { "proficiency": "prof_closures" } ]
+    "steps": [
+      {
+        "name": "Cutting the pieces",
+        "time": "1 h 45 m",
+        "activity_level": "LIGHT_EXERCISE",
+        "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ]
+      },
+      {
+        "name": "Sewing the pieces together",
+        "time": "1 h 45 m",
+        "activity_level": "LIGHT_EXERCISE",
+        "proficiencies": [ { "proficiency": "prof_closures" } ],
+        "using": [ [ "sewing_tool", 105 ] ]
+      }
+    ]
   },
   {
     "result": "shorts_cargo",
     "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
     "category": "CC_ARMOR",
     "subcategory": "CSC_ARMOR_LEGS",
     "skill_used": "tailor",
     "difficulty": 2,
-    "time": "4 h 30 m",
     "autolearn": true,
     "book_learn": [ [ "manual_tailor", 1 ] ],
     "using": [ [ "tailoring_cotton_patchwork", 10 ], [ "fastener_small", 3 ] ],
     "byproducts": [ [ "cotton_patchwork", 2 ] ],
-    "proficiencies": [ { "proficiency": "prof_closures" } ]
+    "steps": [
+      {
+        "name": "Cutting the pieces",
+        "time": "2 h 15 m",
+        "activity_level": "LIGHT_EXERCISE",
+        "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ]
+      },
+      {
+        "name": "Sewing the pieces together",
+        "time": "2 h 15 m",
+        "activity_level": "LIGHT_EXERCISE",
+        "proficiencies": [ { "proficiency": "prof_closures" } ],
+        "using": [ [ "sewing_tool", 135 ] ]
+      }
+    ]
   },
   {
     "result": "shorts_cargo",
     "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
     "id_suffix": "from_pants",
     "category": "CC_ARMOR",
     "subcategory": "CSC_ARMOR_LEGS",
     "skill_used": "tailor",
-    "time": "30 m",
     "autolearn": true,
     "using": [ [ "sewing_standard", 12 ] ],
     "byproducts": [ [ "cotton_patchwork", 4 ] ],
-    "components": [ [ [ "pants_cargo", 1 ] ] ]
+    "components": [ [ [ "pants_cargo", 1 ] ] ],
+    "steps": [
+      {
+        "name": "Sewing the pockets onto the shorts",
+        "time": "30 m",
+        "activity_level": "LIGHT_EXERCISE",
+        "using": [ [ "sewing_tool", 30 ] ]
+      }
+    ]
   },
   {
     "result": "shorts_denim",
-    "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
     "id_suffix": "from_fabric",
-    "category": "CC_ARMOR",
-    "subcategory": "CSC_ARMOR_LEGS",
-    "skill_used": "tailor",
+    "copy-from": "shorts",
+    "type": "recipe",
     "difficulty": 2,
-    "time": "20 m",
-    "book_learn": [ [ "textbook_tailor", 3 ], [ "manual_tailor", 3 ] ],
     "using": [ [ "tailoring_denim_patchwork", 4 ], [ "fastener_small", 1 ] ],
-    "byproducts": [ [ "denim_patch", 6 ], [ "scrap_denim", 14 ] ],
-    "proficiencies": [ { "proficiency": "prof_closures" } ]
+    "byproducts": [ [ "denim_patch", 6 ], [ "scrap_denim", 14 ] ]
   },
   {
     "result": "shorts_denim",
@@ -1206,30 +1309,54 @@
   {
     "result": "stockings_tent_legs",
     "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
     "category": "CC_ARMOR",
     "subcategory": "CSC_ARMOR_LEGS",
     "skill_used": "tailor",
     "difficulty": 1,
-    "time": "3 h",
     "autolearn": true,
     "using": [ [ "tailoring_cotton_patchwork", 9 ] ],
-    "byproducts": [ [ "cotton_patchwork", 3 ] ]
+    "byproducts": [ [ "cotton_patchwork", 3 ] ],
+    "steps": [
+      {
+        "name": "Cutting the pieces",
+        "time": "1 h 30 m",
+        "activity_level": "LIGHT_EXERCISE",
+        "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ]
+      },
+      {
+        "name": "Sewing the pieces together",
+        "time": "1 h 30 m",
+        "activity_level": "LIGHT_EXERCISE",
+        "using": [ [ "sewing_tool", 90 ] ]
+      }
+    ]
   },
   {
     "result": "under_armor_shorts",
     "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
     "category": "CC_ARMOR",
     "subcategory": "CSC_ARMOR_LEGS",
     "skill_used": "tailor",
     "difficulty": 3,
-    "time": "3 h",
     "autolearn": true,
     "book_learn": [ [ "mag_tailor", 2 ], [ "manual_tailor", 2 ] ],
-    "proficiencies": [ { "proficiency": "prof_elastics" } ],
     "using": [ [ "tailoring_lycra_patchwork", 3 ] ],
-    "byproducts": [ [ "scrap_lycra", 2 ] ]
+    "byproducts": [ [ "scrap_lycra", 2 ] ],
+    "steps": [
+      {
+        "name": "Cutting the pieces",
+        "time": "1 h 30 m",
+        "activity_level": "LIGHT_EXERCISE",
+        "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ]
+      },
+      {
+        "name": "Sewing the pieces together",
+        "time": "1 h 30 m",
+        "activity_level": "LIGHT_EXERCISE",
+        "proficiencies": [ { "proficiency": "prof_elastics" } ],
+        "using": [ [ "sewing_tool", 90 ] ]
+      }
+    ]
   },
   {
     "result": "lc_chainmail_legs",
@@ -2920,16 +3047,28 @@
   {
     "result": "gaiter_boot_makeshift",
     "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
     "category": "CC_ARMOR",
     "subcategory": "CSC_ARMOR_LEGS",
     "skill_used": "tailor",
     "skills_required": [ [ "survival", 2 ], [ "fabrication", 1 ] ],
     "difficulty": 2,
-    "time": "1 h 30m",
     "autolearn": true,
     "book_learn": [ [ "mag_tailor", 1 ], [ "manual_tailor", 1 ] ],
     "using": [ [ "tailoring_cotton_patchwork", 3 ] ],
-    "components": [ [ [ "duct_tape", 150 ] ], [ [ "zipper_long_plastic", 1 ] ] ]
+    "components": [ [ [ "duct_tape", 150 ] ], [ [ "zipper_long_plastic", 1 ] ] ],
+    "steps": [
+      {
+        "name": "Forming the gaiters",
+        "time": "45 m",
+        "activity_level": "LIGHT_EXERCISE",
+        "qualities": [ { "id": "FABRIC_CUT", "level": 1 } ]
+      },
+      {
+        "name": "Sewing the zippers",
+        "time": "45 m",
+        "activity_level": "LIGHT_EXERCISE",
+        "using": [ [ "sewing_tool", 45 ] ]
+      }
+    ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Many recipes without steps when having steps is better, if only because it allows them to be sped up with the right tools, like sewing machines.

But also many small issue listed below:

1. `xsboy_shorts` uses filaments when those are already included in the `tailoring_cotton`-type requirement groups.
2. Byproducts in `xsboy_shorts` are the same as the copy-from recipe despite being a "smaller" craft.
3. Same as 2 but for `xlboy_shorts`.
4. `Briefs` use tailoring cotton instead of the patchwork requirement group version for no reason.
5. `skirt_denim` doesn't copy-from `skirt` despite being just a material change.
6. `shorts_denim` doesn't copy-from `shorts`, same as 5.
7. Survivor pants recipes still exist despite the item being obsolete, there's also a spawn for it.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Step them. I split the step times evenly. I moved the proficiencies to the actual crafting part when applicable.

As for the minor tweaks:

1. Removed the filaments.
2. Less byproducts.
3. More byproducts.
4. Now uses the tailoring cotton patchwork requirements group.
5. `skirt_denim` now copy-from `skirt`.
6. `shorts_denim` now copy-from `shorts`.
7. Just remove, in both spawn group and recipes.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Hope I haven't missed something while listing the changes.

I could have split the PR but it's annoying to make 20 PRs for as many recipes, at this rate we're gonna need to merge thousands of PRs to step everything.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded fine, unlocked the recipes, took a cursory glance at a few modified recipes which seemed fine.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
