### PR TITLE
Process `contents_change_handler` in contents_change_activity_actor

### DIFF
--- a/data/json/player_activities.json
+++ b/data/json/player_activities.json
@@ -1132,5 +1132,12 @@
     "activity_level": "NO_EXERCISE",
     "based_on": "speed",
     "verb": "aiming the artillery"
+  },
+  {
+    "id": "ACT_CONTENTS_CHANGE",
+    "type": "activity_type",
+    "activity_level": "NO_EXERCISE",
+    "based_on": "neither",
+    "verb": "handling items"
   }
 ]

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -158,6 +158,7 @@ static const activity_id ACT_CHOP_TREE( "ACT_CHOP_TREE" );
 static const activity_id ACT_CHURN( "ACT_CHURN" );
 static const activity_id ACT_CLEAR_RUBBLE( "ACT_CLEAR_RUBBLE" );
 static const activity_id ACT_CONSUME( "ACT_CONSUME" );
+static const activity_id ACT_CONTENTS_CHANGE( "ACT_CONTENTS_CHANGE" );
 static const activity_id ACT_CRACKING( "ACT_CRACKING" );
 static const activity_id ACT_CRAFT( "ACT_CRAFT" );
 static const activity_id ACT_DISABLE( "ACT_DISABLE" );
@@ -6111,11 +6112,9 @@ void unload_activity_actor::unload( Character &who, item_location &target )
             if( changed ) {
                 it.on_contents_changed();
                 who.invalidate_weight_carried_cache();
-                handler.handle_by( who );
-                // Warning: the above call to `contents_change_handler::handle_by` will
-                // call `Character::handle_contents_changed`, which might invalidate items
-                // and item_locations. See description for `::handle_contents_changed`
-                // in character.h .
+                who.assign_activity( contents_change_activity_actor( handler ) );
+                // Warning: the above call might invalidate items and item_locations.
+                // See description for `::handle_contents_changed` in `contents_change_handler.h`
                 // Therefore, it is important that we don't use `target` or `it` after here.
                 break;
             }
@@ -6881,7 +6880,7 @@ void drop_activity_actor::do_turn( player_activity &, Character &who )
 
 void drop_activity_actor::canceled( player_activity &, Character &who )
 {
-    handler.handle_by( who );
+    who.assign_activity( contents_change_activity_actor( handler ) );
 }
 
 void drop_activity_actor::serialize( JsonOut &jsout ) const
@@ -7118,7 +7117,7 @@ void stash_activity_actor::do_turn( player_activity &, Character &who )
 
 void stash_activity_actor::canceled( player_activity &, Character &who )
 {
-    handler.handle_by( who );
+    who.assign_activity( contents_change_activity_actor( handler ) );
 }
 
 void stash_activity_actor::serialize( JsonOut &jsout ) const
@@ -7731,8 +7730,8 @@ void insert_item_activity_actor::finish( player_activity &act, Character &who )
     items.pop_front();
     if( items.empty() || !success || items.front().first == item_location::nowhere ) {
         holster.make_active();
-        handler.handle_by( who );
         act.set_to_null();
+        who.assign_activity( contents_change_activity_actor( handler ) );
         if( !items_remain.empty() ) {
             g->insert_item( items_remain );
         }
@@ -7747,7 +7746,7 @@ void insert_item_activity_actor::finish( player_activity &act, Character &who )
 
 void insert_item_activity_actor::canceled( player_activity &/*act*/, Character &who )
 {
-    handler.handle_by( who );
+    who.assign_activity( contents_change_activity_actor( handler ) );
 }
 
 void insert_item_activity_actor::serialize( JsonOut &jsout ) const
@@ -9499,7 +9498,9 @@ void wield_activity_actor::do_turn( player_activity &, Character &who )
                         target_item.remove_item();
                     }
                 }
-                handler.handle_by( who );
+                who.cancel_activity();
+                who.assign_activity( contents_change_activity_actor( handler ) );
+                return;
             }
         }
 
@@ -9575,8 +9576,8 @@ void wear_activity_actor::do_turn( player_activity &, Character &who )
 
     // If there are no items left we are done
     if( target_items.empty() ) {
-        handler.handle_by( who );
         who.cancel_activity();
+        who.assign_activity( contents_change_activity_actor( handler ) );
     }
 }
 
@@ -11293,7 +11294,7 @@ void vehicle_activity_actor::complete_vehicle( player_activity &act, Character &
                     you.add_msg_if_player( m_good, _( "There's some left over!" ) );
                 }
 
-                handler.handle_by( you );
+                you.assign_activity( contents_change_activity_actor( handler ) );
             } else if( vp.is_fuel_store() ) {
                 contents_change_handler handler;
                 handler.unseal_pocket_containing( src );
@@ -11304,7 +11305,7 @@ void vehicle_activity_actor::complete_vehicle( player_activity &act, Character &
                 //~ 1$s vehicle name, 2$s reactor name
                 you.add_msg_if_player( m_good, _( "You refuel the %1$s's %2$s." ), veh.name, vp.name() );
 
-                handler.handle_by( you );
+                you.assign_activity( contents_change_activity_actor( handler ) );
             } else {
                 debugmsg( "vehicle part is not reloadable" );
                 break;
@@ -14697,6 +14698,45 @@ std::unique_ptr<activity_actor> zone_sort_activity_actor::deserialize( JsonValue
     return actor.clone();
 }
 
+void contents_change_activity_actor::start( player_activity &, Character & )
+{
+    handler.sort_containers();
+}
+
+void contents_change_activity_actor::do_turn( player_activity &act, Character &who )
+{
+    if( handler.finished() ) {
+        // prevent backlogged activity UI from reprompting with now-invalid item_locations
+        if( handled_any_items ) {
+            if( !who.backlog.empty() ) {
+                who.backlog.pop_front();
+            }
+            uistate.open_menu.reset();
+        }
+        act.set_to_null();
+        return;
+    }
+    handled_any_items = true;
+    handler.handle_contents_changed( who );
+}
+
+void contents_change_activity_actor::serialize( JsonOut &jsout ) const
+{
+    jsout.start_object();
+    jsout.member( "handler", handler );
+    jsout.member( "handled_any_items", handled_any_items );
+    jsout.end_object();
+}
+
+std::unique_ptr<activity_actor> contents_change_activity_actor::deserialize( JsonValue &jsin )
+{
+    contents_change_activity_actor actor;
+    JsonObject data = jsin.get_object();
+    data.read( "handler", actor.handler );
+    data.read( "handled_any_items", actor.handled_any_items );
+    return actor.clone();
+}
+
 namespace activity_actors
 {
 
@@ -14721,6 +14761,7 @@ deserialize_functions = {
     { ACT_CHURN, &churn_activity_actor::deserialize },
     { ACT_CLEAR_RUBBLE, &clear_rubble_activity_actor::deserialize },
     { ACT_CONSUME, &consume_activity_actor::deserialize },
+    { ACT_CONTENTS_CHANGE, &contents_change_activity_actor::deserialize },
     { ACT_CRACKING, &safecracking_activity_actor::deserialize },
     { ACT_CRAFT, &craft_activity_actor::deserialize },
     { ACT_DISABLE, &disable_activity_actor::deserialize },

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -2456,6 +2456,34 @@ class insert_item_activity_actor : public activity_actor
         static std::unique_ptr<activity_actor> deserialize( JsonValue &jsin );
 };
 
+// Forwarding activity for handling contents of changed items.
+// Iterates through unsealed items and processes changes per-turn,
+// assigning related activities as needed.
+class contents_change_activity_actor : public activity_actor
+{
+        bool handled_any_items = false;
+        contents_change_handler handler;
+        contents_change_activity_actor() = default;
+    public:
+        explicit contents_change_activity_actor( const contents_change_handler &handler ) : handler(
+                handler ) {};
+        const activity_id &get_type() const override {
+            static const activity_id ACT_CONTENTS_CHANGE( "ACT_CONTENTS_CHANGE" );
+            return ACT_CONTENTS_CHANGE;
+        }
+
+        void start( player_activity &, Character & ) override;
+        void do_turn( player_activity &act, Character &who ) override;
+        void finish( player_activity &, Character & ) override {};
+
+        std::unique_ptr<activity_actor> clone() const override {
+            return std::make_unique<contents_change_activity_actor>( *this );
+        }
+
+        void serialize( JsonOut &jsout ) const override;
+        static std::unique_ptr<activity_actor> deserialize( JsonValue &jsin );
+};
+
 class tent_placement_activity_actor : public activity_actor
 {
     private:

--- a/src/character.h
+++ b/src/character.h
@@ -2181,23 +2181,6 @@ class Character : public Creature, public visitable
         */
         bool i_drop_at( item &it, int qty = 1 );
 
-        /**
-         * Check any already unsealed pockets in items pointed to by `containers`
-         * and propagate the unsealed status through the container tree. In the
-         * process the player may be asked to handle containers or spill contents,
-         * so make sure all unsealed containers are passed to this function in a
-         * single batch; items (not limited to the ones listed in `containers` and
-         * their contents) may be invalidated or moved after a call to this function.
-         *
-         * @param containers Item locations pointing to containers. Item locations
-         *        in this vector can contain each other, but should always be valid
-         *        (i.e. if A contains B and B contains C, A and C can be in the vector
-         *        at the same time and should be valid, but B shouldn't be invalidated
-         *        either, otherwise C is invalidated). Item location in this vector
-         *        should be unique.
-         */
-        void handle_contents_changed( const std::vector<item_location> &containers );
-
         /** Only use for UI things. Returns all invlets that are currently used in
          * the player inventory, the weapon slot and the worn items. */
         std::bitset<std::numeric_limits<char>::max()> allocated_invlets() const;

--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -24,10 +24,12 @@
 #include "cached_options.h"
 #include "calendar.h"
 #include "catacharset.h"
+#include "cata_utility.h"
 #include "character.h"
 #include "character_attire.h"
 #include "character_martial_arts.h"
 #include "color.h"
+#include "contents_change_handler.h"
 #include "coordinates.h"
 #include "debug.h"
 #include "effect.h"
@@ -102,113 +104,78 @@ static const proficiency_id proficiency_prof_trapsetting( "prof_trapsetting" );
 
 static const trait_id trait_DEBUG_HS( "DEBUG_HS" );
 
-void Character::handle_contents_changed( const std::vector<item_location> &containers )
+void contents_change_handler::handle_contents_changed( Character &who )
 {
-    if( containers.empty() ) {
-        return;
-    }
-
-    class item_loc_with_depth
-    {
-        public:
-            // NOLINTNEXTLINE(google-explicit-constructor)
-            item_loc_with_depth( const item_location &_loc )
-                : _loc( _loc ) {
-                item_location ancestor = _loc;
-                while( ancestor.has_parent() ) {
-                    ++_depth;
-                    ancestor = ancestor.parent_item();
-                }
-            }
-
-            const item_location &loc() const {
-                return _loc;
-            }
-
-            int depth() const {
-                return _depth;
-            }
-
-        private:
-            item_location _loc;
-            int _depth = 0;
-    };
-
-    class sort_by_depth
-    {
-        public:
-            bool operator()( const item_loc_with_depth &lhs, const item_loc_with_depth &rhs ) const {
-                return lhs.depth() < rhs.depth();
-            }
-    };
-
-    std::multiset<item_loc_with_depth, sort_by_depth> sorted_containers(
-        containers.begin(), containers.end() );
+    // some containers could have been destroyed by e.g. monster attack in-between calls
+    // remove only invalid containers (valid contents of those containers are okay)
+    erase_if( sorted_containers, []( const item_loc_with_depth & ctr ) {
+        return !ctr.loc();
+    } );
     map &m = get_map();
 
     // unseal and handle containers, from innermost (max depth) to outermost (min depth)
     // so inner containers are always handled before outer containers are possibly removed.
-    while( !sorted_containers.empty() ) {
-        item_location loc = std::prev( sorted_containers.end() )->loc();
-        sorted_containers.erase( std::prev( sorted_containers.end() ) );
-        if( !loc ) {
-            debugmsg( "invalid item location" );
-            continue;
-        }
-        loc->on_contents_changed();
-        const bool handle_drop = loc.where() != item_location::type::map && !is_wielding( *loc );
-        bool drop_unhandled = false;
-        for( item_pocket *const pocket : loc->get_container_pockets() ) {
-            if( pocket && !pocket->sealed() ) {
-                // pockets are unsealed but on_contents_changed is not called
-                // in contents_change_handler::unseal_pocket_containing
-                pocket->on_contents_changed();
-            }
-            if( pocket && handle_drop && pocket->will_spill() ) {
-                // the pocket's contents (with a larger depth value) are not
-                // inside `sorted_containers` and can be safely disposed of.
-                pocket->handle_liquid_or_spill( *this, /*avoid=*/&*loc );
-                // drop the container instead if canceled.
-                if( !pocket->empty() ) {
-                    // drop later since we still need to access the container item
-                    drop_unhandled = true;
-                    // canceling one pocket cancels spilling for the whole container
-                    break;
-                }
-            }
-        }
 
-        if( loc.has_parent() ) {
-            item_location parent_loc = loc.parent_item();
-            item_loc_with_depth parent( parent_loc );
-            item_pocket *const pocket = loc.parent_pocket();
-            pocket->unseal();
-            bool exists = false;
-            auto it = sorted_containers.lower_bound( parent );
-            for( ; it != sorted_containers.end() && it->depth() == parent.depth(); ++it ) {
-                if( it->loc() == parent_loc ) {
-                    exists = true;
-                    break;
-                }
-            }
-            if( !exists ) {
-                sorted_containers.emplace_hint( it, parent );
+    item_location loc = std::prev( sorted_containers.end() )->loc();
+    sorted_containers.erase( std::prev( sorted_containers.end() ) );
+    if( !loc ) {
+        debugmsg( "invalid item location" );
+        return; // continue;
+    }
+    loc->on_contents_changed();
+    const bool handle_drop = loc.where() != item_location::type::map && !who.is_wielding( *loc );
+    bool drop_unhandled = false;
+    for( item_pocket *const pocket : loc->get_container_pockets() ) {
+        if( pocket && !pocket->sealed() ) {
+            // pockets are unsealed but on_contents_changed is not called
+            // in contents_change_handler::unseal_pocket_containing
+            pocket->on_contents_changed();
+        }
+        if( pocket && handle_drop && pocket->will_spill() ) {
+            // the pocket's contents (with a larger depth value) are not
+            // inside `sorted_containers` and can be safely disposed of.
+            pocket->handle_liquid_or_spill( who, /*avoid=*/&*loc );
+            // drop the container instead if canceled.
+            if( !pocket->empty() ) {
+                // drop later since we still need to access the container item
+                drop_unhandled = true;
+                // canceling one pocket cancels spilling for the whole container
+                break;
             }
         }
+    }
 
-        if( drop_unhandled ) {
-            // We can drop the unhandled container now since the container and
-            // its contents (with a larger depth) are not inside `sorted_containers`.
-            add_msg_player_or_npc(
-                _( "To avoid spilling its contents, you set your %1$s on the %2$s." ),
-                _( "To avoid spilling its contents, <npcname> sets their %1$s on the %2$s." ),
-                loc->display_name(), m.name( pos_bub() )
-            );
-            item it_copy( *loc );
-            loc.remove_item();
-            // target item of `loc` is invalidated and should not be used from now on
-            m.add_item_or_charges( pos_bub(), it_copy );
+    if( loc.has_parent() ) {
+        item_location parent_loc = loc.parent_item();
+        item_loc_with_depth parent( parent_loc );
+        item_pocket *const pocket = loc.parent_pocket();
+        pocket->unseal();
+        bool exists = false;
+        auto it = sorted_containers.lower_bound( parent );
+        for( ; it != sorted_containers.end() && it->depth() == parent.depth(); ++it ) {
+            if( it->loc() == parent_loc ) {
+                exists = true;
+                break;
+            }
         }
+        if( !exists ) {
+            sorted_containers.emplace_hint( it, parent );
+        }
+    }
+
+    if( drop_unhandled ) {
+        const tripoint_bub_ms char_pos_bub = who.pos_bub();
+        // We can drop the unhandled container now since the container and
+        // its contents (with a larger depth) are not inside `sorted_containers`.
+        who.add_msg_player_or_npc(
+            _( "To avoid spilling its contents, you set your %1$s on the %2$s." ),
+            _( "To avoid spilling its contents, <npcname> sets their %1$s on the %2$s." ),
+            loc->display_name(), m.name( char_pos_bub )
+        );
+        item it_copy( *loc );
+        loc.remove_item();
+        // target item of `loc` is invalidated and should not be used from now on
+        m.add_item_or_charges( char_pos_bub, it_copy );
     }
 }
 

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -15,6 +15,7 @@
 #include <utility>
 #include <vector>
 
+#include "activity_actor_definitions.h"
 #include "addiction.h"
 #include "avatar.h"
 #include "bodypart.h"
@@ -2023,14 +2024,15 @@ trinary Character::consume( item_location loc, bool force )
     trinary result = consume( target, force );
     if( result != trinary::NONE ) {
         handler.unseal_pocket_containing( loc );
-    }
-    if( result == trinary::ALL ) {
-        if( loc.where() == item_location::type::character ) {
-            i_rem( loc.get_item() );
-        } else {
-            loc.remove_item();
+
+        if( result == trinary::ALL ) {
+            if( loc.where() == item_location::type::character ) {
+                i_rem( loc.get_item() );
+            } else {
+                loc.remove_item();
+            }
         }
+        assign_activity( contents_change_activity_actor( handler ) );
     }
-    handler.handle_by( *this );
     return result;
 }

--- a/src/contents_change_handler.cpp
+++ b/src/contents_change_handler.cpp
@@ -1,11 +1,25 @@
 #include <algorithm>
 
-#include "character.h"
 #include "contents_change_handler.h"
 #include "debug.h"
 #include "flexbuffer_json.h"
+#include "item.h" // IWYU pragma: keep
 #include "item_pocket.h"
 #include "json.h"
+
+
+void contents_change_handler::sort_containers()
+{
+    sorted_containers.clear();
+    for( const item_location &loc : unsealed ) {
+        sorted_containers.emplace( loc );
+    }
+}
+
+bool contents_change_handler::finished() const
+{
+    return sorted_containers.empty();
+}
 
 void contents_change_handler::add_unsealed( const item_location &loc )
 {
@@ -31,25 +45,30 @@ void contents_change_handler::unseal_pocket_containing( const item_location &loc
     }
 }
 
-void contents_change_handler::handle_by( Character &guy )
-{
-    // some containers could have been destroyed by e.g. monster attack
-    auto it = std::remove_if( unsealed.begin(), unsealed.end(),
-    []( const item_location & loc ) -> bool {
-        return !loc;
-    } );
-    unsealed.erase( it, unsealed.end() );
-    guy.handle_contents_changed( unsealed );
-    unsealed.clear();
-}
-
 void contents_change_handler::serialize( JsonOut &jsout ) const
 {
     jsout.write( unsealed );
+    jsout.write( sorted_containers );
 }
 
 void contents_change_handler::deserialize( const JsonValue &jsin )
 {
     jsin.read( unsealed );
+    jsin.read( sorted_containers );
 }
 
+void item_loc_with_depth::serialize( JsonOut &jsout ) const
+{
+    jsout.start_object();
+
+    jsout.member( "item_location", _loc );
+    jsout.member( "depth", _depth );
+
+    jsout.end_object();
+}
+
+void item_loc_with_depth::deserialize( const JsonObject &obj )
+{
+    obj.read( "item_location", _loc );
+    obj.read( "depth", _depth );
+}

--- a/src/contents_change_handler.h
+++ b/src/contents_change_handler.h
@@ -2,24 +2,69 @@
 #ifndef CATA_SRC_CONTENTS_CHANGE_HANDLER_H
 #define CATA_SRC_CONTENTS_CHANGE_HANDLER_H
 
+#include <set>
 #include <vector>
 
 #include "item_location.h"
 
 class Character;
+class JsonObject;
 class JsonOut;
 class JsonValue;
 
+class item_loc_with_depth
+{
+    public:
+        item_loc_with_depth() = default;
+        explicit item_loc_with_depth( const item_location &_loc )
+            : _loc( _loc ) {
+            item_location ancestor = _loc;
+            while( ancestor.has_parent() ) {
+                ++_depth;
+                ancestor = ancestor.parent_item();
+            }
+        }
+
+        const item_location &loc() const {
+            return _loc;
+        }
+
+        int depth() const {
+            return _depth;
+        }
+
+        void serialize( JsonOut &jsout ) const;
+        void deserialize( const JsonObject &obj );
+
+    private:
+        item_location _loc;
+        int _depth = 0;
+};
+
+class sort_by_depth
+{
+    public:
+        bool operator()( const item_loc_with_depth &lhs, const item_loc_with_depth &rhs ) const {
+            return lhs.depth() < rhs.depth();
+        }
+};
+
 /**
  * Records a batch of unsealed containers and handles spilling at once. This
- * is preferred over handling containers right after unsealing because the latter
+ * is preferred over handling containers immediately after unsealing because the latter
  * can cause items to be invalidated when later code still needs to access them.
- * See @ref `Character::handle_contents_changed` for more detail.
+ *
+ * You should use `contents_change_activity_actor` to utilize `contents_change_handler`
+ * in a `Character` context.
  */
 class contents_change_handler
 {
     public:
         contents_change_handler() = default;
+        // sort `unsealed` into `sorted_containers`
+        void sort_containers();
+        // are any containers left to process?
+        bool finished() const;
         /**
          * Add an already unsealed container to the list. This item location
          * should remain valid when `handle_by` is called.
@@ -33,10 +78,13 @@ class contents_change_handler
          */
         void unseal_pocket_containing( const item_location &loc );
         /**
-         * Let the guy handle any container that needs spilling. This may invalidate
+         * Let the character handle a single container that needs spilling. This may invalidate
          * items in and out of the list of containers. The list is cleared after handling.
+         *
+         * Check any already unsealed pockets in items pointed to by `sorted_containers`
+         * and propagate the unsealed status through the container tree.
          */
-        void handle_by( Character &guy );
+        void handle_contents_changed( Character &who );
         /**
          * Serialization for activities
          */
@@ -46,7 +94,17 @@ class contents_change_handler
          */
         void deserialize( const JsonValue &jsin );
     private:
+        /*
+        * Item locations pointing to containers. Item locations
+        * in this vector can contain each other, but should always be valid
+        * (i.e. if A contains B and B contains C, A and C can be in the vector
+        * at the same time and should be valid, but B shouldn't be invalidated
+        * either, otherwise C is invalidated).Item location in this vector
+        * should be unique.
+        */
         std::vector<item_location> unsealed;
+        // sorted, cached, ready-to-process `unsealed`
+        std::multiset<item_loc_with_depth, sort_by_depth> sorted_containers;
 };
 
 #endif // CATA_SRC_CONTENTS_CHANGE_HANDLER_H

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2260,7 +2260,7 @@ int game::inventory_item_menu( item_location locThisItem,
                         add_msg( m_info, _( "You can't use a %s there." ), locThisItem->tname() );
                         break;
                     }
-                    handler.handle_by( u );
+                    u.assign_activity( contents_change_activity_actor( handler ) );
                     break;
                 }
                 case 'E':
@@ -2277,7 +2277,7 @@ int game::inventory_item_menu( item_location locThisItem,
                     contents_change_handler handler;
                     handler.unseal_pocket_containing( locThisItem );
                     u.wear( locThisItem );
-                    handler.handle_by( u );
+                    u.assign_activity( contents_change_activity_actor( handler ) );
                     break;
                 }
                 case 'w':
@@ -2285,7 +2285,7 @@ int game::inventory_item_menu( item_location locThisItem,
                         contents_change_handler handler;
                         handler.unseal_pocket_containing( locThisItem );
                         u.wield( locThisItem );
-                        handler.handle_by( u );
+                        u.assign_activity( contents_change_activity_actor( handler ) );
                     } else {
                         add_msg( m_info, "%s", u.can_wield( *locThisItem ).c_str() );
                     }
@@ -2295,7 +2295,7 @@ int game::inventory_item_menu( item_location locThisItem,
                     contents_change_handler handler;
                     handler.unseal_pocket_containing( locThisItem );
                     avatar_action::plthrow( u, locThisItem );
-                    handler.handle_by( u );
+                    u.assign_activity( contents_change_activity_actor( handler ) );
                     break;
                 }
                 case 'c':

--- a/tests/item_pocket_test.cpp
+++ b/tests/item_pocket_test.cpp
@@ -3058,6 +3058,10 @@ TEST_CASE( "unload_from_spillable_container", "[item][pocket]" )
             item_location steelpan_loc( backpack_loc, steelpan );
             item_location bottle1_loc( steelpan_loc, bottle1 );
             unload_activity_actor::unload( u, bottle1_loc );
+            // process contents_change_activity_actor
+            while( u.activity ) {
+                u.activity.do_turn( u );
+            }
             THEN( "pill is unloaded into bottle that previously had 4 pills, remaining empty bottle is kept" ) {
                 // Expected inventory after unloading should be:
                 //   backpack >

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -80,6 +80,7 @@
 class Creature;
 enum npc_action : int;
 
+static const activity_id ACT_CONTENTS_CHANGE( "ACT_CONTENTS_CHANGE" );
 static const activity_id ACT_FORAGE( "ACT_FORAGE" );
 static const activity_id ACT_HARVEST( "ACT_HARVEST" );
 static const activity_id ACT_START_FIRE( "ACT_START_FIRE" );
@@ -2597,9 +2598,8 @@ TEST_CASE( "npc_harvest_scavenging", "[npc][needs]" )
         const size_t items_before = here.i_at( adj ).size();
 
         guy.address_needs( 0 );
-
         CHECK( here.i_at( adj ).size() < items_before );
-        CHECK_FALSE( guy.has_activity() );
+        CHECK( guy.activity.id() == ACT_CONTENTS_CHANGE );
     }
 
     SECTION( "distant reachable food preferred over nearby harvestable" ) {
@@ -2633,7 +2633,7 @@ TEST_CASE( "npc_harvest_scavenging", "[npc][needs]" )
 
         guy.address_needs( 0 );
 
-        CHECK_FALSE( guy.has_activity() );
+        CHECK( guy.activity.id() == ACT_CONTENTS_CHANGE );
         CHECK( cargo->items().size() < cargo_before );
     }
 

--- a/tests/unseal_and_spill_test.cpp
+++ b/tests/unseal_and_spill_test.cpp
@@ -8,6 +8,7 @@
 #include <utility>
 #include <vector>
 
+#include "activity_actor_definitions.h"
 #include "avatar.h"
 #include "cached_options.h"
 #include "cata_catch.h"
@@ -22,6 +23,7 @@
 #include "map.h"
 #include "map_helpers.h"
 #include "map_selector.h"
+#include "player_activity.h"
 #include "player_helpers.h"
 #include "pocket_type.h"
 #include "ret_val.h"
@@ -611,10 +613,13 @@ void test_scenario::run()
     INFO( player_action_str );
 
     contents_change_handler handler;
-    // TODO replace with actual activities
     unseal_items_containing( handler, it_loc,
                              std::set<itype_id> { itype_test_liquid_1ml, itype_test_solid_1ml } );
-    handler.handle_by( guy );
+    guy.assign_activity( contents_change_activity_actor( handler ) );
+
+    while( guy.activity ) {
+        guy.activity.do_turn( guy );
+    }
 
     // check final state
     // whether the outermost container will spill. inner containers will always spill.


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Infrastructure "Process `contents_change_handler` in contents_change_activity_actor"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

While working on #84782, I ran into an issue: if liquid handling is to be performed in a `fill_liquid_activity_actor`, then the `unseal_and_spill` test should use that activity. However, `contents_change_handler` handles pocket unsealing instantaneously and therefore can and will spill multiple liquids instantaneously, so it must be moved to an activity before `fill_liquid_activity_actor` can be implemented.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

`contents_change_handler` now processes a container per-turn (instead of all at once) inside `contents_change_activity_actor`, replacing `contents_change_handler::handle_by()`. 

`Character::handle_contents_changed` is now `contents_change_activity_actor::handle_contents_changed` for more accurate modularization.

If this works out, my next intended move is to refactor #84782 so that `contents_change_activity_actor` assigns `fill_liquid_activity_actor` and backlogs itself until finished, similarly to multi-activities.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Unsealed items using activities that involve `contents_change_handler`, including: drop, stash, insert_item, wear, wield, unload.

Consumed a sealed item (sports drink), refilled a vehicle from a sealed container, threw a bucket of liquid (it doesn't spill?!).

Ran tests locally, didn't see any related failures, but double-check CI. Notably, test cases `unseal_and_spill` and `unload_from_spillable_container` both passed.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
