### PR TITLE
Disable colored light tint overlay in isometric mode

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1860,7 +1860,13 @@ void cata_tiles::draw( const point &dest, const tripoint_bub_ms &center, int wid
         // For each row
         const bool iso = is_isometric();
         const level_cache &zlev_cache = here.access_cache( cur_zlevel );
-        const bool zlev_has_color = zlev_cache.has_colored_lights;
+        // FIXME: colored light tint overlay disabled in isometric mode pending
+        // a non-silhouette implementation. The hybrid mask path requires render
+        // target switches that stall the GPU pipeline, and the simple diamond
+        // path alone does not justify the per-sprite bounds tracking overhead
+        // in the layer loop. Revisit when SDL_gpu or a shader-based tint path
+        // is available.
+        const bool zlev_has_color = zlev_cache.has_colored_lights && !iso;
         for( int row = cur_any_tile_range.p_min.y; row < cur_any_tile_range.p_max.y; row ++ ) {
             // --- Per-tile prepass ---
             // Initialize base height and decide which tiles need a colored light


### PR DESCRIPTION
#### Summary
Bugfixes "Disable colored light tint overlay in isometric mode"

#### Purpose of change
The colored light tint overlay landed for ortho mode with a silhouette-mask hybrid path. Iso was left out because the mask path is GPU-expensive (render target switches stall the pipeline) and the simple diamond path alone doesn't justify the per-sprite bounds tracking added to the layer loop. In practice, trying to ship iso tint made the game slow as hell even with batching, per-tile gating, and `small_literal_vector` shenanigans.

Rather than keeping a broken iso tint in the tree or deleting the whole system, this disables the overlay for iso only. Ortho keeps working, colored light info in the level cache still flows, and the feature comes back the moment the rendering backend stops charging per-target-switch.

Attempts leading to this:
- Flat rect overlay (original landing). Broke visually in iso (diamond-on-wall artifacts).
- Diamond geometry via `SDL_RenderGeometry`. Fixed simple ground tiles, still had tall-sprite seams.
- Silhouette mask path for tall sprites. Visually correct, GPU-bound.
- Hybrid iso/ortho unification, plus batching, `small_literal_vector<4>` for tint sprites, pre-classification of complex tiles, union area caps. Measurable CPU wins, no change to GPU bottleneck.

#### Describe the solution
Gate `zlev_has_color` on `!is_isometric()` in `cata_tiles::draw`. Needs-tint stays false for every iso tile, nothing gets added to `row_tinted`, no overlay pass runs, no bounds tracking fires in the layer loop. FIXME comment in place with rationale.

#### Describe alternatives you've considered
Shipping the silhouette path anyway and letting users eat the framerate hit. No thanks.

Ripping out the tint system entirely. Throws away a genuinely nice ortho feature for no gain.

Waiting for the right fix. SDL3 is already on the way and exposes `SDL_gpu` plus shader-based blending, which makes a per-pixel tint one draw call with no target switches. That's the sensible place to revisit this, not now.

#### Testing
Verified in-game: iso mode no longer tints tiles with colored light (expected), ortho still does (unchanged). No test suite impact -- compile-only gate.

#### Additional context
N/A