### PR TITLE
Split farm fields from hay fields for overmap routing

### DIFF
--- a/data/json/overmap/overmap_terrain/overmap_terrain_agricultural.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_agricultural.json
@@ -105,7 +105,8 @@
       "farm_9"
     ],
     "copy-from": "generic_rural_field",
-    "name": "farm field"
+    "name": "farm field",
+    "travel_cost_type": "crop_field"
   },
   {
     "type": "overmap_terrain",
@@ -152,6 +153,7 @@
     ],
     "copy-from": "generic_rural_field",
     "name": "farm field",
+    "travel_cost_type": "crop_field",
     "extras": "agricultural",
     "looks_like": "farm_5",
     "spawns": { "group": "GROUP_FOREST", "population": [ 0, 2 ], "chance": 15 }

--- a/src/omdata.h
+++ b/src/omdata.h
@@ -341,6 +341,7 @@ enum class oter_travel_cost_type : int {
     highway,
     road,
     field,
+    crop_field,
     dirt_road,
     trail,
     forest,

--- a/src/overmap_terrain.cpp
+++ b/src/overmap_terrain.cpp
@@ -468,6 +468,7 @@ std::string enum_to_string<oter_travel_cost_type>( oter_travel_cost_type data )
         case oter_travel_cost_type::highway: return "highway";
         case oter_travel_cost_type::road: return "road";
         case oter_travel_cost_type::field: return "field";
+        case oter_travel_cost_type::crop_field: return "crop_field";
         case oter_travel_cost_type::dirt_road: return "dirt_road";
         case oter_travel_cost_type::trail: return "trail";
         case oter_travel_cost_type::forest: return "forest";
@@ -556,6 +557,7 @@ static string_id<map_data_summary> map_data_for_travel_cost( oter_travel_cost_ty
         case oter_travel_cost_type::field:
         case oter_travel_cost_type::dirt_road:
             return map_data_summary_empty_omt;
+        case oter_travel_cost_type::crop_field:
         case oter_travel_cost_type::trail:
         case oter_travel_cost_type::forest:
         case oter_travel_cost_type::shore:

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -1000,6 +1000,7 @@ overmap_path_params overmap_path_params::for_player()
     ret.set_cost( oter_travel_cost_type::road, 24 );
     ret.set_cost( oter_travel_cost_type::dirt_road, 24 );
     ret.set_cost( oter_travel_cost_type::field, 36 );
+    ret.set_cost( oter_travel_cost_type::crop_field, 54 );
     ret.set_cost( oter_travel_cost_type::trail, 43 );
     ret.set_cost( oter_travel_cost_type::shore, 48 );
     ret.set_cost( oter_travel_cost_type::forest, 72 );
@@ -1030,6 +1031,8 @@ overmap_path_params overmap_path_params::for_land_vehicle( float offroad_coeff, 
     ret.set_cost( oter_travel_cost_type::road, 8 ); // limited by vehicle autodrive speed
     const int field_cost = can_offroad ? std::lround( 12 / std::min( 1.0f, offroad_coeff ) ) : -1;
     ret.set_cost( oter_travel_cost_type::field, field_cost );
+    ret.set_cost( oter_travel_cost_type::crop_field,
+                  can_offroad ? std::lround( 36 / std::min( 1.0f, offroad_coeff ) ) : -1 );
     ret.set_cost( oter_travel_cost_type::dirt_road, field_cost );
     ret.set_cost( oter_travel_cost_type::trail,
                   ( can_offroad && tiny ) ? field_cost + 8 : -1 );


### PR DESCRIPTION
#### Summary
Infrastructure "Add crop_field overmap travel cost type so vehicle autodrive avoids farm fields"

#### Purpose of change
Land vehicle autodrive treats "farm field" and "hay field" overmap tiles as the same `field` travel cost, so it happily routes cars straight through rows of crops and tilled soil. Mapgen for `farmland_*` is full of crop furniture and obstacles, while `hayfield_*` is basically flat grass with a few haystacks. They should not path identically.

#### Describe the solution
New `oter_travel_cost_type::crop_field` sits next to `field` in the enum. Player foot cost is 54 (between field 36 and forest 72), vehicle cost is 3x the usual `field_cost` and -1 for no-offroad.

Both "farm field" overmap_terrain entries in `overmap_terrain_agricultural.json` now override `travel_cost_type: crop_field`. `hayfield_*` keeps the plain `field` type from `generic_rural_field`.

Farms that inherit via `copy-from: 2farm_1` (the Isherwood farms, etc.) also pick up the new type, which is probably fine since those tiles mix crops and structures and weren't great to drive through either.

#### Describe alternatives you've considered
Overloading an existing type like `forest` would have worked with zero C++ changes but would overcharge pedestrians who can stroll through corn rows just fine. Marking farm fields outright impassable was tempting but would annoy anyone with a monster truck build.

#### Testing
Verified in-game. Autodrive now lays routes through hay fields and roads instead of cutting across farm fields.

#### Additional context
N/A