### PR TITLE
Restore default name setting in custom chargen

### DIFF
--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -755,6 +755,9 @@ bool avatar::create( character_type type, const std::string &tempname )
 
     switch( type ) {
         case character_type::CUSTOM:
+            if( !get_option<std::string>( "DEF_CHAR_NAME" ).empty() ) {
+                name = get_option<std::string>( "DEF_CHAR_NAME" );
+            }
             randomize_cosmetics();
             break;
         case character_type::RANDOM:


### PR DESCRIPTION
#### Summary
Bugfixes "Restore default name setting in custom chargen"

#### Purpose of change
Correct a minor regression in #86250

#### Describe the solution
Add a check for `DEF_CHAR_NAME` option in `avatar::create` for the `character_type::CUSTOM` type avatars.  If present, sets the avatar's name to that string. The `character_type::RANDOM` option still correctly uses the  `DEF_CHAR_NAME` option.

#### Describe alternatives you've considered

#### Testing
Made new characters with and without a default name set. Properly shows up on custom and random character creation options.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
