### PR TITLE
Fix washing machine accepting soapy water as valid water source

### DIFF
--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1487,7 +1487,6 @@ void vehicle::use_washing_machine( map &here, int p )
         int chosen_detergent = UILIST_CANCEL;
         std::vector<itype_id> det_types;
 
-        
         if( fuel_left( here, itype_soapy_water ) < 24 ) {
             for( const item *it : detergents ) {
                 itype_id det_type = it->typeId();

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1446,9 +1446,12 @@ void vehicle::use_autoclave( map &here, int p )
 // TODO: Organize magic number consumption.
 void vehicle::use_washing_machine( map &here, int p )
 {
+    static const itype_id itype_water( "water" );
+    static const itype_id itype_water_clean( "water_clean" );
+    static const itype_id itype_soapy_water( "soapy_water" );
+
     vehicle_part &vp = parts[p];
     avatar &player_character = get_avatar();
-    // Get all the items that can be used as detergent
     const inventory &inv = player_character.crafting_inventory();
     std::vector<const item *> detergents = inv.items_with( [inv]( const item & it ) {
         return it.has_flag( json_flag_DETERGENT ) && inv.has_charges( it.typeId(), 5 );
@@ -1465,47 +1468,45 @@ void vehicle::use_washing_machine( map &here, int p )
 
     if( vp.enabled ) {
         vp.enabled = false;
-        add_msg( m_bad,
-                 _( "You turn the washing machine off before it's finished its cycle, and open its lid." ) );
+        add_msg( m_bad, _( "You turn the washing machine off before it's finished its cycle, and open its lid." ) );
     } else if( items.empty() ) {
         add_msg( m_bad, _( "The washing machine is empty; there's no point in starting it." ) );
-    } else if( fuel_left( here, itype_water ) < 24 && fuel_left( here, itype_water_clean ) < 24 ) {
-        add_msg( m_bad,
-                 _( "You need 24 charges of water in the tanks of the %s to fill the washing machine." ), name );
-    } else if( detergents.empty() ) {
+    } else if( fuel_left( here, itype_water ) < 24 && fuel_left( here, itype_water_clean ) < 24 && fuel_left( here, itype_soapy_water ) < 24 ) {
+        add_msg( m_bad, _( "You need 24 charges of water in the tanks of the %s to fill the washing machine." ), name );
+    } else if( detergents.empty() && fuel_left( here, itype_soapy_water ) < 24 ) {
         add_msg( m_bad, _( "You need 5 charges of a detergent for the washing machine." ) );
     } else if( !filthy_items ) {
-        add_msg( m_bad,
-                 _( "You need to remove all non-filthy items from the washing machine to start the washing program." ) );
+        add_msg( m_bad, _( "You need to remove all non-filthy items from the washing machine to start the washing program." ) );
     } else if( cbms ) {
         add_msg( m_bad, _( "CBMs can't be cleaned in a washing machine.  You need to remove them." ) );
     } else {
-        uilist detergent_selector;
-        detergent_selector.text = _( "Use what detergent?" );
-
+        int chosen_detergent = UILIST_CANCEL;
         std::vector<itype_id> det_types;
-        for( const item *it : detergents ) {
-            itype_id det_type = it->typeId();
-            // If the vector does not contain the detergent type, add it
-            if( std::find( det_types.begin(), det_types.end(), det_type ) == det_types.end() ) {
-                det_types.emplace_back( det_type );
+
+        
+        if( fuel_left( here, itype_soapy_water ) < 24 ) {
+            for( const item *it : detergents ) {
+                itype_id det_type = it->typeId();
+                if( std::find( det_types.begin(), det_types.end(), det_type ) == det_types.end() ) {
+                    det_types.emplace_back( det_type );
+                }
             }
 
-        }
-        int chosen_detergent = 0;
-        // If there's a choice to be made on what detergent to use, ask the player
-        if( det_types.size() > 1 ) {
-            for( size_t i = 0; i < det_types.size(); ++i ) {
-                detergent_selector.addentry( i, true, 0, item::nname( det_types[i] ) );
+            if( det_types.size() > 1 ) {
+                uilist detergent_selector;
+                detergent_selector.text = _( "Use what detergent?" );
+                for( size_t i = 0; i < det_types.size(); ++i ) {
+                    detergent_selector.addentry( i, true, 0, item::nname( det_types[i] ) );
+                }
+                detergent_selector.addentry( UILIST_CANCEL, true, 0, _( "Cancel" ) );
+                detergent_selector.query();
+                chosen_detergent = detergent_selector.ret;
+                if( chosen_detergent == UILIST_CANCEL ) {
+                    return;
+                }
+            } else if( !det_types.empty() ) {
+                chosen_detergent = 0;
             }
-            detergent_selector.addentry( UILIST_CANCEL, true, 0, _( "Cancel" ) );
-            detergent_selector.query();
-            chosen_detergent = detergent_selector.ret;
-        }
-
-        // If the player exits the menu, don't do anything else
-        if( chosen_detergent == UILIST_CANCEL ) {
-            return;
         }
 
         vp.enabled = true;
@@ -1513,24 +1514,29 @@ void vehicle::use_washing_machine( map &here, int p )
             n.set_age( 0_turns );
         }
 
-        if( fuel_left( here, itype_water ) >= 24 ) {
-            drain( here, itype_water, 24 );
+        if( fuel_left( here, itype_soapy_water ) >= 24 ) {
+            drain( here, itype_soapy_water, 24 );
         } else {
-            drain( here, itype_water_clean, 24 );
+            if( fuel_left( here, itype_water ) >= 24 ) {
+                drain( here, itype_water, 24 );
+            } else {
+                drain( here, itype_water_clean, 24 );
+            }
+            std::vector<item_comp> detergent;
+            detergent.emplace_back( det_types[chosen_detergent], 5 );
+            player_character.consume_items( detergent, 1, is_crafting_component );
         }
 
-        std::vector<item_comp> detergent;
-        detergent.emplace_back( det_types[chosen_detergent], 5 );
-        player_character.consume_items( detergent, 1, is_crafting_component );
-
-        add_msg( m_good,
-                 _( "You pour some detergent into the washing machine, close its lid, and turn it on.  The washing machine is being filled from the water tanks." ) );
+        add_msg( m_good, _( "You close the lid and turn the washing machine on. It is being filled from the water tanks." ) );
     }
 }
 
 // TODO: Organize magic number consumption.
 void vehicle::use_dishwasher( map &here, int p )
 {
+    static const itype_id itype_water( "water" );
+    static const itype_id itype_water_clean( "water_clean" );
+
     vehicle_part &vp = parts[p];
     avatar &player_character = get_avatar();
     bool detergent_is_enough = player_character.crafting_inventory().has_charges( itype_detergent, 5 );

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1468,7 +1468,8 @@ void vehicle::use_washing_machine( map &here, int p )
 
     if( vp.enabled ) {
         vp.enabled = false;
-        add_msg( m_bad, _( "You turn the washing machine off before it's finished its cycle, and open its lid." ) );
+        add_msg( m_bad,
+                 _( "You turn the washing machine off before it's finished its cycle, and open its lid." ) );
     } else if( items.empty() ) {
         add_msg( m_bad, _( "The washing machine is empty; there's no point in starting it." ) );
     } else if( fuel_left( here, itype_water ) < 24 && fuel_left( here, itype_water_clean ) < 24 && fuel_left( here, itype_soapy_water ) < 24 ) {

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1479,7 +1479,8 @@ void vehicle::use_washing_machine( map &here, int p )
     } else if( detergents.empty() && fuel_left( here, itype_soapy_water ) < 24 ) {
         add_msg( m_bad, _( "You need 5 charges of a detergent for the washing machine." ) );
     } else if( !filthy_items ) {
-        add_msg( m_bad, _( "You need to remove all non-filthy items from the washing machine to start the washing program." ) );
+        add_msg( m_bad,
+                 _( "You need to remove all non-filthy items from the washing machine to start the washing program." ) );
     } else if( cbms ) {
         add_msg( m_bad, _( "CBMs can't be cleaned in a washing machine.  You need to remove them." ) );
     } else {

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1472,8 +1472,10 @@ void vehicle::use_washing_machine( map &here, int p )
                  _( "You turn the washing machine off before it's finished its cycle, and open its lid." ) );
     } else if( items.empty() ) {
         add_msg( m_bad, _( "The washing machine is empty; there's no point in starting it." ) );
-    } else if( fuel_left( here, itype_water ) < 24 && fuel_left( here, itype_water_clean ) < 24 && fuel_left( here, itype_soapy_water ) < 24 ) {
-        add_msg( m_bad, _( "You need 24 charges of water in the tanks of the %s to fill the washing machine." ), name );
+    } else if( fuel_left( here, itype_water ) < 24 && fuel_left( here, itype_water_clean ) < 24 &&
+               fuel_left( here, itype_soapy_water ) < 24 ) {
+        add_msg( m_bad,
+                 _( "You need 24 charges of water in the tanks of the %s to fill the washing machine." ), name );
     } else if( detergents.empty() && fuel_left( here, itype_soapy_water ) < 24 ) {
         add_msg( m_bad, _( "You need 5 charges of a detergent for the washing machine." ) );
     } else if( !filthy_items ) {

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1530,7 +1530,8 @@ void vehicle::use_washing_machine( map &here, int p )
             player_character.consume_items( detergent, 1, is_crafting_component );
         }
 
-        add_msg( m_good, _( "You close the lid and turn the washing machine on. It is being filled from the water tanks." ) );
+        add_msg( m_good,
+                 _( "You close the lid and turn the washing machine on. It is being filled from the water tanks." ) );
     }
 }
 

--- a/tests/washing_machine_test.cpp
+++ b/tests/washing_machine_test.cpp
@@ -71,7 +71,7 @@ TEST_CASE( "washing_machine_soapy_water_starts_without_detergent", "[vehicle][wa
     // Avatar has no detergent — soapy water must be sufficient
     avatar &player = get_avatar();
     REQUIRE( player.crafting_inventory().items_with(
-                 std::function<bool( const item & )>( []( const item & it ) {
+    std::function<bool( const item & )>( []( const item & it ) {
         return it.has_flag( flag_id( "DETERGENT" ) );
     } ) ).empty() );
 

--- a/tests/washing_machine_test.cpp
+++ b/tests/washing_machine_test.cpp
@@ -1,18 +1,18 @@
 #include <functional>
-#include <string>
+#include <utility>
 #include <vector>
 
 #include "avatar.h"
 #include "cata_catch.h"
 #include "coordinates.h"
-#include "flag.h"
+#include "inventory.h"
 #include "item.h"
 #include "map.h"
 #include "map_helpers.h"
 #include "player_helpers.h"
+#include "point.h"
 #include "type_id.h"
 #include "units.h"
-#include "veh_type.h"
 #include "vehicle.h"
 
 static const itype_id itype_soap( "soap" );

--- a/tests/washing_machine_test.cpp
+++ b/tests/washing_machine_test.cpp
@@ -1,0 +1,140 @@
+#include <functional>
+#include <string>
+#include <vector>
+
+#include "avatar.h"
+#include "cata_catch.h"
+#include "coordinates.h"
+#include "flag.h"
+#include "item.h"
+#include "map.h"
+#include "map_helpers.h"
+#include "player_helpers.h"
+#include "type_id.h"
+#include "units.h"
+#include "veh_type.h"
+#include "vehicle.h"
+
+static const itype_id itype_soap( "soap" );
+static const itype_id itype_soapy_water( "soapy_water" );
+static const itype_id itype_t_shirt( "t_shirt" );
+static const itype_id itype_water( "water" );
+static const itype_id itype_water_clean( "water_clean" );
+
+static const vproto_id vehicle_prototype_none( "none" );
+
+static const vpart_id vpart_tank_medium( "tank_medium" );
+static const vpart_id vpart_washing_machine( "washing_machine" );
+
+// Helper: set up a vehicle with a washing machine and a tank, returns the vehicle and wm part index
+static std::pair<vehicle *, int> setup_washing_machine( map &here, const tripoint_bub_ms &pos )
+{
+    vehicle *veh = here.add_vehicle( vehicle_prototype_none, pos, 0_degrees, 0, 0 );
+    REQUIRE( veh != nullptr );
+
+    const int wm_idx  = veh->install_part( here, point_rel_ms::zero, vpart_washing_machine );
+    const int tan_idx = veh->install_part( here, point_rel_ms::zero, vpart_tank_medium );
+    REQUIRE( wm_idx  >= 0 );
+    REQUIRE( tan_idx >= 0 );
+
+    return { veh, wm_idx };
+}
+
+// Helper: add liquid charges to a vehicle tank part
+static void add_liquid_to_vehicle( map &here, vehicle &veh, int tank_idx,
+                                   const itype_id &liquid_id, int charges )
+{
+    item liquid( liquid_id );
+    liquid.charges = charges;
+    veh.add_item( here, veh.part( tank_idx ), liquid );
+}
+
+TEST_CASE( "washing_machine_soapy_water_starts_without_detergent", "[vehicle][washing_machine]" )
+{
+    map &here = get_map();
+    clear_map();
+    clear_avatar();
+
+    const tripoint_bub_ms veh_pos( 60, 60, 0 );
+    auto [veh, wm_idx] = setup_washing_machine( here, veh_pos );
+
+    // Tank is the second installed part (index wm_idx + 1)
+    const int tan_idx = wm_idx + 1;
+    add_liquid_to_vehicle( here, *veh, tan_idx, itype_soapy_water, 30 );
+    REQUIRE( veh->fuel_left( here, itype_soapy_water ) >= 24 );
+
+    // Add a filthy item to the washing machine
+    item filthy_shirt( itype_t_shirt );
+    filthy_shirt.set_flag( flag_id( "FILTHY" ) );
+    veh->add_item( here, veh->part( wm_idx ), filthy_shirt );
+
+    // Avatar has no detergent — soapy water must be sufficient
+    avatar &player = get_avatar();
+    REQUIRE( player.crafting_inventory().items_with(
+                 std::function<bool( const item & )>( []( const item & it ) {
+        return it.has_flag( flag_id( "DETERGENT" ) );
+    } ) ).empty() );
+
+    const int soapy_before = veh->fuel_left( here, itype_soapy_water );
+
+    veh->use_washing_machine( here, wm_idx );
+
+    // Soapy water was consumed → machine started successfully
+    CHECK( veh->fuel_left( here, itype_soapy_water ) < soapy_before );
+}
+
+TEST_CASE( "washing_machine_normal_water_with_detergent_still_works", "[vehicle][washing_machine]" )
+{
+    map &here = get_map();
+    clear_map();
+    clear_avatar();
+
+    const tripoint_bub_ms veh_pos( 60, 60, 0 );
+    auto [veh, wm_idx] = setup_washing_machine( here, veh_pos );
+
+    const int tan_idx = wm_idx + 1;
+    add_liquid_to_vehicle( here, *veh, tan_idx, itype_water, 30 );
+    REQUIRE( veh->fuel_left( here, itype_water ) >= 24 );
+    REQUIRE( veh->fuel_left( here, itype_soapy_water ) == 0 );
+
+    item filthy_shirt( itype_t_shirt );
+    filthy_shirt.set_flag( flag_id( "FILTHY" ) );
+    veh->add_item( here, veh->part( wm_idx ), filthy_shirt );
+
+    // Give avatar soap as detergent
+    avatar &player = get_avatar();
+    item soap( itype_soap );
+    soap.charges = 10;
+    player.i_add( soap );
+
+    const int water_before = veh->fuel_left( here, itype_water );
+
+    veh->use_washing_machine( here, wm_idx );
+
+    // Normal water was consumed → machine started successfully
+    CHECK( veh->fuel_left( here, itype_water ) < water_before );
+}
+
+TEST_CASE( "washing_machine_blocked_without_any_water", "[vehicle][washing_machine]" )
+{
+    map &here = get_map();
+    clear_map();
+    clear_avatar();
+
+    const tripoint_bub_ms veh_pos( 60, 60, 0 );
+    auto [veh, wm_idx] = setup_washing_machine( here, veh_pos );
+
+    REQUIRE( veh->fuel_left( here, itype_water ) == 0 );
+    REQUIRE( veh->fuel_left( here, itype_water_clean ) == 0 );
+    REQUIRE( veh->fuel_left( here, itype_soapy_water ) == 0 );
+
+    item filthy_shirt( itype_t_shirt );
+    filthy_shirt.set_flag( flag_id( "FILTHY" ) );
+    veh->add_item( here, veh->part( wm_idx ), filthy_shirt );
+
+    veh->use_washing_machine( here, wm_idx );
+
+    // Nothing consumed → machine did not start
+    CHECK( veh->fuel_left( here, itype_water ) == 0 );
+    CHECK( veh->fuel_left( here, itype_soapy_water ) == 0 );
+}


### PR DESCRIPTION
#### Summary
Bugfixes "Fix washing machine accepting soapy water as valid water source"

#### Purpose of change
Fixes Fixes #83731 where filling a washing machine's tank with soapy water would
block the machine from being used or refilled with normal water afterwards,
due to soapy water not being recognized as a valid water source.

Steps to reproduce:
1. Fill a vehicle washing machine tank with soapy water
2. Try to use the washing machine
3. Despite having valid items, the machine cannot be started

#### Describe the solution
Added soapy water as a third valid water source alongside water and
water_clean. Soapy water takes priority when available and does not
require additional detergent since it already contains soap.

#### Describe alternatives you've considered
An alternative would be to simply block soapy water from being inserted
into the tank at all. However, accepting soapy water and using it
directly is more intuitive and useful gameplay-wise.

#### Testing
Tested in-game on Windows 10, cdda-experimental-2026-04-22-0147:
- Filled washing machine with soapy water → starts without detergent 
- Filled with normal water + detergent → still works 
- No water → correctly blocked 

Unit tests added in tests/washing_machine_test.cpp.

#### Additional context
No additional context.