### PR TITLE
Guard snmalloc Windows libraries behind WIN32

### DIFF
--- a/src/third-party/CMakeLists.txt
+++ b/src/third-party/CMakeLists.txt
@@ -240,9 +240,16 @@ target_link_libraries(
         third-party
         INTERFACE
         snmalloc
-        Synchronization.lib
-        WindowsApp.lib
         )
+
+if (WIN32)
+    target_link_libraries(
+            third-party
+            INTERFACE
+            Synchronization.lib
+            WindowsApp.lib
+            )
+endif ()
 
 # Zstandard
 file(GLOB ZSTD_HEADERS zstd/**/*.h)


### PR DESCRIPTION
#### Summary
Build "Guard snmalloc Windows libraries behind WIN32"

#### Purpose of change
#86577 added `Synchronization.lib` and `WindowsApp.lib` unconditionally. Non-Windows CMake builds now fail at link with `cannot find -lSynchronization.lib`. GCC 9 Ubuntu CMake lane is red.

#### Describe the solution
Wrap the two entries in `if (WIN32)`.

#### Describe alternatives you've considered
N/A

#### Testing
Linux CMake Tiles+Sound links clean.

#### Additional context
N/A