### PR TITLE
Correct highway bridge support rotation on overmap

### DIFF
--- a/data/json/obsoletion_and_migration_0.J/obsolete_overmap_terrain.json
+++ b/data/json/obsoletion_and_migration_0.J/obsolete_overmap_terrain.json
@@ -588,5 +588,10 @@
       "central_lab_shaft_west": "empty_rock",
       "central_lab_entrance_west": "forest"
     }
+  },
+  {
+    "type": "oter_id_migration",
+    "//": "Corrected rotation in 0.J experimental",
+    "oter_ids": { "hw_supports": "hw_supports_north" }
   }
 ]

--- a/data/json/overmap/overmap_special/highway_specials.json
+++ b/data/json/overmap/overmap_special/highway_specials.json
@@ -58,18 +58,18 @@
     "joins": [ { "id": "support_join", "into_locations": [ "lake_surface", "open_air", "lake_water_cube", "lake_bed" ] } ],
     "overmaps": {
       "support_top": {
-        "overmap": "hw_supports",
+        "overmap": "hw_supports_north",
         "below": { "id": "support_join", "type": "available" },
         "locations": [ "lake_surface", "open_air" ]
       },
       "support": {
-        "overmap": "hw_supports",
+        "overmap": "hw_supports_north",
         "above": { "id": "support_join", "type": "available" },
         "below": { "id": "support_join", "type": "available" },
         "locations": [ "open_air", "lake_water_cube" ]
       },
       "support_bottom": {
-        "overmap": "hw_supports",
+        "overmap": "hw_supports_north",
         "above": { "id": "support_join", "type": "available" },
         "locations": [ "water", "lake_bed", "subterranean" ]
       }

--- a/data/json/overmap/overmap_terrain/overmap_terrain_transportation.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_transportation.json
@@ -579,11 +579,19 @@
   },
   {
     "type": "overmap_terrain",
-    "id": [ "hw_fb_supports", "hw_supports" ],
+    "id": [ "hw_fb_supports" ],
     "copy-from": "generic_highway",
     "color": "blue",
     "travel_cost_type": "water",
     "extend": { "flags": [ "RIVER", "LAKE", "REQUIRES_PREDECESSOR", "NO_ROTATE" ] }
+  },
+  {
+    "type": "overmap_terrain",
+    "id": [ "hw_supports" ],
+    "copy-from": "generic_highway",
+    "color": "blue",
+    "travel_cost_type": "water",
+    "extend": { "flags": [ "RIVER", "LAKE", "REQUIRES_PREDECESSOR" ] }
   },
   {
     "type": "overmap_terrain",


### PR DESCRIPTION
#### Summary
Bugfixes "Correct highway bridge support rotation on overmap"

#### Purpose of change
Fixes #86649, Highway Bridge Supports being drawn on overmap in a fixed rotation.

#### Describe the solution
Splits the `hw_fb_supports` and `hw_supports` OMT definitions into two sepearate definitions and remove the `NO_ROTATE` flag from `hw_supports`. 
This then required adding the `_north` suffix to the references to `hw_supports` in `highway_support_mutable`

#### Describe alternatives you've considered
Removing the `NO_ROTATE` flag from `hw_fb_supports` as well and adding the rotation suffixes where it is use in specials but that causes half of the support columns to disappear from the highways. It is likely something to do with how the highway placement code handles the placement `hw_supports` on top of the `hw_fb_supports` but I don't fully understand how it works.

#### Testing
<img width="1035" height="547" alt="image" src="https://github.com/user-attachments/assets/696c99c8-0a0b-4d4c-8008-a9b1924dd34e" />


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
