### PR TITLE
[XEDRA Evolved] Change sweet dreams message log color to `good`

### DIFF
--- a/data/mods/Xedra_Evolved/eocs/eoc_conditions.json
+++ b/data/mods/Xedra_Evolved/eocs/eoc_conditions.json
@@ -133,7 +133,7 @@
     "condition": { "or": [ { "one_in_chance": 2 }, { "u_has_effect": "effect_hedge_no_nightmares" } ] },
     "effect": [
       { "u_message": "You have a good dream.", "type": "neutral" },
-      { "u_message": "sweet_dreams", "snippet": true, "type": "bad" },
+      { "u_message": "sweet_dreams", "snippet": true, "type": "good" },
       { "u_add_morale": "morale_sweet_dreams", "bonus": [ 15, 40 ], "max_bonus": 40 },
       { "math": [ "dream_counter = 1" ] },
       { "u_cast_spell": { "id": "dream_mana_gain" } },
@@ -188,7 +188,7 @@
     "condition": { "or": [ { "one_in_chance": 2 }, { "u_has_effect": "effect_hedge_no_nightmares" } ] },
     "effect": [
       { "u_message": "You have a good dream.", "type": "neutral" },
-      { "u_message": "XE_SWEET_DREAMS", "snippet": true, "type": "bad" },
+      { "u_message": "XE_SWEET_DREAMS", "snippet": true, "type": "good" },
       { "u_add_morale": "morale_sweet_dreams", "bonus": [ 15, 40 ], "max_bonus": 40 },
       { "math": [ "dream_counter = 1" ] },
       { "run_eocs": "EOC_RESET_DREAM_COUNTER", "time_in_future": 1 }


### PR DESCRIPTION


#### Summary
None

#### Purpose of change
For some reason, good dreams are colored red in the message log, so i fix that.

#### Describe the solution

`"type": "bad"` -> `"type": "good"`

#### Describe alternatives you've considered
Assume the character just scared of good dreams?

#### Testing

<img width="395" height="265" alt="Screenshot_20260423_221137" src="https://github.com/user-attachments/assets/1b14a2e3-ece6-4644-91f6-8ce03a1bbf27" />


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
