### PR TITLE
Fix float-to-int truncation of upgrade_mult in LoadMonsterGroup

### DIFF
--- a/src/mongroup.cpp
+++ b/src/mongroup.cpp
@@ -513,7 +513,7 @@ void MonsterGroupManager::LoadMonsterGroup( const JsonObject &jo )
                 pack_min = packarr.next_int();
                 pack_max = packarr.next_int();
             }
-            const int upgrade_mult = mon_upgrade_factor > 0 ? mon_upgrade_factor : 1;
+            const float upgrade_mult = mon_upgrade_factor > 0.0f ? mon_upgrade_factor : 1.0f;
             const time_duration starts = mon.has_member( "starts" )
                                          ? read_from_json_string<time_duration>( mon.get_member( "starts" ),
                                                  time_duration::units ) * upgrade_mult

--- a/tests/mongroup_test.cpp
+++ b/tests/mongroup_test.cpp
@@ -429,3 +429,27 @@ TEST_CASE( "mongroup_multi_spawn_restrictions", "[mongroup]" )
         CHECK( counts.count( mon_test_zombie_cop ) > 0 );
     }
 }
+TEST_CASE( "mongroup_upgrade_mult_scales_starts_and_ends", "[mongroup]" )
+{
+    const std::set<mtype_id> all_types { mon_test_shearable, mon_test_CBM, mon_test_zombie_cop };
+
+    SECTION( "starts scaled down by EVOLUTION_INVERSE_MULTIPLIER" ) {
+        // multiplier 0.5: starts "28 days" becomes 14 days
+        override_option evo_mult( "EVOLUTION_INVERSE_MULTIPLIER", "0.5" );
+        std::map<mtype_id, int> counts;
+        // at day 20: scaled starts=14 days already passed, shearable should spawn
+        test_multi_spawn( mon_test_bovine, 5, 4, 6, calendar::turn_zero + 20_days,
+                          all_types, counts );
+        CHECK( counts.count( mon_test_shearable ) > 0 );
+    }
+
+    SECTION( "starts not yet reached after scaling" ) {
+        // multiplier 0.5: starts "28 days" becomes 14 days
+        override_option evo_mult( "EVOLUTION_INVERSE_MULTIPLIER", "0.5" );
+        std::map<mtype_id, int> counts;
+        // at day 10: scaled starts=14 days not yet reached, shearable should NOT spawn
+        test_multi_spawn( mon_test_bovine, 5, 4, 6, calendar::turn_zero + 10_days,
+                          all_types, counts );
+        CHECK( counts.count( mon_test_shearable ) == 0 );
+    }
+}


### PR DESCRIPTION
#### Summary
Bugfixes "Fix float-to-int truncation of upgrade_mult in LoadMonsterGroup"

#### Purpose of change
Fixes #82516

`EVOLUTION_INVERSE_MULTIPLIER` is a float option set by the difficulty slider (e.g. 0.75 at highest difficulty). In `LoadMonsterGroup`, this value was stored as `const int upgrade_mult`, causing truncation of any value < 1.0 to 0. This meant all `starts` and `ends` time restrictions in monstergroups were multiplied by 0, collapsing them to `0_turns`. As a result, monsters with `starts` constraints spawned immediately and monsters with `ends` constraints disappeared instantly, breaking time-based spawn progression across hundreds of monstergroup entries at higher difficulty settings.

#### Describe the solution
Changed `upgrade_mult` from `const int` to `const float` so fractional multiplier values are preserved correctly.

#### Describe alternatives you've considered
No alternatives considered — the fix is a straightforward type correction.

#### Testing
Added a test `mongroup_upgrade_mult_scales_starts_and_ends` to `tests/mongroup_test.cpp` that verifies `starts` times are correctly scaled when `EVOLUTION_INVERSE_MULTIPLIER` is set to a fractional value.

#### Additional context
None