### PR TITLE
Entering the labyrinth requires a blood tax

### DIFF
--- a/data/json/npcs/exodii/netherum/labyrinth_safehouse_computers.json
+++ b/data/json/npcs/exodii/netherum/labyrinth_safehouse_computers.json
@@ -13,10 +13,7 @@
     "id": "COMP_labyrinthine_safehouse_computer",
     "dynamic_line": "& █████╗ ██╗  ████████╗ █████╗ ██████╗      ██████╗ ███████╗\n██╔══██╗██║  ╚══██╔══╝██╔══██╗██╔══██╗    ██╔═══██╗██╔════╝\n███████║██║     ██║   ███████║██████╔╝    ██║   ██║███████╗\n██╔══██║██║     ██║   ██╔══██║██╔══██╗    ██║   ██║╚════██║\n██║  ██║███████╗██║   ██║  ██║██║  ██║    ╚██████╔╝███████║\n╚═╝  ╚═╝╚══════╝╚═╝   ╚═╝  ╚═╝╚═╝  ╚═╝     ╚═════╝ ╚══════╝\n\nᵖˡᵉᵃˢᵉ select a program\n\n<color_light_green> @User > _</color>",
     "responses": [
-      {
-        "text": "<color_light_green>Activate entry protocol",
-        "topic": "COMP_labyrinthine_safehouse_computer_blood_tax"
-      },
+      { "text": "<color_light_green>Activate entry protocol", "topic": "COMP_labyrinthine_safehouse_computer_blood_tax" },
       {
         "text": "<color_light_green>Check for updates",
         "condition": { "math": [ "nl_boiler_placed != 1" ] },
@@ -59,13 +56,7 @@
     "type": "talk_topic",
     "id": "COMP_labyrinthine_safehouse_computer_blood_tax_yes",
     "dynamic_line": "&You place your hand on the terminal.  There is a pinch, then a wet, mechanical hiss, as the needle draws a bit of blood.  Your vision blurs.",
-    "responses": [
-      {
-        "text": "…",
-        "topic": "TALK_DONE",
-        "effect": { "run_eocs": "EOC_LS_SAFEHOUSE_Teleport_to_labyrinth" }
-      }
-    ]
+    "responses": [ { "text": "…", "topic": "TALK_DONE", "effect": { "run_eocs": "EOC_LS_SAFEHOUSE_Teleport_to_labyrinth" } } ]
   },
   {
     "type": "talk_topic",

--- a/data/json/npcs/exodii/netherum/labyrinth_safehouse_computers.json
+++ b/data/json/npcs/exodii/netherum/labyrinth_safehouse_computers.json
@@ -15,8 +15,7 @@
     "responses": [
       {
         "text": "<color_light_green>Activate entry protocol",
-        "effect": { "run_eocs": "EOC_LS_SAFEHOUSE_Teleport_to_labyrinth" },
-        "topic": "TALK_DONE"
+        "topic": "COMP_labyrinthine_safehouse_computer_blood_tax"
       },
       {
         "text": "<color_light_green>Check for updates",
@@ -41,6 +40,31 @@
         "topic": "TALK_DONE"
       },
       { "text": "<color_yellow>Log off", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "COMP_labyrinthine_safehouse_computer_blood_tax",
+    "dynamic_line": "&<color_light_green> @User > skill -ENTER -@User\n\n<color_light_green> Blood required for reality stabilization.\n\nA drawer on the side of the terminal slides open, revealing a small, thin needle.\n\n<color_light_green> @User > _",
+    "responses": [
+      {
+        "text": "[Prick yourself with the needle]",
+        "topic": "COMP_labyrinthine_safehouse_computer_blood_tax_yes",
+        "effect": [ { "math": [ "u_vitamin('blood') -= 500" ] } ]
+      },
+      { "text": "Log off.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "COMP_labyrinthine_safehouse_computer_blood_tax_yes",
+    "dynamic_line": "&You place your hand on the terminal.  There is a pinch, then a wet, mechanical hiss, as the needle draws a bit of blood.  Your vision blurs.",
+    "responses": [
+      {
+        "text": "…",
+        "topic": "TALK_DONE",
+        "effect": { "run_eocs": "EOC_LS_SAFEHOUSE_Teleport_to_labyrinth" }
+      }
     ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Content "A cost to enter the labyrinth"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

A cost to enter the labyrinth

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

AltarOS is kinda out to get you, and uses you for various means.  It now asks for 500 blood vitamin each time you enter the labyrinth.  The exact amount is hidden from the player, and it isn't remotely enough to easily kill them (or even really hurt them), but it is enough to cause slow attrition (because iron and water are rare in the labyrinth), and is a psychological burden.  More practically, it will gate the number of times one can enter/exit the labyrinth in a short period.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

More or less blood

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Entered many times, got hypovolemic shock after a while.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

This follows I-am-Erk's original design ideas that the major resources in the labyrinth should be things like blood/hunger.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
