### PR TITLE
[MoM] Momentum alteration effectiveness cap

### DIFF
--- a/data/mods/MindOverMatter/effects/effects_psionic.json
+++ b/data/mods/MindOverMatter/effects/effects_psionic.json
@@ -554,7 +554,10 @@
     "enchantments": [
       {
         "condition": {
-          "and": [ { "not": { "u_has_effect": "effect_teleport_stride" } }, { "not": { "u_has_effect": "effect_telekin_momentum" } } ]
+          "and": [
+            { "not": { "u_has_effect": "effect_teleport_stride" } },
+            { "not": { "u_has_effect": "effect_telekinetic_momentum" } }
+          ]
         },
         "values": [
           {
@@ -566,7 +569,9 @@
         ]
       },
       {
-        "condition": { "and": [ { "u_has_effect": "effect_teleport_stride" }, { "not": { "u_has_effect": "effect_telekin_momentum" } } ] },
+        "condition": {
+          "and": [ { "u_has_effect": "effect_teleport_stride" }, { "not": { "u_has_effect": "effect_telekinetic_momentum" } } ]
+        },
         "values": [
           {
             "value": "MOVE_COST",
@@ -579,7 +584,9 @@
         ]
       },
       {
-        "condition": { "and": [ { "u_has_effect": "effect_telekin_momentum" }, { "not": { "u_has_effect": "effect_teleport_stride" } } ] },
+        "condition": {
+          "and": [ { "u_has_effect": "effect_telekinetic_momentum" }, { "not": { "u_has_effect": "effect_teleport_stride" } } ]
+        },
         "values": [
           {
             "value": "MOVE_COST",
@@ -592,7 +599,7 @@
         ]
       },
       {
-        "condition": { "and": [ { "u_has_effect": "effect_teleport_stride" }, { "u_has_effect": "effect_telekin_momentum" } ] },
+        "condition": { "and": [ { "u_has_effect": "effect_teleport_stride" }, { "u_has_effect": "effect_telekinetic_momentum" } ] },
         "values": [
           {
             "value": "MOVE_COST",
@@ -1977,25 +1984,25 @@
         "incoming_damage_mod": [
           {
             "type": "bash",
-            "multiply": { "math": [ "( u_spell_level('telekinetic_momentum') * -0.01 ) * psionic_power_modifiers()" ] }
+            "multiply": { "math": [ "max( ( u_spell_level('telekinetic_momentum') * -0.01 ) * psionic_power_modifiers() ), -0.2)" ] }
           },
           {
             "type": "stab",
-            "multiply": { "math": [ "( u_spell_level('telekinetic_momentum') * -0.005 ) * psionic_power_modifiers()" ] }
+            "multiply": { "math": [ "max( ( u_spell_level('telekinetic_momentum') * -0.005 ) * psionic_power_modifiers() ), -0.1)" ] }
           },
           {
             "type": "cut",
-            "multiply": { "math": [ "( u_spell_level('telekinetic_momentum') * -0.005 ) * psionic_power_modifiers()" ] }
+            "multiply": { "math": [ "max( ( u_spell_level('telekinetic_momentum') * -0.005 ) * psionic_power_modifiers() ), -0.1)" ] }
           },
           {
             "type": "bullet",
-            "multiply": { "math": [ "( u_spell_level('telekinetic_momentum') * -0.02 ) * psionic_power_modifiers()" ] }
+            "multiply": { "math": [ "max( ( u_spell_level('telekinetic_momentum') * -0.02 ) * psionic_power_modifiers() ), -0.4)" ] }
           }
         ],
         "values": [
           {
             "value": "ATTACK_SPEED",
-            "multiply": { "math": [ "( u_spell_level('telekinetic_momentum') * -0.01 ) * psionic_power_modifiers()" ] }
+            "multiply": { "math": [ "max( ( u_spell_level('telekinetic_momentum') * -0.01 ) * psionic_power_modifiers(), -0.2)" ] }
           }
         ]
       },
@@ -2009,7 +2016,7 @@
         "values": [
           {
             "value": "MOVE_COST",
-            "multiply": { "math": [ "max( ( ( u_spell_level('telekinetic_momentum') * -0.005 ) * psionic_power_modifiers() ), -0.15)" ] }
+            "multiply": { "math": [ "max( ( ( u_spell_level('telekinetic_momentum') * -0.005 ) * psionic_power_modifiers() ), -0.1)" ] }
           }
         ]
       },

--- a/data/mods/MindOverMatter/effects/effects_psionic.json
+++ b/data/mods/MindOverMatter/effects/effects_psionic.json
@@ -1984,25 +1984,25 @@
         "incoming_damage_mod": [
           {
             "type": "bash",
-            "multiply": { "math": [ "max( ( u_spell_level('telekinetic_momentum') * -0.01 ) * psionic_power_modifiers() ), -0.3)" ] }
+            "multiply": { "math": [ "max( ( ( u_spell_level('telekinetic_momentum') * -0.01 ) * psionic_power_modifiers() ), -0.3)" ] }
           },
           {
             "type": "stab",
-            "multiply": { "math": [ "max( ( u_spell_level('telekinetic_momentum') * -0.005 ) * psionic_power_modifiers() ), -0.15)" ] }
+            "multiply": { "math": [ "max( ( ( u_spell_level('telekinetic_momentum') * -0.005 ) * psionic_power_modifiers() ), -0.15)" ] }
           },
           {
             "type": "cut",
-            "multiply": { "math": [ "max( ( u_spell_level('telekinetic_momentum') * -0.005 ) * psionic_power_modifiers() ), -0.15)" ] }
+            "multiply": { "math": [ "max( ( ( u_spell_level('telekinetic_momentum') * -0.005 ) * psionic_power_modifiers() ), -0.15)" ] }
           },
           {
             "type": "bullet",
-            "multiply": { "math": [ "max( ( u_spell_level('telekinetic_momentum') * -0.02 ) * psionic_power_modifiers() ), -0.6)" ] }
+            "multiply": { "math": [ "max( ( ( u_spell_level('telekinetic_momentum') * -0.02 ) * psionic_power_modifiers() ), -0.6)" ] }
           }
         ],
         "values": [
           {
             "value": "ATTACK_SPEED",
-            "multiply": { "math": [ "max( ( u_spell_level('telekinetic_momentum') * -0.01 ) * psionic_power_modifiers(), -0.3)" ] }
+            "multiply": { "math": [ "max( ( ( u_spell_level('telekinetic_momentum') * -0.01 ) * psionic_power_modifiers(), -0.3)" ] }
           }
         ]
       },

--- a/data/mods/MindOverMatter/effects/effects_psionic.json
+++ b/data/mods/MindOverMatter/effects/effects_psionic.json
@@ -2002,7 +2002,7 @@
         "values": [
           {
             "value": "ATTACK_SPEED",
-            "multiply": { "math": [ "max( ( ( u_spell_level('telekinetic_momentum') * -0.01 ) * psionic_power_modifiers(), -0.3)" ] }
+            "multiply": { "math": [ "max( ( ( u_spell_level('telekinetic_momentum') * -0.01 ) * psionic_power_modifiers() ), -0.3)" ] }
           }
         ]
       },

--- a/data/mods/MindOverMatter/effects/effects_psionic.json
+++ b/data/mods/MindOverMatter/effects/effects_psionic.json
@@ -1984,25 +1984,25 @@
         "incoming_damage_mod": [
           {
             "type": "bash",
-            "multiply": { "math": [ "max( ( u_spell_level('telekinetic_momentum') * -0.01 ) * psionic_power_modifiers() ), -0.2)" ] }
+            "multiply": { "math": [ "max( ( u_spell_level('telekinetic_momentum') * -0.01 ) * psionic_power_modifiers() ), -0.3)" ] }
           },
           {
             "type": "stab",
-            "multiply": { "math": [ "max( ( u_spell_level('telekinetic_momentum') * -0.005 ) * psionic_power_modifiers() ), -0.1)" ] }
+            "multiply": { "math": [ "max( ( u_spell_level('telekinetic_momentum') * -0.005 ) * psionic_power_modifiers() ), -0.15)" ] }
           },
           {
             "type": "cut",
-            "multiply": { "math": [ "max( ( u_spell_level('telekinetic_momentum') * -0.005 ) * psionic_power_modifiers() ), -0.1)" ] }
+            "multiply": { "math": [ "max( ( u_spell_level('telekinetic_momentum') * -0.005 ) * psionic_power_modifiers() ), -0.15)" ] }
           },
           {
             "type": "bullet",
-            "multiply": { "math": [ "max( ( u_spell_level('telekinetic_momentum') * -0.02 ) * psionic_power_modifiers() ), -0.4)" ] }
+            "multiply": { "math": [ "max( ( u_spell_level('telekinetic_momentum') * -0.02 ) * psionic_power_modifiers() ), -0.6)" ] }
           }
         ],
         "values": [
           {
             "value": "ATTACK_SPEED",
-            "multiply": { "math": [ "max( ( u_spell_level('telekinetic_momentum') * -0.01 ) * psionic_power_modifiers(), -0.2)" ] }
+            "multiply": { "math": [ "max( ( u_spell_level('telekinetic_momentum') * -0.01 ) * psionic_power_modifiers(), -0.3)" ] }
           }
         ]
       },
@@ -2016,7 +2016,7 @@
         "values": [
           {
             "value": "MOVE_COST",
-            "multiply": { "math": [ "max( ( ( u_spell_level('telekinetic_momentum') * -0.005 ) * psionic_power_modifiers() ), -0.1)" ] }
+            "multiply": { "math": [ "max( ( ( u_spell_level('telekinetic_momentum') * -0.005 ) * psionic_power_modifiers() ), -0.15)" ] }
           }
         ]
       },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "[MoM] Momentum alteration effectiveness cap"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Because Momentum Alteration had percentage-based scaling, it was possible to become invincible to physical damage using it if your scaling was high enough. 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Cap each parameter at 30x the base level. This is the max level you can get in MoM (with 20 int), but now that weariness causes power effectiveness penalties it means that your Nether Attunement won't automatically be wasted if you're at that high a level. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Cap percentage-based scaling much lower and also add additive scaling.

OR

Add a flat bonus and reduce the scaling. Might still do this. 

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
