### PR TITLE
Speed up mapgen near item-heavy locations

### DIFF
--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -37,6 +37,7 @@
 #include "enums.h"
 #include "faction.h"
 #include "flag.h"
+#include "flat_set.h" // IWYU pragma: keep
 #include "game.h"
 #include "game_constants.h"
 #include "game_inventory.h"

--- a/src/event_field_transformations.cpp
+++ b/src/event_field_transformations.cpp
@@ -7,6 +7,7 @@
 #include <utility>
 
 #include "coordinates.h"
+#include "flat_set.h" // IWYU pragma: keep
 #include "itype.h"
 #include "mapdata.h"
 #include "mtype.h"

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -39,6 +39,7 @@
 #include "faction.h"
 #include "field_type.h"
 #include "flag.h"
+#include "flat_set.h" // IWYU pragma: keep
 #include "fungal_effects.h"
 #include "game.h"
 #include "game_constants.h"

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1415,7 +1415,7 @@ void item::update_inherited_flags()
     auto const inehrit_flags = [this]( FlagsSetType const & Flags ) {
         for( flag_id const &f : Flags ) {
             if( f->inherit() ) {
-                inherited_tags_cache.emplace( f );
+                inherited_tags_cache.insert( f );
             }
         }
     };
@@ -1464,10 +1464,10 @@ void item::update_prefix_suffix_flags()
 void item::update_prefix_suffix_flags( const flag_id &f )
 {
     if( !f->item_prefix().empty() ) {
-        prefix_tags_cache.emplace( f );
+        prefix_tags_cache.insert( f );
     }
     if( !f->item_suffix().empty() ) {
-        suffix_tags_cache.emplace( f );
+        suffix_tags_cache.insert( f );
     }
 }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -833,15 +833,16 @@ bool _stacks_components( item const &lhs, item const &rhs, bool check_components
 stacking_info item::stacks_with( const item &rhs, bool check_components, bool combine_liquid,
                                  bool check_cat, int depth, int maxdepth, bool precise ) const
 {
+    // Type mismatch cannot stack without a CATEGORY check.
+    if( type != rhs.type && !check_cat ) {
+        return {};
+    }
+
     tname::segment_bitset bits;
     if( type == rhs.type ) {
         bits.set( tname::segments::TYPE );
         bits.set( tname::segments::WHEEL_DIAMETER );
         bits.set( tname::segments::WHITEBLACKLIST, _stacks_whiteblacklist( *this, rhs ) );
-    }
-
-    if( !check_cat && bits.none() ) {
-        return {};
     }
 
     bits.set( tname::segments::CATEGORY,
@@ -2088,26 +2089,19 @@ bool item::has_own_flag( const flag_id &f ) const
 
 bool item::has_flag( const flag_id &f ) const
 {
-    bool ret = false;
     if( !f.is_valid() ) {
         debugmsg( "Attempted to check invalid flag_id %s", f.str() );
         return false;
     }
 
-    ret = inherited_tags_cache.find( f ) != inherited_tags_cache.end();
-    if( ret ) {
-        return ret;
+    // Itype flags cover the common case; check them first.
+    if( type->has_flag( f ) ) {
+        return true;
     }
-
-    // other item type flags
-    ret = type->has_flag( f );
-    if( ret ) {
-        return ret;
+    if( inherited_tags_cache.find( f ) != inherited_tags_cache.end() ) {
+        return true;
     }
-
-    // now check for item specific flags
-    ret = has_own_flag( f );
-    return ret;
+    return has_own_flag( f );
 }
 
 item &item::set_flag( const flag_id &flag )

--- a/src/item.h
+++ b/src/item.h
@@ -1023,10 +1023,12 @@ class item : public visitable
         int insert_cost( const item &it ) const;
 
         /**
-         * Puts the given item into this one.
+         * Puts the given item into this one. When @p quiet is true, failure
+         * returns silently instead of triggering a debugmsg.
          */
         ret_val<void> put_in( const item &payload, pocket_type pk_type,
-                              bool unseal_pockets = false, Character *carrier = nullptr );
+                              bool unseal_pockets = false, Character *carrier = nullptr,
+                              bool quiet = false );
         void force_insert_item( const item &it, pocket_type pk_type );
 
         /**

--- a/src/item.h
+++ b/src/item.h
@@ -22,6 +22,7 @@
 #include "coordinates.h"
 #include "craft_command.h"
 #include "enums.h"
+#include "flat_set.h"
 #include "global_vars.h"
 #include "gun_mode.h"
 #include "io_tags.h"
@@ -198,7 +199,7 @@ struct stacking_info {
 class item : public visitable
 {
     public:
-        using FlagsSetType = std::set<flag_id>;
+        using FlagsSetType = cata::flat_set<flag_id>;
 
         item();
 

--- a/src/item_container.cpp
+++ b/src/item_container.cpp
@@ -165,12 +165,14 @@ int item::insert_cost( const item &it ) const
 }
 
 ret_val<void> item::put_in( const item &payload, pocket_type pk_type,
-                            const bool unseal_pockets, Character *carrier )
+                            const bool unseal_pockets, Character *carrier, const bool quiet )
 {
     ret_val<item *> result = contents.insert_item( payload, pk_type, false, unseal_pockets );
     if( !result.success() ) {
-        debugmsg( "tried to put an item (%s) count (%d) in a container (%s) that cannot contain it: %s",
-                  payload.typeId().str(), payload.count(), typeId().str(), result.str() );
+        if( !quiet ) {
+            debugmsg( "tried to put an item (%s) count (%d) in a container (%s) that cannot contain it: %s",
+                      payload.typeId().str(), payload.count(), typeId().str(), result.str() );
+        }
         return ret_val<void>::make_failure( result.str() );
     }
     if( pk_type == pocket_type::MOD ) {

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -1036,7 +1036,9 @@ std::set<flag_id> item_contents::magazine_flag_restrictions() const
     std::set<flag_id> ret;
     for( const item_pocket &pocket : contents ) {
         if( pocket.is_type( pocket_type::MAGAZINE_WELL ) ) {
-            ret = pocket.get_pocket_data()->get_flag_restrictions();
+            const pocket_data::FlagsSetType &src = pocket.get_pocket_data()->get_flag_restrictions();
+            ret.clear();
+            ret.insert( src.begin(), src.end() );
         }
     }
     return ret;

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -137,31 +137,32 @@ static void put_into_container(
     }
     Item_spawn_data::ItemList excess;
     for( auto it = items.end() - num_items; it != items.end(); ++it ) {
-        ret_val<void> ret = ctr.can_contain_directly( *it );
+        // quiet=true: caller handles failure via the overflow path below.
+        const pocket_type pk_type = guess_pocket_for( ctr, *it );
+        ret_val<void> ret = ctr.put_in( *it, pk_type, false, nullptr, /*quiet=*/true );
         if( ret.success() ) {
-            const pocket_type pk_type = guess_pocket_for( ctr, *it );
-            ctr.put_in( *it, pk_type );
-        } else if( ctr.is_corpse() ) {
-            const pocket_type pk_type = guess_pocket_for( ctr, *it );
+            continue;
+        }
+        if( ctr.is_corpse() ) {
             ctr.force_insert_item( *it, pk_type );
-        } else {
-            switch( on_overflow ) {
-                case Item_spawn_data::overflow_behaviour::none:
-                    debugmsg( "item %s could not be put in container %s when spawning item group %s: %s.  "
-                              "This can be resolved either by changing the container or contents "
-                              "to ensure that they fit, or by specifying an overflow behaviour via "
-                              "\"on_overflow\" on the item group.",
-                              it->typeId().str(), container_type->str(), context, ret.str() );
-                    break;
-                case Item_spawn_data::overflow_behaviour::spill:
-                    excess.push_back( *it );
-                    break;
-                case Item_spawn_data::overflow_behaviour::discard:
-                    break;
-                case Item_spawn_data::overflow_behaviour::last:
-                    debugmsg( "Invalid overflow_behaviour" );
-                    break;
-            }
+            continue;
+        }
+        switch( on_overflow ) {
+            case Item_spawn_data::overflow_behaviour::none:
+                debugmsg( "item %s could not be put in container %s when spawning item group %s: %s.  "
+                          "This can be resolved either by changing the container or contents "
+                          "to ensure that they fit, or by specifying an overflow behaviour via "
+                          "\"on_overflow\" on the item group.",
+                          it->typeId().str(), container_type->str(), context, ret.str() );
+                break;
+            case Item_spawn_data::overflow_behaviour::spill:
+                excess.push_back( *it );
+                break;
+            case Item_spawn_data::overflow_behaviour::discard:
+                break;
+            case Item_spawn_data::overflow_behaviour::last:
+                debugmsg( "Invalid overflow_behaviour" );
+                break;
         }
     }
     ctr.add_automatic_whitelist();
@@ -858,6 +859,7 @@ void Item_group::add_entry( std::unique_ptr<Item_spawn_data> ptr )
         sic->inherit_ammo_mag_chances( with_ammo, with_magazine );
     }
     items.push_back( std::move( ptr ) );
+    cached_cum_prob.clear();
 }
 
 std::size_t Item_group::create( Item_spawn_data::ItemList &list,
@@ -872,17 +874,8 @@ std::size_t Item_group::create( Item_spawn_data::ItemList &list,
             elem->create( list, birthday, rec, flags );
         }
     } else if( type == G_DISTRIBUTION ) {
-        int p = rng( 0, sum_prob - 1 );
-        for( const auto &elem : items ) {
-            bool ev_based = elem->is_event_based();
-            int prob = elem->get_probability( false );
-            int real_prob = elem->get_probability( true );
-            p -= real_prob;
-            if( ( ev_based && prob == 0 ) || p >= 0 ) {
-                continue;
-            }
+        if( const Item_spawn_data *elem = pick_distribution_entry() ) {
             elem->create( list, birthday, rec, flags );
-            break;
         }
     }
     const std::size_t items_created = list.size() - prev_list_size;
@@ -902,19 +895,40 @@ item Item_group::create_single( const time_point &birthday, RecursionList &rec )
             return elem->create_single( birthday, rec );
         }
     } else if( type == G_DISTRIBUTION ) {
-        int p = rng( 0, sum_prob - 1 );
-        for( const auto &elem : items ) {
-            bool ev_based = elem->is_event_based();
-            int prob = elem->get_probability( false );
-            int real_prob = elem->get_probability( true );
-            p -= real_prob;
-            if( ( ev_based && prob == 0 ) || p >= 0 ) {
-                continue;
-            }
+        if( const Item_spawn_data *elem = pick_distribution_entry() ) {
             return elem->create_single( birthday, rec );
         }
     }
     return item( itype_id::NULL_ID(), birthday );
+}
+
+const Item_spawn_data *Item_group::pick_distribution_entry() const
+{
+    if( sum_prob <= 0 || items.empty() ) {
+        return nullptr;
+    }
+    // Lazy cumulative-probability table for binary-search picks.
+    if( cached_cum_prob.size() != items.size() ) {
+        cached_cum_prob.clear();
+        cached_cum_prob.reserve( items.size() );
+        int acc = 0;
+        for( const std::unique_ptr<Item_spawn_data> &elem : items ) {
+            acc += elem->get_probability( true );
+            cached_cum_prob.push_back( acc );
+        }
+    }
+    const int picked = rng( 1, sum_prob );
+    const auto it = std::lower_bound( cached_cum_prob.begin(), cached_cum_prob.end(), picked );
+    if( it == cached_cum_prob.end() ) {
+        return nullptr;
+    }
+    const Item_spawn_data *elem = items[std::distance( cached_cum_prob.begin(), it )].get();
+    // Event-based entries reserve their slot in sum_prob even when inactive:
+    // a pick that lands on one yields no spawn rather than falling through.
+    if( elem->is_event_based() && elem->get_probability( false ) == 0 ) {
+        return nullptr;
+    }
+    return elem;
 }
 
 void Item_group::check_consistency( bool actually_spawn ) const
@@ -957,6 +971,7 @@ bool Item_group::remove_item( const itype_id &itemid )
         if( ( *a )->remove_item( itemid ) ) {
             sum_prob -= ( *a )->get_probability( true );
             a = items.erase( a );
+            cached_cum_prob.clear();
         } else {
             ++a;
         }

--- a/src/item_group.h
+++ b/src/item_group.h
@@ -417,6 +417,12 @@ class Item_group : public Item_spawn_data
 
     protected:
         /**
+         * Sample one entry from a G_DISTRIBUTION. Returns nullptr when the
+         * distribution is empty or the pick lands on an inactive event-based
+         * entry. Requires type == G_DISTRIBUTION.
+         */
+        const Item_spawn_data *pick_distribution_entry() const;
+        /**
          * Contains the sum of the probability of all entries
          * that this group contains.
          */
@@ -425,6 +431,11 @@ class Item_group : public Item_spawn_data
          * Links to the entries in this group.
          */
         prop_list items;
+        /**
+         * Cumulative probability table, lazily built for binary-search
+         * picks; cleared when @ref items mutates.
+         */
+        mutable std::vector<int> cached_cum_prob;
 };
 
 #endif // CATA_SRC_ITEM_GROUP_H

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -2365,38 +2365,65 @@ units::mass item_pocket::remaining_weight() const
 
 int item_pocket::charges_per_remaining_volume( const item &it ) const
 {
-    if( it.count_by_charges() ) {
-        units::volume non_it_volume = volume_capacity();
-        int contained_charges = 0;
-        for( const item &contained : contents ) {
-            if( contained.stacks_with( it ) ) {
-                contained_charges += contained.charges;
-            } else {
-                non_it_volume -= contained.volume();
-            }
-        }
-        return it.charges_per_volume( non_it_volume, true ) - contained_charges;
-    } else {
+    if( !it.count_by_charges() ) {
         return it.charges_per_volume( remaining_volume(), true );
     }
+    // Skip contents walk when no typeId match is possible.
+    bool any_same_type = false;
+    for( const item &contained : contents ) {
+        if( contained.typeId() == it.typeId() ) {
+            any_same_type = true;
+            break;
+        }
+    }
+    if( !any_same_type ) {
+        return it.charges_per_volume( remaining_volume(), true );
+    }
+    units::volume non_it_volume = volume_capacity();
+    int contained_charges = 0;
+    for( const item &contained : contents ) {
+        if( contained.typeId() != it.typeId() ) {
+            non_it_volume -= contained.volume();
+            continue;
+        }
+        if( contained.stacks_with( it ) ) {
+            contained_charges += contained.charges;
+        } else {
+            non_it_volume -= contained.volume();
+        }
+    }
+    return it.charges_per_volume( non_it_volume, true ) - contained_charges;
 }
 
 int item_pocket::charges_per_remaining_weight( const item &it ) const
 {
-    if( it.count_by_charges() ) {
-        units::mass non_it_weight = weight_capacity();
-        int contained_charges = 0;
-        for( const item &contained : contents ) {
-            if( contained.stacks_with( it ) ) {
-                contained_charges += contained.charges;
-            } else {
-                non_it_weight -= contained.weight();
-            }
-        }
-        return it.charges_per_weight( non_it_weight, true ) - contained_charges;
-    } else {
+    if( !it.count_by_charges() ) {
         return it.charges_per_weight( remaining_weight(), true );
     }
+    bool any_same_type = false;
+    for( const item &contained : contents ) {
+        if( contained.typeId() == it.typeId() ) {
+            any_same_type = true;
+            break;
+        }
+    }
+    if( !any_same_type ) {
+        return it.charges_per_weight( remaining_weight(), true );
+    }
+    units::mass non_it_weight = weight_capacity();
+    int contained_charges = 0;
+    for( const item &contained : contents ) {
+        if( contained.typeId() != it.typeId() ) {
+            non_it_weight -= contained.weight();
+            continue;
+        }
+        if( contained.stacks_with( it ) ) {
+            contained_charges += contained.charges;
+        } else {
+            non_it_weight -= contained.weight();
+        }
+    }
+    return it.charges_per_weight( non_it_weight, true ) - contained_charges;
 }
 
 int item_pocket::best_quality( const quality_id &id ) const

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -466,7 +466,7 @@ struct pocket_noise {
 class pocket_data
 {
     public:
-        using FlagsSetType = std::set<flag_id>;
+        using FlagsSetType = cata::flat_set<flag_id>;
 
         bool was_loaded = false;
 

--- a/src/itype.h
+++ b/src/itype.h
@@ -23,6 +23,7 @@
 #include "damage.h"
 #include "enums.h" // point
 #include "explosion.h"
+#include "flat_set.h"
 #include "flexbuffer_json.h"
 #include "game_constants.h"
 #include "global_vars.h"
@@ -1286,7 +1287,7 @@ struct itype {
         friend class Item_factory;
         friend struct mod_tracker;
 
-        using FlagsSetType = std::set<flag_id>;
+        using FlagsSetType = cata::flat_set<flag_id>;
 
         /**
          * Slots for various item type properties. Each slot may contain a valid pointer or null, check

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -53,6 +53,7 @@
 #include "field.h"
 #include "field_type.h"
 #include "flag.h"
+#include "flat_set.h" // IWYU pragma: keep
 #include "flexbuffer_json.h"
 #include "fungal_effects.h"
 #include "game.h"
@@ -2043,7 +2044,7 @@ class exosuit_interact
             if( !pkt->get_pocket_data()->pocket_name.empty() ) {
                 return pkt->get_pocket_data()->pocket_name.translated();
             }
-            const std::set<flag_id> flags = pkt->get_pocket_data()->get_flag_restrictions();
+            const pocket_data::FlagsSetType &flags = pkt->get_pocket_data()->get_flag_restrictions();
             return enumerate_as_string( flags, []( const flag_id & fid ) {
                 if( fid->name().empty() ) {
                     return fid.str();
@@ -2185,7 +2186,7 @@ class exosuit_interact
         int insert_replace_activate_mod( item_pocket *pkt, item *it ) {
             Character &c = get_player_character();
             map &here = get_map();
-            const std::set<flag_id> flags = pkt->get_pocket_data()->get_flag_restrictions();
+            const pocket_data::FlagsSetType &flags = pkt->get_pocket_data()->get_flag_restrictions();
             if( flags.empty() ) {
                 //~ Modular exoskeletons require pocket restrictions to insert modules. %s = pocket name.
                 popup( _( "%s doesn't define any restrictions for modules!" ), get_pocket_name( pkt ) );

--- a/src/weighted_list.h
+++ b/src/weighted_list.h
@@ -284,30 +284,33 @@ template <typename T> struct weighted_int_list : public weighted_list<T, int> {
             if( this->objects.size() == 1 ) {
                 return 0;
             }
-            size_t i;
             const int picked = ( randi % ( this->total_weight ) ) + 1;
             if( !precalc_array.empty() ) {
                 // if the precalc_array is populated, use it for O(1) lookup
-                i = precalc_array[picked - 1];
-            } else {
-                // otherwise do O(N) search through items
-                int accumulated_weight = 0;
-                for( i = 0; i < this->objects.size(); i++ ) {
-                    accumulated_weight += this->objects[i].second;
-                    if( accumulated_weight >= picked ) {
-                        break;
-                    }
+                return precalc_array[picked - 1];
+            }
+            // lazy-populate cumulative-weight table for O(log N) binary search
+            if( cum_weights.size() != this->objects.size() ) {
+                cum_weights.clear();
+                cum_weights.reserve( this->objects.size() );
+                int acc = 0;
+                for( const std::pair<T, int> &o : this->objects ) {
+                    acc += o.second;
+                    cum_weights.push_back( acc );
                 }
             }
-            return i;
+            return std::distance( cum_weights.begin(),
+                                  std::lower_bound( cum_weights.begin(), cum_weights.end(), picked ) );
         }
 
         void invalidate_precalc() override {
             precalc_array.clear();
+            cum_weights.clear();
         }
 
         int default_weight = 1;
         std::vector<int> precalc_array;
+        mutable std::vector<int> cum_weights;
 };
 
 static_assert( std::is_nothrow_move_constructible_v<weighted_int_list<int>> );

--- a/tests/bionics_test.cpp
+++ b/tests/bionics_test.cpp
@@ -218,8 +218,8 @@ TEST_CASE( "bionic_weapons", "[bionics] [weapon] [item]" )
         bionic &customizable_bionic = dummy.bionic_at_index( dummy.my_bionics->size() - 1 );
         REQUIRE_FALSE( dummy.get_bionics().empty() );
         REQUIRE_FALSE( dummy.has_weapon() );
-        item::FlagsSetType *allowed_flags = const_cast<item::FlagsSetType *>
-                                            ( &customizable_weapon_bionic_id->installable_weapon_flags );
+        std::set<json_character_flag> *allowed_flags = const_cast<std::set<json_character_flag> *>
+                ( &customizable_weapon_bionic_id->installable_weapon_flags );
         allowed_flags->insert( json_flag_PSEUDO );
 
         GIVEN( "weapon bionic allows installation of new weapons" ) {


### PR DESCRIPTION
#### Summary

Performance "Speed up mapgen near item-heavy locations"

#### Purpose of change

Walking up to an unvisited inland container depot freezes the game for a while as the reality bubble generates everything. Profile time mostly lives in item group sampling and container packing under `map::place_items`. This trims the hottest paths. Supermarkets and other item-dense locations benefit too, just less visibly.

#### Describe the solution

Three commits, each doing one thing:

1. Speed up mapgen item-group sampling and container packing. Three small changes to the mapgen trunk. `Item_group::create` used to linear-scan its entries for each G_DISTRIBUTION pick; it now lazily builds a cumulative-probability table and binary-searches it, and `Item_group::create_single` goes through the same picker. `weighted_int_list::pick_ent` had an O(N) fallback when `precalc()` was never called, which happens for distribution-source and weighted nested-mapgen lookups during mapgen; it now lazily builds a cumulative-weight table and does a binary search. And `put_into_container` stops doing a `can_contain_directly` pre-check before `put_in` -- both functions walked the pockets independently. Failure is routed through the existing overflow path via a new `quiet` flag on `item::put_in` that suppresses the "this was supposed to have been pre-checked" debugmsg.

2. Use flat_set for item/itype/pocket flag storage. Swaps `FlagsSetType` from `std::set<flag_id>` to `cata::flat_set<flag_id>` on `item`, `itype`, and `pocket_data`. Sorted vector instead of red-black tree. Small win on its own -- sets are tiny (5-20 flags per item) so lookup counts are similar, but it kills the Rb_tree node allocations and gets better cache locality on iteration.

3. Trim item hot-path flag and stacking checks. `item::has_flag` now checks itype flags first since they cover the common case. `item::stacks_with` returns early on a type mismatch when `check_cat` is false, instead of running the bitset setup then falling through the `bits.none()` guard. `item_pocket::charges_per_remaining_volume`/`_weight` do a cheap typeId scan first and fall through to the simple `remaining_volume()` path when no stack match is possible at all.

Numbers from a local benchmark that generates a fixed set of container yard OMTs with a pinned RNG seed:

- master: 80.4s
- with commit 1 only: 66.2s
- with all three: 64.8s

Most of the win is commit 1. Commits 2 and 3 are small but each came for free as a side effect while looking at the profile.

#### Describe alternatives you've considered

Moving flag storage to `int_id<json_flag>` would be a bigger perf win but might affect save compatibility; flat_set got most of the layout benefit for basically no risk. `charges_per_remaining_*` could stash a cached charge total per typeId on the pocket, but the invalidation surface for the ~1pp win wasn't appealing.

#### Testing

Built a local benchmark that places o_container_yard_inland on a pre-filled overmap and runs `map::generate` on every OMT it lays down, with a fixed seed so runs are comparable across commits. Profiled. Also walked around a freshly-unvisited container depot in-game, perceptively better than master. Existing tests for items pass.

#### Additional context

N/A