### PR TITLE
Update armories at multiple military locations

### DIFF
--- a/data/json/mapgen/bunker.json
+++ b/data/json/mapgen/bunker.json
@@ -167,7 +167,7 @@
           { "item": "grenade_can_pa120_grenades_full", "chance": 10 }
         ],
         "U": { "item": "SUS_janitors_closet", "chance": 100 },
-        "L": { "item": "milspec_arsenal_group_only_ammo", "chance": 100， "repeat": [ 2, 4 ] },
+        "L": { "item": "milspec_arsenal_group_only_ammo", "chance": 100, "repeat": [ 2, 4 ] },
         "G": { "item": "arsenal_armor_collection", "chance": 100 },
         "E": { "item": "guns_rifle_milspec", "chance": 100 }
       },

--- a/data/json/mapgen/bunker.json
+++ b/data/json/mapgen/bunker.json
@@ -167,7 +167,7 @@
           { "item": "grenade_can_pa120_grenades_full", "chance": 10 }
         ],
         "U": { "item": "SUS_janitors_closet", "chance": 100 },
-        "L": { "item": "milspec_arsenal_group_only_ammo", "chance": 100 },
+        "L": { "item": "milspec_arsenal_group_only_ammo", "chance": 100， "repeat": [ 2, 4 ] },
         "G": { "item": "arsenal_armor_collection", "chance": 100 },
         "E": { "item": "guns_rifle_milspec", "chance": 100 }
       },

--- a/data/json/mapgen/helipad.json
+++ b/data/json/mapgen/helipad.json
@@ -19,7 +19,7 @@
         ".F..pppppyppppyppp...|____C___B____________|..F.",
         ".F..pppppyppppypppooom___________B______%__|..F.",
         ".F..pppppyppppyppp...||||||||m|MMMMMMMMM||||..F.",
-        ".F..pppppyppppyppp...|_rrrr|____________%__|..F.",
+        ".F..pppppyppppyppp...|_qqqq|____________%__|..F.",
         ".F..oooooooooooooo...|_____|_______________|..F.",
         ".F..............oo...|_rrrr|___IIIIIIIII_RR|..F.",
         ".F..WwWWwWwwWwwW++WwW|M|||||___IUUUUUUUI_sR|..F.",

--- a/data/json/mapgen/helipad.json
+++ b/data/json/mapgen/helipad.json
@@ -80,8 +80,7 @@
           },
           "chance": 50
         },
-        "r": 
-          [
+        "r": [
           { "item": "milspec_arsenal_group_only_guns", "chance": 100 },
           { "item": "arsenal_mics_group", "chance": 70 },
           { "item": "c4_box_part", "chance": 10 },

--- a/data/json/mapgen/helipad.json
+++ b/data/json/mapgen/helipad.json
@@ -86,7 +86,7 @@
           { "item": "c4_box_part", "chance": 10 },
           { "item": "grenade_can_pa120_grenades_full", "chance": 10 }
         ],
-        "q": { "item": "milspec_arsenal_group_only_ammo", "chance": 100 ,"repeat": [ 1, 2 ] },
+        "q": { "item": "milspec_arsenal_group_only_ammo", "chance": 100, "repeat": [ 1, 2 ] },
         "l": {
           "item": {
             "subtype": "distribution",

--- a/data/json/mapgen/helipad.json
+++ b/data/json/mapgen/helipad.json
@@ -80,13 +80,14 @@
           },
           "chance": 50
         },
-        "r": {
-          "item": {
-            "subtype": "distribution",
-            "entries": [ { "group": "military_standard_assault_rifles", "prob": 45 }, { "group": "military_standard_shotguns", "prob": 5 } ]
-          },
-          "chance": 10
-        },
+        "r": 
+          [
+          { "item": "milspec_arsenal_group_only_guns", "chance": 100 },
+          { "item": "arsenal_mics_group", "chance": 70 },
+          { "item": "c4_box_part", "chance": 10 },
+          { "item": "grenade_can_pa120_grenades_full", "chance": 10 }
+        ],
+        "q": { "item": "milspec_arsenal_group_only_ammo", "chance": 100 ,"repeat": [ 1, 2 ] },
         "l": {
           "item": {
             "subtype": "distribution",

--- a/data/json/mapgen/military/mil_base/mil_base_z0.json
+++ b/data/json/mapgen/military/mil_base/mil_base_z0.json
@@ -776,7 +776,7 @@
         { "group": "ammo_can_223_any_full", "x": 14, "y": [ 9, 12 ], "chance": 75, "repeat": 20 },
         { "group": "modular_m4a1", "x": 16, "y": [ 9, 11 ], "magazine": 100, "chance": 75, "repeat": 36 },
         { "item": "stanag30", "x": 16, "y": 12, "chance": 75, "repeat": 100 },
-        { "group": "ammo_can_223_any_full", "x": 14, "y": [ 9, 12 ], "chance": 75, "repeat": 20 },
+        { "group": "ammo_can_223_any_full", "x": 18, "y": [ 9, 12 ], "chance": 75, "repeat": 20 },
         { "item": "m249", "x": 20, "y": 9, "chance": 75, "repeat": 6 },
         { "item": "m240", "x": 20, "y": 9, "chance": 75, "repeat": 4 },
         { "item": "m1014", "x": 20, "y": 10, "chance": 75, "repeat": 10 },

--- a/data/json/mapgen_palettes/helipad.json
+++ b/data/json/mapgen_palettes/helipad.json
@@ -40,6 +40,7 @@
     "furniture": {
       "C": "f_crate_c",
       "r": "f_rack",
+      "q": "f_rack",
       "z": [ "f_indoor_plant_y", "f_indoor_plant" ],
       "L": "f_locker",
       "4": "f_locker",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Balance "Change the ammunition stocks in the armory of multiple existing military locations"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
When I discovered a military helicopter landing pad in the game and entered its armory, I was shocked to find only one gun after cutting open the iron door! This is so unbelievable!
During the modification process, I discovered that due to another one of my pull requests, the ammunition group in the military base was spawning at the wrong position, leaving one shelf empty. Additionally, while comparing ammunition quantities, I noticed that the amount of ammunition in military bunkers is significantly lower than the stock in military outposts.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
I have updated the armory of the military helicopter landing pad. It is now similar to a military bunker, with one side storing items like explosives and the other side storing ammunition. I have also adjusted the item groups in the military base to their correct positions, so they will no longer spawn incorrectly. Finally, I increased the amount of ammunition in military bunkers.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Do nothing and go to HD2.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Check in the game.

This is the armory on the tarmac. Currently, it contains some explosives, vests, backpacks and ammunition.<img width="550" height="443" alt="3d485c1f-6896-4ef4-8acd-620d89f7f5ff" src="https://github.com/user-attachments/assets/09ab95c3-1f77-4b5a-8f21-b7e7d9fd205e" />
The ammunition at the military base is generated correctly<img width="820" height="638" alt="9710808f-8b0b-413e-938e-a40e33820aa3" src="https://github.com/user-attachments/assets/420192da-79f3-4e0a-97ad-c8c6f8adbf63" />
The number of ammunition in military bunkers is higher than before.<img width="1265" height="664" alt="403fed65-0832-4451-96ee-f5114416c01a" src="https://github.com/user-attachments/assets/fddacccc-4dc3-4776-a316-842ab67740cf" />

#### Additional context
Shocking inventory levels before changes.  : )<img width="455" height="436" alt="QQ20260424-111902" src="https://github.com/user-attachments/assets/ec51d327-37cd-451d-93fe-e58736fddc2e" />


Perhaps I should consider converting the rack for storing ammunition cans on the apron into a lockbox

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
