### PR TITLE
Going from Earth Exodii castle to labyrinth has a 5 day cooldown

### DIFF
--- a/data/json/npcs/exodii/exodii_merchant_talk_netherum_labyrinth.json
+++ b/data/json/npcs/exodii/exodii_merchant_talk_netherum_labyrinth.json
@@ -99,12 +99,12 @@
     "id": "TALK_EXODII_MERCHANT_netherum_labyrinth_intro_how",
     "type": "talk_topic",
     "dynamic_line": {
-      "//~": "Getting there is tricky, but easier than moving a castle.  They're less expensive and dangerous than a whole jump, which itself is curious.  Downstiars is a metal ring with a terminal - I wrote the messages, so you'll understand it.  We'll consider you a volunteer who wants to scout the place out.  It's good for both of us.  You're free to use it.  Your first time will leave you dizzy, but it'll pass if you're tough.",
-      "str": "Gettin' there a mite tricky, but not so tangled as jumpin' this whole castle.  They're less dear to go to an' fro, so t'speak, which is odd itself, I s'pose.\n\nDown below, ye'll find a ring o' metal, wi' a terminal us'n has just set up.  Ol' Rubik set the words by hand, in preparation, so ye should ken it well enough.  Ye'll be a free - a volunteer to escolt it.  Good for you, good for we - more metal for you, and sell extras to we, aye?  Ye're free to go an' make use of it.\n\nFirst time'll leave ya' addled, though, spin o' the boat race.  If ye've the grit, passes quick enough."
+      "//~": "Getting there is tricky, but easier than moving a castle.  They're less expensive and dangerous than a whole jump, which itself is curious.  Downstairs is a metal ring with a terminal - I wrote the messages, so you'll understand it.  We'll consider you a volunteer who wants to scout the place out.  It's good for both of us.  You're free to use it.  Keep in mind that the teleporter needs to recharge for 5 days between jumps.  Your first time will leave you dizzy, but it'll pass if you're tough.",
+      "str": "Gettin' there a mite tricky, but not so tangled as jumpin' this whole castle.  They're less dear to go to an' fro, so t'speak, which is odd itself, I s'pose.\n\nDown below, ye'll find a ring o' metal, wi' a terminal us'n has just set up.  Ol' Rubik set the words by hand, in preparation, so ye should ken it well enough.  Ye'll be a free - a volunteer to escolt it.  Good for you, good for we - more metal for you, and sell extras to we, aye?  Ye're free to go an' make use of it.  Keep mind 'at once you jump, the ring'll need a full five day rest afore it'll take ye again.\n\nFirst time'll leave ya' addled, though, spin o' the boat race.  If ye've the grit, passes quick enough."
     },
     "responses": [
       {
-        "text": "So there's a terminal downstairs?  Just stand on the metal ring and use it?  Sounds too easy.  Sure, thanks Rubik.",
+        "text": "So there's a terminal downstairs?  I can just stand on the metal ring and use the terminal, but only once every five days or so?  Sounds too easy.  Sure, thanks Rubik.",
         "effect": [
           { "u_add_var": "rubik_told_about_labyrinth", "value": "yes" },
           { "assign_mission": "MISSION_EXODII_LABYRINTHS_INTRO" }

--- a/data/json/npcs/exodii/netherum/exodii_labyrinth_computer.json
+++ b/data/json/npcs/exodii/netherum/exodii_labyrinth_computer.json
@@ -5,14 +5,35 @@
     "dynamic_line": "&You see a black computer screen with a flickering cursor and some text.  The cursor looks to be controlled by an old mouse that has been hard-wired to the side of terminal.  Only one option appears:\n\n<color_light_green> Labyrinth AB02123.3-4a</color>",
     "responses": [
       {
-        "text": "[Select \"Labyrinth AB02123.3-4a\"] ",
+        "text": "[Select \"Labyrinth AB02123.3-4a\"]",
         "condition": { "not": { "compare_string": [ "yes", { "u_val": "rubik_told_about_labyrinth" } ] } },
         "topic": "COMP_LS_Entrance_Controls2_no"
       },
       {
-        "text": "[Select \"Labyrinth AB02123.3-4a\"] ",
-        "condition": { "compare_string": [ "yes", { "u_val": "rubik_told_about_labyrinth" } ] },
+        "text": "[Select \"Labyrinth AB02123.3-4a\"]",
+        "condition": {
+          "and": [
+            { "compare_string": [ "yes", { "u_val": "rubik_told_about_labyrinth" } ] },
+            {
+              "or": [
+                { "not": { "math": [ "has_var(u_timer_exodii_labyrinth_cooldown)" ] } },
+                { "math": [ "time_since(u_timer_exodii_labyrinth_cooldown) >= time('5 d')" ] }
+              ]
+            }
+          ]
+        },
         "topic": "COMP_LS_Entrance_Controls2"
+      },
+      {
+        "text": "[Select \"Labyrinth AB02123.3-4a\"]",
+        "condition": {
+          "and": [
+            { "compare_string": [ "yes", { "u_val": "rubik_told_about_labyrinth" } ] },
+            { "math": [ "has_var(u_timer_exodii_labyrinth_cooldown)" ] },
+            { "math": [ "time_since(u_timer_exodii_labyrinth_cooldown) < time('5 d')" ] }
+          ]
+        },
+        "topic": "COMP_LS_Entrance_Controls2_wait"
       },
       { "text": "[Step away]", "topic": "TALK_DONE" }
     ]
@@ -20,30 +41,37 @@
   {
     "type": "talk_topic",
     "id": "COMP_LS_Entrance_Controls2_no",
-    "dynamic_line": "&NO",
+    "dynamic_line": "& User not permitted.",
+    "responses": [ { "text": "[Step away]", "topic": "TALK_DONE" } ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "COMP_LS_Entrance_Controls2_wait",
+    "dynamic_line": "& Cycle in effect.  Wait five days from last jump.",
     "responses": [ { "text": "[Step away]", "topic": "TALK_DONE" } ]
   },
   {
     "type": "talk_topic",
     "id": "COMP_LS_Entrance_Controls2",
-    "dynamic_line": "&Truly?  Yes/No",
+    "dynamic_line": "& Truly?  Aye/Nay",
     "responses": [
       {
-        "text": "[Select \"Yes\"] (enter the Labyrinthine Structure alpha test 0.1, which is still low on content and lacking combat balance)",
+        "text": "[Select \"Aye\"] (enter the Labyrinthine Structure alpha test 0.1, which is still low on content and lacking combat balance)",
         "condition": { "u_has_trait": "LS_Alphatest" },
         "effect": [
           { "finish_mission": "MISSION_EXODII_LABYRINTHS_INTRO", "success": true },
+          { "math": [ "u_timer_exodii_labyrinth_cooldown = time('now')" ] },
           { "run_eocs": "EOC_LS_Teleport_to_labyrinth" }
         ],
         "topic": "TALK_DONE"
       },
       {
-        "text": "[Select \"Yes\"]",
+        "text": "[Select \"Aye\"]",
         "condition": { "not": { "u_has_trait": "LS_Alphatest" } },
         "effect": { "u_message": "The screen glitches and the terminal reboots.", "popup": true },
         "topic": "COMP_LS_Entrance_Controls"
       },
-      { "text": "[Select \"No\"]", "topic": "COMP_LS_Entrance_Controls" }
+      { "text": "[Select \"Nay\"]", "topic": "COMP_LS_Entrance_Controls" }
     ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Make it so a player doesn't just sleep in the relative safety of the labyrinth safehouse every night, and also encourage players to spend some time in the labyrinth once there, rather than jumping in and out to rest, heat, get water, etc.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

You can only use the teleporter to the netherum labyrinth safehouse once every 5 days.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Some other cost, like traded goods (fuel, scrap, etc.).  Still on the table.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Can't use the teleporter unless Rubik authorizes it.
Can use the teleporter once Rubik authorizes it.
Can't use the teleporter 1, 2, 3, or 4 days after using it.
Can use the teleporter if you wait 5 days.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

To be clear: this does not gate the _return_ to earth, only earth to labyrinth.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
