### PR TITLE
Tweak labyrinth stiltwalkers

### DIFF
--- a/data/json/monster_weakpoints/netherium_weakpoints.json
+++ b/data/json/monster_weakpoints/netherium_weakpoints.json
@@ -21,17 +21,17 @@
       {
         "id": "chink in the armor",
         "name": "a narrow crack in the armor plating",
-        "coverage": 5,
-        "difficulty": { "melee": 7, "ranged": 10 },
+        "coverage": 20,
+        "difficulty": { "melee": 4, "ranged": 5 },
         "coverage_mult": { "point": 2 },
-        "armor_mult": { "all": 0.25 }
+        "armor_mult": { "all": 0.01 }
       },
       {
         "id": "chink in the armor",
         "name": "a softer spot in its armor plating",
-        "coverage": 15,
-        "difficulty": { "melee": 4, "ranged": 6 },
-        "armor_mult": { "bullet": 0.8, "cut": 0.9, "stab": 0.8, "bash": 0.6 }
+        "coverage": 40,
+        "difficulty": { "melee": 3, "ranged": 4 },
+        "armor_mult": { "bullet": 0.25, "cut": 0.5, "stab": 0.25, "bash": 0.5 }
       }
     ]
   },

--- a/data/json/monsters/netherum/labyrinth_monsters.json
+++ b/data/json/monsters/netherum/labyrinth_monsters.json
@@ -135,12 +135,12 @@
     "species": [ "CYBORG" ],
     "bodytype": "dog",
     "material": [ "steel", "aluminum" ],
-    "speed": 200,
-    "attack_cost": 200,
+    "speed": 140,
+    "attack_cost": 140,
     "symbol": "W",
     "aggression": 100,
-    "morale": 100,
-    "hp": 50,
+    "morale": 60,
+    "hp": 35,
     "color": "light_gray",
     "melee_skill": 10,
     "melee_dice": 3,
@@ -156,7 +156,7 @@
     "death_drops": { "subtype": "collection", "groups": [ [ "robots", 80 ] ] },
     "death_function": { "corpse_type": "BROKEN" },
     "flags": [ "SEES", "HEARS", "GOODHEARING", "PRIORITIZE_TARGETS" ],
-    "armor": { "bash": 32, "cut": 28, "acid": 0, "heat": 0, "bullet": 35 }
+    "armor": { "bash": 28, "cut": 35, "acid": 0, "heat": 0, "bullet": 40 }
   },
   {
     "id": "mon_fleshborg_2_3_string_dimension",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Got permission from I-am-Erik to revive #84045.  Doing it in parts.

Stiltwakers closed the gap too fast, and the only counter was melee or extremely big guns.  Design goal: "Stiltwalkers are meant to present an urgent threat, when one gets into view you should consider focus firing on it before it gets close. However, you're supposed to be able to take them out with most ranged weapons, even plinkers, by hitting weak points. Skill helps here."

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

- Raised base ballistic armor.
- Lowered speed and attack speed
- Increased weakpoint coverage, increased weakpoint armor penalty, and decreased skill to hit them
- Decreased HP

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Tested with various guns and weapons with a test character of 8/8/8/8 attributes and all skills at 5.

- 2-3 shots of 5.56 kills it, as it penetrates armor.
- 9mm bounces off it's armor, but hits occasionally through weak-points, killing in ~3 hits.
- .22 bounces off its armor, but hits occasionally through weakpoints.  Can plink it to death with enough skill.
- You can melee them, but they pack a serious punch, and their armor is still nothing to scoff at.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
