### PR TITLE
Fix border showing on loading screen

### DIFF
--- a/src/loading_ui.cpp
+++ b/src/loading_ui.cpp
@@ -52,9 +52,9 @@ static ui_state *gLUI = nullptr;
 static void redraw()
 {
 #ifdef TILES
-    // make window slightly larger as it is shifted
-    ImGui::SetNextWindowSize( ImGui::GetMainViewport()->Size + ImVec2{ 2, 2 } );
-    ImGui::SetNextWindowPos( {-1, -1}, ImGuiCond_Always );
+    ImGui::SetNextWindowSize( ImGui::GetMainViewport()->Size );
+    ImGui::SetNextWindowPos( {0, 0}, ImGuiCond_Always );
+    ImGui::PushStyleVar( ImGuiStyleVar_WindowBorderSize, 0.0f );
     if( ImGui::Begin( "Loading…", nullptr,
                       ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove |
                       ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoSavedSettings ) ) {
@@ -93,6 +93,7 @@ static void redraw()
         cataimgui::draw_colored_text( loading_msg, ImGui::GetContentRegionAvail().x );
     }
     ImGui::End();
+    ImGui::PopStyleVar();
 
 #else
     int x = ( TERMX - static_cast<int>( gLUI->splash_width ) ) / 2;

--- a/src/loading_ui.cpp
+++ b/src/loading_ui.cpp
@@ -52,7 +52,8 @@ static ui_state *gLUI = nullptr;
 static void redraw()
 {
 #ifdef TILES
-    ImGui::SetNextWindowSize( ImGui::GetMainViewport()->Size );
+    // make window slightly larger as it is shifted
+    ImGui::SetNextWindowSize( ImGui::GetMainViewport()->Size + ImVec2{ 2, 2 } );
     ImGui::SetNextWindowPos( {-1, -1}, ImGuiCond_Always );
     if( ImGui::Begin( "Loading…", nullptr,
                       ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove |


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "Fix ImGui window border showing on loading screen"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
On the loading screen, the ImGui border is showing on the right and bottom of the screen due to the window being shifted to the top left.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Don't shift the window and just remove the border.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Compiled in Windows
Loaded a game and verified the borders were no longer visible
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Is it really this easy, or am I missing some context?
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
