### PR TITLE
Tweak labyrinth fleshborg bone darts

### DIFF
--- a/data/json/items/ammo_types.json
+++ b/data/json/items/ammo_types.json
@@ -935,5 +935,11 @@
     "id": "3030",
     "name": ".30-30 Winchester",
     "default": "3030"
+  },
+  {
+    "type": "ammunition_type",
+    "id": "bone_dart",
+    "name": "bone dart",
+    "default": "bone_dart"
   }
 ]

--- a/data/json/items/netherum/labyrinth_monster_items.json
+++ b/data/json/items/netherum/labyrinth_monster_items.json
@@ -1,18 +1,6 @@
 [
   {
     "type": "ITEM",
-    "subtypes": [ "AMMO" ],
-    "id": "bone_dart",
-    "copy-from": "rock",
-    "looks_like": "bee_sting",
-    "color": "white",
-    "name": { "str": "bone dart" },
-    "description": "A naturally fletched projectile made of bone and cartilage.  It feels denser than you'd expect.",
-    "material": [ "cyber_bone" ],
-    "weight": "250 g"
-  },
-  {
-    "type": "ITEM",
     "id": "broken_stiltwalker_1_1",
     "symbol": ",",
     "color": "light_gray",

--- a/data/json/monster_special_attacks/monster_ammo.json
+++ b/data/json/monster_special_attacks/monster_ammo.json
@@ -82,5 +82,18 @@
     "id": "BILE_BLIND",
     "type": "ammo_effect",
     "on_hit_effects": [ { "effect": "boomered", "duration": "30 s", "intensity": 1, "need_touch_skin": true } ]
+  },
+  {
+    "type": "ITEM",
+    "subtypes": [ "AMMO" ],
+    "id": "bone_dart",
+    "copy-from": "rock",
+    "looks_like": "bee_sting",
+    "color": "white",
+    "name": { "str": "bone dart" },
+    "description": "A naturally fletched projectile made of bone and cartilage.  It feels denser than you'd expect.",
+    "material": [ "cyber_bone" ],
+    "ammo_type": "bone_dart",
+    "weight": "250 g"
   }
 ]

--- a/data/json/monster_special_attacks/monster_gun.json
+++ b/data/json/monster_special_attacks/monster_gun.json
@@ -182,6 +182,51 @@
     "melee_damage": { "bash": 2 }
   },
   {
+    "id": "bone_dart_launcher",
+    "type": "ITEM",
+    "subtypes": [ "GUN" ],
+    "symbol": "%",
+    "color": "red",
+    "name": { "str": "bone dart launching organ", "//~": "NO_I18N" },
+    "description": { "str": "Bone dart launched from a netherum creature.", "//~": "NO_I18N" },
+    "material": [ "cyber_bone" ],
+    "flags": [
+      "PRIMITIVE_RANGED_WEAPON",
+      "PSEUDO",
+      "NEVER_JAMS",
+      "NONCONDUCTIVE",
+      "NO_REPAIR",
+      "WATERPROOF_GUN",
+      "NO_SALVAGE",
+      "NO_UNLOAD",
+      "RELOAD_AND_SHOOT"
+    ],
+    "skill": "throw",
+    "ammo": [ "bone_dart" ],
+    "ammo_effects": [ "NEVER_MISFIRES" ],
+    "clip_size": 1,
+    "weight": "540 g",
+    "volume": "750 ml",
+    "longest_side": "25 cm",
+    "to_hit": { "grip": "none", "length": "hand", "surface": "any", "balance": "clumsy" },
+    "reload_noise_volume": 2,
+    "loudness": 2,
+    "range": 8,
+    "dispersion": 130,
+    "durability": 8,
+    "pocket_data": [
+      {
+        "pocket_type": "MAGAZINE",
+        "rigid": true,
+        "max_contains_volume": "200 L",
+        "max_contains_weight": "400 kg",
+        "max_item_length": "2000 m",
+        "ammo_restriction": { "bone_dart": 20 }
+      }
+    ],
+    "melee_damage": { "bash": 2 }
+  },
+  {
     "id": "nether_huntsman_arm",
     "type": "ITEM",
     "subtypes": [ "GUN" ],

--- a/data/json/monsters/netherum/labyrinth_monsters.json
+++ b/data/json/monsters/netherum/labyrinth_monsters.json
@@ -30,9 +30,9 @@
     "special_attacks": [
       {
         "type": "gun",
-        "cooldown": 5,
+        "cooldown": 10,
         "move_cost": 100,
-        "gun_type": "feral_human_thrown_rock",
+        "gun_type": "bone_dart_launcher",
         "ammo_type": "bone_dart",
         "fake_skills": [ [ "throw", 4 ] ],
         "fake_str": 14,
@@ -65,9 +65,9 @@
     "special_attacks": [
       {
         "type": "gun",
-        "cooldown": 5,
+        "cooldown": 10,
         "move_cost": 100,
-        "gun_type": "feral_human_thrown_rock",
+        "gun_type": "bone_dart_launcher",
         "ammo_type": "bone_dart",
         "fake_skills": [ [ "throw", 4 ] ],
         "fake_str": 16,
@@ -174,9 +174,9 @@
     "special_attacks": [
       {
         "type": "gun",
-        "cooldown": 5,
+        "cooldown": 10,
         "move_cost": 100,
-        "gun_type": "feral_human_thrown_rock",
+        "gun_type": "bone_dart_launcher",
         "ammo_type": "bone_dart",
         "fake_skills": [ [ "throw", 4 ] ],
         "fake_str": 16,

--- a/tools/json_tools/generic_guns_validator.py
+++ b/tools/json_tools/generic_guns_validator.py
@@ -15,6 +15,7 @@ AMMO_TYPE_WHITELIST = {
     'atgm',  # Rocket
     'atlatl',
     'bolt_ballista',
+    'bone_dart',
     'barb',
     'battery',
     'BB',
@@ -48,6 +49,7 @@ SKILL_WHITELIST = {
 # This could go away if obsolete stuff were explicitly marked as such.
 ID_WHITELIST = {
     # Guns
+    'bone_dart_launcher',
     'coilgun',
     'slamfire_shotgun',
     'slamfire_shotgun_d',


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Got permission from I-am-Erk to finish #84045.  From there: "Fleshborg darts do basically nothing except shred your backpack. They also spam a ton of them very fast, so I hope you hate your backpack."  Design goal: "the objective here is that these darts should not be a significant threat to an armoured player, but they should at least do occasional 'chip' damage. Even against an unarmoured player, I do not want them to machinegun you into pulp. They're supposed to be a minor threat that becomes more dangerous when layered with status effects from other mobs later."

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Mostly a copy/paste job:

- Gave them bespoke "gun" (written by I-am-Erk, just changed material to `cyber_bone`)
- Increased cooldown
- Fixed ammo, and moved to `monster_ammo.json`
 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Also considered upping damage/armor piercing, but this will have to be retuned after adding phase goo anyway.  Waiting until phase goo is done to see how it fares.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Fought a few fleshborgs.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
