### PR TITLE
Mapgen palette for labyrinthine structures that don't intrinsically spawn monsters

### DIFF
--- a/data/json/mapgen/netherum/labyrinth_mapgen_1ofakind_maps.json
+++ b/data/json/mapgen/netherum/labyrinth_mapgen_1ofakind_maps.json
@@ -30,7 +30,7 @@
         "vvvvvvvvv      vvvvvvvvv",
         "vvvvvvvvv      vvvvvvvvv"
       ],
-      "palettes": [ "labyrinthine_base_palette" ],
+      "palettes": [ "labyrinthine_base_palette_no_enemies" ],
       "nested": {
         "1": { "chunks": [ "ls_12x12hall4way_basic" ] },
         "2": { "chunks": [ "ls_ew_6x6hall_basic" ] },
@@ -70,7 +70,7 @@
         "vvvvvvvvv      vvvvvvvvv",
         "vvvvvvvvv      vvvvvvvvv"
       ],
-      "palettes": [ "labyrinthine_base_palette" ],
+      "palettes": [ "labyrinthine_base_palette_no_enemies" ],
       "nested": {
         "1": { "chunks": [ "ls_12x12hall4way_basic" ] },
         "2": { "chunks": [ "ls_ew_6x6hall_basic" ] },

--- a/data/json/mapgen_palettes/netherum/labryinth_mapgen_palettes.json
+++ b/data/json/mapgen_palettes/netherum/labryinth_mapgen_palettes.json
@@ -46,6 +46,47 @@
   },
   {
     "type": "palette",
+    "id": "labyrinthine_base_palette_no_enemies",
+    "terrain": {
+      "|": "t_nl_metal_wall",
+      "_": "t_nl_metal_floor",
+      ".": "t_nl_catwalk",
+      "!": "t_nl_metal_wall_edge",
+      "v": "t_nl_chasm",
+      "+": "t_nl_door_c",
+      "=": "t_nl_door_l",
+      "ϴ": "t_nl_catwalk",
+      "o": [ [ "t_nl_catwalk", 3 ], [ "t_nl_chasm", 1 ] ]
+    },
+    "furniture": {
+      "â": "f_autodoc",
+      "ä": "f_autodoc_couch",
+      "A": "f_scrap_antenna",
+      "b": "f_exodii_charger",
+      "B": "f_exodii_charger_cheap",
+      "c": [ [ "f_metal_crate_r", 1 ], [ "f_metal_crate_c", 3 ] ],
+      "C": [ [ "f_metal_crate_r", 9 ], [ "f_metal_crate_c", 1 ] ],
+      "¢": [ "f_metal_crate_r", "f_metal_crate_c", [ "f_null", 2 ] ],
+      "Ç": "f_control_station",
+      "d": "f_dialysis",
+      "E": "f_exodii_scanner",
+      "F": "f_curtain",
+      "l": "f_locker",
+      "L": "f_exodii_lamp",
+      "ϴ": [ [ "f_null", 75 ], [ "f_exodii_lamp", 20 ], [ "f_electrical_conduit", 5 ] ],
+      "M": "f_machinery_electronic",
+      "U": "f_utility_shelf",
+      "P": "f_exodii_pump",
+      "(": "f_electrical_conduit",
+      "Ƥ": "f_exodii_printer_large",
+      "ƥ": "f_exodii_printer_small",
+      "Ṫ": "f_metal_table",
+      "ϟ": "f_capacitor",
+      "ß": "f_metal_bench"
+    }
+  },
+  {
+    "type": "palette",
     "id": "labyrinthine_item_palette_utility_tier0",
     "items": {
       "c": { "item": "LS_SUS_crate_tier0_materials", "chance": 75 },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Got permission from I-am-Erk to finish #84045.  Problem: "Monsters start in the entrance room, and can smash the computer, leaving you forever stranded."

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Made a new mapgen_palette `labyrinthine_base_palette_no_enemies`, to make it obvious which mapgens do and don't spawn monsters.  Added it to the standard entrance room, and to the boiler-mission exit room.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Checked.  No monsters in the rooms.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
