### PR TITLE
Reduce prying test flake by raising difficulty

### DIFF
--- a/data/mods/TEST_DATA/terrain.json
+++ b/data/mods/TEST_DATA/terrain.json
@@ -160,7 +160,7 @@
     "color": "blue",
     "move_cost": 1,
     "bash": { "sound": "thump", "ter_set": "t_null", "str_min": 50, "str_max": 100, "str_min_supported": 100, "bash_below": true },
-    "prying": { "result": "t_dirt", "duration": "30 seconds", "prying_data": { "difficulty": 100 } }
+    "prying": { "result": "t_dirt", "duration": "30 seconds", "prying_data": { "difficulty": 1000 } }
   },
   {
     "type": "terrain",
@@ -191,7 +191,7 @@
       "ter_set": "t_dirt",
       "items": [ { "item": "glass_shard", "count": [ 21, 29 ] } ]
     },
-    "prying": { "result": "t_grass", "duration": "30 seconds", "prying_data": { "difficulty": 100, "breakable": true } }
+    "prying": { "result": "t_grass", "duration": "30 seconds", "prying_data": { "difficulty": 1000, "breakable": true } }
   },
   {
     "type": "terrain",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Prying tests use test_t_prying2 and test_t_prying4 with difficulty 100, not deterministic given dice(4, N) rolls. Observed flake in CI: https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/24867079502/job/72806244699?pr=86668

#### Describe the solution
Bump difficulty 100 -> 1000 on both terrains. Flake probability drops from ~3e-4 to ~3e-8 per run.

#### Describe alternatives you've considered
N/A

#### Testing
Bad seed isn't bad anymore.

#### Additional context
N/A