### PR TITLE
Fix NPCs not seeing the player through gaps the player sees them through

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7137,11 +7137,12 @@ npc_attitude Character::get_attitude() const
     return NPCATT_NULL;
 }
 
-bool Character::sees( const map &here, const tripoint_bub_ms &t, bool, int ) const
+bool Character::sees( const map &here, const tripoint_bub_ms &t, bool is_avatar,
+                      int range_mod ) const
 {
     const int wanted_range = rl_dist( pos_bub( here ), t );
     bool can_see = this->is_avatar() ? here.pl_sees( t, std::min( sight_max, wanted_range ) ) :
-                   Creature::sees( here, t );
+                   Creature::sees( here, t, is_avatar, range_mod );
     // Clairvoyance is now pretty cheap, so we can check it early
     if( wanted_range < MAX_CLAIRVOYANCE && wanted_range < clairvoyance() ) {
         return true;

--- a/src/faction_ui.cpp
+++ b/src/faction_ui.cpp
@@ -81,7 +81,7 @@ static bool can_contact( const Character &alpha, const Character &beta )
     const map &here = get_map();
 
     const bool too_far_omt = rl_dist( alpha.pos_abs_omt(), beta.pos_abs_omt() ) > 3;
-    const bool see_each_other = alpha.sees( here, beta.pos_bub( here ) );
+    const bool see_each_other = alpha.sees( here, beta );
     return !too_far_omt || see_each_other ;
 }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1233,7 +1233,7 @@ void game::on_witness_theft( const item &target )
     std::vector<npc *> witnesses;
     for( npc &elem : g->all_npcs() ) {
         if( rl_dist( elem.pos_bub(), p.pos_bub() ) < MAX_VIEW_DISTANCE &&
-            elem.sees( here, p.pos_bub( here ) ) &&
+            elem.sees( here, p ) &&
             target.is_owned_by( elem ) ) {
             witnesses.push_back( &elem );
         }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1355,7 +1355,7 @@ void item::handle_pickup_ownership( Character &c )
                     owned_by = is_owned_by( *as_monster );
                 }
                 return &cr != &c && owned_by && rl_dist( cr.pos_abs(), c.pos_abs() ) < MAX_VIEW_DISTANCE &&
-                       cr.sees( here, c.pos_bub( here ) );
+                       cr.sees( here, c );
             };
             const auto sort_criteria = []( const Creature * lhs, const Creature * rhs ) {
                 const npc *const lnpc = lhs->as_npc();

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2039,7 +2039,7 @@ int npc::indoor_voice() const
     const int distance_to_player = rl_dist( pos_abs(), player.pos_abs() );
     if( is_following() || is_ally( player ) ) {
         wanted_volume = distance_to_player;
-    } else if( is_enemy() && sees( here, player.pos_bub( here ) ) ) {
+    } else if( is_enemy() && sees( here, player ) ) {
         // Battle cry! Bandits have no concept of indoor voice, even when not threatened.
         wanted_volume = max_volume;
     }

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -908,7 +908,7 @@ void npc::assess_danger()
     }
 
     Character &player_character = get_player_character();
-    bool sees_player = sees( here, player_character.pos_bub( here ) );
+    bool sees_player = sees( here, player_character );
     const bool self_defense_only = rules.engagement == combat_engagement::NO_MOVE ||
                                    rules.engagement == combat_engagement::NONE;
     const bool no_fighting = rules.has_flag( ally_rule::forbid_engage );
@@ -1360,7 +1360,7 @@ void npc::act_on_danger_assessment()
                 if( !is_player_ally() ) {
                     set_attitude( NPCATT_FLEE_TEMP );
                 }
-                if( mem_combat.panic > 5 && is_player_ally() && sees( here, player_character.pos_bub( here ) ) ) {
+                if( mem_combat.panic > 5 && is_player_ally() && sees( here, player_character ) ) {
                     // consider warning player about panic
                     int panic_alert = rl_dist( pos_bub(), player_character.pos_bub() ) - player_character.get_per();
                     if( mem_combat.panic - personality.bravery > panic_alert ) {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -5109,7 +5109,7 @@ bool vehicle::handle_potential_theft( Character const &you, bool check_only, boo
         Character const *const elem = cr.as_character();
         return elem != nullptr && you.getID() != elem->getID() && is_owned_by( *elem ) &&
                rl_dist( elem->pos_bub( here ), you.pos_bub( here ) ) < MAX_VIEW_DISTANCE &&
-               elem->sees( here, you.pos_bub( here ) );
+               elem->sees( here, you );
     } );
     if( !has_owner() || ( witnesses.empty() && ( has_old_owner() || you.is_npc() ) ) ) {
         if( !has_owner() ||


### PR DESCRIPTION
#### Summary
Bugfixes "Fix NPCs not seeing the player through gaps the player sees them through"

#### Purpose of change
Fixes #86657. Likely also the cause of #76923, #86524, #86261.

`Creature::sees( Creature & )` has a reciprocal path that uses the player's shadow-cast seen_cache when the target is the avatar. It was unreachable: `Character::sees( tripoint, bool, int )` had unnamed params, silently dropped `is_avatar`/`range_mod`, and forwarded to the asymmetric bresenham path. `npc::assess_danger` then cached `sees_player` via that tripoint overload, short-circuiting the later Creature-overload check in the hostile branch.

Regressed in #69623 when `sees_player` started being cached.

#### Describe the solution
- Name and forward `is_avatar`/`range_mod` in `Character::sees` tripoint override.
- Route `sees_player` cache through the Creature overload.
- Same pattern in panic warn, enemy battle cry, theft/witness checks, ally contact.

Monsters unaffected, they already use `Creature::sees` directly.

#### Describe alternatives you've considered
N/A

#### Testing
Loaded the save from #86657. Before: fort bandits stay passive in open daylight through partial cover. After: they engage.

#### Additional context
N/A