### PR TITLE
Fix duplication problems with Hub 01 XM bionics

### DIFF
--- a/data/json/enchantments.json
+++ b/data/json/enchantments.json
@@ -425,7 +425,8 @@
       { "value": "MOVE_COST", "multiply": -0.15 },
       { "value": "MOVECOST_OBSTACLE_MOD", "multiply": -0.5 },
       { "value": "CARRY_WEIGHT", "add": 20000 }
-    ]
+    ],
+    "encumbrance_modifier": [ { "part": "leg_l", "add": -40 }, { "part": "leg_r", "add": -40 } ]
   },
   {
     "id": "robofac_XM_ARM_on",
@@ -439,7 +440,8 @@
       { "value": "WEAPON_DISPERSION", "multiply": -0.1 },
       { "value": "THROW_STR", "multiply": 0.5 },
       { "value": "THROW_DAMAGE", "multiply": 0.25 }
-    ]
+    ],
+    "encumbrance_modifier": [ { "part": "arm_l", "add": -40 }, { "part": "arm_r", "add": -40 }, { "part": "hand_l", "add": -40 }, { "part": "hand_r", "add": -40 } ]
   },
   {
     "id": "robofac_XM_BACK_on",
@@ -454,6 +456,7 @@
       { "value": "WEAPON_DISPERSION", "multiply": -0.05 },
       { "value": "THROW_STR", "multiply": 0.05 },
       { "value": "THROW_DAMAGE", "multiply": 0.05 }
-    ]
+    ],
+    "encumbrance_modifier": [ { "part": "torso", "add": -40 } ]
   }
 ]

--- a/data/json/enchantments.json
+++ b/data/json/enchantments.json
@@ -441,7 +441,12 @@
       { "value": "THROW_STR", "multiply": 0.5 },
       { "value": "THROW_DAMAGE", "multiply": 0.25 }
     ],
-    "encumbrance_modifier": [ { "part": "arm_l", "add": -40 }, { "part": "arm_r", "add": -40 }, { "part": "hand_l", "add": -40 }, { "part": "hand_r", "add": -40 } ]
+    "encumbrance_modifier": [
+      { "part": "arm_l", "add": -40 },
+      { "part": "arm_r", "add": -40 },
+      { "part": "hand_l", "add": -40 },
+      { "part": "hand_r", "add": -40 }
+    ]
   },
   {
     "id": "robofac_XM_BACK_on",

--- a/data/json/items/armor/integrated.json
+++ b/data/json/items/armor/integrated.json
@@ -2397,7 +2397,7 @@
     "type": "ITEM",
     "subtypes": [ "ARMOR", "TOOL", "ARTIFACT" ],
     "category": "armor",
-    "name": { "str_sp": "Hub 01 XM-LEG (off)" },
+    "name": { "str": "Hub 01 XM-LEG" },
     "description": "The Hub 01 Lower Extremity Gaitframe, or LEG, a powered exoskeleton for the true frontier cyborg.  A metal frame runs along each of your legs, with anchoring pins implanted deep into the sides of your hips, femurs, and knees, twisting at the lower leg into a metal plate with pins anchored to your shin bones.  Inside are various anchors and electronic interfaces for your muscles, connective tissues, and neurobionic interface.  The frame covering the knee and lower leg has clips custom-fit for Hub 01 greaves, and there is a hip-mounted battery compartment.  When powered, you can move 15% faster, traverse obstacles with 50% higher efficiency, and carry 20kg of extra weight.  Unpowered, they are a significant burden.  Activate them to toggle power.",
     "weight": "1600 g",
     "volume": "5000 ml",
@@ -2447,24 +2447,28 @@
       }
     ],
     "armor": [ { "encumbrance": 40, "coverage": 5, "covers": [ "leg_l", "leg_r" ] } ],
-    "use_action": [
-      { "type": "transform", "msg": "You activate your Hub 01 XM-LEG system.", "target": "integrated_bio_robofac_xmleg_on" }
-    ],
+    "use_action": {
+      "type": "effect_on_conditions",
+      "menu_text": "Toggle power",
+      "effect_on_conditions": [
+        {
+          "id": "EOC_activate_robofac_xmleg",
+          "condition": { "math": [ "u_robofac_xmleg_is_on != 1" ] },
+          "effect": [
+            { "transform_item": "integrated_bio_robofac_xmleg", "active": true },
+            { "math": [ "u_robofac_xmleg_is_on = 1" ] },
+            { "u_message": "You activate your XM-LEG." }
+          ],
+          "false_effect": [
+            { "transform_item": "integrated_bio_robofac_xmleg", "active": false },
+            { "math": [ "u_robofac_xmleg_is_on = 0" ] },
+            { "u_message": "You deactivate your XM-LEG." }
+          ]
+        }
+      ]
+    },
     "passive_effects": [ { "id": "robofac_XM_LEG_on" } ],
-    "tool_ammo": [ "battery" ]
-  },
-  {
-    "id": "integrated_bio_robofac_xmleg_on",
-    "copy-from": "integrated_bio_robofac_xmleg",
-    "type": "ITEM",
-    "subtypes": [ "ARMOR", "TOOL", "ARTIFACT" ],
-    "category": "armor",
-    "name": { "str_sp": "Hub 01 XM-LEG (on)" },
-    "extend": { "flags": [ "SPAWN_ACTIVE" ] },
-    "armor": [ { "encumbrance": 0, "coverage": 5, "covers": [ "leg_l", "leg_r" ] } ],
-    "use_action": [
-      { "type": "transform", "msg": "You deactivate your Hub 01 XM-LEG system.", "target": "integrated_bio_robofac_xmleg" }
-    ],
+    "tool_ammo": [ "battery" ],
     "power_draw": "37 W",
     "revert_to": "integrated_bio_robofac_xmleg"
   },
@@ -2473,7 +2477,7 @@
     "type": "ITEM",
     "subtypes": [ "ARMOR", "TOOL", "ARTIFACT" ],
     "category": "armor",
-    "name": { "str_sp": "Hub 01 XM-ARM (off)" },
+    "name": { "str": "Hub 01 XM-ARM" },
     "description": "The Hub 01 Arm Reinforcement Motionframe, or ARM, a powered exoskeleton for the true frontier cyborg.  A metal frame runs along each of your arms and hands, with anchoring pins implanted deep into your joints and bones, twisting at the wrist into a thin, glove-like matrix of implanted steel.  Inside are various anchors and electronic interfaces for your muscles, connective tissues, and neurobionic interface.  The frame has a battery compartment and the elbows and lower arms have clips custom-fit for Hub 01 vambraces.  When powered, your arms are exceptionally stable, reducing firearm recoil by 30% and shot dispersion by 10%.  Moreover, you have better control over thrown objects, allowing you to throw objects 50% further and 25% harder.  Unpowered, they are a significant burden.  Activate them to toggle power.",
     "weight": "1600 g",
     "volume": "5000 ml",
@@ -2523,25 +2527,29 @@
       }
     ],
     "armor": [ { "encumbrance": 40, "coverage": 5, "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ] } ],
-    "use_action": [
-      { "type": "transform", "msg": "You activate your Hub 01 XM-ARM system.", "target": "integrated_bio_robofac_xmarm_on" }
-    ],
+    "use_action": {
+      "type": "effect_on_conditions",
+      "menu_text": "Toggle power",
+      "effect_on_conditions": [
+        {
+          "id": "EOC_activate_robofac_xmarm",
+          "condition": { "math": [ "u_robofac_xmarm_is_on != 1" ] },
+          "effect": [
+            { "transform_item": "integrated_bio_robofac_xmarm", "active": true },
+            { "math": [ "u_robofac_xmarm_is_on = 1" ] },
+            { "u_message": "You activate your XM-ARM" }
+          ],
+          "false_effect": [
+            { "transform_item": "integrated_bio_robofac_xmarm", "active": false },
+            { "math": [ "u_robofac_xmarm_is_on = 0" ] },
+            { "u_message": "You deactivate your XM-ARM." }
+          ]
+        }
+      ]
+    },
     "passive_effects": [ { "id": "robofac_XM_ARM_on" } ],
-    "tool_ammo": [ "battery" ]
-  },
-  {
-    "id": "integrated_bio_robofac_xmarm_on",
-    "copy-from": "integrated_bio_robofac_xmarm",
-    "type": "ITEM",
-    "subtypes": [ "ARMOR", "TOOL", "ARTIFACT" ],
-    "category": "armor",
-    "name": { "str_sp": "Hub 01 XM-ARM (on)" },
-    "extend": { "flags": [ "SPAWN_ACTIVE" ] },
-    "armor": [ { "encumbrance": 0, "coverage": 5, "covers": [ "arm_l", "arm_r", "hand_l", "hand_r" ] } ],
-    "use_action": [
-      { "type": "transform", "msg": "You deactivate your Hub 01 XM-ARM system.", "target": "integrated_bio_robofac_xmarm" }
-    ],
     "power_draw": "37 W",
+    "tool_ammo": [ "battery" ],
     "revert_to": "integrated_bio_robofac_xmarm"
   },
   {
@@ -2549,7 +2557,7 @@
     "type": "ITEM",
     "subtypes": [ "ARMOR", "TOOL", "ARTIFACT" ],
     "category": "armor",
-    "name": { "str_sp": "Hub 01 XM-BACK (off)" },
+    "name": { "str": "Hub 01 XM-BACK" },
     "description": "The Hub 01 Biomechanical Assisted Carrying Kinetoframe, or BACK, a powered exoskeleton for the true frontier cyborg.  A metal frame runs along the back of your shoulders, your spine, and upper waist, with anchoring pins implanted deep into your joints and bones.  Inside are various anchors and electronic interfaces for your muscles, connective tissues, and neurobionic interface.  The frame has a battery compartment at the lower back.  When powered, your frame adapts to effectively distribute force, increasing carrying capacity by 35%, and modestly improving your ability to throw and absorb recoil.  Unpowered, it is a significant burden.  Activate it to toggle power.",
     "weight": "1600 g",
     "volume": "5000 ml",
@@ -2583,24 +2591,28 @@
       }
     ],
     "armor": [ { "encumbrance": 40, "coverage": 5, "covers": [ "torso" ] } ],
-    "use_action": [
-      { "type": "transform", "msg": "You activate your Hub 01 XM-BACK system.", "target": "integrated_bio_robofac_xmback_on" }
-    ],
+    "use_action": {
+      "type": "effect_on_conditions",
+      "menu_text": "Toggle power",
+      "effect_on_conditions": [
+        {
+          "id": "EOC_activate_robofac_xmback",
+          "condition": { "math": [ "u_robofac_xmback_is_on != 1" ] },
+          "effect": [
+            { "transform_item": "integrated_bio_robofac_xmback", "active": true },
+            { "math": [ "u_robofac_xmback_is_on = 1" ] },
+            { "u_message": "You activate your XM-BACK." }
+          ],
+          "false_effect": [
+            { "transform_item": "integrated_bio_robofac_xmback", "active": false },
+            { "math": [ "u_robofac_xmback_is_on = 0" ] },
+            { "u_message": "You deactivate your XM-BACK." }
+          ]
+        }
+      ]
+    },
     "passive_effects": [ { "id": "robofac_XM_BACK_on" } ],
-    "tool_ammo": [ "battery" ]
-  },
-  {
-    "id": "integrated_bio_robofac_xmback_on",
-    "copy-from": "integrated_bio_robofac_xmback",
-    "type": "ITEM",
-    "subtypes": [ "ARMOR", "TOOL", "ARTIFACT" ],
-    "category": "armor",
-    "name": { "str_sp": "Hub 01 XM-BACK (on)" },
-    "extend": { "flags": [ "SPAWN_ACTIVE" ] },
-    "armor": [ { "encumbrance": 0, "coverage": 5, "covers": [ "torso" ] } ],
-    "use_action": [
-      { "type": "transform", "msg": "You deactivate your Hub 01 XM-BACK system.", "target": "integrated_bio_robofac_xmback" }
-    ],
+    "tool_ammo": [ "battery" ],
     "power_draw": "37 W",
     "revert_to": "integrated_bio_robofac_xmback"
   },

--- a/data/json/npcs/robofac/robofac_ancilla_npcs/NPC_ANCILLA_DOCTOR.json
+++ b/data/json/npcs/robofac/robofac_ancilla_npcs/NPC_ANCILLA_DOCTOR.json
@@ -657,10 +657,6 @@
           { "u_add_effect": "sleep", "duration": "2 hours" },
           { "u_assign_activity": "ACT_CBM_SURGERY", "duration": "2 hours" },
           { "u_lose_bionic": "bio_robofac_xmarm" },
-          {
-            "if": { "u_has_items": { "item": "integrated_bio_robofac_xmarm_on", "count": 1 } },
-            "then": { "u_consume_item": "integrated_bio_robofac_xmarm_on", "count": 1, "popup": false }
-          },
           { "u_add_bionic": "bio_robofac_xmarm" },
           { "u_consume_item": "RobofacCoin", "count": 10, "popup": true }
         ]
@@ -680,10 +676,6 @@
           { "u_add_effect": "sleep", "duration": "2 hours" },
           { "u_assign_activity": "ACT_CBM_SURGERY", "duration": "2 hours" },
           { "u_lose_bionic": "bio_robofac_xmleg" },
-          {
-            "if": { "u_has_items": { "item": "integrated_bio_robofac_xmleg_on", "count": 1 } },
-            "then": { "u_consume_item": "integrated_bio_robofac_xmleg_on", "count": 1, "popup": false }
-          },
           { "u_add_bionic": "bio_robofac_xmleg" },
           { "u_consume_item": "RobofacCoin", "count": 10, "popup": true }
         ]
@@ -703,10 +695,6 @@
           { "u_add_effect": "sleep", "duration": "2 hours" },
           { "u_assign_activity": "ACT_CBM_SURGERY", "duration": "2 hours" },
           { "u_lose_bionic": "bio_robofac_xmback" },
-          {
-            "if": { "u_has_items": { "item": "integrated_bio_robofac_xmback_on", "count": 1 } },
-            "then": { "u_consume_item": "integrated_bio_robofac_xmback_on", "count": 1, "popup": false }
-          },
           { "u_add_bionic": "bio_robofac_xmback" },
           { "u_consume_item": "RobofacCoin", "count": 10, "popup": true }
         ]
@@ -800,10 +788,6 @@
           { "u_add_effect": "sleep", "duration": "6 hours" },
           { "u_assign_activity": "ACT_CBM_SURGERY", "duration": "6 hours" },
           { "u_lose_bionic": "bio_robofac_xmarm" },
-          {
-            "if": { "u_has_items": { "item": "integrated_bio_robofac_xmarm_on", "count": 1 } },
-            "then": { "u_consume_item": "integrated_bio_robofac_xmarm_on", "count": 1, "popup": false }
-          },
           { "u_lose_bionic": "bio_armor_arms" },
           { "u_add_trait": "BIONIC_ARM_BASIC_RIGHT" },
           { "u_consume_item": "RobofacCoin", "count": 20, "popup": true }
@@ -825,10 +809,6 @@
           { "u_add_effect": "sleep", "duration": "6 hours" },
           { "u_assign_activity": "ACT_CBM_SURGERY", "duration": "6 hours" },
           { "u_lose_bionic": "bio_robofac_xmarm" },
-          {
-            "if": { "u_has_items": { "item": "integrated_bio_robofac_xmarm_on", "count": 1 } },
-            "then": { "u_consume_item": "integrated_bio_robofac_xmarm_on", "count": 1, "popup": false }
-          },
           { "u_lose_bionic": "bio_armor_arms" },
           { "u_add_trait": "BIONIC_ARM_BASIC_LEFT" },
           { "u_consume_item": "RobofacCoin", "count": 20, "popup": true }
@@ -870,10 +850,6 @@
           { "u_add_effect": "sleep", "duration": "6 hours" },
           { "u_assign_activity": "ACT_CBM_SURGERY", "duration": "6 hours" },
           { "u_lose_bionic": "bio_robofac_xmleg" },
-          {
-            "if": { "u_has_items": { "item": "integrated_bio_robofac_xmleg_on", "count": 1 } },
-            "then": { "u_consume_item": "integrated_bio_robofac_xmleg_on", "count": 1, "popup": false }
-          },
           { "u_lose_bionic": "bio_armor_legs" },
           { "u_add_trait": "BIONIC_LEG_BASIC_RIGHT" },
           { "u_consume_item": "RobofacCoin", "count": 20, "popup": true }
@@ -895,10 +871,6 @@
           { "u_add_effect": "sleep", "duration": "6 hours" },
           { "u_assign_activity": "ACT_CBM_SURGERY", "duration": "6 hours" },
           { "u_lose_bionic": "bio_robofac_xmleg" },
-          {
-            "if": { "u_has_items": { "item": "integrated_bio_robofac_xmleg_on", "count": 1 } },
-            "then": { "u_consume_item": "integrated_bio_robofac_xmleg_on", "count": 1, "popup": false }
-          },
           { "u_lose_bionic": "bio_armor_legs" },
           { "u_add_trait": "BIONIC_LEG_BASIC_LEFT" },
           { "u_consume_item": "RobofacCoin", "count": 20, "popup": true }

--- a/data/json/obsoletion_and_migration_0.J/migration_items.json
+++ b/data/json/obsoletion_and_migration_0.J/migration_items.json
@@ -806,5 +806,20 @@
     "type": "MIGRATION",
     "id": "gloves_bag",
     "replace": "plastic_shopping_bag"
+  },
+  {
+    "type": "MIGRATION",
+    "id": "integrated_bio_robofac_xmleg_on",
+    "replace": "qt_steel_chunk"
+  },
+  {
+    "type": "MIGRATION",
+    "id": "integrated_bio_robofac_xmarm_on",
+    "replace": "qt_steel_chunk"
+  },
+  {
+    "type": "MIGRATION",
+    "id": "integrated_bio_robofac_xmback_on",
+    "replace": "qt_steel_chunk"
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
You must have the below headings. Comments like this may be safely removed, if you want.

If you are opening this pull request from GitHub's web interface, you can use the 'preview' button to see what your pull request will look like to others.

Guidelines for pull requests:
-Keep your changes limited to one specific issue or change, plus the bare minimum related work to make that happen.
-A good rule of thumb is that most pull requests are less than 500 lines of changes.
-You can open extra pull requests to separate out portions of an intended change, ask if you're unsure. We're happy to work with you or advise the best way to get your PR merged.
-->

#### Summary
Bugfixes "No more hub bionic duplications"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these specific categories: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
Some examples:
1. None
2. Features "In-game Armor sprite change"
3. Interface "Show crafting failure chances in the crafting interface"
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fixes #86464

Hub XM bionics are integrated items that work like external electronics.  It's part of their fun and flavor.

But due to the way bionics work:
- Saving with the items on, and reloading, gave you a duplicate off item.
- Removing the bionics while on didn't remove the integrated item.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [GitHub's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Deleted and migrated the `_on` items.  Switched activation to EOCs that simply toggle the activation state of the item, so that the item always has the same ID.  This fixes all of the problems.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Custom iuse transform functions of some kind.

Modifying the bionics system and/or character save/load to be more accommodating.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Toggled on/off.  Let them run out of batteries.  Saved and loaded in on and off states.  All worked as expected.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also, include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game are free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the terms of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
