### PR TITLE
add belt grinder

### DIFF
--- a/data/json/itemgroups/tools.json
+++ b/data/json/itemgroups/tools.json
@@ -16,7 +16,8 @@
       [ "hotcut", 90 ],
       [ "metalworking_tongs", 90 ],
       [ "hammer", 90 ],
-      [ "sandpaper", 90 ]
+      [ "sandpaper", 90 ],
+      [ "belt_grinder", 50 ]
     ]
   },
   {
@@ -204,6 +205,7 @@
       [ "lug_wrench", 20 ],
       [ "jerrycan", 10 ],
       [ "jerrycan_big", 10 ],
+      [ "belt_grinder", 20 ],
       { "item": "char_smoker", "prob": 5, "charges": [ 0, 300 ] },
       { "item": "dehydrator", "prob": 5 },
       [ "tourist_table", 1 ],
@@ -952,7 +954,8 @@
       { "item": "grinder_metal_grinding_disc", "prob": 10 },
       { "item": "masonrysaw_off", "prob": 50, "charges": [ 0, 450 ] },
       { "item": "heavy_masonrysaw_off", "prob": 50, "charges": [ 0, 450 ] },
-      { "item": "electric_masonrysaw_off", "prob": 50, "charges": [ 0, 495 ] }
+      { "item": "electric_masonrysaw_off", "prob": 50, "charges": [ 0, 495 ] },
+      { "item": "belt_grinder", "prob": 20 }
     ]
   },
   {

--- a/data/json/items/tool/metalworking.json
+++ b/data/json/items/tool/metalworking.json
@@ -268,6 +268,28 @@
     "tool_ammo": [ "battery" ]
   },
   {
+    "id": "belt_grinder",
+    "type": "ITEM",
+    "subtypes": [ "TOOL" ],
+    "name": { "str": "belt grinder" },
+    "looks_like": "pedal_grindstone",
+    "description": "A power tool used for grinding and shaping metal or even wood.  It consists of a motorized abrasive belt that spins at high speeds, allowing you to quickly polish, flatten, or overall remove material from surfaces.",
+    "weight": "55 kg",
+    "volume": "70 L",
+    "longest_side": "80 cm",
+    "price": "1500 USD",
+    "price_postapoc": "30 USD",
+    "material": [ "steel", "plastic" ],
+    "symbol": "B",
+    "color": "light_gray",
+    "flags": [ "ALLOWS_REMOTE_USE", "WATER_BREAK" ],
+    "faults": [ { "fault_group": "electronic_general" } ],
+    "charged_qualities": [ { "id": "GRIND", "level": 2, "speed": 0.4 }, { "id": "FILE", "level": 3, "speed": 0.3 } ],
+    "charges_per_use": 25,
+    "use_action": [ { "type": "link_up", "cable_length": 10, "charge_rate": "1600 W" } ],
+    "tool_ammo": [ "battery" ]
+  },
+  {
     "id": "link_sheet",
     "type": "ITEM",
     "subtypes": [ "TOOL" ],

--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -610,7 +610,7 @@
   {
     "id": "metal_file_any",
     "type": "requirement",
-    "tools": [ [ [ "metal_file", -1 ], [ "bronze_file", -1 ] ] ]
+    "tools": [ [ [ "metal_file", -1 ], [ "bronze_file", -1 ], [ "belt_grinder", 25 ] ] ]
   },
   {
     "id": "nm_teeth_removal",


### PR DESCRIPTION

#### Summary

Content "Add another power tool for blacksmithing as a successor to #86591, working towards smithing modernisation"

#### Purpose of change

The player was stuck using a metal fileset for all their grinding and filing. Not only is this incredibly grueling work, it would also take much, much more time than currently portrayed in the game to eat through the roughly hammered steel enough to true it or produce a semi-serviceable bevel. Also, most of the time forge scale will file the file flat before the file files the forge scale. Try saying that ten times fast.

#### Describe the solution

Welcome to modernity! Belt grinders allow for much easier, and much, much faster material removal, profiling etc.
So I added one into the game, to be found in craft shops, light industry, and hardware stores. Also added it to the metal_file requirement group, so you can use it instead of a metal fileset.
Right now, it uses just some unidentified mystery 2x72 belt. IRL there'd be many types of interchangable belts you'd use for different tasks.

#### Describe alternatives you've considered

Continue manually filing everything.
Add multiple abrasive belts for different tasks, but I'm not sure there is infra to support this, or if I want to support it, given how specific they can get.
Make it even faster at filing.
Add them to more spawn locations, since they're generally used in many, many types of shops.

#### Testing

Loaded, teleported around a bunch to check spawns. Checked if it worked correctly plugged and unplugged. Checked the charges it took to work.

#### Additional context

Here's a couple of uses for a belt grinder, and a general overview of what it is:
https://www.soulceramics.com/pages/what-is-a-belt-grinder-used-for