### PR TITLE
Stop spamming furniture-on-open-air debugmsg from burned ground map extra

### DIFF
--- a/data/json/mapgen/map_extras/burned_ground.json
+++ b/data/json/mapgen/map_extras/burned_ground.json
@@ -45,7 +45,8 @@
       ],
       "nested": { "X": { "chunks": [ "1x1_burned_ground" ] }, "x": { "chunks": [ "1x1_burned_ground_slight", "null" ] } },
       "//": "Here rather than the 1x1 nest for mapgen ordering, otherwise the transform occurs afterwards",
-      "furniture": { "X": [ [ "f_null", 7 ], [ "f_fireweed", 1 ] ], "x": [ [ "f_null", 11 ], [ "f_fireweed", 1 ] ] }
+      "furniture": { "X": [ [ "f_null", 7 ], [ "f_fireweed", 1 ] ], "x": [ [ "f_null", 11 ], [ "f_fireweed", 1 ] ] },
+      "flags": [ "SKIP_ON_OPEN_AIR" ]
     }
   },
   {

--- a/doc/JSON/MAPGEN.md
+++ b/doc/JSON/MAPGEN.md
@@ -457,6 +457,7 @@ Currently the defined flags are as follows:
 - Clearing flags for layered mapgens: see [dedicated section below](#clearing-flags-for-layered-mapgens)
 - `NO_UNDERLYING_ROTATE` The map won't be rotated even if the underlying tile is.
 - `AVOID_CREATURES` If a creature is present, terrain, furniture and traps won't be placed.
+- `SKIP_ON_OPEN_AIR` Furniture placement is skipped silently when the target tile is open air. Useful for mapgens (e.g. map extras) that may run above ground level where many tiles are open air.
 
 ### Clearing flags for layered mapgens
 Some mapgens are intended to be layered on top of existing terrain.  This can be update mapgen,

--- a/src/jmapgen_flags.h
+++ b/src/jmapgen_flags.h
@@ -16,6 +16,7 @@ enum class jmapgen_flags {
     erase_items_before_placing_terrain,
     no_underlying_rotate,
     avoid_creatures,
+    skip_on_open_air,
     last
 };
 

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -1714,6 +1714,7 @@ std::string enum_to_string<jmapgen_flags>( jmapgen_flags v )
             return "ERASE_ITEMS_BEFORE_PLACING_TERRAIN";
         case jmapgen_flags::no_underlying_rotate: return "NO_UNDERLYING_ROTATE";
         case jmapgen_flags::avoid_creatures: return "AVOID_CREATURES";
+        case jmapgen_flags::skip_on_open_air: return "SKIP_ON_OPEN_AIR";
         // *INDENT-ON*
         case jmapgen_flags::last:
             break;
@@ -2995,7 +2996,11 @@ class jmapgen_furniture : public jmapgen_piece_with_has_vehicle_collision
             if( chosen_id.id().is_null() ) {
                 return;
             }
-            if( !dat.m.furn_set( tripoint_bub_ms( x.get(), y.get(), dat.zlevel() + z.get() ), chosen_id ) ) {
+            const tripoint_bub_ms p( x.get(), y.get(), dat.zlevel() + z.get() );
+            if( dat.has_flag( jmapgen_flags::skip_on_open_air ) && dat.m.is_open_air( p ) ) {
+                return;
+            }
+            if( !dat.m.furn_set( p, chosen_id ) ) {
                 debugmsg( "Problem setting furniture in %s", context );
             }
         }


### PR DESCRIPTION
#### Summary
Bugfixes "Stop burned ground map extra spamming furniture-on-open-air debugmsg above ground level"

#### Purpose of change
`mx_point_burned_ground` is allowed at z=0..5 (intentional, going back years). When it rolls above ground level, the nested `7x7_burned_ground` mapgen tries to drop `f_fireweed` on whatever tile it lands on, which is mostly `t_open_air`. That triggers two debugmsgs per affected tile: one from `map::furn_set` and a follow-up from `jmapgen_furniture::apply`. Causes "random" CI failures here and there.

The old hardcoded C++ `burned_ground_parser` only matched grass/tree/FLAMMABLE terrain so it was a silent no-op on open_air. The JSON port in #78721 that replaced it has no terrain branching and no way to skip a tile, and the author of that port flagged this exact error as a known TODO in their PR description.

#### Describe the solution
Add a new mapgen flag `SKIP_ON_OPEN_AIR`. When set, `jmapgen_furniture::apply` early-returns silently if the target tile is open air, before calling `furn_set` (so the furniture is never placed and there's no support_dirty churn either).

Tag `7x7_burned_ground` with the new flag.

#### Describe alternatives you've considered
Pinning `mx_point_burned_ground` to `[0, 0]` like its sibling `mx_burned_ground`. Simpler one-line fix but throws away the deliberate z=0..5 range. Realistically the old C++ also did basically nothing on rooftops, so the loss is small, but the flag is more honest: rooftops still get a chance to spawn fireweed where there's actual flooring.

Adding `ALLOW_ON_OPEN_AIR` to `f_fireweed`. Wrong direction, flowers don't float.

#### Testing
Built and ran overmap tests, no errors.

#### Additional context
N/A