### PR TITLE
Fix GCC 15 build error in input_context

### DIFF
--- a/src/input_context.cpp
+++ b/src/input_context.cpp
@@ -966,7 +966,9 @@ bool input_context::action_add( const std::string &name, const std::string &acti
         return false;
     }
 
-    if( !resolve_conflicts( { new_event }, action_id ) ) {
+    std::vector<input_event> new_events;
+    new_events.push_back( new_event );
+    if( !resolve_conflicts( new_events, action_id ) ) {
         return false;
     }
 


### PR DESCRIPTION
#### Summary
Build "Fix GCC 15 build error in input_context"

#### Purpose of change
GCC 15 with RELEASE=1 refuses to build `src/input_context.cpp` with a bogus `-Wfree-nonheap-object` on a temporary one-element `std::vector<input_event>` passed to `resolve_conflicts`. GCC 14 is fine.

#### Describe the solution
Build the vector with `push_back` instead of an initializer list. Same meaning, no warning.

#### Describe alternatives you've considered
Could suppress the warning with a pragma, but that's uglier.

#### Testing
File compiles clean under RELEASE=1 with GCC 15.

#### Additional context
N/A