### PR TITLE
Fix spammy and unsubstituted fault application messages

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -10443,7 +10443,7 @@ void mend_item_activity_actor::finish( player_activity &act, Character &who )
         }
     }
     for( const ::fault_id &id : fix.faults_added ) {
-        target.set_fault( id, true, false );
+        target.set_fault( id, true, nullptr );
     }
     for( const auto& [var_name, var_value] : fix.set_variables ) {
         target.set_var( var_name, var_value );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4173,7 +4173,7 @@ void Character::mend_item( item_location &&obj, bool interactive )
             if( opts[menu.ret].second ) {
                 obj->remove_fault( opts[menu.ret].first );
             } else {
-                obj->set_fault( opts[menu.ret].first, true, false );
+                obj->set_fault( opts[menu.ret].first, true, nullptr );
             }
         }
         return;

--- a/src/character_armor.cpp
+++ b/src/character_armor.cpp
@@ -252,7 +252,8 @@ bool Character::armor_absorb( damage_unit &du, item &armor, const bodypart_id &b
     // check if the armor was damaged
     item::armor_status damaged = armor.damage_armor_durability( du, pre_mitigation, bp,
                                  calculate_by_enchantment( 1,
-                                         enchant_vals::mod::EQUIPMENT_DAMAGE_CHANCE ) );
+                                         enchant_vals::mod::EQUIPMENT_DAMAGE_CHANCE ),
+                                 this );
 
     // describe what happened if the armor took damage
     if( damaged == item::armor_status::DAMAGED || damaged == item::armor_status::DESTROYED ) {
@@ -289,7 +290,8 @@ bool Character::armor_absorb( damage_unit &du, item &armor, const bodypart_id &b
     // check if the armor was damaged
     item::armor_status damaged = armor.damage_armor_durability( du, pre_mitigation, bp,
                                  calculate_by_enchantment( 1,
-                                         enchant_vals::mod::EQUIPMENT_DAMAGE_CHANCE ) );
+                                         enchant_vals::mod::EQUIPMENT_DAMAGE_CHANCE ),
+                                 this );
 
     // describe what happened if the armor took damage
     if( damaged == item::armor_status::DAMAGED || damaged == item::armor_status::DESTROYED ) {
@@ -331,7 +333,8 @@ bool Character::ablative_armor_absorb( damage_unit &du, item &armor, const sub_b
                 } else {
                     damaged = ablative_armor.damage_armor_durability( du, pre_mitigation, bp->parent,
                               calculate_by_enchantment( 1,
-                                                        enchant_vals::mod::EQUIPMENT_DAMAGE_CHANCE ) );
+                                                        enchant_vals::mod::EQUIPMENT_DAMAGE_CHANCE ),
+                              this );
                 }
 
                 if( damaged == item::armor_status::TRANSFORMED ) {

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -876,9 +876,9 @@ void emp_blast( const tripoint_bub_ms &p )
             item_location loc = item_location( map_cursor( p ), &it );
 
             if( get_option<bool>( "GAME_EMP" ) ) {
-                it.set_fault( fault_emp_reboot, true, false );
+                it.set_fault( fault_emp_reboot, true, nullptr );
             } else {
-                it.set_random_fault_of_type( "shorted", true, false );
+                it.set_random_fault_of_type( "shorted", true, nullptr );
             }
             //map::make_active adds the item to the active item processing list, so that it can reboot without further interaction
             here.make_active( loc );

--- a/src/item.h
+++ b/src/item.h
@@ -1480,15 +1480,19 @@ class item : public visitable
         /**
          * Apply damage to const itemrained by @ref min_damage and @ref max_damage
          * @param qty maximum amount by which to adjust damage (negative permissible)
+         * @param holder character who is wearing/wielding/carrying this item, used to
+         *               surface a player-facing fault message when the avatar owns it.
+         *               Pass nullptr (default) for silent application.
          * @return whether item should be destroyed
          */
-        bool mod_damage( int qty );
+        bool mod_damage( int qty, const Character *holder = nullptr );
 
         /**
          * Same as mod_damage( itype::damage_scale ), advances item to next damage level
+         * @param holder see mod_damage. Pass nullptr (default) for silent application.
          * @return whether item should be destroyed
          */
-        bool inc_damage();
+        bool inc_damage( const Character *holder = nullptr );
 
         enum class armor_status {
             UNDAMAGED,
@@ -1500,11 +1504,13 @@ class item : public visitable
         /**
          * Damage related logic for armor items, wraps mod_damage with needed logic
          * This version is for items with durability
+         * @param holder see mod_damage. Pass nullptr (default) for silent application.
          * @return the state of the armor
          */
         armor_status damage_armor_durability( damage_unit &du, damage_unit &premitigated,
                                               const bodypart_id &bp,
-                                              double enchant_multiplier = 1 );
+                                              double enchant_multiplier = 1,
+                                              const Character *holder = nullptr );
 
         /**
          * Damage related logic for armor items that warp and transform instead of degrading.
@@ -2116,16 +2122,22 @@ class item : public visitable
         /** Idempotent filter setting an item specific flag. */
         item &set_flag( const flag_id &flag );
 
-        /** Check if item can have a fault, and if yes, applies it. This version do not print a message, use item_location version instead
-         * `force`, if true, bypasses the check and applies the fault item do not define
+        /** Check if item can have a fault, and if yes, applies it.
+         * `force`, if true, bypasses the check and applies the fault item do not define.
+         * `holder`, when non-null and indicating the avatar carrying this item,
+         * surfaces the fault's "message" JSON (with %s substituted by tname()) to the
+         * player log. Pass nullptr (default) for silent application. Some callers that
+         * already emit bespoke per-damage text should pass nullptr to avoid duplicates.
          */
-        bool set_fault( const fault_id &f_id, bool force = false, bool message = true );
+        bool set_fault( const fault_id &f_id, bool force = false,
+                        const Character *holder = nullptr );
 
-        /** Check if item can have any fault of type, and if yes, applies it. This version do not print a message, use item_location version instead
-        * `force`, if true, bypasses the check and applies the fault item do not define
+        /** Check if item can have any fault of type, and if yes, applies it.
+        * `force`, if true, bypasses the check and applies the fault item do not define.
+        * `holder`, see set_fault. Pass nullptr (default) for silent application.
         */
         void set_random_fault_of_type( const std::string &fault_type, bool force = false,
-                                       bool message = true );
+                                       const Character *holder = nullptr );
 
         /** Removes the fault from the item, if such is presented. Returns true if a fault was removed */
         bool remove_fault( const fault_id &fault_id );

--- a/src/item_degrade.cpp
+++ b/src/item_degrade.cpp
@@ -25,6 +25,7 @@
 #include "bodypart.h"
 #include "cached_options.h"
 #include "calendar.h"
+#include "character.h"
 #include "color.h"
 #include "coordinates.h"
 #include "damage.h"
@@ -62,7 +63,6 @@
 static const item_category_id item_category_drugs( "drugs" );
 static const item_category_id item_category_food( "food" );
 
-class Character;
 class JsonObject;
 
 namespace item_internal
@@ -359,7 +359,7 @@ bool item::can_have_fault( const fault_id &f_id )
     return true;
 }
 
-bool item::set_fault( const fault_id &f_id, bool force, bool message )
+bool item::set_fault( const fault_id &f_id, bool force, const Character *holder )
 {
     if( !force && !can_have_fault( f_id ) ) {
         return false;
@@ -371,19 +371,23 @@ bool item::set_fault( const fault_id &f_id, bool force, bool message )
         remove_fault( f_blocked );
     }
 
-    if( message ) {
-        add_msg( m_bad, f_id.obj().message() );
+    if( holder != nullptr && holder->is_avatar() && holder->has_item( *this ) ) {
+        const std::string raw = f_id.obj().message();
+        if( !raw.empty() ) {
+            holder->add_msg_if_player( m_bad, string_format( raw, tname() ) );
+        }
     }
 
     faults.insert( f_id );
-    mod_damage( f_id->instant_damage() );
+    mod_damage( f_id->instant_damage(), holder );
     return true;
 }
 
-void item::set_random_fault_of_type( const std::string &fault_type, bool force, bool message )
+void item::set_random_fault_of_type( const std::string &fault_type, bool force,
+                                     const Character *holder )
 {
     if( force ) {
-        set_fault( random_entry( faults::all_of_type( fault_type ) ), true, message );
+        set_fault( random_entry( faults::all_of_type( fault_type ) ), true, holder );
         return;
     }
 
@@ -396,7 +400,7 @@ void item::set_random_fault_of_type( const std::string &fault_type, bool force, 
     }
 
     if( !faults_by_type.empty() ) {
-        set_fault( *faults_by_type.pick(), force, message );
+        set_fault( *faults_by_type.pick(), force, holder );
     }
 
 }
@@ -847,7 +851,7 @@ static int get_degrade_amount( const item &it, int dmgNow_, int dmgPrev )
     return std::max( facNow_ - facPrev, 0 ) * max_dmg / degrade_increments;
 }
 
-bool item::mod_damage( int qty )
+bool item::mod_damage( int qty, const Character *holder )
 {
     if( has_flag( flag_UNBREAKABLE ) ) {
         return false;
@@ -867,7 +871,7 @@ bool item::mod_damage( int qty )
         // TODO: think about better way to telling the game what faults should be applied when
         if( qty > 0 ) {
             for( int i = 0; i <= qty; i += itype::damage_scale ) {
-                set_random_fault_of_type( "mechanical_damage" );
+                set_random_fault_of_type( "mechanical_damage", false, holder );
             }
         }
 
@@ -875,9 +879,9 @@ bool item::mod_damage( int qty )
     }
 }
 
-bool item::inc_damage()
+bool item::inc_damage( const Character *holder )
 {
-    return mod_damage( itype::damage_scale );
+    return mod_damage( itype::damage_scale, holder );
 }
 
 int item::repairable_levels() const
@@ -891,7 +895,8 @@ int item::repairable_levels() const
 
 item::armor_status item::damage_armor_durability( damage_unit &du, damage_unit &premitigated,
         const bodypart_id &bp,
-        double enchant_multiplier )
+        double enchant_multiplier,
+        const Character *holder )
 {
     //Energy shields aren't damaged by attacks but do get their health variable reduced.  They are also only
     //damaged by the damage types they actually protect against.
@@ -903,7 +908,7 @@ item::armor_status item::damage_armor_durability( damage_unit &du, damage_unit &
             return armor_status::UNDAMAGED;
         } else {
             //Shields deliberately ignore the enchantment multiplier, as the health mechanic wouldn't make sense otherwise.
-            mod_damage( itype::damage_scale * 6 );
+            mod_damage( itype::damage_scale * 6, holder );
             return armor_status::DESTROYED;
         }
     }
@@ -947,7 +952,7 @@ item::armor_status item::damage_armor_durability( damage_unit &du, damage_unit &
     if( has_flag( flag_STURDY ) && premitigated.amount < armors_own_resist ) {
         return armor_status::UNDAMAGED;
     } else if( x_in_y( damage_chance, 1.0 ) ) {
-        return mod_damage( itype::damage_scale * enchant_multiplier ) ? armor_status::DESTROYED :
+        return mod_damage( itype::damage_scale * enchant_multiplier, holder ) ? armor_status::DESTROYED :
                armor_status::DAMAGED;
     }
     return armor_status::UNDAMAGED;

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -529,7 +529,7 @@ void Item_modifier::modify( item &new_item, const std::string &context ) const
     if( !faults.empty() ) {
         for( const std::pair<fault_id, int> &f : faults ) {
             if( x_in_y( f.second, 100 ) ) {
-                new_item.set_fault( f.first, false, false );
+                new_item.set_fault( f.first, false, nullptr );
             }
         }
     }

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -293,6 +293,9 @@ bool Character::handle_melee_wear( item_location shield, float wear_multiplier )
 
     std::string str = shield->tname(); // save name before we apply damage
 
+    // Pass nullptr (default): the bespoke "Your %s is damaged" message below already
+    // notifies the player; threading holder would double-report alongside the
+    // per-fault "%s was dented!" message.
     if( !shield->inc_damage() ) {
         add_msg_player_or_npc( m_bad, _( "Your %s is damaged by the force of the blow!" ),
                                _( "<npcname>'s %s is damaged by the force of the blow!" ),
@@ -2155,7 +2158,8 @@ bool Character::block_hit( Creature *source, bodypart_id &bp_hit, damage_instanc
             if( source != nullptr && !source->is_hallucination() ) {
                 for( damage_unit &du : dam.damage_units ) {
                     shield->damage_armor_durability( du, du, bp_hit, calculate_by_enchantment( 1,
-                                                     enchant_vals::mod::EQUIPMENT_DAMAGE_CHANCE ) );
+                                                     enchant_vals::mod::EQUIPMENT_DAMAGE_CHANCE ),
+                                                     this );
                 }
             }
 

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -6224,7 +6224,8 @@ talk_effect_fun_t::func f_set_fault( const JsonObject &jo, std::string_view memb
     bool msg = jo.get_bool( "message", true );
     return [fault_var, force, msg, is_npc]( dialogue const & d ) {
         item_location &it = *d.actor( is_npc )->get_item();
-        it.get_item()->set_fault( fault_id( fault_var.evaluate( d ) ), force, msg );
+        const Character *holder = msg ? d.actor( is_npc )->get_character() : nullptr;
+        it.get_item()->set_fault( fault_id( fault_var.evaluate( d ) ), force, holder );
     };
 }
 
@@ -6236,7 +6237,8 @@ talk_effect_fun_t::func f_set_random_fault_of_type( const JsonObject &jo, std::s
     bool msg = jo.get_bool( "message", true );
     return [fault_type_var, force, msg, is_npc]( dialogue const & d ) {
         item_location &it = *d.actor( is_npc )->get_item();
-        it.get_item()->set_random_fault_of_type( fault_type_var.evaluate( d ), force, msg );
+        const Character *holder = msg ? d.actor( is_npc )->get_character() : nullptr;
+        it.get_item()->set_random_fault_of_type( fault_type_var.evaluate( d ), force, holder );
     };
 }
 

--- a/src/talker.h
+++ b/src/talker.h
@@ -898,8 +898,8 @@ class talker: virtual public const_talker
         virtual void set_all_parts_hp_cur( int ) {}
         virtual void set_degradation( int ) {}
         virtual void die( map * ) {}
-        virtual void set_fault( const fault_id &, bool, bool ) {};
-        virtual void set_random_fault_of_type( const std::string &, bool, bool ) {};
+        virtual void set_fault( const fault_id &, bool, const Character * ) {};
+        virtual void set_random_fault_of_type( const std::string &, bool, const Character * ) {};
         virtual void set_mana_cur( int ) {}
         virtual void mod_daily_health( int, int ) {}
         virtual void mod_livestyle( int ) {}

--- a/src/talker_item.cpp
+++ b/src/talker_item.cpp
@@ -179,15 +179,15 @@ void talker_item::die( map * )
     me_it->remove_item();
 }
 
-void talker_item::set_fault( const fault_id &fault_id, bool force, bool message )
+void talker_item::set_fault( const fault_id &fault_id, bool force, const Character *holder )
 {
-    me_it->get_item()->set_fault( fault_id, force, message );
+    me_it->get_item()->set_fault( fault_id, force, holder );
 }
 
 void talker_item::set_random_fault_of_type( const std::string &fault_type, bool force,
-        const bool message )
+        const Character *holder )
 {
-    me_it->get_item()->set_random_fault_of_type( fault_type, force, message );
+    me_it->get_item()->set_random_fault_of_type( fault_type, force, holder );
 }
 
 int talker_item_const::get_price() const

--- a/src/talker_item.h
+++ b/src/talker_item.h
@@ -90,8 +90,9 @@ class talker_item: public talker_item_const, public talker_cloner<talker_item>
         void set_all_parts_hp_cur( int ) override;
         void set_degradation( int ) override;
         void die( map *here ) override;
-        void set_fault( const fault_id &fault_id, bool force, bool message ) override;
-        void set_random_fault_of_type( const std::string &fault_type, bool force, bool message ) override;
+        void set_fault( const fault_id &fault_id, bool force, const Character *holder ) override;
+        void set_random_fault_of_type( const std::string &fault_type, bool force,
+                                       const Character *holder ) override;
 
     private:
         item_location *me_it{};

--- a/tests/fault_message_test.cpp
+++ b/tests/fault_message_test.cpp
@@ -1,0 +1,74 @@
+#include <list>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "avatar.h"
+#include "cata_catch.h"
+#include "fault.h"
+#include "item.h"
+#include "item_location.h"
+#include "map_helpers.h"
+#include "messages.h"
+#include "npc.h"
+#include "player_helpers.h"
+#include "string_formatter.h"
+#include "type_id.h"
+
+static const fault_id fault_cotton_torn( "fault_cotton_torn" );
+
+static const itype_id itype_jacket_leather( "jacket_leather" );
+
+TEST_CASE( "fault_message_substitution_and_gating", "[fault][item][degrade]" )
+{
+    clear_avatar();
+    clear_map();
+    avatar &av = get_avatar();
+    Messages::clear_messages();
+
+    item jacket( itype_jacket_leather );
+
+    SECTION( "ground item with no holder is silent" ) {
+        jacket.set_fault( fault_cotton_torn, true, nullptr );
+        CHECK( Messages::size() == 0 );
+    }
+
+    SECTION( "avatar-worn item emits substituted message" ) {
+        std::optional<std::list<item>::iterator> worn_it =
+            av.wear_item( jacket, false );
+        REQUIRE( worn_it.has_value() );
+        item &worn = **worn_it;
+        REQUIRE( av.has_item( worn ) );
+        Messages::clear_messages();
+
+        worn.set_fault( fault_cotton_torn, true, &av );
+
+        REQUIRE( Messages::size() == 1 );
+        const std::string expected =
+            string_format( fault_cotton_torn->message(), worn.tname() );
+        CHECK( Messages::recent_messages( 1 ).back().second == expected );
+        // %s must have been substituted; raw "%s" should not appear.
+        CHECK( expected.find( "%s" ) == std::string::npos );
+    }
+
+    SECTION( "avatar passed but item not carried is silent" ) {
+        // Same item instance, never added to avatar inventory.
+        item lone_jacket( itype_jacket_leather );
+        REQUIRE_FALSE( av.has_item( lone_jacket ) );
+        Messages::clear_messages();
+
+        lone_jacket.set_fault( fault_cotton_torn, true, &av );
+        CHECK( Messages::size() == 0 );
+    }
+
+    SECTION( "npc-held item does not spam avatar log" ) {
+        standard_npc dude( "TestDude" );
+        item_location npc_jacket = dude.i_add( item( itype_jacket_leather ) );
+        REQUIRE( npc_jacket );
+        Messages::clear_messages();
+
+        npc_jacket.get_item()->set_fault( fault_cotton_torn, true, &dude );
+        CHECK( Messages::size() == 0 );
+    }
+}


### PR DESCRIPTION
#### Summary
Bugfixes "Stop fault messages spamming for unowned items and substitute item name properly"

#### Purpose of change
Closes #86691. Damaged clothing dropped from a zombie was spamming the log with literal `%s' fabric was torn` and similar. The bug was `item::set_fault` calling `add_msg(m_bad, fault.message())` with the raw format string, fired by `item::mod_damage` for every item in the reality bubble.

#### Describe the solution
Drop the `bool message` flag. Thread `const Character *holder` through `mod_damage`/`inc_damage`/`damage_armor_durability`/`set_fault` and the talker boundary, defaulted `nullptr`. Emit the message only when `holder` is the avatar carrying the item, with `string_format(..., tname())` so `%s` expands. Player-side armor and block paths pass `this`; sites that already print their own damage text stay silent.

#### Describe alternatives you've considered
Hoisting emission to all callers. ~20 sites vs threading through ~12 files.

Adding a global avatar lookup inside `set_fault`. Same kind of implicit context that caused the original bug.

Just deleting the JSON messages like #86671. Solves spam by removing feature.

#### Testing
Built and ran the fault/item/degrade tests. Added one new `fault_message_test` covering substitution and ownership gating. Verified in-game: no spam at corpse drops, substituted message when own armor takes a hit.

#### Additional context
N/A