### PR TITLE
Speed up inventory stacking when carrying e-files in nested containers

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -949,8 +949,15 @@ stacking_info item::stacks_with( const item &rhs, bool check_components, bool co
               link_length() == rhs.link_length() && max_link_length() == rhs.max_link_length() );
     bits.set( tname::segments::MODS, _stacks_mods( *this, rhs ) );
     //checking browsed status is not necessary, equal vars are checked earlier
+    const bool lhs_estorage = is_estorage();
+    const bool rhs_estorage = rhs.is_estorage();
+    // Non-estorage pairs short-circuit true (printer skips segment); mixed pairs
+    // stay false so aggregated headers drop free-mem when grouped with non-estorage.
     bits.set( tname::segments::EMEMORY,
-              occupied_ememory() == rhs.occupied_ememory() && total_ememory() == rhs.total_ememory() );
+              lhs_estorage == rhs_estorage &&
+              ( !lhs_estorage ||
+                ( occupied_ememory() == rhs.occupied_ememory() &&
+                  total_ememory() == rhs.total_ememory() ) ) );
     bits.set( tname::segments::last_segment );
 
     // only check contents if everything else matches
@@ -2545,12 +2552,7 @@ units::ememory item::ememory_size() const
 
 units::ememory item::occupied_ememory() const
 {
-    std::vector<const item *> all_efiles = efiles();
-    units::ememory total = 0_KB;
-    for( const item *i : all_efiles ) {
-        total += i->ememory_size();
-    }
-    return total;
+    return contents.occupied_ememory();
 }
 
 units::ememory item::total_ememory() const

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -898,8 +898,9 @@ stacking_info item::stacks_with( const item &rhs, bool check_components, bool co
     bits.set( tname::segments::BROKEN, is_broken() == rhs.is_broken() );
     bits.set( tname::segments::UPS, _stacks_ups( *this, rhs ) );
     // Guns that differ only by dirt/shot_counter can still stack,
-    // but other item_vars such as label/note will prevent stacking
-    static const std::set<std::string> ignore_keys = { "dirt", "shot_counter", "spawn_location", "ethereal", "last_act_by_char_id", "activity_var" };
+    // but other item_vars such as label/note will prevent stacking.
+    // CAMERA_*_PHOTOS_count are derived caches; not part of identity.
+    static const std::set<std::string> ignore_keys = { "dirt", "shot_counter", "spawn_location", "ethereal", "last_act_by_char_id", "activity_var", "CAMERA_EXTENDED_PHOTOS_count", "CAMERA_MONSTER_PHOTOS_count" };
     bits.set( tname::segments::TRAITS, template_traits == rhs.template_traits );
     bits.set( tname::segments::VARS, map_equal_ignoring_keys( item_vars, rhs.item_vars, ignore_keys ) );
     bits.set( tname::segments::ETHEREAL, _stacks_ethereal( *this, rhs ) );
@@ -2585,10 +2586,20 @@ const item *item::get_photo_gallery() const
 
 int item::total_photos() const
 {
-    std::vector<item::extended_photo_def> extended_photos;
-    read_extended_photos( extended_photos, "CAMERA_EXTENDED_PHOTOS", true );
-    read_extended_photos( extended_photos, "CAMERA_MONSTER_PHOTOS", true );
-    return extended_photos.size();
+    // Reading a cached count avoids reparsing the JSON blob in stacks_with.
+    const auto count_for = [this]( const std::string & var_name ) -> int {
+        const std::string count_var = var_name + "_count";
+        if( has_var( count_var ) )
+        {
+            return static_cast<int>( get_var( count_var, 0.0 ) );
+        }
+        std::vector<item::extended_photo_def> v;
+        read_extended_photos( v, var_name, true );
+        const int n = static_cast<int>( v.size() );
+        const_cast<item *>( this )->set_var( count_var, n );
+        return n;
+    };
+    return count_for( "CAMERA_EXTENDED_PHOTOS" ) + count_for( "CAMERA_MONSTER_PHOTOS" );
 }
 
 bool item::is_software() const

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -101,6 +101,8 @@ static const efftype_id effect_weed_high( "weed_high" );
 
 static const fault_id fault_emp_reboot( "fault_emp_reboot" );
 
+static const flag_id json_flag_LOCATION_PRECISE_CLOSEST_CITY( "LOCATION_PRECISE_CLOSEST_CITY" );
+
 static const furn_str_id furn_f_metal_smoking_rack_active( "f_metal_smoking_rack_active" );
 static const furn_str_id furn_f_smoking_rack_active( "f_smoking_rack_active" );
 static const furn_str_id furn_f_water_mill_active( "f_water_mill_active" );
@@ -681,6 +683,11 @@ bool _stacks_location_hint( item const &lhs, item const &rhs )
 
 bool _stacks_location_precise_closest_city( item const &lhs, item const &rhs )
 {
+    // Skip the closest_city sort unless both items can actually display the segment.
+    if( !lhs.has_flag( json_flag_LOCATION_PRECISE_CLOSEST_CITY ) ||
+        !rhs.has_flag( json_flag_LOCATION_PRECISE_CLOSEST_CITY ) ) {
+        return true;
+    }
     static const std::string omt_loc_var = "spawn_location";
     const tripoint_abs_ms this_loc( lhs.get_var( omt_loc_var, tripoint_abs_ms::invalid ) );
     const tripoint_abs_ms that_loc( rhs.get_var( omt_loc_var, tripoint_abs_ms::invalid ) );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8,6 +8,7 @@
 #include <set>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <utility>
 
@@ -899,8 +900,8 @@ stacking_info item::stacks_with( const item &rhs, bool check_components, bool co
     bits.set( tname::segments::UPS, _stacks_ups( *this, rhs ) );
     // Guns that differ only by dirt/shot_counter can still stack,
     // but other item_vars such as label/note will prevent stacking.
-    // CAMERA_*_PHOTOS_count are derived caches; not part of identity.
-    static const std::set<std::string> ignore_keys = { "dirt", "shot_counter", "spawn_location", "ethereal", "last_act_by_char_id", "activity_var", "CAMERA_EXTENDED_PHOTOS_count", "CAMERA_MONSTER_PHOTOS_count" };
+    // CAMERA_*_PHOTOS_count and EIPC_RECIPES_count are derived caches; not part of identity.
+    static const std::set<std::string> ignore_keys = { "dirt", "shot_counter", "spawn_location", "ethereal", "last_act_by_char_id", "activity_var", "CAMERA_EXTENDED_PHOTOS_count", "CAMERA_MONSTER_PHOTOS_count", "EIPC_RECIPES_count" };
     bits.set( tname::segments::TRAITS, template_traits == rhs.template_traits );
     bits.set( tname::segments::VARS, map_equal_ignoring_keys( item_vars, rhs.item_vars, ignore_keys ) );
     bits.set( tname::segments::ETHEREAL, _stacks_ethereal( *this, rhs ) );
@@ -2498,11 +2499,37 @@ bool item::efiles_all_browsed() const
     return true;
 }
 
+static int count_valid_recipes( const std::string_view csv )
+{
+    // Match get_saved_recipes() semantics: deduplicate via set so a malformed
+    // CSV like ",balclava,balclava," returns 1, not 2.
+    std::set<recipe_id> seen;
+    for( const std::string &rid_str : string_split( csv, ',' ) ) {
+        const recipe_id rid( rid_str );
+        if( !rid.is_empty() && rid.is_valid() ) {
+            seen.emplace( rid );
+        }
+    }
+    return static_cast<int>( seen.size() );
+}
+
 units::ememory item::ememory_size() const
 {
     units::ememory ememory_return = type->ememory_size;
     if( typeId() == itype_efile_recipes ) {
-        ememory_return *= get_saved_recipes().size();
+        if( is_broken_on_active() ) {
+            return 0_KB;
+        }
+        // Reading a cached count avoids parsing EIPC_RECIPES and validating
+        // every recipe_id in stacks_with.
+        int n;
+        if( has_var( "EIPC_RECIPES_count" ) ) {
+            n = static_cast<int>( get_var( "EIPC_RECIPES_count", 0.0 ) );
+        } else {
+            n = count_valid_recipes( get_var( "EIPC_RECIPES" ) );
+            const_cast<item *>( this )->set_var( "EIPC_RECIPES_count", n );
+        }
+        ememory_return *= n;
     } else if( typeId() == itype_efile_photos ) {
         ememory_return *= total_photos();
     }
@@ -3239,7 +3266,11 @@ std::set<recipe_id> item::get_saved_recipes() const
 
 void item::set_saved_recipes( const std::set<recipe_id> &recipes )
 {
-    set_var( "EIPC_RECIPES", string_join( recipes, "," ) );
+    const std::string csv = string_join( recipes, "," );
+    set_var( "EIPC_RECIPES", csv );
+    // Compute from the persisted CSV so the cache reflects steady-state validity,
+    // not transient state like is_broken_on_active().
+    set_var( "EIPC_RECIPES_count", count_valid_recipes( csv ) );
 }
 
 void item::generate_recipes()

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -2071,6 +2071,17 @@ std::vector<const item *> item_contents::efiles() const
     return efiles;
 }
 
+units::ememory item_contents::occupied_ememory() const
+{
+    units::ememory total = 0_KB;
+    for( const item_pocket &pocket : contents ) {
+        if( pocket.is_type( pocket_type::E_FILE_STORAGE ) ) {
+            total += pocket.occupied_ememory();
+        }
+    }
+    return total;
+}
+
 std::vector<item *> item_contents::cables()
 {
     std::vector<item *> cables;

--- a/src/item_contents.h
+++ b/src/item_contents.h
@@ -172,6 +172,10 @@ class item_contents
         std::vector<item *> efiles();
         std::vector<const item *> efiles() const;
 
+        // Sum of ememory_size() across all efiles. Avoids the heap-allocated
+        // intermediate containers that efiles() builds, on the stacking hot path.
+        units::ememory occupied_ememory() const;
+
         std::vector<item *> cables();
         std::vector<const item *> cables() const;
 

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -511,6 +511,15 @@ std::list<const item *> item_pocket::all_items_top() const
     return items;
 }
 
+units::ememory item_pocket::occupied_ememory() const
+{
+    units::ememory total = 0_KB;
+    for( const item &it : contents ) {
+        total += it.ememory_size();
+    }
+    return total;
+}
+
 std::list<item *> item_pocket::all_items_ptr( pocket_type pk_type )
 {
     if( !is_type( pk_type ) ) {

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -170,6 +170,10 @@ class item_pocket
         std::list<item *> all_items_ptr( pocket_type pk_type );
         std::list<const item *> all_items_ptr( pocket_type pk_type ) const;
 
+        // Sum of ememory_size() across top-level contents. Only meaningful
+        // for E_FILE_STORAGE pockets, used by item::occupied_ememory().
+        units::ememory occupied_ememory() const;
+
         item &back();
         const item &back() const;
         item &front();

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -6489,6 +6489,7 @@ void item::write_extended_photos( const std::vector<extended_photo_def> &extende
     JsonOut json( extended_photos_data );
     json.write( extended_photos );
     set_var( var_name, extended_photos_data.str() );
+    set_var( var_name + "_count", static_cast<int>( extended_photos.size() ) );
 }
 
 static bool show_photo_selection( Character &p, item &it, const std::string &var_name )

--- a/tests/item_test.cpp
+++ b/tests/item_test.cpp
@@ -19,6 +19,7 @@
 #include "cata_catch.h"
 #include "character_attire.h"
 #include "coordinates.h"
+#include "enum_bitset.h"
 #include "enums.h"
 #include "flag.h"
 #include "game.h"
@@ -26,6 +27,7 @@
 #include "item_category.h"
 #include "item_factory.h"
 #include "item_location.h"
+#include "item_tname.h"
 #include "itype.h"
 #include "material.h"
 #include "math_defines.h"
@@ -72,6 +74,7 @@ static const itype_id itype_chem_black_powder( "chem_black_powder" );
 static const itype_id itype_chem_muriatic_acid( "chem_muriatic_acid" );
 static const itype_id itype_detergent( "detergent" );
 static const itype_id itype_duffelbag( "duffelbag" );
+static const itype_id itype_efile_photos( "efile_photos" );
 static const itype_id itype_hammer( "hammer" );
 static const itype_id itype_hat_hard( "hat_hard" );
 static const itype_id itype_jeans( "jeans" );
@@ -379,6 +382,81 @@ TEST_CASE( "item_variables_round-trip_accurately", "[item]" )
     CHECK( i.get_var( "B", 0.0 ) == 0.125 );
     i.set_var( "C", tripoint_abs_ms( 2, 3, 4 ) );
     CHECK( i.get_var( "C", tripoint_abs_ms::zero ) == tripoint_abs_ms( 2, 3, 4 ) );
+}
+
+static item make_photo_gallery( int n_photos )
+{
+    item gallery( itype_efile_photos );
+    std::vector<item::extended_photo_def> photos;
+    photos.reserve( n_photos );
+    for( int i = 0; i < n_photos; ++i ) {
+        item::extended_photo_def photo;
+        photo.quality = 3;
+        photo.name = string_format( "test_photo_%d", i );
+        photo.description = "A test photo for stacking comparison.";
+        photos.push_back( photo );
+    }
+    gallery.write_extended_photos( photos, "CAMERA_EXTENDED_PHOTOS" );
+    return gallery;
+}
+
+TEST_CASE( "efile_photos_total_photos_count_cache", "[item][estorage]" )
+{
+    SECTION( "fresh write caches the count" ) {
+        item gallery = make_photo_gallery( 5 );
+        CHECK( gallery.has_var( "CAMERA_EXTENDED_PHOTOS_count" ) );
+        CHECK( gallery.get_var( "CAMERA_EXTENDED_PHOTOS_count", 0 ) == 5 );
+        CHECK( gallery.total_photos() == 5 );
+    }
+
+    SECTION( "legacy save without cache var lazy-fills on first call" ) {
+        item gallery = make_photo_gallery( 7 );
+        gallery.erase_var( "CAMERA_EXTENDED_PHOTOS_count" );
+        REQUIRE_FALSE( gallery.has_var( "CAMERA_EXTENDED_PHOTOS_count" ) );
+        CHECK( gallery.total_photos() == 7 );
+        CHECK( gallery.has_var( "CAMERA_EXTENDED_PHOTOS_count" ) );
+        CHECK( gallery.get_var( "CAMERA_EXTENDED_PHOTOS_count", 0 ) == 7 );
+    }
+
+    SECTION( "two galleries with same photos stack" ) {
+        item a = make_photo_gallery( 3 );
+        item b = make_photo_gallery( 3 );
+        stacking_info info = a.stacks_with( b );
+        CHECK( static_cast<bool>( info ) );
+        CHECK( info.bits[tname::segments::EMEMORY] );
+    }
+
+    SECTION( "mixed cache state still stacks" ) {
+        // Cache key is derived; VARS must ignore it or lazy-fill desyncs split stacks.
+        item a = make_photo_gallery( 4 );
+        item b = make_photo_gallery( 4 );
+        b.erase_var( "CAMERA_EXTENDED_PHOTOS_count" );
+        REQUIRE( a.has_var( "CAMERA_EXTENDED_PHOTOS_count" ) );
+        REQUIRE_FALSE( b.has_var( "CAMERA_EXTENDED_PHOTOS_count" ) );
+        stacking_info info = a.stacks_with( b );
+        CHECK( static_cast<bool>( info ) );
+        CHECK( info.bits[tname::segments::VARS] );
+    }
+
+    SECTION( "differing photo counts do not stack" ) {
+        item a = make_photo_gallery( 3 );
+        item b = make_photo_gallery( 5 );
+        REQUIRE( a.total_photos() != b.total_photos() );
+        stacking_info info = a.stacks_with( b );
+        CHECK_FALSE( static_cast<bool>( info ) );
+        CHECK_FALSE( info.bits[tname::segments::VARS] );
+    }
+
+    SECTION( "containers with differing nested galleries report EMEMORY mismatch" ) {
+        // EMEMORY bit drives aggregated free-mem display, must reflect real mismatch.
+        item a( itype_usb_drive );
+        item b( itype_usb_drive );
+        REQUIRE( a.put_in( make_photo_gallery( 3 ), pocket_type::E_FILE_STORAGE ).success() );
+        REQUIRE( b.put_in( make_photo_gallery( 5 ), pocket_type::E_FILE_STORAGE ).success() );
+        stacking_info info = a.stacks_with( b );
+        CHECK_FALSE( static_cast<bool>( info ) );
+        CHECK_FALSE( info.bits[tname::segments::EMEMORY] );
+    }
 }
 
 TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" )

--- a/tests/item_test.cpp
+++ b/tests/item_test.cpp
@@ -75,6 +75,7 @@ static const itype_id itype_chem_muriatic_acid( "chem_muriatic_acid" );
 static const itype_id itype_detergent( "detergent" );
 static const itype_id itype_duffelbag( "duffelbag" );
 static const itype_id itype_efile_photos( "efile_photos" );
+static const itype_id itype_efile_recipes( "efile_recipes" );
 static const itype_id itype_hammer( "hammer" );
 static const itype_id itype_hat_hard( "hat_hard" );
 static const itype_id itype_jeans( "jeans" );
@@ -106,6 +107,10 @@ static const itype_id itype_wrapper( "wrapper" );
 static const json_character_flag json_flag_DEAF( "DEAF" );
 
 static const mod_id MOD_INFORMATION_test_data( "test_data" );
+
+static const recipe_id recipe_2byarm_guard( "2byarm_guard" );
+static const recipe_id recipe_armguard_chitin( "armguard_chitin" );
+static const recipe_id recipe_balclava( "balclava" );
 
 TEST_CASE( "item_volume", "[item]" )
 {
@@ -456,6 +461,74 @@ TEST_CASE( "efile_photos_total_photos_count_cache", "[item][estorage]" )
         stacking_info info = a.stacks_with( b );
         CHECK_FALSE( static_cast<bool>( info ) );
         CHECK_FALSE( info.bits[tname::segments::EMEMORY] );
+    }
+}
+
+static item make_recipe_book( const std::set<recipe_id> &recipes )
+{
+    item book( itype_efile_recipes );
+    book.set_saved_recipes( recipes );
+    return book;
+}
+
+TEST_CASE( "efile_recipes_count_cache", "[item][estorage]" )
+{
+    const std::set<recipe_id> two = { recipe_balclava, recipe_2byarm_guard };
+    const std::set<recipe_id> three = { recipe_balclava, recipe_2byarm_guard, recipe_armguard_chitin };
+
+    SECTION( "set_saved_recipes caches the count" ) {
+        item book = make_recipe_book( two );
+        CHECK( book.has_var( "EIPC_RECIPES_count" ) );
+        CHECK( book.get_var( "EIPC_RECIPES_count", 0 ) == 2 );
+    }
+
+    SECTION( "legacy save without cache var lazy-fills via ememory_size" ) {
+        item book = make_recipe_book( three );
+        book.erase_var( "EIPC_RECIPES_count" );
+        REQUIRE_FALSE( book.has_var( "EIPC_RECIPES_count" ) );
+        const bool nonzero = book.ememory_size().value() > 0;
+        REQUIRE( nonzero );
+        CHECK( book.has_var( "EIPC_RECIPES_count" ) );
+        CHECK( book.get_var( "EIPC_RECIPES_count", 0 ) == 3 );
+    }
+
+    SECTION( "broken e-file reports zero ememory_size" ) {
+        item book = make_recipe_book( two );
+        book.set_flag( flag_ITEM_BROKEN );
+        REQUIRE( book.is_broken_on_active() );
+        CHECK( book.ememory_size().value() == 0 );
+    }
+
+    SECTION( "lazy fill deduplicates malformed CSV" ) {
+        item book( itype_efile_recipes );
+        book.set_var( "EIPC_RECIPES", std::string( ",balclava,balclava," ) );
+        REQUIRE_FALSE( book.has_var( "EIPC_RECIPES_count" ) );
+        const bool nonzero = book.ememory_size().value() > 0;
+        REQUIRE( nonzero );
+        CHECK( book.get_var( "EIPC_RECIPES_count", 0 ) == 1 );
+    }
+
+    SECTION( "set_saved_recipes while broken caches steady-state count" ) {
+        item book( itype_efile_recipes );
+        book.set_flag( flag_ITEM_BROKEN );
+        REQUIRE( book.is_broken_on_active() );
+        book.set_saved_recipes( two );
+        CHECK( book.get_var( "EIPC_RECIPES_count", 0 ) == 2 );
+        book.unset_flag( flag_ITEM_BROKEN );
+        REQUIRE_FALSE( book.is_broken_on_active() );
+        const bool nonzero = book.ememory_size().value() > 0;
+        CHECK( nonzero );
+    }
+
+    SECTION( "mixed cache state still stacks" ) {
+        item a = make_recipe_book( two );
+        item b = make_recipe_book( two );
+        b.erase_var( "EIPC_RECIPES_count" );
+        REQUIRE( a.has_var( "EIPC_RECIPES_count" ) );
+        REQUIRE_FALSE( b.has_var( "EIPC_RECIPES_count" ) );
+        stacking_info info = a.stacks_with( b );
+        CHECK( static_cast<bool>( info ) );
+        CHECK( info.bits[tname::segments::VARS] );
     }
 }
 

--- a/tests/item_test.cpp
+++ b/tests/item_test.cpp
@@ -462,6 +462,35 @@ TEST_CASE( "efile_photos_total_photos_count_cache", "[item][estorage]" )
         CHECK_FALSE( static_cast<bool>( info ) );
         CHECK_FALSE( info.bits[tname::segments::EMEMORY] );
     }
+
+    SECTION( "occupied_ememory sums every top-level efile" ) {
+        item drive( itype_usb_drive );
+        const item g1 = make_photo_gallery( 2 );
+        const item g2 = make_photo_gallery( 5 );
+        const units::ememory expected = g1.ememory_size() + g2.ememory_size();
+        REQUIRE( drive.put_in( g1, pocket_type::E_FILE_STORAGE ).success() );
+        REQUIRE( drive.put_in( g2, pocket_type::E_FILE_STORAGE ).success() );
+        const bool sum_matches = drive.occupied_ememory() == expected;
+        CHECK( sum_matches );
+    }
+
+    SECTION( "estorage and non-estorage pair fails EMEMORY bit" ) {
+        // Aggregated headers AND this bit; mixed pairs must drop it.
+        item drive( itype_usb_drive );
+        item rock( itype_test_rock );
+        REQUIRE( drive.is_estorage() );
+        REQUIRE_FALSE( rock.is_estorage() );
+        stacking_info info = drive.stacks_with( rock );
+        CHECK_FALSE( info.bits[tname::segments::EMEMORY] );
+    }
+
+    SECTION( "non-estorage pair short-circuits EMEMORY bit to true" ) {
+        item a( itype_test_rock );
+        item b( itype_test_rock );
+        REQUIRE_FALSE( a.is_estorage() );
+        stacking_info info = a.stacks_with( b );
+        CHECK( info.bits[tname::segments::EMEMORY] );
+    }
 }
 
 static item make_recipe_book( const std::set<recipe_id> &recipes )


### PR DESCRIPTION
#### Summary
Performance "Speed up inventory stacking for e-files in nested containers"

#### Purpose of change

Fixes #86690. A laptop full of scanned books inside a dimensional bag froze inventory for several seconds per open. Pairwise stacking reparsed photo JSON, walked recipe validation, and ran the closest-city sort on every item.

#### Describe the solution

- Cache `CAMERA_*_PHOTOS_count` next to the JSON blob; `total_photos` reads the cache and lazy-fills legacy saves.
- Cache `EIPC_RECIPES_count` in `set_saved_recipes`; computed from the persisted CSV with dedupe so it survives transient broken state.
- Skip the closest-city sort when neither item has `LOCATION_PRECISE_CLOSEST_CITY`.
- Direct-sum efile ememory on `item_contents` / `item_pocket`; skip the EMEMORY segment for non-estorage pairs while keeping mixed pairs false so aggregated headers drop free-mem correctly.

#### Describe alternatives you've considered

Removing the EMEMORY segment outright would break aggregated content names (one laptop's free-mem suffix on a multi-laptop header). Caching the size keeps the segment honest. Caching `ememory_size` directly was more invasive than caching the two counts that actually drive it.

#### Testing

Verified in-game on the issue save: inventory opens (almost) instantly; some lag around the dimensional bag remains and needs a different approach. Taking a photo keeps the cache consistent; save/load lazy-fills legacy items. 15 new test sections across two TEST_CASEs cover cache write, legacy refill, mixed cache state, differing counts, EMEMORY mismatch, broken-zero, malformed CSV dedupe.

#### Additional context

N/A