### PR TITLE
Fix recruited follower oscillating between guard post and player

### DIFF
--- a/src/character_oracle.cpp
+++ b/src/character_oracle.cpp
@@ -340,6 +340,9 @@ status_t character_oracle_t::displaced_from_post( std::string_view ) const
     if( n->has_flag( json_flag_CANNOT_MOVE ) ) {
         return status_t::failure;
     }
+    if( n->is_walking_with() ) {
+        return status_t::failure;
+    }
     std::optional<tripoint_abs_ms> gp = n->get_guard_post();
     if( !gp ) {
         return status_t::failure;
@@ -351,6 +354,10 @@ status_t character_oracle_t::on_shift( std::string_view ) const
 {
     const npc *n = dynamic_cast<const npc *>( subject );
     if( !n || !n->get_guard_post() || !n->myclass.is_valid() ) {
+        return status_t::failure;
+    }
+    // Player-attached state suspends duty; mirrors has_sound_alerts.
+    if( n->is_walking_with() ) {
         return status_t::failure;
     }
     const auto &[start, end] = n->myclass.obj().get_work_hours();
@@ -366,6 +373,9 @@ float character_oracle_t::duty_urgency( std::string_view ) const
     }
     std::optional<tripoint_abs_ms> gp = n->get_guard_post();
     if( !gp || !n->myclass.is_valid() ) {
+        return 0.0f;
+    }
+    if( n->is_walking_with() ) {
         return 0.0f;
     }
     const auto &[start, end] = n->myclass.obj().get_work_hours();
@@ -391,15 +401,12 @@ float character_oracle_t::duty_urgency( std::string_view ) const
 status_t character_oracle_t::npc_is_following( std::string_view ) const
 {
     const npc *n = dynamic_cast<const npc *>( subject );
-    if( !n || !n->should_follow_close() ) {
-        return status_t::failure;
-    }
-    if( n->get_guard_post() ) {
+    if( !n || !n->can_follow_player_now() ) {
         return status_t::failure;
     }
     const Character &player = get_player_character();
     const int dist = rl_dist( n->pos_abs(), player.pos_abs() );
-    if( dist <= n->follow_distance() && n->posz() == player.posz() ) {
+    if( dist <= n->desired_follow_radius() && n->posz() == player.posz() ) {
         return status_t::success;
     }
     return status_t::running;
@@ -408,7 +415,7 @@ status_t character_oracle_t::npc_is_following( std::string_view ) const
 float character_oracle_t::npc_following_urgency( std::string_view ) const
 {
     const npc *n = dynamic_cast<const npc *>( subject );
-    if( !n || !n->should_follow_close() ) {
+    if( !n || !n->can_follow_player_now() ) {
         return 0.0f;
     }
     const Character &player = get_player_character();
@@ -416,10 +423,11 @@ float character_oracle_t::npc_following_urgency( std::string_view ) const
         return 0.6f;
     }
     const int dist = rl_dist( n->pos_abs(), player.pos_abs() );
-    if( dist <= n->follow_distance() ) {
+    const int radius = n->desired_follow_radius();
+    if( dist <= radius ) {
         return 0.0f;
     }
-    return std::clamp( 0.3f + ( dist - n->follow_distance() ) * 0.015f, 0.3f, 0.6f );
+    return std::clamp( 0.3f + ( dist - radius ) * 0.015f, 0.3f, 0.6f );
 }
 
 status_t character_oracle_t::npc_has_goto_order( std::string_view ) const

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2691,12 +2691,9 @@ bool npc::is_walking_with() const
     return attitude == NPCATT_FOLLOW || attitude == NPCATT_LEAD || attitude == NPCATT_WAIT;
 }
 
-bool npc::should_follow_close() const
+bool npc::can_follow_player_now() const
 {
     if( !is_following() ) {
-        return false;
-    }
-    if( !rules.has_flag( ally_rule::follow_close ) ) {
         return false;
     }
     if( has_flag( json_flag_CANNOT_MOVE ) ) {
@@ -2710,6 +2707,11 @@ bool npc::should_follow_close() const
         return false;
     }
     return true;
+}
+
+int npc::desired_follow_radius() const
+{
+    return rules.has_flag( ally_rule::follow_close ) ? follow_distance() : 6;
 }
 
 bool npc::is_obeying( const Character &p ) const

--- a/src/npc.h
+++ b/src/npc.h
@@ -976,9 +976,10 @@ class npc : public Character
         bool is_leader() const;
         // Leading, following, or waiting for the player
         bool is_walking_with() const;
-        // Can actively close-follow right now: walking_with + follow_close
-        // rule + can move + no vehicle mismatch with player.
-        bool should_follow_close() const;
+        // FOLLOW/WAIT (not LEAD), mobile, vehicle-compatible with player.
+        bool can_follow_player_now() const;
+        // Spacing preference: follow_close on -> follow_distance(), off -> 6.
+        int desired_follow_radius() const;
         // In the same faction
         bool is_ally( const Character &p ) const override;
         // Is an ally of the player

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -483,7 +483,7 @@ tripoint_bub_ms npc::good_escape_direction( bool include_pos )
     } else if( path.empty() && run_to_friend && is_player_ally() ) {
         Character &player_character = get_player_character();
         int dist = rl_dist( pos_bub(), player_character.pos_bub() );
-        int def_radius = rules.has_flag( ally_rule::follow_close ) ? follow_distance() : 6;
+        int def_radius = desired_follow_radius();
         if( dist > def_radius ) {
             add_msg_debug( debugmode::DF_NPC_MOVEAI,
                            "<color_light_gray>%s is repositioning closer to</color> you", name );
@@ -887,7 +887,7 @@ void npc::assess_danger()
     float highest_priority = 1.0f;
     int hostile_count = 0; // for tallying nearby threatening enemies
     int friendly_count = 1; // count yourself as a friendly
-    int def_radius = rules.has_flag( ally_rule::follow_close ) ? follow_distance() : 6;
+    int def_radius = desired_follow_radius();
     bool npc_ranged = get_wielded_item() && get_wielded_item()->is_gun();
 
     if( !confident_range_cache ) {
@@ -1858,6 +1858,10 @@ void npc::move()
                 action = npc_goto_to_this_pos;
             } else if( new_goal == "hold_position" ) {
                 action = address_needs( NPC_DANGER_VERY_LOW + 1 );
+                if( action == npc_undecided ) {
+                    // Otherwise legacy cascade overrides BT's duty decision.
+                    action = npc_pause;
+                }
             } else if( new_goal == "camp_work" ) {
                 last_job_scan = calendar::turn;
                 if( find_job_to_perform() ) {
@@ -1882,6 +1886,9 @@ void npc::move()
                     // Only for NPCs actively on guard mission, not NPCs
                     // with stale guard_pos from a previous assignment.
                     action = address_needs( NPC_DANGER_VERY_LOW + 1 );
+                    if( action == npc_undecided ) {
+                        action = npc_pause;
+                    }
                 } else if( ai_cache.guard_pos && !guard_pos ) {
                     // Temp anchor (sound investigation): return to origin.
                     // Excluded when guard_pos is set -- that means
@@ -1960,8 +1967,8 @@ void npc::move()
         path.clear();
     }
 
-    if( action == npc_undecided && should_follow_close() &&
-        rl_dist( pos_bub(), player_character.pos_bub() ) > follow_distance() ) {
+    if( action == npc_undecided && can_follow_player_now() &&
+        rl_dist( pos_bub(), player_character.pos_bub() ) > desired_follow_radius() ) {
         action = npc_follow_player;
     }
 

--- a/tests/behavior_test.cpp
+++ b/tests/behavior_test.cpp
@@ -1392,16 +1392,21 @@ TEST_CASE( "npc_is_following_predicate", "[npc][behavior]" )
         guy.set_attitude( NPCATT_NULL );
         CHECK( oracle.npc_is_following( "" ) == behavior::status_t::failure );
     }
-    SECTION( "failure when follow_close not set" ) {
-        guy.set_attitude( NPCATT_FOLLOW );
-        guy.rules.clear_flag( ally_rule::follow_close );
+    SECTION( "failure when leader: leaders are not pulled toward player" ) {
+        guy.set_attitude( NPCATT_LEAD );
         CHECK( oracle.npc_is_following( "" ) == behavior::status_t::failure );
     }
-    SECTION( "failure when has guard_pos" ) {
+    SECTION( "fires even with follow_close cleared: rule controls spacing only" ) {
         guy.set_attitude( NPCATT_FOLLOW );
-        guy.rules.set_flag( ally_rule::follow_close );
+        guy.rules.clear_flag( ally_rule::follow_close );
+        get_player_character().setpos( here, tripoint_bub_ms( 60, 50, 0 ) );
+        CHECK( oracle.npc_is_following( "" ) == behavior::status_t::running );
+    }
+    SECTION( "fires even with guard_pos: predicate reports state, not priority" ) {
+        guy.set_attitude( NPCATT_FOLLOW );
         guy.set_guard_pos( guy.pos_abs() + tripoint( 10, 0, 0 ) );
-        CHECK( oracle.npc_is_following( "" ) == behavior::status_t::failure );
+        get_player_character().setpos( here, tripoint_bub_ms( 60, 50, 0 ) );
+        CHECK( oracle.npc_is_following( "" ) == behavior::status_t::running );
     }
     SECTION( "failure when player in vehicle and NPC not" ) {
         guy.set_attitude( NPCATT_FOLLOW );
@@ -1472,10 +1477,17 @@ TEST_CASE( "npc_following_urgency_policy", "[npc][behavior]" )
         float hunger_score = oracle.hunger_urgency( "" );
         CHECK( follow_score > hunger_score );
     }
-    SECTION( "follow does not fire without follow_close" ) {
+    SECTION( "follow_close cleared: still fires, loose radius (6)" ) {
+        // follow_close rule controls preferred spacing, not whether-to-follow.
+        // Cleared rule = loose follow at radius 6.
         guy.rules.clear_flag( ally_rule::follow_close );
-        get_player_character().setpos( here, tripoint_bub_ms( 70, 50, 0 ) );
+        get_player_character().setpos( here, tripoint_bub_ms( 55, 50, 0 ) );
+        REQUIRE( rl_dist( guy.pos_abs(), get_player_character().pos_abs() ) == 5 );
+        // Within loose radius -> 0 urgency (already in position).
         CHECK( oracle.npc_following_urgency( "" ) == Approx( 0.0f ) );
+        get_player_character().setpos( here, tripoint_bub_ms( 70, 50, 0 ) );
+        // Beyond loose radius -> non-zero urgency.
+        CHECK( oracle.npc_following_urgency( "" ) > 0.0f );
     }
     SECTION( "follow capped below life-threatening needs" ) {
         get_player_character().setpos( here, tripoint_bub_ms( 100, 50, 0 ) );
@@ -1525,18 +1537,20 @@ TEST_CASE( "bt_goal_category_mapping_follow", "[npc][behavior]" )
     CHECK( bt_goal_to_category( "follow_player" ) == decision_category::follow );
 }
 
-TEST_CASE( "follow_and_duty_are_mutually_exclusive", "[npc][behavior]" )
+TEST_CASE( "follow_suppresses_duty_when_recruited", "[npc][behavior]" )
 {
     clear_map_without_vision();
     map &here = get_map();
     get_player_character().setpos( here, tripoint_bub_ms( 50, 50, 0 ) );
+    behavior::tree npc_decision;
+    npc_decision.add( &behavior_node_t_npc_decision.obj() );
     npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
     clear_character( guy );
     guy.set_fac( faction_your_followers );
     behavior::character_oracle_t oracle( &guy );
     calendar::turn = calendar::turn_zero + 12_hours;
 
-    SECTION( "guard_pos set: duty fires, follow fails" ) {
+    SECTION( "walking_with + guard_pos: follow fires, duty suppressed" ) {
         guy.set_attitude( NPCATT_FOLLOW );
         guy.rules.set_flag( ally_rule::follow_close );
         const tripoint_abs_ms post = guy.pos_abs() + tripoint( 5, 0, 0 );
@@ -1546,10 +1560,33 @@ TEST_CASE( "follow_and_duty_are_mutually_exclusive", "[npc][behavior]" )
         const auto &[wh_start, wh_end] = guy.myclass.obj().get_work_hours();
         REQUIRE( ( wh_start == 0 && wh_end == 24 ) );
         get_player_character().setpos( here, tripoint_bub_ms( 60, 50, 0 ) );
-        CHECK( oracle.displaced_from_post( "" ) == behavior::status_t::running );
-        CHECK( oracle.npc_is_following( "" ) == behavior::status_t::failure );
+        CHECK( oracle.npc_is_following( "" ) == behavior::status_t::running );
+        CHECK( oracle.on_shift( "" ) == behavior::status_t::failure );
+        CHECK( oracle.displaced_from_post( "" ) == behavior::status_t::failure );
+        CHECK( oracle.duty_urgency( "" ) == Approx( 0.0f ) );
+        CHECK( npc_decision.tick( &oracle ) == "follow_player" );
     }
-    SECTION( "no guard_pos: follow fires, duty fails" ) {
+    SECTION( "walking_with + guard_pos at-post: still follows player away" ) {
+        guy.set_attitude( NPCATT_FOLLOW );
+        guy.rules.set_flag( ally_rule::follow_close );
+        guy.set_guard_pos( guy.pos_abs() );
+        REQUIRE( guy.pos_abs() == *guy.get_guard_post() );
+        get_player_character().setpos( here, tripoint_bub_ms( 70, 50, 0 ) );
+        CHECK( oracle.on_shift( "" ) == behavior::status_t::failure );
+        CHECK( npc_decision.tick( &oracle ) == "follow_player" );
+    }
+    SECTION( "non-walking_with + guard_pos displaced: duty fires" ) {
+        guy.set_attitude( NPCATT_NULL );
+        const tripoint_abs_ms post = guy.pos_abs() + tripoint( 5, 0, 0 );
+        guy.set_guard_pos( post );
+        REQUIRE( guy.get_guard_post().has_value() );
+        REQUIRE_FALSE( guy.is_walking_with() );
+        CHECK( oracle.on_shift( "" ) == behavior::status_t::running );
+        CHECK( oracle.displaced_from_post( "" ) == behavior::status_t::running );
+        CHECK( oracle.duty_urgency( "" ) > 0.0f );
+        CHECK( npc_decision.tick( &oracle ) == "return_to_guard_pos" );
+    }
+    SECTION( "no guard_pos: follow fires, duty inert" ) {
         guy.set_attitude( NPCATT_FOLLOW );
         guy.rules.set_flag( ally_rule::follow_close );
         guy.guard_pos = std::nullopt;
@@ -1557,6 +1594,24 @@ TEST_CASE( "follow_and_duty_are_mutually_exclusive", "[npc][behavior]" )
         REQUIRE_FALSE( guy.get_guard_post().has_value() );
         get_player_character().setpos( here, tripoint_bub_ms( 60, 50, 0 ) );
         CHECK( oracle.npc_is_following( "" ) == behavior::status_t::running );
+        CHECK( oracle.displaced_from_post( "" ) == behavior::status_t::failure );
+        CHECK( oracle.duty_urgency( "" ) == Approx( 0.0f ) );
+    }
+    SECTION( "WAIT + guard_pos: duty suppressed" ) {
+        guy.set_attitude( NPCATT_WAIT );
+        const tripoint_abs_ms post = guy.pos_abs() + tripoint( 5, 0, 0 );
+        guy.set_guard_pos( post );
+        REQUIRE( guy.is_walking_with() );
+        CHECK( oracle.on_shift( "" ) == behavior::status_t::failure );
+        CHECK( oracle.displaced_from_post( "" ) == behavior::status_t::failure );
+        CHECK( oracle.duty_urgency( "" ) == Approx( 0.0f ) );
+    }
+    SECTION( "LEAD + guard_pos: duty suppressed" ) {
+        guy.set_attitude( NPCATT_LEAD );
+        const tripoint_abs_ms post = guy.pos_abs() + tripoint( 5, 0, 0 );
+        guy.set_guard_pos( post );
+        REQUIRE( guy.is_walking_with() );
+        CHECK( oracle.on_shift( "" ) == behavior::status_t::failure );
         CHECK( oracle.displaced_from_post( "" ) == behavior::status_t::failure );
         CHECK( oracle.duty_urgency( "" ) == Approx( 0.0f ) );
     }
@@ -1653,9 +1708,16 @@ TEST_CASE( "bt_priority_matrix", "[npc][behavior]" )
         get_player_character().setpos( here, tripoint_bub_ms( 70, 50, 0 ) );
         CHECK( bt_goal( guy ) == "follow_player" );
     }
-    SECTION( "guard_pos set: duty beats follow" ) {
+    SECTION( "guard_pos + walking_with: follow beats duty" ) {
         guy.set_attitude( NPCATT_FOLLOW );
         guy.rules.set_flag( ally_rule::follow_close );
+        const tripoint_abs_ms post = guy.pos_abs() + tripoint( 5, 0, 0 );
+        guy.set_guard_pos( post );
+        get_player_character().setpos( here, tripoint_bub_ms( 70, 50, 0 ) );
+        CHECK( bt_goal( guy ) == "follow_player" );
+    }
+    SECTION( "guard_pos + not walking_with: duty fires" ) {
+        guy.set_attitude( NPCATT_NULL );
         const tripoint_abs_ms post = guy.pos_abs() + tripoint( 5, 0, 0 );
         guy.set_guard_pos( post );
         get_player_character().setpos( here, tripoint_bub_ms( 70, 50, 0 ) );
@@ -1687,10 +1749,17 @@ TEST_CASE( "bt_priority_matrix", "[npc][behavior]" )
         guy.goto_to_this_pos = guy.pos_abs() + tripoint( 10, 0, 0 );
         CHECK( bt_goal( guy ) == "goto_ordered_position" );
     }
-    SECTION( "no follow_close rule: idle" ) {
+    SECTION( "follow_close cleared: still follows at loose radius" ) {
         guy.set_attitude( NPCATT_FOLLOW );
         guy.rules.clear_flag( ally_rule::follow_close );
         get_player_character().setpos( here, tripoint_bub_ms( 70, 50, 0 ) );
+        CHECK( bt_goal( guy ) == "follow_player" );
+    }
+    SECTION( "follow_close cleared and within loose radius: idle" ) {
+        guy.set_attitude( NPCATT_FOLLOW );
+        guy.rules.clear_flag( ally_rule::follow_close );
+        get_player_character().setpos( here, tripoint_bub_ms( 55, 50, 0 ) );
+        REQUIRE( rl_dist( guy.pos_abs(), get_player_character().pos_abs() ) <= 6 );
         CHECK( bt_goal( guy ) == "idle" );
     }
     SECTION( "player in vehicle, NPC not: no follow" ) {

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -3901,7 +3901,7 @@ TEST_CASE( "bt_idle_falls_through_to_cascade_goto", "[npc][behavior]" )
     CHECK( rl_dist( guy.pos_abs(), target ) < 5 );
 }
 
-TEST_CASE( "anchored_follower_uses_duty_not_follow", "[npc][behavior]" )
+TEST_CASE( "recruited_follower_with_guard_pos_follows_player", "[npc][behavior]" )
 {
     clear_map_without_vision();
     clear_avatar();
@@ -3918,7 +3918,6 @@ TEST_CASE( "anchored_follower_uses_duty_not_follow", "[npc][behavior]" )
     guy.set_fac( faction_your_followers );
     guy.set_attitude( NPCATT_FOLLOW );
     guy.rules.set_flag( ally_rule::follow_close );
-    guy.set_mission( NPC_MISSION_GUARD_ALLY );
     const tripoint_abs_ms post = guy.pos_abs() + tripoint( 10, 0, 0 );
     guy.set_guard_pos( post );
     calendar::turn = calendar::turn_zero + 12_hours;
@@ -3934,16 +3933,21 @@ TEST_CASE( "anchored_follower_uses_duty_not_follow", "[npc][behavior]" )
     const auto &[wh_start, wh_end] = guy.myclass.obj().get_work_hours();
     REQUIRE( ( wh_start == 0 && wh_end == 24 ) );
     REQUIRE( guy.get_guard_post().has_value() );
+    REQUIRE( guy.is_walking_with() );
     REQUIRE( guy.pos_abs() != post );
     REQUIRE( rl_dist( guy.pos_abs(), get_player_character().pos_abs() ) > 4 );
 
-    SECTION( "BT returns return_to_guard_pos, not follow_player" ) {
+    SECTION( "BT picks follow_player, suppresses duty" ) {
         behavior::character_oracle_t oracle( &guy );
+        CHECK( oracle.on_shift( "" ) == behavior::status_t::failure );
+        CHECK( oracle.displaced_from_post( "" ) == behavior::status_t::failure );
+        CHECK( oracle.duty_urgency( "" ) == Approx( 0.0f ) );
+        CHECK( oracle.npc_is_following( "" ) == behavior::status_t::running );
         behavior::tree decision_tree;
         decision_tree.add( &behavior_node_t_npc_decision.obj() );
-        CHECK( decision_tree.tick( &oracle ) == "return_to_guard_pos" );
+        CHECK( decision_tree.tick( &oracle ) == "follow_player" );
     }
-    SECTION( "live turns: NPC moves toward post, not player" ) {
+    SECTION( "live turns: NPC closes distance to player, not post" ) {
         const int initial_dist_post = rl_dist( guy.pos_abs(), post );
         const int initial_dist_player = rl_dist( guy.pos_abs(),
                                         get_player_character().pos_abs() );
@@ -3951,10 +3955,34 @@ TEST_CASE( "anchored_follower_uses_duty_not_follow", "[npc][behavior]" )
             guy.set_moves( 100 );
             guy.move();
         }
-        CHECK( rl_dist( guy.pos_abs(), post ) < initial_dist_post );
         CHECK( rl_dist( guy.pos_abs(), get_player_character().pos_abs() )
-               > initial_dist_player );
+               < initial_dist_player );
+        CHECK( rl_dist( guy.pos_abs(), post ) >= initial_dist_post );
     }
+}
+
+TEST_CASE( "follow_only_engages_follow_regardless_of_rules", "[npc][behavior]" )
+{
+    clear_map_without_vision();
+    clear_avatar();
+    map &here = get_map();
+    get_player_character().setpos( here, tripoint_bub_ms( 50, 50, 0 ) );
+
+    npc &guy = spawn_npc( { 50, 50 }, "test_talker" );
+    clear_character( guy, true );
+    guy.set_attitude( NPCATT_NULL );
+    // Simulate a stale "move freely" toggle from a prior interaction:
+    // base flag cleared. Mission-attached follow must engage anyway,
+    // since follow_close controls spacing, not whether-to-follow.
+    guy.rules.clear_flag( ally_rule::follow_close );
+    REQUIRE_FALSE( guy.rules.has_flag( ally_rule::follow_close ) );
+
+    talk_function::follow_only( guy );
+
+    CHECK( guy.get_attitude() == NPCATT_FOLLOW );
+    CHECK( guy.can_follow_player_now() );
+    // Loose-follow radius applies because follow_close stays cleared.
+    CHECK( guy.desired_follow_radius() == 6 );
 }
 
 TEST_CASE( "guard_assignment_clears_follow_commitment", "[npc][behavior]" )


### PR DESCRIPTION
#### Summary
Bugfixes "Fix recruited NPC follower oscillating between guard post and player"

#### Purpose of change

Fixes #86693. Recruiting an NPC with a guard_pos via `follow_only` (e.g. Cranberry's radio tower mission) made them flip-flop between hold_position and return_to_guard_pos instead of following.

Duty predicates ignored attached-follower state. `should_follow_close()` also mixed "is this NPC a follower" with "does the player want close spacing" (the `follow_close` ally rule), so mission follow had to force the spacing rule via override just to fire.

#### Describe the solution

Split `should_follow_close()` into `can_follow_player_now()` (follower state) and `desired_follow_radius()` (spacing). BT predicates, the legacy follow fallback, and combat-radius helpers reuse the split.

Duty predicates (`on_shift`, `displaced_from_post`, `duty_urgency`) gate on `is_walking_with()` so any FOLLOW/WAIT/LEAD suppresses duty, same as the existing `has_sound_alerts` gate. Drops the `get_guard_post()` early-return from `npc_is_following`.

`hold_position` and guarding-idle pause when `address_needs` is undecided so the legacy cascade can't override BT duty with `npc_follow_player`.

#### Describe alternatives you've considered

Tried forcing the `follow_close` rule via override in `follow_only` / clear in `stop_following`. Worked, but conflated mission state with a player UI toggle, which is the conflation that caused the bug.

Could clear `guard_pos` on recruitment, but `RETURN_TO_START_POS` re-sets it next regen, and persistent guard_pos is intentionally durable.

#### Testing

Verified in-game with the reproducing save: Cranberry now closes distance to the player every turn. `DF_NPC_NEEDS` log shows converged instead of DIVERGED.

New tests for the split helpers, duty-suppression-under-walking_with, LEAD exclusion, and a recruited-follower-with-guard_pos integration test. Existing NPC behavior tests pass.

#### Additional context

N/A.