### PR TITLE
Putting all Age references in constants, related bug fixes

### DIFF
--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -2276,7 +2276,8 @@ static void character_edit_desc_menu( Character &you )
         break;
         case 2: {
             int result = you.base_age();
-            if( query_int( result, true, _( "Enter age in years.  Minimum %d, maximum %d" ), CHARACTER_AGE_MIN, CHARACTER_AGE_MAX ) && result > 0 ) {
+            if( query_int( result, true, _( "Enter age in years.  Minimum %d, maximum %d" ), CHARACTER_AGE_MIN,
+                           CHARACTER_AGE_MAX ) && result > 0 ) {
                 you.set_base_age( clamp( result, CHARACTER_AGE_MIN, CHARACTER_AGE_MAX ) );
             }
         }

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -2276,8 +2276,8 @@ static void character_edit_desc_menu( Character &you )
         break;
         case 2: {
             int result = you.base_age();
-            if( query_int( result, true, _( "Enter age in years.  Minimum 16, maximum 55" ) ) && result > 0 ) {
-                you.set_base_age( clamp( result, 16, 55 ) );
+            if( query_int( result, true, _( "Enter age in years.  Minimum %d, maximum %d" ), CHARACTER_AGE_MIN, CHARACTER_AGE_MAX ) && result > 0 ) {
+                you.set_base_age( clamp( result, CHARACTER_AGE_MIN, CHARACTER_AGE_MAX ) );
             }
         }
         break;

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -463,6 +463,12 @@ void Character::randomize( const bool random_scenario, bool play_now )
     zero_all_skills();
 
     init_age = rng( this->prof->age_lower, this->prof->age_upper );
+    // random NPCs have a special minimum age
+    if ( init_age < NPC_RAND_AGE_MIN ) {
+        init_age = NPC_RAND_AGE_MIN ;
+    }
+
+
     starting_city = std::nullopt;
     world_origin = std::nullopt;
     random_start_location = true;

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -464,7 +464,7 @@ void Character::randomize( const bool random_scenario, bool play_now )
 
     init_age = rng( this->prof->age_lower, this->prof->age_upper );
     // random NPCs have a special minimum age
-    if ( init_age < NPC_RAND_AGE_MIN ) {
+    if( init_age < NPC_RAND_AGE_MIN ) {
         init_age = NPC_RAND_AGE_MIN ;
     }
 

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -613,8 +613,7 @@ void npc::randomize( const npc_class_id &type, const npc_template_id &tem_id )
     male = one_in( 2 );
     pick_name();
     randomize_height();
-    // Normally 16-55, but potential violence towards *underage* NPCs is a more problematic than towards adults.
-    set_base_age( rng( 18, 55 ) );
+    set_base_age( rng( NPC_RAND_AGE_MIN, NPC_RAND_AGE_MAX ) );
     int str_base = dice( 4, 3 );
     int dex_base = dice( 4, 3 );
     int int_base = dice( 4, 3 );

--- a/src/npc.h
+++ b/src/npc.h
@@ -65,6 +65,10 @@ struct faction_price_rule;
 
 constexpr int NPC_PERSONALITY_MIN = -10;
 constexpr int NPC_PERSONALITY_MAX = 10;
+// Normally 16-55, but potential violence towards *underage* NPCs is a more problematic than towards adults
+// Note: npcs with ages defined in json files are not limited to these values.
+constexpr int NPC_RAND_AGE_MIN = 18;
+constexpr int NPC_RAND_AGE_MAX = 55;
 constexpr float NPC_DANGER_VERY_LOW = 5.0f;
 constexpr float NPC_MONSTER_DANGER_MAX = 150.0f;
 constexpr float NPC_CHARACTER_DANGER_MAX = 250.0f;

--- a/src/profession.cpp
+++ b/src/profession.cpp
@@ -270,8 +270,8 @@ void profession::load( const JsonObject &jo, std::string_view )
     optional( jo, was_loaded, "npc_background", _starting_npc_background,
               Trait_group_BG_survival_story_UNIVERSAL );
     optional( jo, was_loaded, "chargen_allow_npc", _chargen_allow_npc, true );
-    optional( jo, was_loaded, "age_lower", age_lower, 16 );
-    optional( jo, was_loaded, "age_upper", age_upper, 55 );
+    optional( jo, was_loaded, "age_lower", age_lower, DEFAULT_PROF_AGE_LOWER );
+    optional( jo, was_loaded, "age_upper", age_upper, DEFAULT_PROF_AGE_UPPER );
     optional( jo, was_loaded, "starting_cash", _starting_cash );
 
     if( jo.has_string( "vehicle" ) ) {

--- a/src/profession.h
+++ b/src/profession.h
@@ -136,8 +136,10 @@ class profession
         int ma_choice_amount;
         StartingSkillList skills() const;
         const std::vector<mission_type_id> &missions() const;
-        int age_lower = 21;
-        int age_upper = 55;
+        static constexpr int DEFAULT_PROF_AGE_LOWER = 21;
+        static constexpr int DEFAULT_PROF_AGE_UPPER = 55;
+        int age_lower = DEFAULT_PROF_AGE_LOWER;
+        int age_upper = DEFAULT_PROF_AGE_UPPER;
 
         std::vector<std::pair<string_id<profession>, mod_id>> src;
 


### PR DESCRIPTION
There already were constants defined for CHARACTER_AGE_MIN/MAX, but they weren't used everywhere.  Some references just had static numbers in .cpp files.

There were also what appeared to be constants in profession.h, but those were just initialized variables.  And the value there was never used.  Notably that created the impression that professions had a default min age of 21 that was not actually the case, creating a bug of number 'Doogie Howsers' where random characters and NPCs were teenagers with unrealistic jobs.

Lastly there was an attempt to restrict NPCs to only be 18 and up. For one, that age was hard coded, so I set it to a constant.  But additionally it was only used for NPCs created via json files that had no ages assigned.  Random NPCs with professions used the normal profession code (and thus had characters aged 16-17 that really should have been 21+).  NPCs can have ages assigned in 3 ways, and the 18+ bit only applied to one.  It now applies to all NPCs that have random ages.  NPCs with specific ages in json files (such as Luke Isherwood) will still avoid that 18+ check.  However I assume that will be policed as necessary as specific NPCs get added.


#### Summary
Bugfixes "Age Constants and fixes"

#### Purpose of change

I've run into NPCs with ridiculous ages.  Once the Refugee Center mercenary, a seasoned combat
vet with a taste for single malt scotch, was 17.

Additionally the code had an odd mix of constants defined for certain age ranges that weren't always
used, what appeared to be similar constants that didn't work that way at all, and a variety of hard coded
number in .cpp files that weren't always universally applied the way they stated they were.

#### Describe the solution

There are now 3 different sets of age range constants.
CHARACTER_AGE_MIN/MAX: used for when players set their ages at character creation, as well as when they change their age via the debug menu.

NPC_RAND_AGE_MIN/MAX: ages assigned to random NPCs.  The full range is only used for NPCs defined in json files with no age specified.  Other characters get ages based on their profession (or via json data).  I added an extra bit so the MIN is always used, even for NPCs with professions that could otherwise be under 18.  I figure Juvenile Delinquents are still reasonable at age 18, and it removes the issues around player violence against underage characters that was the point of the special NPC age minimum of 18 in the code.

DEFAULT_PROF_AGE_LOWER/UPPER: This is the default age range for professions.  Many have no specific range, including many that imply adults with specialized degrees or years of experience.  Note, the lower/upper doesn't match the min/max of the others.  The variables age_lower and age_upper already were there and in use for assigning these ages (though the initialized values in profsesions.h did nothing).  That naming scheme did not match the already existing CHARAGER_AGE_MIN/MAX.  My options were to either change one of these or simply leave the lack of naming scheme as is.  I chose the latter.

Fixes:
NPCs with random ages will now never spawn with ages of 16 or 17.
Professions with no defined age range get a defined range that is currently 21-55.


#### Describe alternatives you've considered

I thought about different naming schemes that might match better but instead left existing names as they were.

I thought about changing the NPC minimum age bit to use a constant (as was done), but not also apply that constant for NPCs with profession based ages.

I thought about adding a bit to have NPC maximum age also used to constrain NPCs with profession based ages.  Currently that would do nothing, but could have an effect if values get changed in the future.  But while I understand the reasoning behind a minimum age for NPCs, I don't see a similar reason for a maximum age, so I did not add one.

#### Testing

I added various debugmsg lines so I knew what exactly was going on and when.  These were all removed from the code before this PR.  However, after the removal I did a final build and played around in a new world to ensure all still worked.

I went to a variety of locations with json defined NPCs (mainly Isherwood's farm and the Refugee Center) and ensured that json based NPCs with random ages were never younger than 18.

I created a slew of random NPCs via the debug menu to ensure they all had profession appropriate ages, including the new default of 21 for professions with no specific ages.

#### Additional context

