### PR TITLE
Stop billboard mapgen tripping on field furniture

### DIFF
--- a/data/json/mapgen/billboard.json
+++ b/data/json/mapgen/billboard.json
@@ -4,6 +4,7 @@
     "om_terrain": [ "billboard_0" ],
     "object": {
       "predecessor_mapgen": "field",
+      "flags": [ "ERASE_FURNITURE_BEFORE_PLACING_TERRAIN" ],
       "rows": [
         "                        ",
         "                        ",


### PR DESCRIPTION
#### Summary
Bugfixes "Stop billboard_0 mapgen tripping debugmsgs over field furniture"

#### Purpose of change
`billboard_0` layers a ladder over `predecessor_mapgen: field`. When the ladder tile lands on a flower (fireweed, dandelion, salsify, ...) the layered-mapgen check fires a debugmsg. Recurring CI noise.

#### Describe the solution
Add `ERASE_FURNITURE_BEFORE_PLACING_TERRAIN` to `billboard_0`.

#### Describe alternatives you've considered
N/A

#### Testing
N/A, just a JSON flag.

#### Additional context
N/A