### PR TITLE
Speed up stacks_with

### DIFF
--- a/src/flag.h
+++ b/src/flag.h
@@ -11,8 +11,33 @@
 #include "translation.h"
 #include "type_id.h"
 
+#include <cstdint>
+
 class JsonObject;
 template <typename T> class generic_factory;
+
+// Bit positions for the flags that drive item::stacks_with.
+// Reload-safe: positions are compile-time constants, not int_ids.
+enum class hot_flag_bit : uint64_t {
+    REMOVED_STOCK = 1ULL << 0,
+    DIAMOND       = 1ULL << 1,
+    FIT           = 1ULL << 2,
+    VARSIZE       = 1ULL << 3,
+    MUSHY         = 1ULL << 4,
+    DIRTY         = 1ULL << 5,
+    HIDDEN_POISON = 1ULL << 6,
+    HIDDEN_HALLU  = 1ULL << 7,
+    IRRADIATED    = 1ULL << 8,
+    INEDIBLE      = 1ULL << 9,
+    NO_PACKED     = 1ULL << 10,
+    NO_STERILE    = 1ULL << 11,
+    USE_UPS       = 1ULL << 12,
+    LOC_CITY      = 1ULL << 13,
+    ITEM_BROKEN   = 1ULL << 14,
+};
+
+// Returns the hot bit for f, or 0 if f is not in the hot set.
+uint64_t hot_bit_for( const flag_id &f ) noexcept;
 
 extern const flag_id flag_NULL;
 extern const flag_id flag_ABLATIVE_LARGE;

--- a/src/flag_hot_bits.cpp
+++ b/src/flag_hot_bits.cpp
@@ -1,0 +1,57 @@
+#include "flag.h"
+
+#include <cstdint>
+
+#include "type_id.h"
+
+static const flag_id json_flag_LOCATION_PRECISE_CLOSEST_CITY( "LOCATION_PRECISE_CLOSEST_CITY" );
+
+uint64_t hot_bit_for( const flag_id &f ) noexcept
+{
+    if( f == flag_REMOVED_STOCK ) {
+        return static_cast<uint64_t>( hot_flag_bit::REMOVED_STOCK );
+    }
+    if( f == flag_DIAMOND ) {
+        return static_cast<uint64_t>( hot_flag_bit::DIAMOND );
+    }
+    if( f == flag_FIT ) {
+        return static_cast<uint64_t>( hot_flag_bit::FIT );
+    }
+    if( f == flag_VARSIZE ) {
+        return static_cast<uint64_t>( hot_flag_bit::VARSIZE );
+    }
+    if( f == flag_MUSHY ) {
+        return static_cast<uint64_t>( hot_flag_bit::MUSHY );
+    }
+    if( f == flag_DIRTY ) {
+        return static_cast<uint64_t>( hot_flag_bit::DIRTY );
+    }
+    if( f == flag_HIDDEN_POISON ) {
+        return static_cast<uint64_t>( hot_flag_bit::HIDDEN_POISON );
+    }
+    if( f == flag_HIDDEN_HALLU ) {
+        return static_cast<uint64_t>( hot_flag_bit::HIDDEN_HALLU );
+    }
+    if( f == flag_IRRADIATED ) {
+        return static_cast<uint64_t>( hot_flag_bit::IRRADIATED );
+    }
+    if( f == flag_INEDIBLE ) {
+        return static_cast<uint64_t>( hot_flag_bit::INEDIBLE );
+    }
+    if( f == flag_NO_PACKED ) {
+        return static_cast<uint64_t>( hot_flag_bit::NO_PACKED );
+    }
+    if( f == flag_NO_STERILE ) {
+        return static_cast<uint64_t>( hot_flag_bit::NO_STERILE );
+    }
+    if( f == flag_USE_UPS ) {
+        return static_cast<uint64_t>( hot_flag_bit::USE_UPS );
+    }
+    if( f == json_flag_LOCATION_PRECISE_CLOSEST_CITY ) {
+        return static_cast<uint64_t>( hot_flag_bit::LOC_CITY );
+    }
+    if( f == flag_ITEM_BROKEN ) {
+        return static_cast<uint64_t>( hot_flag_bit::ITEM_BROKEN );
+    }
+    return 0;
+}

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -101,8 +101,6 @@ static const efftype_id effect_weed_high( "weed_high" );
 
 static const fault_id fault_emp_reboot( "fault_emp_reboot" );
 
-static const flag_id json_flag_LOCATION_PRECISE_CLOSEST_CITY( "LOCATION_PRECISE_CLOSEST_CITY" );
-
 static const furn_str_id furn_f_metal_smoking_rack_active( "f_metal_smoking_rack_active" );
 static const furn_str_id furn_f_smoking_rack_active( "f_smoking_rack_active" );
 static const furn_str_id furn_f_water_mill_active( "f_water_mill_active" );
@@ -448,6 +446,7 @@ item &item::convert( const itype_id &new_type, Character *carrier )
 
     item_counter = 0;
     update_link_traits();
+    update_inherited_flags();
     update_prefix_suffix_flags();
     return *this;
 }
@@ -649,9 +648,10 @@ bool _stacks_weapon_mods( item const &lhs, item const &rhs )
 {
     item const *const lb = lhs.is_gun() ? lhs.gunmod_find( itype_barrel_small ) : nullptr;
     item const *const rb = rhs.is_gun() ? rhs.gunmod_find( itype_barrel_small ) : nullptr;
+    constexpr uint64_t mask = static_cast<uint64_t>( hot_flag_bit::REMOVED_STOCK ) |
+                              static_cast<uint64_t>( hot_flag_bit::DIAMOND );
     return ( ( lb && rb ) || ( !lb && !rb ) ) &&
-           lhs.has_flag( flag_REMOVED_STOCK ) == rhs.has_flag( flag_REMOVED_STOCK ) &&
-           lhs.has_flag( flag_DIAMOND ) == rhs.has_flag( flag_DIAMOND );
+           ( lhs.combined_hot_flags() & mask ) == ( rhs.combined_hot_flags() & mask );
 }
 
 bool _stacks_location_hint( item const &lhs, item const &rhs )
@@ -684,8 +684,8 @@ bool _stacks_location_hint( item const &lhs, item const &rhs )
 bool _stacks_location_precise_closest_city( item const &lhs, item const &rhs )
 {
     // Skip the closest_city sort unless both items can actually display the segment.
-    if( !lhs.has_flag( json_flag_LOCATION_PRECISE_CLOSEST_CITY ) ||
-        !rhs.has_flag( json_flag_LOCATION_PRECISE_CLOSEST_CITY ) ) {
+    constexpr uint64_t bit = static_cast<uint64_t>( hot_flag_bit::LOC_CITY );
+    if( !( lhs.combined_hot_flags() & bit ) || !( rhs.combined_hot_flags() & bit ) ) {
         return true;
     }
     static const std::string omt_loc_var = "spawn_location";
@@ -724,8 +724,10 @@ bool _stacks_rot( item const &lhs, item const &rhs, bool combine_liquid )
 
 bool _stacks_mushy_dirty( item const &lhs, item const &rhs )
 {
-    return lhs.has_flag( flag_MUSHY ) == rhs.has_flag( flag_MUSHY ) &&
-           lhs.has_own_flag( flag_DIRTY ) == rhs.has_own_flag( flag_DIRTY );
+    constexpr uint64_t mushy = static_cast<uint64_t>( hot_flag_bit::MUSHY );
+    constexpr uint64_t dirty = static_cast<uint64_t>( hot_flag_bit::DIRTY );
+    return ( lhs.combined_hot_flags() & mushy ) == ( rhs.combined_hot_flags() & mushy ) &&
+           ( lhs.own_hot_flags() & dirty ) == ( rhs.own_hot_flags() & dirty );
 }
 
 bool _stacks_food_status( item const &lhs, item const &rhs )
@@ -737,32 +739,36 @@ bool _stacks_food_status( item const &lhs, item const &rhs )
 
 bool _stacks_food_traits( item const &lhs, item const &rhs )
 {
+    constexpr uint64_t mask = static_cast<uint64_t>( hot_flag_bit::HIDDEN_POISON ) |
+                              static_cast<uint64_t>( hot_flag_bit::HIDDEN_HALLU );
     return ( !lhs.is_food() && !rhs.is_food() ) ||
            ( lhs.is_food() && rhs.is_food() &&
-             lhs.has_flag( flag_HIDDEN_POISON ) == rhs.has_flag( flag_HIDDEN_POISON ) &&
-             lhs.has_flag( flag_HIDDEN_HALLU ) == rhs.has_flag( flag_HIDDEN_HALLU ) );
+             ( lhs.combined_hot_flags() & mask ) == ( rhs.combined_hot_flags() & mask ) );
 }
 
 bool _stacks_food_irradiated( item const &lhs, item const &rhs )
 {
-    return lhs.has_flag( flag_IRRADIATED ) == rhs.has_flag( flag_IRRADIATED );
+    constexpr uint64_t bit = static_cast<uint64_t>( hot_flag_bit::IRRADIATED );
+    return ( lhs.combined_hot_flags() & bit ) == ( rhs.combined_hot_flags() & bit );
 }
 
 bool _stacks_food_perishable( item const &lhs, item const &rhs, bool check_cat )
 {
+    constexpr uint64_t bit = static_cast<uint64_t>( hot_flag_bit::INEDIBLE );
     return !check_cat || ( !lhs.is_food() && !rhs.is_food() ) ||
            ( lhs.is_food() && rhs.is_food() && lhs.goes_bad() == rhs.goes_bad() &&
-             lhs.has_flag( flag_INEDIBLE ) == rhs.has_flag( flag_INEDIBLE ) );
+             ( lhs.combined_hot_flags() & bit ) == ( rhs.combined_hot_flags() & bit ) );
 }
 
 bool _stacks_clothing_size( item const &lhs, item const &rhs )
 {
     avatar &u = get_avatar();
     item::sizing const u_sizing = lhs.get_sizing( u );
+    constexpr uint64_t mask = static_cast<uint64_t>( hot_flag_bit::FIT ) |
+                              static_cast<uint64_t>( hot_flag_bit::VARSIZE );
     return u_sizing == rhs.get_sizing( u ) &&
            ( u_sizing == item::sizing::ignore ||
-             ( lhs.has_flag( flag_FIT ) == rhs.has_flag( flag_FIT ) &&
-               lhs.has_flag( flag_VARSIZE ) == rhs.has_flag( flag_VARSIZE ) ) );
+             ( lhs.combined_hot_flags() & mask ) == ( rhs.combined_hot_flags() & mask ) );
 }
 
 bool _stacks_wetness( item const &lhs, item const &rhs, bool precise )
@@ -772,10 +778,11 @@ bool _stacks_wetness( item const &lhs, item const &rhs, bool precise )
 
 bool _stacks_cbm_status( item const &lhs, item const &rhs )
 {
+    constexpr uint64_t mask = static_cast<uint64_t>( hot_flag_bit::NO_PACKED ) |
+                              static_cast<uint64_t>( hot_flag_bit::NO_STERILE );
     return ( !lhs.is_bionic() && !rhs.is_bionic() ) ||
            ( lhs.is_bionic() && rhs.is_bionic() &&
-             lhs.has_flag( flag_NO_PACKED ) == rhs.has_flag( flag_NO_PACKED ) &&
-             lhs.has_flag( flag_NO_STERILE ) == rhs.has_flag( flag_NO_STERILE ) );
+             ( lhs.combined_hot_flags() & mask ) == ( rhs.combined_hot_flags() & mask ) );
 }
 
 bool _stacks_ethereal( item const &lhs, item const &rhs )
@@ -787,9 +794,10 @@ bool _stacks_ethereal( item const &lhs, item const &rhs )
 
 bool _stacks_ups( item const &lhs, item const &rhs )
 {
+    constexpr uint64_t bit = static_cast<uint64_t>( hot_flag_bit::USE_UPS );
     return ( !lhs.is_tool() && !rhs.is_tool() ) ||
            ( lhs.is_tool() && rhs.is_tool() &&
-             lhs.has_flag( flag_USE_UPS ) == rhs.has_flag( flag_USE_UPS ) );
+             ( lhs.combined_hot_flags() & bit ) == ( rhs.combined_hot_flags() & bit ) );
 }
 
 bool _stacks_mods( item const &lhs, item const &rhs )
@@ -1461,6 +1469,12 @@ void item::update_inherited_flags()
         }
     }
 
+    hot_flags_inherited = 0;
+    const FlagsSetType &inherited = inherited_tags_cache;
+    for( const flag_id &f : inherited ) {
+        hot_flags_inherited |= hot_bit_for( f );
+    }
+
     update_prefix_suffix_flags();
 }
 
@@ -2095,7 +2109,13 @@ int item::lift_strength() const
 void item::unset_flags()
 {
     item_tags.clear();
+    hot_flags_own = 0;
     requires_tags_processing = true;
+}
+
+uint64_t item::combined_hot_flags() const
+{
+    return ( type ? type->hot_flag_bits : 0 ) | hot_flags_own | hot_flags_inherited;
 }
 
 bool item::has_own_flag( const flag_id &f ) const
@@ -2124,6 +2144,7 @@ item &item::set_flag( const flag_id &flag )
 {
     if( flag.is_valid() ) {
         item_tags.insert( flag );
+        hot_flags_own |= hot_bit_for( flag );
         update_prefix_suffix_flags( flag );
         requires_tags_processing = true;
     } else {
@@ -2153,6 +2174,7 @@ bool item::has_vitamin( const vitamin_id &v ) const
 item &item::unset_flag( const flag_id &flag )
 {
     item_tags.erase( flag );
+    hot_flags_own &= ~hot_bit_for( flag );
     update_prefix_suffix_flags();
     requires_tags_processing = true;
     return *this;

--- a/src/item.h
+++ b/src/item.h
@@ -3351,6 +3351,15 @@ class item : public visitable
          * This flag is reset to `true` if item tags are changed.
          */
         bool requires_tags_processing = true;
+        uint64_t hot_flags_own = 0;
+        uint64_t hot_flags_inherited = 0;
+    public:
+        // Combined hot-flag bits across type, instance, and inherited contents.
+        uint64_t combined_hot_flags() const;
+        uint64_t own_hot_flags() const {
+            return hot_flags_own;
+        }
+    private:
         cata::heap<FlagsSetType> item_tags; // generic item specific flags
         cata::heap<FlagsSetType> inherited_tags_cache;
         cata::heap<FlagsSetType> prefix_tags_cache; // flags that will add prefixes to this item

--- a/src/item_degrade.cpp
+++ b/src/item_degrade.cpp
@@ -1074,14 +1074,23 @@ bool item::can_repair_with( const material_id &mat_ident ) const
 
 bool item::is_broken() const
 {
-    return has_flag( flag_ITEM_BROKEN ) || has_fault_flag( std::string( "ITEM_BROKEN" ) );
+    constexpr uint64_t bit = static_cast<uint64_t>( hot_flag_bit::ITEM_BROKEN );
+    if( combined_hot_flags() & bit ) {
+        return true;
+    }
+    return has_fault_flag( std::string( "ITEM_BROKEN" ) );
 }
 
 bool item::is_broken_on_active() const
 {
-    return has_flag( flag_ITEM_BROKEN ) ||
-           has_fault_flag( std::string( "ITEM_BROKEN" ) ) ||
-           ( wetness && has_flag( flag_WATER_BREAK_ACTIVE ) );
+    constexpr uint64_t bit = static_cast<uint64_t>( hot_flag_bit::ITEM_BROKEN );
+    if( combined_hot_flags() & bit ) {
+        return true;
+    }
+    if( has_fault_flag( std::string( "ITEM_BROKEN" ) ) ) {
+        return true;
+    }
+    return wetness && has_flag( flag_WATER_BREAK_ACTIVE );
 }
 
 std::set<fault_id> item::faults_potential() const

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -889,6 +889,11 @@ void Item_factory::finalize_post( itype &obj )
         return false;
     } );
 
+    obj.hot_flag_bits = 0;
+    for( const flag_id &f : obj.item_tags ) {
+        obj.hot_flag_bits |= hot_bit_for( f );
+    }
+
     if( obj.gun && !obj.gunmod && !obj.has_flag( flag_PRIMITIVE_RANGED_WEAPON ) ) {
         const quality_id qual_gun_skill( to_upper_case( obj.gun->skill_used.str() ) );
 

--- a/src/itype.h
+++ b/src/itype.h
@@ -3,6 +3,7 @@
 #define CATA_SRC_ITYPE_H
 
 #include <cstddef>
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <optional>
@@ -1469,6 +1470,8 @@ struct itype {
         mtype_id source_monster = mtype_id::NULL_ID();
     private:
         FlagsSetType item_tags;
+        uint64_t hot_flag_bits = 0;
+        friend class item;
 
     public:
         // memory card related per-type static data

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -3088,6 +3088,12 @@ void item::io( Archive &archive )
         return !f.is_valid();
     } );
 
+    hot_flags_own = 0;
+    const item::FlagsSetType &owned = item_tags;
+    for( const flag_id &f : owned ) {
+        hot_flags_own |= hot_bit_for( f );
+    }
+
     if( note_read ) {
         snip_id = SNIPPET.migrate_hash_to_id( note );
     } else {

--- a/tests/hot_flag_bits_test.cpp
+++ b/tests/hot_flag_bits_test.cpp
@@ -1,0 +1,143 @@
+#include <cstdint>
+#include <sstream>
+#include <string>
+
+#include "cata_catch.h"
+#include "flag.h"
+#include "flexbuffer_json.h"
+#include "item.h"
+#include "json.h"
+#include "json_loader.h"
+#include "pocket_type.h"
+#include "ret_val.h"
+#include "type_id.h"
+
+static const itype_id itype_attachable_ear_muffs( "attachable_ear_muffs" );
+static const itype_id itype_helmet_army( "helmet_army" );
+
+static constexpr uint64_t bit_fit = static_cast<uint64_t>( hot_flag_bit::FIT );
+static constexpr uint64_t bit_dirty = static_cast<uint64_t>( hot_flag_bit::DIRTY );
+static constexpr uint64_t bit_varsize = static_cast<uint64_t>( hot_flag_bit::VARSIZE );
+static constexpr uint64_t bit_diamond = static_cast<uint64_t>( hot_flag_bit::DIAMOND );
+
+TEST_CASE( "hot_flag_bits_set_unset_toggle_own_bits", "[item][flag]" )
+{
+    item it( itype_helmet_army );
+    REQUIRE( ( it.own_hot_flags() & bit_fit ) == 0 );
+
+    it.set_flag( flag_FIT );
+    CHECK( ( it.own_hot_flags() & bit_fit ) == bit_fit );
+    CHECK( ( it.combined_hot_flags() & bit_fit ) == bit_fit );
+
+    it.unset_flag( flag_FIT );
+    CHECK( ( it.own_hot_flags() & bit_fit ) == 0 );
+}
+
+TEST_CASE( "hot_flag_bits_unset_flags_clears_all_own_bits", "[item][flag]" )
+{
+    item it( itype_helmet_army );
+    it.set_flag( flag_FIT );
+    it.set_flag( flag_DIRTY );
+    REQUIRE( ( it.own_hot_flags() & ( bit_fit | bit_dirty ) ) == ( bit_fit | bit_dirty ) );
+
+    it.unset_flags();
+    CHECK( it.own_hot_flags() == 0 );
+}
+
+TEST_CASE( "hot_flag_bits_type_bits_reflect_itype_json_flags", "[item][flag]" )
+{
+    item it( itype_helmet_army );
+    // helmet_army declares VARSIZE in JSON.
+    CHECK( ( it.combined_hot_flags() & bit_varsize ) == bit_varsize );
+    CHECK( ( it.own_hot_flags() & bit_varsize ) == 0 );
+}
+
+TEST_CASE( "hot_flag_bits_set_flag_with_non_hot_flag_does_not_set_bits", "[item][flag]" )
+{
+    item it( itype_helmet_army );
+    const uint64_t before = it.own_hot_flags();
+    it.set_flag( flag_ALARMCLOCK );
+    CHECK( it.own_hot_flags() == before );
+}
+
+TEST_CASE( "hot_flag_bits_convert_recomputes_inherited_bits", "[item][flag]" )
+{
+    item it( itype_helmet_army );
+    it.convert( itype_helmet_army, nullptr );
+    CHECK( ( it.combined_hot_flags() & bit_varsize ) == bit_varsize );
+}
+
+TEST_CASE( "hot_flag_bits_save_load_restores_own_bits", "[item][flag]" )
+{
+    item original( itype_helmet_army );
+    original.set_flag( flag_FIT );
+    REQUIRE( ( original.own_hot_flags() & bit_fit ) == bit_fit );
+
+    std::ostringstream os;
+    JsonOut jsout( os );
+    original.serialize( jsout );
+
+    item loaded;
+    JsonValue jv = json_loader::from_string( os.str() );
+    JsonObject jo = jv;
+    loaded.deserialize( jo );
+
+    CHECK( loaded.has_flag( flag_FIT ) );
+    CHECK( ( loaded.own_hot_flags() & bit_fit ) == bit_fit );
+    CHECK( ( loaded.combined_hot_flags() & bit_varsize ) == bit_varsize );
+}
+
+// Build a helmet_army with an inherits_flags pocket holding an item that carries
+// flag_FIT, so the parent's hot_flags_inherited gains the FIT bit.
+static item make_parent_with_inherited_fit()
+{
+    item parent( itype_helmet_army );
+    item child( itype_attachable_ear_muffs );
+    child.set_flag( flag_FIT );
+    parent.put_in( child, pocket_type::CONTAINER );
+    return parent;
+}
+
+TEST_CASE( "hot_flag_bits_inherited_bits_set_when_contents_change", "[item][flag]" )
+{
+    item parent = make_parent_with_inherited_fit();
+    CHECK( ( parent.combined_hot_flags() & bit_fit ) == bit_fit );
+    CHECK( ( parent.own_hot_flags() & bit_fit ) == 0 );
+}
+
+TEST_CASE( "hot_flag_bits_convert_preserves_inherited_bits_via_rebuild", "[item][flag]" )
+{
+    item parent = make_parent_with_inherited_fit();
+    REQUIRE( ( parent.combined_hot_flags() & bit_fit ) == bit_fit );
+    parent.convert( itype_helmet_army, nullptr );
+    CHECK( ( parent.combined_hot_flags() & bit_fit ) == bit_fit );
+}
+
+TEST_CASE( "hot_flag_bits_save_load_restores_inherited_bits", "[item][flag]" )
+{
+    item parent = make_parent_with_inherited_fit();
+    REQUIRE( ( parent.combined_hot_flags() & bit_fit ) == bit_fit );
+
+    std::ostringstream os;
+    JsonOut jsout( os );
+    parent.serialize( jsout );
+
+    item loaded;
+    JsonValue jv = json_loader::from_string( os.str() );
+    JsonObject jo = jv;
+    loaded.deserialize( jo );
+
+    CHECK( loaded.has_flag( flag_FIT ) );
+    CHECK( ( loaded.combined_hot_flags() & bit_fit ) == bit_fit );
+    CHECK( ( loaded.own_hot_flags() & bit_fit ) == 0 );
+}
+
+TEST_CASE( "hot_flag_bits_combined_view_agrees_with_public_has_flag", "[item][flag]" )
+{
+    item it( itype_helmet_army );
+    it.set_flag( flag_FIT );
+    CHECK( it.has_flag( flag_FIT ) == ( ( it.combined_hot_flags() & bit_fit ) != 0 ) );
+    CHECK( it.has_flag( flag_DIAMOND ) == ( ( it.combined_hot_flags() & bit_diamond ) != 0 ) );
+    CHECK( it.has_flag( flag_VARSIZE ) == ( ( it.combined_hot_flags() & bit_varsize ) != 0 ) );
+    CHECK( it.has_flag( flag_DIRTY ) == ( ( it.combined_hot_flags() & bit_dirty ) != 0 ) );
+}


### PR DESCRIPTION
#### Summary

Performance "Cache hot flag bits on item and itype to speed up stacks_with"

#### Purpose of change

Follow-up to #86668 (`flat_set` flag storage) and #86695 (efile photo/recipe count caches). Inventory selector redraw and the mapgen bench from #86668 still spent meaningful time inside `flat_set<flag_id>` lookups driven by `stacks_with`. Profiling pointed at the `_stacks_*` family and `is_broken`.

#### Describe the solution

`hot_flag_bit` enum (15 bits) covers the flags driving `_stacks_*` and `is_broken`: REMOVED_STOCK, DIAMOND, FIT, VARSIZE, MUSHY, DIRTY, HIDDEN_POISON, HIDDEN_HALLU, IRRADIATED, INEDIBLE, NO_PACKED, NO_STERILE, USE_UPS, LOCATION_PRECISE_CLOSEST_CITY, ITEM_BROKEN. Bit positions are compile-time constants, so the cache is reload-safe.

`itype::hot_flag_bits` is built once in `Item_factory::finalize_post`. `item::hot_flags_own` / `hot_flags_inherited` are maintained by `set_flag` / `unset_flag` / `unset_flags`, rebuilt in `update_inherited_flags` (now called from `convert`) and from `item_tags` in the post-load path. The nine equality `_stacks_*` helpers and both `is_broken` variants switch to bit-AND on `combined_hot_flags()`. Public `has_flag` is unchanged.

Inventory selector redraw profile:

- `__lower_bound<vector<flag_id>>`: 6.58% -> 2.98%
- `__advance<vector<flag_id>>`: 1.99% -> 0.87%
- `flat_set<json_flag>::lower_bound/find/count`: ~4.3% -> ~2.0%
- `find_id`: 1.68% -> <0.5%
- combined flag-machinery: ~14.5% -> ~6.5%

Mapgen container yard bench from #86668:

- combined flag-machinery: ~20.8% -> ~13.0%
- wall time: 52.6s -> 49.7s

stacks_with microbench: 1.16 us -> 0.94 us (-19%).

#### Describe alternatives you've considered

First tried migrating `FlagsSetType` to `int_id<json_flag>`. Ran 6-30% slower per call: `flat_set<flag_id>::find` was already doing int compares via cached `_cid`, so the migration only added `find_id` overhead. Hot bits sidestep the lookup for the actually-hot flags without introducing reload-unsafe state on item.

Could widen the bit set further, but the 15 here cover what the trace fingered. Easy to extend if a future profile points elsewhere.

#### Testing

`tests/hot_flag_bits_test.cpp`: 11 cases covering set/unset/clear, type bits from itype JSON, non-hot flag no-op, convert(), inherited bits via `inherits_flags` pocket insertion, save/load round-trip for own and inherited bits.

Existing item, inventory, pocket, crafting tests pass. Verified in-game.

#### Additional context

N/A